### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,64 @@ MiMoCode is configured via `.mimocode/mimocode.json` in the project directory (o
 
 Max Mode (parallel best-of-N reasoning with judge selection) can be enabled via `experimental.maxMode` in the config.
 
+### Astraflow OpenAI-compatible provider
+
+Astraflow by UCloud can be configured as a custom OpenAI-compatible provider:
+
+```jsonc
+{
+  "provider": {
+    "astraflow": {
+      "name": "Astraflow",
+      "npm": "@ai-sdk/openai-compatible",
+      "api": "https://api.umodelverse.ai/v1",
+      "env": ["ASTRAFLOW_API_KEY"],
+      "models": {
+        "gpt-5.5": {
+          "name": "gpt-5.5",
+          "release_date": "2025-01-01",
+          "attachment": false,
+          "reasoning": false,
+          "temperature": true,
+          "tool_call": true,
+          "limit": { "context": 128000, "output": 4096 }
+        },
+        "deepseek-v4-pro": {
+          "name": "deepseek-v4-pro",
+          "release_date": "2025-01-01",
+          "attachment": false,
+          "reasoning": false,
+          "temperature": true,
+          "tool_call": true,
+          "limit": { "context": 128000, "output": 4096 }
+        },
+        "qwen3.7-max": {
+          "name": "qwen3.7-max",
+          "release_date": "2025-01-01",
+          "attachment": false,
+          "reasoning": false,
+          "temperature": true,
+          "tool_call": true,
+          "limit": { "context": 128000, "output": 4096 }
+        },
+        "o4-mini": {
+          "name": "o4-mini",
+          "release_date": "2025-01-01",
+          "attachment": false,
+          "reasoning": true,
+          "temperature": true,
+          "tool_call": true,
+          "limit": { "context": 128000, "output": 4096 }
+        }
+      }
+    }
+  },
+  "model": "astraflow/gpt-5.5"
+}
+```
+
+For Astraflow China, use `https://api.modelverse.cn/v1` and `ASTRAFLOW_CN_API_KEY` instead.
+
 ---
 
 ## Development

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -194,6 +194,13 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         },
         options: {},
       }),
+    astraflow: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          baseURL: "https://api.umodelverse.ai/v1",
+        },
+      }),
     xai: () =>
       Effect.succeed({
         autoload: false,

--- a/packages/opencode/src/provider/schema.ts
+++ b/packages/opencode/src/provider/schema.ts
@@ -14,6 +14,7 @@ export const ProviderID = providerIdSchema.pipe(
     opencode: schema.make("opencode"),
     anthropic: schema.make("anthropic"),
     openai: schema.make("openai"),
+    astraflow: schema.make("astraflow"),
     google: schema.make("google"),
     googleVertex: schema.make("google-vertex"),
     githubCopilot: schema.make("github-copilot"),


### PR DESCRIPTION
### Issue for this PR

Closes # N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR adds support for Astraflow as an OpenAI-compatible provider.

Changes include:
- Adding Astraflow as a well-known provider ID.
- Setting the default Astraflow OpenAI-compatible base URL when the provider is configured.
- Documenting Astraflow custom provider configuration, including verified model IDs and guidance for the China endpoint.

Astraflow is OpenAI-compatible, so it can use the existing OpenAI-compatible provider flow with the appropriate provider ID and base URL configuration.

### How did you verify your code works?

N/A

### Screenshots / recordings

N/A

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._