### PR TITLE
fix(tui): add Super+V paste support and simplify clipboard handling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1492,21 +1492,15 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
-                // Check clipboard for images before terminal-handled paste runs.
-                // This helps terminals that forward Ctrl+V to the app; Windows
-                // Terminal 1.25+ usually handles Ctrl+V before this path.
+                // Handle Ctrl+V for terminals that forward it to the app as a raw
+                // keypress (common on macOS/Linux). The textarea has no built-in
+                // paste action, so without this nothing gets inserted. Terminals
+                // that handle paste natively (e.g. Windows Terminal 1.25+) emit a
+                // bracketed paste instead and never reach this path.
                 if (keybind.match("input_paste", e)) {
-                  const content = await Clipboard.read()
-                  if (content?.mime.startsWith("image/")) {
-                    e.preventDefault()
-                    await pasteAttachment({
-                      filename: "clipboard",
-                      mime: content.mime,
-                      content: content.data,
-                    })
-                    return
-                  }
-                  // If no image, let the default paste behavior continue
+                  e.preventDefault()
+                  await pasteFromClipboard()
+                  return
                 }
                 if (keybind.match("input_clear", e) && store.prompt.input !== "") {
                   input.clear()

--- a/packages/opencode/src/config/keybinds.ts
+++ b/packages/opencode/src/config/keybinds.ts
@@ -65,7 +65,7 @@ const KeybindsSchema = Schema.Struct({
   variant_cycle: keybind("ctrl+t", "Cycle model variants"),
   variant_list: keybind("none", "List model variants"),
   input_clear: keybind("ctrl+c", "Clear input field"),
-  input_paste: keybind("ctrl+v", "Paste from clipboard"),
+  input_paste: keybind("super+v,ctrl+v", "Paste from clipboard"),
   input_submit: keybind("return", "Submit input"),
   input_newline: keybind("shift+return,ctrl+return,alt+return,ctrl+j", "Insert newline in input"),
   input_move_left: keybind("left,ctrl+b", "Move cursor left in input"),


### PR DESCRIPTION
- Support Cmd+V on macOS alongside Ctrl+V for paste keybind
- Simplify paste handler to always delegate to pasteFromClipboard()
- Update comments to clarify terminal paste behavior

Co-Author by MiMoCode