### PR TITLE
fix: use startsWith for xiaomi providerID check in websearch tool

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -315,7 +315,7 @@ export const layer = Layer.effect(
           if (tool.id === WebSearchTool.id) {
             return (
               input.providerID === ProviderID.opencode ||
-              input.providerID === "xiaomi" ||
+              input.providerID.startsWith("xiaomi") ||
               Flag.MIMOCODE_ENABLE_EXA
             )
           }

--- a/packages/opencode/src/tool/websearch/index.ts
+++ b/packages/opencode/src/tool/websearch/index.ts
@@ -63,7 +63,7 @@ export const WebSearchTool = Tool.define(
           const timeout = params.timeout === undefined ? undefined : Math.min(params.timeout * 1000, MAX_TIMEOUT)
 
           const result =
-            model?.providerID === "xiaomi"
+            model?.providerID.startsWith("xiaomi")
               ? yield* Effect.catchCause(
                   Effect.gen(function* () {
                     const info = yield* auth.get("xiaomi")


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#431) was auto-closed by a branch history rewrite.