### PR TITLE
fix(upgrade): 支持 curl 安装方式的 mimo upgrade

### DIFF
--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -46,7 +46,7 @@ export const UpgradeCommand = {
     prompts.log.info("Using method: " + method)
     const target = args.target
       ? args.target.replace(/^v/, "")
-      : await AppRuntime.runPromise(Installation.Service.use((svc) => svc.latest()))
+      : await AppRuntime.runPromise(Installation.Service.use((svc) => svc.latest(method)))
 
     if (InstallationVersion === target) {
       prompts.log.warn(`opencode upgrade skipped: ${target} is already installed`)

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -14,6 +14,7 @@ import { InstallationChannel, InstallationVersion } from "./version"
 const log = Log.create({ service: "installation" })
 
 const PACKAGE_NAME = "@mimo-ai/cli"
+const GITHUB_REPO = "XiaomiMiMo/MiMo-Code"
 
 export type Method = "curl" | "npm" | "pnpm" | "bun" | "brew" | "scoop" | "choco" | "unknown"
 
@@ -69,9 +70,9 @@ export class UpgradeFailedError extends Schema.TaggedErrorClass<UpgradeFailedErr
   stderr: Schema.String,
 }) {}
 
-// TODO(mimocode): uncomment when corresponding channels are supported
-// const GitHubRelease = Schema.Struct({ tag_name: Schema.String })
+const GitHubRelease = Schema.Struct({ tag_name: Schema.String })
 const NpmPackage = Schema.Struct({ version: Schema.String })
+// TODO(mimocode): uncomment when corresponding channels are supported
 // const BrewFormula = Schema.Struct({ versions: Schema.Struct({ stable: Schema.String }) })
 // const BrewInfoV2 = Schema.Struct({
 //   formulae: Schema.Array(Schema.Struct({ versions: Schema.Struct({ stable: Schema.String }) })),
@@ -230,6 +231,16 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
           return data.version
         }
 
+        if (detectedMethod === "curl") {
+          const response = yield* httpOk.execute(
+            HttpClientRequest.get(`https://api.github.com/repos/${GITHUB_REPO}/releases/latest`).pipe(
+              HttpClientRequest.acceptJson,
+            ),
+          )
+          const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
+          return data.tag_name.replace(/^v/, "")
+        }
+
         // TODO(mimocode): uncomment when mimocode is published to chocolatey
         // if (detectedMethod === "choco") {
         //   const response = yield* httpOk.execute(
@@ -251,15 +262,6 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
         //   const data = yield* HttpClientResponse.schemaBodyJson(ScoopManifest)(response)
         //   return data.version
         // }
-
-        // TODO(mimocode): uncomment when mimocode has github releases
-        // const response = yield* httpOk.execute(
-        //   HttpClientRequest.get("https://api.github.com/repos/anomalyco/opencode/releases/latest").pipe(
-        //     HttpClientRequest.acceptJson,
-        //   ),
-        // )
-        // const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
-        // return data.tag_name.replace(/^v/, "")
 
         log.warn("unsupported update channel, skipping", { method: detectedMethod })
         return yield* Effect.die(new Error(`unsupported update channel: ${detectedMethod}`))

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -143,9 +143,22 @@ describe("installation", () => {
       expect(result).toBe("1.7.0")
     })
 
-    test("dies for unsupported channels (brew/choco/scoop/curl/unknown)", async () => {
+    test("reads version from github releases for curl method", async () => {
+      const layer = testLayer((req) => {
+        expect(req.url).toContain("api.github.com")
+        expect(req.url).toContain("releases/latest")
+        return jsonResponse({ tag_name: "v1.8.0" })
+      })
+
+      const result = await Effect.runPromise(
+        Installation.Service.use((svc) => svc.latest("curl")).pipe(Effect.provide(layer)),
+      )
+      expect(result).toBe("1.8.0")
+    })
+
+    test("dies for unsupported channels (brew/choco/scoop/unknown)", async () => {
       const layer = testLayer(() => jsonResponse({}))
-      const unsupported: Installation.Method[] = ["brew", "choco", "scoop", "curl", "unknown"]
+      const unsupported: Installation.Method[] = ["brew", "choco", "scoop", "unknown"]
 
       for (const method of unsupported) {
         const result = Effect.runPromise(


### PR DESCRIPTION
## 问题

通过 curl 脚本（默认安装方式）安装后，`mimo upgrade` 会报错退出：

```
unsupported update channel: curl
```

加上 `--method npm` 也没用，同样报这个错。对应 issue #211、#212。

## 原因

排查下来是两处问题叠加：

1. `Installation.latest()` 里只处理了 npm/pnpm/bun，没有 curl 分支，于是直接落到末尾 `Effect.die("unsupported update channel: curl")`。但其实 `upgrade()` 早就支持 curl 了（`upgradeCurl` 会重新跑一遍安装脚本），缺的只是"查最新版本号"这一步。

2. `upgrade` 命令调用 `svc.latest()` 时没把已经确定的 `method` 传进去，导致它内部又重新探测了一次、再次得到 `curl`。这也是为什么用户加 `--method npm` 绕不过去。

## 改动

- `latest()` 增加 curl 分支，从 GitHub releases API 读取最新版本号（仓库的 releases 是有的，安装脚本本身也是从这里下载二进制）。
- `upgrade` 命令把解析后的 `method` 透传给 `latest()`。
- 更新了原先断言 curl 不受支持的测试，并补了一个走 GitHub releases 路径的用例。

## 测试

`bun test test/installation` 中相关用例通过，`typecheck` 和 `lint` 均无新增报错。
