### PR TITLE
fix: unify ctrl+v paste to handle text via pasteFromClipboard

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1492,21 +1492,9 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
-                // Check clipboard for images before terminal-handled paste runs.
-                // This helps terminals that forward Ctrl+V to the app; Windows
-                // Terminal 1.25+ usually handles Ctrl+V before this path.
                 if (keybind.match("input_paste", e)) {
-                  const content = await Clipboard.read()
-                  if (content?.mime.startsWith("image/")) {
-                    e.preventDefault()
-                    await pasteAttachment({
-                      filename: "clipboard",
-                      mime: content.mime,
-                      content: content.data,
-                    })
-                    return
-                  }
-                  // If no image, let the default paste behavior continue
+                  e.preventDefault()
+                  await pasteFromClipboard()
                 }
                 if (keybind.match("input_clear", e) && store.prompt.input !== "") {
                   input.clear()


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#277) was auto-closed by a branch history rewrite.