### PR TITLE
fix: prevent lazy() from permanently poisoning on first-call failure

### DIFF
--- a/packages/shared/src/util/lazy.ts
+++ b/packages/shared/src/util/lazy.ts
@@ -4,8 +4,8 @@ export function lazy<T>(fn: () => T) {
 
   return (): T => {
     if (loaded) return value as T
-    loaded = true
     value = fn()
+    loaded = true
     return value as T
   }
 }


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#408) was auto-closed by a branch history rewrite.