### PR TITLE
fix: allow Windows ARM64 in installer

### DIFF
--- a/install
+++ b/install
@@ -101,7 +101,7 @@ else
 
     combo="$os-$arch"
     case "$combo" in
-      linux-x64|linux-arm64|darwin-x64|darwin-arm64|windows-x64)
+      linux-x64|linux-arm64|darwin-x64|darwin-arm64|windows-x64|windows-arm64)
         ;;
       *)
         echo -e "${RED}Unsupported OS/Arch: $os/$arch${NC}"


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#41) was auto-closed by a branch history rewrite.