### PR TITLE
feat: add session lifecycle hooks with trajectory serialization

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -54,6 +54,13 @@ import { SessionSummary } from "./summary"
 import { NamedError } from "@mimo-ai/shared/util/error"
 import { SessionProcessor } from "./processor"
 import { buildLLMRequestPrefix } from "./llm-request-prefix"
+import {
+  serializeTrajectoryMessages,
+  withAssistantParts,
+  userQueryText,
+  assistantFinalText,
+  sessionErrorText,
+} from "./trajectory"
 import { prefixCaptureRef } from "./prefix-capture-ref"
 import { spawnRef } from "@/actor/spawn-ref"
 import { Inbox } from "@/inbox"
@@ -1779,7 +1786,83 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         // 与 invalidContinuations（generic invalid）分离，互不污染。局部于 runLoop，
         // 新一轮用户 turn 自动归零。
         let structuredRetries = 0
+        const resolvedAgentID = agentID ?? "main"
+        // Tracks plugin-driven cancellation (session.pre OR any session.userQuery.pre)
+        // so session.post reports outcome="cancelled" instead of "error".
+        let cancelled = false
+        let cancelReason: string | undefined
+
+        // Fires session.post exactly once via Effect.onExit on the body below.
+        // Without this wrapper any yielded failure inside the while loop (provider
+        // error, network error, thrown defect) would skip the hook entirely.
+        //
+        // Trajectory parity: uses MessageV2.filterCompactedEffect with the session's
+        // contextFrom / contextWatermark so compaction boundaries trim history to
+        // what the agent actually saw, and child-session parent prefixes are
+        // included — matching session.userQuery.post semantics.
+        const firePostSession = (exit: Exit.Exit<MessageV2.WithParts, unknown>) =>
+          Effect.gen(function* () {
+            const sliceMsgs = yield* MessageV2.filterCompactedEffect(sessionID, {
+              contextFrom: session.contextFrom,
+              contextWatermark: session.contextWatermark,
+              agentID: resolvedAgentID,
+            }).pipe(Effect.catch(() => Effect.succeed([] as MessageV2.WithParts[])))
+            const lastSlice = sliceMsgs.findLast((m) => m.info.role === "assistant")
+            const finalAsst =
+              lastSlice && lastSlice.info.role === "assistant" ? lastSlice.info : undefined
+            const finalParts = lastSlice?.parts ?? []
+            const failed = Exit.isFailure(exit)
+            const finalIsError = !!finalAsst?.error
+            const outcome: "completed" | "error" | "cancelled" = cancelled
+              ? "cancelled"
+              : failed || finalIsError
+                ? "error"
+                : "completed"
+            const error = cancelled
+              ? cancelReason
+              : failed
+                ? Cause.pretty(exit.cause)
+                : finalAsst
+                  ? sessionErrorText(finalAsst.error)
+                  : undefined
+            yield* plugin.trigger(
+              "session.post",
+              {
+                sessionID,
+                agentID: resolvedAgentID,
+                task_id,
+                outcome,
+                error,
+                finalText: finalAsst ? assistantFinalText(finalAsst, finalParts) : undefined,
+                assistantMessageID: finalAsst?.id,
+                trajectory: serializeTrajectoryMessages(sliceMsgs),
+              },
+              {},
+            )
+          }).pipe(Effect.ignore)
+
+        return yield* Effect.gen(function* () {
+          const preSession = { cancel: undefined as boolean | undefined, cancelReason: undefined as string | undefined }
+          yield* plugin.trigger(
+            "session.pre",
+            { sessionID, agentID: resolvedAgentID, task_id },
+            preSession,
+          )
+          if (preSession.cancel) {
+            cancelled = true
+            cancelReason = preSession.cancelReason
+            return yield* Effect.fail(
+              new NamedError.Unknown({
+                message: preSession.cancelReason ?? "Session cancelled by plugin",
+              }),
+            )
+          }
         const agentMetrics = { tokens_in: 0, tokens_out: 0, files_changed: 0 }
+        const trajectoryForStep = (currentMsgs: MessageV2.WithParts[], assistant: MessageV2.Assistant) =>
+          serializeTrajectoryMessages(
+            withAssistantParts(currentMsgs, assistant, MessageV2.parts(assistant.id)),
+          )
+
         const publishAgentRequest = (phase: string, taskType: string) =>
           bus
             .publish(Metrics.AgentRequest, {
@@ -2701,34 +2784,96 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               // Schema parity with parent is currently a consequence of checkpoint-writer
               // having no toolAllowlist (Task 2.6 + agent.test.ts guard). See ForkContext.tools
               // JSDoc in packages/opencode/src/actor/spawn.ts for the full contract.
-              const result = yield* handle.process({
-                user: lastUser,
-                agent,
-                // Fork inherits the parent agent's permission (captured at spawn into
-                // ForkContext). This drives llm.ts resolveTools/disabled() to the SAME
-                // visible tool set as the parent → prompt-cache parity on the inherited
-                // prefix. Scope: this affects tool VISIBILITY only; the per-call ask
-                // ruleset (built separately in resolveTools' ask closure) is unchanged.
-                // Parity is exact modulo non-default `session.permission`: the parent's
-                // visibility ruleset is merge(parent.permission, session.permission)
-                // while the fork's is merge(writer.permission, parentPermission) — so a
-                // session-level rule pins the parent but not the fork. Still a strict
-                // improvement over the old bespoke "*":"deny" block (which always
-                // diverged). The `?? session.permission` is defense-in-depth only:
-                // parentPermission is a required field (empty `[]` on a missed capture,
-                // which `??` does NOT override), so the fallback fires solely if a future
-                // refactor makes the field optional.
-                permission: forkCtx.parentPermission ?? session.permission,
-                sessionID,
-                parentSessionID: session.parentID,
-                system: additions,
-                prebuiltSystem,
-                messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
-                tools,
-                model,
-                toolChoice: format.type === "json_schema" ? "required" : undefined,
-                agentID: lastUser.agentID,
-              })
+              const queryParts =
+                msgs.findLast((m) => m.info.role === "user" && m.info.id === lastUser.id)?.parts ?? []
+              const query = userQueryText(queryParts)
+              const preQuery = {
+                cancel: undefined as boolean | undefined,
+                cancelReason: undefined as string | undefined,
+              }
+              yield* plugin.trigger(
+                "session.userQuery.pre",
+                { sessionID, agentID: resolvedAgentID, step, messageID: lastUser.id, query },
+                preQuery,
+              )
+              if (preQuery.cancel) {
+                cancelled = true
+                cancelReason = preQuery.cancelReason
+                handle.message.error = new MessageV2.AbortedError({
+                  message: preQuery.cancelReason ?? "Step cancelled by plugin",
+                }).toObject()
+                handle.message.finish = "cancelled"
+                yield* sessions.updateMessage(handle.message)
+                yield* plugin.trigger(
+                  "session.userQuery.post",
+                  {
+                    sessionID,
+                    agentID: resolvedAgentID,
+                    step,
+                    messageID: lastUser.id,
+                    query,
+                    assistantMessageID: handle.message.id,
+                    finish: handle.message.finish,
+                    error: preQuery.cancelReason,
+                    trajectory: trajectoryForStep(msgs, handle.message),
+                  },
+                  {},
+                )
+                return "break" as const
+              }
+              const result = yield* handle
+                .process({
+                  user: lastUser,
+                  agent,
+                  // Fork inherits the parent agent's permission (captured at spawn into
+                  // ForkContext). This drives llm.ts resolveTools/disabled() to the SAME
+                  // visible tool set as the parent → prompt-cache parity on the inherited
+                  // prefix. Scope: this affects tool VISIBILITY only; the per-call ask
+                  // ruleset (built separately in resolveTools' ask closure) is unchanged.
+                  // Parity is exact modulo non-default `session.permission`: the parent's
+                  // visibility ruleset is merge(parent.permission, session.permission)
+                  // while the fork's is merge(writer.permission, parentPermission) — so a
+                  // session-level rule pins the parent but not the fork. Still a strict
+                  // improvement over the old bespoke "*":"deny" block (which always
+                  // diverged). The `?? session.permission` is defense-in-depth only:
+                  // parentPermission is a required field (empty `[]` on a missed capture,
+                  // which `??` does NOT override), so the fallback fires solely if a future
+                  // refactor makes the field optional.
+                  permission: forkCtx.parentPermission ?? session.permission,
+                  sessionID,
+                  parentSessionID: session.parentID,
+                  system: additions,
+                  prebuiltSystem,
+                  messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
+                  tools,
+                  model,
+                  toolChoice: format.type === "json_schema" ? "required" : undefined,
+                  agentID: lastUser.agentID,
+                })
+                .pipe(
+                  Effect.onExit((exit) =>
+                    plugin
+                      .trigger(
+                        "session.userQuery.post",
+                        {
+                          sessionID,
+                          agentID: resolvedAgentID,
+                          step,
+                          messageID: lastUser.id,
+                          query,
+                          assistantMessageID: handle.message.id,
+                          finish: handle.message.finish,
+                          error: Exit.isFailure(exit)
+                            ? Cause.pretty(exit.cause)
+                            : sessionErrorText(handle.message.error),
+                          finalText: assistantFinalText(handle.message, MessageV2.parts(handle.message.id)),
+                          trajectory: trajectoryForStep(msgs, handle.message),
+                        },
+                        {},
+                      )
+                      .pipe(Effect.ignore),
+                  ),
+                )
 
               if (
                 result === "continue" &&
@@ -2860,8 +3005,46 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               agentID: lastUser.agentID,
             }
 
-            const result = useMaxMode
-              ? yield* MaxMode.runMaxStep({
+            const queryParts =
+              msgs.findLast((m) => m.info.role === "user" && m.info.id === lastUser.id)?.parts ?? []
+            const query = userQueryText(queryParts)
+            const preQuery = {
+              cancel: undefined as boolean | undefined,
+              cancelReason: undefined as string | undefined,
+            }
+            yield* plugin.trigger(
+              "session.userQuery.pre",
+              { sessionID, agentID: resolvedAgentID, step, messageID: lastUser.id, query },
+              preQuery,
+            )
+            if (preQuery.cancel) {
+              cancelled = true
+              cancelReason = preQuery.cancelReason
+              handle.message.error = new MessageV2.AbortedError({
+                message: preQuery.cancelReason ?? "Step cancelled by plugin",
+              }).toObject()
+              handle.message.finish = "cancelled"
+              yield* sessions.updateMessage(handle.message)
+              yield* plugin.trigger(
+                "session.userQuery.post",
+                {
+                  sessionID,
+                  agentID: resolvedAgentID,
+                  step,
+                  messageID: lastUser.id,
+                  query,
+                  assistantMessageID: handle.message.id,
+                  finish: handle.message.finish,
+                  error: preQuery.cancelReason,
+                  trajectory: trajectoryForStep(msgs, handle.message),
+                },
+                {},
+              )
+              return "break" as const
+            }
+
+            const stepEffect = useMaxMode
+              ? MaxMode.runMaxStep({
                   // runMaxStep reuses the identical per-step args as handle.process,
                   // plus the orchestration handles it needs.
                   ...processArgs,
@@ -2871,7 +3054,32 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   setStatus: (message) =>
                     status.set(sessionID, message ? { type: "busy", message } : { type: "busy" }),
                 })
-              : yield* handle.process(processArgs)
+              : handle.process(processArgs)
+
+            const result = yield* stepEffect.pipe(
+              Effect.onExit((exit) =>
+                plugin
+                  .trigger(
+                    "session.userQuery.post",
+                    {
+                      sessionID,
+                      agentID: resolvedAgentID,
+                      step,
+                      messageID: lastUser.id,
+                      query,
+                      assistantMessageID: handle.message.id,
+                      finish: handle.message.finish,
+                      error: Exit.isFailure(exit)
+                        ? Cause.pretty(exit.cause)
+                        : sessionErrorText(handle.message.error),
+                      finalText: assistantFinalText(handle.message, MessageV2.parts(handle.message.id)),
+                      trajectory: trajectoryForStep(msgs, handle.message),
+                    },
+                    {},
+                  )
+                  .pipe(Effect.ignore),
+              ),
+            )
 
             if (
               result === "continue" &&
@@ -3082,6 +3290,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           Option.isSome(lastUserForMetrics) ? lastUserForMetrics.value.info.agent : final.info.agent,
         )
         return final
+        }).pipe(Effect.onExit(firePostSession), Effect.orDie)
       },
     )
 

--- a/packages/opencode/src/session/trajectory.ts
+++ b/packages/opencode/src/session/trajectory.ts
@@ -1,0 +1,98 @@
+import type { TrajectoryMessage, TrajectoryPart } from "@mimo-ai/plugin"
+import { MessageV2 } from "./message-v2"
+
+/**
+ * Replace `data:` URLs in file parts with a compact summary tag, leaving
+ * non-data URLs (file paths, http(s) attachments) untouched. Keeps the
+ * trajectory JSON-safe without exploding payload size on inline images.
+ */
+function fileUrlSummary(url: string, mime: string, filename?: string) {
+  if (!url.startsWith("data:")) return url
+  return `[data-url:${mime}${filename ? `:${filename}` : ""}]`
+}
+
+function serializeFilePart(part: MessageV2.FilePart): MessageV2.FilePart {
+  return { ...part, url: fileUrlSummary(part.url, part.mime, part.filename) }
+}
+
+/**
+ * Strip `data:` URLs from any FilePart attachments inside a tool result.
+ * Mutation is shallow — original part is not modified.
+ */
+function sanitizeToolState(state: MessageV2.ToolPart["state"]): MessageV2.ToolPart["state"] {
+  if (state.status === "completed" && state.attachments && state.attachments.length > 0) {
+    return { ...state, attachments: state.attachments.map(serializeFilePart) }
+  }
+  return state
+}
+
+/**
+ * Serialize a MessageV2.Part for the trajectory wire format. Preserves every
+ * field the runtime stores (ID, time, metadata, source, raw, attachments,
+ * tokens, etc.) — only `data:` URLs are summarized to keep payloads tractable.
+ * The result is a structural superset of MessageV2.Part and is safe to
+ * round-trip through JSON.
+ */
+export function serializePart(part: MessageV2.Part): TrajectoryPart {
+  if (part.type === "file") return serializeFilePart(part) as unknown as TrajectoryPart
+  if (part.type === "tool") return { ...part, state: sanitizeToolState(part.state) } as unknown as TrajectoryPart
+  return part as unknown as TrajectoryPart
+}
+
+/** Stringify an assistant error blob (NamedError, AbortedError, etc.) for plugin payloads. */
+export function sessionErrorText(error: MessageV2.Assistant["error"]): string | undefined {
+  if (!error) return undefined
+  if (typeof error === "object" && error !== null && "message" in error && typeof error.message === "string") {
+    return error.message
+  }
+  return JSON.stringify(error)
+}
+
+/** Concatenate non-synthetic, non-ignored user text parts (the visible user query). */
+export function userQueryText(parts: MessageV2.Part[]): string {
+  return parts
+    .filter((p): p is MessageV2.TextPart => p.type === "text" && !p.synthetic && !p.ignored)
+    .map((p) => p.text)
+    .join("\n")
+}
+
+/** Last non-synthetic assistant text, or stringified structured output if present. */
+export function assistantFinalText(message: MessageV2.Assistant, parts: MessageV2.Part[]): string | undefined {
+  if (message.structured !== undefined) return JSON.stringify(message.structured)
+  return parts.findLast((p): p is MessageV2.TextPart => p.type === "text" && !p.synthetic)?.text
+}
+
+/**
+ * Serialize a slice of session messages into the wire trajectory format.
+ *
+ * Field-level fidelity:
+ * - Spreads the full MessageV2 info (model, tools, format, tokens, cost,
+ *   modelID, providerID, agent, agentID, error, finish, structured, summary,
+ *   provenance, path, parentID, mode, variant, …) so a consumer can replay
+ *   the conversation exactly as the runtime saw it.
+ * - Spreads the full MessageV2.Part (PartID, time, metadata, source, raw,
+ *   attachments, tokens, snapshot, …) for every part type — including unknown
+ *   future types — without dropping fields.
+ *
+ * Slice-level fidelity is the caller's responsibility: pass the same slice the
+ * agent actually saw (e.g. via MessageV2.filterCompactedEffect with the
+ * session's contextFrom/contextWatermark) for replay parity.
+ */
+export function serializeTrajectoryMessages(msgs: MessageV2.WithParts[]): TrajectoryMessage[] {
+  return msgs.map((msg) => ({
+    ...msg.info,
+    created: msg.info.time.created,
+    parts: msg.parts.map(serializePart),
+  })) as unknown as TrajectoryMessage[]
+}
+
+/** Replace the assistant entry in a message slice with freshly loaded parts. */
+export function withAssistantParts(
+  msgs: MessageV2.WithParts[],
+  assistant: MessageV2.Assistant,
+  parts: MessageV2.Part[],
+): MessageV2.WithParts[] {
+  const idx = msgs.findIndex((m) => m.info.id === assistant.id)
+  if (idx === -1) return [...msgs, { info: assistant, parts }]
+  return msgs.map((m, i) => (i === idx ? { info: assistant, parts } : m))
+}

--- a/packages/opencode/src/util/env-info.ts
+++ b/packages/opencode/src/util/env-info.ts
@@ -60,32 +60,3 @@ export async function getEnvInfo() {
     },
   }
 }
