### PR TITLE
fix(cli): redact access token from MCP auth status output

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -678,7 +678,7 @@ export const McpDebugCommand = cmd({
         prompts.log.info(`Auth status: ${getAuthStatusIcon(authStatus)} ${getAuthStatusText(authStatus)}`)
 
         if (entry?.tokens) {
-          prompts.log.info(`  Access token: ${entry.tokens.accessToken.substring(0, 20)}...`)
+          prompts.log.info(`  Access token: present`)
           if (entry.tokens.expiresAt) {
             const expiresDate = new Date(entry.tokens.expiresAt * 1000)
             const isExpired = entry.tokens.expiresAt < Date.now() / 1000


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#156) was auto-closed by a branch history rewrite.