### PR TITLE
fix: anchor env date to session creation time for prefix cache parity

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -246,9 +246,15 @@ export const layer = Layer.effect(
           .getModel(input.providerID as ProviderID, input.modelID as ModelID)
           .pipe(Effect.catch(() => Effect.succeed(undefined)))
         if (!model) return empty
+        // Anchor the env date to the session's creation time so the captured prefix is
+        // byte-identical to the runLoop's (which uses session.time.created), preserving
+        // Anthropic cache parity. If the session can't be loaded we can't guarantee that
+        // parity, so fall through to empty rather than emit a divergent date.
+        const captureSession = yield* sessions.get(input.sessionID).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        if (!captureSession) return empty
         const [skills, env, instructions] = yield* Effect.all([
           sys.skills(ag),
-          Effect.sync(() => sys.environment(model)),
+          Effect.sync(() => sys.environment(model, captureSession.time.created)),
           instruction.system().pipe(Effect.orDie),
         ])
         // (checkpoint-writer never requests json_schema output, so STRUCTURED_OUTPUT_SYSTEM_PROMPT
@@ -2792,7 +2798,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             const [skills, env, instructions] = yield* Effect.all([
               sys.skills(agent),
-              Effect.sync(() => sys.environment(model)),
+              Effect.sync(() => sys.environment(model, session.time.created)),
               instruction.system().pipe(Effect.orDie),
             ])
             // Surface which instruction files (CLAUDE.md, AGENTS.md, ...) were loaded.

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -33,7 +33,7 @@ export function provider(model: Provider.Model) {
 }
 
 export interface Interface {
-  readonly environment: (model: Provider.Model) => string[]
+  readonly environment: (model: Provider.Model, now: number) => string[]
   readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
 }
 
@@ -45,7 +45,7 @@ export const layer = Layer.effect(
     const skill = yield* Skill.Service
 
     return Service.of({
-      environment(model) {
+      environment(model, now) {
         const project = Instance.project
         return [
           [
@@ -57,7 +57,11 @@ export const layer = Layer.effect(
             `  Workspace root folder: ${Instance.worktree}`,
             `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
             `  Platform: ${process.platform}`,
-            `  Today's date: ${new Date().toDateString()}`,
+            // Anchored to the session's creation time (not request time) so this block
+            // stays byte-identical across every turn of a session — including ones that
+            // cross midnight — keeping it inside the Anthropic cached system prefix.
+            // Both the runLoop and checkpoint prefix-capture paths pass the same value.
+            `  Today's date: ${new Date(now).toDateString()}`,
             `</env>`,
           ].join("\n"),
           `IMPORTANT: Your response must ALWAYS strictly follow the same major language as the user.`,


### PR DESCRIPTION
## Summary
- Anchor the environment block's "Today's date" to `session.time.created` instead of `new Date()` so it stays byte-identical across every turn of a session
- Both the runLoop and checkpoint-capture paths now pass the same session creation timestamp to `sys.environment()`
- Prevents Anthropic cached system prefix divergence when turns cross midnight

## Changes
- `system.ts`: `environment()` now accepts a `now: number` parameter; date is derived from it
- `prompt.ts`: Checkpoint-writer path loads the session and passes `session.time.created`; runLoop path passes `session.time.created` directly