### PR TITLE
fix: remove hardcoded absolute db path in drizzle config

### DIFF
--- a/packages/opencode/drizzle.config.ts
+++ b/packages/opencode/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   schema: "./src/**/*.sql.ts",
   out: "./migration",
   dbCredentials: {
-    url: "/home/thdxr/.local/share/opencode/opencode.db",
+    url: process.env.DATABASE_URL ?? "./opencode.db",
   },
 })


### PR DESCRIPTION
Resubmitting community contribution; the original PR (#882) was auto-closed by a branch history rewrite.