### PR TITLE
fix(opencode): use mimocode in upgrade warnings

### DIFF
--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -29,7 +29,7 @@ export const UpgradeCommand = {
     const detectedMethod = await AppRuntime.runPromise(Installation.Service.use((svc) => svc.method()))
     const method = (args.method as Installation.Method) ?? detectedMethod
     if (method === "unknown") {
-      prompts.log.error(`opencode is installed to ${process.execPath} and may be managed by a package manager`)
+      prompts.log.error(`mimocode is installed to ${process.execPath} and may be managed by a package manager`)
       const install = await prompts.select({
         message: "Install anyways?",
         options: [
@@ -49,7 +49,7 @@ export const UpgradeCommand = {
       : await AppRuntime.runPromise(Installation.Service.use((svc) => svc.latest()))
 
     if (InstallationVersion === target) {
-      prompts.log.warn(`opencode upgrade skipped: ${target} is already installed`)
+      prompts.log.warn(`mimocode upgrade skipped: ${target} is already installed`)
       prompts.outro("Done")
       return
     }

--- a/packages/opencode/test/cli/upgrade.test.ts
+++ b/packages/opencode/test/cli/upgrade.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+
+const errors: string[] = []
+const warnings: string[] = []
+const runtimeResults: unknown[] = []
+
+mock.module("@clack/prompts", () => ({
+  intro: mock(() => undefined),
+  outro: mock(() => undefined),
+  select: mock(() => Promise.resolve(false)),
+  spinner: mock(() => ({
+    start: mock(() => undefined),
+    stop: mock(() => undefined),
+  })),
+  log: {
+    error: mock((message: string) => errors.push(message)),
+    info: mock(() => undefined),
+    warn: mock((message: string) => warnings.push(message)),
+  },
+}))
+
+mock.module("@/effect/app-runtime", () => ({
+  AppRuntime: {
+    runPromise: mock(() => Promise.resolve(runtimeResults.shift())),
+  },
+}))
+
+import { UpgradeCommand } from "../../src/cli/cmd/upgrade"
+
+describe("UpgradeCommand", () => {
+  afterEach(() => {
+    errors.length = 0
+    warnings.length = 0
+    runtimeResults.length = 0
+  })
+
+  test("uses the MiMoCode name when the install method is unknown", async () => {
+    runtimeResults.push("unknown")
+
+    await UpgradeCommand.handler({})
+
+    expect(errors).toContain(`mimocode is installed to ${process.execPath} and may be managed by a package manager`)
+    expect(errors.join("\n")).not.toContain("opencode")
+  })
+
+  test("uses the MiMoCode name when the target version is already installed", async () => {
+    runtimeResults.push("unknown")
+
+    await UpgradeCommand.handler({ method: "npm", target: "local" })
+
+    expect(warnings).toContain("mimocode upgrade skipped: local is already installed")
+    expect(warnings.join("\n")).not.toContain("opencode")
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #329.

- Replace the remaining OpenCode product name in `mimo upgrade` warnings with `mimocode`.
- Add a focused CLI regression test for the unknown-install-method prompt and already-installed warning.

## Verification

- `bun test test/cli/upgrade.test.ts --timeout 30000`
- `bun typecheck`
- `bun run lint` (0 errors, existing warnings)
- `bun run --conditions=browser src/index.ts upgrade local --method npm`
- pre-push: `bun turbo typecheck`

## Note

`test/installation/installation.test.ts` still has pre-existing failures expecting `@mimocode/cli-ai` and the Xiaomi registry while the current implementation uses `@mimo-ai/cli` and npm registry. I left that unrelated baseline mismatch out of this focused PR.
