### PR TITLE
feat: support personal local instruction overrides via .local.md

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,0 +1,10 @@
+# CLAUDE.local.md
+
+---
+
+## [最高行为准则 - 严禁污染上游]
+
+- 严禁以任何形式修改、暂存（stage）或提交项目全局的 `AGENTS.md` 或 `CLAUDE.md`，它们对你而言是绝对只读的。
+- 所有个人偏好、本地工作流或提示词调整，只能写入当前本地文件（`AGENTS.local.md` 或 `CLAUDE.local.md`）。
+
+---

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -149,6 +149,19 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
               }
             }
           }
+
+          // .local.md files are project-local personal overrides (typically gitignored),
+          // stacked on top of the main AGENTS.md/CLAUDE.md. Like the main files, local
+          // overrides are first-match-wins across candidates: AGENTS.local.md beats CLAUDE.local.md.
+          if (!Flag.MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT) {
+            for (const name of ["AGENTS.local.md", "CLAUDE.local.md"]) {
+              const local = yield* fs.findUp(name, ctx.directory, ctx.worktree)
+              if (local.length > 0) {
+                local.forEach((item) => paths.add(path.resolve(item)))
+                break // first-match-wins
+              }
+            }
+          }
         }
 
         for (const file of globalFiles()) {

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -270,6 +270,86 @@ describe("Instruction.system", () => {
       }
     }
   })
+
+  test("loads CLAUDE.local.md alongside AGENTS.md (stacking)", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Project Instructions")
+        await Bun.write(path.join(dir, "CLAUDE.local.md"), "# Personal Local")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const paths = yield* svc.systemPaths()
+              expect(paths.has(path.join(tmp.path, "AGENTS.md"))).toBe(true)
+              expect(paths.has(path.join(tmp.path, "CLAUDE.local.md"))).toBe(true)
+
+              const rules = (yield* svc.system()).content
+              expect(rules).toContain(
+                `Instructions from: ${path.join(tmp.path, "CLAUDE.local.md")}\n# Personal Local`,
+              )
+            }),
+          ),
+        ),
+    })
+  })
+
+  test("loads CLAUDE.local.md alongside CLAUDE.md fallback (no AGENTS.md)", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "CLAUDE.md"), "# Claude Instructions")
+        await Bun.write(path.join(dir, "CLAUDE.local.md"), "# Personal Local")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const paths = yield* svc.systemPaths()
+              expect(paths.has(path.join(tmp.path, "CLAUDE.md"))).toBe(true)
+              expect(paths.has(path.join(tmp.path, "CLAUDE.local.md"))).toBe(true)
+            }),
+          ),
+        ),
+    })
+  })
+
+  test("prefers AGENTS.local.md over CLAUDE.local.md (first-match-wins)", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Project Instructions")
+        await Bun.write(path.join(dir, "AGENTS.local.md"), "# Agents Local")
+        await Bun.write(path.join(dir, "CLAUDE.local.md"), "# Claude Local")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const paths = yield* svc.systemPaths()
+              expect(paths.has(path.join(tmp.path, "AGENTS.local.md"))).toBe(true)
+              expect(paths.has(path.join(tmp.path, "CLAUDE.local.md"))).toBe(false)
+
+              const rules = (yield* svc.system()).content
+              expect(rules).toContain(
+                `Instructions from: ${path.join(tmp.path, "AGENTS.local.md")}\n# Agents Local`,
+              )
+              expect(rules).not.toContain(
+                `Instructions from: ${path.join(tmp.path, "CLAUDE.local.md")}\n# Claude Local`,
+              )
+            }),
+          ),
+        ),
+    })
+  })
 })
 
 describe("Instruction.systemPaths MIMOCODE_CONFIG_DIR", () => {


### PR DESCRIPTION
Closes #872

> Supersedes #873, which was auto-closed when the repo force-pushed/rewrote `main` history on 2026-06-18 (a batch of PRs from multiple contributors were closed within seconds). This is the same feature, re-applied on top of the new `main`.

## What
Adds a `.local.md` personal local instruction override layer in `Instruction.systemPaths` (`packages/opencode/src/session/instruction.ts`), stacked on top of the main `AGENTS.md` / `CLAUDE.md` (unchanged):
- Candidates `AGENTS.local.md` / `CLAUDE.local.md`, **first-match-wins** (only one is loaded — `AGENTS.local.md` wins if present, `CLAUDE.local.md` is then skipped).
- Gated behind the existing `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` flag, and sits inside the `MIMOCODE_DISABLE_PROJECT_CONFIG` gate (added upstream after #873).
- All ancestor matches of the winning candidate within the worktree are loaded via the existing `fs.findUp`.

Also adds a `CLAUDE.local.md` at the repo root as a **reference template** showing a personal "no-upstream-pollution" constraint (intentionally committed as an example; it does not affect the build).

Motivation and full loading logic in #872.

## Verification
- `bun test test/session/instruction.test.ts` → **13 pass / 1 todo / 0 fail** (3 new `.local.md` tests: stacking / CLAUDE.md fallback / first-match-wins; original 10 tests no regression)
- `bun typecheck` (`@mimo-ai/cli`) → clean
- Manually verified in the TUI (`bun dev`): `CLAUDE.local.md` loads when no `AGENTS.local.md`; adding `AGENTS.local.md` makes it win and `CLAUDE.local.md` is skipped.

---

## 改动内容
在 `Instruction.systemPaths`（`packages/opencode/src/session/instruction.ts`）新增 `.local.md` 个人本地指令覆盖层，叠加在既有主指令（`AGENTS.md` / `CLAUDE.md`，不变）之上：
- 候选 `AGENTS.local.md` / `CLAUDE.local.md`，**first-match-wins**（只加载其中一个——若存在 `AGENTS.local.md` 则它胜出，随即跳过 `CLAUDE.local.md`）。
- 受既有 `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` flag 门控，并位于 #873 之后上游新增的 `MIMOCODE_DISABLE_PROJECT_CONFIG` 门控之内。
- 胜出候选在 worktree 内的所有祖先匹配都加载（复用既有 `fs.findUp`）。

另外在仓库根目录新增 `CLAUDE.local.md` 作为**参考模板**，示范一个个人"禁止污染上游"约束（作为示例提交，不影响构建）。

动机与完整加载逻辑见 #872。

## 验证
- `bun test test/session/instruction.test.ts` → **13 pass / 1 todo / 0 fail**（3 个新增 `.local.md` 测试：stacking / CLAUDE.md fallback / first-match-wins；原 10 个测试零回归）
- `bun typecheck`（`@mimo-ai/cli`）→ 无错误
- TUI 手动验证（`bun dev`）：无 `AGENTS.local.md` 时加载 `CLAUDE.local.md`；加入 `AGENTS.local.md` 后它胜出，`CLAUDE.local.md` 被跳过。