### PR TITLE
fix: evict completed WorkflowRuntime entries from runs Map

### DIFF
--- a/packages/opencode/src/workflow/runtime.ts
+++ b/packages/opencode/src/workflow/runtime.ts
@@ -355,6 +355,9 @@ export const layer = Layer.effect(
         entry.status = "cancelled"
         yield* Deferred.succeed(entry.deferred, { status: "cancelled" })
         yield* bus.publish(WorkflowFinished, { sessionID: entry.sessionID, runID: entry.runID, status: "cancelled" })
+        // Evict the cancelled entry after a grace period so status/wait
+        // callers can still read the terminal outcome briefly.
+        setTimeout(() => runs.delete(entry.runID), 30_000)
       })
 
     const waitFor = (childRunID: string) =>
@@ -1066,6 +1069,9 @@ export const layer = Layer.effect(
               content: `Workflow completed. run_id: ${runID}\n` + JSON.stringify(result.success ?? null).slice(0, 4000),
             })
             .pipe(Effect.ignore)
+          // Evict the completed entry after a grace period so status/wait
+          // callers can still read the terminal outcome briefly.
+          setTimeout(() => runs.delete(runID), 30_000)
           return
         }
         // Non-success terminal: reclaim in-flight agents + worktrees so a
@@ -1089,6 +1095,8 @@ export const layer = Layer.effect(
             content: `Workflow failed. run_id: ${runID}\nerror: ${error}`,
           })
           .pipe(Effect.ignore)
+        // Evict the failed entry after a grace period.
+        setTimeout(() => runs.delete(runID), 30_000)
       })
 
       entry.fiber = yield* work.pipe(Effect.forkIn(scope))

--- a/packages/opencode/test/workflow/runtime.test.ts
+++ b/packages/opencode/test/workflow/runtime.test.ts
@@ -354,6 +354,38 @@ describe("WorkflowRuntime cancel cascade", () => {
     ),
     20000,
   )
+
+  it.live("cancelled run is evicted from the runs Map after grace period", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const runtime = yield* WorkflowRuntime.Service
+        const session = yield* Session.Service
+        const parent = yield* session.create({
+          title: "wf cancel eviction",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* llm.hang
+        const script = [
+          `export const meta = { name: "t", description: "d" }`,
+          `return await agent("a")`,
+        ].join("\n")
+        const { runID } = yield* runtime.start({ script, sessionID: parent.id, parentActorID: "main", model: ref })
+        yield* Effect.sleep("250 millis")
+        yield* runtime.cancel({ runID })
+
+        // Immediately after cancel, status should be "cancelled" (still in Map)
+        const s1 = yield* runtime.status({ runID })
+        expect(s1.status).toBe("cancelled")
+
+        // After the 30s grace period, the entry should be evicted
+        yield* Effect.sleep("31 seconds")
+        const s2 = yield* runtime.status({ runID })
+        expect(s2.status).toBe("unknown")
+      }),
+      { git: true, config: providerCfg },
+    ),
+    45000,
+  )
 })
 
 describe("WorkflowRuntime concurrency clamp", () => {


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#468) was auto-closed by a branch history rewrite.