### PR TITLE
feat(tui): add i18n translations for slash command descriptions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -11,6 +11,8 @@ import { useTuiConfig } from "../../context/tui-config"
 import { useTheme, selectedForeground } from "@tui/context/theme"
 import { SplitBorder } from "@tui/component/border"
 import { useCommandDialog } from "@tui/component/dialog-command"
+import { useLanguage } from "@tui/context/language"
+import { slashCommandDescription } from "@tui/i18n/slash-command"
 import { useTerminalDimensions } from "@opentui/solid"
 import { Locale } from "@/util"
 import type { PromptInfo } from "./history"
@@ -80,6 +82,7 @@ export function Autocomplete(props: {
   const sdk = useSDK()
   const sync = useSync()
   const command = useCommandDialog()
+  const lang = useLanguage()
   const { theme } = useTheme()
   const dimensions = useTerminalDimensions()
   const frecency = useFrecency()
@@ -368,7 +371,7 @@ export function Autocomplete(props: {
       const label = serverCommand.source === "mcp" ? ":mcp" : ""
       results.push({
         display: "/" + serverCommand.name + label,
-        description: serverCommand.description,
+        description: slashCommandDescription(lang.t, serverCommand.name, serverCommand.description),
         onSelect: () => {
           const newText = "/" + serverCommand.name + " "
           const cursor = props.input().logicalCursor

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -183,6 +183,18 @@ export const dict: Record<string, string> = {
   "tui.command.category.internal": "Internal",
   "tui.command.category.external": "External",
 
+  // Built-in slash command descriptions
+  "tui.slash.init.description": "guided AGENTS.md setup",
+  "tui.slash.review.description": "review changes [commit|branch|pr], defaults to uncommitted",
+  "tui.slash.dream.description":
+    "manually consolidate project memory from memory files and raw trajectory",
+  "tui.slash.distill.description":
+    "find repeated workflows in recent work and package them into skills, subagents, or commands",
+  "tui.slash.goal.description":
+    "set a stop-condition goal; runs until a judge says it's met. /goal clear to abort",
+  "tui.slash.deep-research.description":
+    "deep multi-source, fact-checked research report (runs the deep-research workflow)",
+
   // Language switching
   "tui.command.language.switch.title": "Switch language",
   "tui.command.language.switch.description": "Change the display language",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -259,6 +259,18 @@ export const dict = {
   "tui.command.category.internal": "Interno",
   "tui.command.category.external": "Externo",
 
+  // Built-in slash command descriptions
+  "tui.slash.init.description": "configuración guiada de AGENTS.md",
+  "tui.slash.review.description": "revisar cambios [commit|branch|pr], por defecto sin confirmar",
+  "tui.slash.dream.description":
+    "consolidar manualmente la memoria del proyecto desde archivos memory y la trayectoria en bruto",
+  "tui.slash.distill.description":
+    "encontrar flujos repetidos en el trabajo reciente y empaquetarlos en skills, subagentes o comandos",
+  "tui.slash.goal.description":
+    "definir un objetivo con condición de parada; se ejecuta hasta que un juez confirme. /goal clear para abortar",
+  "tui.slash.deep-research.description":
+    "informe de investigación profunda multi-fuente y verificado (ejecuta el workflow deep-research)",
+
   // Language switching
   "tui.command.language.switch.title": "Cambiar idioma",
   "tui.command.language.switch.description": "Cambiar el idioma de la interfaz",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -247,6 +247,18 @@ export const dict = {
   "tui.command.category.internal": "Interne",
   "tui.command.category.external": "Externe",
 
+  // Built-in slash command descriptions
+  "tui.slash.init.description": "configuration guidée de AGENTS.md",
+  "tui.slash.review.description": "revoir les changements [commit|branch|pr], par défaut non commités",
+  "tui.slash.dream.description":
+    "consolider manuellement la mémoire du projet à partir des fichiers memory et de la trajectoire brute",
+  "tui.slash.distill.description":
+    "trouver les workflows répétés dans le travail récent et les empaqueter en skills, sous-agents ou commandes",
+  "tui.slash.goal.description":
+    "définir un objectif avec condition d'arrêt ; s'exécute jusqu'à ce qu'un juge confirme. /goal clear pour annuler",
+  "tui.slash.deep-research.description":
+    "rapport de recherche approfondi multi-sources et vérifié (exécute le workflow deep-research)",
+
   // Language switching
   "tui.command.language.switch.title": "Changer de langue",
   "tui.command.language.switch.description": "Modifier la langue d'affichage",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -200,6 +200,14 @@ export const dict = {
   "tui.command.category.internal": "組み込み",
   "tui.command.category.external": "外部",
 
+  // Built-in slash command descriptions
+  "tui.slash.init.description": "AGENTS.md をガイド付きでセットアップ",
+  "tui.slash.review.description": "変更をレビュー [commit|branch|pr]、デフォルトは未コミット",
+  "tui.slash.dream.description": "memory ファイルと生の軌跡からプロジェクトメモリを手動で統合",
+  "tui.slash.distill.description": "最近の作業から繰り返しワークフローを見つけ、skill・サブエージェント・コマンドにパッケージ化",
+  "tui.slash.goal.description": "停止条件付きゴールを設定；判定が達成と言うまで実行。/goal clear で中止",
+  "tui.slash.deep-research.description": "深い多ソース・ファクトチェック済み調査レポート（deep-research ワークフローを実行）",
+
   // Language switching
   "tui.command.language.switch.title": "言語を切り替え",
   "tui.command.language.switch.description": "表示言語を変更します",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -262,6 +262,18 @@ export const dict = {
   "tui.command.category.internal": "Внутренние",
   "tui.command.category.external": "Внешние",
 
+  // Built-in slash command descriptions
+  "tui.slash.init.description": "пошаговая настройка AGENTS.md",
+  "tui.slash.review.description": "просмотр изменений [commit|branch|pr], по умолчанию незакоммиченные",
+  "tui.slash.dream.description":
+    "вручную консолидировать память проекта из memory-файлов и сырой траектории",
+  "tui.slash.distill.description":
+    "найти повторяющиеся workflow в недавней работе и упаковать их в skills, субагентов или команды",
+  "tui.slash.goal.description":
+    "задать цель с условием остановки; выполняется, пока судья не подтвердит. /goal clear для отмены",
+  "tui.slash.deep-research.description":
+    "глубокий многоисточниковый проверенный отчёт (запускает workflow deep-research)",
+
   // Language switching
   "tui.command.language.switch.title": "Сменить язык",
   "tui.command.language.switch.description": "Изменить язык интерфейса",

--- a/packages/opencode/src/cli/cmd/tui/i18n/slash-command.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/slash-command.ts
@@ -1,0 +1,11 @@
+const BUILTIN = new Set(["init", "review", "dream", "distill", "goal", "deep-research"])
+
+export function slashCommandDescription(
+  t: (key: string) => string,
+  name: string,
+  fallback?: string,
+) {
+  if (!BUILTIN.has(name)) return fallback
+  const translated = t(`tui.slash.${name}.description`)
+  return translated || fallback
+}

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -176,6 +176,14 @@ export const dict = {
   "tui.command.category.internal": "内置",
   "tui.command.category.external": "第三方",
 
+  // Built-in slash command descriptions
+  "tui.slash.init.description": "引导式 AGENTS.md 设置",
+  "tui.slash.review.description": "审查变更 [commit|branch|pr]，默认未提交的变更",
+  "tui.slash.dream.description": "从 memory 文件与原始轨迹中手动整合项目记忆",
+  "tui.slash.distill.description": "在最近工作中发现重复流程，打包为 skill、子智能体或命令",
+  "tui.slash.goal.description": "设置终止条件目标；运行直到判定达成。使用 /goal clear 中止",
+  "tui.slash.deep-research.description": "深度多来源、事实核查的研究报告（运行 deep-research 工作流）",
+
   // Language switching
   "tui.command.language.switch.title": "切换语言",
   "tui.command.language.switch.description": "更改显示语言",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -176,6 +176,14 @@ export const dict = {
   "tui.command.category.internal": "內建",
   "tui.command.category.external": "第三方",
 
+  // Built-in slash command descriptions
+  "tui.slash.init.description": "引導式 AGENTS.md 設定",
+  "tui.slash.review.description": "審查變更 [commit|branch|pr]，預設未提交的變更",
+  "tui.slash.dream.description": "從 memory 檔案與原始軌跡中手動整合專案記憶",
+  "tui.slash.distill.description": "在最近工作中發現重複流程，打包為 skill、子智慧代理或命令",
+  "tui.slash.goal.description": "設定終止條件目標；執行直到判定達成。使用 /goal clear 中止",
+  "tui.slash.deep-research.description": "深度多來源、事實核查的研究報告（執行 deep-research 工作流程）",
+
   // Language switching
   "tui.command.language.switch.title": "切換語言",
   "tui.command.language.switch.description": "變更顯示語言",


### PR DESCRIPTION
## Summary
- Add localized descriptions for built-in slash commands (`/init`, `/review`, `/dream`, `/distill`, `/goal`, `/deep-research`) across all 7 supported languages (en, es, fr, ja, ru, zh, zht)
- Introduce `slashCommandDescription` helper in new `i18n/slash-command.ts` module
- Wire translated descriptions into the autocomplete component

## Changes
- **New file**: `i18n/slash-command.ts` — `slashCommandDescription()` utility that maps built-in command names to i18n keys
- **Modified**: `autocomplete.tsx` — uses `slashCommandDescription()` for slash command display
- **Modified**: All 7 locale files (`en.ts`, `es.ts`, `fr.ts`, `ja.ts`, `ru.ts`, `zh.ts`, `zht.ts`) — add `tui.slash.*.description` entries