### PR TITLE
fix(acp): honor config.json model when provider not yet loaded

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1568,7 +1568,7 @@ async function defaultModel(config: ACPConfig, cwd?: string): Promise<{ provider
     if (provider && provider.models[specified.modelID]) return specified
     // Provider not yet loaded or model not found — still honor the user's explicit choice
     // rather than falling through to Provider.sort() which may pick a paid model
-    if (!provider) return specified
+    if (!provider || !provider.models[specified.modelID]) return specified
   }
 
   if (specified && !providers.length) return specified

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1566,6 +1566,9 @@ async function defaultModel(config: ACPConfig, cwd?: string): Promise<{ provider
   if (specified && providers.length) {
     const provider = providers.find((p) => p.id === specified.providerID)
     if (provider && provider.models[specified.modelID]) return specified
+    // Provider not yet loaded or model not found — still honor the user's explicit choice
+    // rather than falling through to Provider.sort() which may pick a paid model
+    if (!provider) return specified
   }
 
   if (specified && !providers.length) return specified


### PR DESCRIPTION
## Summary

When `defaultModel()` finds a model specified in `config.json` but the corresponding provider is not in the providers list, return the specified model instead of falling through to `Provider.sort()`.

## Current Behavior

```
config.json: {"model": "mimo/mimo-auto"}
providers:   [xiaomi]  (mimo not yet indexed)

defaultModel():
  ├─ config.json → specified = "mimo/mimo-auto"          ✅
  ├─ providers.find("mimo") → NOT FOUND
  ├─ (specified exists BUT providers.length > 0)
  │   └─ does NOT return specified
  ├─ falls through ↓
  ├─ Provider.sort([xiaomi models...])
  │   └─ picks "xiaomi/mimo-v2.5-pro-ultraspeed"         ❌ paid
  └─ calls paid API → 0 tokens → "(no response)"
```

## Expected Behavior

```
config.json: {"model": "mimo/mimo-auto"}
providers:   [xiaomi]  (mimo not yet indexed)

defaultModel():
  ├─ config.json → specified = "mimo/mimo-auto"          ✅
  ├─ providers.find("mimo") → NOT FOUND
  ├─ (specified exists, provider missing)
  │   └─ RETURNS specified  ← trust user's explicit config
  └─ calls mimo-auto API → works                         ✅
```

## Fix

When the specified provider is not found in the providers list, return the user's choice rather than falling through to `Provider.sort()` which picks an unintended paid model.

Fixes #865