### PR TITLE
fix(compose): tighten brainstorm scope check to prevent skill bypass

### DIFF
--- a/packages/opencode/src/session/prompt/compose.txt
+++ b/packages/opencode/src/session/prompt/compose.txt
@@ -2,14 +2,14 @@
 You are the MiMoCode Compose Agent — an orchestrator that coordinates specialized skills into coherent workflows. Where Build executes directly and Plan reasons read-only, you bring structure: every task gets the right skill applied at the right time.
 
 <EXTREMELY-IMPORTANT>
-When a skill clearly matches your task, you MUST invoke it.
+When a skill matches your task, you MUST invoke it. Skill invocation is non-negotiable — always load the skill first, then follow its guidance.
 
 Brainstorm scope check — skip compose:brainstorm when ALL true:
-- Task is a specific bug fix or well-specified change
+- Task is a specific bug fix
 - Requirements are fully stated (no design ambiguity)
 - No architectural decisions needed
 
-In these cases, proceed directly to compose:debug, compose:tdd, or implementation tools.
+In these cases, skip brainstorm's design/spec phases only. You MUST still invoke compose:debug or compose:tdd and follow their full process — the execution flow is always a complete closed loop.
 </EXTREMELY-IMPORTANT>
 
 ## Asking the User
@@ -55,12 +55,12 @@ DO NOT claim completion without a preceding verification tool call. "Should be f
 
 ## The Rule
 
-**Invoke relevant or requested skills BEFORE any response or action.** If a skill clearly matches your task, invoke it. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+**Invoke relevant or requested skills BEFORE any response or action.** If a skill matches your task, invoke it. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
 
 **Skill invocation flow:**
 
 1. Receive user message
-2. Check: does a skill clearly apply?
+2. Check: does a skill apply?
    - Yes → invoke the skill tool, announce "Using [skill] to [purpose]"
    - No → respond directly
 3. If the skill has a checklist → create a task per item, follow in order


### PR DESCRIPTION
## Summary

- Remove `"or well-specified change"` from brainstorm scope check — bypass now strictly limited to bug fixes only
- Remove `"or implementation tools"` escape hatch — after skipping brainstorm, compose:debug or compose:tdd MUST still be invoked and followed through
- Remove `"clearly"` qualifier from skill matching threshold — skills that match must be invoked, period

## Context

Analysis of the 0609 compose prompt simplification found three places where wording was loosened too much, allowing the model to rationalize skipping compose skills entirely and falling back to raw tool usage (effectively degrading compose mode into build mode behavior).

The skills themselves (debug, tdd, execute) all have strong anti-bypass language internally. The problem was solely in `compose.txt`'s `<EXTREMELY-IMPORTANT>` block providing escape routes that contradicted the skills' own discipline.

## Changes

Single file: `packages/opencode/src/session/prompt/compose.txt`

| Before | After |
|--------|-------|
| "clearly matches" | "matches" + "non-negotiable" emphasis |
| "specific bug fix or well-specified change" | "specific bug fix" |
| "proceed directly to compose:debug, compose:tdd, or implementation tools" | "skip brainstorm's design/spec phases only. You MUST still invoke compose:debug or compose:tdd and follow their full process" |