### PR TITLE
fix(security): enforce TLS verification for console db outside development

### DIFF
--- a/packages/console/core/drizzle.config.ts
+++ b/packages/console/core/drizzle.config.ts
@@ -13,8 +13,6 @@ export default defineConfig({
     user: Resource.Database.username,
     password: Resource.Database.password,
     port: Resource.Database.port,
-    ssl: {
-      rejectUnauthorized: false,
-    },
+    ssl: process.env.NODE_ENV === "development" ? { rejectUnauthorized: false } : { rejectUnauthorized: true },
   },
 })


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#883) was auto-closed by a branch history rewrite.