### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/packages/opencode/src/plugin/astraflow.ts
+++ b/packages/opencode/src/plugin/astraflow.ts
@@ -1,0 +1,66 @@
+import type { Hooks, PluginInput } from "@mimo-ai/plugin"
+
+const GLOBAL_MODELS = {
+  "gpt-4o-mini": {
+    name: "GPT-4o Mini",
+    attachment: true,
+    reasoning: false,
+    tool_call: true,
+    temperature: true,
+    limit: { context: 128_000, output: 16_384 },
+  },
+  "gpt-4.1-mini": {
+    name: "GPT-4.1 Mini",
+    attachment: true,
+    reasoning: false,
+    tool_call: true,
+    temperature: true,
+    limit: { context: 1_000_000, output: 32_768 },
+  },
+  "gpt-4.1-nano": {
+    name: "GPT-4.1 Nano",
+    attachment: true,
+    reasoning: false,
+    tool_call: true,
+    temperature: true,
+    limit: { context: 1_000_000, output: 32_768 },
+  },
+  "o3-2025-04-16": {
+    name: "o3",
+    attachment: true,
+    reasoning: true,
+    tool_call: true,
+    temperature: false,
+    limit: { context: 200_000, output: 100_000 },
+  },
+  "text-embedding-3-large": {
+    name: "Text Embedding 3 Large",
+    attachment: false,
+    reasoning: false,
+    tool_call: false,
+    temperature: false,
+    limit: { context: 8_191, output: 1 },
+  },
+}
+
+export async function AstraflowAuthPlugin(_input: PluginInput): Promise<Hooks> {
+  return {
+    config: async (input) => {
+      input.provider ??= {}
+      input.provider.astraflow ??= {
+        name: "Astraflow",
+        env: ["ASTRAFLOW_API_KEY"],
+        npm: "@ai-sdk/openai-compatible",
+        api: "https://api-us-ca.umodelverse.ai/v1",
+        models: GLOBAL_MODELS,
+      }
+      input.provider["astraflow-cn"] ??= {
+        name: "Astraflow China",
+        env: ["ASTRAFLOW_CN_API_KEY"],
+        npm: "@ai-sdk/openai-compatible",
+        api: "https://api.modelverse.cn/v1",
+        models: GLOBAL_MODELS,
+      }
+    },
+  }
+}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -20,6 +20,7 @@ import { Flag } from "../flag/flag"
 import { CodexAuthPlugin } from "./codex"
 import { MimoAuthPlugin, AnthropicProxyPlugin } from "./mimo"
 import { MimoFreeAuthPlugin } from "./mimo-free"
+import { AstraflowAuthPlugin } from "./astraflow"
 import { Session } from "../session"
 import type { SessionID } from "../session/schema"
 import { NamedError } from "@mimo-ai/shared/util/error"
@@ -124,6 +125,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Pl
 const INTERNAL_PLUGINS: PluginInstance[] = [
   MimoFreeAuthPlugin,
   MimoAuthPlugin,
+  AstraflowAuthPlugin,
   AnthropicProxyPlugin,
   CodexAuthPlugin,
   CopilotAuthPlugin,


### PR DESCRIPTION
### Issue for this PR

Closes #N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds built-in Astraflow provider support using the OpenAI-compatible AI SDK provider.

This PR registers both global and China Astraflow endpoints with their corresponding environment variables, and includes representative verified Astraflow model IDs so they can be selected.

### How did you verify your code works?

Not run (not requested).

### Screenshots / recordings

N/A

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._