### PR TITLE
refactor(zen-provider): eliminate 279 'as any' casts via proper request/response types

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/anthropic.ts
+++ b/packages/console/app/src/routes/zen/util/provider/anthropic.ts
@@ -16,6 +16,77 @@ type Usage = {
   }
 }
 
+// ---- Anthropic API request/response types ----
+// Pragmatic interfaces covering fields actually accessed by the converters.
+
+interface AnthSource {
+  type?: string
+  url?: string
+  media_type?: string
+  data?: string
+}
+
+interface AnthContentPart {
+  type?: string
+  text?: string
+  source?: AnthSource
+  tool_use_id?: string
+  content?: string | object
+  name?: string
+  id?: string
+  input?: object
+}
+
+interface AnthMessage {
+  role?: string
+  content?: string | AnthContentPart[]
+}
+
+interface AnthTool {
+  name?: string
+  description?: string
+  input_schema?: object
+}
+
+interface AnthToolChoice {
+  type?: string
+  name?: string
+}
+
+interface AnthropicRequestBody {
+  model?: string
+  system?: Array<{ type?: string; text?: string }>
+  messages?: AnthMessage[]
+  max_tokens?: number
+  temperature?: number
+  top_p?: number
+  stop_sequences?: string | string[]
+  stream?: boolean
+  tools?: AnthTool[]
+  tool_choice?: AnthToolChoice
+}
+
+interface AnthResponse {
+  type?: string
+  id?: string
+  model?: string
+  stop_reason?: string
+  content?: AnthContentPart[]
+  usage?: Usage
+}
+
+interface AnthChunk {
+  type?: string
+  id?: string
+  model?: string
+  delta?: { type?: string; text?: string; stop_reason?: string; partial_json?: string }
+  content_block?: { type?: string; id?: string; name?: string; text?: string }
+  index?: number
+  message?: { id?: string; model?: string; usage?: Usage }
+  usage?: Usage
+  response?: AnthResponse
+}
+
 export const anthropicHelper: ProviderHelper = ({ reqModel, providerModel }) => {
   const isBedrockModelArn = providerModel.startsWith("arn:aws:bedrock:")
   const isBedrockModelID = providerModel.startsWith("global.anthropic.")
@@ -187,7 +258,7 @@ export const anthropicHelper: ProviderHelper = ({ reqModel, providerModel }) => 
   }
 }
 
