### PR TITLE
Fix curl upgrade latest resolution

### DIFF
--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -46,7 +46,7 @@ export const UpgradeCommand = {
     prompts.log.info("Using method: " + method)
     const target = args.target
       ? args.target.replace(/^v/, "")
-      : await AppRuntime.runPromise(Installation.Service.use((svc) => svc.latest()))
+      : await AppRuntime.runPromise(Installation.Service.use((svc) => svc.latest(method)))
 
     if (InstallationVersion === target) {
       prompts.log.warn(`opencode upgrade skipped: ${target} is already installed`)

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -69,8 +69,7 @@ export class UpgradeFailedError extends Schema.TaggedErrorClass<UpgradeFailedErr
   stderr: Schema.String,
 }) {}
 
-// TODO(mimocode): uncomment when corresponding channels are supported
-// const GitHubRelease = Schema.Struct({ tag_name: Schema.String })
+const GitHubRelease = Schema.Struct({ tag_name: Schema.String })
 const NpmPackage = Schema.Struct({ version: Schema.String })
 // const BrewFormula = Schema.Struct({ versions: Schema.Struct({ stable: Schema.String }) })
 // const BrewInfoV2 = Schema.Struct({
@@ -217,6 +216,16 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
         //   return data.versions.stable
         // }
 
+        if (detectedMethod === "curl") {
+          const response = yield* httpOk.execute(
+            HttpClientRequest.get("https://api.github.com/repos/XiaomiMiMo/MiMo-Code/releases/latest").pipe(
+              HttpClientRequest.acceptJson,
+            ),
+          )
+          const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
+          return data.tag_name.replace(/^v/, "")
+        }
+
         if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm") {
           const r = (yield* text(["npm", "config", "get", "registry"])).trim()
           const reg = r || "https://registry.npmjs.org"
@@ -251,15 +260,6 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
         //   const data = yield* HttpClientResponse.schemaBodyJson(ScoopManifest)(response)
         //   return data.version
         // }
