### PR TITLE
fix(tui): force full screen clear after interactive command resume

### DIFF
--- a/docs/compose/reports/2025-06-18-tui-repaint-after-interactive-resume.md
+++ b/docs/compose/reports/2025-06-18-tui-repaint-after-interactive-resume.md
@@ -1,0 +1,42 @@
+# Report: TUI Full Repaint After Interactive Command Resume
+
+## Problem
+
+After an interactive command (e.g. `git push` triggering `bun turbo typecheck` via pre-push hook), the MiMoCode TUI resumes with visual artifacts: cells that only contain background color show the terminal's native background (VSCode theme color) instead of the TUI's dark theme background.
+
+## Root Cause
+
+`renderer.resume()` in @opentui/core internally calls:
+
+```js
+this.currentRenderBuffer.clear(this.backgroundColor)
+```
+
+This sets `currentRenderBuffer` to the theme's background color (e.g., dark gray). On the next frame, the renderer diffs `nextRenderBuffer` against `currentRenderBuffer`. Background-only cells in `nextRenderBuffer` also contain the same theme background color. The diff sees them as identical → skips writing them to the terminal. But the physical terminal (alternate screen just re-entered) doesn't have that color — it has the terminal emulator's native background.
+
+## Fix
+
+After `renderer.resume()`, call `renderer.currentRenderBuffer.clear()` **without arguments** (clears to transparent/zeros). This creates a mismatch:
+
+- `currentRenderBuffer`: transparent (RGBA 0,0,0,0)  
+- `nextRenderBuffer`: theme background color (e.g., RGBA 30,30,30,255)
+
+The diff now sees ALL cells as different → writes every cell → full repaint.
+
+## Affected Call Sites (3)
+
+1. `packages/opencode/src/cli/cmd/tui/app.tsx` — interactive bash handler (finally block)
+2. `packages/opencode/src/cli/cmd/tui/app.tsx` — Ctrl+Z SIGCONT handler
+3. `packages/opencode/src/cli/cmd/tui/util/editor.ts` — external editor resume
+
+## Approaches Tried and Rejected
+
+| Approach | Why it failed |
+|----------|--------------|
+| `process.stdout.write("\x1b[2J\x1b[H")` after resume | Clears screen but renderer still skips background cells in the diff — they appear briefly then go missing |
+| `renderer.clearPaletteCache()` | Only clears color code lookup cache, doesn't force cell writes |
+| `--ui stream` / `TURBO_UI=0` / `CI=1` on turbo | Not a turbo bug — stream mode output itself causes the issue by writing to the terminal during suspend |
+
+## Verification
+
+Tested with local build `0.0.0-local-202606181503`: interactive `bun typecheck` completes, TUI resumes with clean full repaint, no VSCode background bleeding through.

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -829,6 +829,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       onSelect: () => {
         process.once("SIGCONT", () => {
           renderer.resume()
+          renderer.currentRenderBuffer.clear()
         })
 
         renderer.suspend()
@@ -1050,6 +1051,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       } finally {
         renderer.currentRenderBuffer.clear()
         renderer.resume()
+        renderer.currentRenderBuffer.clear()
         renderer.requestRender()
       }
 

--- a/packages/opencode/src/cli/cmd/tui/util/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/editor.ts
@@ -30,6 +30,7 @@ export async function open(opts: { value: string; renderer: CliRenderer }): Prom
   } finally {
     opts.renderer.currentRenderBuffer.clear()
     opts.renderer.resume()
+    opts.renderer.currentRenderBuffer.clear()
     opts.renderer.requestRender()
   }
 }


### PR DESCRIPTION
## Summary

- Force full TUI repaint after interactive command resume by clearing `currentRenderBuffer` to transparent after `renderer.resume()`
- Fixes visual artifacts (VSCode terminal background bleeding through) in cells the diff renderer incorrectly skips

## Root Cause

`renderer.resume()` internally clears `currentRenderBuffer` to the theme's background color. On the next frame, background-only cells in `nextRenderBuffer` have the same color → diff says "no change" → skips writing them. But the physical terminal doesn't have that color after re-entering alternate screen.

## Fix

Call `renderer.currentRenderBuffer.clear()` (no args = transparent) AFTER `resume()`. This makes `currentRenderBuffer` differ from `nextRenderBuffer` for ALL cells, forcing a complete repaint.

## Changes

- `packages/opencode/src/cli/cmd/tui/app.tsx` — interactive bash handler + SIGCONT handler
- `packages/opencode/src/cli/cmd/tui/util/editor.ts` — external editor resume
- `docs/compose/reports/2025-06-18-tui-repaint-after-interactive-resume.md` — investigation report

## Verified

Tested with local build `0.0.0-local-202606181503`: interactive `bun typecheck` (turbo stream output), TUI resumes with clean full repaint, no artifacts.