### PR TITLE
fix(tui): context meter shows summarize call usage right after compaction

### DIFF
--- a/packages/app/src/components/session/session-context-metrics.test.ts
+++ b/packages/app/src/components/session/session-context-metrics.test.ts
@@ -92,6 +92,34 @@ describe("getSessionContextMetrics", () => {
     expect(two.totalCost).toBe(1)
   })
 
+  test("counts only output tokens when latest assistant is a compaction summary", () => {
+    const summary = {
+      ...(assistant("a2", { input: 900000, output: 8000, reasoning: 2000, read: 50000, write: 0 }, 0) as object),
+      summary: true,
+    } as unknown as Message
+    const messages = [
+      user("u1"),
+      assistant("a1", { input: 300000, output: 50000, reasoning: 0, read: 50000, write: 0 }, 1),
+      summary,
+    ]
+    const providers = [
+      {
+        id: "openai",
+        models: {
+          "gpt-4.1": {
+            limit: { context: 1000000 },
+          },
+        },
+      },
+    ]
+
+    const metrics = getSessionContextMetrics(messages, providers)
+
+    expect(metrics.context?.message.id).toBe("a2")
+    expect(metrics.context?.total).toBe(8000)
+    expect(metrics.context?.usage).toBe(1)
+  })
+
   test("returns empty metrics when inputs are undefined", () => {
     const metrics = getSessionContextMetrics(undefined, undefined)
 

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -38,6 +38,14 @@ const tokenTotal = (msg: AssistantMessage) => {
   return msg.tokens.input + msg.tokens.output + msg.tokens.reasoning + msg.tokens.cache.read + msg.tokens.cache.write
 }
 
+// A compaction summary's input/cache tokens describe the discarded pre-compact
+// history it summarized; only its output (the summary text that seeds the new
+// context window) counts toward occupancy.
+const contextTotal = (msg: AssistantMessage) => {
+  if (msg.summary) return msg.tokens.output
+  return tokenTotal(msg)
+}
+
 const lastAssistantWithTokens = (messages: Message[]) => {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i]
@@ -55,7 +63,7 @@ const build = (messages: Message[] = [], providers: Provider[] = []): Metrics =>
   const provider = providers.find((item) => item.id === message.providerID)
   const model = provider?.models[message.modelID]
   const limit = model?.limit.context
-  const total = tokenTotal(message)
+  const total = contextTotal(message)
 
   return {
     totalCost,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -25,6 +25,7 @@ import { useLanguage } from "@tui/context/language"
 import { useRenderer, type JSX } from "@opentui/solid"
 import * as Editor from "@tui/util/editor"
 import * as Voice from "@tui/util/voice"
+import { contextTokens } from "@tui/util/context-tokens"
 import { useExit } from "../../context/exit"
 import * as Clipboard from "../../util/clipboard"
 import type { AssistantMessage, FilePart, UserMessage } from "@mimo-ai/sdk/v2"
@@ -463,8 +464,7 @@ export function Prompt(props: PromptProps) {
     const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
     if (!last) return
 
-    const tokens =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
+    const tokens = contextTokens(last)
     if (tokens <= 0) return
 
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@mimo-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi, TuiPluginModule } from "@mimo-ai/plugin/tui"
 import { Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import { completedTPS, formatTPS, streamingTPS } from "./tps"
+import { contextTokens } from "@tui/util/context-tokens"
 
 const id = "internal:sidebar-context"
 const REFRESH_MS = 1000
@@ -73,8 +74,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       }
     }
 
-    const tokens =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
+    const tokens = contextTokens(last)
     const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     return {
       tokens,

--- a/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
@@ -6,6 +6,7 @@ import { SplitBorder } from "@tui/component/border"
 import type { AssistantMessage } from "@mimo-ai/sdk/v2"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useKeybind } from "../../context/keybind"
+import { contextTokens } from "@tui/util/context-tokens"
 import { Locale } from "@/util"
 import { useTerminalDimensions } from "@opentui/solid"
 
@@ -43,12 +44,7 @@ export function SubagentFooter() {
       (item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0,
     )
     if (!last) return
-    const tokens =
-      last.tokens.input +
-      last.tokens.output +
-      last.tokens.reasoning +
-      last.tokens.cache.read +
-      last.tokens.cache.write
+    const tokens = contextTokens(last)
     if (tokens <= 0) return
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     const pct = model?.limit.context

--- a/packages/opencode/src/cli/cmd/tui/util/context-tokens.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/context-tokens.ts
@@ -1,0 +1,16 @@
+import type { AssistantMessage } from "@mimo-ai/sdk/v2"
+
+// Context occupancy represented by the latest assistant message. A compaction
+// summary's input/cache tokens describe the discarded pre-compact history it
+// was asked to summarize, so only its output — the summary text that seeds the
+// new context window — counts toward occupancy.
+export function contextTokens(message: AssistantMessage): number {
+  if (message.summary) return message.tokens.output
+  return (
+    message.tokens.input +
+    message.tokens.output +
+    message.tokens.reasoning +
+    message.tokens.cache.read +
+    message.tokens.cache.write
+  )
+}

--- a/packages/opencode/test/cli/tui/context-tokens.test.ts
+++ b/packages/opencode/test/cli/tui/context-tokens.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import type { AssistantMessage } from "@mimo-ai/sdk/v2"
+import { contextTokens } from "../../../src/cli/cmd/tui/util/context-tokens"
+
+const message = (input: {
+  input: number
+  output: number
+  reasoning: number
+  read: number
+  write: number
+  summary?: boolean
+}) => {
+  return {
+    role: "assistant",
+    summary: input.summary,
+    tokens: {
+      input: input.input,
+      output: input.output,
+      reasoning: input.reasoning,
+      cache: { read: input.read, write: input.write },
+    },
+  } as unknown as AssistantMessage
+}
+
+test("sums every token class for a normal assistant message", () => {
+  const tokens = contextTokens(message({ input: 300, output: 100, reasoning: 50, read: 25, write: 25 }))
+  expect(tokens).toBe(500)
+})
+
+test("counts only output for a compaction summary message", () => {
+  const tokens = contextTokens(
+    message({ input: 900000, output: 8000, reasoning: 2000, read: 50000, write: 0, summary: true }),
+  )
+  expect(tokens).toBe(8000)
+})


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#445) was auto-closed by a branch history rewrite.