### PR TITLE
fix: multiedit crash, hardcoded Chinese strings, missing zht i18n

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -232,7 +232,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const info = provider?.models[value.modelID]
           return {
             provider: provider?.name ?? value.providerID,
-            model: value.modelID === "mimo-auto" ? "MiMo Auto（MiMo-V2.5 限免中）" : (info?.name ?? value.modelID),
+            model: value.modelID === "mimo-auto" ? "MiMo Auto (free during promotion)" : (info?.name ?? value.modelID),
             reasoning: info?.capabilities?.reasoning ?? false,
           }
         }),

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -394,4 +394,7 @@ export const dict: Record<string, string> = {
 
   // Session badges
   "tui.session.badge.auto": "Auto",
+
+  // Model display
+  "tui.model.mimo_auto_free_promo": "MiMo Auto (free during promotion)",
 }

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -387,4 +387,7 @@ export const dict = {
 
   // Session badges
   "tui.session.badge.auto": "自动",
+
+  // Model display
+  "tui.model.mimo_auto_free_promo": "MiMo Auto（MiMo-V2.5 限免中）",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -357,4 +357,43 @@ export const dict = {
 
   // Session badges
   "tui.session.badge.auto": "自動",
+
+  // Login dialog
+  "tui.dialog.login.title": "選擇服務商",
+  "tui.dialog.login.xiaomi": "小米",
+  "tui.dialog.login.xiaomi.desc": "（推薦）",
+  "tui.dialog.login.mimo_free": "MiMo Auto (free)",
+  "tui.dialog.login.mimo_free.desc": "免費匿名通道，無需登入",
+  "tui.dialog.login.mimo_free.success": "MiMo Auto (free) 已就緒 — 預設模型設為 mimo/mimo-auto",
+  "tui.dialog.login.mimo_free.unavailable": "MiMo Auto (free) 通道未載入",
+  "tui.dialog.login.import_claude": "從 Claude Code 匯入",
+  "tui.dialog.login.import_claude.no_key": "未找到 Claude Code API Key",
+  "tui.dialog.login.import_claude.read_failed": "讀取 ~/.claude/settings.json 失敗",
+  "tui.dialog.login.import_claude.success": "已從 Claude Code 匯入設定",
+  "tui.dialog.login.other": "其他服務商",
+  "tui.dialog.login.start_failed": "啟動登入失敗",
+
+  // Login flow
+  "tui.dialog.login.flow.title": "MiMo 登入",
+  "tui.dialog.login.flow.placeholder": "貼上 Code（或等待瀏覽器回呼）",
+  "tui.dialog.login.flow.busy": "登入中...",
+  "tui.dialog.login.flow.manual_hint": "瀏覽器未開啟？手動前往：",
+  "tui.dialog.login.flow.waiting": "等待瀏覽器授權中...",
+  "tui.dialog.login.flow.invalid_code": "Code 無效，請重試",
+
+  // CLI provider keys
+  "cli.providers.select": "選擇服務商",
+  "cli.providers.other": "其他 Provider",
+  "cli.providers.mimo.recommended_hint": "推薦",
+  "cli.providers.mimo_free.hint": "免費匿名通道 / mimo-auto",
+  "cli.providers.mimo_free.verifying": "正在驗證 MiMo Auto (free) 通道...",
+  "cli.providers.mimo_free.ready": "MiMo Auto (free) 通道已就緒",
+  "cli.providers.mimo_free.failed": "MiMo Auto (free) 驗證失敗",
+  "cli.providers.mimo_free.default_set": "預設模型已切換為 mimo/mimo-auto（1M 上下文，免費）",
+  "cli.providers.mimo_free.usage_hint": "無需登入，直接 mimo run 即可使用。如需付費/更高級模型，可重新選擇 MiMo 瀏覽器登入。",
+  "cli.providers.mimo_login.decrypt_retry": "解密失敗，請重試（剩餘 {remaining} 次）",
+  "cli.providers.mimo_login.decrypt_exhausted": "解密失敗，已達最大重試次數",
+
+  // Model display
+  "tui.model.mimo_auto_free_promo": "MiMo Auto（MiMo-V2.5 限免中）",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/opencode/src/plugin/mimo.ts
+++ b/packages/opencode/src/plugin/mimo.ts
@@ -99,7 +99,7 @@ export async function MimoAuthPlugin(_input: PluginInput): Promise<Hooks> {
       },
       methods: [
         {
-          label: "浏览器登录",
+          label: "Browser Login",
           type: "oauth" as const,
           authorize: async () => {
             const { publicKey, privateKeyDer } = generateKeyPair()
@@ -159,7 +159,7 @@ export async function MimoAuthPlugin(_input: PluginInput): Promise<Hooks> {
             return {
               url: manualUrl,
               method: "auto" as const,
-              instructions: "在浏览器中完成授权，或粘贴 Code 完成登录。",
+              instructions: "Complete authorization in the browser, or paste the Code to log in.",
               callback: async (code?: string) => {
                 if (code) {
                   try {

--- a/packages/opencode/src/tool/multiedit.ts
+++ b/packages/opencode/src/tool/multiedit.ts
@@ -25,6 +25,7 @@ export const MultiEditTool = Tool.define(
               replaceAll: z.boolean().optional().describe("Replace all occurrences of oldString (default false)"),
             }),
           )
+          .min(1)
           .describe("Array of edit operations to perform sequentially on the file"),
       }),
       execute: (
@@ -53,7 +54,7 @@ export const MultiEditTool = Tool.define(
             metadata: {
               results: results.map((r) => r.metadata),
             },
-            output: results.at(-1)!.output,
+            output: results.length > 0 ? results.at(-1)!.output : "(no edits applied)",
           }
         }),
     }


### PR DESCRIPTION
Fixes #565

- **multiedit.ts**: Added .min(1) to edits schema + runtime guard so empty edits array no longer crashes with `Cannot read properties of undefined (reading 'output')`
- **mimo.ts**: Replaced hardcoded Chinese label and instructions with English so non-Chinese users can understand the login flow
- **local.tsx**: Replaced hardcoded Chinese promo text with English
- **zht.ts**: Added 30 missing login/cli-provider i18n keys in Traditional Chinese (zh-TW)
- **en.ts/zh.ts**: Added tui.model.mimo_auto_free_promo i18n key for model display