-
-export function getEnvTelemetry() {
-  const cpus = os.cpus()
-
-  return {
-    os: {
-      platform: os.platform(),
-      arch: os.arch(),
-      release: os.release(),
-    },
-    cpu: {
-      model: cpus[0]?.model ?? "unknown",
-      count: cpus.length,
-    },
-    memory: {
-      total_bytes: os.totalmem(),
-    },
-    runtime: {
-      bun_version: Bun.version,
-      node_version: process.versions.node,
-      timezone: timezone(),
-      locale: locale(),
-    },
-    mimocode: {
-      version: InstallationVersion,
-      channel: InstallationChannel,
-    },
-  }
-}

--- a/packages/opencode/src/util/env-info.ts
+++ b/packages/opencode/src/util/env-info.ts
@@ -1,0 +1,49 @@
+import os from "os"
+import { Global } from "@/global"
+import { InstallationChannel, InstallationVersion } from "@/installation/version"
+import { getInstallationID } from "@/metrics/installation"
+import { MIMOCODE_PROCESS_ROLE, MIMOCODE_RUN_ID } from "./mimo-process"
+
+function username() {
+  if (process.env.USER) return process.env.USER
+  if (process.env.USERNAME) return process.env.USERNAME
+  return os.userInfo().username
+}
+
+function locale() {
+  return Intl.DateTimeFormat().resolvedOptions().locale
+}
+
+function timezone() {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone
+}
+
+
+export function getEnvInfo() {
+  const cpus = os.cpus()
+
+  return {
+    os: {
+      platform: os.platform(),
+      arch: os.arch(),
+      release: os.release(),
+    },
+    cpu: {
+      model: cpus[0]?.model ?? "unknown",
+      count: cpus.length,
+    },
+    memory: {
+      total_bytes: os.totalmem(),
+    },
+    runtime: {
+      bun_version: Bun.version,
+      node_version: process.versions.node,
+      timezone: timezone(),
+      locale: locale(),
+    },
+    mimocode: {
+      version: InstallationVersion,
+      channel: InstallationChannel,
+    },
+  }
+}

