### PR TITLE
fix: handle bare filenames in path helpers

### DIFF
--- a/packages/shared/src/util/path.ts
+++ b/packages/shared/src/util/path.ts
@@ -9,12 +9,15 @@ export function getDirectory(path: string | undefined) {
   if (!path) return ""
   const trimmed = path.replace(/[/\\]+$/, "")
   const parts = trimmed.split(/[/\\]/)
+  if (parts.length <= 1) return ""
   return parts.slice(0, parts.length - 1).join("/") + "/"
 }
 
 export function getFileExtension(path: string | undefined) {
   if (!path) return ""
-  const parts = path.split(".")
+  const filename = getFilename(path)
+  const parts = filename.split(".")
+  if (parts.length <= 1 || !parts[0]) return ""
   return parts[parts.length - 1]
 }
 

--- a/packages/shared/test/util/path.test.ts
+++ b/packages/shared/test/util/path.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { getDirectory, getFileExtension, getFilename } from "../../src/util/path"
+
+describe("path utilities", () => {
+  test("gets filenames from slash and backslash paths", () => {
+    expect(getFilename("src/index.ts")).toBe("index.ts")
+    expect(getFilename("src\\index.ts")).toBe("index.ts")
+    expect(getFilename("README.md/")).toBe("README.md")
+  })
+
+  test("returns an empty directory for bare filenames", () => {
+    expect(getDirectory("README.md")).toBe("")
+    expect(getDirectory("README.md/")).toBe("")
+  })
+
+  test("gets directory labels for nested paths", () => {
+    expect(getDirectory("src/index.ts")).toBe("src/")
+    expect(getDirectory("src/components/button.tsx")).toBe("src/components/")
+    expect(getDirectory("src\\components\\button.tsx")).toBe("src/components/")
+  })
+
+  test("returns an empty extension for files without one", () => {
+    expect(getFileExtension("README")).toBe("")
+    expect(getFileExtension(".gitignore")).toBe("")
+  })
+
+  test("gets file extensions from filenames", () => {
+    expect(getFileExtension("README.md")).toBe("md")
+    expect(getFileExtension("archive.tar.gz")).toBe("gz")
+    expect(getFileExtension("src/archive.tar.gz")).toBe("gz")
+  })
+})


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#36) was auto-closed by a branch history rewrite.