### PR TITLE
feat(tui): wrap long URLs in session view

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -22,7 +22,7 @@ import { useEvent } from "@tui/context/event"
 import { SplitBorder } from "@tui/component/border"
 import { Spinner } from "@tui/component/spinner"
 import { selectedForeground, useTheme } from "@tui/context/theme"
-import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, RGBA, MouseEvent } from "@opentui/core"
+import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, detectLinks, TextAttributes, RGBA, MouseEvent } from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type {
   AssistantMessage,
@@ -1556,6 +1556,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
           <box paddingLeft={inMinimal() ? 2 : 0} marginTop={1}>
             <code
               filetype="markdown"
+              onChunks={detectLinks}
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={subtleSyntax()}
@@ -1634,6 +1635,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
           <Match when={!Flag.MIMOCODE_EXPERIMENTAL_MARKDOWN}>
             <code
               filetype="markdown"
+              onChunks={detectLinks}
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={syntax()}

--- a/packages/opencode/test/cli/tui/markdown-link-wrap.test.ts
+++ b/packages/opencode/test/cli/tui/markdown-link-wrap.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test"
+import { Readable } from "node:stream"
+import { detectLinks, getLinkId, StyledText, TextRenderable } from "@opentui/core"
+import { createTestRenderer } from "@opentui/core/testing"
+
+// TODO: testRender from @opentui/solid requires resolving the Effect version
+// mismatch in the test environment. Every test that imports `@opentui/solid`
+// fails under bun 1.3.11 (installed) with:
+//   error: Cannot find module 'effect/Context'
+//   SyntaxError: Export named 'Context' not found in module 'effect/dist/index.js'
+// The repo requires bun ^1.3.13 per packageManager field in root package.json.
+// Once that version is available, add Solid-level tests that render the
+// actual `<code filetype="markdown" onChunks={detectLinks}>` element.
+
+function ids(attrs: Uint32Array, cols: number, row: number, len: number) {
+  return new Set(Array.from({ length: len }, (_, i) => getLinkId(attrs[row * cols + i])).filter(Boolean))
+}
+
+async function render(content: string, start: number, end: number) {
+  const chunks = detectLinks(
+    [
+      {
+        __isChunk: true as const,
+        text: content,
+        attributes: 0,
+      },
+    ],
+    {
+      content,
+      highlights: [[start, end, "markup.link.url"]],
+    },
+  )
+
+  const { renderer, renderOnce, captureCharFrame } = await createTestRenderer({
+    width: 20,
+    height: 10,
+    stdin: new Readable({ read() {} }) as NodeJS.ReadStream,
+  })
+
+  try {
+    renderer.root.add(
+      new TextRenderable(renderer, {
+        width: "100%",
+        content: new StyledText(chunks),
+      }),
+    )
+
+    await renderOnce()
+
+    const lines = captureCharFrame()
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .filter(Boolean)
+
+    const attrs = renderer.currentRenderBuffer.buffers.attributes
+    const all = lines.map((line, row) => ids(attrs, renderer.currentRenderBuffer.width, row, line.length))
+    return { chunks, lines, all }
+  } finally {
+    renderer.destroy()
+  }
+}
+
+describe("tui markdown link wrap", () => {
+  test("keeps one hyperlink id across wrapped visual lines", async () => {
+    const url = "file:///tmp/" + "very-long-path/".repeat(4) + "file.txt"
+    const { chunks, lines, all } = await render(url, 0, url.length)
+
+    expect(chunks[0]?.link?.url).toBe(url)
+
+    expect(lines.length).toBeGreaterThan(1)
+    expect(lines.join("")).toBe(url)
+    expect(all[0]!.size).toBe(1)
+    expect(all[1]!.size).toBe(1)
+    expect([...all[0]!][0]).toBeGreaterThan(0)
+
+    for (const row of all) {
+      expect(row.size).toBe(1)
+      expect(row).toEqual(all[0])
+    }
+  })
+
+  test("keeps one hyperlink id across wrapped visual lines for reasoning content", async () => {
+    const url = "file:///tmp/" + "very-long-path/".repeat(4) + "file.txt"
+    const content = "_Thinking:_ " + url
+    const { chunks, lines, all } = await render(content, content.indexOf(url), content.length)
+
+    expect(chunks[0]?.link?.url).toBe(url)
+    expect(lines.length).toBeGreaterThan(1)
+    expect(lines.join("")).toBe(content)
+    expect(all[0]!.size).toBe(1)
+    expect(all[1]!.size).toBe(1)
+    expect([...all[0]!][0]).toBeGreaterThan(0)
+
+    for (const row of all) {
+      expect(row.size).toBe(1)
+      expect(row).toEqual(all[0])
+    }
+  })
+})


### PR DESCRIPTION
Ported from https://github.com/anomalyco/opencode/pull/21559

### Issue for this PR

Closes [Wrapped URLs in session view are not clickable #14966](https://github.com/anomalyco/opencode/issues/14966)

Related: [URLs in session not clickable #18394](https://github.com/anomalyco/opencode/issues/18394)
Overlaps: [fix(tui): detectLinks for markdown #20400](https://github.com/anomalyco/opencode/issues/20400)
Upstream: anomalyco/opentui#735, anomalyco/opentui#736, anomalyco/opentui#737

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Wires `detectLinks` into the non-experimental markdown `<code filetype="markdown">` path in TUI session rendering.

This ensures tree-sitter markdown chunks carry hyperlink metadata so wrapped markdown URLs remain one clickable OSC 8 target instead of relying on terminal auto-detection at visual wraps.

### Why use this instead of [fix(tui): detectLinks for markdown #20400](https://github.com/anomalyco/opencode/issues/20400)?

`[fix(tui): detectLinks for markdown #20400](https://github.com/anomalyco/opencode/issues/20400)` proves the same minimal code path, but it relies on manual verification only.

This PR keeps the fix small and in the same location, but adds renderer-level regression coverage for the wrapped-link behavior. The new test renders a super-long file URL through OpenTUI test renderer, verifies the wrapped lines reconstruct the original URL, and verifies every wrapped line carries the same nonzero hyperlink identity across the row boundary.

That makes this PR safer to merge and maintain because the exact wrap regression now has an automated test instead of depending on a terminal-specific manual check.

### How did you verify your code works?

- Added renderer-level regression coverage in `packages/opencode/test/cli/tui/markdown-link-wrap.test.ts`
- `bun test --timeout 30000 packages/opencode/test/cli/tui/markdown-link-wrap.test.ts`
- `bun typecheck` in `packages/opencode`

### Screenshots / recordings

_Not a UI screenshot change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

### Note on force pushes to main

This PR was originally raised as #596 but was auto-closed when the `main` branch was force-pushed (see [#760](https://github.com/XiaomiMiMo/MiMo-Code/issues/760)). Force-pushing to a shared branch breaks PR reopenability and orphans review comments.

[#1010](https://github.com/XiaomiMiMo/MiMo-Code/issues/1010) is a duplicate of this PR and can be closed once this is merged.
