### PR TITLE
fix: properly encode PowerShell commands for UTF-8 support on Windows

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -306,14 +306,37 @@ const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) 
   })
 })
 
+function encodePowerShellCommand(command: string) {
+  return Buffer.from(command, "utf16le").toString("base64")
+}
+
+function withPowerShellUtf8Preamble(command: string) {
+  return `
+[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false);
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);
+$OutputEncoding = [Console]::OutputEncoding;
+${command}
+`
+}
+
 function cmd(shell: string, name: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && PS.has(name)) {
-    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
-      cwd,
-      env,
-      stdin: "ignore",
-      detached: false,
-    })
+    return ChildProcess.make(
+      shell,
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-EncodedCommand",
+        encodePowerShellCommand(withPowerShellUtf8Preamble(command)),
+      ],
+      {
+        cwd,
+        env,
+        stdin: "ignore",
+        detached: false,
+      },
+    )
   }
 
   return ChildProcess.make(command, [], {


### PR DESCRIPTION
### Issue for this PR
Closes #267

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
On Windows, PowerShell commands via the bash tool produce garbled output for non-ASCII characters (Chinese, emoji, etc.) because PS defaults to the system legacy encoding (e.g. CP936).

This PR switches from `-Command` to `-EncodedCommand` with a UTF-8 preamble, so all command output is properly encoded in UTF-8.

Changes in `packages/opencode/src/tool/bash.ts`:
- Add `encodePowerShellCommand()` helper (base64 UTF-16LE encoding for `-EncodedCommand`)
- Add `withPowerShellUtf8Preamble()` helper (sets console I/O to UTF-8 without BOM)
- Update `cmd()` to use these instead of raw `-Command` string passing

### How did you verify your code works?
- `bun turbo typecheck` passes all 17 packages (0 errors)
- Tested locally on Windows 11 with Chinese locale: non-ASCII output now displays correctly
- Only affects the `process.platform === "win32" && PS.has(name)` code path — other shells unchanged

### Screenshots / recordings
N/A

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR