### PR TITLE
feat: add oh-my-mimocode-slim skills (simplify, codemap, clonedeps, council)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ tsconfig.tsbuildinfo
 experiment/*.log
 experiment/last-outcome.json
 /experiment
+
+# Internal workspace (separate private repo, must not be tracked here)
+/mimocode-internal/

--- a/.mimocode/skills/clonedeps/SKILL.md
+++ b/.mimocode/skills/clonedeps/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: clonedeps
+description: >
+  Clone important project dependency source code into an ignored local workspace
+  so you can inspect library internals. Use when user asks to clone dependencies,
+  inspect dependency/source internals, understand SDK/framework behavior from source,
+  or debug library implementation details.
+  Trigger: "clone deps", "inspect dependency source", "clonedeps".
+---
+
+# Clonedeps Skill
+
+Make important dependency source repositories locally readable for inspection.
+
+## When to Use
+
+- User asks to clone dependencies or inspect dependency source
+- Need to understand SDK/framework behavior from source code
+- Debugging library implementation details
+- Making core dependency repos locally readable
+
+**When NOT to use:**
+- Ordinary API/docs questions — use webfetch or grep instead
+- Tiny utilities or transitive dependencies
+
+## Workflow
+
+### Step 1: Check Existing State
+
+Check if `.mimocode/clonedeps.json` exists.
+
+If exists:
+1. Read it before planning new clones
+2. Check each listed `path` exists under `.mimocode/clonedeps/repos/`
+3. Reuse existing clones when they satisfy the task
+4. Only plan new clones if manifest is missing, stale, or insufficient
+
+### Step 2: Plan Dependencies to Clone
+
+Analyze the project to recommend repos worth cloning:
+
+1. Read `package.json` / `go.mod` / `requirements.txt` / `Cargo.toml` etc.
+2. Identify 3-5 core dependencies (frameworks, SDKs, ORMs, runtime APIs)
+3. Skip: tiny utilities, transitive deps, dev-only tools
+
+For each recommendation:
+- dependency name
+- repo URL (HTTPS only)
+- tag/commit/ref to check out
+- why cloning source helps
+- caveats (huge repo, missing tag, etc.)
+
+### Step 3: Verify and Confirm
+
+Before cloning:
+1. Verify refs with `git ls-remote` where practical
+2. Prefer pinned tags or commit SHAs
+3. Only use HTTPS GitHub/GitLab-style URLs
+4. Present plan to user with dependency, URL, ref, reason, caveats
+5. Ask for confirmation before network operations
+
+### Step 4: Clone Sources
+
+Create folder per repo under:
+
+```text
+.mimocode/clonedeps/repos/<safe-repo-name>/
+```
+
+Derive safe name from repo owner/name:
+- `https://github.com/opencode-ai/opencode.git` → `opencode-ai__opencode`
+- Replace `/` with `__`, strip `.git`, replace unsafe chars with `_`
+
+Clone pattern:
+1. `git ls-remote <repoUrl> <ref>` to verify
+2. Clone without submodules
+3. Prefer shallow clone
+4. Clone into temp dir, move after checkout succeeds
+5. Remove failed temp clones
+
+Do NOT run dependency install/build/test scripts from cloned repos.
+
+### Step 5: Write State
+
+Write `.mimocode/clonedeps.json`:
+
+```json
+{
+  "version": "1.0.0",
+  "updatedAt": "2026-01-01T00:00:00.000Z",
+  "dependencies": [
+    {
+      "name": "example-lib",
+      "resolvedVersion": "1.2.3",
+      "repoUrl": "https://github.com/user/example-lib.git",
+      "ref": "v1.2.3",
+      "path": ".mimocode/clonedeps/repos/user__example-lib",
+      "reason": "Core SDK source for debugging"
+    }
+  ]
+}
+```
+
+### Step 6: Update Ignore Files
+
+Add to `.gitignore`:
+
+```gitignore
+# BEGIN mimocode-clonedeps
+.mimocode/clonedeps/repos/
+# END mimocode-clonedeps
+```
+
+Add to `.ignore` (so MiMo Code can read cloned source):
+
+```
+# BEGIN mimocode-clonedeps
+!.mimocode/
+!.mimocode/clonedeps.json
+!.mimocode/clonedeps/
+!.mimocode/clonedeps/repos/
+!.mimocode/clonedeps/repos/**
+.mimocode/clonedeps/repos/**/.git/
+.mimocode/clonedeps/repos/**/.git/**
+# END mimocode-clonedeps
+```
+
+### Step 7: Register in AGENTS.md
+
+Update root `AGENTS.md` with:
+
+```markdown
+## Cloned Dependency Source
+
+Read-only dependency source repositories are available under
+`.mimocode/clonedeps/repos/` for inspection. Do not edit these clones.
+
+- `.mimocode/clonedeps/repos/<safe-name>/` — `<repo>` at `<ref>`; <why useful>.
+```
+
+## Cleanup
+
+When user asks to clean cloned dependencies, remove:
+- `.mimocode/clonedeps/repos/`
+- managed marker blocks from `.gitignore` and `.ignore`
+
+Ask before removing `.mimocode/clonedeps.json` or `AGENTS.md` section.

--- a/.mimocode/skills/codemap/SKILL.md
+++ b/.mimocode/skills/codemap/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: codemap
+description: >
+  Generate comprehensive hierarchical codemaps for unfamiliar repositories.
+  Expensive operation — only use when explicitly asked for codebase documentation
+  or initial repository mapping.
+  Trigger: "codemap", "map this repo", "codebase documentation", "understand this project".
+---
+
+# Codemap Skill
+
+Create hierarchical codemaps to understand and map repositories.
+
+## When to Use
+
+- User asks to understand/map a repository
+- User wants codebase documentation
+- Starting work on an unfamiliar codebase
+
+## Workflow
+
+### Step 1: Check for Existing State
+
+Check if `.mimocode/codemap.json` exists in repo root.
+
+If it exists: skip to Step 3 (Detect Changes).
+If not: continue to Step 2 (Initialize).
+
+### Step 2: Initialize
+
+1. **Analyze repository structure** — list files, understand directories
+2. **Infer patterns** for core code/config files ONLY:
+   - Include: `src/**/*.ts`, `package.json`, etc.
+   - Exclude (MANDATORY): tests, docs, translations
+     - Tests: `**/*.test.ts`, `**/*.spec.ts`, `tests/**`, `__tests__/**`
+     - Docs: `docs/**`, `*.md` (except root README), `LICENSE`
+     - Build/Deps: `node_modules/**`, `dist/**`, `build/**`, `*.min.js`
+   - Respect `.gitignore`
+3. **Create `.mimocode/codemap.json`** with file/folder structure
+4. **Write codemap.md files** — one per relevant subdirectory
+
+Use `glob` to discover files, `read` to understand code, `write` to create codemap files.
+
+### Step 3: Detect Changes (if state exists)
+
+1. Read `.mimocode/codemap.json` for previous state
+2. Use `glob` to detect added/removed/modified files
+3. Only update affected codemaps
+4. Update `.mimocode/codemap.json` with new state
+
+### Step 4: Create Root Codemap (Atlas)
+
+Once all directories mapped, create/update root `codemap.md`:
+
+1. **Map Root Assets** — document root-level files and project purpose
+2. **Aggregate Sub-Maps** — extract Responsibility summary from each folder's codemap.md
+3. **Cross-Reference** — include paths to sub-maps for navigation
+
+### Step 5: Register in AGENTS.md
+
+Update (or create) `AGENTS.md` at repo root with:
+
+```markdown
+## Repository Map
+
+A full codemap is available at `codemap.md` in the project root.
+
+Before working on any task, read `codemap.md` to understand:
+- Project architecture and entry points
+- Directory responsibilities and design patterns
+- Data flow and integration points between modules
+
+For deep work on a specific folder, also read that folder's `codemap.md`.
+```
+
+This is idempotent — repeated runs detect existing section and skip.
+
+## Codemap Content
+
+Each `codemap.md` should document:
+
+- **Responsibility** — specific role of directory (e.g., "Service Layer", "Data Access Object")
+- **Design Patterns** — named patterns used (e.g., "Observer", "Singleton", "Factory")
+- **Data & Control Flow** — how data enters/leaves module, function call sequences
+- **Integration Points** — dependencies, consumer modules, hooks, events, API endpoints
+
+Example codemap:
+
+```markdown
+# src/agents/
+
+## Responsibility
+Defines agent personalities and manages their configuration lifecycle.
+
+## Design
+Each agent is a prompt + permission set. Config system uses:
+- Default prompts (orchestrator.ts, explorer.ts, etc.)
+- User overrides from config file
+- Permission wildcards for skill/MCP access control
+
+## Flow
+1. Plugin loads → calls getAgentConfigs()
+2. Reads user config preset
+3. Merges defaults with overrides
+4. Applies permission rules (wildcard expansion)
+5. Returns agent configs
+
+## Integration
+- Consumed by: Main plugin (src/index.ts)
+- Depends on: Config loader, skills registry
+```
+
+Example **Root Codemap (Atlas)**:
+
+```markdown
+# Repository Atlas: my-project
+
+## Project Responsibility
+A high-performance agent orchestration system.
+
+## System Entry Points
+- `src/index.ts`: Plugin initialization
+- `package.json`: Dependency manifest
+
+## Directory Map
+| Directory | Responsibility | Detail |
+|-----------|---------------|--------|
+| `src/agents/` | Agent personalities and model routing | [View](src/agents/codemap.md) |
+| `src/config/` | Configuration loading pipeline | [View](src/config/codemap.md) |
+```

--- a/.mimocode/skills/council/SKILL.md
+++ b/.mimocode/skills/council/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: council
+description: >
+  Multi-LLM consensus mechanism. Runs multiple models in parallel via actor system,
+  collects their judgments, and synthesizes a final verdict. Use for architecture decisions,
+  complex debugging, strategy comparison, or when a single model's perspective isn't enough.
+  Trigger: "council", "multi-model consensus", "ask multiple models", "vote on approach".
+---
+
+# Council Skill
+
+Multi-LLM consensus: run parallel subagents with different models, synthesize verdict.
+
+## When to Use
+
+- Architecture decisions with no clear winner
+- Complex debugging where single model may have blind spots
+- Strategy comparison ("which approach is better?")
+- Code review requiring multiple perspectives
+- User explicitly asks for council/consensus
+
+**When NOT to use:**
+- Simple tasks one model can handle
+- Urgent fixes (council is slower)
+- Cost-sensitive situations (runs multiple models)
+
+## How It Works
+
+Council uses MiMo Code's `actor` tool to spawn parallel subagents, each with a different model. Results are collected and synthesized into a final verdict.
+
+## Workflow
+
+### Step 1: Frame the Question
+
+Clearly state what needs deciding. Include:
+- The problem context
+- Available options (if any)
+- Constraints (performance, compatibility, time, etc.)
+- What "good" looks like
+
+### Step 2: Spawn Councillors
+
+Use `actor` tool to spawn parallel subagents. Each gets the same question but a different model.
+
+**Recommended model mix** (adjust based on availability):
+
+| Councillor | Model | Role |
+|-----------|-------|------|
+| Councillor A | mimo-v2.5-pro | Strong reasoning |
+| Councillor B | A different model (e.g., deepseek, qwen) | Alternative perspective |
+| Councillor C | A third model | Tie-breaker / edge cases |
+
+**Actor spawn pattern:**
+
+```
+actor({
+  operation: {
+    action: "run",
+    subagent_type: "general",
+    description: "Council: model-A perspective",
+    prompt: "<the question with full context>",
+    model: "mimo-v2.5-pro"
+  }
+})
+```
+
+```
+actor({
+  operation: {
+    action: "run",
+    subagent_type: "general",
+    description: "Council: model-B perspective",
+    prompt: "<the question with full context>",
+    model: "<different-model>"
+  }
+})
+```
+
+Spawn all councillors in parallel (single message with multiple actor calls).
+
+### Step 3: Collect Results
+
+Use `actor({ operation: { action: "wait", actor_id: "<id>" } })` to collect each result.
+
+### Step 4: Synthesize Verdict
+
+As the orchestrator, analyze all councillor responses:
+
+1. **Find agreements** — where models converge, confidence is high
+2. **Find disagreements** — where they diverge, examine reasoning
+3. **Weigh perspectives** — consider each model's strength relative to the question
+4. **Produce verdict** — clear recommendation with reasoning
+
+**Synthesis format:**
+
+```markdown
+## Council Verdict
+
+### Question
+<restated question>
+
+### Models Consulted
+- Councillor A (<model>): <one-line position>
+- Councillor B (<model>): <one-line position>
+- Councillor C (<model>): <one-line position>
+
+### Areas of Agreement
+- <what all models agree on>
+
+### Areas of Disagreement
+- <point of divergence and why>
+
+### Verdict
+<clear recommendation with reasoning>
+
+### Confidence
+High / Medium / Low (based on model agreement level)
+```
+
+### Step 5: Optional Follow-up
+
+If disagreement is significant and the stakes are high:
+- Ask follow-up questions to specific councillors
+- Request they address the other models' counterarguments
+- Re-synthesize with the new information
+
+## Example
+
+**User asks:** "Should we use REST or gRPC for the internal service communication?"
+
+**Council spawns:**
+1. Councillor A (mimo-v2.5-pro) — strong on architecture
+2. Councillor B (deepseek model) — strong on practical implementation
+3. Councillor C (qwen model) — strong on ecosystem analysis
+
+**Synthesis:**
+- All agree: gRPC better for internal high-throughput
+- Disagree on: migration complexity assessment
+- Verdict: gRPC for new services, REST gateway for external, phased migration
+
+## Tips
+
+- Keep councillor prompts identical for fair comparison
+- Include full context in each prompt (councillors don't share context)
+- For binary decisions (A vs B), 3 councillors is ideal
+- For open-ended exploration, 2 councillors often sufficient
+- Budget consideration: each councillor = separate model invocation cost

--- a/.mimocode/skills/simplify/SKILL.md
+++ b/.mimocode/skills/simplify/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: simplify
+description: >
+  Simplifies code for clarity without changing behavior. Use for readability,
+  maintainability, and complexity reduction after behavior is understood.
+  Trigger: "simplify", "clean up code", "refactor for readability".
+---
+
+# Code Simplification
+
+Simplify code by reducing complexity while preserving exact behavior.
+Goal: code that is easier to read, understand, modify, and debug.
+Test: "Would a new team member understand this faster than the original?"
+
+## When to Use
+
+- After a feature is working and tests pass, but implementation feels heavy
+- During code review when readability/complexity issues flagged
+- Deeply nested logic, long functions, or unclear names
+- Refactoring code written under time pressure
+- Consolidating related logic scattered across files
+- After merging changes that introduced duplication
+
+**When NOT to use:**
+
+- Code is already clean — don't simplify for sake of it
+- Don't understand what code does yet — comprehend first
+- Performance-critical and "simpler" version would be measurably slower
+- About to rewrite module entirely — simplifying throwaway code wastes effort
+
+## Five Principles
+
+### 1. Preserve Behavior Exactly
+
+Don't change what code does — only how it expresses it.
+All inputs, outputs, side effects, error behavior, edge cases must remain identical.
+
+Before every change ask:
+- Same output for every input?
+- Same error behavior?
+- Same side effects and ordering?
+- All existing tests still pass?
+
+### 2. Follow Project Conventions
+
+Simplification = making code more consistent with codebase, not imposing external preferences.
+
+Before simplifying:
+1. Read `AGENTS.md` / project conventions
+2. Study how neighboring code handles similar patterns
+3. Match project's style for imports, naming, function style, error handling
+
+### 3. Prefer Clarity Over Cleverness
+
+Explicit > compact when compact requires mental pause to parse.
+- Replace nested ternaries with readable control flow
+- Replace dense inline transforms with named intermediate steps when they clarify intent
+- Keep helpful names even if they cost a few extra lines
+
+### 4. Maintain Balance
+
+Watch for over-simplification:
+- Don't inline away names that carry meaning
+- Don't merge unrelated logic into one larger function
+- Don't remove abstractions that serve testability or extensibility
+- Don't optimize for line count over comprehension
+
+### 5. Scope to What Changed
+
+Default to simplifying recently modified code.
+Avoid unrelated drive-by refactors unless explicitly asked.
+
+## Process
+
+### Step 1: Understand Before Touching
+
+Before changing/removing anything, understand why it exists.
+Answer: responsibility, callers/callees, edge cases, tests, why written this way.
+If can't answer these, read more context first.
+
+### Step 2: Look for Simplification Opportunities
+
+Signals:
+- Deep nesting
+- Long functions with mixed responsibilities
+- Nested ternaries
+- Boolean flag arguments
+- Repeated conditionals
+- Generic or misleading names
+- Duplicated logic
+- Dead code
+- Wrappers/abstractions that add no value
+
+### Step 3: Apply Changes Incrementally
+
+Make one simplification at a time.
+For each: make change → run tests → keep only if behavior preserved.
+Separate refactoring from feature work when possible.
+
+### Step 4: Verify the Result
+
+After simplifying, confirm:
+- Code is genuinely easier to understand
+- Diff is clean and reviewable
+- Project conventions still match
+- No behavior, error handling, or side effects changed
+
+## Verification Checklist
+
+- [ ] Existing tests pass without modification
+- [ ] Build/typecheck/lint still pass
+- [ ] No unrelated files were refactored
+- [ ] No error handling weakened or removed
+- [ ] Result is simpler to review than original


### PR DESCRIPTION
## Summary

Port useful skills from [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim) for MiMo Code, bringing proven multi-agent patterns to the MiMo Code ecosystem.

### Skills Added

| Skill | Description |
|-------|-------------|
| **simplify** | Code simplification guidance with 5 principles (preserve behavior, follow conventions, clarity over cleverness, maintain balance, scope to changes) and 4-step process |
| **codemap** | Hierarchical codebase mapping — generates `codemap.md` files per directory + root atlas for understanding large repos |
| **clonedeps** | Clone important dependency source repos locally for inspection (e.g., SDK internals, framework source) |
| **council** | Multi-LLM consensus mechanism using MiMo Code's actor system — spawn parallel subagents with different models, synthesize a final verdict |

### Why These Skills?

oh-my-opencode-slim has a rich set of agent orchestration features. These 4 skills represent the most transferable patterns:

- **simplify** — directly improves code quality workflow
- **codemap** — essential for onboarding to unfamiliar codebases
- **clonedeps** — debugging library issues requires reading source
- **council** — leverages MiMo Code's actor system for multi-model decision making

### How Council Works (MiMo Code native)

Unlike oh-my-opencode-slim's Council which depends on OpenCode's plugin system, this implementation uses MiMo Code's built-in `actor` tool:

```
actor({ operation: { action: "spawn", model: "mimo-v2.5-pro", ... } })
actor({ operation: { action: "spawn", model: "deepseek-chat", ... } })
// collect results → synthesize verdict
```

No external dependencies required.

### Testing

- [x] Skills load correctly from `~/.agents/skills/`
- [x] Council mechanism tested with parallel actor spawns
- [x] Simplify, codemap, clonedeps follow existing skill format (SKILL.md with frontmatter)