### PR TITLE
fix: rename opencode references to mimocode in upgrade command

### DIFF
--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -29,7 +29,7 @@ export const UpgradeCommand = {
     const detectedMethod = await AppRuntime.runPromise(Installation.Service.use((svc) => svc.method()))
     const method = (args.method as Installation.Method) ?? detectedMethod
     if (method === "unknown") {
-      prompts.log.error(`opencode is installed to ${process.execPath} and may be managed by a package manager`)
+      prompts.log.error(`mimocode is installed to ${process.execPath} and may be managed by a package manager`)
       const install = await prompts.select({
         message: "Install anyways?",
         options: [
@@ -49,7 +49,7 @@ export const UpgradeCommand = {
       : await AppRuntime.runPromise(Installation.Service.use((svc) => svc.latest()))
 
     if (InstallationVersion === target) {
-      prompts.log.warn(`opencode upgrade skipped: ${target} is already installed`)
+      prompts.log.warn(`mimocode upgrade skipped: ${target} is already installed`)
       prompts.outro("Done")
       return
     }

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -88,7 +88,7 @@ export interface Interface {
   readonly upgrade: (method: Method, target: string) => Effect.Effect<void, UpgradeFailedError>
 }
 
-export class Service extends Context.Service<Service, Interface>()("@opencode/Installation") {}
+export class Service extends Context.Service<Service, Interface>()("@mimocode/Installation") {}
 
 export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildProcessSpawner.ChildProcessSpawner> =
   Layer.effect(


### PR DESCRIPTION
## Summary

- Replace leftover "opencode" branding with "mimocode" in user-facing upgrade messages
- Rename internal Effect service tag from `@opencode/Installation` to `@mimocode/Installation`

## Context

Users running `mimo upgrade` see "opencode is installed to..." which is confusing. These are leftover references from the original opencode fork that were missed during the rename.

The root cause of the `unsupported update channel: curl` error (initial release missing curl branch in `latestImpl`) was already fixed in ab53d06.