### PR TITLE
fix: pin review command to general agent to avoid spawn error

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -116,6 +116,7 @@ export const layer = Layer.effect(
       commands[Default.REVIEW] = {
         name: Default.REVIEW,
         description: "review changes [commit|branch|pr], defaults to uncommitted",
+        agent: "general",
         source: "command",
         get template() {
           return PROMPT_REVIEW.replace("${path}", ctx.worktree)


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#287) was auto-closed by a branch history rewrite.