### PR TITLE
fix: update website links from /en/mimocode to /coder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <a href="https://mimo.xiaomi.com/en/mimocode">Website</a> | <a href="https://mimo.xiaomi.com/en/blog/mimo-code-long-horizon">Blog</a>
+  <a href="https://mimo.xiaomi.com/coder">Website</a> | <a href="https://mimo.xiaomi.com/en/blog/mimo-code-long-horizon">Blog</a>
 </p>
 
 ---

--- a/README_npm.md
+++ b/README_npm.md
@@ -3,7 +3,7 @@
 <p align="center"><strong>MiMo Code: Where Models and Agents Co-Evolve</strong></p>
 
 <p align="center">
-  <a href="https://mimo.xiaomi.com/en/mimocode">Website</a> | <a href="https://mimo.xiaomi.com/en/blog/mimo-code-long-horizon">Blog</a> | <a href="https://github.com/XiaomiMiMo/MiMo-Code">GitHub</a>
+  <a href="https://mimo.xiaomi.com/coder">Website</a> | <a href="https://mimo.xiaomi.com/en/blog/mimo-code-long-horizon">Blog</a> | <a href="https://github.com/XiaomiMiMo/MiMo-Code">GitHub</a>
 </p>
 
 ---

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -273,7 +273,7 @@ for (const item of targets) {
         description: "Platform-specific binary for @mimo-ai/cli.",
         license: "MIT",
         author: "Xiaomi MiMo Team",
-        homepage: "https://mimo.xiaomi.com/en/mimocode",
+        homepage: "https://mimo.xiaomi.com/coder",
         repository: {
           type: "git",
           url: "git+https://github.com/XiaomiMiMo/MiMo-Code.git",

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -45,7 +45,7 @@ await Bun.file(`./dist/${pkg.name}/package.json`).write(
       description: "MiMo Code: Where Models and Agents Co-Evolve",
       license: "MIT",
       author: "Xiaomi MiMo Team",
-      homepage: "https://mimo.xiaomi.com/en/mimocode",
+      homepage: "https://mimo.xiaomi.com/coder",
       repository: {
         type: "git",
         url: "git+https://github.com/XiaomiMiMo/MiMo-Code.git",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "license": "MIT",
   "author": "Xiaomi MiMo Team",
-  "homepage": "https://mimo.xiaomi.com/en/mimocode",
+  "homepage": "https://mimo.xiaomi.com/coder",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/XiaomiMiMo/MiMo-Code.git",

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "license": "MIT",
   "author": "Xiaomi MiMo Team",
-  "homepage": "https://mimo.xiaomi.com/en/mimocode",
+  "homepage": "https://mimo.xiaomi.com/coder",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/XiaomiMiMo/MiMo-Code.git",


### PR DESCRIPTION
## Summary

- Replace all occurrences of `https://mimo.xiaomi.com/en/mimocode` with `https://mimo.xiaomi.com/coder` across the repository
- Affected files: `README.md`, `README_npm.md`, `packages/opencode/script/build.ts`, `packages/opencode/script/publish.ts`, `packages/plugin/package.json`, `packages/sdk/js/package.json`

## Notes

This is a pure documentation/link replacement change — no logic or runtime code is affected, and no tests are impacted.

Any pre-existing test failures in CI are unrelated to this PR (see #911 for context).