### PR TITLE
feat(session): add sliding-window n-gram repetition detection for streamed text

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -68,6 +68,13 @@ export const Flag = {
   MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT: number("MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT") ?? 3,
   MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT: number("MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT") ?? 2,
 
+  // Sliding-window n-gram repetition detection for streamed reasoning + text.
+  // An n-gram of size N appearing REPEAT_THRESHOLD times within the last
+  // WINDOW_TOKENS tokens triggers recovery (remind → replan → terminate).
+  MIMOCODE_TEXT_NGRAM_N: number("MIMOCODE_TEXT_NGRAM_N") ?? 6,
+  MIMOCODE_TEXT_REPEAT_THRESHOLD: number("MIMOCODE_TEXT_REPEAT_THRESHOLD") ?? 3,
+  MIMOCODE_TEXT_WINDOW_TOKENS: number("MIMOCODE_TEXT_WINDOW_TOKENS") ?? 500,
+
   // Caps applied to image attachments before a prompt is sent. Both default to
   // undefined (no limit). MIMOCODE_MAX_PROMPT_IMAGES bounds how many images may
   // be sent per request (oldest excess images are dropped); MIMOCODE_MAX_PROMPT_IMAGE_SIZE

--- a/packages/opencode/src/session/classify.ts
+++ b/packages/opencode/src/session/classify.ts
@@ -34,7 +34,7 @@ export function classifyAssistantStep(input: {
   parts: MessageV2.Part[]
   phase: "existing-assistant" | "after-process"
   // Reserved for T01–T05 (stop/overflow control flow stays in runLoop for T00).
-  processResult?: "continue" | "stop" | "overflow"
+  processResult?: "continue" | "stop" | "overflow" | "text-repeat"
 }): StepClassification {
   const assistant = input.assistant
 

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -80,7 +80,7 @@ export interface Interface {
     auto: boolean
     overflow?: boolean
     agentID?: string
-  }) => Effect.Effect<"continue" | "stop">
+  }) => Effect.Effect<"continue" | "stop" | "text-repeat">
   readonly create: (input: {
     sessionID: SessionID
     agent: string
@@ -370,6 +370,8 @@ export const layer: Layer.Layer<
         yield* session.updateMessage(processor.message)
         return "stop"
       }
+
+      if (result === "text-repeat") return "stop"
 
       if (compactionPart && selected.tail_start_id && compactionPart.tail_start_id !== selected.tail_start_id) {
         yield* session.updatePart({

--- a/packages/opencode/src/session/max-mode.ts
+++ b/packages/opencode/src/session/max-mode.ts
@@ -7,6 +7,11 @@ import * as Session from "./session"
 import type { Provider } from "@/provider"
 import type { Agent } from "@/agent/agent"
 import type { MessageV2 } from "./message-v2"
+import {
+  createTextNgramMonitor,
+  isTextNgramRepeat,
+  textNgramRepeat,
+} from "./prompt/text-ngram-detection"
 import type { Permission } from "@/permission"
 import { Log } from "@/util"
 
@@ -100,8 +105,12 @@ export function toSchemaOnlyTools(tools: Record<string, AITool>): Record<string,
  */
 // Exported for integration tests (drives the real candidate path with a mock
 // llm.stream). Not part of the public surface — call sites use runMaxStep.
-export const runCandidate = (input: MaxStepInput, index: number): Effect.Effect<Candidate | null> =>
+export const runCandidate = (
+  input: MaxStepInput,
+  index: number,
+): Effect.Effect<Candidate | null | "text-repeat"> =>
   Effect.gen(function* () {
+    const monitor = createTextNgramMonitor()
     // Fresh accumulator per attempt: the retry below re-runs this whole block,
     // so partial reasoning/text/toolCalls from a failed attempt must not carry
     // over into the retry.
@@ -132,10 +141,12 @@ export const runCandidate = (input: MaxStepInput, index: number): Effect.Effect<
       switch (event.type) {
         case "reasoning-delta":
           candidate.reasoning += event.text
+          if (monitor.append(event.text)) return Effect.fail(textNgramRepeat())
           if (event.providerMetadata) candidate.reasoningMetadata = event.providerMetadata
           break
         case "text-delta":
           candidate.text += event.text
+          if (monitor.append(event.text)) return Effect.fail(textNgramRepeat())
           if (event.providerMetadata) candidate.textMetadata = event.providerMetadata
           break
         case "tool-call":
@@ -182,6 +193,7 @@ export const runCandidate = (input: MaxStepInput, index: number): Effect.Effect<
       while: LLM.isTransientCapacityError,
       schedule: LLM.persistentRetrySchedule,
     }),
+    Effect.catchIf(isTextNgramRepeat, () => Effect.succeed("text-repeat" as const)),
     Effect.catch((e) =>
       Effect.sync(() => {
         log.warn("candidate failed", { index, error: e instanceof Error ? e.message : String(e) })
@@ -325,7 +337,8 @@ export const runMaxStep = (input: MaxStepInput): Effect.Effect<SessionProcessor.
       Array.from({ length: n }, (_, i) => runCandidate(input, i)),
       { concurrency: n },
     )
-    const survivors = results.filter((c): c is Candidate => c !== null)
+    if (results.some((result) => result === "text-repeat")) return "text-repeat"
+    const survivors = results.filter((c): c is Candidate => c !== null && c !== "text-repeat")
 
     if (survivors.length === 0) {
       log.warn("all candidates failed, falling back to single process")

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -23,11 +23,12 @@ import { errorMessage } from "@/util/error"
 import { isRecoverableError } from "@/tool/recoverable"
 import { Log } from "@/util"
 import { isRecord } from "@/util/record"
+import { createTextNgramMonitor, type TextNgramMonitor } from "./prompt/text-ngram-detection"
 
 const DOOM_LOOP_THRESHOLD = 3
 const log = Log.create({ service: "session.processor" })
 
-export type Result = "overflow" | "stop" | "continue"
+export type Result = "overflow" | "stop" | "continue" | "text-repeat"
 
 export type Event = LLM.Event
 
@@ -145,6 +146,8 @@ interface ProcessorContext extends Input {
   stepStartedAt: number | undefined
   firstTokenAt: number | undefined
   stepPartIds: PartID[]
+  textNgramMonitor: TextNgramMonitor | undefined
+  textNgramRepeat: boolean
 }
 
 type StreamEvent = Event
@@ -199,6 +202,8 @@ export const layer: Layer.Layer<
         stepStartedAt: undefined,
         firstTokenAt: undefined,
         stepPartIds: [],
+        textNgramMonitor: undefined,
+        textNgramRepeat: false,
       }
       let aborted = false
       // Only the main agent owns session-level status. Subagents (explore,
@@ -302,6 +307,11 @@ export const layer: Layer.Layer<
         return true
       })
 
+      const checkTextNgram = (text: string) => {
+        if (ctx.textNgramRepeat || !ctx.textNgramMonitor) return
+        if (ctx.textNgramMonitor.append(text)) ctx.textNgramRepeat = true
+      }
+
       const handleEvent = Effect.fnUntraced(function* (value: StreamEvent) {
         switch (value.type) {
           case "start":
@@ -330,6 +340,7 @@ export const layer: Layer.Layer<
             if (!ctx.firstTokenAt) ctx.firstTokenAt = Date.now()
             if (!(value.id in ctx.reasoningMap)) return
             ctx.reasoningMap[value.id].text += value.text
+            checkTextNgram(value.text)
             if (value.providerMetadata) ctx.reasoningMap[value.id].metadata = value.providerMetadata
             yield* session.updatePartDelta({
               sessionID: ctx.reasoningMap[value.id].sessionID,
@@ -555,6 +566,7 @@ export const layer: Layer.Layer<
             if (!ctx.firstTokenAt) ctx.firstTokenAt = Date.now()
             if (!ctx.currentText) return
             ctx.currentText.text += value.text
+            checkTextNgram(value.text)
             if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
             yield* session.updatePartDelta({
               sessionID: ctx.currentText.sessionID,
@@ -683,11 +695,13 @@ export const layer: Layer.Layer<
             ctx.reasoningMap = {}
             ctx.stepPartIds = []
             ctx.toolcalls = {}
+            ctx.textNgramRepeat = false
+            ctx.textNgramMonitor = createTextNgramMonitor()
             const stream = llm.stream(streamInput)
 
             yield* stream.pipe(
               Stream.tap((event) => handleEvent(event)),
-              Stream.takeUntil(() => ctx.needsOverflowHandling),
+              Stream.takeUntil(() => ctx.needsOverflowHandling || ctx.textNgramRepeat),
               Stream.runDrain,
             )
           }).pipe(
@@ -734,6 +748,7 @@ export const layer: Layer.Layer<
           )
 
           if (ctx.needsOverflowHandling) return "overflow"
+          if (ctx.textNgramRepeat) return "text-repeat"
           if (ctx.blocked || ctx.assistantMessage.error) return "stop"
           return "continue"
         })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -38,6 +38,11 @@ import {
   normalizeForLoopDetection,
   detectTextLoop,
 } from "../session/prompt/text-loop-recovery"
+import {
+  TEXT_NGRAM_MAX_RECOVERY,
+  TEXT_NGRAM_RECOVERY_REMIND,
+  TEXT_NGRAM_RECOVERY_REPLAN,
+} from "../session/prompt/text-ngram-detection"
 import { composeSkillsBlock } from "@/skill/compose/extract"
 import { ToolRegistry } from "../tool"
 import { MCP } from "../mcp"
@@ -1883,6 +1888,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
         const textLoopBuffer: string[] = []
         let textLoopRecoveryAttempts = 0
+        let textNgramRecoveryAttempts = 0
 
         // Contract (T05): on finish="length", inject a continuation nudge ONLY for
         // plain text. If any non-providerExecuted client tool part exists we bail
@@ -2227,6 +2233,48 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               "</system-reminder>",
             ].join("\n"),
           } satisfies MessageV2.TextPart)
+          return true
+        })
+
+        // Sliding-window n-gram repetition recovery. Symmetric across main and
+        // fork branches: 1st hit injects REMIND, 2nd hit injects REPLAN, 3rd
+        // hit (>= TEXT_NGRAM_MAX_RECOVERY) writes an error and signals break.
+        const handleTextRepeat = Effect.fn("SessionPrompt.handleTextRepeat")(function* (input: {
+          lastUser: MessageV2.User
+        }) {
+          if (textNgramRecoveryAttempts >= TEXT_NGRAM_MAX_RECOVERY) {
+            yield* slog.info("text n-gram: max recovery exceeded, terminating")
+            yield* bus.publish(Session.Event.Error, {
+              sessionID,
+              error: new NamedError.Unknown({
+                message: `Text repetition detected: repeated n-grams after ${TEXT_NGRAM_MAX_RECOVERY} recovery attempts. Session terminated.`,
+              }).toObject(),
+            })
+            return false
+          }
+          const recoveryText =
+            textNgramRecoveryAttempts === 0 ? TEXT_NGRAM_RECOVERY_REMIND : TEXT_NGRAM_RECOVERY_REPLAN
+          const reentry = yield* sessions.updateMessage({
+            id: MessageID.ascending(),
+            role: "user" as const,
+            sessionID,
+            agentID: input.lastUser.agentID,
+            agent: input.lastUser.agent,
+            model: input.lastUser.model,
+            tools: input.lastUser.tools,
+            format: input.lastUser.format,
+            time: { created: Date.now() },
+          })
+          yield* sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: reentry.id,
+            sessionID,
+            type: "text",
+            synthetic: true,
+            text: recoveryText,
+          } satisfies MessageV2.TextPart)
+          textNgramRecoveryAttempts++
+          yield* slog.info("text n-gram: recovery injected", { attempt: textNgramRecoveryAttempts })
           return true
         })
 
@@ -2882,6 +2930,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 return "continue" as const
               }
 
