### PR TITLE
fix(acp): resolve cold-start race with belt-and-suspenders defense

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -38,6 +38,7 @@ import { ACPSessionManager } from "./session"
 import type { ACPConfig } from "./types"
 import { Provider } from "../provider"
 import { ModelID, ProviderID } from "../provider/schema"
+import { resolveDefaultModel } from "./resolve-model"
 import { Agent as AgentModule } from "../agent/agent"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Installation } from "@/installation"
@@ -1563,12 +1564,8 @@ async function defaultModel(config: ACPConfig, cwd?: string): Promise<{ provider
       return []
     })
 
-  if (specified && providers.length) {
-    const provider = providers.find((p) => p.id === specified.providerID)
-    if (provider && provider.models[specified.modelID]) return specified
-  }
-
-  if (specified && !providers.length) return specified
+  const resolved = resolveDefaultModel(specified, providers)
+  if (resolved) return resolved
 
   const opencodeProvider = providers.find((p) => p.id === "opencode")
   if (opencodeProvider) {

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1590,8 +1590,6 @@ async function defaultModel(config: ACPConfig, cwd?: string): Promise<{ provider
     }
   }
 
-  if (specified) return specified
-
   return { providerID: ProviderID.opencode, modelID: ModelID.make("big-pickle") }
 }
 

--- a/packages/opencode/src/acp/resolve-model.ts
+++ b/packages/opencode/src/acp/resolve-model.ts
@@ -1,0 +1,22 @@
+import { ModelID, ProviderID } from "../provider/schema"
+
+/**
+ * Pure resolution logic for choosing the default model.
+ * Separated for testability — no SDK calls, no side effects.
+ */
+export function resolveDefaultModel(
+  specified: { providerID: ProviderID; modelID: ModelID } | undefined,
+  providers: Array<{ id: string; models: Record<string, unknown> }>,
+): { providerID: ProviderID; modelID: ModelID } | undefined {
+  if (specified && providers.length) {
+    const provider = providers.find((p) => p.id === specified.providerID)
+    if (provider && provider.models[specified.modelID]) return specified
+    // Provider not yet loaded or model not found — still honor the user's explicit choice
+    // rather than falling through to Provider.sort() which may pick a paid model
+    if (!provider || !provider.models[specified.modelID]) return specified
+  }
+
+  if (specified && !providers.length) return specified
+
+  return undefined // let caller handle fallback
+}

