### PR TITLE
fix(clipboard): throw errors on Windows/Linux clipboard failures

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -126,11 +126,15 @@ const getCopyMethod = lazy(async () => {
     if (process.env["WAYLAND_DISPLAY"] && which("wl-copy")) {
       console.log("clipboard: using wl-copy")
       return async (text: string) => {
-        const proc = Process.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
-        if (!proc.stdin) return
+        const proc = Process.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "pipe" })
+        if (!proc.stdin) throw new Error("Failed to open stdin for wl-copy process")
         proc.stdin.write(text)
         proc.stdin.end()
-        await proc.exited.catch(() => {})
+        const exitCode = await proc.exited
+        if (exitCode !== 0) {
+          const stderr = await proc.stderr.text()
+          throw new Error(`wl-copy failed with exit code ${exitCode}: ${stderr}`)
+        }
       }
     }
     if (which("xclip")) {
@@ -139,12 +143,16 @@ const getCopyMethod = lazy(async () => {
         const proc = Process.spawn(["xclip", "-selection", "clipboard"], {
           stdin: "pipe",
           stdout: "ignore",
-          stderr: "ignore",
+          stderr: "pipe",
         })
-        if (!proc.stdin) return
+        if (!proc.stdin) throw new Error("Failed to open stdin for xclip process")
         proc.stdin.write(text)
         proc.stdin.end()
-        await proc.exited.catch(() => {})
+        const exitCode = await proc.exited
+        if (exitCode !== 0) {
+          const stderr = await proc.stderr.text()
+          throw new Error(`xclip failed with exit code ${exitCode}: ${stderr}`)
+        }
       }
     }
     if (which("xsel")) {
@@ -153,12 +161,16 @@ const getCopyMethod = lazy(async () => {
         const proc = Process.spawn(["xsel", "--clipboard", "--input"], {
           stdin: "pipe",
           stdout: "ignore",
-          stderr: "ignore",
+          stderr: "pipe",
         })
-        if (!proc.stdin) return
+        if (!proc.stdin) throw new Error("Failed to open stdin for xsel process")
         proc.stdin.write(text)
         proc.stdin.end()
-        await proc.exited.catch(() => {})
+        const exitCode = await proc.exited
+        if (exitCode !== 0) {
+          const stderr = await proc.stderr.text()
+          throw new Error(`xsel failed with exit code ${exitCode}: ${stderr}`)
+        }
       }
     }
   }
@@ -178,14 +190,18 @@ const getCopyMethod = lazy(async () => {
         {
           stdin: "pipe",
           stdout: "ignore",
-          stderr: "ignore",
+          stderr: "pipe",
         },
       )
 
-      if (!proc.stdin) return
+      if (!proc.stdin) throw new Error("Failed to open stdin for PowerShell clipboard process")
       proc.stdin.write(text)
       proc.stdin.end()
-      await proc.exited.catch(() => {})
+      const exitCode = await proc.exited
+      if (exitCode !== 0) {
+        const stderr = await proc.stderr.text()
+        throw new Error(`PowerShell clipboard failed with exit code ${exitCode}: ${stderr}`)
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Fixes #349

The `/copy` command showed "Session transcript copied to clipboard!" even when clipboard operations failed because errors were silently swallowed. On Windows, the PowerShell clipboard process failures were caught and ignored, causing the UI to always show success.

## Changes

- Check exit codes for PowerShell, wl-copy, xclip, and xsel clipboard methods
- Throw errors when stdin is unavailable or process fails
- Capture stderr for better error messages
- Change `stderr: "ignore"` to `stderr: "pipe"` to capture error output

## Testing

- Verified on Windows 11 with Windows Terminal
- Tested `/copy` command with empty session - now shows error toast if clipboard fails
- Tested `/copy` command with content - works correctly

## Impact

This fix ensures users get proper feedback when clipboard operations fail, rather than a misleading success message.