-
-        // TODO(mimocode): uncomment when mimocode has github releases
-        // const response = yield* httpOk.execute(
-        //   HttpClientRequest.get("https://api.github.com/repos/anomalyco/opencode/releases/latest").pipe(
-        //     HttpClientRequest.acceptJson,
-        //   ),
-        // )
-        // const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
-        // return data.tag_name.replace(/^v/, "")
 
         log.warn("unsupported update channel, skipping", { method: detectedMethod })
         return yield* Effect.die(new Error(`unsupported update channel: ${detectedMethod}`))

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -50,11 +50,11 @@ function testLayer(
 
 describe("installation", () => {
   describe("method", () => {
-    test("detects npm when @mimocode/cli-ai is in npm list output", async () => {
+    test("detects npm when @mimo-ai/cli is in npm list output", async () => {
       const layer = testLayer(
         () => jsonResponse({}),
         (cmd, args) => {
-          if (cmd === "npm" && args.includes("-g")) return "@mimocode/cli-ai@1.0.0"
+          if (cmd === "npm" && args.includes("-g")) return "@mimo-ai/cli@1.0.0"
           return ""
         },
       )
@@ -65,11 +65,11 @@ describe("installation", () => {
       expect(result).toBe("npm")
     })
 
-    test("detects pnpm when @mimocode/cli-ai is in pnpm list output", async () => {
+    test("detects pnpm when @mimo-ai/cli is in pnpm list output", async () => {
       const layer = testLayer(
         () => jsonResponse({}),
         (cmd, args) => {
-          if (cmd === "pnpm" && args.includes("-g")) return "@mimocode/cli-ai@1.0.0"
+          if (cmd === "pnpm" && args.includes("-g")) return "@mimo-ai/cli@1.0.0"
           return ""
         },
       )
@@ -80,11 +80,11 @@ describe("installation", () => {
       expect(result).toBe("pnpm")
     })
 
-    test("detects bun when @mimocode/cli-ai is in bun pm ls output", async () => {
+    test("detects bun when @mimo-ai/cli is in bun pm ls output", async () => {
       const layer = testLayer(
         () => jsonResponse({}),
         (cmd, args) => {
-          if (cmd === "bun" && args.includes("-g")) return "@mimocode/cli-ai@1.0.0"
+          if (cmd === "bun" && args.includes("-g")) return "@mimo-ai/cli@1.0.0"
           return ""
         },
       )
@@ -95,7 +95,7 @@ describe("installation", () => {
       expect(result).toBe("bun")
     })
 
-    test("returns unknown when no package manager has @mimocode/cli-ai", async () => {
+    test("returns unknown when no package manager has @mimo-ai/cli", async () => {
       const layer = testLayer(
         () => jsonResponse({}),
         () => "",
@@ -109,11 +109,11 @@ describe("installation", () => {
   })
 
   describe("latest", () => {
-    test("reads version from xiaomi npm registry for npm method", async () => {
+    test("reads version from configured npm registry for npm method", async () => {
       const layer = testLayer(
         (req) => {
-          expect(req.url).toContain("pkgs.d.xiaomi.net")
-          expect(req.url).toContain(encodeURIComponent("@mimocode/cli-ai"))
+          expect(req.url).toContain("registry.npmjs.org")
+          expect(req.url).toContain(encodeURIComponent("@mimo-ai/cli"))
           return jsonResponse({ version: "1.5.0" })
         },
         () => "",
@@ -125,7 +125,19 @@ describe("installation", () => {
       expect(result).toBe("1.5.0")
     })
 
-    test("reads version from xiaomi npm registry for pnpm method", async () => {
+    test("reads version from github releases for curl method", async () => {
+      const layer = testLayer((req) => {
+        expect(req.url).toContain("api.github.com/repos/XiaomiMiMo/MiMo-Code/releases/latest")
+        return jsonResponse({ tag_name: "v1.4.0" })
+      })
+
+      const result = await Effect.runPromise(
+        Installation.Service.use((svc) => svc.latest("curl")).pipe(Effect.provide(layer)),
+      )
+      expect(result).toBe("1.4.0")
+    })
+
+    test("reads version from configured npm registry for pnpm method", async () => {
       const layer = testLayer(() => jsonResponse({ version: "1.6.0" }))
 
       const result = await Effect.runPromise(
@@ -134,7 +146,7 @@ describe("installation", () => {
       expect(result).toBe("1.6.0")
     })
 
-    test("reads version from xiaomi npm registry for bun method", async () => {
+    test("reads version from configured npm registry for bun method", async () => {
       const layer = testLayer(() => jsonResponse({ version: "1.7.0" }))
 
       const result = await Effect.runPromise(
@@ -143,9 +155,9 @@ describe("installation", () => {
       expect(result).toBe("1.7.0")
     })
 
-    test("dies for unsupported channels (brew/choco/scoop/curl/unknown)", async () => {
+    test("dies for unsupported channels (brew/choco/scoop/unknown)", async () => {
       const layer = testLayer(() => jsonResponse({}))
-      const unsupported: Installation.Method[] = ["brew", "choco", "scoop", "curl", "unknown"]
+      const unsupported: Installation.Method[] = ["brew", "choco", "scoop", "unknown"]
 
       for (const method of unsupported) {
         const result = Effect.runPromise(
@@ -176,8 +188,7 @@ describe("installation", () => {
       )
       expect(capturedCmd).toBe("npm")
       expect(capturedArgs).toContain("-g")
-      expect(capturedArgs).toContain("@mimocode/cli-ai@2.0.0")
-      expect(capturedArgs.find((a) => a.startsWith("--registry="))).toContain("pkgs.d.xiaomi.net")
+      expect(capturedArgs).toContain("@mimo-ai/cli@2.0.0")
     })
 
     test("runs pnpm install with correct package and registry", async () => {
@@ -193,8 +204,7 @@ describe("installation", () => {
       await Effect.runPromise(
         Installation.Service.use((svc) => svc.upgrade("pnpm", "2.0.0")).pipe(Effect.provide(layer)),
       )
-      expect(capturedArgs).toContain("@mimocode/cli-ai@2.0.0")
-      expect(capturedArgs.find((a) => a.startsWith("--registry="))).toContain("pkgs.d.xiaomi.net")
+      expect(capturedArgs).toContain("@mimo-ai/cli@2.0.0")
     })
 
     test("runs bun install with correct package and registry", async () => {
@@ -210,8 +220,7 @@ describe("installation", () => {
       await Effect.runPromise(
         Installation.Service.use((svc) => svc.upgrade("bun", "2.0.0")).pipe(Effect.provide(layer)),
       )
-      expect(capturedArgs).toContain("@mimocode/cli-ai@2.0.0")
-      expect(capturedArgs.find((a) => a.startsWith("--registry="))).toContain("pkgs.d.xiaomi.net")
+      expect(capturedArgs).toContain("@mimo-ai/cli@2.0.0")
     })
 
     test("fails for unknown method", async () => {


### PR DESCRIPTION
## Summary
- Resolve curl-installed upgrades from the latest XiaomiMiMo/MiMo-Code GitHub release
- Pass the selected upgrade method into latest-version resolution
- Update installation tests for the current @mimo-ai/cli package name and curl release lookup

## Testing
- bun test test/installation/installation.test.ts
- bun typecheck
- bun run script/build.ts --single --skip-embed-web-ui --skip-install
- Built binary smoke-tested with `mimo upgrade --method curl` using a fake installer shell