### PR TITLE
fix: add missing session.get() to TUI plugin state API

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -149,6 +149,9 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
       count() {
         return sync.data.session.length
       },
+      get(sessionID) {
+        return sync.session.get(sessionID)
+      },
       diff(sessionID) {
         return sync.data.session_diff[sessionID] ?? []
       },

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -284,6 +284,7 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
       },
       session: {
         count: opts.state?.session?.count ?? (() => 0),
+        get: opts.state?.session?.get ?? (() => undefined),
         diff: opts.state?.session?.diff ?? (() => []),
         todo: opts.state?.session?.todo ?? (() => []),
         task: opts.state?.session?.task ?? (() => []),

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -5,6 +5,7 @@ import type {
   FilePart,
   LspStatus,
   McpStatus,
+  Session,
   Todo,
   SessionTaskResponse,
   Message,
@@ -275,6 +276,7 @@ export type TuiState = {
   readonly vcs: { branch?: string } | undefined
   session: {
     count: () => number
+    get: (sessionID: string) => Session | undefined
     diff: (sessionID: string) => ReadonlyArray<TuiSidebarFileItem>
     todo: (sessionID: string) => ReadonlyArray<TuiSidebarTodoItem>
     task: (sessionID: string) => ReadonlyArray<TuiSidebarTaskItem>


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#829) was auto-closed by a branch history rewrite.