### PR TITLE
refactor(app): extract useVcsState hook from Page component

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -58,6 +58,7 @@ import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
+import { useVcsState } from "@/pages/session/use-vcs-state"
 import { Identifier } from "@/utils/id"
 import { diffs as list } from "@/utils/diffs"
 import { Persist, persisted } from "@/utils/persist"
@@ -71,7 +72,6 @@ type FollowupEdit = Pick<FollowupItem, "id" | "prompt" | "context">
 const emptyFollowups: FollowupItem[] = []
 
 type ChangeMode = "git" | "branch" | "turn"
-type VcsMode = "git" | "branch"
 
 type SessionHistoryWindowInput = {
   sessionID: () => string | undefined
@@ -566,68 +566,27 @@ export default function Page() {
     return open
   }, desktopReviewOpen())
 
-  const turnDiffs = createMemo(() => list(lastUserMessage()?.summary?.diffs))
-  const nogit = createMemo(() => !!sync.project && sync.project.vcs !== "git")
-  const changesOptions = createMemo<ChangeMode[]>(() => {
-    const list: ChangeMode[] = []
-    if (sync.project?.vcs === "git") list.push("git")
-    if (
-      sync.project?.vcs === "git" &&
-      sync.data.vcs?.branch &&
-      sync.data.vcs?.default_branch &&
-      sync.data.vcs.branch !== sync.data.vcs.default_branch
-    ) {
-      list.push("branch")
-    }
-    list.push("turn")
-    return list
+  const {
+    nogit,
+    changesOptions,
+    mobileChanges,
+    wantsReview,
+    refreshVcs,
+    reviewDiffs,
+    reviewCount,
+    hasReview,
+    reviewReady,
+  } = useVcsState({
+    sync,
+    store,
+    sdk,
+    queryClient,
+    isDesktop,
+    desktopFileTreeOpen,
+    desktopReviewOpen,
+    activeTab,
+    lastUserMessage,
   })
-  const mobileChanges = createMemo(() => !isDesktop() && store.mobileTab === "changes")
-  const wantsReview = createMemo(() =>
-    isDesktop()
-      ? desktopFileTreeOpen() || (desktopReviewOpen() && activeTab() === "review")
-      : store.mobileTab === "changes",
-  )
-  const vcsMode = createMemo<VcsMode | undefined>(() => {
-    if (store.changes === "git" || store.changes === "branch") return store.changes
-  })
-  const vcsKey = createMemo(
-    () => ["session-vcs", sdk.directory, sync.data.vcs?.branch ?? "", sync.data.vcs?.default_branch ?? ""] as const,
-  )
-  const vcsQuery = createQuery(() => {
-    const mode = vcsMode()
-    const enabled = wantsReview() && sync.project?.vcs === "git"
-
-    return {
-      queryKey: [...vcsKey(), mode] as const,
-      enabled,
-      staleTime: Number.POSITIVE_INFINITY,
-      gcTime: 60 * 1000,
-      queryFn: mode
-        ? () =>
-            sdk.client.vcs
-              .diff({ mode })
-              .then((result) => list(result.data))
-              .catch((error) => {
-                console.debug("[session-review] failed to load vcs diff", { mode, error })
-                return []
-              })
-        : skipToken,
-    }
-  })
-  const refreshVcs = () => void queryClient.invalidateQueries({ queryKey: vcsKey() })
-  const reviewDiffs = () => {
-    if (store.changes === "git" || store.changes === "branch")
-      // avoids suspense
-      return vcsQuery.isFetched ? (vcsQuery.data ?? []) : []
-    return turnDiffs()
-  }
-  const reviewCount = () => reviewDiffs().length
-  const hasReview = () => reviewCount() > 0
-  const reviewReady = () => {
-    if (store.changes === "git" || store.changes === "branch") return !vcsQuery.isPending
-    return true
-  }
 
   const newSessionWorktree = createMemo(() => {
     if (store.newSessionWorktree === "create") return "create"
@@ -846,18 +805,6 @@ export default function Page() {
       { defer: true },
     ),
   )
-
-  const stopVcs = sdk.event.listen((evt) => {
-    if (evt.details.type !== "file.watcher.updated") return
-    const props =
-      typeof evt.details.properties === "object" && evt.details.properties
-        ? (evt.details.properties as Record<string, unknown>)
-        : undefined
-    const file = typeof props?.file === "string" ? props.file : undefined
-    if (!file || file.startsWith(".git/")) return
-    refreshVcs()
-  })
-  onCleanup(stopVcs)
 
   createEffect(
     on(

--- a/packages/app/src/pages/session/use-vcs-state.ts
+++ b/packages/app/src/pages/session/use-vcs-state.ts
@@ -1,0 +1,118 @@
+import { createMemo, onCleanup } from "solid-js"
+import { createQuery, skipToken } from "@tanstack/solid-query"
+import { diffs as list } from "@/utils/diffs"
+
+type ChangeMode = "git" | "branch" | "turn"
+type VcsMode = "git" | "branch"
+
+export const useVcsState = (input: {
+  sync: {
+    project?: { vcs?: string } | null
+    data: { vcs?: { branch?: string; default_branch?: string } }
+  }
+  store: { changes: ChangeMode; mobileTab: string }
+  sdk: {
+    directory: string
+    event: { listen: (handler: (evt: { details: { type: string; properties: unknown } }) => void) => () => void }
+    client: { vcs: { diff: (req: { mode: VcsMode }) => Promise<{ data?: unknown[] }> } }
+  }
+  queryClient: { invalidateQueries: (opts: { queryKey: readonly unknown[] }) => void }
+  isDesktop: () => boolean
+  desktopFileTreeOpen: () => boolean
+  desktopReviewOpen: () => boolean
+  activeTab: () => string
+  lastUserMessage: () => { summary?: { diffs?: unknown[] } } | undefined
+}) => {
+  const turnDiffs = createMemo(() => list(input.lastUserMessage()?.summary?.diffs))
+  const nogit = createMemo(() => !!input.sync.project && input.sync.project.vcs !== "git")
+  const changesOptions = createMemo<ChangeMode[]>(() => {
+    const result: ChangeMode[] = []
+    if (input.sync.project?.vcs === "git") result.push("git")
+    if (
+      input.sync.project?.vcs === "git" &&
+      input.sync.data.vcs?.branch &&
+      input.sync.data.vcs?.default_branch &&
+      input.sync.data.vcs.branch !== input.sync.data.vcs.default_branch
+    ) {
+      result.push("branch")
+    }
+    result.push("turn")
+    return result
+  })
+  const mobileChanges = createMemo(() => !input.isDesktop() && input.store.mobileTab === "changes")
+  const wantsReview = createMemo(() =>
+    input.isDesktop()
+      ? input.desktopFileTreeOpen() || (input.desktopReviewOpen() && input.activeTab() === "review")
+      : input.store.mobileTab === "changes",
+  )
+  const vcsMode = createMemo<VcsMode | undefined>(() => {
+    if (input.store.changes === "git" || input.store.changes === "branch") return input.store.changes
+  })
+  const vcsKey = createMemo(
+    () =>
+      [
+        "session-vcs",
+        input.sdk.directory,
+        input.sync.data.vcs?.branch ?? "",
+        input.sync.data.vcs?.default_branch ?? "",
+      ] as const,
+  )
+  const vcsQuery = createQuery(() => {
+    const mode = vcsMode()
+    const enabled = wantsReview() && input.sync.project?.vcs === "git"
+
+    return {
+      queryKey: [...vcsKey(), mode] as const,
+      enabled,
+      staleTime: Number.POSITIVE_INFINITY,
+      gcTime: 60 * 1000,
+      queryFn: mode
+        ? () =>
+            input.sdk.client.vcs
+              .diff({ mode })
+              .then((result) => list(result.data))
+              .catch((error) => {
+                console.debug("[session-review] failed to load vcs diff", { mode, error })
+                return []
+              })
+        : skipToken,
+    }
+  })
+  const refreshVcs = () => void input.queryClient.invalidateQueries({ queryKey: vcsKey() })
+
+  const stopVcs = input.sdk.event.listen((evt) => {
+    if (evt.details.type !== "file.watcher.updated") return
+    const props =
+      typeof evt.details.properties === "object" && evt.details.properties
+        ? (evt.details.properties as Record<string, unknown>)
+        : undefined
+    const file = typeof props?.file === "string" ? props.file : undefined
+    if (!file || file.startsWith(".git/")) return
+    refreshVcs()
+  })
+  onCleanup(stopVcs)
+
+  const reviewDiffs = () => {
+    if (input.store.changes === "git" || input.store.changes === "branch")
+      return vcsQuery.isFetched ? (vcsQuery.data ?? []) : []
+    return turnDiffs()
+  }
+  const reviewCount = () => reviewDiffs().length
+  const hasReview = () => reviewCount() > 0
+  const reviewReady = () => {
+    if (input.store.changes === "git" || input.store.changes === "branch") return !vcsQuery.isPending
+    return true
+  }
+
+  return {
+    nogit,
+    changesOptions,
+    mobileChanges,
+    wantsReview,
+    refreshVcs,
+    reviewDiffs,
+    reviewCount,
+    hasReview,
+    reviewReady,
+  }
+}


### PR DESCRIPTION
## Summary

Extract the VCS/review reactive state cluster from the 200-line `Page` component into a dedicated `useVcsState` hook, following the existing [`use-session-hash-scroll.ts`](packages/app/src/pages/session/use-session-hash-scroll.ts) convention.

## What moved to `use-vcs-state.ts`

**External (returned):**
- `nogit`, `changesOptions`, `mobileChanges`, `wantsReview` — reactive memos
- `refreshVcs` — query invalidation
- `reviewDiffs`, `reviewCount`, `hasReview`, `reviewReady` — review state

**Internal (not returned):**
- `vcsMode`, `vcsKey`, `vcsQuery` — query plumbing
- `turnDiffs` — fallback diffs from last user message
- `stopVcs` — file-watcher listener + `onCleanup`

## Page component impact

- **−53 net lines** (74 removed, 21 added for the hook call + destructuring)
- VCS logic is now isolated and independently testable
- Follows the established hook pattern in `pages/session/`

## Dependencies

The hook takes 9 inputs as getter functions/objects (matching the `use-session-hash-scroll` convention): `sync`, `store`, `sdk`, `queryClient`, `isDesktop`, `desktopFileTreeOpen`, `desktopReviewOpen`, `activeTab`, `lastUserMessage`.

## Verification

- [x] `bun typecheck` passes (tsgo -b)
- [x] Code follows existing hook conventions in the codebase
- [x] Behavior unchanged — all reactive values created identically, just in a different scope
