### PR TITLE
fix: add log file rotation when exceeding 10MB

### DIFF
--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -57,6 +57,9 @@ let write = (msg: any) => {
   return msg.length
 }
 
+const MAX_LOG_SIZE = 10 * 1024 * 1024 // 10MB
+let currentLogSize = 0
+
 export async function init(options: Options) {
   if (options.level) level = options.level
   void cleanup(Global.Path.log)
@@ -76,10 +79,29 @@ export async function init(options: Options) {
       }
     } catch {}
   } else {
-    await fs.truncate(logpath).catch(() => {})
+    const stat = await fs.stat(logpath).catch(() => null)
+    currentLogSize = stat?.size ?? 0
+    if (currentLogSize > MAX_LOG_SIZE) {
+      await fs.truncate(logpath).catch(() => {})
+      currentLogSize = 0
+    }
   }
   const stream = createWriteStream(logpath, { flags: "a" })
   write = async (msg: any) => {
+    currentLogSize += msg.length
+    if (currentLogSize > MAX_LOG_SIZE) {
+      stream.end()
+      const stamp = new Date().toISOString().split(".")[0].replace(/:/g, "")
+      await fs.rename(logpath, `${logpath}.${stamp}`).catch(() => {})
+      const newStream = createWriteStream(logpath, { flags: "a" })
+      currentLogSize = 0
+      return new Promise((resolve, reject) => {
+        newStream.write(msg, (err) => {
+          if (err) reject(err)
+          else resolve(msg.length)
+        })
+      })
+    }
     return new Promise((resolve, reject) => {
       stream.write(msg, (err) => {
         if (err) reject(err)


### PR DESCRIPTION
## Summary

Log files can grow very large during long sessions (we've seen 2.9MB files), causing disk space issues and potential lag. The permission evaluation logs are particularly verbose because they include the entire ruleset in each log entry.

## Changes

- Add 10MB size limit (`MAX_LOG_SIZE`) for log files
- When log file exceeds 10MB, rotate it by renaming to `<timestamp>.log.<timestamp>` and create a new file
- Check file size on startup and truncate if needed

## How I verified

- The `cleanup()` function only removes old files when there are more than 10, but doesn't limit individual file sizes
- The permission evaluation logs we observed in `2026-06-11T111836.log` were extremely verbose
- 10MB limit is reasonable for log files

Fixes #209, #219
