### PR TITLE
fix: system locale detection prioritizes env vars over timezone

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/system-locale.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/system-locale.ts
@@ -172,9 +172,15 @@ const EN_TIMEZONES = new Set([
   "Pacific/Auckland",
 ])
 
-function detectTimezoneLocale(): Locale | undefined {
+function matchLocale(value: string): Locale | undefined {
+  const cleaned = value.replace(/[.@].*$/, "").replace(/_/g, "-").toLowerCase()
+  if (!cleaned || cleaned === "c" || cleaned === "posix") return undefined
+  return matchers.find((m) => m.test(cleaned))?.locale
+}
+
+function detectTimezoneLocale(timeZone?: string): Locale | undefined {
   try {
-    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+    const tz = timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone
     if (!tz) return undefined
     if (ZHT_TIMEZONES.has(tz)) return "zht"
     if (CN_TIMEZONES.has(tz)) return "zh"
@@ -187,23 +193,25 @@ function detectTimezoneLocale(): Locale | undefined {
   return undefined
 }
 
-export function detectSystemLocale(): Locale {
-  const tz = detectTimezoneLocale()
-  if (tz) return tz
+export function detectSystemLocale(input?: {
+  env?: Partial<Pick<NodeJS.ProcessEnv, "LC_ALL" | "LC_MESSAGES" | "LANG" | "LANGUAGE">>
+  intlLocale?: string
+  timeZone?: string
+}): Locale {
+  const source = input?.env ?? process.env
   for (const env of ["LC_ALL", "LC_MESSAGES", "LANG", "LANGUAGE"] as const) {
-    const value = process.env[env]
+    const value = source[env]
     if (!value) continue
     for (const raw of value.split(":")) {
-      const cleaned = raw.replace(/[.@].*$/, "").replace(/_/g, "-").toLowerCase()
-      if (!cleaned || cleaned === "c" || cleaned === "posix") continue
-      const match = matchers.find((m) => m.test(cleaned))
-      if (match) return match.locale
+      const match = matchLocale(raw)
+      if (match) return match
     }
   }
   try {
-    const intl = Intl.DateTimeFormat().resolvedOptions().locale.toLowerCase()
-    const match = matchers.find((m) => m.test(intl))
-    if (match) return match.locale
+    const match = matchLocale(input?.intlLocale ?? Intl.DateTimeFormat().resolvedOptions().locale)
+    if (match) return match
   } catch {}
+  const tz = detectTimezoneLocale(input?.timeZone)
+  if (tz) return tz
   return "en"
 }

--- a/packages/opencode/test/cli/system-locale.test.ts
+++ b/packages/opencode/test/cli/system-locale.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { detectSystemLocale } from "../../src/cli/cmd/tui/util/system-locale"
+
+describe("detectSystemLocale", () => {
+  test("uses explicit locale environment before timezone fallback", () => {
+    expect(
+      detectSystemLocale({
+        env: { LANG: "en_US.UTF-8" },
+        intlLocale: "zh-CN",
+        timeZone: "Asia/Shanghai",
+      }),
+    ).toBe("en")
+  })
+
+  test("uses Intl locale before timezone fallback", () => {
+    expect(
+      detectSystemLocale({
+        env: {},
+        intlLocale: "en-US",
+        timeZone: "Asia/Shanghai",
+      }),
+    ).toBe("en")
+  })
+
+  test("uses timezone as a last resort", () => {
+    expect(
+      detectSystemLocale({
+        env: {},
+        intlLocale: "C",
+        timeZone: "Asia/Shanghai",
+      }),
+    ).toBe("zh")
+  })
+})


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#236) was auto-closed by a branch history rewrite.