### PR TITLE
feat: add Android/Termux support to postinstall and wrapper

### DIFF
--- a/packages/opencode/bin/mimo
+++ b/packages/opencode/bin/mimo
@@ -6,7 +6,10 @@ const path = require("path")
 const os = require("os")
 
 function run(target) {
-  const result = childProcess.spawnSync(target, process.argv.slice(2), {
+  // On Android/Termux, glibc-linked binaries need grun (glibc-runner)
+  const isAndroid = os.platform() === "android"
+  const args = isAndroid ? ["grun", target, ...process.argv.slice(2)] : [target, ...process.argv.slice(2)]
+  const result = childProcess.spawnSync(args[0], args.slice(1), {
     stdio: "inherit",
   })
   if (result.error) {
@@ -35,6 +38,7 @@ const platformMap = {
   darwin: "darwin",
   linux: "linux",
   win32: "windows",
+  android: "linux", // Termux/Android uses linux binary via grun
 }
 const archMap = {
   x64: "x64",

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -19,6 +19,10 @@ function detectPlatformAndArch() {
     case "linux":
       platform = "linux"
       break
+    case "android":
+      // Termux/Android — use linux-arm64 binary via grun (glibc runner)
+      platform = "linux"
+      break
     case "win32":
       platform = "windows"
       break


### PR DESCRIPTION
### Issue for this PR

Closes #1139, #305

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Termux (Android arm64), `os.platform()` returns `"android"`. The `platformMap` in both `postinstall.mjs` and `bin/mimo` only mapped `darwin`, `linux`, and `win32`. This caused:

1. **postinstall.mjs** constructs `@mimo-ai/mimocode-android-arm64` — a package that doesn't exist. The correct binary is `@mimo-ai/mimocode-linux-arm64`.
2. **bin/mimo** fails at runtime with the same wrong lookup, and `spawn()` tries to execute the glibc-linked binary directly. On Termux, the linux-arm64 binary is compiled against glibc and can't run natively (Termux uses Android's bionic libc).

**Changes:**
- `postinstall.mjs`: add `android: "linux"` to `platformMap` so the postinstall resolves the correct binary package.
- `bin/mimo`: add `android: "linux"` to `platformMap`; in the `run()` function, detect Android and use `grun` (glibc-runner) as the command wrapper, passing the target binary as the first argument.

**Why this works:** Termux provides `grun` (via the `glibc-runner` package from `tur-repo`) which loads a full glibc userspace and executes glibc-linked binaries. The linux-arm64 binary can run under `grun`, and the platform mapping fix ensures the correct package (`@mimo-ai/mimocode-linux-arm64`) is looked up.

### How did you verify your code works?

Tested on Termux (Android 16, aarch64) with Node v24 and npm v11:
- Installed `@mimo-ai/cli@0.1.1` with `--ignore-scripts`
- Installed `@mimo-ai/mimocode-linux-arm64@0.1.1`
- Ran `postinstall.mjs` manually to verify binary is correctly resolved and linked
- Ran `mimo --version` — outputs `0.1.1`
- Ran `mimo --help` — full help output with commands, options, and agent listing
- Database migration ran successfully on first launch

The `--force` flag is still needed on Termux to bypass the `os` constraint on optional dependency packages. The generated `package.json` for binary packages only lists `"os": ["linux"]`, so npm filters them out on Android. Fixing that in the build script is a separate concern.

### Screenshots / recordings

![Screenshot 1 -  VersionHelpStart](https://github.com/user-attachments/assets/68214197-b4ed-40c8-bb06-e6bc28a57625)

![Screenshot 2 - HomeScreen](https://github.com/user-attachments/assets/3d80fe7a-c512-4005-8df5-43296372c6fa)

![Screenshot 3 - Running](https://github.com/user-attachments/assets/ad15a8d9-1d25-4f0b-bcaa-948340f82858)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR