### PR TITLE
feat(tui): wrap long URLs in session view

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -22,7 +22,7 @@ import { useEvent } from "@tui/context/event"
 import { SplitBorder } from "@tui/component/border"
 import { Spinner } from "@tui/component/spinner"
 import { selectedForeground, useTheme } from "@tui/context/theme"
-import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, RGBA, MouseEvent } from "@opentui/core"
+import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, detectLinks, TextAttributes, RGBA, MouseEvent } from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type {
   AssistantMessage,
@@ -1556,6 +1556,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
           <box paddingLeft={inMinimal() ? 2 : 0} marginTop={1}>
             <code
               filetype="markdown"
+              onChunks={detectLinks}
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={subtleSyntax()}
@@ -1634,6 +1635,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
           <Match when={!Flag.MIMOCODE_EXPERIMENTAL_MARKDOWN}>
             <code
               filetype="markdown"
+              onChunks={detectLinks}
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={syntax()}

--- a/packages/opencode/test/cli/tui/markdown-link-wrap.test.ts
+++ b/packages/opencode/test/cli/tui/markdown-link-wrap.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test"
+import { Readable } from "node:stream"
+import { detectLinks, getLinkId, StyledText, TextRenderable } from "@opentui/core"
+import { createTestRenderer } from "@opentui/core/testing"
+
+// TODO: testRender from @opentui/solid requires resolving the Effect version
+// mismatch in the test environment. Every test that imports `@opentui/solid`
+// fails under bun 1.3.11 (installed) with:
+//   error: Cannot find module 'effect/Context'
+//   SyntaxError: Export named 'Context' not found in module 'effect/dist/index.js'
+// The repo requires bun ^1.3.13 per packageManager field in root package.json.
+// Once that version is available, add Solid-level tests that render the
+// actual `<code filetype="markdown" onChunks={detectLinks}>` element.
+
+function ids(attrs: Uint32Array, cols: number, row: number, len: number) {
+  return new Set(Array.from({ length: len }, (_, i) => getLinkId(attrs[row * cols + i])).filter(Boolean))
+}
+
+async function render(content: string, start: number, end: number) {
+  const chunks = detectLinks(
+    [
+      {
+        __isChunk: true as const,
+        text: content,
+        attributes: 0,
+      },
+    ],
+    {
+      content,
+      highlights: [[start, end, "markup.link.url"]],
+    },
+  )
+
+  const { renderer, renderOnce, captureCharFrame } = await createTestRenderer({
+    width: 20,
+    height: 10,
+    stdin: new Readable({ read() {} }) as NodeJS.ReadStream,
+  })
+
+  try {
+    renderer.root.add(
+      new TextRenderable(renderer, {
+        width: "100%",
+        content: new StyledText(chunks),
+      }),
+    )
+
+    await renderOnce()
+
+    const lines = captureCharFrame()
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .filter(Boolean)
+
+    const attrs = renderer.currentRenderBuffer.buffers.attributes
+    const all = lines.map((line, row) => ids(attrs, renderer.currentRenderBuffer.width, row, line.length))
+    return { chunks, lines, all }
+  } finally {
+    renderer.destroy()
+  }
+}
+
+describe("tui markdown link wrap", () => {
+  test("keeps one hyperlink id across wrapped visual lines", async () => {
+    const url = "file:///tmp/" + "very-long-path/".repeat(4) + "file.txt"
+    const { chunks, lines, all } = await render(url, 0, url.length)
+
+    expect(chunks[0]?.link?.url).toBe(url)
+
+    expect(lines.length).toBeGreaterThan(1)
+    expect(lines.join("")).toBe(url)
+    expect(all[0]!.size).toBe(1)
+    expect(all[1]!.size).toBe(1)
+    expect([...all[0]!][0]).toBeGreaterThan(0)
+
+    for (const row of all) {
+      expect(row.size).toBe(1)
+      expect(row).toEqual(all[0])
+    }
+  })
+
+  test("keeps one hyperlink id across wrapped visual lines for reasoning content", async () => {
+    const url = "file:///tmp/" + "very-long-path/".repeat(4) + "file.txt"
+    const content = "_Thinking:_ " + url
+    const { chunks, lines, all } = await render(content, content.indexOf(url), content.length)
+
+    expect(chunks[0]?.link?.url).toBe(url)
+    expect(lines.length).toBeGreaterThan(1)
+    expect(lines.join("")).toBe(content)
+    expect(all[0]!.size).toBe(1)
+    expect(all[1]!.size).toBe(1)
+    expect([...all[0]!][0]).toBeGreaterThan(0)
+
+    for (const row of all) {
+      expect(row.size).toBe(1)
+      expect(row).toEqual(all[0])
+    }
+  })
+})


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#596) was auto-closed by a branch history rewrite.