--- a/packages/opencode/src/util/env-info.ts
+++ b/packages/opencode/src/util/env-info.ts
@@ -18,8 +18,50 @@ function timezone() {
   return Intl.DateTimeFormat().resolvedOptions().timeZone
 }
 
+export async function getEnvInfo() {
+  const cpus = os.cpus()
 
-export function getEnvInfo() {
+  return {
+    os: {
+      platform: os.platform(),
+      arch: os.arch(),
+      release: os.release(),
+      hostname: os.hostname(),
+    },
+    cpu: {
+      model: cpus[0]?.model ?? "unknown",
+      count: cpus.length,
+    },
+    memory: {
+      total_bytes: os.totalmem(),
+    },
+    user: {
+      username: username(),
+      homedir: os.homedir(),
+    },
+    runtime: {
+      bun_version: Bun.version,
+      node_version: process.versions.node,
+      pid: process.pid,
+      timezone: timezone(),
+      locale: locale(),
+    },
+    paths: {
+      cwd: process.cwd(),
+      data: Global.Path.data,
+      config: Global.Path.config,
+    },
+    mimocode: {
+      version: InstallationVersion,
+      channel: InstallationChannel,
+      installation_id: await getInstallationID(),
+      run_id: MIMOCODE_RUN_ID,
+      process_role: MIMOCODE_PROCESS_ROLE,
+    },
+  }
+}
+
+export function getEnvTelemetry() {
   const cpus = os.cpus()
 
   return {

--- a/packages/opencode/src/util/index.ts
+++ b/packages/opencode/src/util/index.ts
@@ -1,5 +1,6 @@
 export * as Archive from "./archive"
 export * as Color from "./color"
+export { getEnvInfo, getEnvTelemetry } from "./env-info"
 export * as Filesystem from "./filesystem"
 export * as Keybind from "./keybind"
 export * as LocalContext from "./local-context"

--- a/packages/opencode/src/util/index.ts
+++ b/packages/opencode/src/util/index.ts
@@ -1,6 +1,6 @@
 export * as Archive from "./archive"
 export * as Color from "./color"
-export { getEnvInfo, getEnvTelemetry } from "./env-info"
+export { getEnvInfo } from "./env-info"
 export * as Filesystem from "./filesystem"
 export * as Keybind from "./keybind"
 export * as LocalContext from "./local-context"

--- a/packages/opencode/test/plugin/session-loop-hooks.test.ts
+++ b/packages/opencode/test/plugin/session-loop-hooks.test.ts
@@ -1,0 +1,159 @@
+import path from "path"
+import { pathToFileURL } from "url"
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Exit, Layer } from "effect"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Log } from "../../src/util"
+import { tmpdir } from "../fixture/fixture"
+import { startScriptedLLMServer, textStopResponse } from "../lib/scripted-llm-server"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+function run<A, E>(fx: Effect.Effect<A, E, SessionPrompt.Service | Session.Service>) {
+  return Effect.runPromise(
+    fx.pipe(Effect.scoped, Effect.provide(Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer))),
+  )
+}
+
+describe("SessionPrompt session loop hooks", () => {
+  test(
+    "session.pre cancel aborts before LLM and fires session.post",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+      const stub = startScriptedLLMServer([{ lines: textStopResponse("should not run") }])
+      try {
+        const file = path.join(tmp.path, "plugin.ts")
+        await Bun.write(
+          file,
+          [
+            "export default async () => ({",
+            '  "session.pre": async (_input, output) => {',
+            "    output.cancel = true",
+            '    output.cancelReason = "blocked by test"',
+            "  },",
+            '  "session.post": async (input) => {',
+            '    if (input.outcome !== "cancelled") throw new Error(`expected cancelled, got ${input.outcome}`)',
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        )
+        await Bun.write(
+          path.join(tmp.path, "mimocode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            plugin: [pathToFileURL(file).href],
+            enabled_providers: ["alibaba"],
+            provider: {
+              alibaba: { options: { apiKey: "test-key", baseURL: `${stub.origin}/v1` } },
+            },
+            agent: { build: { model: "alibaba/qwen-plus" } },
+          }),
+        )
+
+        const exit = await Instance.provide({
+          directory: tmp.path,
+          fn: () =>
+            run(
+              Effect.gen(function* () {
+                const sessions = yield* Session.Service
+                const prompt = yield* SessionPrompt.Service
+                const session = yield* sessions.create({ title: "pre-cancel" })
+                return yield* prompt
+                  .prompt({
+                    sessionID: session.id,
+                    agent: "build",
+                    parts: [{ type: "text", text: "hello" }],
+                  })
+                  .pipe(Effect.exit)
+              }),
+            ),
+        })
+
+        expect(Exit.isFailure(exit)).toBe(true)
+        expect(stub.captures.length).toBe(0)
+      } finally {
+        await stub.stop()
+      }
+    },
+    { timeout: 30_000 },
+  )
+
+  test(
+    "fires pre/post session and userQuery hooks around a single LLM step",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+      const stub = startScriptedLLMServer([{ lines: textStopResponse("hook answer") }])
+      const markerPath = path.join(tmp.path, "hook-events.json")
+      try {
+        const file = path.join(tmp.path, "plugin.ts")
+        await Bun.write(
+          file,
+          [
+            "import * as fs from 'fs/promises'",
+            `const MARKER = ${JSON.stringify(markerPath)}`,
+            "async function push(label: string) {",
+            "  let cur: string[] = []",
+            "  try { cur = JSON.parse(await fs.readFile(MARKER, 'utf8')) } catch {}",
+            "  cur.push(label)",
+            "  await fs.writeFile(MARKER, JSON.stringify(cur))",
+            "}",
+            "export default async () => ({",
+            '  "session.pre": async (input) => { await push(`pre:${input.agentID}`) },',
+            '  "session.userQuery.pre": async (input) => { await push(`query.pre:${input.step}:${input.query}`) },',
+          '  "session.userQuery.post": async (input) => { await push(`query.post:${input.step}:${input.finalText ?? ""}:${input.trajectory.length}`) },',
+          '  "session.post": async (input) => { await push(`post:${input.outcome}:${input.finalText ?? ""}:${input.trajectory.length}`) },',
+            "})",
+            "",
+          ].join("\n"),
+        )
+        await Bun.write(
+          path.join(tmp.path, "mimocode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            plugin: [pathToFileURL(file).href],
+            enabled_providers: ["alibaba"],
+            provider: {
+              alibaba: { options: { apiKey: "test-key", baseURL: `${stub.origin}/v1` } },
+            },
+            agent: { build: { model: "alibaba/qwen-plus" } },
+          }),
+        )
+
+        await Instance.provide({
+          directory: tmp.path,
+          fn: () =>
+            run(
+              Effect.gen(function* () {
+                const sessions = yield* Session.Service
+                const prompt = yield* SessionPrompt.Service
+                const session = yield* sessions.create({ title: "hook-order" })
+                yield* prompt.prompt({
+                  sessionID: session.id,
+                  agent: "build",
+                  parts: [{ type: "text", text: "What is the answer?" }],
+                })
+              }),
+            ),
+        })
+
+        const events = JSON.parse(await Bun.file(markerPath).text()) as string[]
+        expect(events[0]).toBe("pre:main")
+        expect(events[1]).toMatch(/^query\.pre:1:/)
+        expect(events[2]).toMatch(/^query\.post:1:hook answer:\d+$/)
+        expect(events[3]).toMatch(/^post:completed:hook answer:\d+$/)
+        expect(Number(events[3]?.split(":").pop())).toBeGreaterThan(0)
+        expect(stub.captures.length).toBe(1)
+      } finally {
+        await stub.stop()
+      }
+    },
+    { timeout: 30_000 },
+  )
+})

