### PR TITLE
fix(acp): wait for providers to load before accepting requests

### DIFF
--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -32,10 +32,17 @@ export const AcpCommand = cmd({
       // Wait for providers to be fully loaded after potential DB migration.
       // Without this, the first request may race with provider initialization
       // and fall back to Provider.sort() which picks a paid model.
+      let providersReady = false
       for (let i = 0; i < 10; i++) {
         const resp = await sdk.config.providers({ directory: args.cwd }, { throwOnError: false })
-        if (resp.data?.providers?.length) break
+        if (resp.data?.providers?.length) {
+          providersReady = true
+          break
+        }
         await new Promise((r) => setTimeout(r, 500))
+      }
+      if (!providersReady) {
+        log.warn("providers not loaded within 5s, proceeding anyway")
       }
 
       const input = new WritableStream<Uint8Array>({

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -29,6 +29,15 @@ export const AcpCommand = cmd({
         baseUrl: `http://${server.hostname}:${server.port}`,
       })
 
+      // Wait for providers to be fully loaded after potential DB migration.
+      // Without this, the first request may race with provider initialization
+      // and fall back to Provider.sort() which picks a paid model.
+      for (let i = 0; i < 10; i++) {
+        const resp = await sdk.config.providers({ directory: args.cwd }, { throwOnError: false })
+        if (resp.data?.providers?.length) break
+        await new Promise((r) => setTimeout(r, 500))
+      }
+
       const input = new WritableStream<Uint8Array>({
         write(chunk) {
           return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary

After DB migration, the SDK server may not have fully indexed providers before the first ACP request arrives. Add a readiness check before accepting connections.

## Current Behavior

```
┌─── mimo acp cold start ─────────────────────────────────────────┐
│                                                                  │
│  t0  DB migration runs (rewrites SQLite tables)                  │
│  t1  migration done                                              │
│  t2  Server.listen()                                             │
│  t3  ACP agent created ← IMMEDIATELY accepts stdin               │
│  t4  1st request arrives                                         │
│       ├─ sdk.config.providers()                                  │
│       │   └─ [xiaomi] ← mimo provider NOT YET INDEXED   ❌       │
│       ├─ defaultModel() → Provider.sort()                        │
│       │   └─ picks mimo-v2.5-pro-ultraspeed (paid)      ❌       │
│       └─ 0 tokens → "(no response)"                             │
│                                                                  │
│  t5  2nd request → providers fully loaded → works        ✅      │
│                                                                  │
└──────────────────────────────────────────────────────────────────┘
```

## Expected Behavior

```
┌─── mimo acp cold start (with fix) ──────────────────────────────┐
│                                                                  │
│  t0  DB migration runs                                           │
│  t1  migration done                                              │
│  t2  Server.listen()                                             │
│  t3  readiness loop: poll providers every 500ms (max 5s)         │
│       └─ waits until providers.length > 0                        │
│  t4  providers loaded → ACP agent created → accepts stdin        │
│  t5  1st request arrives                                         │
│       ├─ sdk.config.providers()                                  │
│       │   └─ [mimo, xiaomi, ...]                         ✅      │
│       ├─ defaultModel() → mimo/mimo-auto                 ✅      │
│       └─ works on first try!                                     │
│                                                                  │
└──────────────────────────────────────────────────────────────────┘
```

## Relationship to #865

Belt-and-suspenders with PR #1170:
- **#1170**: if provider missing, still honor user config (defensive)
- **#1171**: ensure provider IS loaded before accepting requests (proactive)

Fixes #866