### PR TITLE
fix: omit unsupported image attachments from prompts

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -11,7 +11,7 @@ import { MessageTable, PartTable, SessionTable } from "./session.sql"
 import { ProviderError } from "@/provider"
 import { iife } from "@/util/iife"
 import { errorMessage } from "@/util/error"
-import { isMedia } from "@/util/media"
+import { isMedia, isSupportedMediaAttachment } from "@/util/media"
 import type { SystemError } from "bun"
 import type { Provider } from "@/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
@@ -610,6 +610,14 @@ function providerMeta(metadata: Record<string, any> | undefined) {
   return Object.keys(rest).length > 0 ? rest : undefined
 }
 
+function unsupportedImageAttachmentText(input: { mime: string; filename?: string }) {
+  return `[Unsupported image attachment omitted: ${input.filename ?? "file"} (${input.mime})]`
+}
+
+function isUnsupportedImageAttachment(mime: string) {
+  return mime.startsWith("image/") && !isSupportedMediaAttachment(mime)
+}
+
 export const toModelMessagesEffect = Effect.fnUntraced(function* (
   input: WithParts[],
   model: Provider.Model,
@@ -687,7 +695,12 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           })
         // text/plain and directory files are converted into text parts, ignore them
         if (part.type === "file" && part.mime !== "text/plain" && part.mime !== "application/x-directory") {
-          if (options?.stripMedia && isMedia(part.mime)) {
+          if (isUnsupportedImageAttachment(part.mime)) {
+            userMessage.parts.push({
+              type: "text",
+              text: unsupportedImageAttachmentText(part),
+            })
+          } else if (options?.stripMedia && isMedia(part.mime)) {
             userMessage.parts.push({
               type: "text",
               text: `[Attached ${part.mime}: ${part.filename ?? "file"}]`,
@@ -755,17 +768,24 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         if (part.type === "tool") {
           toolNames.add(part.tool)
           if (part.state.status === "completed") {
-            const outputText = part.state.time.compacted ? "[Old tool result content cleared]" : part.state.output
             const attachments = part.state.time.compacted || options?.stripMedia ? [] : (part.state.attachments ?? [])
+            const unsupportedImageAttachments = attachments.filter((a) => isUnsupportedImageAttachment(a.mime))
+            const supportedAttachments = attachments.filter((a) => !isUnsupportedImageAttachment(a.mime))
+            const outputText = [
+              part.state.time.compacted ? "[Old tool result content cleared]" : part.state.output,
+              unsupportedImageAttachments.map(unsupportedImageAttachmentText).join("\n"),
+            ]
+              .filter((item) => item.length > 0)
+              .join("\n\n")
 
             // For providers that don't support media in tool results, extract media files
             // (images, PDFs) to be sent as a separate user message
-            const mediaAttachments = attachments.filter((a) => isMedia(a.mime))
-            const nonMediaAttachments = attachments.filter((a) => !isMedia(a.mime))
+            const mediaAttachments = supportedAttachments.filter((a) => isMedia(a.mime))
+            const nonMediaAttachments = supportedAttachments.filter((a) => !isMedia(a.mime))
             if (!supportsMediaInToolResults && mediaAttachments.length > 0) {
               media.push(...mediaAttachments)
             }
-            const finalAttachments = supportsMediaInToolResults ? attachments : nonMediaAttachments
+            const finalAttachments = supportsMediaInToolResults ? supportedAttachments : nonMediaAttachments
 
             const output =
               finalAttachments.length > 0

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -11,7 +11,7 @@ import { Instance } from "../project/instance"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { SessionCwd } from "./session-cwd"
 import { Instruction } from "../session/instruction"
-import { isImageAttachment, isPdfAttachment, sniffAttachmentMime } from "@/util/media"
+import { isImageAttachment, isPdfAttachment, isSupportedMediaAttachment, sniffAttachmentMime } from "@/util/media"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
@@ -208,7 +208,12 @@ export const ReadTool = Tool.define(
       const sample = yield* readSample(filepath, Number(stat.size), SAMPLE_BYTES)
 
       const mime = sniffAttachmentMime(sample, AppFileSystem.mimeType(filepath))
-      if (isImageAttachment(mime) || isPdfAttachment(mime)) {
+      if (isImageAttachment(mime) && !isSupportedMediaAttachment(mime)) {
+        return yield* Effect.fail(
+          new Error(`Unsupported image format: ${mime}. Supported formats: bmp, gif, png, jpeg, webp`),
+        )
+      }
+      if (isSupportedMediaAttachment(mime)) {
         const bytes = yield* fs.readFile(filepath)
         const msg = isPdfAttachment(mime) ? "PDF read successfully" : "Image read successfully"
         return {

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -12,6 +12,14 @@ export function isImageAttachment(mime: string) {
   return mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
 }
 
+export function isSupportedImageAttachment(mime: string) {
+  return ["image/bmp", "image/gif", "image/png", "image/jpeg", "image/webp"].includes(mime.toLowerCase())
+}
+
+export function isSupportedMediaAttachment(mime: string) {
+  return isPdfAttachment(mime) || isSupportedImageAttachment(mime)
+}
+
 export function sniffAttachmentMime(bytes: Uint8Array, fallback: string) {
   if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png"
   if (startsWith(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg"

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -262,6 +262,40 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("omits unsupported user image attachments", async () => {
+    const messageID = "m-user-unsupported-image"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(messageID),
+        parts: [
+          {
+            ...basePart(messageID, "p1"),
+            type: "text",
+            text: "describe this",
+          },
+          {
+            ...basePart(messageID, "p2"),
+            type: "file",
+            mime: "image/x-icon",
+            filename: "icon.ico",
+            url: "data:image/x-icon;base64,AAAB",
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          { type: "text", text: "[Unsupported image attachment omitted: icon.ico (image/x-icon)]" },
+        ],
+      },
+    ])
+  })
+
   test("extracts tool-result media into a user message for openai models", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"
@@ -357,6 +391,85 @@ describe("session.message-v2.toModelMessage", () => {
             mediaType: "image/png",
             filename: "attachment.png",
             data: "data:image/png;base64,Zm9v",
+          },
+        ],
+      },
+    ])
+  })
+
+  test("omits unsupported tool-result image attachments from follow-up requests", async () => {
+    const userID = "m-user-unsupported-tool-image"
+    const assistantID = "m-assistant-unsupported-tool-image"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "read icon",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-icon",
+            tool: "read",
+            state: {
+              status: "completed",
+              input: { filePath: "/tmp/icon.ico" },
+              output: "Image read successfully",
+              title: "Read",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments: [
+                {
+                  ...basePart(assistantID, "file-icon"),
+                  type: "file",
+                  mime: "image/x-icon",
+                  filename: "icon.ico",
+                  url: "data:image/x-icon;base64,AAAB",
+                },
+              ],
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "read icon" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-icon",
+            toolName: "read",
+            input: { filePath: "/tmp/icon.ico" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-icon",
+            toolName: "read",
+            output: {
+              type: "text",
+              value: "Image read successfully\n\n[Unsupported image attachment omitted: icon.ico (image/x-icon)]",
+            },
           },
         ],
       },

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -407,6 +407,17 @@ describe("tool.read truncation", () => {
     }),
   )
 
+  it.live("rejects unsupported image formats instead of attaching them", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "icon.ico"), Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00]))
+
+      const err = yield* fail(dir, { filePath: path.join(dir, "icon.ico") })
+      expect(err.message).toContain("Unsupported image format:")
+      expect(err.message).toContain("Supported formats: bmp, gif, png, jpeg, webp")
+    }),
+  )
+
   it.live("large image files are properly attached without error", () =>
     Effect.gen(function* () {
       const result = yield* exec(FIXTURES_DIR, { filePath: path.join(FIXTURES_DIR, "large-image.png") })


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#365) was auto-closed by a branch history rewrite.