### PR TITLE
fix: restore provider display and correct OpenCode links

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ bun turbo typecheck      # Type check
 
 ## Relationship to OpenCode
 
-MiMoCode is built as a fork of [OpenCode](https://github.com/XiaomiMiMo/MiMo-Code). It keeps all core OpenCode capabilities (multiple providers, TUI, LSP, MCP, plugins) and adds persistent memory, intelligent context management, subagent orchestration, goal-driven autonomous loops, compose workflows, and self-improvement via dream/distill.
+MiMoCode is built as a fork of [OpenCode](https://github.com/anomalyco/opencode). It keeps all core OpenCode capabilities (multiple providers, TUI, LSP, MCP, plugins) and adds persistent memory, intelligent context management, subagent orchestration, goal-driven autonomous loops, compose workflows, and self-improvement via dream/distill.
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -203,7 +203,7 @@ bun turbo typecheck      # 类型检查
 
 ## 与 OpenCode 的关系
 
-MiMoCode 基于 [OpenCode](https://github.com/XiaomiMiMo/MiMo-Code) fork 构建，保留其全部核心能力（多 Provider、TUI、LSP、MCP、插件），并在此基础上构建了持久化记忆、智能上下文管理、子智能体编排、目标驱动的自主循环、Compose 工作流，以及通过 dream/distill 实现的自我进化。
+MiMoCode 基于 [OpenCode](https://github.com/anomalyco/opencode) fork 构建，保留其全部核心能力（多 Provider、TUI、LSP、MCP、插件），并在此基础上构建了持久化记忆、智能上下文管理、子智能体编排、目标驱动的自主循环、Compose 工作流，以及通过 dream/distill 实现的自我进化。
 
 ---
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -128,6 +128,7 @@ export function Prompt(props: PromptProps) {
   const voiceEnabled = createMemo(() => kv.get("voice_enabled", false))
   const voiceSendEnabled = createMemo(() => kv.get("voice_send_command", false))
   const voiceControlEnabled = createMemo(() => kv.get("voice_control_enabled", false))
+  const currentProviderLabel = createMemo(() => local.model.parsed().provider)
   const [voiceState, setVoiceState] = createSignal<"idle" | "listening" | "speaking" | "processing" | "finishing">(
     activeVoice ? (activeVoice.pending > 0 ? "processing" : "listening") : "idle",
   )
@@ -1641,6 +1642,9 @@ export function Prompt(props: PromptProps) {
                             fg={fadeColor(keybind.leader ? theme.textMuted : theme.text, modelMetaAlpha())}
                           >
                             {local.model.parsed().model}
+                          </text>
+                          <text fg={fadeColor(theme.textMuted, modelMetaAlpha())}>
+                            {currentProviderLabel()}
                           </text>
                           <Show when={showVariant()}>
                             <text fg={fadeColor(theme.textMuted, variantMetaAlpha())}>·</text>


### PR DESCRIPTION
## Summary / 概述

- Restore grey provider name display next to model name in prompt area, matching opencode upstream implementation
- Fix OpenCode repository links in README files

- 恢复输入框区域模型名称旁的灰色 provider 显示，与 opencode 上游实现一致
- 修复 README 文件中 OpenCode 仓库链接

## Changes / 变更

1. **`packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`**: Added `currentProviderLabel` memo and display it after model name / 添加 `currentProviderLabel` 并在模型名称后显示
2. **`README.md`**: Fix OpenCode link from `XiaomiMiMo/MiMo-Code` to `anomalyco/opencode` / 修正 OpenCode 链接
3. **`README.zh.md`**: Same as above / 同上

## Context / 背景

This restores the provider display following the official opencode implementation (see [anomalyco/opencode](https://github.com/anomalyco/opencode)).

按照 opencode 官方实现恢复 provider 显示。