--- a/packages/opencode/src/acp/resolve-model.ts
+++ b/packages/opencode/src/acp/resolve-model.ts
@@ -10,7 +10,8 @@ import { ModelID, ProviderID } from "../provider/schema"
  */
 export function resolveDefaultModel(
   specified: { providerID: ProviderID; modelID: ModelID } | undefined,
-  providers: Array<{ id: string; models: Record<string, unknown> }>,
+  // Kept in signature for future validation (e.g. warn if provider not found)
+  _providers: Array<{ id: string; models: Record<string, unknown> }>,
 ): { providerID: ProviderID; modelID: ModelID } | undefined {
   if (specified) return specified
   return undefined

--- a/packages/opencode/src/acp/resolve-model.ts
+++ b/packages/opencode/src/acp/resolve-model.ts
@@ -3,20 +3,15 @@ import { ModelID, ProviderID } from "../provider/schema"
 /**
  * Pure resolution logic for choosing the default model.
  * Separated for testability — no SDK calls, no side effects.
+ *
+ * If the user specified a model in config.json, always honor it —
+ * regardless of whether the provider/model is currently loaded.
+ * This prevents falling through to Provider.sort() which may pick a paid model.
  */
 export function resolveDefaultModel(
   specified: { providerID: ProviderID; modelID: ModelID } | undefined,
   providers: Array<{ id: string; models: Record<string, unknown> }>,
 ): { providerID: ProviderID; modelID: ModelID } | undefined {
-  if (specified && providers.length) {
-    const provider = providers.find((p) => p.id === specified.providerID)
-    if (provider && provider.models[specified.modelID]) return specified
-    // Provider not yet loaded or model not found — still honor the user's explicit choice
-    // rather than falling through to Provider.sort() which may pick a paid model
-    if (!provider || !provider.models[specified.modelID]) return specified
-  }
-
-  if (specified && !providers.length) return specified
-
-  return undefined // let caller handle fallback
+  if (specified) return specified
+  return undefined
 }

--- a/packages/opencode/src/acp/wait-for-providers.ts
+++ b/packages/opencode/src/acp/wait-for-providers.ts
@@ -12,8 +12,12 @@ export async function waitForProviders(
 ): Promise<boolean> {
   const { maxAttempts = 10, intervalMs = 500 } = opts
   for (let i = 0; i < maxAttempts; i++) {
-    const resp = await poll()
-    if (resp.data?.providers?.length) return true
+    try {
+      const resp = await poll()
+      if (resp.data?.providers?.length) return true
+    } catch {
+      // SDK/network errors during startup are expected (e.g. DB migration in progress)
+    }
     await new Promise((r) => setTimeout(r, intervalMs))
   }
   log.warn("providers not loaded within timeout, proceeding anyway")

--- a/packages/opencode/src/acp/wait-for-providers.ts
+++ b/packages/opencode/src/acp/wait-for-providers.ts
@@ -1,0 +1,21 @@
+import { Log } from "../util"
+
+const log = Log.create({ service: "acp-command" })
+
+/**
+ * Wait for at least one provider to be loaded.
+ * Returns true if providers loaded, false if timed out.
+ */
+export async function waitForProviders(
+  poll: () => Promise<{ data?: { providers?: unknown[] } }>,
+  opts: { maxAttempts?: number; intervalMs?: number } = {},
+): Promise<boolean> {
+  const { maxAttempts = 10, intervalMs = 500 } = opts
+  for (let i = 0; i < maxAttempts; i++) {
+    const resp = await poll()
+    if (resp.data?.providers?.length) return true
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+  log.warn("providers not loaded within timeout, proceeding anyway")
+  return false
+}

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -33,9 +33,12 @@ export const AcpCommand = cmd({
       // Wait for providers to be fully loaded after potential DB migration.
       // Without this, the first request may race with provider initialization
       // and fall back to Provider.sort() which picks a paid model.
-      await waitForProviders(() =>
+      const providersReady = await waitForProviders(() =>
         sdk.config.providers({ directory: args.cwd }, { throwOnError: false }),
       )
+      if (!providersReady) {
+        log.warn("providers not ready after timeout; relying on config-specified model fallback")
+      }
 
       const input = new WritableStream<Uint8Array>({
         write(chunk) {

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -6,6 +6,7 @@ import { ACP } from "@/acp/agent"
 import { Server } from "@/server/server"
 import { createOpencodeClient } from "@mimo-ai/sdk/v2"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { waitForProviders } from "@/acp/wait-for-providers"
 
 const log = Log.create({ service: "acp-command" })
 
@@ -28,6 +29,13 @@ export const AcpCommand = cmd({
       const sdk = createOpencodeClient({
         baseUrl: `http://${server.hostname}:${server.port}`,
       })
+
+      // Wait for providers to be fully loaded after potential DB migration.
+      // Without this, the first request may race with provider initialization
+      // and fall back to Provider.sort() which picks a paid model.
+      await waitForProviders(() =>
+        sdk.config.providers({ directory: args.cwd }, { throwOnError: false }),
+      )
 
       const input = new WritableStream<Uint8Array>({
         write(chunk) {

--- a/packages/opencode/test/acp/default-model.test.ts
+++ b/packages/opencode/test/acp/default-model.test.ts
@@ -1,0 +1,48 @@
+import { test, expect, describe } from "bun:test"
+import { resolveDefaultModel } from "../../src/acp/resolve-model"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+
+describe("resolveDefaultModel", () => {
+  const mimo = {
+    providerID: ProviderID.make("mimo"),
+    modelID: ModelID.make("mimo-auto"),
+  }
+
+  test("returns specified when provider is not in providers list", () => {
+    const result = resolveDefaultModel(mimo, [
+      { id: "xiaomi", models: { "some-model": {} } },
+    ])
+    expect(result).toEqual(mimo)
+  })
+
+  test("returns specified when provider exists but model not indexed", () => {
+    const result = resolveDefaultModel(mimo, [
+      { id: "mimo", models: {} },
+    ])
+    expect(result).toEqual(mimo)
+  })
+
+  test("returns specified when providers list is empty", () => {
+    const result = resolveDefaultModel(mimo, [])
+    expect(result).toEqual(mimo)
+  })
+
+  test("returns specified when provider and model both present", () => {
+    const result = resolveDefaultModel(mimo, [
+      { id: "mimo", models: { "mimo-auto": { id: "mimo-auto" } } },
+    ])
+    expect(result).toEqual(mimo)
+  })
+
+  test("returns undefined when no specified model", () => {
+    const result = resolveDefaultModel(undefined, [
+      { id: "mimo", models: { "mimo-auto": {} } },
+    ])
+    expect(result).toBeUndefined()
+  })
+
+  test("returns undefined when no specified and no providers", () => {
+    const result = resolveDefaultModel(undefined, [])
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/acp/wait-for-providers.test.ts
+++ b/packages/opencode/test/acp/wait-for-providers.test.ts
@@ -31,4 +31,16 @@ describe("waitForProviders", () => {
     const result = await waitForProviders(poll, { maxAttempts: 2, intervalMs: 10 })
     expect(result).toBe(false)
   })
+
+  test("handles poll rejection without crashing", async () => {
+    let calls = 0
+    const poll = () => {
+      calls++
+      if (calls < 3) return Promise.reject(new Error("DB migration in progress"))
+      return Promise.resolve({ data: { providers: [{ id: "mimo" }] } })
+    }
+    const result = await waitForProviders(poll, { maxAttempts: 5, intervalMs: 10 })
+    expect(result).toBe(true)
+    expect(calls).toBe(3)
+  })
 })

--- a/packages/opencode/test/acp/wait-for-providers.test.ts
+++ b/packages/opencode/test/acp/wait-for-providers.test.ts
@@ -1,0 +1,34 @@
+import { test, expect, describe } from "bun:test"
+import { waitForProviders } from "../../src/acp/wait-for-providers"
+
+describe("waitForProviders", () => {
+  test("returns true immediately when providers are available", async () => {
+    const poll = () => Promise.resolve({ data: { providers: [{ id: "mimo" }] } })
+    const result = await waitForProviders(poll, { maxAttempts: 3, intervalMs: 10 })
+    expect(result).toBe(true)
+  })
+
+  test("retries and returns true when providers load on Nth attempt", async () => {
+    let calls = 0
+    const poll = () => {
+      calls++
+      if (calls < 3) return Promise.resolve({ data: { providers: [] } })
+      return Promise.resolve({ data: { providers: [{ id: "mimo" }] } })
+    }
+    const result = await waitForProviders(poll, { maxAttempts: 5, intervalMs: 10 })
+    expect(result).toBe(true)
+    expect(calls).toBe(3)
+  })
+
+  test("returns false after exhausting all attempts", async () => {
+    const poll = () => Promise.resolve({ data: { providers: [] } })
+    const result = await waitForProviders(poll, { maxAttempts: 3, intervalMs: 10 })
+    expect(result).toBe(false)
+  })
+
+  test("handles undefined data gracefully", async () => {
+    const poll = () => Promise.resolve({ data: undefined })
+    const result = await waitForProviders(poll, { maxAttempts: 2, intervalMs: 10 })
+    expect(result).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Belt-and-suspenders fix for the ACP cold-start race condition where DB migration delays provider loading, causing `defaultModel()` to fall through to `Provider.sort()` and pick a paid model.

Supersedes #1170 and #1171 (combined into one PR with unit tests).

## Problem

```
┌─── ACP cold start (before fix) ─────────────────────────────────┐
│                                                                   │
│  t0  DB migration runs (rewrites SQLite tables)                   │
│  t1  Server.listen()                                              │
│  t2  ACP agent accepts stdin immediately                          │
│  t3  1st request arrives                                          │
│       ├─ sdk.config.providers()                                   │
│       │   └─ [xiaomi] ← mimo provider NOT YET INDEXED    ❌      │
│       ├─ defaultModel() → Provider.sort()                         │
│       │   └─ picks xiaomi/mimo-v2.5-pro-ultraspeed (paid) ❌      │
│       └─ 0 tokens → "(no response)"                              │
│                                                                   │
└───────────────────────────────────────────────────────────────────┘
```

## Solution

```
┌─── ACP cold start (after fix) ──────────────────────────────────┐
│                                                                   │
│  t0  DB migration runs                                            │
│  t1  Server.listen()                                              │
│  t2  waitForProviders() polls until ready (max 5s)       ← FIX 1 │
│       └─ providers loaded ✅ (or log.warn + proceed)              │
│  t3  ACP agent accepts stdin                                      │
│  t4  1st request arrives                                          │
│       ├─ sdk.config.providers() → [mimo, xiaomi, ...]    ✅      │
│       ├─ defaultModel()                                           │
│       │   ├─ provider found + model found → return it    ✅      │
│       │   └─ (if still missing: return user config)      ← FIX 2 │
│       └─ calls mimo-auto → works!                        ✅      │
│                                                                   │
└───────────────────────────────────────────────────────────────────┘

FIX 1 (proactive)  — waitForProviders() in acp.ts
FIX 2 (defensive)  — resolveDefaultModel() in agent.ts
```

## Changes

| File | Change |
|------|--------|
| `src/acp/wait-for-providers.ts` | New: poll providers with retry + log.warn on timeout |
| `src/acp/resolve-model.ts` | New: pure model resolution — honors user config when provider/model missing |
| `src/acp/agent.ts` | Use `resolveDefaultModel()` instead of inline logic |
| `src/cli/cmd/acp.ts` | Use `waitForProviders()` before accepting requests |
| `test/acp/default-model.test.ts` | 6 unit tests for resolution logic |
| `test/acp/wait-for-providers.test.ts` | 4 unit tests for polling behavior |

## Tests

```
$ bun test test/acp/
 21 pass, 0 fail (includes existing acp tests)
```

## Verification

- `bun test test/acp/` — ✅ 21 pass
- `bun run typecheck` — ✅ clean

Fixes #865, Fixes #866