### PR TITLE
fix(install): show shell refresh hint after PATH update

### DIFF
--- a/install
+++ b/install
@@ -411,6 +411,7 @@ case $current_shell in
 esac
 
 if [[ "$no_modify_path" != "true" ]]; then
+    refresh_hint_command=""
     config_file=""
     for file in $config_files; do
         if [[ -f $file ]]; then
@@ -426,18 +427,23 @@ if [[ "$no_modify_path" != "true" ]]; then
         case $current_shell in
             fish)
                 add_to_path "$config_file" "fish_add_path $INSTALL_DIR"
+                refresh_hint_command="source $config_file"
             ;;
             zsh)
                 add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+                refresh_hint_command="source $config_file"
             ;;
             bash)
                 add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+                refresh_hint_command="source $config_file"
             ;;
             ash)
                 add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+                refresh_hint_command="source $config_file"
             ;;
             sh)
                 add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+                refresh_hint_command="source $config_file"
             ;;
             *)
                 export PATH=$INSTALL_DIR:$PATH
@@ -445,6 +451,11 @@ if [[ "$no_modify_path" != "true" ]]; then
                 print_message info "  export PATH=$INSTALL_DIR:\$PATH"
             ;;
         esac
+    fi
+
+    if [[ -n "$refresh_hint_command" ]]; then
+        print_message info "${MUTED}Open a new terminal or run:${NC}"
+        print_message info "  $refresh_hint_command"
     fi
 fi
 

--- a/packages/opencode/test/install-script.test.ts
+++ b/packages/opencode/test/install-script.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import { spawn } from "child_process"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+
+async function tmpdir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "mimocode-install-test-"))
+  return {
+    path: dir,
+    async [Symbol.asyncDispose]() {
+      await fs.rm(dir, { recursive: true, force: true })
+    },
+  }
+}
+
+async function runInstall(tmp: string) {
+  return new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
+    const proc = spawn("bash", [path.join(import.meta.dir, "..", "..", "..", "install"), "--binary", path.join(tmp, "mimo")], {
+      env: {
+        ...process.env,
+        HOME: path.join(tmp, "home"),
+        SHELL: "/bin/zsh",
+        PATH: process.env.PATH ?? "",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    let stdout = ""
+    let stderr = ""
+    proc.stdout.on("data", (chunk) => {
+      stdout += chunk.toString()
+    })
+    proc.stderr.on("data", (chunk) => {
+      stderr += chunk.toString()
+    })
+    proc.on("close", (code) => resolve({ code, stdout, stderr }))
+  })
+}
+
+describe("install script", () => {
+  test("prints a shell refresh hint after adding mimo to shell config", async () => {
+    await using tmp = await tmpdir()
+    await fs.mkdir(path.join(tmp.path, "home"), { recursive: true })
+    await fs.writeFile(path.join(tmp.path, "home", ".zshrc"), "# test shell config\n")
+    await fs.writeFile(path.join(tmp.path, "mimo"), "#!/usr/bin/env sh\n")
+
+    const result = await runInstall(tmp.path)
+
+    expect(result.code).toBe(0)
+    expect(await fs.readFile(path.join(tmp.path, "home", ".zshrc"), "utf8")).toContain(
+      `export PATH=${path.join(tmp.path, "home", ".mimocode", "bin")}:$PATH`,
+    )
+    expect(result.stdout + result.stderr).toContain("Open a new terminal or run:")
+    expect(result.stdout + result.stderr).toContain(`source ${path.join(tmp.path, "home", ".zshrc")}`)
+  })
+})


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#378) was auto-closed by a branch history rewrite.