### PR TITLE
fix: support curl channel in upgrade version check

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -217,7 +217,7 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
         //   return data.versions.stable
         // }
 
-        if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm") {
+        if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm" || detectedMethod === "curl") {
           const r = (yield* text(["npm", "config", "get", "registry"])).trim()
           const reg = r || "https://registry.npmjs.org"
           const registry = reg.endsWith("/") ? reg.slice(0, -1) : reg


### PR DESCRIPTION
## Summary

`mimo upgrade` fails with "unsupported update channel: curl" when installed via the curl script. The `latestImpl()` function doesn't handle the "curl" channel, even though `upgradeImpl()` already supports it.

## Changes

- Add `"curl"` to the npm/pnpm/bun check in `latestImpl()` so curl-installed users can query the npm registry for the latest version

## How I verified

- `methodImpl()` returns "curl" for executables in `.mimocode/bin` or `.local/bin` (line 168-169)
- `upgradeImpl()` already handles "curl" channel (line 271-272)
- `latestImpl()` was missing the "curl" case, causing the error

Fixes #212
