### PR TITLE
fix: filter unsupported image formats before sending to API

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -353,6 +353,18 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
       const filename = part.type === "file" ? part.filename : undefined
       const modality = mimeToModality(mime)
       if (!modality) return part
+
+      // Check if image format is supported by the API
+      if (modality === "image") {
+        const supportedFormats = ["image/bmp", "image/gif", "image/png", "image/jpeg", "image/webp"]
+        if (!supportedFormats.includes(mime.toLowerCase())) {
+          return {
+            type: "text" as const,
+            text: `ERROR: Unsupported image format "${mime}". Only bmp, gif, png, jpeg, and webp are supported. Please convert the image to a supported format.`,
+          }
+        }
+      }
+
       const supported = modality === "image" ? supportsImageInput(model) : model.capabilities.input[modality]
       if (supported) return part
 


### PR DESCRIPTION
## Summary

When an unsupported image format (e.g., .ico) is sent to the API, it returns an error but the invalid media reference stays in the conversation context. This causes a loop of errors on subsequent messages because the same invalid image keeps being sent.

## Changes

- Add format validation in `unsupportedParts()` to check if the image format is supported before sending to the API
- Supported formats: bmp, gif, png, jpeg, webp (matching API requirements)
- Replace unsupported images with a clear error message

## How I verified

- The error message "invalid image format, only bmp/gif/png/jpeg/webp are supported" comes from the API, not the code
- The current code only checks if the model supports image input, not if the specific format is supported
- Adding format validation prevents invalid images from reaching the API

Fixes #351