--- a/packages/opencode/test/session/trajectory.test.ts
+++ b/packages/opencode/test/session/trajectory.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, test } from "bun:test"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionID, MessageID, PartID } from "../../src/session/schema"
+import { serializeTrajectoryMessages } from "../../src/session/trajectory"
+
+describe("serializeTrajectoryMessages", () => {
+  test("preserves all fields for replay (synthetic reminders, tool state, reasoning, IDs, timing, metadata)", () => {
+    const sessionID = SessionID.make("ses_test")
+    const userID = MessageID.make("msg_user")
+    const asstID = MessageID.make("msg_asst")
+    const msgs: MessageV2.WithParts[] = [
+      {
+        info: {
+          id: userID,
+          sessionID,
+          role: "user",
+          agent: "build",
+          model: { providerID: "alibaba" as any, modelID: "qwen" as any },
+          time: { created: 1 },
+        },
+        parts: [
+          {
+            id: PartID.make("part_1"),
+            messageID: userID,
+            sessionID,
+            type: "text",
+            text: "fix the bug",
+          },
+          {
+            id: PartID.make("part_2"),
+            messageID: userID,
+            sessionID,
+            type: "text",
+            synthetic: true,
+            text: "<system-reminder>recall memory</system-reminder>",
+          },
+        ],
+      },
+      {
+        info: {
+          id: asstID,
+          sessionID,
+          role: "assistant",
+          parentID: userID,
+          agent: "build",
+          mode: "build",
+          modelID: "qwen" as any,
+          providerID: "alibaba" as any,
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0.0123,
+          tokens: { input: 1, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: 2, completed: 3 },
+          finish: "tool-calls",
+        },
+        parts: [
+          {
+            id: PartID.make("part_3"),
+            messageID: asstID,
+            sessionID,
+            type: "reasoning",
+            text: "I'll read the file first",
+            time: { start: 2 },
+          },
+          {
+            id: PartID.make("part_4"),
+            messageID: asstID,
+            sessionID,
+            type: "tool",
+            tool: "read",
+            callID: "call_1",
+            state: {
+              status: "completed",
+              input: { file_path: "src/a.ts" },
+              output: "export const x = 1",
+              title: "Read src/a.ts",
+              metadata: { lines: 1 },
+              time: { start: 2, end: 3 },
+            },
+          },
+        ],
+      },
+    ]
+
+    const out = serializeTrajectoryMessages(msgs)
+    expect(out).toHaveLength(2)
+
+    // User message: full info preserved + parts.
+    expect(out[0]).toMatchObject({
+      role: "user",
+      id: userID,
+      sessionID,
+      agent: "build",
+      model: { providerID: "alibaba", modelID: "qwen" },
+      created: 1,
+      time: { created: 1 },
+    })
+    expect(out[0]?.parts).toHaveLength(2)
+    expect(out[0]?.parts[0]).toMatchObject({
+      type: "text",
+      id: "part_1",
+      sessionID,
+      messageID: userID,
+      text: "fix the bug",
+    })
+    expect(out[0]?.parts[1]).toMatchObject({
+      type: "text",
+      synthetic: true,
+      text: "<system-reminder>recall memory</system-reminder>",
+    })
+
+    // Assistant message: tokens, cost, modelID, providerID, path, parentID all preserved.
+    expect(out[1]).toMatchObject({
+      role: "assistant",
+      id: asstID,
+      parentID: userID,
+      modelID: "qwen",
+      providerID: "alibaba",
+      cost: 0.0123,
+      tokens: { input: 1, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+      path: { cwd: "/tmp", root: "/tmp" },
+      finish: "tool-calls",
+      created: 2,
+      time: { created: 2, completed: 3 },
+    })
+
+    // Reasoning part: id + time + text preserved.
+    expect(out[1]?.parts[0]).toMatchObject({
+      type: "reasoning",
+      id: "part_3",
+      text: "I'll read the file first",
+      time: { start: 2 },
+    })
+
+    // Tool part: nested state preserved (status, input, output, title, metadata, time).
+    expect(out[1]?.parts[1]).toMatchObject({
+      type: "tool",
+      id: "part_4",
+      tool: "read",
+      callID: "call_1",
+      state: {
+        status: "completed",
+        input: { file_path: "src/a.ts" },
+        output: "export const x = 1",
+        title: "Read src/a.ts",
+        metadata: { lines: 1 },
+        time: { start: 2, end: 3 },
+      },
+    })
+  })
+
+  test("summarizes data: URLs in file parts and tool attachments without dropping fields", () => {
+    const sessionID = SessionID.make("ses_test2")
+    const userID = MessageID.make("msg_user2")
+    const asstID = MessageID.make("msg_asst2")
+    const msgs: MessageV2.WithParts[] = [
+      {
+        info: {
+          id: userID,
+          sessionID,
+          role: "user",
+          agent: "build",
+          model: { providerID: "alibaba" as any, modelID: "qwen" as any },
+          time: { created: 1 },
+        },
+        parts: [
+          {
+            id: PartID.make("part_f"),
+            messageID: userID,
+            sessionID,
+            type: "file",
+            mime: "image/png",
+            filename: "shot.png",
+            url: "data:image/png;base64,AAAAAAAAAAA",
+            source: { type: "file", path: "/tmp/shot.png", text: { value: "shot.png", start: 0, end: 8 } },
+          },
+        ],
+      },
+      {
+        info: {
+          id: asstID,
+          sessionID,
+          role: "assistant",
+          parentID: userID,
+          agent: "build",
+          mode: "build",
+          modelID: "qwen" as any,
+          providerID: "alibaba" as any,
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: 2 },
+        },
+        parts: [
+          {
+            id: PartID.make("part_t"),
+            messageID: asstID,
+            sessionID,
+            type: "tool",
+            tool: "screenshot",
+            callID: "call_s",
+            state: {
+              status: "completed",
+              input: {},
+              output: "see attachment",
+              title: "screenshot",
+              metadata: {},
+              time: { start: 2, end: 3 },
+              attachments: [
+                {
+                  id: PartID.make("part_att"),
+                  messageID: asstID,
+                  sessionID,
+                  type: "file",
+                  mime: "image/png",
+                  url: "data:image/png;base64,BBBBBBBBBBB",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]
+
+    const out = serializeTrajectoryMessages(msgs)
+    expect(out[0]?.parts[0]).toMatchObject({
+      type: "file",
+      mime: "image/png",
+      filename: "shot.png",
+      url: "[data-url:image/png:shot.png]",
+      source: { type: "file", path: "/tmp/shot.png" },
+    })
+    const toolPart = out[1]?.parts[0] as any
+    expect(toolPart.state.attachments[0].url).toBe("[data-url:image/png]")
+    expect(toolPart.state.attachments[0].mime).toBe("image/png")
+  })
+})

--- a/packages/opencode/test/util/env-info.test.ts
+++ b/packages/opencode/test/util/env-info.test.ts
@@ -1,32 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import os from "os"
-import { getEnvInfo, getEnvTelemetry } from "../../src/util/env-info"
+import { getEnvInfo } from "../../src/util/env-info"
 
 describe("util.env-info", () => {
-  test("getEnvTelemetry returns only telemetry-safe fields", () => {
-    const telemetry = getEnvTelemetry()
-
-    expect(telemetry.os.platform).toBe(os.platform())
-    expect(telemetry.os.arch).toBe(os.arch())
-    expect(telemetry.os.release).toBe(os.release())
-    expect(telemetry.cpu.count).toBe(os.cpus().length)
-    expect(telemetry.cpu.model).toBe(os.cpus()[0]?.model ?? "unknown")
-    expect(telemetry.memory.total_bytes).toBe(os.totalmem())
-    expect(telemetry.runtime.bun_version).toBe(Bun.version)
-    expect(telemetry.runtime.node_version).toBe(process.versions.node)
-    expect(telemetry.mimocode.version).toBeTruthy()
-    expect(telemetry.mimocode.channel).toBeTruthy()
-
-    expect(telemetry).not.toHaveProperty("user")
-    expect(telemetry).not.toHaveProperty("paths")
-    expect(telemetry.os).not.toHaveProperty("hostname")
-    expect(telemetry.memory).not.toHaveProperty("free_bytes")
-    expect(telemetry.runtime).not.toHaveProperty("pid")
-    expect(telemetry.mimocode).not.toHaveProperty("installation_id")
-    expect(telemetry.mimocode).not.toHaveProperty("run_id")
-    expect(telemetry.mimocode).not.toHaveProperty("process_role")
-  })
-
   test("returns host, user, runtime, and mimocode metadata", async () => {
     const info = await getEnvInfo()
 

--- a/packages/opencode/test/util/env-info.test.ts
+++ b/packages/opencode/test/util/env-info.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import os from "os"
+import { getEnvInfo, getEnvTelemetry } from "../../src/util/env-info"
+
+describe("util.env-info", () => {
+  test("getEnvTelemetry returns only telemetry-safe fields", () => {
+    const telemetry = getEnvTelemetry()
+
+    expect(telemetry.os.platform).toBe(os.platform())
+    expect(telemetry.os.arch).toBe(os.arch())
+    expect(telemetry.os.release).toBe(os.release())
+    expect(telemetry.cpu.count).toBe(os.cpus().length)
+    expect(telemetry.cpu.model).toBe(os.cpus()[0]?.model ?? "unknown")
+    expect(telemetry.memory.total_bytes).toBe(os.totalmem())
+    expect(telemetry.runtime.bun_version).toBe(Bun.version)
+    expect(telemetry.runtime.node_version).toBe(process.versions.node)
+    expect(telemetry.mimocode.version).toBeTruthy()
+    expect(telemetry.mimocode.channel).toBeTruthy()
+
+    expect(telemetry).not.toHaveProperty("user")
+    expect(telemetry).not.toHaveProperty("paths")
+    expect(telemetry.os).not.toHaveProperty("hostname")
+    expect(telemetry.memory).not.toHaveProperty("free_bytes")
+    expect(telemetry.runtime).not.toHaveProperty("pid")
+    expect(telemetry.mimocode).not.toHaveProperty("installation_id")
+    expect(telemetry.mimocode).not.toHaveProperty("run_id")
+    expect(telemetry.mimocode).not.toHaveProperty("process_role")
+  })
+
+  test("returns host, user, runtime, and mimocode metadata", async () => {
+    const info = await getEnvInfo()
+
+    expect(info.os.platform).toBe(os.platform())
+    expect(info.os.arch).toBe(os.arch())
+    expect(info.os.hostname).toBe(os.hostname())
+    expect(info.cpu.count).toBe(os.cpus().length)
+    expect(info.cpu.model).toBe(os.cpus()[0]?.model ?? "unknown")
+    expect(info.memory.total_bytes).toBe(os.totalmem())
+    expect(info.user.homedir).toBe(os.homedir())
+    expect(info.runtime.bun_version).toBe(Bun.version)
+    expect(info.runtime.node_version).toBe(process.versions.node)
+    expect(info.runtime.pid).toBe(process.pid)
+    expect(info.paths.cwd).toBe(process.cwd())
+    expect(info.mimocode.version).toBeTruthy()
+    expect(info.mimocode.channel).toBeTruthy()
+    expect(info.mimocode.installation_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    )
+  })
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -299,6 +299,126 @@ export type ActorPostStopRegistration =
   | ActorPostStopHook
   | { matcher?: ActorMatcher; run: ActorPostStopHook }
 
+/**
+ * Wire-format part inside a trajectory. Mirrors MessageV2.Part with full
+ * field-level fidelity for replay: `id`, `time`, `metadata`, `source`,
+ * `attachments`, `tokens`, `raw`, etc. are all preserved.
+ *
+ * Common discriminators and notable fields are documented below; consumers
+ * can read any field via the index signature for forward-compat with new
+ * part types.
+ */
+export type TrajectoryPart = {
+  /** Discriminator: text | reasoning | tool | file | agent | subtask | compaction | checkpoint | step-start | step-finish | retry | patch | snapshot | … */
+  type: string
+  /** Stable PartID — present on all runtime parts. */
+  id?: string
+  sessionID?: string
+  messageID?: string
+  /** Free-form metadata stored on text/reasoning/tool parts. */
+  metadata?: Record<string, unknown>
+  /** Tool parts: nested ToolState (status, input, output, error, attachments, time, raw, …). */
+  state?: Record<string, unknown>
+  /** Tool call ID for tool parts. */
+  callID?: string
+  /** Tool name for tool parts. */
+  tool?: string
+  /** File parts: data: URLs are summarized to "[data-url:mime[:filename]]"; other URLs untouched. */
+  url?: string
+  mime?: string
+  filename?: string
+  /** Text parts: visible content; reasoning parts: thought content. */
+  text?: string
+  synthetic?: boolean
+  ignored?: boolean
+  /** Step-finish: reason / cost / tokens / snapshot. */
+  reason?: string
+  cost?: number
+  tokens?: Record<string, unknown>
+  /** Patch parts: full file list (not just count) for replay. */
+  files?: string[] | number
+  hash?: string
+  /** Compaction parts. */
+  auto?: boolean
+  overflow?: boolean
+  tail_start_id?: string
+  /** Checkpoint parts. */
+  checkpointDir?: string
+  checkpointNumber?: number
+  coveredUpTo?: string
+  /** Subtask parts. */
+  prompt?: string
+  description?: string
+  agent?: string
+  command?: string
+  model?: { providerID: string; modelID: string; variant?: string }
+  /** Agent / file parts: source span pointing back at the originating prompt slice. */
+  source?: Record<string, unknown>
+  /** Retry parts. */
+  attempt?: number
+  error?: unknown
+  /** Step-start / snapshot parts. */
+  snapshot?: string
+  /** Timing for parts that record start/end. */
+  time?: { start?: number; end?: number; created?: number; compacted?: number }
+  [key: string]: unknown
+}
+
+/**
+ * Wire-format message inside a trajectory. Mirrors MessageV2.User and
+ * MessageV2.Assistant with full field-level fidelity for replay: `model`,
+ * `tools`, `format`, `tokens`, `cost`, `modelID`, `providerID`, `path`,
+ * `provenance`, `summary`, `error`, `finish`, `structured`, `parentID`, etc.
+ *
+ * `created` is hoisted from `time.created` for convenience; `time` is also
+ * preserved on the object.
+ */
+export type TrajectoryMessage = {
+  role: "user" | "assistant"
+  id: string
+  sessionID?: string
+  agentID?: string
+  agent: string
+  /** Hoisted from time.created for convenience. The full `time` object is also present. */
+  created: number
+  time?: { created: number; completed?: number }
+  parts: TrajectoryPart[]
+  /** User: the system prompt override the user pinned to this turn (rare). */
+  system?: string
+  /** User: per-turn model selection (providerID/modelID/variant). */
+  model?: { providerID: string; modelID: string; variant?: string }
+  /** User: per-turn tool allowlist override. */
+  tools?: Record<string, boolean>
+  /** User: structured-output format request. */
+  format?: { type: string; [key: string]: unknown }
+  /** User: provenance for hook-injected synthetic messages. */
+  provenance?: { hookPhase: string; hookIteration: number; pluginNames: string[]; hookIDs: string[] }
+  /** Either role: condensed summary used by compaction/checkpoint. */
+  summary?: unknown
+  /** Assistant: parent user-message ID this turn replied to. */
+  parentID?: string
+  /** Assistant: model identifiers (separate from User.model for cross-turn mismatches). */
+  modelID?: string
+  providerID?: string
+  /** Assistant: deprecated mode field, still emitted for replay. */
+  mode?: string
+  /** Assistant: variant alias. */
+  variant?: string
+  /** Assistant: working-directory snapshot at turn start. */
+  path?: { cwd: string; root: string }
+  /** Assistant: total cost in USD for this turn. */
+  cost?: number
+  /** Assistant: token usage breakdown (input/output/reasoning/cache). */
+  tokens?: { total?: number; input: number; output: number; reasoning: number; cache: { read: number; write: number } }
+  /** Assistant: structured-output payload (when format=json_schema). */
+  structured?: unknown
+  /** Assistant: finish reason ("stop" | "length" | "tool-calls" | "cancelled" | …). */
+  finish?: string
+  /** Assistant: serialized error blob (NamedError, AbortedError, etc.). Preserved as-is for replay. */
+  error?: unknown
+  [key: string]: unknown
+}
+
 export interface Hooks {
   event?: (input: { event: Event }) => Promise<void>
   config?: (input: Config) => Promise<void>
@@ -425,4 +545,69 @@ export interface Hooks {
    * Default matcher excludes BUILT_IN_AGENTS.
    */
   "actor.postStop"?: ActorPostStopRegistration
+  /**
+   * Fires once when SessionPrompt.runLoop starts (before the first LLM step).
+   * Fires for every agent slice — main and any subagent that drives its own runLoop.
+   * Set `output.cancel = true` to abort the run without calling the model.
+   */
+  "session.pre"?: (
+    input: { sessionID: string; agentID: string; task_id?: string },
+    output: { cancel?: boolean; cancelReason?: string },
+  ) => Promise<void>
+  /**
+   * Fires once when SessionPrompt.runLoop finishes — guaranteed to fire even on
+   * thrown failures / interruptions (wired via Effect.onExit, not the success path).
+   * `outcome` is "cancelled" when either session.pre or any session.userQuery.pre
+   * set `output.cancel = true`; "error" on Effect failure or model error;
+   * "completed" otherwise.
+   */
+  "session.post"?: (
+    input: {
+      sessionID: string
+      agentID: string
+      task_id?: string
+      outcome: "completed" | "error" | "cancelled"
+      error?: string
+      finalText?: string
+      assistantMessageID?: string
+      /** Full raw agent slice: user text, synthetic reminders, tool calls/results, reasoning, etc. */
+      trajectory: TrajectoryMessage[]
+    },
+    output: {},
+  ) => Promise<void>
+  /**
+   * Fires immediately before each LLM step in SessionPrompt.runLoop.
+   * `step` increments per loop iteration, NOT per user message — a single user
+   * turn typically spans several steps (tool round-trips, retries, continuations).
+   * Set `output.cancel = true` to skip the model call; the step short-circuits and
+   * the surrounding session ends with `outcome: "cancelled"`.
+   */
+  "session.userQuery.pre"?: (
+    input: { sessionID: string; agentID: string; step: number; messageID: string; query: string },
+    output: { cancel?: boolean; cancelReason?: string },
+  ) => Promise<void>
+  /**
+   * Fires immediately after each LLM step in SessionPrompt.runLoop — guaranteed
+   * to fire even when handle.process / MaxMode.runMaxStep yield a failure
+   * (wired via Effect.onExit). `error` is populated from the failure cause in
+   * that case; otherwise from the assistant message's recorded error.
+   */
+  "session.userQuery.post"?: (
+    input: {
+      sessionID: string
+      agentID: string
+      step: number
+      messageID: string
+      /** Non-synthetic user text only (summary). See `trajectory` for the full raw slice. */
+      query: string
+      assistantMessageID: string
+      finish?: string
+      error?: string
+      /** Non-synthetic assistant text / structured output (summary). See `trajectory`. */
+      finalText?: string
+      /** Raw messages through this step (includes synthetic reminders, tools, reasoning). */
+      trajectory: TrajectoryMessage[]
+    },
+    output: {},
+  ) => Promise<void>
 }


### PR DESCRIPTION
## Summary

- Add `session.pre`, `session.post`, `session.userQuery.pre`, `session.userQuery.post` plugin hooks to `SessionPrompt.runLoop`
- Hooks fire reliably via `Effect.onExit` — guaranteed even on thrown failures/interruptions
- Include full trajectory data (`TrajectoryMessage[]`) for replay with field-level fidelity
- Add `getEnvInfo` / `getEnvTelemetry` utilities for environment metadata collection

## Details

**Plugin hooks:**
- `session.pre` — fires once before the first LLM step; supports cancellation via `output.cancel`
- `session.post` — fires once when runLoop ends; reports `outcome: "completed" | "error" | "cancelled"` with final text and trajectory
- `session.userQuery.pre` — fires before each LLM step; supports per-step cancellation
- `session.userQuery.post` — fires after each LLM step (via `Effect.onExit`); includes error, finalText, and step trajectory

**Trajectory types** (`TrajectoryMessage`, `TrajectoryPart`) in `@mimo-ai/plugin` provide the wire format for full raw agent slice replay.

**Tests:** unit tests for trajectory serialization, env-info, and session-loop hook integration.