### PR TITLE
test(write): add umask tests for deterministic file permissions

### DIFF
--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -133,7 +133,7 @@ describe("tool.write", () => {
 
     const writeAndCheckMode = (dir: string, umask: number, expected: number) =>
       Effect.gen(function* () {
-        if (process.platform === "win32") return
+        if (process.platform === "win32" || typeof process.umask !== "function") return
         const filepath = path.join(dir, "sensitive.json")
         const prev = process.umask(umask)
         try {
@@ -158,9 +158,7 @@ describe("tool.write", () => {
       provideTmpdirInstance((dir) => writeAndCheckMode(dir, 0o077, base & ~0o077)),
     )
     it.live("0o777 fully masks the 0o666 base mode", () =>
-      Effect.sync(() => {
-        expect(base & ~0o777).toBe(0o000)
-      }),
+      provideTmpdirInstance((dir) => writeAndCheckMode(dir, 0o777, base & ~0o777)),
     )
   })
 

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -135,14 +135,16 @@ describe("tool.write", () => {
       Effect.gen(function* () {
         if (process.platform === "win32" || typeof process.umask !== "function") return
         const filepath = path.join(dir, "sensitive.json")
-        const prev = process.umask(umask)
-        try {
-          yield* run({ filePath: filepath, content: JSON.stringify({ secret: "data" }) })
-          const stats = yield* Effect.promise(() => fs.stat(filepath))
-          expect(stats.mode & 0o777).toBe(expected)
-        } finally {
-          process.umask(prev)
-        }
+        yield* Effect.acquireUseRelease(
+          Effect.sync(() => process.umask(umask)),
+          () =>
+            Effect.gen(function* () {
+              yield* run({ filePath: filepath, content: JSON.stringify({ secret: "data" }) })
+              const stats = yield* Effect.promise(() => fs.stat(filepath))
+              expect(stats.mode & 0o777).toBe(expected)
+            }),
+          (prev) => Effect.sync(() => process.umask(prev)),
+        )
       })
 
     it.live("base mode is 0o666 before umask masking", () =>

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -129,18 +129,38 @@ describe("tool.write", () => {
   })
 
   describe("file permissions", () => {
-    it.live("sets file permissions when writing sensitive data", () =>
-      provideTmpdirInstance((dir) =>
-        Effect.gen(function* () {
-          const filepath = path.join(dir, "sensitive.json")
-          yield* run({ filePath: filepath, content: JSON.stringify({ secret: "data" }) })
+    const base = 0o666
 
-          if (process.platform !== "win32") {
-            const stats = yield* Effect.promise(() => fs.stat(filepath))
-            expect(stats.mode & 0o777).toBe(0o644)
-          }
-        }),
-      ),
+    const writeAndCheckMode = (dir: string, umask: number, expected: number) =>
+      Effect.gen(function* () {
+        if (process.platform === "win32") return
+        const filepath = path.join(dir, "sensitive.json")
+        const prev = process.umask(umask)
+        try {
+          yield* run({ filePath: filepath, content: JSON.stringify({ secret: "data" }) })
+          const stats = yield* Effect.promise(() => fs.stat(filepath))
+          expect(stats.mode & 0o777).toBe(expected)
+        } finally {
+          process.umask(prev)
+        }
+      })
+
+    it.live("base mode is 0o666 before umask masking", () =>
+      provideTmpdirInstance((dir) => writeAndCheckMode(dir, 0o000, base)),
+    )
+    it.live("respects umask 0o022 → 0o644", () =>
+      provideTmpdirInstance((dir) => writeAndCheckMode(dir, 0o022, base & ~0o022)),
+    )
+    it.live("respects corner umask 0o027 → 0o640", () =>
+      provideTmpdirInstance((dir) => writeAndCheckMode(dir, 0o027, base & ~0o027)),
+    )
+    it.live("respects umask 0o077 → 0o600", () =>
+      provideTmpdirInstance((dir) => writeAndCheckMode(dir, 0o077, base & ~0o077)),
+    )
+    it.live("0o777 fully masks the 0o666 base mode", () =>
+      Effect.sync(() => {
+        expect(base & ~0o777).toBe(0o000)
+      }),
     )
   })
 


### PR DESCRIPTION
Ported from https://github.com/anomalyco/opencode/pull/21233

### Issue for this PR

Fixes [tool.write should enforce 0644 file mode despite umask #19076](https://github.com/anomalyco/opencode/issues/19076)

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This keeps the PR surgical and limited to `packages/opencode/test/tool/write.test.ts`.

It updates the write-permission tests to reflect the actual contract: the write path respects the process umask instead of forcing a fixed `0644` file mode.

The permission coverage now models the real base mode and masking behavior directly:

- `0o000` confirms the unmasked base mode is `0o666`
- `0o022` confirms the common masked result is `0o644`
- `0o027` covers the corner case where the masked result is `0o640`
- `0o077` confirms a restrictive mask produces `0o600`
- `0o777` is kept as a math-only assertion so the suite documents the full masking boundary without creating an unreadable file in-process

This also avoids the competing approach in [fix(write): enforce explicit file mode despite umask #19077](https://github.com/anomalyco/opencode/issues/19077), which forces `0644` after write and would loosen a user's explicit umask-based security boundary.

### How did you verify your code works?

- Verified the PR diff is a single-file change with no unrelated files included.
- Confirmed `packages/opencode/test/tool/write.test.ts` is clean under LSP diagnostics.
- Ran `bun install` to bootstrap the worktree-local dependencies.
- Ran `bun test test/tool/write.test.ts` → 17 pass, 0 fail.
- Ran `bun typecheck` in `packages/opencode` → pass.

### Screenshots / recordings

N/A — non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

### Note on force pushes to main

This PR was originally raised as #593 but was auto-closed when the `main` branch was force-pushed (see [#760](https://github.com/XiaomiMiMo/MiMo-Code/issues/760)). Force-pushing to a shared branch breaks PR reopenability and orphans review comments.
