### PR TITLE
fix(actor): recover stringified operation before validation

### DIFF
--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -94,8 +94,20 @@ function wrap<Parameters extends z.ZodType, Result extends Metadata>(
           ...(ctx.callID ? { "tool.call_id": ctx.callID } : {}),
         }
         return Effect.gen(function* () {
-          yield* Effect.try({
-            try: () => toolInfo.parameters.parse(args),
+          const parsedArgs = yield* Effect.try({
+            try: () => {
+              const parsed = toolInfo.parameters.safeParse(args)
+              if (parsed.success) return parsed.data
+
+              const recovered = toolInfo.shell?.recover?.(args)
+              if (recovered !== undefined) {
+                const recoveredParsed = toolInfo.parameters.safeParse(recovered)
+                if (recoveredParsed.success) return recoveredParsed.data
+                throw recoveredParsed.error
+              }
+
+              throw parsed.error
+            },
             catch: (error) => {
               if (error instanceof z.ZodError && toolInfo.formatValidationError) {
                 return new Error(toolInfo.formatValidationError(error), { cause: error })
@@ -106,7 +118,7 @@ function wrap<Parameters extends z.ZodType, Result extends Metadata>(
               )
             },
           })
-          const result = yield* execute(args, ctx)
+          const result = yield* execute(parsedArgs, ctx)
           if (result.metadata.truncated !== undefined) {
             return result
           }

--- a/packages/opencode/test/tool/tool-define.test.ts
+++ b/packages/opencode/test/tool/tool-define.test.ts
@@ -8,6 +8,15 @@ import { Truncate } from "../../src/tool"
 const runtime = ManagedRuntime.make(Layer.mergeAll(Truncate.defaultLayer, Agent.defaultLayer))
 
 const params = z.object({ input: z.string() })
+const ctx = {
+  sessionID: "ses_x" as never,
+  messageID: "msg_x" as never,
+  agent: "build",
+  abort: new AbortController().signal,
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+} as unknown as Tool.Context
 
 function makeTool(id: string, executeFn?: () => void) {
   return {
@@ -55,5 +64,45 @@ describe("Tool.define", () => {
     const second = await Effect.runPromise(info.init())
 
     expect(first).not.toBe(second)
+  })
+
+  test("recovers JSON args before execute when the tool opts in", async () => {
+    const parameters = z.object({
+      operation: z.object({
+        action: z.literal("run"),
+        prompt: z.string(),
+      }),
+    })
+    let received: z.infer<typeof parameters> | undefined
+    const info = await runtime.runPromise(
+      Tool.define(
+        "test-recover",
+        Effect.succeed({
+          description: "test tool",
+          parameters,
+          execute(args) {
+            received = args
+            return Effect.succeed({ title: "test", output: "ok", metadata: { truncated: false } })
+          },
+          shell: {
+            description: "test shell",
+            parse: () => Effect.succeed([] as z.infer<typeof parameters>[]),
+            recover(rawArgs) {
+              const operation = (rawArgs as { operation?: unknown }).operation
+              if (typeof operation !== "string") return undefined
+              return { operation: JSON.parse(operation) }
+            },
+          },
+        }),
+      ),
+    )
+    const tool = await Effect.runPromise(info.init())
+
+    const result = await Effect.runPromise(
+      tool.execute({ operation: '{"action":"run","prompt":"inspect"}' } as never, ctx),
+    )
+
+    expect(received).toEqual({ operation: { action: "run", prompt: "inspect" } })
+    expect(result.output).toBe("ok")
   })
 })


### PR DESCRIPTION
Fixes #417
Refs #394

## What changed

- Recover tool arguments through an opt-in `shell.recover` hook before failing JSON argument validation.
- Execute tools with the parsed or recovered argument object instead of the raw invalid payload.
- Add a regression test for a stringified `operation` payload reaching `execute` as an object.

## Why

Some model calls send actor arguments as `{"operation":"{...}"}`. `recoverActorArgs` already handles that shape, but the normal JSON tool path failed zod validation before recovery could run. This lets actor recovery handle the same shape outside shell mode.

## Verification

- `BUN_CONFIG_REGISTRY=https://registry.npmjs.org /tmp/bun-1.3.11/bun-darwin-aarch64/bun install --ignore-scripts`
- `/tmp/bun-1.3.11/bun-darwin-aarch64/bun test test/tool/tool-define.test.ts test/tool/actor-recover.test.ts --timeout 30000`
- `/tmp/bun-1.3.11/bun-darwin-aarch64/bun test test/tool/shell-wrap-missing-script.test.ts test/tool/shell-wrap.test.ts --timeout 30000`
- `/tmp/bun-1.3.11/bun-darwin-aarch64/bun test test/tool/task-recover.test.ts --timeout 30000`
- `/tmp/bun-1.3.11/bun-darwin-aarch64/bun run typecheck`
- `git diff --check`
