### PR TITLE
fix: rebrand leftover OpenCode references to MiMo Code across server, desktop i18n, and frontend JS

### DIFF
--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -31,8 +31,8 @@ export default defineConfig({
     reuseExistingServer: reuse,
     timeout: 120_000,
     env: {
-      VITE_OPENCODE_SERVER_HOST: serverHost,
-      VITE_OPENCODE_SERVER_PORT: serverPort,
+      VITE_MIMOCODE_SERVER_HOST: serverHost,
+      VITE_MIMOCODE_SERVER_PORT: serverPort,
     },
   },
   use: {

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -153,7 +153,7 @@ export function SessionHeader() {
   })
   const hotkey = createMemo(() => command.keybind("file.open"))
   const os = createMemo(() => detectOS(platform))
-  const isDesktopBeta = platform.platform === "desktop" && import.meta.env.VITE_OPENCODE_CHANNEL === "beta"
+  const isDesktopBeta = platform.platform === "desktop" && import.meta.env.VITE_MIMOCODE_CHANNEL === "beta"
   const search = createMemo(() => !isDesktopBeta || settings.general.showSearch())
   const tree = createMemo(() => !isDesktopBeta || settings.general.showFileTree())
   const term = createMemo(() => !isDesktopBeta || settings.general.showTerminal())

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -707,7 +707,7 @@ export const SettingsGeneral: Component = () => {
           }}
         </Show>
 
