### PR TITLE
fix: route bash apply_patch through dedicated tool and improve path/prompt handling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -60,11 +60,15 @@ async function target() {
   return new URL("./worker.ts", import.meta.url)
 }
 
+function normalizePromptText(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+}
+
 async function input(value?: string) {
   const piped = process.stdin.isTTY ? undefined : await Bun.stdin.text()
-  if (!value) return piped
-  if (!piped) return value
-  return piped + "\n" + value
+  if (!value) return piped ? normalizePromptText(piped) : piped
+  if (!piped) return normalizePromptText(value)
+  return normalizePromptText(piped + "\n" + value)
 }
 
 async function promptWorkspaceTrust(directory: string, level: "untrusted" | "dangerous"): Promise<boolean> {

--- a/packages/opencode/src/memory/paths.ts
+++ b/packages/opencode/src/memory/paths.ts
@@ -42,8 +42,12 @@ function detectType(key: string): MemoryType {
   return "free"
 }
 
+function normalizeAbsPath(absPath: string): string {
+  return absPath.replace(/\\/g, "/")
+}
+
 export function parsePath(absPath: string): MemoryLocator | null {
-  const m = absPath.match(/\/memory\/(global|projects|sessions)(?:\/([^/]+))?\/(.+)\.md$/)
+  const m = normalizeAbsPath(absPath).match(/\/memory\/(global|projects|sessions)(?:\/([^/]+))?\/(.+)\.md$/)
   if (!m) return null
   const [, scope, idMaybe, keyRaw] = m
   const scope_id = scope === "global" ? "" : (idMaybe ?? "")
@@ -57,7 +61,7 @@ export function parsePath(absPath: string): MemoryLocator | null {
 const CC_PATH_RE = /\/\.claude\/projects\/([^/]+)\/memory\/(.+)\.md$/
 
 export function parseCcPath(absPath: string): MemoryLocator | null {
-  const m = absPath.match(CC_PATH_RE)
+  const m = normalizeAbsPath(absPath).match(CC_PATH_RE)
   if (!m) return null
   const [, slug, keyRaw] = m
   return {

--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -301,6 +301,33 @@ export function maybeParseApplyPatch(
   return { type: MaybeApplyPatch.NotApplyPatch }
 }
 
+// Parse apply_patch invocations embedded in a bash tool command string.
+// Models often run apply_patch via bash heredoc instead of the dedicated tool,
+// bypassing approval and safety checks.
+export function maybeParseApplyPatchFromCommand(
+  command: string,
+):
+  | { type: MaybeApplyPatch.Body; args: ApplyPatchArgs }
+  | { type: MaybeApplyPatch.PatchParseError; error: Error }
+  | { type: MaybeApplyPatch.NotApplyPatch } {
+  const trimmed = command.trim()
+  if (!trimmed) return { type: MaybeApplyPatch.NotApplyPatch }
+
+  const fromScript = maybeParseApplyPatch(["bash", "-lc", trimmed])
+  if (fromScript.type !== MaybeApplyPatch.NotApplyPatch) {
+    return fromScript
+  }
+
+  for (const cmd of ["apply_patch", "applypatch"] as const) {
+    if (!trimmed.startsWith(`${cmd} `)) continue
+    const patchText = trimmed.slice(cmd.length + 1).trim()
+    if (!patchText) return { type: MaybeApplyPatch.NotApplyPatch }
+    return maybeParseApplyPatch([cmd, patchText])
+  }
+
+  return { type: MaybeApplyPatch.NotApplyPatch }
+}
+
 // File content manipulation
 interface ApplyPatchFileUpdate {
   unified_diff: string

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -22,6 +22,8 @@ import { Effect, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import * as BashInteractive from "./bash-interactive"
+import { Patch } from "../patch"
+import { ApplyPatchTool } from "./apply_patch"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
@@ -360,6 +362,7 @@ export const BashTool = Tool.define(
     const fs = yield* AppFileSystem.Service
     const trunc = yield* Truncate.Service
     const plugin = yield* Plugin.Service
+    const applyPatch = yield* ApplyPatchTool.pipe(Effect.flatMap((info) => info.init()))
 
     const cygpath = Effect.fn("BashTool.cygpath")(function* (shell: string, text: string) {
       const lines = yield* spawner
@@ -632,6 +635,24 @@ export const BashTool = Tool.define(
           parameters: Parameters,
           execute: (params: z.infer<typeof Parameters>, ctx: Tool.Context) =>
             Effect.gen(function* () {
+              const intercepted = Patch.maybeParseApplyPatchFromCommand(params.command)
+              if (intercepted.type === Patch.MaybeApplyPatch.PatchParseError) {
+                throw intercepted.error
+              }
+              if (intercepted.type === Patch.MaybeApplyPatch.Body) {
+                const result = yield* applyPatch.execute({ patchText: intercepted.args.patch }, ctx)
+                return {
+                  title: result.title,
+                  metadata: {
+                    output: result.output,
+                    exit: 0,
+                    description: params.description,
+                    truncated: false,
+                  },
+                  output: result.output,
+                }
+              }
+
               const effectiveCwd = SessionCwd.get(ctx.sessionID)
               const cwd = params.workdir
                 ? yield* resolvePath(params.workdir, effectiveCwd, shell)

--- a/packages/opencode/test/memory/paths.test.ts
+++ b/packages/opencode/test/memory/paths.test.ts
@@ -11,6 +11,24 @@ describe("parsePath", () => {
     })
   })
 
+  test("Windows backslash paths parse correctly", () => {
+    expect(parsePath("C:\\data\\memory\\global\\tooling-prefs.md")).toEqual({
+      scope: "global",
+      scope_id: "",
+      type: "free",
+      key: "tooling-prefs",
+    })
+  })
+
+  test("Windows project memory path parses correctly", () => {
+    expect(parsePath("C:\\Users\\me\\.mimocode\\memory\\projects\\uuid-1\\memory.md")).toEqual({
+      scope: "projects",
+      scope_id: "uuid-1",
+      type: "memory",
+      key: "memory",
+    })
+  })
+
   test("project memory: <pid>/memory.md", () => {
     expect(parsePath("/data/memory/projects/uuid-1/memory.md")).toEqual({
       scope: "projects",

--- a/packages/opencode/test/patch/patch.test.ts
+++ b/packages/opencode/test/patch/patch.test.ts
@@ -133,6 +133,36 @@ PATCH`
     })
   })
 
+  describe("maybeParseApplyPatchFromCommand", () => {
+    test("should parse heredoc command strings", () => {
+      const command = `apply_patch <<'PATCH'
+*** Begin Patch
+*** Add File: test.txt
++Content
+*** End Patch
+PATCH`
+
+      const result = Patch.maybeParseApplyPatchFromCommand(command)
+      expect(result.type).toBe(Patch.MaybeApplyPatch.Body)
+      if (result.type === Patch.MaybeApplyPatch.Body) {
+        expect(result.args.hunks).toHaveLength(1)
+      }
+    })
+
+    test("should parse direct apply_patch command strings", () => {
+      const patchText = `*** Begin Patch
+*** Add File: test.txt
++Content
+*** End Patch`
+      const result = Patch.maybeParseApplyPatchFromCommand(`apply_patch ${patchText}`)
+      expect(result.type).toBe(Patch.MaybeApplyPatch.Body)
+    })
+
+    test("should return NotApplyPatch for regular shell commands", () => {
+      expect(Patch.maybeParseApplyPatchFromCommand("echo hello").type).toBe(Patch.MaybeApplyPatch.NotApplyPatch)
+    })
+  })
+
   describe("applyPatch", () => {
     test("should add a new file", async () => {
       const patchText = `*** Begin Patch

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -14,6 +14,9 @@ import { SessionID, MessageID } from "../../src/session/schema"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { Plugin } from "../../src/plugin"
+import { LSP } from "../../src/lsp"
+import { Format } from "../../src/format"
+import { Bus } from "../../src/bus"
 
 const runtime = ManagedRuntime.make(
   Layer.mergeAll(
@@ -22,6 +25,9 @@ const runtime = ManagedRuntime.make(
     Plugin.defaultLayer,
     Truncate.defaultLayer,
     Agent.defaultLayer,
+    LSP.defaultLayer,
+    Format.defaultLayer,
+    Bus.layer,
   ),
 )
 


### PR DESCRIPTION
## Summary

This PR adds three small reliability improvements:

- **Route bash `apply_patch` invocations through the dedicated tool** — Models often run `apply_patch <<'PATCH'...` via the bash tool instead of calling `apply_patch` directly, which bypasses diff preview, write permissions, and LSP post-checks. MiMo-Code already had `Patch.maybeParseApplyPatch()` but it was never wired into `BashTool`. This PR adds `maybeParseApplyPatchFromCommand()` and delegates matching commands to `ApplyPatchTool`.

- **Fix Windows memory path parsing (#861)** — `parsePath()` and `parseCcPath()` used forward-slash-only regexes, causing memory reconcile to skip all files on Windows. Paths are now normalized before matching.

- **Normalize CRLF in CLI `--prompt` input** — MiMo-Code already normalized line endings for TUI paste events, but not for `--prompt` / piped stdin, which could garble the first message on Windows.

## Test plan

- [x] `bun test test/memory/paths.test.ts` — includes new Windows backslash cases
- [x] `bun test test/patch/patch.test.ts` — includes `maybeParseApplyPatchFromCommand` cases
- [x] Pre-push `turbo typecheck` passes across all packages
- [ ] Manual: run `mimo --prompt "fix tests\r\n"` on Windows and confirm no stray `\r` in first turn
- [ ] Manual: in agent session, invoke `apply_patch <<'PATCH'...` via bash and confirm diff approval UI appears

## Related issues

- Fixes #861 (Windows memory path parsing)
- Related to #475 (plan mode bash write bypass — not addressed here, but apply_patch interception reduces one bypass vector)