+              if (result === "text-repeat") {
+                if (yield* handleTextRepeat({ lastUser })) return "continue" as const
+                return "break" as const
+              }
+
               if (structured !== undefined) {
                 handle.message.structured = structured
                 handle.message.finish = handle.message.finish ?? "stop"
@@ -3086,6 +3139,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               (yield* autoContinueOutputLength({ lastUser, assistant: handle.message }))
             ) {
               return "continue" as const
+            }
+
+            if (result === "text-repeat") {
+              if (yield* handleTextRepeat({ lastUser })) return "continue" as const
+              return "break" as const
             }
 
             if (structured !== undefined) {

--- a/packages/opencode/src/session/prompt/text-ngram-detection.ts
+++ b/packages/opencode/src/session/prompt/text-ngram-detection.ts
@@ -1,0 +1,87 @@
+import { Flag } from "@/flag/flag"
+
+export const TEXT_NGRAM_MAX_RECOVERY = 2
+
+export function tokenizeForNgram(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean)
+}
+
+export function detectRepeatedNgram(tokens: readonly string[], n: number, threshold: number): boolean {
+  if (tokens.length < n || threshold < 2) return false
+  const counts = new Map<string, number>()
+  for (let i = 0; i <= tokens.length - n; i++) {
+    const gram = tokens.slice(i, i + n).join("\0")
+    const next = (counts.get(gram) ?? 0) + 1
+    if (next >= threshold) return true
+    counts.set(gram, next)
+  }
+  return false
+}
+
+export class TextNgramMonitor {
+  private buffer = ""
+  private tokens: string[] = []
+
+  constructor(
+    private readonly n: number,
+    private readonly threshold: number,
+    private readonly windowTokens: number,
+  ) {}
+
+  append(text: string): boolean {
+    if (!text) return false
+    this.buffer += text
+    const all = tokenizeForNgram(this.buffer)
+    this.tokens = all.length > this.windowTokens ? all.slice(-this.windowTokens) : all
+    if (all.length > this.windowTokens * 2) this.buffer = this.tokens.join(" ")
+    return detectRepeatedNgram(this.tokens, this.n, this.threshold)
+  }
+
+  reset() {
+    this.buffer = ""
+    this.tokens = []
+  }
+}
+
+export function createTextNgramMonitor() {
+  return new TextNgramMonitor(
+    Flag.MIMOCODE_TEXT_NGRAM_N,
+    Flag.MIMOCODE_TEXT_REPEAT_THRESHOLD,
+    Flag.MIMOCODE_TEXT_WINDOW_TOKENS,
+  )
+}
+
+export function textNgramRepeat() {
+  return { _tag: "TextNgramRepeat" as const }
+}
+
+export function isTextNgramRepeat(value: unknown): value is { _tag: "TextNgramRepeat" } {
+  return typeof value === "object" && value !== null && "_tag" in value && value._tag === "TextNgramRepeat"
+}
+
+export const TEXT_NGRAM_RECOVERY_REMIND = `<system-reminder>
+REPETITION DETECTED: Your recent output contains repeated phrases (sliding n-gram match within your last ${Flag.MIMOCODE_TEXT_WINDOW_TOKENS} tokens).
+
+STOP repeating yourself and retry with a different approach:
+- Vary your wording and reasoning — do not reuse the same phrases
+- If you were about to call a tool, try a different tool or different arguments
+- If you are blocked, explain what is blocking you instead of looping
+
+Do NOT output the same phrases again.
+</system-reminder>`
+
+export const TEXT_NGRAM_RECOVERY_REPLAN = `<system-reminder>
+CRITICAL REPETITION: You are STILL repeating phrases after a recovery attempt.
+
+You MUST completely replan before continuing:
+1. Abandon your current approach entirely — it is stuck in repetition
+2. Write out a NEW plan with different steps and a different strategy
+3. State what you were trying to do, why it failed, and how your new plan differs
+
+Do NOT continue the same line of reasoning or reuse the same wording.
+</system-reminder>`

