### PR TITLE
fix(cli): enable VT processing on Windows to prevent garbled ANSI output

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -14,7 +14,7 @@ import {
   batch,
   Show,
 } from "solid-js"
-import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
+import { win32DisableProcessedInput, win32EnableVTProcessing, win32InstallCtrlCGuard } from "./win32"
 import { Flag } from "@/flag/flag"
 import semver from "semver"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
@@ -138,6 +138,7 @@ export function tui(input: {
   return new Promise<void>(async (resolve) => {
     const unguard = win32InstallCtrlCGuard()
     win32DisableProcessedInput()
+    win32EnableVTProcessing()
 
     const onExit = async () => {
       unguard?.()

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1525,7 +1525,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
   const [expanded, setExpanded] = createSignal(false)
 
   const content = createMemo(() => {
-    return props.part.text.replace("[REDACTED]", "").trim()
+    return stripAnsi(props.part.text.replace("[REDACTED]", "").trim())
   })
   const isDone = createMemo(() => props.part.time.end !== undefined)
   const inMinimal = createMemo(() => ctx.thinkingMode() === "hide")
@@ -1617,15 +1617,16 @@ function ReasoningHeader(props: {
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const cleanText = createMemo(() => stripAnsi(props.part.text.trim()))
   return (
-    <Show when={props.part.text.trim()}>
+    <Show when={cleanText()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <Switch>
           <Match when={Flag.MIMOCODE_EXPERIMENTAL_MARKDOWN}>
             <markdown
               syntaxStyle={syntax()}
               streaming={true}
-              content={props.part.text.trim()}
+              content={cleanText()}
               conceal={ctx.conceal()}
               fg={theme.markdownText}
               bg={theme.background}
@@ -1637,7 +1638,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={syntax()}
-              content={props.part.text.trim()}
+              content={cleanText()}
               conceal={ctx.conceal()}
               fg={theme.text}
             />

--- a/packages/opencode/src/cli/cmd/tui/win32.ts
+++ b/packages/opencode/src/cli/cmd/tui/win32.ts
@@ -2,7 +2,10 @@ import { dlopen, ptr } from "bun:ffi"
 import type { ReadStream } from "node:tty"
 
 const STD_INPUT_HANDLE = -10
+const STD_OUTPUT_HANDLE = -11
 const ENABLE_PROCESSED_INPUT = 0x0001
+const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200
 
 const kernel = () =>
   dlopen("kernel32.dll", {
@@ -21,6 +24,37 @@ function load() {
     return true
   } catch {
     return false
+  }
+}
+
+/**
+ * Enable VT (Virtual Terminal) processing on both stdin and stdout.
+ *
+ * Without ENABLE_VIRTUAL_TERMINAL_INPUT on stdin, the terminal echoes mouse
+ * tracking reports as raw text (e.g. "[55;65;1M") instead of delivering them
+ * as input events. Without ENABLE_VIRTUAL_TERMINAL_PROCESSING on stdout,
+ * ANSI escape sequences may not be processed correctly.
+ */
+export function win32EnableVTProcessing() {
+  if (process.platform !== "win32") return
+  if (!load()) return
+
+  // Enable VT input on stdin so mouse/key events arrive as VT sequences
+  if (process.stdin.isTTY) {
+    const stdinHandle = k32!.symbols.GetStdHandle(STD_INPUT_HANDLE)
+    const buf = new Uint32Array(1)
+    if (k32!.symbols.GetConsoleMode(stdinHandle, ptr(buf)) !== 0) {
+      k32!.symbols.SetConsoleMode(stdinHandle, buf[0]! | ENABLE_VIRTUAL_TERMINAL_INPUT)
+    }
+  }
+
+  // Enable VT output on stdout so ANSI escape sequences render correctly
+  if (process.stdout.isTTY) {
+    const stdoutHandle = k32!.symbols.GetStdHandle(STD_OUTPUT_HANDLE)
+    const buf = new Uint32Array(1)
+    if (k32!.symbols.GetConsoleMode(stdoutHandle, ptr(buf)) !== 0) {
+      k32!.symbols.SetConsoleMode(stdoutHandle, buf[0]! | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+    }
   }
 }
 
@@ -84,8 +118,8 @@ export function win32InstallCtrlCGuard() {
   const enforce = () => {
     if (k32!.symbols.GetConsoleMode(handle, ptr(buf)) === 0) return
     const mode = buf[0]!
-    if ((mode & ENABLE_PROCESSED_INPUT) === 0) return
-    k32!.symbols.SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)
+    const desired = (mode & ~ENABLE_PROCESSED_INPUT) | ENABLE_VIRTUAL_TERMINAL_INPUT
+    if (desired !== mode) k32!.symbols.SetConsoleMode(handle, desired)
   }
 
   // Some runtimes can re-apply console modes on the next tick; enforce twice.


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#698) was auto-closed by a branch history rewrite.