### PR TITLE
fix: remove claude-origin MCP skip for local servers

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -518,11 +518,6 @@ export const layer = Layer.effect(
                 return
               }
 
-              if (mcp.type === "local" && cfg.mcp_origins?.[key]?.type === "claude") {
-                s.status[key] = { status: "pending" }
-                return
-              }
-
               const result = yield* create(key, mcp).pipe(Effect.catch(() => Effect.void))
               if (!result) return
 


### PR DESCRIPTION
## Summary
- Remove the special-case block in `packages/opencode/src/mcp/index.ts` that prevented local MCP servers from being created when the origin type was "claude"
- This allows all local MCP servers to initialize regardless of origin configuration