-        <Show when={desktop() && import.meta.env.VITE_OPENCODE_CHANNEL === "beta"}>
+        <Show when={desktop() && import.meta.env.VITE_MIMOCODE_CHANNEL === "beta"}>
           <AdvancedSection />
         </Show>
       </div>

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -171,7 +171,7 @@ export const Terminal = (props: TerminalProps) => {
   const client = sdk.client
   const url = sdk.url
   const auth = server.current?.http
-  const username = auth?.username ?? "opencode"
+  const username = auth?.username ?? "mimocode"
   const password = auth?.password ?? ""
   const sameOrigin = new URL(url, location.href).origin === location.origin
   let container!: HTMLDivElement

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -80,7 +80,7 @@ export function Titlebar() {
   const canBack = createMemo(() => history.index > 0)
   const canForward = createMemo(() => history.index < history.stack.length - 1)
   const hasProjects = createMemo(() => layout.projects.list().length > 0)
-  const nav = createMemo(() => import.meta.env.VITE_OPENCODE_CHANNEL !== "beta" || settings.general.showNavigation())
+  const nav = createMemo(() => import.meta.env.VITE_MIMOCODE_CHANNEL !== "beta" || settings.general.showNavigation())
 
   const back = () => {
     const next = backPath(history)
@@ -287,10 +287,10 @@ export function Titlebar() {
                   </Tooltip>
                 </div>
               </Show>
-              <div id="opencode-titlebar-left" class="flex items-center gap-3 min-w-0 px-2" />
-              {["beta", "dev"].includes(import.meta.env.VITE_OPENCODE_CHANNEL) && (
+              <div id="mimocode-titlebar-left" class="flex items-center gap-3 min-w-0 px-2" />
+              {["beta", "dev"].includes(import.meta.env.VITE_MIMOCODE_CHANNEL) && (
                 <div class="bg-icon-interactive-base text-[#FFF] font-medium px-2 rounded-sm uppercase font-mono">
-                  {import.meta.env.VITE_OPENCODE_CHANNEL.toUpperCase()}
+                  {import.meta.env.VITE_MIMOCODE_CHANNEL.toUpperCase()}
                 </div>
               )}
             </div>
@@ -299,7 +299,7 @@ export function Titlebar() {
       </div>
 
       <div class="min-w-0 flex items-center justify-center pointer-events-none">
-        <div id="opencode-titlebar-center" class="pointer-events-auto min-w-0 flex justify-center w-fit max-w-full" />
+        <div id="mimocode-titlebar-center" class="pointer-events-auto min-w-0 flex justify-center w-fit max-w-full" />
       </div>
 
       <div
@@ -310,7 +310,7 @@ export function Titlebar() {
         data-tauri-drag-region
         onMouseDown={drag}
       >
-        <div id="opencode-titlebar-right" class="flex items-center gap-1 shrink-0 justify-end" />
+        <div id="mimocode-titlebar-right" class="flex items-center gap-1 shrink-0 justify-end" />
         <Show when={windows()}>
           {!tauriApi() && <div class="w-36 shrink-0" />}
           <div data-tauri-decorum-tb class="flex flex-row" />

--- a/packages/app/src/context/highlights.tsx
+++ b/packages/app/src/context/highlights.tsx
@@ -7,7 +7,7 @@ import { useSettings } from "@/context/settings"
 import { persisted } from "@/utils/persist"
 import { DialogReleaseNotes, type Highlight } from "@/components/dialog-release-notes"
 
-const CHANGELOG_URL = "https://opencode.ai/changelog.json"
+const CHANGELOG_URL = "https://mimo.xiaomi.com/changelog.json"
 
 type Store = {
   version?: string

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -9,7 +9,7 @@ import { handleNotificationClick } from "@/utils/notification-click"
 import pkg from "../package.json"
 import { ServerConnection } from "./context/server"
 
-const DEFAULT_SERVER_URL_KEY = "opencode.settings.dat:defaultServerUrl"
+const DEFAULT_SERVER_URL_KEY = "mimocode.settings.dat:defaultServerUrl"
 
 const getLocale = () => {
   if (typeof navigator !== "object") return "en" as const
@@ -67,7 +67,7 @@ const notify: Platform["notify"] = async (title, description, href) => {
 
   const notification = new Notification(title, {
     body: description ?? "",
-    icon: "https://opencode.ai/favicon-96x96-v3.png",
+    icon: "https://mimo.xiaomi.com/favicon-96x96-v3.png",
   })
 
   notification.onclick = () => {
@@ -98,9 +98,9 @@ if (!(root instanceof HTMLElement) && import.meta.env.DEV) {
 }
 
 const getCurrentUrl = () => {
-  if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
+  if (location.hostname.includes("mimo.xiaomi.com")) return "http://localhost:4096"
   if (import.meta.env.DEV)
-    return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
+    return `http://${import.meta.env.VITE_MIMOCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_MIMOCODE_SERVER_PORT ?? "4096"}`
   return location.origin
 }
 

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -1,7 +1,7 @@
 interface ImportMetaEnv {
-  readonly VITE_OPENCODE_SERVER_HOST: string
-  readonly VITE_OPENCODE_SERVER_PORT: string
-  readonly VITE_OPENCODE_CHANNEL?: "dev" | "beta" | "prod"
+  readonly VITE_MIMOCODE_SERVER_HOST: string
+  readonly VITE_MIMOCODE_SERVER_PORT: string
+  readonly VITE_MIMOCODE_CHANNEL?: "dev" | "beta" | "prod"
 }
 
 interface ImportMeta {

--- a/packages/app/src/pages/layout/deep-links.ts
+++ b/packages/app/src/pages/layout/deep-links.ts
@@ -1,7 +1,7 @@
-export const deepLinkEvent = "opencode:deep-link"
+export const deepLinkEvent = "mimocode:deep-link"
 
 const parseUrl = (input: string) => {
-  if (!input.startsWith("opencode://")) return
+  if (!input.startsWith("mimo://")) return
   if (typeof URL.canParse === "function" && !URL.canParse(input)) return
   try {
     return new URL(input)
@@ -36,15 +36,15 @@ export const collectOpenProjectDeepLinks = (urls: string[]) =>
 export const collectNewSessionDeepLinks = (urls: string[]) =>
   urls.map(parseNewSessionDeepLink).filter((link): link is { directory: string; prompt?: string } => !!link)
 
-type OpenCodeWindow = Window & {
-  __OPENCODE__?: {
+type MiMoCodeWindow = Window & {
+  __MIMOCODE__?: {
     deepLinks?: string[]
   }
 }
 
-export const drainPendingDeepLinks = (target: OpenCodeWindow) => {
-  const pending = target.__OPENCODE__?.deepLinks ?? []
+export const drainPendingDeepLinks = (target: MiMoCodeWindow) => {
+  const pending = target.__MIMOCODE__?.deepLinks ?? []
   if (pending.length === 0) return []
-  if (target.__OPENCODE__) target.__OPENCODE__.deepLinks = []
+  if (target.__MIMOCODE__) target.__MIMOCODE__.deepLinks = []
   return pending
 }

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -55,7 +55,7 @@ export function SessionSidePanel(props: {
   const shown = createMemo(
     () =>
       platform.platform !== "desktop" ||
-      import.meta.env.VITE_OPENCODE_CHANNEL !== "beta" ||
+      import.meta.env.VITE_MIMOCODE_CHANNEL !== "beta" ||
       settings.general.showFileTree(),
   )
 

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -72,7 +72,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   const closableTab = tabState.closableTab
   const shown = () =>
     platform.platform !== "desktop" ||
-    import.meta.env.VITE_OPENCODE_CHANNEL !== "beta" ||
+    import.meta.env.VITE_MIMOCODE_CHANNEL !== "beta" ||
     settings.general.showFileTree()
 
   const idle = { type: "idle" as const }

--- a/packages/app/src/utils/persist.ts
+++ b/packages/app/src/utils/persist.ts
@@ -20,8 +20,8 @@ type PersistTarget = {
 }
 
 const LEGACY_STORAGE = "default.dat"
-const GLOBAL_STORAGE = "opencode.global.dat"
-const LOCAL_PREFIX = "opencode."
+const GLOBAL_STORAGE = "mimocode.global.dat"
+const LOCAL_PREFIX = "mimocode."
 const fallback = new Map<string, boolean>()
 
 const CACHE_MAX_ENTRIES = 500
@@ -211,7 +211,7 @@ function normalize(defaults: unknown, raw: string, migrate?: (value: unknown) =>
 function workspaceStorage(dir: string) {
   const head = (dir.slice(0, 12) || "workspace").replace(/[^a-zA-Z0-9._-]/g, "-")
   const sum = checksum(dir) ?? "0"
-  return `opencode.workspace.${head}.${sum}.dat`
+  return `mimocode.workspace.${head}.${sum}.dat`
 }
 
 function localStorageWithPrefix(prefix: string): SyncStorage {

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -10,7 +10,7 @@ export function createSdkForServer({
   const auth = (() => {
     if (!server.password) return
     return {
-      Authorization: `Basic ${btoa(`${server.username ?? "opencode"}:${server.password}`)}`,
+      Authorization: `Basic ${btoa(`${server.username ?? "mimocode"}:${server.password}`)}`,
     }
   })()
 

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -3,19 +3,19 @@ import appPlugin from "@mimo-ai/app/vite"
 import * as fs from "node:fs/promises"
 
 const channel = (() => {
-  const raw = process.env.OPENCODE_CHANNEL
+  const raw = process.env.MIMOCODE_CHANNEL
   if (raw === "dev" || raw === "beta" || raw === "prod") return raw
   return "dev"
 })()
 
-const OPENCODE_SERVER_DIST = "../opencode/dist/node"
+const MIMOCODE_SERVER_DIST = "../opencode/dist/node"
 
 const nodePtyPkg = `@lydell/node-pty-${process.platform}-${process.arch}`
 
 export default defineConfig({
   main: {
     define: {
-      "import.meta.env.OPENCODE_CHANNEL": JSON.stringify(channel),
+      "import.meta.env.MIMOCODE_CHANNEL": JSON.stringify(channel),
     },
     build: {
       rollupOptions: {
@@ -25,25 +25,25 @@ export default defineConfig({
     },
     plugins: [
       {
-        name: "opencode:node-pty-narrower",
+        name: "mimocode:node-pty-narrower",
         enforce: "pre",
         resolveId(s) {
           if (s === "@lydell/node-pty") return nodePtyPkg
         },
       },
       {
-        name: "opencode:virtual-server-module",
+        name: "mimocode:virtual-server-module",
         enforce: "pre",
         resolveId(id) {
-          if (id === "virtual:opencode-server") return this.resolve(`${OPENCODE_SERVER_DIST}/node.js`)
+          if (id === "virtual:mimocode-server") return this.resolve(`${MIMOCODE_SERVER_DIST}/node.js`)
         },
       },
       {
-        name: "opencode:copy-server-assets",
+        name: "mimocode:copy-server-assets",
         async writeBundle() {
-          for (const l of await fs.readdir(OPENCODE_SERVER_DIST)) {
+          for (const l of await fs.readdir(MIMOCODE_SERVER_DIST)) {
             if (!l.endsWith(".wasm")) continue
-            await fs.writeFile(`./out/main/chunks/${l}`, await fs.readFile(`${OPENCODE_SERVER_DIST}/${l}`))
+            await fs.writeFile(`./out/main/chunks/${l}`, await fs.readFile(`${MIMOCODE_SERVER_DIST}/${l}`))
           }
         },
       },
@@ -65,7 +65,7 @@ export default defineConfig({
     publicDir: "../../../app/public",
     root: "src/renderer",
     define: {
-      "import.meta.env.VITE_OPENCODE_CHANNEL": JSON.stringify(channel),
+      "import.meta.env.VITE_MIMOCODE_CHANNEL": JSON.stringify(channel),
     },
     build: {
       rollupOptions: {

--- a/packages/desktop/src/main/constants.ts
+++ b/packages/desktop/src/main/constants.ts
@@ -1,10 +1,10 @@
 import { app } from "electron"
 
 type Channel = "dev" | "beta" | "prod"
-const raw = import.meta.env.OPENCODE_CHANNEL
+const raw = import.meta.env.MIMOCODE_CHANNEL
 export const CHANNEL: Channel = raw === "dev" || raw === "beta" || raw === "prod" ? raw : "dev"
 
-export const SETTINGS_STORE = "opencode.settings"
+export const SETTINGS_STORE = "mimocode.settings"
 export const DEFAULT_SERVER_URL_KEY = "defaultServerUrl"
 export const WSL_ENABLED_KEY = "wslEnabled"
 export const UPDATER_ENABLED = app.isPackaged && CHANNEL !== "dev"

--- a/packages/desktop/src/main/env.d.ts
+++ b/packages/desktop/src/main/env.d.ts
@@ -1,11 +1,11 @@
 interface ImportMetaEnv {
-  readonly OPENCODE_CHANNEL: string
+  readonly MIMOCODE_CHANNEL: string
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
-declare module "virtual:opencode-server" {
+declare module "virtual:mimocode-server" {
   export namespace Server {
     export const listen: typeof import("../../../opencode/dist/types/src/node").Server.listen
     export type Listener = import("../../../opencode/dist/types/src/node").Server.Listener

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -16,7 +16,7 @@ try {
   process.chdir(homedir())
 } catch {}
 
-process.env.OPENCODE_DISABLE_EMBEDDED_WEB_UI = "true"
+process.env.MIMOCODE_DISABLE_EMBEDDED_WEB_UI = "true"
 
 const APP_NAMES: Record<string, string> = {
   dev: "OpenCode Dev",
@@ -50,7 +50,7 @@ import {
   setDockIcon,
 } from "./windows"
 import { drizzle } from "drizzle-orm/node-sqlite/driver"
-import type { Server } from "virtual:opencode-server"
+import type { Server } from "virtual:mimocode-server"
 
 const initEmitter = new EventEmitter()
 let initStep: InitStep = { phase: "server_waiting" }
@@ -81,7 +81,7 @@ function setupApp() {
   }
 
   app.on("second-instance", (_event: Event, argv: string[]) => {
-    const urls = argv.filter((arg: string) => arg.startsWith("opencode://"))
+    const urls = argv.filter((arg: string) => arg.startsWith("mimo://"))
     if (urls.length) {
       logger.log("deep link received via second-instance", { urls })
       emitDeepLinks(urls)
@@ -158,7 +158,7 @@ async function initialize() {
     })
 
     if (needsMigration) {
-      const { Database, JsonMigration } = await import("virtual:opencode-server")
+      const { Database, JsonMigration } = await import("virtual:mimocode-server")
       await JsonMigration.run(drizzle({ client: Database.Client().$client }), {
         progress: (event: { current: number; total: number }) => {
           const percent = Math.round(event.current / event.total) * 100
@@ -179,7 +179,7 @@ async function initialize() {
     server = listener
     serverReady.resolve({
       url,
-      username: "opencode",
+      username: "mimocode",
       password,
     })
 
@@ -293,7 +293,7 @@ function ensureLoopbackNoProxy() {
 }
 
 async function getSidecarPort() {
-  const fromEnv = process.env.OPENCODE_PORT
+  const fromEnv = process.env.MIMOCODE_PORT
   if (fromEnv) {
     const parsed = Number.parseInt(fromEnv, 10)
     if (!Number.isNaN(parsed)) return parsed

--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -32,12 +32,12 @@ export function setWslConfig(config: WslConfig) {
 
 export async function spawnLocalServer(hostname: string, port: number, password: string) {
   prepareServerEnv(password)
-  const { Log, Server } = await import("virtual:opencode-server")
+  const { Log, Server } = await import("virtual:mimocode-server")
   await Log.init({ level: "WARN" })
   const listener = await Server.listen({
     port,
     hostname,
-    username: "opencode",
+    username: "mimocode",
     password,
     cors: ["oc://renderer"],
   })

--- a/packages/desktop/src/renderer/i18n/ar.ts
+++ b/packages/desktop/src/renderer/i18n/ar.ts
@@ -11,11 +11,11 @@ export const dict = {
   "desktop.updater.checkFailed.title": "فشل التحقق من التحديثات",
   "desktop.updater.checkFailed.message": "فشل التحقق من وجود تحديثات",
   "desktop.updater.none.title": "لا توجد تحديثات متاحة",
-  "desktop.updater.none.message": "أنت تستخدم بالفعل أحدث إصدار من OpenCode",
+  "desktop.updater.none.message": "أنت تستخدم بالفعل أحدث إصدار من MiMo Code",
   "desktop.updater.downloadFailed.title": "فشل التحديث",
   "desktop.updater.downloadFailed.message": "فشل تنزيل التحديث",
   "desktop.updater.downloaded.title": "تم تنزيل التحديث",
-  "desktop.updater.downloaded.prompt": "تم تنزيل إصدار {{version}} من OpenCode، هل ترغب في تثبيته وإعادة تشغيله؟",
+  "desktop.updater.downloaded.prompt": "تم تنزيل إصدار {{version}} من MiMo Code، هل ترغب في تثبيته وإعادة تشغيله؟",
   "desktop.updater.installFailed.title": "فشل التحديث",
   "desktop.updater.installFailed.message": "فشل تثبيت التحديث",
 

--- a/packages/desktop/src/renderer/i18n/br.ts
+++ b/packages/desktop/src/renderer/i18n/br.ts
@@ -11,12 +11,12 @@ export const dict = {
   "desktop.updater.checkFailed.title": "Falha ao verificar atualizações",
   "desktop.updater.checkFailed.message": "Falha ao verificar atualizações",
   "desktop.updater.none.title": "Nenhuma atualização disponível",
-  "desktop.updater.none.message": "Você já está usando a versão mais recente do OpenCode",
+  "desktop.updater.none.message": "Você já está usando a versão mais recente do MiMo Code",
   "desktop.updater.downloadFailed.title": "Falha na atualização",
   "desktop.updater.downloadFailed.message": "Falha ao baixar a atualização",
   "desktop.updater.downloaded.title": "Atualização baixada",
   "desktop.updater.downloaded.prompt":
-    "A versão {{version}} do OpenCode foi baixada. Você gostaria de instalá-la e reiniciar?",
+    "A versão {{version}} do MiMo Code foi baixada. Você gostaria de instalá-la e reiniciar?",
   "desktop.updater.installFailed.title": "Falha na atualização",
   "desktop.updater.installFailed.message": "Falha ao instalar a atualização",
 

--- a/packages/desktop/src/renderer/i18n/bs.ts
+++ b/packages/desktop/src/renderer/i18n/bs.ts
@@ -11,12 +11,12 @@ export const dict = {
   "desktop.updater.checkFailed.title": "Provjera ažuriranja nije uspjela",
   "desktop.updater.checkFailed.message": "Nije moguće provjeriti ažuriranja",
   "desktop.updater.none.title": "Nema dostupnog ažuriranja",
-  "desktop.updater.none.message": "Već koristiš najnoviju verziju OpenCode-a",
+  "desktop.updater.none.message": "Već koristiš najnoviju verziju MiMo Code-a",
   "desktop.updater.downloadFailed.title": "Ažuriranje nije uspjelo",
   "desktop.updater.downloadFailed.message": "Neuspjelo preuzimanje ažuriranja",
   "desktop.updater.downloaded.title": "Ažuriranje preuzeto",
   "desktop.updater.downloaded.prompt":
-    "Verzija {{version}} OpenCode-a je preuzeta. Želiš li da je instaliraš i ponovo pokreneš aplikaciju?",
+    "Verzija {{version}} MiMo Code-a je preuzeta. Želiš li da je instaliraš i ponovo pokreneš aplikaciju?",
   "desktop.updater.installFailed.title": "Ažuriranje nije uspjelo",
   "desktop.updater.installFailed.message": "Neuspjela instalacija ažuriranja",
 

--- a/packages/desktop/src/renderer/i18n/da.ts
+++ b/packages/desktop/src/renderer/i18n/da.ts
@@ -11,12 +11,12 @@ export const dict = {
   "desktop.updater.checkFailed.title": "Opdateringstjek mislykkedes",
   "desktop.updater.checkFailed.message": "Kunne ikke tjekke for opdateringer",
   "desktop.updater.none.title": "Ingen opdatering tilgængelig",
-  "desktop.updater.none.message": "Du bruger allerede den nyeste version af OpenCode",
+  "desktop.updater.none.message": "Du bruger allerede den nyeste version af MiMo Code",
   "desktop.updater.downloadFailed.title": "Opdatering mislykkedes",
   "desktop.updater.downloadFailed.message": "Kunne ikke downloade opdateringen",
   "desktop.updater.downloaded.title": "Opdatering downloadet",
   "desktop.updater.downloaded.prompt":
-    "Version {{version}} af OpenCode er blevet downloadet. Vil du installere den og genstarte?",
+    "Version {{version}} af MiMo Code er blevet downloadet. Vil du installere den og genstarte?",
   "desktop.updater.installFailed.title": "Opdatering mislykkedes",
   "desktop.updater.installFailed.message": "Kunne ikke installere opdateringen",
 

--- a/packages/desktop/src/renderer/i18n/de.ts
+++ b/packages/desktop/src/renderer/i18n/de.ts
@@ -11,12 +11,12 @@ export const dict = {
   "desktop.updater.checkFailed.title": "Updateprüfung fehlgeschlagen",
   "desktop.updater.checkFailed.message": "Updates konnten nicht geprüft werden",
   "desktop.updater.none.title": "Kein Update verfügbar",
-  "desktop.updater.none.message": "Sie verwenden bereits die neueste Version von OpenCode",
+  "desktop.updater.none.message": "Sie verwenden bereits die neueste Version von MiMo Code",
   "desktop.updater.downloadFailed.title": "Update fehlgeschlagen",
   "desktop.updater.downloadFailed.message": "Update konnte nicht heruntergeladen werden",
   "desktop.updater.downloaded.title": "Update heruntergeladen",
   "desktop.updater.downloaded.prompt":
-    "Version {{version}} von OpenCode wurde heruntergeladen. Möchten Sie sie installieren und neu starten?",
+    "Version {{version}} von MiMo Code wurde heruntergeladen. Möchten Sie sie installieren und neu starten?",
   "desktop.updater.installFailed.title": "Update fehlgeschlagen",
   "desktop.updater.installFailed.message": "Update konnte nicht installiert werden",
 

--- a/packages/desktop/src/renderer/i18n/en.ts
+++ b/packages/desktop/src/renderer/i18n/en.ts
@@ -11,12 +11,12 @@ export const dict = {
   "desktop.updater.checkFailed.title": "Update Check Failed",
   "desktop.updater.checkFailed.message": "Failed to check for updates",
   "desktop.updater.none.title": "No Update Available",
-  "desktop.updater.none.message": "You are already using the latest version of OpenCode",
+  "desktop.updater.none.message": "You are already using the latest version of MiMo Code",
   "desktop.updater.downloadFailed.title": "Update Failed",
   "desktop.updater.downloadFailed.message": "Failed to download update",
   "desktop.updater.downloaded.title": "Update Downloaded",
   "desktop.updater.downloaded.prompt":
-    "Version {{version}} of OpenCode has been downloaded, would you like to install it and relaunch?",
+    "Version {{version}} of MiMo Code has been downloaded, would you like to install it and relaunch?",
   "desktop.updater.installFailed.title": "Update Failed",
   "desktop.updater.installFailed.message": "Failed to install update",
 

--- a/packages/desktop/src/renderer/i18n/es.ts
+++ b/packages/desktop/src/renderer/i18n/es.ts
@@ -11,12 +11,12 @@ export const dict = {
   "desktop.updater.checkFailed.title": "Comprobación de actualizaciones fallida",
   "desktop.updater.checkFailed.message": "No se pudieron buscar actualizaciones",
   "desktop.updater.none.title": "No hay actualizaciones disponibles",
-  "desktop.updater.none.message": "Ya estás usando la versión más reciente de OpenCode",
+  "desktop.updater.none.message": "Ya estás usando la versión más reciente de MiMo Code",
   "desktop.updater.downloadFailed.title": "Actualización fallida",
   "desktop.updater.downloadFailed.message": "No se pudo descargar la actualización",
   "desktop.updater.downloaded.title": "Actualización descargada",
   "desktop.updater.downloaded.prompt":
-    "Se ha descargado la versión {{version}} de OpenCode. ¿Quieres instalarla y reiniciar?",
+    "Se ha descargado la versión {{version}} de MiMo Code. ¿Quieres instalarla y reiniciar?",
   "desktop.updater.installFailed.title": "Actualización fallida",
   "desktop.updater.installFailed.message": "No se pudo instalar la actualización",
 

--- a/packages/desktop/src/renderer/i18n/fr.ts
+++ b/packages/desktop/src/renderer/i18n/fr.ts
@@ -11,12 +11,12 @@ export const dict = {
   "desktop.updater.checkFailed.title": "Échec de la vérification des mises à jour",
   "desktop.updater.checkFailed.message": "Impossible de vérifier les mises à jour",
   "desktop.updater.none.title": "Aucune mise à jour disponible",
-  "desktop.updater.none.message": "Vous utilisez déjà la dernière version d'OpenCode",
+  "desktop.updater.none.message": "Vous utilisez déjà la dernière version de MiMo Code",
   "desktop.updater.downloadFailed.title": "Échec de la mise à jour",
   "desktop.updater.downloadFailed.message": "Impossible de télécharger la mise à jour",
   "desktop.updater.downloaded.title": "Mise à jour téléchargée",
   "desktop.updater.downloaded.prompt":
-    "La version {{version}} d'OpenCode a été téléchargée. Voulez-vous l'installer et redémarrer ?",
+    "La version {{version}} de MiMo Code a été téléchargée. Voulez-vous l'installer et redémarrer ?",
   "desktop.updater.installFailed.title": "Échec de la mise à jour",
   "desktop.updater.installFailed.message": "Impossible d'installer la mise à jour",
 

--- a/packages/desktop/src/renderer/i18n/ja.ts
+++ b/packages/desktop/src/renderer/i18n/ja.ts
@@ -11,12 +11,12 @@ export const dict = {
   "desktop.updater.checkFailed.title": "アップデートの確認に失敗しました",
   "desktop.updater.checkFailed.message": "アップデートを確認できませんでした",
   "desktop.updater.none.title": "利用可能なアップデートはありません",
-  "desktop.updater.none.message": "すでに最新バージョンの OpenCode を使用しています",
+  "desktop.updater.none.message": "すでに最新バージョンの MiMo Code を使用しています",
   "desktop.updater.downloadFailed.title": "アップデートに失敗しました",
   "desktop.updater.downloadFailed.message": "アップデートをダウンロードできませんでした",
   "desktop.updater.downloaded.title": "アップデートをダウンロードしました",
   "desktop.updater.downloaded.prompt":
-    "OpenCode のバージョン {{version}} がダウンロードされました。インストールして再起動しますか？",
+    "MiMo Code のバージョン {{version}} がダウンロードされました。インストールして再起動しますか？",
   "desktop.updater.installFailed.title": "アップデートに失敗しました",
   "desktop.updater.installFailed.message": "アップデートをインストールできませんでした",
 

--- a/packages/desktop/src/renderer/i18n/ko.ts
+++ b/packages/desktop/src/renderer/i18n/ko.ts
@@ -11,11 +11,11 @@ export const dict = {
   "desktop.updater.checkFailed.title": "업데이트 확인 실패",
   "desktop.updater.checkFailed.message": "업데이트를 확인하지 못했습니다",
   "desktop.updater.none.title": "사용 가능한 업데이트 없음",
-  "desktop.updater.none.message": "이미 최신 버전의 OpenCode를 사용하고 있습니다",
+  "desktop.updater.none.message": "이미 최신 버전의 MiMo Code를 사용하고 있습니다",
   "desktop.updater.downloadFailed.title": "업데이트 실패",
   "desktop.updater.downloadFailed.message": "업데이트를 다운로드하지 못했습니다",
   "desktop.updater.downloaded.title": "업데이트 다운로드 완료",
-  "desktop.updater.downloaded.prompt": "OpenCode {{version}} 버전을 다운로드했습니다. 설치하고 다시 실행할까요?",
+  "desktop.updater.downloaded.prompt": "MiMo Code {{version}} 버전을 다운로드했습니다. 설치하고 다시 실행할까요?",
   "desktop.updater.installFailed.title": "업데이트 실패",
   "desktop.updater.installFailed.message": "업데이트를 설치하지 못했습니다",
 

--- a/packages/desktop/src/renderer/i18n/no.ts
+++ b/packages/desktop/src/renderer/i18n/no.ts
@@ -11,12 +11,12 @@ export const dict = {
   "desktop.updater.checkFailed.title": "Oppdateringssjekk mislyktes",
   "desktop.updater.checkFailed.message": "Kunne ikke se etter oppdateringer",
   "desktop.updater.none.title": "Ingen oppdatering tilgjengelig",
-  "desktop.updater.none.message": "Du bruker allerede den nyeste versjonen av OpenCode",
+  "desktop.updater.none.message": "Du bruker allerede den nyeste versjonen av MiMo Code",
   "desktop.updater.downloadFailed.title": "Oppdatering mislyktes",
   "desktop.updater.downloadFailed.message": "Kunne ikke laste ned oppdateringen",
   "desktop.updater.downloaded.title": "Oppdatering lastet ned",
   "desktop.updater.downloaded.prompt":
-    "Versjon {{version}} av OpenCode er lastet ned. Vil du installere den og starte på nytt?",
+    "Versjon {{version}} av MiMo Code er lastet ned. Vil du installere den og starte på nytt?",
   "desktop.updater.installFailed.title": "Oppdatering mislyktes",
   "desktop.updater.installFailed.message": "Kunne ikke installere oppdateringen",
 

--- a/packages/desktop/src/renderer/i18n/pl.ts
+++ b/packages/desktop/src/renderer/i18n/pl.ts
@@ -11,12 +11,12 @@ export const dict = {
   "desktop.updater.checkFailed.title": "Nie udało się sprawdzić aktualizacji",
   "desktop.updater.checkFailed.message": "Nie udało się sprawdzić aktualizacji",
   "desktop.updater.none.title": "Brak dostępnych aktualizacji",
-  "desktop.updater.none.message": "Korzystasz już z najnowszej wersji OpenCode",
+  "desktop.updater.none.message": "Korzystasz już z najnowszej wersji MiMo Code",
   "desktop.updater.downloadFailed.title": "Aktualizacja nie powiodła się",
   "desktop.updater.downloadFailed.message": "Nie udało się pobrać aktualizacji",
   "desktop.updater.downloaded.title": "Aktualizacja pobrana",
   "desktop.updater.downloaded.prompt":
-    "Pobrano wersję {{version}} OpenCode. Czy chcesz ją zainstalować i uruchomić ponownie?",
+    "Pobrano wersję {{version}} MiMo Code. Czy chcesz ją zainstalować i uruchomić ponownie?",
   "desktop.updater.installFailed.title": "Aktualizacja nie powiodła się",
   "desktop.updater.installFailed.message": "Nie udało się zainstalować aktualizacji",
 

--- a/packages/desktop/src/renderer/i18n/ru.ts
+++ b/packages/desktop/src/renderer/i18n/ru.ts
@@ -11,11 +11,11 @@ export const dict = {
   "desktop.updater.checkFailed.title": "Не удалось проверить обновления",
   "desktop.updater.checkFailed.message": "Не удалось проверить обновления",
   "desktop.updater.none.title": "Обновлений нет",
-  "desktop.updater.none.message": "Вы уже используете последнюю версию OpenCode",
+  "desktop.updater.none.message": "Вы уже используете последнюю версию MiMo Code",
   "desktop.updater.downloadFailed.title": "Обновление не удалось",
   "desktop.updater.downloadFailed.message": "Не удалось скачать обновление",
   "desktop.updater.downloaded.title": "Обновление загружено",
-  "desktop.updater.downloaded.prompt": "Версия OpenCode {{version}} загружена. Хотите установить и перезапустить?",
+  "desktop.updater.downloaded.prompt": "Версия MiMo Code {{version}} загружена. Хотите установить и перезапустить?",
   "desktop.updater.installFailed.title": "Обновление не удалось",
   "desktop.updater.installFailed.message": "Не удалось установить обновление",
 

--- a/packages/desktop/src/renderer/i18n/zh.ts
+++ b/packages/desktop/src/renderer/i18n/zh.ts
@@ -11,11 +11,11 @@ export const dict = {
   "desktop.updater.checkFailed.title": "检查更新失败",
   "desktop.updater.checkFailed.message": "无法检查更新",
   "desktop.updater.none.title": "没有可用更新",
-  "desktop.updater.none.message": "你已经在使用最新版本的 OpenCode",
+  "desktop.updater.none.message": "你已经在使用最新版本的 MiMo Code",
   "desktop.updater.downloadFailed.title": "更新失败",
   "desktop.updater.downloadFailed.message": "无法下载更新",
   "desktop.updater.downloaded.title": "更新已下载",
-  "desktop.updater.downloaded.prompt": "已下载 OpenCode {{version}} 版本，是否安装并重启？",
+  "desktop.updater.downloaded.prompt": "已下载 MiMo Code {{version}} 版本，是否安装并重启？",
   "desktop.updater.installFailed.title": "更新失败",
   "desktop.updater.installFailed.message": "无法安装更新",
 

--- a/packages/desktop/src/renderer/i18n/zht.ts
+++ b/packages/desktop/src/renderer/i18n/zht.ts
@@ -11,11 +11,11 @@ export const dict = {
   "desktop.updater.checkFailed.title": "檢查更新失敗",
   "desktop.updater.checkFailed.message": "無法檢查更新",
   "desktop.updater.none.title": "沒有可用更新",
-  "desktop.updater.none.message": "你已在使用最新版的 OpenCode",
+  "desktop.updater.none.message": "你已在使用最新版的 MiMo Code",
   "desktop.updater.downloadFailed.title": "更新失敗",
   "desktop.updater.downloadFailed.message": "無法下載更新",
   "desktop.updater.downloaded.title": "更新已下載",
-  "desktop.updater.downloaded.prompt": "已下載 OpenCode {{version}} 版本，是否安裝並重新啟動？",
+  "desktop.updater.downloaded.prompt": "已下載 MiMo Code {{version}} 版本，是否安裝並重新啟動？",
   "desktop.updater.installFailed.title": "更新失敗",
   "desktop.updater.installFailed.message": "無法安裝更新",
 

--- a/packages/enterprise/src/routes/share/[shareID].tsx
+++ b/packages/enterprise/src/routes/share/[shareID].tsx
@@ -165,15 +165,15 @@ export default function () {
               modelParam = "unknown"
             }
             const version = `v${info().version}`
-            return `https://social-cards.sst.dev/opencode-share/${encodedTitle}.png?model=${modelParam}&version=${version}&id=${data().shareID}`
+            return `https://social-cards.sst.dev/mimocode-share/${encodedTitle}.png?model=${modelParam}&version=${version}&id=${data().shareID}`
           })
 
           return (
             <>
               <Show when={info().title}>
-                <Title>{info().title} | OpenCode</Title>
+                <Title>{info().title} | MiMo Code</Title>
               </Show>
-              <Meta name="description" content="opencode - The AI coding agent built for the terminal." />
+              <Meta name="description" content="MiMo Code - The AI coding agent built for the terminal." />
               <Meta property="og:image" content={ogImage()} />
               <Meta name="twitter:image" content={ogImage()} />
               <ClientOnlyWorkerPoolProvider>
@@ -260,21 +260,21 @@ export default function () {
                         <div class="relative bg-background-stronger w-screen h-screen overflow-hidden flex flex-col">
                           <header class="h-12 px-6 py-2 flex items-center justify-between self-stretch bg-background-base border-b border-border-weak-base">
                             <div class="">
-                              <a href="https://opencode.ai">
+                              <a href="https://mimo.xiaomi.com">
                                 <Mark />
                               </a>
                             </div>
                             <div class="flex gap-3 items-center">
                               <IconButton
                                 as={"a"}
-                                href="https://github.com/anomalyco/opencode"
+                                href="https://github.com/XiaomiMiMo/MiMo-Code"
                                 target="_blank"
                                 icon="github"
                                 variant="ghost"
                               />
                               <IconButton
                                 as={"a"}
-                                href="https://opencode.ai/discord"
+                                href="https://mimo.xiaomi.com/discord"
                                 target="_blank"
                                 icon="discord"
                                 variant="ghost"

--- a/packages/opencode/src/server/routes/instance/config.ts
+++ b/packages/opencode/src/server/routes/instance/config.ts
@@ -13,7 +13,7 @@ export const ConfigRoutes = lazy(() =>
       "/",
       describeRoute({
         summary: "Get configuration",
-        description: "Retrieve the current OpenCode configuration settings and preferences.",
+        description: "Retrieve the current MiMo Code configuration settings and preferences.",
         operationId: "config.get",
         responses: {
           200: {
@@ -36,7 +36,7 @@ export const ConfigRoutes = lazy(() =>
       "/",
       describeRoute({
         summary: "Update configuration",
-        description: "Update OpenCode configuration settings and preferences.",
+        description: "Update MiMo Code configuration settings and preferences.",
         operationId: "config.update",
         responses: {
           200: {

--- a/packages/opencode/src/server/routes/instance/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/experimental.ts
@@ -109,7 +109,7 @@ export const ExperimentalRoutes = lazy(() =>
       "/console/switch",
       describeRoute({
         summary: "Switch active Console org",
-        description: "Persist a new active Console account/org selection for the current local OpenCode state.",
+        description: "Persist a new active Console account/org selection for the current local MiMo Code state.",
         operationId: "experimental.console.switchOrg",
         responses: {
           200: {
@@ -328,7 +328,7 @@ export const ExperimentalRoutes = lazy(() =>
       describeRoute({
         summary: "List sessions",
         description:
-          "Get a list of all OpenCode sessions across projects, sorted by most recently updated. Archived sessions are excluded by default.",
+          "Get a list of all MiMo Code sessions across projects, sorted by most recently updated. Archived sessions are excluded by default.",
         operationId: "experimental.session.list",
         responses: {
           200: {

--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -71,7 +71,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
       "/instance/dispose",
       describeRoute({
         summary: "Dispose instance",
-        description: "Clean up and dispose the current OpenCode instance, releasing all resources.",
+        description: "Clean up and dispose the current MiMo Code instance, releasing all resources.",
         operationId: "instance.dispose",
         responses: {
           200: {
@@ -93,7 +93,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
       "/path",
       describeRoute({
         summary: "Get paths",
-        description: "Retrieve the current working directory and related path information for the OpenCode instance.",
+        description: "Retrieve the current working directory and related path information for the MiMo Code instance.",
         operationId: "path.get",
         responses: {
           200: {
@@ -187,7 +187,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
       "/command",
       describeRoute({
         summary: "List commands",
-        description: "Get a list of all available commands in the OpenCode system.",
+        description: "Get a list of all available commands in the MiMo Code system.",
         operationId: "command.list",
         responses: {
           200: {
@@ -210,7 +210,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
       "/agent",
       describeRoute({
         summary: "List agents",
-        description: "Get a list of all available AI agents in the OpenCode system.",
+        description: "Get a list of all available AI agents in the MiMo Code system.",
         operationId: "app.agents",
         responses: {
           200: {
@@ -233,7 +233,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
       "/skill",
       describeRoute({
         summary: "List skills",
-        description: "Get a list of all available skills in the OpenCode system.",
+        description: "Get a list of all available skills in the MiMo Code system.",
         operationId: "app.skills",
         responses: {
           200: {

--- a/packages/opencode/src/server/routes/instance/project.ts
+++ b/packages/opencode/src/server/routes/instance/project.ts
@@ -17,7 +17,7 @@ export const ProjectRoutes = lazy(() =>
       "/",
       describeRoute({
         summary: "List all projects",
-        description: "Get a list of projects that have been opened with OpenCode.",
+        description: "Get a list of projects that have been opened with MiMo Code.",
         operationId: "project.list",
         responses: {
           200: {
@@ -39,7 +39,7 @@ export const ProjectRoutes = lazy(() =>
       "/current",
       describeRoute({
         summary: "Get current project",
-        description: "Retrieve the currently active project that OpenCode is working with.",
+        description: "Retrieve the currently active project that MiMo Code is working with.",
         operationId: "project.current",
         responses: {
           200: {

--- a/packages/opencode/src/server/routes/instance/pty.ts
+++ b/packages/opencode/src/server/routes/instance/pty.ts
@@ -23,7 +23,7 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       "/",
       describeRoute({
         summary: "List PTY sessions",
-        description: "Get a list of all active pseudo-terminal (PTY) sessions managed by OpenCode.",
+        description: "Get a list of all active pseudo-terminal (PTY) sessions managed by MiMo Code.",
         operationId: "pty.list",
         responses: {
           200: {

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -67,7 +67,7 @@ export const SessionRoutes = lazy(() =>
       "/",
       describeRoute({
         summary: "List sessions",
-        description: "Get a list of all OpenCode sessions, sorted by most recently updated.",
+        description: "Get a list of all MiMo Code sessions, sorted by most recently updated.",
         operationId: "session.list",
         responses: {
           200: {
@@ -136,7 +136,7 @@ export const SessionRoutes = lazy(() =>
       "/:sessionID",
       describeRoute({
         summary: "Get session",
-        description: "Retrieve detailed information about a specific OpenCode session.",
+        description: "Retrieve detailed information about a specific MiMo Code session.",
         tags: ["Session"],
         operationId: "session.get",
         responses: {
@@ -276,7 +276,7 @@ export const SessionRoutes = lazy(() =>
       "/",
       describeRoute({
         summary: "Create session",
-        description: "Create a new OpenCode session for interacting with AI assistants and managing conversations.",
+        description: "Create a new MiMo Code session for interacting with AI assistants and managing conversations.",
         operationId: "session.create",
         responses: {
           ...errors(400),


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#235) was auto-closed by a branch history rewrite.