--- a/packages/opencode/test/session/max-mode-econnreset.test.ts
+++ b/packages/opencode/test/session/max-mode-econnreset.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import * as Stream from "effect/Stream"
-import { runCandidate, judge, type MaxStepInput } from "../../src/session/max-mode"
+import { runCandidate, judge, type Candidate, type MaxStepInput } from "../../src/session/max-mode"
 import type { LLM } from "../../src/session/llm"
+
+function expectCandidate(value: Candidate | null | "text-repeat"): Candidate {
+  if (!value || value === "text-repeat") throw new Error(`expected candidate, got ${String(value)}`)
+  return value
+}
 
 /**
  * Integration tests for the ECONNRESET fix: drive the REAL runCandidate / judge
@@ -73,16 +78,15 @@ describe("max-mode ECONNRESET handling (integration)", () => {
       ],
     })
 
-    const candidate = await Effect.runPromise(runCandidate(baseInput(llm), 0))
+    const candidate = expectCandidate(await Effect.runPromise(runCandidate(baseInput(llm), 0)))
 
-    expect(candidate).not.toBeNull()
     expect(attempts()).toBe(3) // 2 failed + 1 success
     // fresh accumulator: NO "PARTIAL " leaked from the failed attempts
-    expect(candidate!.text).toBe("final answer")
-    expect(candidate!.reasoning).toBe("think")
-    expect(candidate!.toolCalls).toHaveLength(1)
-    expect(candidate!.toolCalls[0].toolName).toBe("read")
-    expect(candidate!.finishReason).toBe("tool-calls")
+    expect(candidate.text).toBe("final answer")
+    expect(candidate.reasoning).toBe("think")
+    expect(candidate.toolCalls).toHaveLength(1)
+    expect(candidate.toolCalls[0].toolName).toBe("read")
+    expect(candidate.finishReason).toBe("tool-calls")
   })
 
   test("candidate gives up (returns null) on a non-transient error part", async () => {
@@ -194,8 +198,7 @@ describe("max-mode defect handling (SSE timeout surfaces as Cause.die)", () => {
 
     expect(exit._tag).toBe("Success")
     if (exit._tag === "Success") {
-      expect(exit.value).not.toBeNull()
-      expect(exit.value!.text).toBe("recovered")
+      expect(expectCandidate(exit.value).text).toBe("recovered")
     }
     expect(attempts()).toBe(3) // 2 defect attempts + 1 success
   })

--- a/packages/opencode/test/session/text-ngram-detection.test.ts
+++ b/packages/opencode/test/session/text-ngram-detection.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+import {
+  TextNgramMonitor,
+  detectRepeatedNgram,
+  tokenizeForNgram,
+} from "../../src/session/prompt/text-ngram-detection"
+
+describe("tokenizeForNgram", () => {
+  test("normalizes whitespace and case", () => {
+    expect(tokenizeForNgram("  Hello   WORLD  ")).toEqual(["hello", "world"])
+  })
+})
+
+describe("detectRepeatedNgram", () => {
+  test("returns false when window is too small", () => {
+    expect(detectRepeatedNgram(["a", "b", "c"], 6, 3)).toBe(false)
+  })
+
+  test("detects repeated 6-gram appearing 3 times", () => {
+    const gram = ["one", "two", "three", "four", "five", "six"]
+    const tokens = [...gram, ...gram, ...gram]
+    expect(detectRepeatedNgram(tokens, 6, 3)).toBe(true)
+  })
+
+  test("returns false when same phrase appears only twice", () => {
+    const gram = ["one", "two", "three", "four", "five", "six"]
+    const tokens = [...gram, ...gram]
+    expect(detectRepeatedNgram(tokens, 6, 3)).toBe(false)
+  })
+})
+
+describe("TextNgramMonitor", () => {
+  test("detects repetition across incremental appends", () => {
+    const monitor = new TextNgramMonitor(6, 3, 500)
+    const chunk = "one two three four five six "
+    expect(monitor.append(chunk)).toBe(false)
+    expect(monitor.append(chunk)).toBe(false)
+    expect(monitor.append(chunk)).toBe(true)
+  })
+
+  test("reset clears prior repetition state", () => {
+    const monitor = new TextNgramMonitor(6, 3, 500)
+    const chunk = "one two three four five six "
+    monitor.append(chunk)
+    monitor.append(chunk)
+    monitor.append(chunk)
+    monitor.reset()
+    expect(monitor.append(chunk)).toBe(false)
+  })
+
+  test("respects sliding window token limit", () => {
+    const monitor = new TextNgramMonitor(3, 3, 10)
+    const filler = Array.from({ length: 10 }, (_, i) => `f${i}`).join(" ") + " "
+    const repeated = "alpha beta gamma "
+    expect(monitor.append(filler + repeated + repeated + repeated)).toBe(true)
+    monitor.reset()
+    monitor.append(filler)
+    expect(monitor.append(repeated)).toBe(false)
+    expect(monitor.append(repeated)).toBe(false)
+    expect(monitor.append(repeated)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds real-time sliding-window n-gram repetition detection for reasoning and text stream deltas
- Terminates the stream when repeated n-grams are detected and triggers a recovery flow (remind → replan → terminate after max attempts)
- Exposes tunable flags: `MIMOCODE_TEXT_NGRAM_N`, `MIMOCODE_TEXT_REPEAT_THRESHOLD`, `MIMOCODE_TEXT_WINDOW_TOKENS`

## Changes
- **New module**: `src/session/prompt/text-ngram-detection.ts` — `TextNgramMonitor` with sliding-window n-gram detection
- **processor.ts**: Integrates monitor into main agent stream handling; returns `"text-repeat"` result
- **max-mode.ts**: Integrates monitor into candidate parallel streaming; propagates `"text-repeat"` result
- **prompt.ts**: Adds `handleTextRepeat` recovery handler (symmetric main/fork branches)
- **classify.ts / compaction.ts**: Thread `"text-repeat"` through result types
- **flag.ts**: Register 3 new environment-variable flags for tuning
- **Tests**: Unit tests for n-gram detection + updated max-mode integration tests