### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.mimocode/mimocode.jsonc
+++ b/.mimocode/mimocode.jsonc
@@ -1,6 +1,51 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "provider": {},
+  "provider": {
+    "astraflow": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Astraflow",
+      "env": ["ASTRAFLOW_API_KEY"],
+      "options": {
+        "baseURL": "https://api-us-ca.umodelverse.ai/v1"
+      },
+      "models": {
+        "kimi-k2-0711-preview": {
+          "name": "Kimi K2 0711 Preview",
+          "release_date": "2025-07-11",
+          "attachment": false,
+          "reasoning": false,
+          "temperature": true,
+          "tool_call": true,
+          "limit": {
+            "context": 128000,
+            "output": 16384
+          }
+        }
+      }
+    },
+    "astraflow-cn": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Astraflow China",
+      "env": ["ASTRAFLOW_CN_API_KEY"],
+      "options": {
+        "baseURL": "https://api.modelverse.cn/v1"
+      },
+      "models": {
+        "kimi-k2-0711-preview": {
+          "name": "Kimi K2 0711 Preview",
+          "release_date": "2025-07-11",
+          "attachment": false,
+          "reasoning": false,
+          "temperature": true,
+          "tool_call": true,
+          "limit": {
+            "context": 128000,
+            "output": 16384
+          }
+        }
+      }
+    }
+  },
   "permission": {
     "edit": {
       "packages/opencode/migration/*": "deny",

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The first launch guides you through configuration automatically. Supported optio
 - **Import from Claude Code** — migrate existing authentication in one step
 - **Custom Provider** — add any OpenAI-compatible API in the TUI
 
+Astraflow by UCloud is available as an OpenAI-compatible provider. Configure `astraflow` with `ASTRAFLOW_API_KEY` for the global endpoint (`https://api-us-ca.umodelverse.ai/v1`) or `astraflow-cn` with `ASTRAFLOW_CN_API_KEY` for the China endpoint (`https://api.modelverse.cn/v1`).
+
 Astraflow by UCloud is also supported as an OpenAI-compatible provider via `ASTRAFLOW_API_KEY` and the global endpoint `https://api-us-ca.umodelverse.ai/v1`.
 
 ---

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The first launch guides you through configuration automatically. Supported optio
 - **Import from Claude Code** — migrate existing authentication in one step
 - **Custom Provider** — add any OpenAI-compatible API in the TUI
 
+Astraflow by UCloud is also supported as an OpenAI-compatible provider via `ASTRAFLOW_API_KEY` and the global endpoint `https://api-us-ca.umodelverse.ai/v1`.
+
 ---
 
 ## Core Features

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -201,6 +201,20 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           baseURL: "https://api-us-ca.umodelverse.ai/v1",
         },
       }),
+    "astraflow-cn": () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          baseURL: "https://api.modelverse.cn/v1",
+        },
+      }),
+    astraflow: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          baseURL: "https://api-us-ca.umodelverse.ai/v1",
+        },
+      }),
     xai: () =>
       Effect.succeed({
         autoload: false,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -208,13 +208,6 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           baseURL: "https://api.modelverse.cn/v1",
         },
       }),
-    astraflow: () =>
-      Effect.succeed({
-        autoload: false,
-        options: {
-          baseURL: "https://api-us-ca.umodelverse.ai/v1",
-        },
-      }),
     xai: () =>
       Effect.succeed({
         autoload: false,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -194,6 +194,13 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         },
         options: {},
       }),
+    astraflow: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          baseURL: "https://api-us-ca.umodelverse.ai/v1",
+        },
+      }),
     xai: () =>
       Effect.succeed({
         autoload: false,

--- a/packages/opencode/src/provider/schema.ts
+++ b/packages/opencode/src/provider/schema.ts
@@ -14,6 +14,7 @@ export const ProviderID = providerIdSchema.pipe(
     opencode: schema.make("opencode"),
     anthropic: schema.make("anthropic"),
     openai: schema.make("openai"),
+    astraflow: schema.make("astraflow"),
     google: schema.make("google"),
     googleVertex: schema.make("google-vertex"),
     githubCopilot: schema.make("github-copilot"),

--- a/packages/opencode/src/provider/schema.ts
+++ b/packages/opencode/src/provider/schema.ts
@@ -15,6 +15,7 @@ export const ProviderID = providerIdSchema.pipe(
     anthropic: schema.make("anthropic"),
     openai: schema.make("openai"),
     astraflow: schema.make("astraflow"),
+    astraflowCn: schema.make("astraflow-cn"),
     google: schema.make("google"),
     googleVertex: schema.make("google-vertex"),
     githubCopilot: schema.make("github-copilot"),
@@ -23,8 +24,6 @@ export const ProviderID = providerIdSchema.pipe(
     openrouter: schema.make("openrouter"),
     mistral: schema.make("mistral"),
     gitlab: schema.make("gitlab"),
-    astraflow: schema.make("astraflow"),
-    astraflowCn: schema.make("astraflow-cn"),
   })),
 )
 

--- a/packages/opencode/src/provider/schema.ts
+++ b/packages/opencode/src/provider/schema.ts
@@ -23,6 +23,8 @@ export const ProviderID = providerIdSchema.pipe(
     openrouter: schema.make("openrouter"),
     mistral: schema.make("mistral"),
     gitlab: schema.make("gitlab"),
+    astraflow: schema.make("astraflow"),
+    astraflowCn: schema.make("astraflow-cn"),
   })),
 )
 


### PR DESCRIPTION
### Issue for this PR

Closes # N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds Astraflow provider support to the opencode provider registry.

- Registers `astraflow` and `astraflow-cn` as OpenAI-compatible providers with endpoint-specific API key environment variables
- Adds provider schema entries for both global and China endpoints
- Adds local provider metadata and model definitions

Provider endpoint notes:

- Global endpoint uses `ASTRAFLOW_API_KEY` and `https://api-us-ca.umodelverse.ai/v1`
- China endpoint uses `ASTRAFLOW_CN_API_KEY` and `https://api.modelverse.cn/v1`

### How did you verify your code works?

Verified that the provider schema and factory entries follow the same pattern as existing providers (openai, google, anthropic). The OpenAI-compatible base URL configuration is consistent with the `@ai-sdk/openai-compatible` SDK convention.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._