-export function fromAnthropicRequest(body: any): CommonRequest {
+export function fromAnthropicRequest(body: AnthropicRequestBody): CommonRequest {
   if (!body || typeof body !== "object") return body
 
   const msgs: any[] = []
@@ -196,48 +267,41 @@ export function fromAnthropicRequest(body: any): CommonRequest {
   if (sys && sys.length > 0) {
     for (const s of sys) {
       if (!s) continue
-      if ((s as any).type !== "text") continue
-      if (typeof (s as any).text !== "string") continue
-      if ((s as any).text.length === 0) continue
-      msgs.push({ role: "system", content: (s as any).text })
+      if (s.type !== "text") continue
+      if (typeof s.text !== "string") continue
+      if (s.text.length === 0) continue
+      msgs.push({ role: "system", content: s.text })
     }
   }
 
-  const toImg = (src: any) => {
+  const toImg = (src: AnthSource | undefined) => {
     if (!src || typeof src !== "object") return undefined
-    if ((src as any).type === "url" && typeof (src as any).url === "string")
-      return { type: "image_url", image_url: { url: (src as any).url } }
-    if (
-      (src as any).type === "base64" &&
-      typeof (src as any).media_type === "string" &&
-      typeof (src as any).data === "string"
-    )
+    if (src.type === "url" && typeof src.url === "string") return { type: "image_url", image_url: { url: src.url } }
+    if (src.type === "base64" && typeof src.media_type === "string" && typeof src.data === "string")
       return {
         type: "image_url",
-        image_url: { url: `data:${(src as any).media_type};base64,${(src as any).data}` },
+        image_url: { url: `data:${src.media_type};base64,${src.data}` },
       }
     return undefined
   }
 
-  const inMsgs = Array.isArray(body.messages) ? body.messages : []
+  const inMsgs: AnthMessage[] = Array.isArray(body.messages) ? body.messages : []
   for (const m of inMsgs) {
-    if (!m || !(m as any).role) continue
+    if (!m || !m.role) continue
 
-    if ((m as any).role === "user") {
-      const partsIn = Array.isArray((m as any).content) ? (m as any).content : []
+    if (m.role === "user") {
+      const partsIn = Array.isArray(m.content) ? m.content : []
       const partsOut: any[] = []
       for (const p of partsIn) {
-        if (!p || !(p as any).type) continue
-        if ((p as any).type === "text" && typeof (p as any).text === "string")
-          partsOut.push({ type: "text", text: (p as any).text })
-        if ((p as any).type === "image") {
-          const ip = toImg((p as any).source)
+        if (!p || !p.type) continue
+        if (p.type === "text" && typeof p.text === "string") partsOut.push({ type: "text", text: p.text })
+        if (p.type === "image") {
+          const ip = toImg(p.source)
           if (ip) partsOut.push(ip)
         }
-        if ((p as any).type === "tool_result") {
-          const id = (p as any).tool_use_id
-          const content =
-            typeof (p as any).content === "string" ? (p as any).content : JSON.stringify((p as any).content)
+        if (p.type === "tool_result") {
+          const id = p.tool_use_id
+          const content = typeof p.content === "string" ? p.content : JSON.stringify(p.content)
           msgs.push({ role: "tool", tool_call_id: id, content })
         }
       }
@@ -248,17 +312,17 @@ export function fromAnthropicRequest(body: any): CommonRequest {
       continue
     }
 
-    if ((m as any).role === "assistant") {
-      const partsIn = Array.isArray((m as any).content) ? (m as any).content : []
+    if (m.role === "assistant") {
+      const partsIn = Array.isArray(m.content) ? m.content : []
       const texts: string[] = []
       const tcs: any[] = []
       for (const p of partsIn) {
-        if (!p || !(p as any).type) continue
-        if ((p as any).type === "text" && typeof (p as any).text === "string") texts.push((p as any).text)
-        if ((p as any).type === "tool_use") {
-          const name = (p as any).name
-          const id = (p as any).id
-          const inp = (p as any).input
+        if (!p || !p.type) continue
+        if (p.type === "text" && typeof p.text === "string") texts.push(p.text)
+        if (p.type === "tool_use") {
+          const name = p.name
+          const id = p.id
+          const inp = p.input
           const input = (() => {
             if (typeof inp === "string") return inp
             try {
@@ -279,13 +343,13 @@ export function fromAnthropicRequest(body: any): CommonRequest {
 
   const tools = Array.isArray(body.tools)
     ? body.tools
-        .filter((t: any) => t && typeof t === "object" && "input_schema" in t)
-        .map((t: any) => ({
+        .filter((t) => t && typeof t === "object" && "input_schema" in t)
+        .map((t) => ({
           type: "function",
           function: {
-            name: (t as any).name,
-            description: (t as any).description,
-            parameters: (t as any).input_schema,
+            name: t.name,
+            description: t.description,
+            parameters: t.input_schema,
           },
         }))
     : undefined
@@ -293,10 +357,10 @@ export function fromAnthropicRequest(body: any): CommonRequest {
   const tcin = body.tool_choice
   const tc = (() => {
     if (!tcin) return undefined
-    if ((tcin as any).type === "auto") return "auto"
-    if ((tcin as any).type === "any") return "required"
-    if ((tcin as any).type === "tool" && typeof (tcin as any).name === "string")
-      return { type: "function" as const, function: { name: (tcin as any).name } }
+    if (tcin.type === "auto") return "auto"
+    if (tcin.type === "any") return "required"
+    if (tcin.type === "tool" && typeof tcin.name === "string")
+      return { type: "function" as const, function: { name: tcin.name } }
     return undefined
   })()
 
@@ -309,14 +373,14 @@ export function fromAnthropicRequest(body: any): CommonRequest {
   })()
 
   return {
-    model: body.model,
+    model: body.model ?? "",
     max_tokens: body.max_tokens,
     temperature: body.temperature,
     top_p: body.top_p,
     stop,
     messages: msgs,
     stream: !!body.stream,
-    tools,
+    tools: tools as CommonRequest["tools"],
     tool_choice: tc,
   }
 }
@@ -337,10 +401,10 @@ export function toAnthropicRequest(body: CommonRequest) {
   const msgsIn = Array.isArray(body.messages) ? body.messages : []
   const msgsOut: any[] = []
 
-  const toSrc = (p: any) => {
+  const toSrc = (p: { type?: string; image_url?: { url: string } | string }) => {
     if (!p || typeof p !== "object") return undefined
-    if ((p as any).type === "image_url" && (p as any).image_url) {
-      const u = (p as any).image_url.url ?? (p as any).image_url
+    if (p.type === "image_url" && p.image_url) {
+      const u = typeof p.image_url === "string" ? p.image_url : p.image_url.url
       if (typeof u === "string" && u.startsWith("data:")) {
         const m = u.match(/^data:([^;]+);base64,(.*)$/)
         if (m) return { type: "base64", media_type: m[1], data: m[2] }
@@ -351,21 +415,20 @@ export function toAnthropicRequest(body: CommonRequest) {
   }
 
   for (const m of msgsIn) {
-    if (!m || !(m as any).role) continue
+    if (!m || !m.role) continue
 
-    if ((m as any).role === "user") {
-      if (typeof (m as any).content === "string") {
+    if (m.role === "user") {
+      if (typeof m.content === "string") {
         msgsOut.push({
           role: "user",
-          content: [{ type: "text", text: (m as any).content, ...cc() }],
+          content: [{ type: "text", text: m.content, ...cc() }],
         })
-      } else if (Array.isArray((m as any).content)) {
+      } else if (Array.isArray(m.content)) {
         const parts: any[] = []
-        for (const p of (m as any).content) {
-          if (!p || !(p as any).type) continue
-          if ((p as any).type === "text" && typeof (p as any).text === "string")
-            parts.push({ type: "text", text: (p as any).text, ...cc() })
-          if ((p as any).type === "image_url") {
+        for (const p of m.content) {
+          if (!p || !p.type) continue
+          if (p.type === "text" && typeof p.text === "string") parts.push({ type: "text", text: p.text, ...cc() })
+          if (p.type === "image_url") {
             const s = toSrc(p)
             if (s) parts.push({ type: "image", source: s, ...cc() })
           }
@@ -375,16 +438,16 @@ export function toAnthropicRequest(body: CommonRequest) {
       continue
     }
 
-    if ((m as any).role === "assistant") {
-      const out: any = { role: "assistant", content: [] as any[] }
-      if (typeof (m as any).content === "string" && (m as any).content.length > 0) {
-        ;(out.content as any[]).push({ type: "text", text: (m as any).content, ...cc() })
+    if (m.role === "assistant") {
+      const out: { role: string; content: any[] } = { role: "assistant", content: [] }
+      if (typeof m.content === "string" && m.content.length > 0) {
+        out.content.push({ type: "text", text: m.content, ...cc() })
       }
-      if (Array.isArray((m as any).tool_calls)) {
-        for (const tc of (m as any).tool_calls) {
-          if ((tc as any).type === "function" && (tc as any).function) {
+      if (Array.isArray(m.tool_calls)) {
+        for (const tc of m.tool_calls) {
+          if (tc.type === "function" && tc.function) {
             let input: any
-            const a = (tc as any).function.arguments
+            const a = tc.function.arguments
             if (typeof a === "string") {
               try {
                 input = JSON.parse(a)
@@ -392,29 +455,29 @@ export function toAnthropicRequest(body: CommonRequest) {
                 input = a
               }
             } else input = a
-            const id = (tc as any).id || `toolu_${Math.random().toString(36).slice(2)}`
-            ;(out.content as any[]).push({
+            const id = tc.id || `toolu_${Math.random().toString(36).slice(2)}`
+            out.content.push({
               type: "tool_use",
               id,
-              name: (tc as any).function.name,
+              name: tc.function.name,
               input,
               ...cc(),
             })
           }
         }
       }
-      if ((out.content as any[]).length > 0) msgsOut.push(out)
+      if (out.content.length > 0) msgsOut.push(out)
       continue
     }
 
-    if ((m as any).role === "tool") {
+    if (m.role === "tool") {
       msgsOut.push({
         role: "user",
         content: [
           {
             type: "tool_result",
-            tool_use_id: (m as any).tool_call_id,
-            content: (m as any).content,
+            tool_use_id: m.tool_call_id,
+            content: m.content,
             ...cc(),
           },
         ],
@@ -425,11 +488,11 @@ export function toAnthropicRequest(body: CommonRequest) {
 
   const tools = Array.isArray(body.tools)
     ? body.tools
-        .filter((t: any) => t && typeof t === "object" && (t as any).type === "function")
-        .map((t: any) => ({
-          name: (t as any).function.name,
-          description: (t as any).function.description,
-          input_schema: (t as any).function.parameters,
+        .filter((t) => t && typeof t === "object" && t.type === "function")
+        .map((t) => ({
+          name: t.function.name,
+          description: t.function.description,
+          input_schema: t.function.parameters,
           ...cc(),
         }))
     : undefined
@@ -439,8 +502,8 @@ export function toAnthropicRequest(body: CommonRequest) {
     if (!tcIn) return undefined
     if (tcIn === "auto") return { type: "auto" }
     if (tcIn === "required") return { type: "any" }
-    if ((tcIn as any).type === "function" && (tcIn as any).function?.name)
-      return { type: "tool", name: (tcIn as any).function.name }
+    if (typeof tcIn !== "string" && tcIn.type === "function" && tcIn.function?.name)
+      return { type: "tool", name: tcIn.function.name }
     return undefined
   })()
 
@@ -465,30 +528,30 @@ export function toAnthropicRequest(body: CommonRequest) {
   }
 }
 
-export function fromAnthropicResponse(resp: any): CommonResponse {
-  if (!resp || typeof resp !== "object") return resp
+export function fromAnthropicResponse(resp: AnthResponse): CommonResponse {
+  if (!resp || typeof resp !== "object") return resp as unknown as CommonResponse
 
-  if (Array.isArray((resp as any).choices)) return resp
+  if (Array.isArray(resp.content) === false && !("type" in resp)) return resp as unknown as CommonResponse
 
-  const isAnthropic = typeof (resp as any).type === "string" && (resp as any).type === "message"
-  if (!isAnthropic) return resp
+  const isAnthropic = typeof resp.type === "string" && resp.type === "message"
+  if (!isAnthropic) return resp as unknown as CommonResponse
 
-  const idIn = (resp as any).id
+  const idIn = resp.id
   const id =
     typeof idIn === "string" ? idIn.replace(/^msg_/, "chatcmpl_") : `chatcmpl_${Math.random().toString(36).slice(2)}`
-  const model = (resp as any).model
+  const model = resp.model
 
-  const blocks: any[] = Array.isArray((resp as any).content) ? (resp as any).content : []
+  const blocks: AnthContentPart[] = Array.isArray(resp.content) ? resp.content : []
   const text = blocks
-    .filter((b) => b && b.type === "text" && typeof (b as any).text === "string")
-    .map((b: any) => b.text)
+    .filter((b) => b && b.type === "text" && typeof b.text === "string")
+    .map((b) => b.text)
     .join("")
   const tcs = blocks
     .filter((b) => b && b.type === "tool_use")
-    .map((b: any) => {
-      const name = (b as any).name
+    .map((b) => {
+      const name = b.name
       const args = (() => {
-        const inp = (b as any).input
+        const inp = b.input
         if (typeof inp === "string") return inp
         try {
           return JSON.stringify(inp ?? {})
@@ -496,11 +559,8 @@ export function fromAnthropicResponse(resp: any): CommonResponse {
           return String(inp ?? "")
         }
       })()
-      const tid =
-        typeof (b as any).id === "string" && (b as any).id.length > 0
-          ? (b as any).id
-          : `toolu_${Math.random().toString(36).slice(2)}`
-      return { id: tid, type: "function" as const, function: { name, arguments: args } }
+      const tid = typeof b.id === "string" && b.id.length > 0 ? b.id : `toolu_${Math.random().toString(36).slice(2)}`
+      return { id: tid, type: "function" as const, function: { name: name ?? "", arguments: args } }
     })
 
   const finish = (r: string | null) => {
@@ -511,14 +571,13 @@ export function fromAnthropicResponse(resp: any): CommonResponse {
     return null
   }
 
-  const u = (resp as any).usage
+  const u = resp.usage
   const usage = (() => {
-    if (!u) return undefined as any
-    const pt = typeof (u as any).input_tokens === "number" ? (u as any).input_tokens : undefined
-    const ct = typeof (u as any).output_tokens === "number" ? (u as any).output_tokens : undefined
+    if (!u) return undefined
+    const pt = typeof u.input_tokens === "number" ? u.input_tokens : undefined
+    const ct = typeof u.output_tokens === "number" ? u.output_tokens : undefined
     const total = pt != null && ct != null ? pt + ct : undefined
-    const cached =
-      typeof (u as any).cache_read_input_tokens === "number" ? (u as any).cache_read_input_tokens : undefined
+    const cached = typeof u.cache_read_input_tokens === "number" ? u.cache_read_input_tokens : undefined
     const details = cached != null ? { cached_tokens: cached } : undefined
     return {
       prompt_tokens: pt,
@@ -532,7 +591,7 @@ export function fromAnthropicResponse(resp: any): CommonResponse {
     id,
     object: "chat.completion",
     created: Math.floor(Date.now() / 1000),
-    model,
+    model: model ?? "",
     choices: [
       {
         index: 0,
@@ -541,7 +600,7 @@ export function fromAnthropicResponse(resp: any): CommonResponse {
           ...(text && text.length > 0 ? { content: text } : {}),
           ...(tcs.length > 0 ? { tool_calls: tcs } : {}),
         },
-        finish_reason: finish((resp as any).stop_reason ?? null),
+        finish_reason: finish(resp.stop_reason ?? null),
       },
     ],
     ...(usage ? { usage } : {}),
@@ -551,9 +610,9 @@ export function fromAnthropicResponse(resp: any): CommonResponse {
 export function toAnthropicResponse(resp: CommonResponse) {
   if (!resp || typeof resp !== "object") return resp
 
-  if (!Array.isArray((resp as any).choices)) return resp
+  if (!Array.isArray(resp.choices)) return resp
 
-  const choice = (resp as any).choices[0]
+  const choice = resp.choices[0]
   if (!choice) return resp
 
   const message = choice.message
@@ -566,17 +625,17 @@ export function toAnthropicResponse(resp: CommonResponse) {
 
   if (Array.isArray(message.tool_calls)) {
     for (const tc of message.tool_calls) {
-      if ((tc as any).type === "function" && (tc as any).function) {
+      if (tc.type === "function" && tc.function) {
         let input: any
         try {
-          input = JSON.parse((tc as any).function.arguments)
+          input = JSON.parse(tc.function.arguments)
         } catch {
-          input = (tc as any).function.arguments
+          input = tc.function.arguments
         }
         content.push({
           type: "tool_use",
-          id: (tc as any).id,
-          name: (tc as any).function.name,
+          id: tc.id,
+          name: tc.function.name,
           input,
         })
       }
@@ -593,7 +652,7 @@ export function toAnthropicResponse(resp: CommonResponse) {
   })()
 
   const usage = (() => {
-    const u = (resp as any).usage
+    const u = resp.usage
     if (!u) return undefined
     return {
       input_tokens: u.prompt_tokens,
@@ -603,11 +662,11 @@ export function toAnthropicResponse(resp: CommonResponse) {
   })()
 
   return {
-    id: (resp as any).id,
+    id: resp.id,
     type: "message",
     role: "assistant",
     content: content.length > 0 ? content : [{ type: "text", text: "" }],
-    model: (resp as any).model,
+    model: resp.model,
     stop_reason,
     usage,
   }
@@ -619,7 +678,7 @@ export function fromAnthropicChunk(chunk: string): CommonChunk | string {
   const dataLine = lines.find((l) => l.startsWith("data: "))
   if (!dataLine) return chunk
 
-  let json
+  let json: AnthChunk
   try {
     json = JSON.parse(dataLine.slice(6))
   } catch {

--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -144,10 +144,14 @@ export function toOaCompatibleRequest(body: CommonRequest) {
   const msgsIn = Array.isArray(body.messages) ? body.messages : []
   const msgsOut: any[] = []
 
-  const toImg = (p: any) => {
+  const toImg = (p: {
+    type?: string
+    image_url?: { url: string }
+    source?: { type: string; url?: string; media_type?: string; data?: string }
+  }) => {
     if (!p || typeof p !== "object") return undefined
     if (p.type === "image_url" && p.image_url) return { type: "image_url", image_url: p.image_url }
-    const s = (p as any).source
+    const s = p.source
     if (!s || typeof s !== "object") return undefined
     if (s.type === "url" && typeof s.url === "string") return { type: "image_url", image_url: { url: s.url } }
     if (s.type === "base64" && typeof s.media_type === "string" && typeof s.data === "string")
@@ -217,16 +221,16 @@ export function toOaCompatibleRequest(body: CommonRequest) {
     stream: !!body.stream,
     tools,
     tool_choice: body.tool_choice,
-    response_format: (body as any).response_format,
+    response_format: (body as CommonRequest & { response_format?: unknown }).response_format,
   }
 }
 
 export function fromOaCompatibleResponse(resp: any): CommonResponse {
   if (!resp || typeof resp !== "object") return resp
 
-  if (!Array.isArray((resp as any).choices)) return resp
+  if (!Array.isArray(resp.choices)) return resp
 
-  const choice = (resp as any).choices[0]
+  const choice = resp.choices[0]
   if (!choice) return resp
 
   const message = choice.message
@@ -267,7 +271,7 @@ export function fromOaCompatibleResponse(resp: any): CommonResponse {
   })()
 
   const usage = (() => {
-    const u = (resp as any).usage
+    const u = resp.usage
     if (!u) return undefined
     return {
       prompt_tokens: u.prompt_tokens,
@@ -280,10 +284,10 @@ export function fromOaCompatibleResponse(resp: any): CommonResponse {
   })()
 
   return {
-    id: (resp as any).id,
+    id: resp.id,
     object: "chat.completion" as const,
     created: Math.floor(Date.now() / 1000),
-    model: (resp as any).model,
+    model: resp.model,
     choices: [
       {
         index: 0,
@@ -319,20 +323,35 @@ export function fromOaCompatibleResponse(resp: any): CommonResponse {
   }
 }
 
-export function toOaCompatibleResponse(resp: CommonResponse) {
+type OaCompatResponse = CommonResponse & {
+  type?: string
+  content?: Array<{ type?: string; text?: string; name?: string; id?: string; input?: unknown }>
+  stop_reason?: string
+  usage?: {
+    prompt_tokens?: number
+    completion_tokens?: number
+    total_tokens?: number
+    prompt_tokens_details?: { cached_tokens?: number }
+    input_tokens?: number
+    output_tokens?: number
+    cache_read_input_tokens?: number
+  }
+}
+
+export function toOaCompatibleResponse(resp: OaCompatResponse) {
   if (!resp || typeof resp !== "object") return resp
 
-  if (Array.isArray((resp as any).choices)) return resp
+  if (Array.isArray(resp.choices)) return resp
 
-  const isAnthropic = typeof (resp as any).type === "string" && (resp as any).type === "message"
+  const isAnthropic = typeof resp.type === "string" && resp.type === "message"
   if (!isAnthropic) return resp
 
-  const idIn = (resp as any).id
+  const idIn = resp.id
   const id =
     typeof idIn === "string" ? idIn.replace(/^msg_/, "chatcmpl_") : `chatcmpl_${Math.random().toString(36).slice(2)}`
-  const model = (resp as any).model
+  const model = resp.model
 
-  const blocks: any[] = Array.isArray((resp as any).content) ? (resp as any).content : []
+  const blocks = Array.isArray(resp.content) ? resp.content : []
   const text = blocks
     .filter((b) => b && b.type === "text" && typeof b.text === "string")
     .map((b) => b.text)
@@ -340,9 +359,9 @@ export function toOaCompatibleResponse(resp: CommonResponse) {
   const tcs = blocks
     .filter((b) => b && b.type === "tool_use")
     .map((b) => {
-      const name = (b as any).name
+      const name = b.name
       const args = (() => {
-        const inp = (b as any).input
+        const inp = b.input
         if (typeof inp === "string") return inp
         try {
           return JSON.stringify(inp ?? {})
@@ -350,11 +369,8 @@ export function toOaCompatibleResponse(resp: CommonResponse) {
           return String(inp ?? "")
         }
       })()
-      const tid =
-        typeof (b as any).id === "string" && (b as any).id.length > 0
-          ? (b as any).id
-          : `toolu_${Math.random().toString(36).slice(2)}`
-      return { id: tid, type: "function" as const, function: { name, arguments: args } }
+      const tid = typeof b.id === "string" && b.id.length > 0 ? b.id : `toolu_${Math.random().toString(36).slice(2)}`
+      return { id: tid, type: "function" as const, function: { name: name ?? "", arguments: args } }
     })
 
   const finish = (r: string | null) => {
@@ -365,9 +381,9 @@ export function toOaCompatibleResponse(resp: CommonResponse) {
     return null
   }
 
-  const u = (resp as any).usage
+  const u = resp.usage
   const usage = (() => {
-    if (!u) return undefined as any
+    if (!u) return undefined
     const pt = typeof u.input_tokens === "number" ? u.input_tokens : undefined
     const ct = typeof u.output_tokens === "number" ? u.output_tokens : undefined
     const total = pt != null && ct != null ? pt + ct : undefined
@@ -385,7 +401,7 @@ export function toOaCompatibleResponse(resp: CommonResponse) {
     id,
     object: "chat.completion",
     created: Math.floor(Date.now() / 1000),
-    model,
+    model: model ?? "",
     choices: [
       {
         index: 0,
@@ -394,7 +410,7 @@ export function toOaCompatibleResponse(resp: CommonResponse) {
           ...(text && text.length > 0 ? { content: text } : {}),
           ...(tcs.length > 0 ? { tool_calls: tcs } : {}),
         },
-        finish_reason: finish((resp as any).stop_reason ?? null),
+        finish_reason: finish(resp.stop_reason ?? null),
       },
     ],
     ...(usage ? { usage } : {}),

--- a/packages/console/app/src/routes/zen/util/provider/openai.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai.ts
@@ -12,6 +12,115 @@ type Usage = {
   total_tokens?: number
 }
 
+// ---- OpenAI Responses/Chat API request body types ----
+// Pragmatic interfaces covering fields actually accessed by the converters below.
+// All fields optional: the code does runtime checks (typeof, Array.isArray) before use.
+
+interface OaiContentPart {
+  type?: string
+  text?: string
+  image_url?: { url: string }
+  source?: { type: string; url?: string; media_type?: string; data?: string }
+  tool_call_id?: string
+  content?: string | object
+}
+
+interface OaiToolCall {
+  type?: string
+  id?: string
+  function?: { name: string; arguments: string | object }
+}
+
+interface OaiInputItem {
+  role?: string
+  type?: string
+  content?: string | OaiContentPart[]
+  tool_calls?: OaiToolCall[]
+  tool_call_id?: string
+  id?: string
+  name?: string
+  arguments?: string | object
+  call_id?: string
+  output?: string | object
+}
+
+interface OaiToolChoice {
+  type?: string
+  function?: { name: string }
+}
+
+interface OaiTool {
+  type?: string
+  function?: { name?: string; description?: string; parameters?: object; strict?: boolean }
+}
+
+interface OpenAIRequestBody {
+  model?: string
+  input?: OaiInputItem[]
+  messages?: OaiInputItem[]
+  max_output_tokens?: number
+  max_tokens?: number
+  temperature?: number
+  top_p?: number
+  stop_sequences?: string[]
+  stop?: string | string[]
+  stream?: boolean
+  tools?: OaiTool[]
+  tool_choice?: "auto" | "required" | OaiToolChoice
+  include?: string[]
+  truncation?: string
+  metadata?: object
+  store?: boolean
+  user?: string
+}
+
+// ---- OpenAI Responses API response types ----
+
+interface OaiResponseItem {
+  type?: string
+  content?: Array<{ type?: string; text?: string }>
+  id?: string
+  name?: string
+  arguments?: string | object
+}
+
+interface OaiUsage {
+  input_tokens?: number
+  output_tokens?: number
+  input_tokens_details?: { cached_tokens?: number }
+  output_tokens_details?: { reasoning_tokens?: number }
+}
+
+interface OaiResponse {
+  id?: string
+  model?: string
+  output?: OaiResponseItem[]
+  stop_reason?: string
+  usage?: OaiUsage
+}
+
+interface OpenAIResponseWrapper {
+  response?: OaiResponse
+  id?: string
+  model?: string
+  usage?: OaiUsage
+  choices?: unknown[]
+}
+
+// ---- OpenAI Responses API SSE chunk types ----
+
+interface OaiChunkData {
+  delta?: string
+  text?: string
+  output_text_delta?: string
+  arguments_delta?: string
+  item?: { type?: string; name?: string; id?: string }
+  response?: { id?: string; model?: string; stop_reason?: string; usage?: OaiUsage }
+  id?: string
+  model?: string
+  stop_reason?: string
+}
+
 export const openaiHelper: ProviderHelper = ({ workspaceID }) => ({
   format: "openai",
   modifyUrl: (providerApi: string) => providerApi + "/responses",
@@ -62,84 +171,80 @@ export const openaiHelper: ProviderHelper = ({ workspaceID }) => ({
   },
 })
 
-export function fromOpenaiRequest(body: any): CommonRequest {
+export function fromOpenaiRequest(body: OpenAIRequestBody): CommonRequest {
   if (!body || typeof body !== "object") return body
 
-  const toImg = (p: any) => {
+  const toImg = (p: OaiContentPart) => {
     if (!p || typeof p !== "object") return undefined
-    if ((p as any).type === "image_url" && (p as any).image_url)
-      return { type: "image_url", image_url: (p as any).image_url }
-    if ((p as any).type === "input_image" && (p as any).image_url)
-      return { type: "image_url", image_url: (p as any).image_url }
-    const s = (p as any).source
+    if (p.type === "image_url" && p.image_url) return { type: "image_url", image_url: p.image_url }
+    if (p.type === "input_image" && p.image_url) return { type: "image_url", image_url: p.image_url }
+    const s = p.source
     if (!s || typeof s !== "object") return undefined
-    if ((s as any).type === "url" && typeof (s as any).url === "string")
-      return { type: "image_url", image_url: { url: (s as any).url } }
-    if (
-      (s as any).type === "base64" &&
-      typeof (s as any).media_type === "string" &&
-      typeof (s as any).data === "string"
-    )
+    if (s.type === "url" && typeof s.url === "string") return { type: "image_url", image_url: { url: s.url } }
+    if (s.type === "base64" && typeof s.media_type === "string" && typeof s.data === "string")
       return {
         type: "image_url",
-        image_url: { url: `data:${(s as any).media_type};base64,${(s as any).data}` },
+        image_url: { url: `data:${s.media_type};base64,${s.data}` },
       }
     return undefined
   }
 
   const msgs: any[] = []
 
-  const inMsgs = Array.isArray(body.input) ? body.input : Array.isArray(body.messages) ? body.messages : []
+  const inMsgs: OaiInputItem[] = Array.isArray(body.input)
+    ? body.input
+    : Array.isArray(body.messages)
+      ? body.messages
+      : []
 
   for (const m of inMsgs) {
     if (!m) continue
 
     // Responses API items without role:
-    if (!(m as any).role && (m as any).type) {
-      if ((m as any).type === "function_call") {
-        const name = (m as any).name
-        const a = (m as any).arguments
+    if (!m.role && m.type) {
+      if (m.type === "function_call") {
+        const name = m.name
+        const a = m.arguments
         const args = typeof a === "string" ? a : JSON.stringify(a ?? {})
         msgs.push({
           role: "assistant",
-          tool_calls: [{ id: (m as any).id, type: "function", function: { name, arguments: args } }],
+          tool_calls: [{ id: m.id, type: "function", function: { name, arguments: args } }],
         })
       }
-      if ((m as any).type === "function_call_output") {
-        const id = (m as any).call_id
-        const out = (m as any).output
+      if (m.type === "function_call_output") {
+        const id = m.call_id
+        const out = m.output
         const content = typeof out === "string" ? out : JSON.stringify(out)
         msgs.push({ role: "tool", tool_call_id: id, content })
       }
       continue
     }
 
-    if ((m as any).role === "system" || (m as any).role === "developer") {
-      const c = (m as any).content
+    if (m.role === "system" || m.role === "developer") {
+      const c = m.content
       if (typeof c === "string" && c.length > 0) msgs.push({ role: "system", content: c })
       if (Array.isArray(c)) {
-        const t = c.find((p: any) => p && typeof p.text === "string")
+        const t = c.find((p) => p && typeof p.text === "string")
         if (t && typeof t.text === "string" && t.text.length > 0) msgs.push({ role: "system", content: t.text })
       }
       continue
     }
 
-    if ((m as any).role === "user") {
-      const c = (m as any).content
+    if (m.role === "user") {
+      const c = m.content
       if (typeof c === "string") {
         msgs.push({ role: "user", content: c })
       } else if (Array.isArray(c)) {
         const parts: any[] = []
         for (const p of c) {
-          if (!p || !(p as any).type) continue
-          if (((p as any).type === "text" || (p as any).type === "input_text") && typeof (p as any).text === "string")
-            parts.push({ type: "text", text: (p as any).text })
+          if (!p || !p.type) continue
+          if ((p.type === "text" || p.type === "input_text") && typeof p.text === "string")
+            parts.push({ type: "text", text: p.text })
           const ip = toImg(p)
           if (ip) parts.push(ip)
-          if ((p as any).type === "tool_result") {
-            const id = (p as any).tool_call_id
-            const content =
-              typeof (p as any).content === "string" ? (p as any).content : JSON.stringify((p as any).content)
+          if (p.type === "tool_result") {
+            const id = p.tool_call_id
+            const content = typeof p.content === "string" ? p.content : JSON.stringify(p.content)
             msgs.push({ role: "tool", tool_call_id: id, content })
           }
         }
@@ -149,20 +254,20 @@ export function fromOpenaiRequest(body: any): CommonRequest {
       continue
     }
 
-    if ((m as any).role === "assistant") {
-      const c = (m as any).content
+    if (m.role === "assistant") {
+      const c = m.content
       const out: any = { role: "assistant" }
       if (typeof c === "string" && c.length > 0) out.content = c
-      if (Array.isArray((m as any).tool_calls)) out.tool_calls = (m as any).tool_calls
+      if (Array.isArray(m.tool_calls)) out.tool_calls = m.tool_calls
       msgs.push(out)
       continue
     }
 
-    if ((m as any).role === "tool") {
+    if (m.role === "tool") {
       msgs.push({
         role: "tool",
-        tool_call_id: (m as any).tool_call_id,
-        content: (m as any).content,
+        tool_call_id: m.tool_call_id,
+        content: m.content,
       })
       continue
     }
@@ -173,8 +278,8 @@ export function fromOpenaiRequest(body: any): CommonRequest {
     if (!tcIn) return undefined
     if (tcIn === "auto") return "auto"
     if (tcIn === "required") return "required"
-    if ((tcIn as any).type === "function" && (tcIn as any).function?.name)
-      return { type: "function" as const, function: { name: (tcIn as any).function.name } }
+    if (typeof tcIn !== "string" && tcIn.type === "function" && tcIn.function?.name)
+      return { type: "function" as const, function: { name: tcIn.function.name } }
     return undefined
   })()
 
@@ -187,14 +292,14 @@ export function fromOpenaiRequest(body: any): CommonRequest {
   })()
 
   return {
-    model: body.model,
+    model: body.model ?? "",
     max_tokens: body.max_output_tokens ?? body.max_tokens,
     temperature: body.temperature,
     top_p: body.top_p,
     stop,
     messages: msgs,
     stream: !!body.stream,
-    tools: Array.isArray(body.tools) ? body.tools : undefined,
+    tools: Array.isArray(body.tools) ? (body.tools as CommonRequest["tools"]) : undefined,
     tool_choice: tc,
   }
 }
@@ -205,39 +310,37 @@ export function toOpenaiRequest(body: CommonRequest) {
   const msgsIn = Array.isArray(body.messages) ? body.messages : []
   const input: any[] = []
 
-  const toPart = (p: any) => {
+  const toPart = (p: {
+    type?: string
+    text?: string
+    image_url?: { url: string }
+    source?: { type: string; url?: string; media_type?: string; data?: string }
+  }) => {
     if (!p || typeof p !== "object") return undefined
-    if ((p as any).type === "text" && typeof (p as any).text === "string")
-      return { type: "input_text", text: (p as any).text }
-    if ((p as any).type === "image_url" && (p as any).image_url)
-      return { type: "input_image", image_url: (p as any).image_url }
-    const s = (p as any).source
+    if (p.type === "text" && typeof p.text === "string") return { type: "input_text", text: p.text }
+    if (p.type === "image_url" && p.image_url) return { type: "input_image", image_url: p.image_url }
+    const s = p.source
     if (!s || typeof s !== "object") return undefined
-    if ((s as any).type === "url" && typeof (s as any).url === "string")
-      return { type: "input_image", image_url: { url: (s as any).url } }
-    if (
-      (s as any).type === "base64" &&
-      typeof (s as any).media_type === "string" &&
-      typeof (s as any).data === "string"
-    )
+    if (s.type === "url" && typeof s.url === "string") return { type: "input_image", image_url: { url: s.url } }
+    if (s.type === "base64" && typeof s.media_type === "string" && typeof s.data === "string")
       return {
         type: "input_image",
-        image_url: { url: `data:${(s as any).media_type};base64,${(s as any).data}` },
+        image_url: { url: `data:${s.media_type};base64,${s.data}` },
       }
     return undefined
   }
 
   for (const m of msgsIn) {
-    if (!m || !(m as any).role) continue
+    if (!m || !m.role) continue
 
-    if ((m as any).role === "system") {
-      const c = (m as any).content
+    if (m.role === "system") {
+      const c = m.content
       if (typeof c === "string") input.push({ role: "system", content: c })
       continue
     }
 
-    if ((m as any).role === "user") {
-      const c = (m as any).content
+    if (m.role === "user") {
+      const c = m.content
       if (typeof c === "string") {
         input.push({ role: "user", content: [{ type: "input_text", text: c }] })
       } else if (Array.isArray(c)) {
@@ -251,27 +354,27 @@ export function toOpenaiRequest(body: CommonRequest) {
       continue
     }
 
-    if ((m as any).role === "assistant") {
-      const c = (m as any).content
+    if (m.role === "assistant") {
+      const c = m.content
       if (typeof c === "string" && c.length > 0) {
         input.push({ role: "assistant", content: [{ type: "output_text", text: c }] })
       }
-      if (Array.isArray((m as any).tool_calls)) {
-        for (const tc of (m as any).tool_calls) {
-          if ((tc as any).type === "function" && (tc as any).function) {
-            const name = (tc as any).function.name
-            const a = (tc as any).function.arguments
+      if (Array.isArray(m.tool_calls)) {
+        for (const tc of m.tool_calls) {
+          if (tc.type === "function" && tc.function) {
+            const name = tc.function.name
+            const a = tc.function.arguments
             const args = typeof a === "string" ? a : JSON.stringify(a)
-            input.push({ type: "function_call", call_id: (tc as any).id, name, arguments: args })
+            input.push({ type: "function_call", call_id: tc.id, name, arguments: args })
           }
         }
       }
       continue
     }
 
-    if ((m as any).role === "tool") {
-      const out = typeof (m as any).content === "string" ? (m as any).content : JSON.stringify((m as any).content)
-      input.push({ type: "function_call_output", call_id: (m as any).tool_call_id, output: out })
+    if (m.role === "tool") {
+      const out = typeof m.content === "string" ? m.content : JSON.stringify(m.content)
+      input.push({ type: "function_call_output", call_id: m.tool_call_id, output: out })
       continue
     }
   }
@@ -289,21 +392,21 @@ export function toOpenaiRequest(body: CommonRequest) {
     if (!tcIn) return undefined
     if (tcIn === "auto") return "auto"
     if (tcIn === "required") return "required"
-    if ((tcIn as any).type === "function" && (tcIn as any).function?.name)
-      return { type: "function", function: { name: (tcIn as any).function.name } }
+    if (typeof tcIn !== "string" && tcIn.type === "function" && tcIn.function?.name)
+      return { type: "function", function: { name: tcIn.function.name } }
     return undefined
   })()
 
   const tools = (() => {
     if (!Array.isArray(body.tools)) return undefined
-    return body.tools.map((tool: any) => {
+    return body.tools.map((tool) => {
       if (tool.type === "function") {
         return {
           type: "function",
           name: tool.function?.name,
           description: tool.function?.description,
           parameters: tool.function?.parameters,
-          strict: tool.function?.strict,
+          strict: (tool.function as { strict?: boolean }).strict,
         }
       }
       return tool
@@ -319,46 +422,45 @@ export function toOpenaiRequest(body: CommonRequest) {
     stream: !!body.stream,
     tools,
     tool_choice,
-    include: Array.isArray((body as any).include) ? (body as any).include : undefined,
-    truncation: (body as any).truncation,
-    metadata: (body as any).metadata,
-    store: (body as any).store,
-    user: (body as any).user,
+    include: undefined,
+    truncation: undefined,
+    metadata: undefined,
+    store: undefined,
+    user: undefined,
     text: { verbosity: body.model === "gpt-5-codex" ? "medium" : "low" },
     reasoning: { effort: "medium" },
   }
 }
 
-export function fromOpenaiResponse(resp: any): CommonResponse {
-  if (!resp || typeof resp !== "object") return resp
-  if (Array.isArray((resp as any).choices)) return resp
+export function fromOpenaiResponse(resp: OpenAIResponseWrapper): CommonResponse {
+  if (!resp || typeof resp !== "object") return resp as unknown as CommonResponse
+  if (Array.isArray(resp.choices)) return resp as unknown as CommonResponse
 
-  const r = (resp as any).response ?? resp
-  if (!r || typeof r !== "object") return resp
+  const r = (resp.response ?? resp) as OaiResponse
+  if (!r || typeof r !== "object") return resp as unknown as CommonResponse
 
-  const idIn = (r as any).id
+  const idIn = r.id
   const id =
     typeof idIn === "string" ? idIn.replace(/^resp_/, "chatcmpl_") : `chatcmpl_${Math.random().toString(36).slice(2)}`
-  const model = (r as any).model ?? (resp as any).model
+  const model = r.model ?? resp.model
 
-  const out = Array.isArray((r as any).output) ? (r as any).output : []
+  const out = Array.isArray(r.output) ? r.output : []
   const text = out
-    .filter((o: any) => o && o.type === "message" && Array.isArray((o as any).content))
-    .flatMap((o: any) => (o as any).content)
-    .filter((p: any) => p && p.type === "output_text" && typeof p.text === "string")
-    .map((p: any) => p.text)
+    .filter((o) => o && o.type === "message" && Array.isArray(o.content))
+    .flatMap((o) => o.content)
+    .filter(
+      (p): p is { type?: string; text?: string } => p != null && p.type === "output_text" && typeof p.text === "string",
+    )
+    .map((p) => p.text)
     .join("")
 
   const tcs = out
-    .filter((o: any) => o && o.type === "function_call")
-    .map((o: any) => {
-      const name = (o as any).name
-      const a = (o as any).arguments
+    .filter((o) => o && o.type === "function_call")
+    .map((o) => {
+      const name = o.name ?? ""
+      const a = o.arguments
       const args = typeof a === "string" ? a : JSON.stringify(a ?? {})
-      const tid =
-        typeof (o as any).id === "string" && (o as any).id.length > 0
-          ? (o as any).id
-          : `toolu_${Math.random().toString(36).slice(2)}`
+      const tid = typeof o.id === "string" && o.id.length > 0 ? o.id : `toolu_${Math.random().toString(36).slice(2)}`
       return { id: tid, type: "function" as const, function: { name, arguments: args } }
     })
 
@@ -370,13 +472,13 @@ export function fromOpenaiResponse(resp: any): CommonResponse {
     return null
   }
 
-  const u = (r as any).usage ?? (resp as any).usage
+  const u = r.usage ?? resp.usage
   const usage = (() => {
-    if (!u) return undefined as any
-    const pt = typeof (u as any).input_tokens === "number" ? (u as any).input_tokens : undefined
-    const ct = typeof (u as any).output_tokens === "number" ? (u as any).output_tokens : undefined
+    if (!u) return undefined
+    const pt = typeof u.input_tokens === "number" ? u.input_tokens : undefined
+    const ct = typeof u.output_tokens === "number" ? u.output_tokens : undefined
     const total = pt != null && ct != null ? pt + ct : undefined
-    const cached = (u as any).input_tokens_details?.cached_tokens
+    const cached = u.input_tokens_details?.cached_tokens
     const details = typeof cached === "number" ? { cached_tokens: cached } : undefined
     return {
       prompt_tokens: pt,
@@ -390,7 +492,7 @@ export function fromOpenaiResponse(resp: any): CommonResponse {
     id,
     object: "chat.completion",
     created: Math.floor(Date.now() / 1000),
-    model,
+    model: model ?? "",
     choices: [
       {
         index: 0,
@@ -399,7 +501,7 @@ export function fromOpenaiResponse(resp: any): CommonResponse {
           ...(text && text.length > 0 ? { content: text } : {}),
           ...(tcs.length > 0 ? { tool_calls: tcs } : {}),
         },
-        finish_reason: finish((r as any).stop_reason ?? null),
+        finish_reason: finish(r.stop_reason ?? null),
       },
     ],
     ...(usage ? { usage } : {}),
@@ -408,9 +510,9 @@ export function fromOpenaiResponse(resp: any): CommonResponse {
 
 export function toOpenaiResponse(resp: CommonResponse) {
   if (!resp || typeof resp !== "object") return resp
-  if (!Array.isArray((resp as any).choices)) return resp
+  if (!Array.isArray(resp.choices)) return resp
 
-  const choice = (resp as any).choices[0]
+  const choice = resp.choices[0]
   if (!choice) return resp
 
   const msg = choice.message
@@ -430,13 +532,13 @@ export function toOpenaiResponse(resp: CommonResponse) {
 
   if (Array.isArray(msg.tool_calls)) {
     for (const tc of msg.tool_calls) {
-      if ((tc as any).type === "function" && (tc as any).function) {
+      if (tc.type === "function" && tc.function) {
         outputItems.push({
-          id: (tc as any).id,
+          id: tc.id,
           type: "function_call",
-          name: (tc as any).function.name,
-          call_id: (tc as any).id,
-          arguments: (tc as any).function.arguments,
+          name: tc.function.name,
+          call_id: tc.id,
+          arguments: tc.function.arguments,
         })
       }
     }
@@ -452,7 +554,7 @@ export function toOpenaiResponse(resp: CommonResponse) {
   })()
 
   const usage = (() => {
-    const u = (resp as any).usage
+    const u = resp.usage
     if (!u) return undefined
     return {
       input_tokens: u.prompt_tokens,
@@ -465,9 +567,9 @@ export function toOpenaiResponse(resp: CommonResponse) {
   })()
 
   return {
-    id: (resp as any).id?.replace(/^chatcmpl_/, "resp_") ?? `resp_${Math.random().toString(36).slice(2)}`,
+    id: resp.id?.replace(/^chatcmpl_/, "resp_") ?? `resp_${Math.random().toString(36).slice(2)}`,
     object: "response",
-    model: (resp as any).model,
+    model: resp.model,
     output: outputItems,
     stop_reason,
     usage,
@@ -480,7 +582,7 @@ export function fromOpenaiChunk(chunk: string): CommonChunk | string {
   const dl = lines[1]
   if (!ev || !dl || !dl.startsWith("data: ")) return chunk
 
-  let json: any
+  let json: OaiChunkData
   try {
     json = JSON.parse(dl.slice(6))
   } catch {
@@ -500,14 +602,14 @@ export function fromOpenaiChunk(chunk: string): CommonChunk | string {
   const e = ev.replace("event: ", "").trim()
 
   if (e === "response.output_text.delta") {
-    const d = (json as any).delta ?? (json as any).text ?? (json as any).output_text_delta
+    const d = json.delta ?? json.text ?? json.output_text_delta
     if (typeof d === "string" && d.length > 0)
       out.choices.push({ index: 0, delta: { content: d }, finish_reason: null })
   }
 
-  if (e === "response.output_item.added" && (json as any).item?.type === "function_call") {
-    const name = (json as any).item?.name
-    const id = (json as any).item?.id
+  if (e === "response.output_item.added" && json.item?.type === "function_call") {
+    const name = json.item?.name
+    const id = json.item?.id
     if (typeof name === "string" && name.length > 0) {
       out.choices.push({
         index: 0,
@@ -520,7 +622,7 @@ export function fromOpenaiChunk(chunk: string): CommonChunk | string {
   }
 
   if (e === "response.function_call_arguments.delta") {
-    const a = (json as any).delta ?? (json as any).arguments_delta
+    const a = json.delta ?? json.arguments_delta
     if (typeof a === "string" && a.length > 0) {
       out.choices.push({
         index: 0,
@@ -532,7 +634,7 @@ export function fromOpenaiChunk(chunk: string): CommonChunk | string {
 
   if (e === "response.completed") {
     const fr = (() => {
-      const sr = (respObj as any).stop_reason ?? (json as any).stop_reason
+      const sr = respObj.stop_reason ?? json.stop_reason
       if (sr === "stop") return "stop"
       if (sr === "tool_call" || sr === "tool_calls") return "tool_calls"
       if (sr === "length" || sr === "max_output_tokens") return "length"
@@ -541,7 +643,7 @@ export function fromOpenaiChunk(chunk: string): CommonChunk | string {
     })()
     out.choices.push({ index: 0, delta: {}, finish_reason: fr })
 
-    const u = (respObj as any).usage ?? (json as any).response?.usage
+    const u = respObj.usage ?? json.response?.usage
     if (u) {
       out.usage = {
         prompt_tokens: u.input_tokens,


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#754) was auto-closed by a branch history rewrite.