### PR TITLE
feat(tui): search command palette by English keyword and pinyin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -376,6 +376,7 @@
         "opencode-poe-auth": "0.0.1",
         "opentui-spinner": "0.0.6",
         "partial-json": "0.1.7",
+        "pinyin-pro": "3.28.1",
         "pngjs": "7.0.0",
         "quickjs-emscripten-core": "0.32.0",
         "remeda": "catalog:",
@@ -4211,6 +4212,8 @@
     "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "pinyin-pro": ["pinyin-pro@3.28.1", "", {}, "sha512-oqz8ulwRgtUXRi0vbqEfGNly19zpyCxYrjhkk5TibGcgSW6eNwS5woajCXRwqURi8Ehc2yOFTiB4uNoZ+NJOnA=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -176,6 +176,7 @@
     "opencode-poe-auth": "0.0.1",
     "opentui-spinner": "0.0.6",
     "partial-json": "0.1.7",
+    "pinyin-pro": "3.28.1",
     "pngjs": "7.0.0",
     "quickjs-emscripten-core": "0.32.0",
     "remeda": "catalog:",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
@@ -58,11 +58,22 @@ function init() {
     return category
   }
 
+  // The command value (e.g. "session.list") and slash names are stable English
+  // identifiers. Expose them as latin search keywords so users in a non-English
+  // locale can still find commands by typing "session", "model", "theme", etc.
+  // without switching input method, even though the visible title is localized.
+  const deriveKeywords = (option: CommandOption) => {
+    const tokens = [option.value, ...option.value.split(/[.\-_:]/)]
+    if (option.slash) tokens.push(option.slash.name, ...(option.slash.aliases ?? []))
+    return [...new Set([...(option.keywords ?? []), ...tokens].filter(Boolean))]
+  }
+
   const entries = createMemo(() => {
     const all = registrations().flatMap((x) => x())
     return all.map((x) => ({
       ...x,
       category: localizeCategory(x.category),
+      keywords: deriveKeywords(x),
       footer: x.keybind ? keybind.print(x.keybind) : undefined,
     }))
   })

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -11,6 +11,7 @@ import { useKeybind } from "@tui/context/keybind"
 import { Keybind } from "@/util"
 import { Locale } from "@/util"
 import { getScrollAcceleration } from "../util/scroll"
+import { pinyinSearch } from "../util/pinyin"
 import { useTuiConfig } from "../context/tui-config"
 import { useLanguage } from "@tui/context/language"
 
@@ -40,6 +41,8 @@ export interface DialogSelectOption<T = any> {
   description?: string
   footer?: JSX.Element | string
   category?: string
+  /** Extra latin search terms (e.g. English keywords) so the item is findable without switching input method. */
+  keywords?: string[]
   categoryView?: JSX.Element
   disabled?: boolean
   bg?: RGBA
@@ -93,10 +96,18 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
     // prioritize title matches (weight: 2) over category matches (weight: 1).
     // users typically search by the item name, and not its category.
+    // keywords carry latin/English aliases (weight 2) and pinyin carries a
+    // romanized form of the title (weight 1), so CJK-locale users can search by
+    // English keyword or pinyin without switching input method.
     const result = fuzzysort
       .go(needle, options, {
-        keys: ["title", "category"],
-        scoreFn: (r) => r[0].score * 2 + r[1].score,
+        keys: [
+          "title",
+          "category",
+          (o) => o.keywords?.join(" ") ?? "",
+          (o) => pinyinSearch(o.title),
+        ],
+        scoreFn: (r) => r[0].score * 2 + r[1].score + r[2].score * 2 + r[3].score,
       })
       .map((x) => x.obj)
 

--- a/packages/opencode/src/cli/cmd/tui/util/pinyin.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/pinyin.ts
@@ -1,0 +1,20 @@
+import { pinyin } from "pinyin-pro"
+
+const CJK = /[㐀-䶿一-鿿豈-﫿]/
+const cache = new Map<string, string>()
+
+// Build a romanized, latin-keyboard-typable search string for CJK text so that
+// users don't have to switch their input method to find an item. For "切换会话"
+// this yields "qiehuanhuihua qie huan hui hua qhhh", matching full pinyin,
+// per-syllable pinyin, and the initials. Returns "" for text without CJK so the
+// extra fuzzysort key is a no-op for already-latin titles.
+export function pinyinSearch(text: string | undefined): string {
+  if (!text || !CJK.test(text)) return ""
+  const cached = cache.get(text)
+  if (cached !== undefined) return cached
+  const syllables = pinyin(text, { toneType: "none", type: "array" })
+  const initials = pinyin(text, { pattern: "first", toneType: "none", type: "array" }).join("")
+  const result = `${syllables.join("")} ${syllables.join(" ")} ${initials}`.toLowerCase()
+  cache.set(text, result)
+  return result
+}


### PR DESCRIPTION
Chinese-locale users had to switch input methods to use the Ctrl+P palette, since it only matched the localized (Chinese) titles. Now the shared DialogSelect filter also matches latin keywords and a romanized (pinyin) form of the title, so typing "theme", "model", "huihua", or the initials "hh" finds the right item without an input-method switch.

- add pinyin-pro and util/pinyin.ts (full pinyin + syllables + initials)
- add keywords?: string[] to DialogSelectOption; extend fuzzysort keys
- auto-derive command keywords from the stable English value id + slashes

Co-Author By MiMoCode
