### PR TITLE
fix(tui): make task sidebar glyph reactive so status updates in real-…

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/task-item.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/task-item.tsx
@@ -20,7 +20,7 @@ export function TaskItem(props: TaskItemProps) {
   const { theme } = useTheme()
   const kv = useKV()
   const running = () => props.status === "in_progress"
-  const glyph =
+  const glyph = () =>
     props.status === "done"
       ? "✓"
       : props.status === "blocked"
@@ -40,7 +40,7 @@ export function TaskItem(props: TaskItemProps) {
         when={running()}
         fallback={
           <text flexShrink={0} style={{ fg: fg() }}>
-            [{glyph}]{" "}
+            [{glyph()}]{" "}
           </text>
         }
       >


### PR DESCRIPTION
…time

The glyph (✓/⏸/✗/ ) in TaskItem was a plain variable computed once on mount, so it never updated when a task changed status. This caused the sidebar to show [ ] instead of [✓] after marking a task done (Fixes #926).

### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
