### PR TITLE
fix: increase worker shutdown timeout and parallelize instance disposal

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -176,7 +176,7 @@ export const TuiThreadCommand = cmd({
         process.off("uncaughtException", error)
         process.off("unhandledRejection", error)
         process.off("SIGUSR2", reload)
-        await withTimeout(client.call("shutdown", undefined), 5000).catch((error) => {
+        await withTimeout(client.call("shutdown", undefined), 15000).catch((error) => {
           Log.Default.warn("worker shutdown failed", {
             error: errorMessage(error),
           })

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -162,25 +162,33 @@ export const Instance = {
     disposal.all = iife(async () => {
       Log.Default.info("disposing all instances")
       const entries = [...cache.entries()]
-      for (const [key, value] of entries) {
-        if (cache.get(key) !== value) continue
 
-        const ctx = await value.catch((error) => {
-          Log.Default.warn("instance dispose failed", { key, error })
-          return undefined
-        })
+      const resolved = await Promise.all(
+        entries.map(async ([key, value]) => {
+          if (cache.get(key) !== value) return undefined
 
-        if (!ctx) {
-          if (cache.get(key) === value) cache.delete(key)
-          continue
-        }
+          const ctx = await value.catch((error) => {
+            Log.Default.warn("instance dispose failed", { key, error })
+            return undefined
+          })
 
-        if (cache.get(key) !== value) continue
+          if (!ctx) {
+            if (cache.get(key) === value) cache.delete(key)
+            return undefined
+          }
 
-        await context.provide(ctx, async () => {
-          await Instance.dispose()
-        })
-      }
+          if (cache.get(key) !== value) return undefined
+          return ctx
+        }),
+      )
+
+      await Promise.allSettled(
+        resolved.filter((ctx): ctx is InstanceContext => ctx !== undefined).map((ctx) =>
+          context.provide(ctx, async () => {
+            await Instance.dispose()
+          }),
+        ),
+      )
     }).finally(() => {
       disposal.all = undefined
     })


### PR DESCRIPTION
## Summary

Worker shutdown was timing out after 5s because `Instance.disposeAll()` ran sequentially, causing `worker.terminate()` to force-kill the process.

## Changes

- Increase shutdown timeout from 5s to 15s in `thread.ts:179`
- Parallelize context resolution and instance disposal using `Promise.allSettled` in `instance.ts`

## How I verified

- TypeScript typecheck passes
- Reviewed shutdown flow: `thread.ts` -> worker RPC -> `Instance.disposeAll()` -> sequential disposal was the bottleneck

Fixes #216
