### PR TITLE
Fix: IME uncommitted text color and add skip_claude_md config

### DIFF
--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -1,15 +1,15 @@
-# js
+# MiMoCode Package
 
-To install dependencies:
+MiMoCode is an open-source, terminal-native AI coding assistant developed by Xiaomi. It is built as a fork of OpenCode and is designed specifically for long-horizon automated programming tasks.
+
+This package contains the core business logic, API server, and TUI implementation for MiMoCode.
+
+## Development
+
+To run MiMoCode locally during development:
 
 ```bash
-bun install
+bun run dev
 ```
 
-To run:
-
-```bash
-bun run index.ts
-```
-
-This project was created using `bun init` in bun v1.2.12. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.
+For more information, please see the [main repository README](../../README.md).

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1623,6 +1623,8 @@ export function Prompt(props: PromptProps) {
               onMouseDown={(r: MouseEvent) => r.target?.focus()}
               focusedBackgroundColor={theme.backgroundElement}
               cursorColor={theme.text}
+              selectionFg={theme.text}
+              selectionBg={theme.backgroundElement}
               syntaxStyle={syntax()}
             />
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1} justifyContent="space-between">

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -414,6 +414,8 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                         textColor={theme.text}
                         focusedTextColor={theme.text}
                         cursorColor={theme.primary}
+                        selectionFg={theme.text}
+                        selectionBg={theme.backgroundElement}
                         keyBindings={bindings()}
                       />
                     </box>

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
@@ -101,6 +101,8 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
             })
           }}
           height={3}
+          selectionFg={theme.text}
+          selectionBg={theme.backgroundElement}
           keyBindings={[{ name: "return", action: "submit" }]}
           ref={(val: TextareaRenderable) => {
             textarea = val

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
@@ -79,6 +79,8 @@ export function DialogPrompt(props: DialogPromptProps) {
             props.onConfirm?.(textarea.plainText)
           }}
           height={3}
+          selectionFg={theme.text}
+          selectionBg={theme.backgroundElement}
           keyBindings={props.busy ? [] : [{ name: "return", action: "submit" }]}
           ref={(val: TextareaRenderable) => {
             textarea = val

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -367,6 +367,9 @@ const InfoSchema = Schema.Struct({
   ).annotate({ description: "Voice input provider and model configuration." }),
   experimental: Schema.optional(
     Schema.Struct({
+      skip_claude_md: Schema.optional(Schema.Boolean).annotate({
+        description: "Skip reading ~/.claude/CLAUDE.md files.",
+      }),
       disable_paste_summary: Schema.optional(Schema.Boolean),
       batch_tool: Schema.optional(Schema.Boolean).annotate({ description: "Enable the batch tool" }),
       openTelemetry: Schema.optional(Schema.Boolean).annotate({

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -24,13 +24,13 @@ const FILES = [
 // sparse and also load CLAUDE.md so its guidance isn't dropped by the first-match-wins rule.
 const CLAUDE_FALLBACK_MAX_CHARS = 500
 
-function globalFiles() {
+function globalFiles(config: Config.Info) {
   const files = []
   if (Flag.MIMOCODE_CONFIG_DIR) {
     files.push(path.join(Flag.MIMOCODE_CONFIG_DIR, "AGENTS.md"))
   }
   files.push(path.join(Global.Path.config, "AGENTS.md"))
-  if (!Flag.MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT) {
+  if (!Flag.MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT && !config.experimental?.skip_claude_md) {
     files.push(path.join(os.homedir(), ".claude", "CLAUDE.md"))
   }
   return files
@@ -125,6 +125,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         const config = yield* cfg.get()
         const ctx = yield* InstanceState.context
         const paths = new Set<string>()
+        const isClaudeDisabled = Flag.MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT || config.experimental?.skip_claude_md
 
         // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
         if (!Flag.MIMOCODE_DISABLE_PROJECT_CONFIG) {
@@ -132,7 +133,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
           if (agents.length > 0) {
             agents.forEach((item) => paths.add(path.resolve(item)))
             // A sparse AGENTS.md likely doesn't carry the full project guidance, so pull in CLAUDE.md too.
-            if (!Flag.MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT) {
+            if (!isClaudeDisabled) {
               const content = (yield* Effect.forEach(agents, read, { concurrency: 8 })).join("").trim()
               if (content.length < CLAUDE_FALLBACK_MAX_CHARS) {
                 const claude = yield* fs.findUp("CLAUDE.md", ctx.directory, ctx.worktree)
@@ -140,7 +141,8 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
               }
             }
           } else {
-            for (const file of FILES) {
+            const filesToSearch = ["AGENTS.md", ...(isClaudeDisabled ? [] : ["CLAUDE.md"]), "CONTEXT.md"]
+            for (const file of filesToSearch) {
               if (file === "AGENTS.md") continue
               const matches = yield* fs.findUp(file, ctx.directory, ctx.worktree)
               if (matches.length > 0) {
@@ -151,7 +153,9 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
           }
         }
 
-        for (const file of globalFiles()) {
+        // We want stable ordering for resolving cache hits etc, so we sort project paths
+        const sortedPaths = Array.from(paths).sort()
+        for (const file of globalFiles(config)) {
           if (yield* fs.existsSafe(file)) {
             paths.add(path.resolve(file))
             break

--- a/packages/web/src/content/docs/ar/cli.mdx
+++ b/packages/web/src/content/docs/ar/cli.mdx
@@ -360,7 +360,7 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 opencode serve
 ```
 
-يشغّل هذا خادم HTTP يوفّر وصولا عبر API لوظائف opencode دون واجهة TUI. اضبط `OPENCODE_SERVER_PASSWORD` لتفعيل مصادقة HTTP الأساسية (اسم المستخدم الافتراضي `opencode`).
+يشغّل هذا خادم HTTP يوفّر وصولا عبر API لوظائف opencode دون واجهة TUI. اضبط `MIMOCODE_SERVER_PASSWORD` لتفعيل مصادقة HTTP الأساسية (اسم المستخدم الافتراضي `opencode`).
 
 #### الرايات
 
@@ -456,7 +456,7 @@ opencode import https://opncd.ai/s/abc123
 opencode web
 ```
 
-يشغّل هذا خادم HTTP ويفتح متصفح ويب للوصول إلى OpenCode عبر واجهة ويب. اضبط `OPENCODE_SERVER_PASSWORD` لتفعيل مصادقة HTTP الأساسية (اسم المستخدم الافتراضي `opencode`).
+يشغّل هذا خادم HTTP ويفتح متصفح ويب للوصول إلى OpenCode عبر واجهة ويب. اضبط `MIMOCODE_SERVER_PASSWORD` لتفعيل مصادقة HTTP الأساسية (اسم المستخدم الافتراضي `opencode`).
 
 #### الرايات
 
@@ -555,29 +555,29 @@ opencode upgrade v0.1.48
 
 | المتغير                               | النوع   | الوصف                                                     |
 | ------------------------------------- | ------- | --------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | مشاركة الجلسات تلقائيا                                    |
-| `OPENCODE_GIT_BASH_PATH`              | string  | مسار ملف Git Bash التنفيذي على Windows                    |
-| `OPENCODE_CONFIG`                     | string  | مسار ملف التهيئة                                          |
-| `OPENCODE_CONFIG_DIR`                 | string  | مسار دليل التهيئة                                         |
-| `OPENCODE_CONFIG_CONTENT`             | string  | محتوى تهيئة JSON مُضمّن                                   |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | تعطيل التحقق التلقائي من التحديثات                        |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | تعطيل تنقية البيانات القديمة                              |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | تعطيل تحديث عنوان terminal تلقائيا                        |
-| `OPENCODE_PERMISSION`                 | string  | تهيئة أذونات JSON مُضمّنة                                 |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | تعطيل الإضافات الافتراضية                                 |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | تعطيل تنزيل خوادم LSP تلقائيا                             |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | تفعيل النماذج التجريبية                                   |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | تعطيل ضغط السياق تلقائيا                                  |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | تعطيل القراءة من `.claude` (الموجه + المهارات)            |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | تعطيل قراءة `~/.claude/CLAUDE.md`                         |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | تعطيل تحميل `.claude/skills`                              |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | تعطيل جلب النماذج من مصادر بعيدة                          |
-| `OPENCODE_FAKE_VCS`                   | string  | مزود VCS وهمي لأغراض الاختبار                             |
-| `OPENCODE_CLIENT`                     | string  | معرّف العميل (الافتراضي `cli`)                            |
-| `OPENCODE_ENABLE_EXA`                 | boolean | تفعيل أدوات بحث الويب من Exa                              |
-| `OPENCODE_SERVER_PASSWORD`            | string  | تفعيل المصادقة الأساسية لخادمي `serve`/`web`              |
-| `OPENCODE_SERVER_USERNAME`            | string  | تجاوز اسم مستخدم المصادقة الأساسية (الافتراضي `opencode`) |
-| `OPENCODE_MODELS_URL`                 | string  | رابط مخصص لجلب تهيئة النماذج                              |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | مشاركة الجلسات تلقائيا                                    |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | مسار ملف Git Bash التنفيذي على Windows                    |
+| `MIMOCODE_CONFIG`                     | string  | مسار ملف التهيئة                                          |
+| `MIMOCODE_CONFIG_DIR`                 | string  | مسار دليل التهيئة                                         |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | محتوى تهيئة JSON مُضمّن                                   |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | تعطيل التحقق التلقائي من التحديثات                        |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | تعطيل تنقية البيانات القديمة                              |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | تعطيل تحديث عنوان terminal تلقائيا                        |
+| `MIMOCODE_PERMISSION`                 | string  | تهيئة أذونات JSON مُضمّنة                                 |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | تعطيل الإضافات الافتراضية                                 |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | تعطيل تنزيل خوادم LSP تلقائيا                             |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | تفعيل النماذج التجريبية                                   |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | تعطيل ضغط السياق تلقائيا                                  |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | تعطيل القراءة من `.claude` (الموجه + المهارات)            |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | تعطيل قراءة `~/.claude/CLAUDE.md`                         |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | تعطيل تحميل `.claude/skills`                              |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | تعطيل جلب النماذج من مصادر بعيدة                          |
+| `MIMOCODE_FAKE_VCS`                   | string  | مزود VCS وهمي لأغراض الاختبار                             |
+| `MIMOCODE_CLIENT`                     | string  | معرّف العميل (الافتراضي `cli`)                            |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | تفعيل أدوات بحث الويب من Exa                              |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | تفعيل المصادقة الأساسية لخادمي `serve`/`web`              |
+| `MIMOCODE_SERVER_USERNAME`            | string  | تجاوز اسم مستخدم المصادقة الأساسية (الافتراضي `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | string  | رابط مخصص لجلب تهيئة النماذج                              |
 
 ---
 
@@ -587,16 +587,16 @@ opencode upgrade v0.1.48
 
 | المتغير                                         | النوع   | الوصف                                       |
 | ----------------------------------------------- | ------- | ------------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | تفعيل جميع الميزات التجريبية                |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | تفعيل اكتشاف الأيقونات                      |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | تعطيل النسخ عند التحديد في TUI              |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | المهلة الافتراضية لأوامر bash بالميلي ثانية |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | الحد الأقصى لرموز المخرجات لاستجابات LLM    |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | تفعيل مراقب الملفات لكامل الدليل            |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | تفعيل مُنسّق oxfmt                          |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | تفعيل أداة LSP تجريبية                      |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | تعطيل مراقب الملفات                         |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | تفعيل ميزات Exa التجريبية                   |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | تمكين TY LSP لملفات python                  |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | تفعيل ميزات markdown تجريبية                |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | تفعيل وضع الخطة                             |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | تفعيل جميع الميزات التجريبية                |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | تفعيل اكتشاف الأيقونات                      |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | تعطيل النسخ عند التحديد في TUI              |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | المهلة الافتراضية لأوامر bash بالميلي ثانية |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | الحد الأقصى لرموز المخرجات لاستجابات LLM    |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | تفعيل مراقب الملفات لكامل الدليل            |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | تفعيل مُنسّق oxfmt                          |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | تفعيل أداة LSP تجريبية                      |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | تعطيل مراقب الملفات                         |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | تفعيل ميزات Exa التجريبية                   |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | تمكين TY LSP لملفات python                  |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolean | تفعيل ميزات markdown تجريبية                |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | تفعيل وضع الخطة                             |

--- a/packages/web/src/content/docs/ar/config.mdx
+++ b/packages/web/src/content/docs/ar/config.mdx
@@ -11,9 +11,9 @@ description: استخدام ملف إعدادات OpenCode بصيغة JSON.
 
 يدعم OpenCode تنسيقي **JSON** و**JSONC** (JSON مع تعليقات).
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   // إعدادات السمة
   "theme": "opencode",
   "model": "anthropic/claude-sonnet-4-5",
@@ -43,11 +43,11 @@ description: استخدام ملف إعدادات OpenCode بصيغة JSON.
 تُحمَّل مصادر الإعدادات بهذا الترتيب (المصادر اللاحقة تتجاوز السابقة):
 
 1. **الإعدادات البعيدة** (من `.well-known/opencode`) - الإعدادات الافتراضية على مستوى المؤسسة
-2. **الإعدادات العامة** (`~/.config/opencode/opencode.json`) - تفضيلات المستخدم
-3. **إعدادات مخصصة** (`OPENCODE_CONFIG` env var) - تجاوزات مخصصة
-4. **إعدادات المشروع** (`opencode.json` داخل المشروع) - إعدادات خاصة بالمشروع
+2. **الإعدادات العامة** (`~/.config/opencode/mimocode.jsonc`) - تفضيلات المستخدم
+3. **إعدادات مخصصة** (`MIMOCODE_CONFIG` env var) - تجاوزات مخصصة
+4. **إعدادات المشروع** (`mimocode.jsonc` داخل المشروع) - إعدادات خاصة بالمشروع
 5. **أدلة `.opencode`** - الوكلاء، الأوامر، الإضافات
-6. **إعدادات ضمنية** (`OPENCODE_CONFIG_CONTENT` env var) - تجاوزات وقت التشغيل
+6. **إعدادات ضمنية** (`MIMOCODE_CONFIG_CONTENT` env var) - تجاوزات وقت التشغيل
 
 هذا يعني أن إعدادات المشروع يمكنها تجاوز الإعدادات العامة، وأن الإعدادات العامة يمكنها تجاوز الإعدادات الافتراضية البعيدة على مستوى المؤسسة.
 
@@ -79,7 +79,7 @@ description: استخدام ملف إعدادات OpenCode بصيغة JSON.
 
 يمكنك تفعيل خوادم محددة في إعداداتك المحلية:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ description: استخدام ملف إعدادات OpenCode بصيغة JSON.
 
 ### عام
 
-ضع إعدادات OpenCode العامة في `~/.config/opencode/opencode.json`. استخدم الإعدادات العامة للتفضيلات على مستوى المستخدم مثل السمات، والمزوّدين، أو اختصارات المفاتيح.
+ضع إعدادات OpenCode العامة في `~/.config/opencode/mimocode.jsonc`. استخدم الإعدادات العامة للتفضيلات على مستوى المستخدم مثل السمات، والمزوّدين، أو اختصارات المفاتيح.
 
 تتجاوز الإعدادات العامة القيم الافتراضية البعيدة الخاصة بالمؤسسة.
 
@@ -103,7 +103,7 @@ description: استخدام ملف إعدادات OpenCode بصيغة JSON.
 
 ### لكل مشروع
 
-أضف `opencode.json` في جذر مشروعك. تمتلك إعدادات المشروع أعلى أولوية بين ملفات الإعدادات القياسية، إذ تتجاوز الإعدادات العامة والبعيدة معًا.
+أضف `mimocode.jsonc` في جذر مشروعك. تمتلك إعدادات المشروع أعلى أولوية بين ملفات الإعدادات القياسية، إذ تتجاوز الإعدادات العامة والبعيدة معًا.
 
 :::tip
 ضع إعدادات المشروع الخاصة في جذر مشروعك.
@@ -117,10 +117,10 @@ description: استخدام ملف إعدادات OpenCode بصيغة JSON.
 
 ### مسار مخصص
 
-حدّد مسار ملف إعدادات مخصصًا باستخدام متغير البيئة `OPENCODE_CONFIG`.
+حدّد مسار ملف إعدادات مخصصًا باستخدام متغير البيئة `MIMOCODE_CONFIG`.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -130,12 +130,12 @@ opencode run "Hello world"
 
 ### دليل مخصص
 
-حدّد دليل إعدادات مخصصًا باستخدام متغير البيئة `OPENCODE_CONFIG_DIR`.
+حدّد دليل إعدادات مخصصًا باستخدام متغير البيئة `MIMOCODE_CONFIG_DIR`.
 سيتم البحث داخل هذا الدليل عن الوكلاء والأوامر والأوضاع والإضافات تمامًا مثل
 الدليل القياسي `.opencode`، ويجب أن يتبع نفس البنية.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -145,7 +145,7 @@ opencode run "Hello world"
 
 ## المخطط
 
-يحتوي ملف الإعدادات على مخطط مُعرَّف في [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+يحتوي ملف الإعدادات على مخطط مُعرَّف في [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
 يفترض أن يتمكن محررك من التحقق والإكمال التلقائي اعتمادًا على هذا المخطط.
 
@@ -155,9 +155,9 @@ opencode run "Hello world"
 
 يمكنك ضبط الإعدادات الخاصة بـ TUI عبر الخيار `tui`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tui": {
     "scroll_speed": 3,
     "scroll_acceleration": {
@@ -182,9 +182,9 @@ opencode run "Hello world"
 
 يمكنك ضبط إعدادات الخادم لأوامر `opencode serve` و`opencode web` عبر الخيار `server`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -211,9 +211,9 @@ opencode run "Hello world"
 
 يمكنك إدارة الأدوات التي يمكن لـ LLM استخدامها عبر الخيار `tools`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -229,9 +229,9 @@ opencode run "Hello world"
 
 يمكنك ضبط المزوّدين والنماذج التي تريد استخدامها في إعدادات OpenCode عبر الخيارات `provider` و`model` و`small_model`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -242,9 +242,9 @@ opencode run "Hello world"
 
 قد تتضمن خيارات المزوّد `timeout` و`setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -271,9 +271,9 @@ opencode run "Hello world"
 
 يدعم Amazon Bedrock إعدادات خاصة بـ AWS:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -302,9 +302,9 @@ opencode run "Hello world"
 
 يمكنك ضبط السمة التي تريد استخدامها في إعدادات OpenCode عبر الخيار `theme`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "theme": ""
 }
 ```
@@ -317,9 +317,9 @@ opencode run "Hello world"
 
 يمكنك ضبط وكلاء متخصصين لمهام محددة عبر الخيار `agent`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -335,7 +335,7 @@ opencode run "Hello world"
 }
 ```
 
-يمكنك أيضًا تعريف الوكلاء باستخدام ملفات markdown في `~/.config/opencode/agents/` أو `.opencode/agents/`. [تعرف على المزيد هنا](/docs/agents).
+يمكنك أيضًا تعريف الوكلاء باستخدام ملفات markdown في `~/.config/opencode/agents/` أو `.mimocode/agents/`. [تعرف على المزيد هنا](/docs/agents).
 
 ---
 
@@ -343,9 +343,9 @@ opencode run "Hello world"
 
 يمكنك تعيين الوكيل الافتراضي باستخدام الخيار `default_agent`. يحدد ذلك أي وكيل سيتم استخدامه عندما لا يتم تحديد وكيل صراحةً.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -360,9 +360,9 @@ opencode run "Hello world"
 
 يمكنك ضبط ميزة [share](/docs/share) عبر الخيار `share`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -381,9 +381,9 @@ opencode run "Hello world"
 
 يمكنك ضبط أوامر مخصصة للمهام المتكررة عبر الخيار `command`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -399,7 +399,7 @@ opencode run "Hello world"
 }
 ```
 
-يمكنك أيضًا تعريف الأوامر باستخدام ملفات markdown في `~/.config/opencode/commands/` أو `.opencode/commands/`. [تعرف على المزيد هنا](/docs/commands).
+يمكنك أيضًا تعريف الأوامر باستخدام ملفات markdown في `~/.config/opencode/commands/` أو `.mimocode/commands/`. [تعرف على المزيد هنا](/docs/commands).
 
 ---
 
@@ -407,9 +407,9 @@ opencode run "Hello world"
 
 يمكنك تخصيص اختصارات المفاتيح عبر الخيار `keybinds`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "keybinds": {}
 }
 ```
@@ -422,9 +422,9 @@ opencode run "Hello world"
 
 سيقوم OpenCode بتنزيل أي تحديثات جديدة تلقائيًا عند بدء التشغيل. يمكنك تعطيل ذلك عبر الخيار `autoupdate`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -438,9 +438,9 @@ opencode run "Hello world"
 
 يمكنك ضبط منسّقات الشفرة عبر الخيار `formatter`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -466,9 +466,9 @@ opencode run "Hello world"
 
 على سبيل المثال، لضمان أن أداتي `edit` و`bash` تتطلبان موافقة المستخدم:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -484,9 +484,9 @@ opencode run "Hello world"
 
 يمكنك التحكم في سلوك ضغط السياق عبر الخيار `compaction`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true
@@ -504,9 +504,9 @@ opencode run "Hello world"
 
 يمكنك ضبط أنماط التجاهل لمراقِب الملفات عبر الخيار `watcher`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -521,9 +521,9 @@ opencode run "Hello world"
 
 يمكنك ضبط خوادم MCP التي تريد استخدامها عبر الخيار `mcp`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -536,11 +536,11 @@ opencode run "Hello world"
 
 [الإضافات](/docs/plugins) توسّع OpenCode بأدوات وخُطافات وتكاملات مخصصة.
 
-ضع ملفات الإضافات في `.opencode/plugins/` أو `~/.config/opencode/plugins/`. يمكنك أيضًا تحميل إضافات من npm عبر الخيار `plugin`.
+ضع ملفات الإضافات في `.mimocode/plugins/` أو `~/.config/opencode/plugins/`. يمكنك أيضًا تحميل إضافات من npm عبر الخيار `plugin`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -553,9 +553,9 @@ opencode run "Hello world"
 
 يمكنك ضبط التعليمات الخاصة بالنموذج الذي تستخدمه عبر الخيار `instructions`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -569,9 +569,9 @@ opencode run "Hello world"
 
 يمكنك تعطيل المزوّدين الذين يتم تحميلهم تلقائيًا عبر الخيار `disabled_providers`. هذا مفيد عندما تريد منع تحميل مزوّدين معينين حتى لو كانت بيانات الاعتماد الخاصة بهم متاحة.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -592,9 +592,9 @@ opencode run "Hello world"
 
 يمكنك تحديد قائمة سماح للمزوّدين عبر الخيار `enabled_providers`. عند ضبطه، سيتم تفعيل المزوّدين المحددين فقط وسيتم تجاهل البقية.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -613,9 +613,9 @@ opencode run "Hello world"
 
 يحتوي المفتاح `experimental` على خيارات قيد التطوير النشط.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -636,10 +636,10 @@ opencode run "Hello world"
 
 استخدم `{env:VARIABLE_NAME}` لاستبدال متغيرات البيئة:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -659,9 +659,9 @@ opencode run "Hello world"
 
 استخدم `{file:path/to/file}` لاستبدال محتويات ملف:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/ar/plugins.mdx
+++ b/packages/web/src/content/docs/ar/plugins.mdx
@@ -19,7 +19,7 @@ description: اكتب إضافاتك الخاصة لتوسيع OpenCode.
 
 ضع ملفات JavaScript أو TypeScript في دليل الإضافات.
 
-- `.opencode/plugins/` - إضافات على مستوى المشروع
+- `.mimocode/plugins/` - إضافات على مستوى المشروع
 - `~/.config/opencode/plugins/` - إضافات عامة
 
 تُحمَّل الملفات في هذه الأدلة تلقائيا عند بدء التشغيل.
@@ -30,9 +30,9 @@ description: اكتب إضافاتك الخاصة لتوسيع OpenCode.
 
 حدّد حزم npm في ملف الإعدادات.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ description: اكتب إضافاتك الخاصة لتوسيع OpenCode.
 
 تُحمَّل الإضافات من جميع المصادر وتعمل جميع الخطافات بالتتابع. ترتيب التحميل هو:
 
-1. إعدادات عامة (`~/.config/opencode/opencode.json`)
-2. إعدادات المشروع (`opencode.json`)
+1. إعدادات عامة (`~/.config/opencode/mimocode.jsonc`)
+2. إعدادات المشروع (`mimocode.jsonc`)
 3. دليل الإضافات العام (`~/.config/opencode/plugins/`)
-4. دليل إضافات المشروع (`.opencode/plugins/`)
+4. دليل إضافات المشروع (`.mimocode/plugins/`)
 
 تُحمَّل حزم npm المكررة ذات الاسم والإصدار نفسيهما مرة واحدة. ومع ذلك، تُحمَّل الإضافة المحلية وإضافة npm ذات الاسم المشابه كلتاهما بشكل مستقل.
 
@@ -75,7 +75,7 @@ description: اكتب إضافاتك الخاصة لتوسيع OpenCode.
 
 يمكن للإضافات المحلية والأدوات المخصصة استخدام حزم npm خارجية. أضف `package.json` إلى دليل الإعدادات لديك متضمنا الاعتماديات التي تحتاجها.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -85,7 +85,7 @@ description: اكتب إضافاتك الخاصة لتوسيع OpenCode.
 
 يشغّل OpenCode الأمر `bun install` عند بدء التشغيل لتثبيتها. بعد ذلك يمكن لإضافاتك وأدواتك استيرادها.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -103,7 +103,7 @@ export const MyPlugin = async (ctx) => {
 
 ### البنية الأساسية
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -218,7 +218,7 @@ export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree
 
 أرسل إشعارات عند وقوع أحداث معينة:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -243,7 +243,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
 
 امنع opencode من قراءة ملفات `.env`:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -261,7 +261,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 احقن متغيرات البيئة في جميع عمليات تنفيذ shell (أدوات الذكاء الاصطناعي وterminal المستخدم):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -278,7 +278,7 @@ export const InjectEnvPlugin = async () => {
 
 يمكن للإضافات أيضا إضافة أدوات مخصصة إلى opencode:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -313,7 +313,7 @@ export const CustomToolsPlugin: Plugin = async (ctx) => {
 
 استخدم `client.app.log()` بدلا من `console.log` للتسجيل البنيوي:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -326,7 +326,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-المستويات: `debug`, `info`, `warn`, `error`. راجع [توثيق SDK](https://opencode.ai/docs/sdk) للتفاصيل.
+المستويات: `debug`, `info`, `warn`, `error`. راجع [توثيق SDK](https://mimocode.ai/docs/sdk) للتفاصيل.
 
 ---
 
@@ -334,7 +334,7 @@ export const MyPlugin = async ({ client }) => {
 
 خصّص السياق الذي يتم تضمينه عند ضغط جلسة:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -358,7 +358,7 @@ Include any state that should persist across compaction:
 
 يمكنك أيضا استبدال موجّه الضغط بالكامل عبر ضبط `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/bs/cli.mdx
+++ b/packages/web/src/content/docs/bs/cli.mdx
@@ -357,7 +357,7 @@ Pokrenite OpenCode headless server za API pristup. Pogledajte [server docs](/doc
 opencode serve
 ```
 
-Ovo pokreće HTTP server koji pruža API pristup funkcionalnosti OpenCode-a bez TUI interfejsa. Postavite `OPENCODE_SERVER_PASSWORD` da omogućite HTTP osnovnu auth (korisničko ime je zadano na `opencode`).
+Ovo pokreće HTTP server koji pruža API pristup funkcionalnosti OpenCode-a bez TUI interfejsa. Postavite `MIMOCODE_SERVER_PASSWORD` da omogućite HTTP osnovnu auth (korisničko ime je zadano na `opencode`).
 
 #### Opcije
 
@@ -453,7 +453,7 @@ Pokrenite OpenCode headless server sa web interfejsom.
 opencode web
 ```
 
-Ovo pokreće HTTP server i otvara web pretraživač za pristup OpenCode-u preko web interfejsa. Postavite `OPENCODE_SERVER_PASSWORD` da omogućite HTTP osnovnu auth (korisničko ime je zadano na `opencode`).
+Ovo pokreće HTTP server i otvara web pretraživač za pristup OpenCode-u preko web interfejsa. Postavite `MIMOCODE_SERVER_PASSWORD` da omogućite HTTP osnovnu auth (korisničko ime je zadano na `opencode`).
 
 #### Opcije
 
@@ -552,30 +552,30 @@ OpenCode se može konfigurirati pomoću varijabli okruženja.
 
 | Varijabla                             | Tip     | Opis                                                               |
 | ------------------------------------- | ------- | ------------------------------------------------------------------ |
-| `OPENCODE_AUTO_SHARE`                 | boolean | Automatski dijeli sesije                                           |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Putanja do Git Bash izvršne datoteke na Windows-u                  |
-| `OPENCODE_CONFIG`                     | string  | Putanja do konfiguracijskog fajla                                  |
-| `OPENCODE_TUI_CONFIG`                 | string  | Putanja do TUI konfiguracijskog fajla                              |
-| `OPENCODE_CONFIG_DIR`                 | string  | Putanja do konfiguracijskog direktorija                            |
-| `OPENCODE_CONFIG_CONTENT`             | string  | Inline json konfiguracijski sadržaj                                |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Onemogući automatske provjere ažuriranja                           |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | Onemogući brisanje (pruning) starih podataka                       |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Onemogući automatsko ažuriranje naslova terminala                  |
-| `OPENCODE_PERMISSION`                 | string  | Inline json konfiguracija dozvola                                  |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Onemogući podrazumijevane dodatke (plugins)                        |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Onemogući automatsko preuzimanje LSP servera                       |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Omogući eksperimentalne modele                                     |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Onemogući automatsko sažimanje konteksta                           |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Onemogući čitanje iz `.claude` (prompt + vještine)                 |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Onemogući čitanje `~/.claude/CLAUDE.md`                            |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Onemogući učitavanje `.claude/skills`                              |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Onemogući dohvaćanje modela iz udaljenih izvora                    |
-| `OPENCODE_FAKE_VCS`                   | string  | Lažni VCS provajder za potrebe testiranja                          |
-| `OPENCODE_CLIENT`                     | string  | Identifikator klijenta (zadano na `cli`)                           |
-| `OPENCODE_ENABLE_EXA`                 | boolean | Omogući Exa alate za web pretraživanje                             |
-| `OPENCODE_SERVER_PASSWORD`            | string  | Omogući osnovnu autentifikaciju za `serve`/`web`                   |
-| `OPENCODE_SERVER_USERNAME`            | string  | Poništi osnovno korisničko ime autentifikacije (zadano `opencode`) |
-| `OPENCODE_MODELS_URL`                 | string  | Prilagođeni URL za dohvaćanje konfiguracije modela                 |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | Automatski dijeli sesije                                           |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | Putanja do Git Bash izvršne datoteke na Windows-u                  |
+| `MIMOCODE_CONFIG`                     | string  | Putanja do konfiguracijskog fajla                                  |
+| `MIMOCODE_TUI_CONFIG`                 | string  | Putanja do TUI konfiguracijskog fajla                              |
+| `MIMOCODE_CONFIG_DIR`                 | string  | Putanja do konfiguracijskog direktorija                            |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | Inline json konfiguracijski sadržaj                                |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | Onemogući automatske provjere ažuriranja                           |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | Onemogući brisanje (pruning) starih podataka                       |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | Onemogući automatsko ažuriranje naslova terminala                  |
+| `MIMOCODE_PERMISSION`                 | string  | Inline json konfiguracija dozvola                                  |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Onemogući podrazumijevane dodatke (plugins)                        |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Onemogući automatsko preuzimanje LSP servera                       |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Omogući eksperimentalne modele                                     |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | Onemogući automatsko sažimanje konteksta                           |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | Onemogući čitanje iz `.claude` (prompt + vještine)                 |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Onemogući čitanje `~/.claude/CLAUDE.md`                            |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Onemogući učitavanje `.claude/skills`                              |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | Onemogući dohvaćanje modela iz udaljenih izvora                    |
+| `MIMOCODE_FAKE_VCS`                   | string  | Lažni VCS provajder za potrebe testiranja                          |
+| `MIMOCODE_CLIENT`                     | string  | Identifikator klijenta (zadano na `cli`)                           |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | Omogući Exa alate za web pretraživanje                             |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | Omogući osnovnu autentifikaciju za `serve`/`web`                   |
+| `MIMOCODE_SERVER_USERNAME`            | string  | Poništi osnovno korisničko ime autentifikacije (zadano `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | string  | Prilagođeni URL za dohvaćanje konfiguracije modela                 |
 
 ---
 
@@ -585,16 +585,16 @@ Ove varijable okruženja omogućavaju eksperimentalne karakteristike koje se mog
 
 | Varijabla                                       | Tip     | Opis                                              |
 | ----------------------------------------------- | ------- | ------------------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | Omogući sve eksperimentalne funkcije              |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Omogući otkrivanje ikona                          |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Onemogući kopiranje pri odabiru u TUI             |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Zadano vremensko ograničenje za bash naredbe u ms |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Maksimalni izlazni tokeni za LLM odgovore         |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Omogući praćenje datoteka za cijeli direktorij    |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | Omogući oxfmt formatter                           |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Omogući eksperimentalni LSP alat                  |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Onemogući praćenje datoteka                       |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Omogući eksperimentalne Exa funkcije              |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Omogući TY LSP za python datoteke                 |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Omogući eksperimentalne Markdown funkcije         |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Omogući Plan mod                                  |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | Omogući sve eksperimentalne funkcije              |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Omogući otkrivanje ikona                          |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Onemogući kopiranje pri odabiru u TUI             |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Zadano vremensko ograničenje za bash naredbe u ms |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Maksimalni izlazni tokeni za LLM odgovore         |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Omogući praćenje datoteka za cijeli direktorij    |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | Omogući oxfmt formatter                           |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Omogući eksperimentalni LSP alat                  |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Onemogući praćenje datoteka                       |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | Omogući eksperimentalne Exa funkcije              |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Omogući TY LSP za python datoteke                 |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Omogući eksperimentalne Markdown funkcije         |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Omogući Plan mod                                  |

--- a/packages/web/src/content/docs/bs/config.mdx
+++ b/packages/web/src/content/docs/bs/config.mdx
@@ -11,9 +11,9 @@ Možete konfigurirati OpenCode koristeći JSON konfiguracijski fajl.
 
 OpenCode podržava i **JSON** i **JSONC** (JSON sa komentarima) formate.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -43,11 +43,11 @@ Na primjer, ako vaša globalna konfiguracija postavlja `autoupdate: true`, a va�
 Izvori konfiguracije se učitavaju ovim redoslijedom (kasniji izvori poništavaju ranije):
 
 1. **Udaljena konfiguracija** (od `.well-known/opencode`) - organizacijske postavke
-2. **Globalna konfiguracija** (`~/.config/opencode/opencode.json`) - korisničke preferencije
-3. **Prilagođena konfiguracija** (`OPENCODE_CONFIG` env var) - prilagođena preinačenja
-4. **Konfiguracija projekta** (`opencode.json` u projektu) - postavke specifične za projekat
+2. **Globalna konfiguracija** (`~/.config/opencode/mimocode.jsonc`) - korisničke preferencije
+3. **Prilagođena konfiguracija** (`MIMOCODE_CONFIG` env var) - prilagođena preinačenja
+4. **Konfiguracija projekta** (`mimocode.jsonc` u projektu) - postavke specifične za projekat
 5. **`.opencode` direktoriji** - agenti, komande, dodaci
-6. **Inline konfiguracija** (`OPENCODE_CONFIG_CONTENT` env var) - runtime preinačenja
+6. **Inline konfiguracija** (`MIMOCODE_CONFIG_CONTENT` env var) - runtime preinačenja
 
 To znači da konfiguracije projekta mogu nadjačati globalne zadane postavke, a globalne konfiguracije mogu nadjačati postavke udaljene organizacije.
 
@@ -79,7 +79,7 @@ Na primjer, ako vaša organizacija nudi MCP servere koji su po defaultu onemogu�
 
 Možete omogućiti određene servere u vašoj lokalnoj konfiguraciji:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ Možete omogućiti određene servere u vašoj lokalnoj konfiguraciji:
 
 ### Globalno
 
-Postavite svoju globalnu OpenCode konfiguraciju u `~/.config/opencode/opencode.json`. Koristite globalnu konfiguraciju za korisničke preferencije kao što su provajderi, modeli i dozvole.
+Postavite svoju globalnu OpenCode konfiguraciju u `~/.config/opencode/mimocode.jsonc`. Koristite globalnu konfiguraciju za korisničke preferencije kao što su provajderi, modeli i dozvole.
 
 Za postavke specifične za TUI, koristite `~/.config/opencode/tui.json`.
 
@@ -105,7 +105,7 @@ Globalna konfiguracija poništava zadane postavke udaljene organizacije.
 
 ### Projekt
 
-Dodajte `opencode.json` u korijen projekta. Konfiguracija projekta ima najveći prioritet među standardnim konfiguracijskim datotekama - ona nadjačava globalne i udaljene konfiguracije.
+Dodajte `mimocode.jsonc` u korijen projekta. Konfiguracija projekta ima najveći prioritet među standardnim konfiguracijskim datotekama - ona nadjačava globalne i udaljene konfiguracije.
 
 Za TUI postavke specifične za projekat, dodajte `tui.json` pored njega.
 
@@ -121,10 +121,10 @@ Ovo je također sigurno provjeriti u Git i koristi istu shemu kao globalna.
 
 ### Prilagođena konfiguracija
 
-Navedite prilagođenu putanju konfiguracijske datoteke koristeći varijablu okruženja `OPENCODE_CONFIG`.
+Navedite prilagođenu putanju konfiguracijske datoteke koristeći varijablu okruženja `MIMOCODE_CONFIG`.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -134,10 +134,10 @@ Prilagođena konfiguracija se učitava između globalne i projektne konfiguracij
 
 ### Prilagođeni direktorij
 
-Navedite prilagođeni konfiguracijski direktorij koristeći `OPENCODE_CONFIG_DIR` varijablu okruženja. U ovom direktoriju će se tražiti agenti, komande, modovi i dodaci baš kao standardni `.opencode` direktorij, i trebali bi pratiti istu strukturu.
+Navedite prilagođeni konfiguracijski direktorij koristeći `MIMOCODE_CONFIG_DIR` varijablu okruženja. U ovom direktoriju će se tražiti agenti, komande, modovi i dodaci baš kao standardni `.opencode` direktorij, i trebali bi pratiti istu strukturu.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -147,9 +147,9 @@ Prilagođeni direktorij se učitava nakon direktorija globalne konfiguracije i `
 
 ## Šema
 
-Konfiguracijski fajl ima šemu koja je definirana u [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+Konfiguracijski fajl ima šemu koja je definirana u [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
-TUI konfiguracija koristi [**`opencode.ai/tui.json`**](https://opencode.ai/tui.json).
+TUI konfiguracija koristi [**`mimocode.ai/tui.json`**](https://mimocode.ai/tui.json).
 
 Vaš editor bi trebao biti u mogućnosti da validira i autodovršava na osnovu šeme.
 
@@ -161,7 +161,7 @@ Koristite namjenski `tui.json` (ili `tui.jsonc`) fajl za postavke specifične za
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "scroll_speed": 3,
   "scroll_acceleration": {
     "enabled": true
@@ -170,9 +170,9 @@ Koristite namjenski `tui.json` (ili `tui.jsonc`) fajl za postavke specifične za
 }
 ```
 
-Koristite `OPENCODE_TUI_CONFIG` da pokažete na prilagođeni TUI konfiguracijski fajl.
+Koristite `MIMOCODE_TUI_CONFIG` da pokažete na prilagođeni TUI konfiguracijski fajl.
 
-Stari `theme`, `keybinds`, i `tui` ključevi u `opencode.json` su zastarjeli i automatski će se migrirati kada je to moguće.
+Stari `theme`, `keybinds`, i `tui` ključevi u `mimocode.jsonc` su zastarjeli i automatski će se migrirati kada je to moguće.
 
 [Saznajte više o korištenju TUI ovdje](/docs/tui#configure).
 
@@ -182,9 +182,9 @@ Stari `theme`, `keybinds`, i `tui` ključevi u `opencode.json` su zastarjeli i a
 
 Možete konfigurirati postavke servera za naredbe `opencode serve` i `opencode web` putem opcije `server`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -211,9 +211,9 @@ Dostupne opcije:
 
 Možete upravljati alatima koje LLM može koristiti putem opcije `tools`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -229,9 +229,9 @@ Možete upravljati alatima koje LLM može koristiti putem opcije `tools`.
 
 Možete konfigurirati dobavljače i modele koje želite koristiti u svojoj OpenCode konfiguraciji kroz opcije `provider`, `model` i `small_model`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -242,9 +242,9 @@ Opcija `small_model` konfigurira poseban model za lagane zadatke poput generiran
 
 Opcije provajdera mogu uključivati ​​`timeout` i `setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -271,9 +271,9 @@ Neki provajderi podržavaju dodatne opcije konfiguracije osim generičkih postav
 
 Amazon Bedrock podržava konfiguraciju specifičnu za AWS:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -304,7 +304,7 @@ Postavite vašu UI temu u `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -317,9 +317,9 @@ Postavite vašu UI temu u `tui.json`.
 
 Možete konfigurirati specijalizirane agente za određene zadatke putem opcije `agent`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -335,7 +335,7 @@ Možete konfigurirati specijalizirane agente za određene zadatke putem opcije `
 }
 ```
 
-Također možete definirati agente koristeći markdown datoteke u `~/.config/opencode/agents/` ili `.opencode/agents/`. [Saznajte više ovdje](/docs/agents).
+Također možete definirati agente koristeći markdown datoteke u `~/.config/opencode/agents/` ili `.mimocode/agents/`. [Saznajte više ovdje](/docs/agents).
 
 ---
 
@@ -343,9 +343,9 @@ Također možete definirati agente koristeći markdown datoteke u `~/.config/ope
 
 Možete postaviti zadanog agenta koristeći opciju `default_agent`. Ovo određuje koji se agent koristi kada nijedan nije eksplicitno specificiran.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -360,9 +360,9 @@ Ova postavka se primjenjuje na sva sučelja: TUI, CLI (`opencode run`), desktop 
 
 Možete konfigurirati funkciju [share](/docs/share) putem opcije `share`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -381,9 +381,9 @@ Podrazumevano, dijeljenje je postavljeno na ručni način rada gdje trebate eksp
 
 Možete konfigurirati prilagođene naredbe za ponavljanje zadataka putem opcije `command`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -399,7 +399,7 @@ Možete konfigurirati prilagođene naredbe za ponavljanje zadataka putem opcije 
 }
 ```
 
-Također možete definirati naredbe koristeći markdown fajlove u `~/.config/opencode/commands/` ili `.opencode/commands/`. [Saznajte više ovdje](/docs/commands).
+Također možete definirati naredbe koristeći markdown fajlove u `~/.config/opencode/commands/` ili `.mimocode/commands/`. [Saznajte više ovdje](/docs/commands).
 
 ---
 
@@ -409,7 +409,7 @@ Prilagodite prečice tipki u `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -422,9 +422,9 @@ Prilagodite prečice tipki u `tui.json`.
 
 OpenCode će automatski preuzeti sva nova ažuriranja kada se pokrene. Ovo možete onemogućiti opcijom `autoupdate`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -438,9 +438,9 @@ Imajte na umu da ovo funkcionira samo ako nije instalirano pomoću upravitelja p
 
 Možete konfigurirati formatere koda putem opcije `formatter`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -466,9 +466,9 @@ Prema zadanim postavkama, OpenCode **dopušta sve operacije** bez potrebe za eks
 
 Na primjer, da osigurate da alati `edit` i `bash` zahtijevaju odobrenje korisnika:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -484,9 +484,9 @@ Na primjer, da osigurate da alati `edit` i `bash` zahtijevaju odobrenje korisnik
 
 Možete kontrolirati ponašanje sažimanja konteksta putem opcije `compaction`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -505,9 +505,9 @@ Možete kontrolirati ponašanje sažimanja konteksta putem opcije `compaction`.
 
 Možete konfigurirati obrasce ignoriranja promatrača datoteka putem opcije `watcher`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -522,9 +522,9 @@ Obrasci prate glob sintaksu. Koristite ovo da isključite bučne direktorije iz 
 
 Možete konfigurirati MCP servere koje želite koristiti putem opcije `mcp`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -537,11 +537,11 @@ Možete konfigurirati MCP servere koje želite koristiti putem opcije `mcp`.
 
 [Plugins](/docs/plugins) proširuju OpenCode sa prilagođenim alatima, kukicama i integracijama.
 
-Postavite datoteke dodataka u `.opencode/plugins/` ili `~/.config/opencode/plugins/`. Također možete učitati dodatke iz npm-a preko opcije `plugin`.
+Postavite datoteke dodataka u `.mimocode/plugins/` ili `~/.config/opencode/plugins/`. Također možete učitati dodatke iz npm-a preko opcije `plugin`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -554,9 +554,9 @@ Postavite datoteke dodataka u `.opencode/plugins/` ili `~/.config/opencode/plugi
 
 Možete konfigurirati upute za model koji koristite putem opcije `instructions`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -569,9 +569,9 @@ Ovo uzima niz putanja i glob uzoraka do datoteka instrukcija. [Saznajte više o 
 
 Možete onemogućiti dobavljače koji se automatski učitavaju preko opcije `disabled_providers`. Ovo je korisno kada želite spriječiti učitavanje određenih provajdera čak i ako su njihovi vjerodajnici dostupni.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -592,9 +592,9 @@ Opcija `disabled_providers` prihvata niz ID-ova provajdera. Kada je provajder on
 
 Možete odrediti listu dozvoljenih dobavljača putem opcije `enabled_providers`. Kada se podesi, samo navedeni provajderi će biti omogućeni, a svi ostali će biti zanemareni.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -613,9 +613,9 @@ Ako se provajder pojavljuje i u `enabled_providers` i `disabled_providers`, `dis
 
 Ključ `experimental` sadrži opcije koje su u aktivnom razvoju.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -636,10 +636,10 @@ Možete koristiti zamjenu varijabli u vašim konfiguracijskim datotekama da bist
 
 Koristite `{env:VARIABLE_NAME}` za zamjenu varijabli okruženja:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -659,9 +659,9 @@ Ako varijabla okruženja nije postavljena, bit će zamijenjena praznim nizom.
 
 Koristite `{file:path/to/file}` da zamijenite sadržaj fajla:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/bs/plugins.mdx
+++ b/packages/web/src/content/docs/bs/plugins.mdx
@@ -16,7 +16,7 @@ Postoje dva načina za učitavanje dodataka.
 
 Postavite JavaScript ili TypeScript datoteke u direktorij dodataka.
 
-- `.opencode/plugins/` - Dodaci na nivou projekta
+- `.mimocode/plugins/` - Dodaci na nivou projekta
 - `~/.config/opencode/plugins/` - Globalni dodaci
   Datoteke u ovim direktorijumima se automatski učitavaju pri pokretanju.
 
@@ -26,9 +26,9 @@ Postavite JavaScript ili TypeScript datoteke u direktorij dodataka.
 
 Navedite npm pakete u vašoj konfiguracijskoj datoteci.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -49,10 +49,10 @@ Pregledajte dostupne dodatke u [ecosystem](/docs/ecosystem#plugins).
 
 Dodaci se učitavaju iz svih izvora i svi zakačnjaci rade u nizu. Redoslijed učitavanja je:
 
-1. Globalna konfiguracija (`~/.config/opencode/opencode.json`)
-2. Konfiguracija projekta (`opencode.json`)
+1. Globalna konfiguracija (`~/.config/opencode/mimocode.jsonc`)
+2. Konfiguracija projekta (`mimocode.jsonc`)
 3. Globalni direktorij dodataka (`~/.config/opencode/plugins/`)
-4. Direktorij dodataka projekta (`.opencode/plugins/`)
+4. Direktorij dodataka projekta (`.mimocode/plugins/`)
    Duplicirani npm paketi sa istim imenom i verzijom se učitavaju jednom. Međutim, lokalni dodatak i npm dodatak sa sličnim nazivima se učitavaju odvojeno.
 
 ---
@@ -68,7 +68,7 @@ funkcije. Svaka funkcija prima objekt konteksta i vraća hooks objekt.
 
 Lokalni dodaci i prilagođeni alati mogu koristiti vanjske npm pakete. Dodajte `package.json` u svoj konfiguracijski direktorij sa zavisnostima koje su vam potrebne.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -78,7 +78,7 @@ Lokalni dodaci i prilagođeni alati mogu koristiti vanjske npm pakete. Dodajte `
 
 OpenCode pokreće `bun install` pri pokretanju da ih instalira. Vaši dodaci i alati ih zatim mogu uvesti.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -96,7 +96,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Osnovna struktura
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -209,7 +209,7 @@ Evo nekoliko primjera dodataka koje možete koristiti za proširenje OpenCode.
 
 Pošaljite obavještenja kada se dogode određeni događaji:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -233,7 +233,7 @@ Ako alat dodatka koristi isto ime kao ugrađeni alat, alat dodatka ima prednost.
 
 Spriječite opencode da čita `.env` fajlove:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -251,7 +251,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Ubacite varijable okruženja u sva izvršavanja ljuske (AI alati i korisnički terminali):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -268,7 +268,7 @@ export const InjectEnvPlugin = async () => {
 
 Dodaci također mogu dodati prilagođene alate u opencode:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -302,7 +302,7 @@ Pomoćnik `tool` kreira prilagođeni alat koji opencode može pozvati. Uzima fun
 
 Koristite `client.app.log()` umjesto `console.log` za strukturirano bilježenje:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -315,13 +315,13 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Nivoi su: `debug`, `info`, `warn`, `error`. Pogledajte [SDK dokumentaciju](https://opencode.ai/docs/sdk) za detalje.
+Nivoi su: `debug`, `info`, `warn`, `error`. Pogledajte [SDK dokumentaciju](https://mimocode.ai/docs/sdk) za detalje.
 
 ### Kuke za sažimanje
 
 Prilagodite kontekst uključen kada se sesija zbije:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -344,7 +344,7 @@ Include any state that should persist across compaction:
 `experimental.session.compacting` kuka se aktivira prije nego što LLM generira sažetak nastavka. Koristite ga za ubacivanje konteksta specifičnog za domenu koji bi zadani prompt za sažimanje propustio.
 Također možete u potpunosti zamijeniti prompt za sabijanje postavljanjem `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -361,7 +361,7 @@ Start a headless OpenCode server for API access. Check out the [server docs](/do
 opencode serve
 ```
 
-This starts an HTTP server that provides API access to opencode functionality without the TUI interface. Set `OPENCODE_SERVER_PASSWORD` to enable HTTP basic auth (username defaults to `opencode`).
+This starts an HTTP server that provides API access to opencode functionality without the TUI interface. Set `MIMOCODE_SERVER_PASSWORD` to enable HTTP basic auth (username defaults to `opencode`).
 
 #### Flags
 
@@ -457,7 +457,7 @@ Start a headless OpenCode server with a web interface.
 opencode web
 ```
 
-This starts an HTTP server and opens a web browser to access OpenCode through a web interface. Set `OPENCODE_SERVER_PASSWORD` to enable HTTP basic auth (username defaults to `opencode`).
+This starts an HTTP server and opens a web browser to access OpenCode through a web interface. Set `MIMOCODE_SERVER_PASSWORD` to enable HTTP basic auth (username defaults to `opencode`).
 
 #### Flags
 
@@ -556,32 +556,32 @@ OpenCode can be configured using environment variables.
 
 | Variable                              | Type    | Description                                       |
 | ------------------------------------- | ------- | ------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | Automatically share sessions                      |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows            |
-| `OPENCODE_CONFIG`                     | string  | Path to config file                               |
-| `OPENCODE_TUI_CONFIG`                 | string  | Path to TUI config file                           |
-| `OPENCODE_CONFIG_DIR`                 | string  | Path to config directory                          |
-| `OPENCODE_HOME`                       | string  | Absolute path to single profile root (holds `config/`, `data/`, `state/`, `cache/` subdirs); overrides all four XDG base dirs when set |
-| `OPENCODE_CONFIG_CONTENT`             | string  | Inline json config content                        |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks                   |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data                       |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates          |
-| `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config                   |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                           |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disable automatic LSP server downloads            |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Enable experimental models                        |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Disable automatic context compaction              |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Disable reading from `.claude` (prompt + skills)  |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disable reading `~/.claude/CLAUDE.md`             |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable loading `.claude/skills`                  |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Disable fetching models from remote sources       |
-| `OPENCODE_DISABLE_MOUSE`              | boolean | Disable mouse capture in the TUI                  |
-| `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
-| `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)             |
-| `OPENCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools                       |
-| `OPENCODE_SERVER_PASSWORD`            | string  | Enable basic auth for `serve`/`web`               |
-| `OPENCODE_SERVER_USERNAME`            | string  | Override basic auth username (default `opencode`) |
-| `OPENCODE_MODELS_URL`                 | string  | Custom URL for fetching models configuration      |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | Automatically share sessions                      |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows            |
+| `MIMOCODE_CONFIG`                     | string  | Path to config file                               |
+| `MIMOCODE_TUI_CONFIG`                 | string  | Path to TUI config file                           |
+| `MIMOCODE_CONFIG_DIR`                 | string  | Path to config directory                          |
+| `MIMOCODE_HOME`                       | string  | Absolute path to single profile root (holds `config/`, `data/`, `state/`, `cache/` subdirs); overrides all four XDG base dirs when set |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | Inline json config content                        |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks                   |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data                       |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates          |
+| `MIMOCODE_PERMISSION`                 | string  | Inlined json permissions config                   |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                           |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disable automatic LSP server downloads            |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Enable experimental models                        |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | Disable automatic context compaction              |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | Disable reading from `.claude` (prompt + skills)  |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disable reading `~/.claude/CLAUDE.md`             |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable loading `.claude/skills`                  |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | Disable fetching models from remote sources       |
+| `MIMOCODE_DISABLE_MOUSE`              | boolean | Disable mouse capture in the TUI                  |
+| `MIMOCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
+| `MIMOCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)             |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools                       |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | Enable basic auth for `serve`/`web`               |
+| `MIMOCODE_SERVER_USERNAME`            | string  | Override basic auth username (default `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | string  | Custom URL for fetching models configuration      |
 
 ---
 
@@ -591,16 +591,16 @@ These environment variables enable experimental features that may change or be r
 
 | Variable                                        | Type    | Description                             |
 | ----------------------------------------------- | ------- | --------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | Enable all experimental features        |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Enable icon discovery                   |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Disable copy on select in TUI           |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Default timeout for bash commands in ms |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Max output tokens for LLM responses     |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Enable file watcher for entire dir      |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | Enable oxfmt formatter                  |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Enable experimental LSP tool            |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Disable file watcher                    |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Enable experimental Exa features        |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Enable TY LSP for python files          |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Enable experimental markdown features   |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Enable plan mode                        |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | Enable all experimental features        |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Enable icon discovery                   |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Disable copy on select in TUI           |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Default timeout for bash commands in ms |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Max output tokens for LLM responses     |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Enable file watcher for entire dir      |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | Enable oxfmt formatter                  |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Enable experimental LSP tool            |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Disable file watcher                    |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | Enable experimental Exa features        |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Enable TY LSP for python files          |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Enable experimental markdown features   |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Enable plan mode                        |

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -11,9 +11,9 @@ You can configure OpenCode using a JSON config file.
 
 OpenCode supports both **JSON** and **JSONC** (JSON with Comments) formats.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -44,11 +44,11 @@ For example, if your global config sets `autoupdate: true` and your project conf
 Config sources are loaded in this order (later sources override earlier ones):
 
 1. **Remote config** (from `.well-known/opencode`) - organizational defaults
-2. **Global config** (`~/.config/opencode/opencode.json`) - user preferences
-3. **Custom config** (`OPENCODE_CONFIG` env var) - custom overrides
-4. **Project config** (`opencode.json` in project) - project-specific settings
+2. **Global config** (`~/.config/opencode/mimocode.jsonc`) - user preferences
+3. **Custom config** (`MIMOCODE_CONFIG` env var) - custom overrides
+4. **Project config** (`mimocode.jsonc` in project) - project-specific settings
 5. **`.opencode` directories** - agents, commands, plugins
-6. **Inline config** (`OPENCODE_CONFIG_CONTENT` env var) - runtime overrides
+6. **Inline config** (`MIMOCODE_CONFIG_CONTENT` env var) - runtime overrides
 7. **Managed config files** (`/Library/Application Support/opencode/` on macOS) - admin-controlled
 8. **macOS managed preferences** (`.mobileconfig` via MDM) - highest priority, not user-overridable
 
@@ -82,7 +82,7 @@ For example, if your organization provides MCP servers that are disabled by defa
 
 You can enable specific servers in your local config:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -98,7 +98,7 @@ You can enable specific servers in your local config:
 
 ### Global
 
-Place your global OpenCode config in `~/.config/opencode/opencode.json`. Use global config for user-wide server/runtime preferences like providers, models, and permissions.
+Place your global OpenCode config in `~/.config/opencode/mimocode.jsonc`. Use global config for user-wide server/runtime preferences like providers, models, and permissions.
 
 For TUI-specific settings, use `~/.config/opencode/tui.json`.
 
@@ -108,7 +108,7 @@ Global config overrides remote organizational defaults.
 
 ### Per project
 
-Add `opencode.json` in your project root. Project config has the highest precedence among standard config files - it overrides both global and remote configs.
+Add `mimocode.jsonc` in your project root. Project config has the highest precedence among standard config files - it overrides both global and remote configs.
 
 For project-specific TUI settings, add `tui.json` alongside it.
 
@@ -124,10 +124,10 @@ This is also safe to be checked into Git and uses the same schema as the global 
 
 ### Custom path
 
-Specify a custom config file path using the `OPENCODE_CONFIG` environment variable.
+Specify a custom config file path using the `MIMOCODE_CONFIG` environment variable.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -137,13 +137,13 @@ Custom config is loaded between global and project configs in the precedence ord
 
 ### Custom directory
 
-Specify a custom config directory using the `OPENCODE_CONFIG_DIR`
+Specify a custom config directory using the `MIMOCODE_CONFIG_DIR`
 environment variable. This directory will be searched for agents, commands,
 modes, and plugins just like the standard `.opencode` directory, and should
 follow the same structure.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -157,7 +157,7 @@ Organizations can enforce configuration that users cannot override. Managed sett
 
 #### File-based
 
-Drop an `opencode.json` or `opencode.jsonc` file in the system managed config directory:
+Drop an `mimocode.jsonc` or `mimocode.jsoncc` file in the system managed config directory:
 
 | Platform | Path                                     |
 | -------- | ---------------------------------------- |
@@ -176,7 +176,7 @@ OpenCode checks these paths:
 1. `/Library/Managed Preferences/<user>/ai.opencode.managed.plist`
 2. `/Library/Managed Preferences/ai.opencode.managed.plist`
 
-The plist keys map directly to `opencode.json` fields. MDM metadata keys (`PayloadUUID`, `PayloadType`, etc.) are stripped automatically.
+The plist keys map directly to `mimocode.jsonc` fields. MDM metadata keys (`PayloadUUID`, `PayloadType`, etc.) are stripped automatically.
 
 **Creating a `.mobileconfig`**
 
@@ -253,9 +253,9 @@ All managed preference keys appear in the resolved config and cannot be overridd
 
 ## Schema
 
-The server/runtime config schema is defined in [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+The server/runtime config schema is defined in [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
-TUI config uses [**`opencode.ai/tui.json`**](https://opencode.ai/tui.json).
+TUI config uses [**`mimocode.ai/tui.json`**](https://mimocode.ai/tui.json).
 
 Your editor should be able to validate and autocomplete based on the schema.
 
@@ -267,7 +267,7 @@ Use a dedicated `tui.json` (or `tui.jsonc`) file for TUI-specific settings.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "scroll_speed": 3,
   "scroll_acceleration": {
     "enabled": true
@@ -277,9 +277,9 @@ Use a dedicated `tui.json` (or `tui.jsonc`) file for TUI-specific settings.
 }
 ```
 
-Use `OPENCODE_TUI_CONFIG` to point to a custom TUI config file.
+Use `MIMOCODE_TUI_CONFIG` to point to a custom TUI config file.
 
-Legacy `theme`, `keybinds`, and `tui` keys in `opencode.json` are deprecated and automatically migrated when possible.
+Legacy `theme`, `keybinds`, and `tui` keys in `mimocode.jsonc` are deprecated and automatically migrated when possible.
 
 ---
 
@@ -287,9 +287,9 @@ Legacy `theme`, `keybinds`, and `tui` keys in `opencode.json` are deprecated and
 
 You can configure server settings for the `opencode serve` and `opencode web` commands through the `server` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -316,9 +316,9 @@ Available options:
 
 You can manage the tools an LLM can use through the `tools` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -334,9 +334,9 @@ You can manage the tools an LLM can use through the `tools` option.
 
 You can configure the providers and models you want to use in your OpenCode config through the `provider`, `model` and `small_model` options.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -347,9 +347,9 @@ The `small_model` option configures a separate model for lightweight tasks like 
 
 Provider options can include `timeout`, `chunkTimeout`, and `setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -378,9 +378,9 @@ Some providers support additional configuration options beyond the generic `time
 
 Amazon Bedrock supports AWS-specific configuration:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -411,7 +411,7 @@ Set your UI theme in `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -424,9 +424,9 @@ Set your UI theme in `tui.json`.
 
 You can configure specialized agents for specific tasks through the `agent` option.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -442,7 +442,7 @@ You can configure specialized agents for specific tasks through the `agent` opti
 }
 ```
 
-You can also define agents using markdown files in `~/.config/opencode/agents/` or `.opencode/agents/`. [Learn more here](/docs/agents).
+You can also define agents using markdown files in `~/.config/opencode/agents/` or `.mimocode/agents/`. [Learn more here](/docs/agents).
 
 ---
 
@@ -450,9 +450,9 @@ You can also define agents using markdown files in `~/.config/opencode/agents/` 
 
 You can set the default agent using the `default_agent` option. This determines which agent is used when none is explicitly specified.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -467,9 +467,9 @@ This setting applies across all interfaces: TUI, CLI (`opencode run`), desktop a
 
 You can configure the [share](/docs/share) feature through the `share` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -488,9 +488,9 @@ By default, sharing is set to manual mode where you need to explicitly share con
 
 You can configure custom commands for repetitive tasks through the `command` option.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -506,7 +506,7 @@ You can configure custom commands for repetitive tasks through the `command` opt
 }
 ```
 
-You can also define commands using markdown files in `~/.config/opencode/commands/` or `.opencode/commands/`. [Learn more here](/docs/commands).
+You can also define commands using markdown files in `~/.config/opencode/commands/` or `.mimocode/commands/`. [Learn more here](/docs/commands).
 
 ---
 
@@ -516,7 +516,7 @@ Customize keybinds in `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -531,9 +531,9 @@ OpenCode uses snapshots to track file changes during agent operations, enabling 
 
 For large repositories or projects with many submodules, the snapshot system can cause slow indexing and significant disk usage as it tracks all changes using an internal git repository. You can disable snapshots using the `snapshot` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "snapshot": false
 }
 ```
@@ -546,9 +546,9 @@ Note that disabling snapshots means changes made by the agent cannot be rolled b
 
 OpenCode will automatically download any new updates when it starts up. You can disable this with the `autoupdate` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -562,9 +562,9 @@ Notice that this only works if it was not installed using a package manager such
 
 You can configure code formatters through the `formatter` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -590,9 +590,9 @@ By default, opencode **allows all operations** without requiring explicit approv
 
 For example, to ensure that the `edit` and `bash` tools require user approval:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -608,9 +608,9 @@ For example, to ensure that the `edit` and `bash` tools require user approval:
 
 You can control context compaction behavior through the `compaction` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -629,9 +629,9 @@ You can control context compaction behavior through the `compaction` option.
 
 You can configure file watcher ignore patterns through the `watcher` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -646,9 +646,9 @@ Patterns follow glob syntax. Use this to exclude noisy directories from file wat
 
 You can configure MCP servers you want to use through the `mcp` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -661,11 +661,11 @@ You can configure MCP servers you want to use through the `mcp` option.
 
 [Plugins](/docs/plugins) extend OpenCode with custom tools, hooks, and integrations.
 
-Place plugin files in `.opencode/plugins/` or `~/.config/opencode/plugins/`. You can also load plugins from npm through the `plugin` option.
+Place plugin files in `.mimocode/plugins/` or `~/.config/opencode/plugins/`. You can also load plugins from npm through the `plugin` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -678,9 +678,9 @@ Place plugin files in `.opencode/plugins/` or `~/.config/opencode/plugins/`. You
 
 You can configure the instructions for the model you're using through the `instructions` option.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -694,9 +694,9 @@ about rules here](/docs/rules).
 
 You can disable providers that are loaded automatically through the `disabled_providers` option. This is useful when you want to prevent certain providers from being loaded even if their credentials are available.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -717,9 +717,9 @@ The `disabled_providers` option accepts an array of provider IDs. When a provide
 
 You can specify an allowlist of providers through the `enabled_providers` option. When set, only the specified providers will be enabled and all others will be ignored.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -738,9 +738,9 @@ If a provider appears in both `enabled_providers` and `disabled_providers`, the 
 
 The `experimental` key contains options that are under active development.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -761,10 +761,10 @@ You can use variable substitution in your config files to reference environment 
 
 Use `{env:VARIABLE_NAME}` to substitute environment variables:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -784,9 +784,9 @@ If the environment variable is not set, it will be replaced with an empty string
 
 Use `{file:path/to/file}` to substitute the contents of a file:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/da/cli.mdx
+++ b/packages/web/src/content/docs/da/cli.mdx
@@ -360,7 +360,7 @@ Start en hovedløs OpenCode-server til API-adgang. Tjek [server docs](/docs/serv
 opencode serve
 ```
 
-Dette starter en HTTP-server, der giver API-adgang til opencode-funktionalitet uden TUI-grænsefladen. Indstil `OPENCODE_SERVER_PASSWORD` for at aktivere HTTP grundlæggende godkendelse (brugernavn er standard til `opencode`).
+Dette starter en HTTP-server, der giver API-adgang til opencode-funktionalitet uden TUI-grænsefladen. Indstil `MIMOCODE_SERVER_PASSWORD` for at aktivere HTTP grundlæggende godkendelse (brugernavn er standard til `opencode`).
 
 #### Flag
 
@@ -456,7 +456,7 @@ Start en hovedløs OpenCode-server med en webgrænseflade.
 opencode web
 ```
 
-Dette starter en HTTP-server og åbner en webbrowser for at få adgang til OpenCode via en webgrænseflade. Indstil `OPENCODE_SERVER_PASSWORD` for at aktivere HTTP grundlæggende godkendelse (brugernavn er standard til `opencode`).
+Dette starter en HTTP-server og åbner en webbrowser for at få adgang til OpenCode via en webgrænseflade. Indstil `MIMOCODE_SERVER_PASSWORD` for at aktivere HTTP grundlæggende godkendelse (brugernavn er standard til `opencode`).
 
 #### Flag
 
@@ -555,30 +555,30 @@ OpenCode kan konfigureres ved hjælp af miljøvariabler.
 
 | Variabel                              | Skriv   | Beskrivelse                                                           |
 | ------------------------------------- | ------- | --------------------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | Del automatisk session                                                |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Sti til Git Bash eksekverbar på Windows                               |
-| `OPENCODE_CONFIG`                     | string  | Sti til konfigurationsfil                                             |
-| `OPENCODE_TUI_CONFIG`                 | string  | Sti til TUI-konfigurationsfil                                         |
-| `OPENCODE_CONFIG_DIR`                 | string  | Sti til konfigurationsmappe                                           |
-| `OPENCODE_CONFIG_CONTENT`             | string  | Indbygget json-konfigurationsindhold                                  |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Deaktiver automatisk opdateringskontrol                               |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | Deaktiver beskæring af gamle data                                     |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Deaktiver automatisk opdatering af terminaltitel                      |
-| `OPENCODE_PERMISSION`                 | string  | Indbygget json-tilladelseskonfiguration                               |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Deaktiver standard plugins                                            |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Deaktiver automatisk LSP-serverdownloads                              |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Aktive eksperimentelle modeller                                       |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Deaktiver automatisk kontekstkomprimering                             |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Deaktiver læsning fra `.claude` (prompt + færdigheder)                |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Deaktiver læsning `~/.claude/CLAUDE.md`                               |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Deaktiver indlæsning af `.claude/skills`                              |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Deaktivering af modeller fra eksterne kilder                          |
-| `OPENCODE_FAKE_VCS`                   | string  | Falsk VCS-udbyder til testformål                                      |
-| `OPENCODE_CLIENT`                     | string  | Klient-id (standard til `cli`)                                        |
-| `OPENCODE_ENABLE_EXA`                 | boolean | Aktiver Exa-websøgeværktøjer                                          |
-| `OPENCODE_SERVER_PASSWORD`            | string  | Aktiver grundlæggende godkendelse for `serve`/`web`                   |
-| `OPENCODE_SERVER_USERNAME`            | string  | Tilsidesæt grundlæggende godkendelsesbrugernavn (standard `opencode`) |
-| `OPENCODE_MODELS_URL`                 | string  | Brugerdefineret URL til hentning af modelkonfiguration                |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | Del automatisk session                                                |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | Sti til Git Bash eksekverbar på Windows                               |
+| `MIMOCODE_CONFIG`                     | string  | Sti til konfigurationsfil                                             |
+| `MIMOCODE_TUI_CONFIG`                 | string  | Sti til TUI-konfigurationsfil                                         |
+| `MIMOCODE_CONFIG_DIR`                 | string  | Sti til konfigurationsmappe                                           |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | Indbygget json-konfigurationsindhold                                  |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | Deaktiver automatisk opdateringskontrol                               |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | Deaktiver beskæring af gamle data                                     |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | Deaktiver automatisk opdatering af terminaltitel                      |
+| `MIMOCODE_PERMISSION`                 | string  | Indbygget json-tilladelseskonfiguration                               |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Deaktiver standard plugins                                            |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Deaktiver automatisk LSP-serverdownloads                              |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Aktive eksperimentelle modeller                                       |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | Deaktiver automatisk kontekstkomprimering                             |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | Deaktiver læsning fra `.claude` (prompt + færdigheder)                |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Deaktiver læsning `~/.claude/CLAUDE.md`                               |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Deaktiver indlæsning af `.claude/skills`                              |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | Deaktivering af modeller fra eksterne kilder                          |
+| `MIMOCODE_FAKE_VCS`                   | string  | Falsk VCS-udbyder til testformål                                      |
+| `MIMOCODE_CLIENT`                     | string  | Klient-id (standard til `cli`)                                        |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | Aktiver Exa-websøgeværktøjer                                          |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | Aktiver grundlæggende godkendelse for `serve`/`web`                   |
+| `MIMOCODE_SERVER_USERNAME`            | string  | Tilsidesæt grundlæggende godkendelsesbrugernavn (standard `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | string  | Brugerdefineret URL til hentning af modelkonfiguration                |
 
 ---
 
@@ -588,16 +588,16 @@ Disse miljøvariabler muliggør eksperimentelle funktioner, der kan ændres elle
 
 | Variabel                                        | Skriv   | Beskrivelse                                |
 | ----------------------------------------------- | ------- | ------------------------------------------ |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | Aktiver alle eksperimentelle funktioner    |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Aktiver ikonopdagelse                      |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Deaktiver kopi ved valg i TUI              |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | nummer  | Standard timeout for bash-kommandoer i ms  |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | nummer  | Maks. output-tokens for LLM-svar           |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Aktiver filovervågning for hele dir        |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | Aktiver oxfmt formatter                    |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Aktive eksperimenter LSP værktøj           |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Deaktiver filovervågning                   |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Aktive eksperimenter Exa-funktioner        |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Aktiver TY LSP for python-filer            |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Aktive eksperimentelle markdown-funktioner |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Aktiver plantilstand                       |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | Aktiver alle eksperimentelle funktioner    |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Aktiver ikonopdagelse                      |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Deaktiver kopi ved valg i TUI              |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | nummer  | Standard timeout for bash-kommandoer i ms  |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | nummer  | Maks. output-tokens for LLM-svar           |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Aktiver filovervågning for hele dir        |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | Aktiver oxfmt formatter                    |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Aktive eksperimenter LSP værktøj           |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Deaktiver filovervågning                   |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | Aktive eksperimenter Exa-funktioner        |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Aktiver TY LSP for python-filer            |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Aktive eksperimentelle markdown-funktioner |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Aktiver plantilstand                       |

--- a/packages/web/src/content/docs/da/config.mdx
+++ b/packages/web/src/content/docs/da/config.mdx
@@ -11,9 +11,9 @@ Du kan konfigurere OpenCode ved hjælp af en JSON-konfigurationsfil.
 
 OpenCode understøtter både **JSON** og **JSONC** (JSON med kommentarer) formater.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -44,11 +44,11 @@ For eksempel, hvis dine globale konfigurationssæt `autoupdate: true`, og dine p
 Konfigurationskilder indlæses i denne rækkefølge (senere kilder tilsidesætter tidligere):
 
 1. **Fjernkonfiguration** (fra `.well-known/opencode`) - organisatoriske standardindstillinger
-2. **Global config** (`~/.config/opencode/opencode.json`) - brugerpræferencer
-3. **Tilpasset konfiguration** (`OPENCODE_CONFIG` env var) - tilpassede tilsidesættelser
-4. **Project config** (`opencode.json` i projekt) - projektspecifikke indstillinger
+2. **Global config** (`~/.config/opencode/mimocode.jsonc`) - brugerpræferencer
+3. **Tilpasset konfiguration** (`MIMOCODE_CONFIG` env var) - tilpassede tilsidesættelser
+4. **Project config** (`mimocode.jsonc` i projekt) - projektspecifikke indstillinger
 5. **`.opencode` mapper** - agent, kommandoer, plugins
-6. **Inline config** (`OPENCODE_CONFIG_CONTENT` env var) - runtime tilsidesættelser
+6. **Inline config** (`MIMOCODE_CONFIG_CONTENT` env var) - runtime tilsidesættelser
 
 Dette betyder, at projektkonfigurationer kan tilsidesætte globale standardindstillinger, og globale konfigurationer kan tilsidesætte eksterne organisatoriske standarder.
 
@@ -80,7 +80,7 @@ Hvis din organisation f.eks. leverer MCP-servere, der er deaktiveret som standar
 
 Du kan aktivere specifikke servere i din lokale konfiguration:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -96,7 +96,7 @@ Du kan aktivere specifikke servere i din lokale konfiguration:
 
 ### Global
 
-Placer din globale OpenCode-konfiguration i `~/.config/opencode/opencode.json`. Brug global konfiguration til brugerdækkende præferencer som temaer, udbydere eller nøglebindinger.
+Placer din globale OpenCode-konfiguration i `~/.config/opencode/mimocode.jsonc`. Brug global konfiguration til brugerdækkende præferencer som temaer, udbydere eller nøglebindinger.
 
 Global config tilsidesætter eksterne organisatoriske standarder.
 
@@ -104,7 +104,7 @@ Global config tilsidesætter eksterne organisatoriske standarder.
 
 ### Projekt-niveau
 
-Tilføj `opencode.json` i dit projektrod. Project config har den højeste forrang blandt standard config-filer - den tilsidesætter både globale og eksterne config.
+Tilføj `mimocode.jsonc` i dit projektrod. Project config har den højeste forrang blandt standard config-filer - den tilsidesætter både globale og eksterne config.
 
 :::tip
 Placer projektspecifik konfiguration i roden af ​​dit projekt.
@@ -118,10 +118,10 @@ Dette er også sikkert at blive tjekket ind i Git og bruger det samme skema som 
 
 ### Brugerdefineret sti
 
-Angiv en brugerdefineret konfigurationsfilsti ved hjælp af miljøvariablen `OPENCODE_CONFIG`.
+Angiv en brugerdefineret konfigurationsfilsti ved hjælp af miljøvariablen `MIMOCODE_CONFIG`.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -131,13 +131,13 @@ Brugerdefineret konfigurationsindlæses mellem globale konfigurationer og projek
 
 ### Brugerdefineret mappe
 
-Angiv en brugerdefineret konfigurationsmappe ved hjælp af `OPENCODE_CONFIG_DIR`
+Angiv en brugerdefineret konfigurationsmappe ved hjælp af `MIMOCODE_CONFIG_DIR`
 miljøvariabel. Dette kort vil blive søgt efter agenter, kommandoer,
 modes og plugins ligesom standard `.opencode` mappen, og bør
 følge samme struktur.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -147,7 +147,7 @@ Den brugerdefinerede mappe indlæses efter den globale konfig og `.opencode` map
 
 ## Skema
 
-Konfigurationsfilen har et skema, der defineres i [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+Konfigurationsfilen har et skema, der defineres i [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
 Din editor skal være i stand til at validere og autofuldføre baseret på skemaet.
 
@@ -157,9 +157,9 @@ Din editor skal være i stand til at validere og autofuldføre baseret på skema
 
 Du kan konfigurere TUI-specifikke indstillinger gennem indstillingen `tui`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tui": {
     "scroll_speed": 3,
     "scroll_acceleration": {
@@ -184,9 +184,9 @@ Tilgængelige muligheder:
 
 Du kan konfigurere serverindstillinger for kommandoerne `opencode serve` og `opencode web` gennem indstillingen `server`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -213,9 +213,9 @@ Tilgængelige muligheder:
 
 Du kan administrere de værktøjer, en LLM kan bruge, gennem indstillingen `tools`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -231,9 +231,9 @@ Du kan administrere de værktøjer, en LLM kan bruge, gennem indstillingen `tool
 
 Du kan konfigurere de udbydere og modeller, du vil bruge i din OpenCode-konfiguration, gennem mulighederne `provider`, `model` og `small_model`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -244,9 +244,9 @@ Indstillingen `small_model` konfigurerer en separat model til lette opgaver som 
 
 Udbydermuligheder kan omfatte `timeout` og `setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -273,9 +273,9 @@ Nogle udbydere understøtter yderligere konfigurationsmuligheder ud over de gene
 
 Amazon Bedrock understøtter AWS-specifik konfiguration:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -304,9 +304,9 @@ Bearer tokens (`AWS_BEARER_TOKEN_BEDROCK` eller `/connect`) har forrang over pro
 
 Du kan konfigurere det tema, du vil bruge i din OpenCode-konfiguration, gennem indstillingen `theme`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "theme": ""
 }
 ```
@@ -319,9 +319,9 @@ Du kan konfigurere det tema, du vil bruge i din OpenCode-konfiguration, gennem i
 
 Du kan konfigurere opgaver specialiserede agenter til specifikke indstillinger gennem indstillingen `agent`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -337,7 +337,7 @@ Du kan konfigurere opgaver specialiserede agenter til specifikke indstillinger g
 }
 ```
 
-Du kan også definere agenter ved at bruge markdown-filer i `~/.config/opencode/agents/` eller `.opencode/agents/`. [Learn more here](/docs/agents).
+Du kan også definere agenter ved at bruge markdown-filer i `~/.config/opencode/agents/` eller `.mimocode/agents/`. [Learn more here](/docs/agents).
 
 ---
 
@@ -345,9 +345,9 @@ Du kan også definere agenter ved at bruge markdown-filer i `~/.config/opencode/
 
 Du kan indstille standardagenten ved at bruge indstillingen `default_agent`. Dette bestemmer, hvilken agent der bruges, når ingen er eksplicit angivet.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -362,9 +362,9 @@ Denne indstilling gælder på tværs af alle grænseflader: TUI, CLI (`opencode 
 
 Du kan konfigurere funktionen [share](/docs/share) gennem indstillingen `share`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -383,9 +383,9 @@ Som standard er deling indstillet til manuel tilstand, hvor du eksplicit skal de
 
 Du kan konfigurere brugerdefinerede kommandoer til gentagne opgaver gennem indstillingen `command`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -401,7 +401,7 @@ Du kan konfigurere brugerdefinerede kommandoer til gentagne opgaver gennem indst
 }
 ```
 
-Du kan også definere kommandoer ved hjælp af markdown-filer i `~/.config/opencode/commands/` eller `.opencode/commands/`. [Learn more here](/docs/commands).
+Du kan også definere kommandoer ved hjælp af markdown-filer i `~/.config/opencode/commands/` eller `.mimocode/commands/`. [Learn more here](/docs/commands).
 
 ---
 
@@ -409,9 +409,9 @@ Du kan også definere kommandoer ved hjælp af markdown-filer i `~/.config/openc
 
 Du kan tilpasse dine nøglebindinger gennem indstillingen `keybinds`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "keybinds": {}
 }
 ```
@@ -424,9 +424,9 @@ Du kan tilpasse dine nøglebindinger gennem indstillingen `keybinds`.
 
 OpenCode vil automatisk downloade alle nye opdateringer, når den starter op. Du kan deaktivere dette med indstillingen `autoupdate`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -440,9 +440,9 @@ Bemærk, at dette kun virker, hvis det ikke blev installeret ved hjælp af en pa
 
 Du kan konfigurere kodeformatere gennem indstillingen `formatter`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -468,9 +468,9 @@ Som standard opencode **tillader alle operationer** uden at kræve eksplicit god
 
 For at sikre, at værktøjerne `edit` og `bash` for eksempel kræver brugergodkendelse:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -486,9 +486,9 @@ For at sikre, at værktøjerne `edit` og `bash` for eksempel kræver brugergodke
 
 Du kan styre kontekstkomprimeringsadfærd gennem indstillingen `compaction`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -507,9 +507,9 @@ Du kan styre kontekstkomprimeringsadfærd gennem indstillingen `compaction`.
 
 Du kan konfigurere ignoreringsmønstre for filovervåger gennem indstillingen `watcher`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -524,9 +524,9 @@ Mønstre følger glob-syntaks. Brug dette til at udelukke støjende mapper fra f
 
 Du kan konfigurere MCP-servere, som du vil bruge, gennem indstillingen `mcp`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -539,11 +539,11 @@ Du kan konfigurere MCP-servere, som du vil bruge, gennem indstillingen `mcp`.
 
 [Plugins](/docs/plugins) udvide OpenCode med brugerdefinerede værktøjer, kroge og integrationer.
 
-Placer plugin-filer i `.opencode/plugins/` eller `~/.config/opencode/plugins/`. Du kan også indlæse plugins fra npm gennem indstillingen `plugin`.
+Placer plugin-filer i `.mimocode/plugins/` eller `~/.config/opencode/plugins/`. Du kan også indlæse plugins fra npm gennem indstillingen `plugin`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -556,9 +556,9 @@ Placer plugin-filer i `.opencode/plugins/` eller `~/.config/opencode/plugins/`. 
 
 Du kan konfigurere brugervejledningen til den model, du kan gennem indstillingen `instructions`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -572,9 +572,9 @@ om regler her](/docs/rules).
 
 Du kan deaktivere udbydere, der indlæses automatisk gennem `disabled_providers`-indstillingen. Dette er nyttigt, når du vil forhindre visse udbydere i at blive indlæst, deres legitimationsoplysninger er tilgængelige.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -595,9 +595,9 @@ Indstillingen `disabled_providers` accepterer en række udbyder-id'er. Når en u
 
 Du kan angive en tilladelsesliste over udbydere gennem muligheden `enabled_providers`. Når den er indstillet, vil kun de angivne udbydere blive aktiveret, og alle andre vil blive ignoreret.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -616,9 +616,9 @@ Hvis en udbyder optræder i både `enabled_providers` og `disabled_providers`, h
 
 Nøglen `experimental` indeholder muligheder, der er under aktiv udvikling.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -639,10 +639,10 @@ Du kan bruge variabelsubstitution i dine konfigurationsfiler til at referere til
 
 Brug `{env:VARIABLE_NAME}` til at erstatte miljøvariabler:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -662,9 +662,9 @@ Hvis miljøvariablen ikke er indstillet, vil den blive erstattet med en tom stre
 
 Brug `{file:path/to/file}` til at erstatte indholdet af en fil:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/da/plugins.mdx
+++ b/packages/web/src/content/docs/da/plugins.mdx
@@ -19,7 +19,7 @@ Der er to måder at indlæse plugins på.
 
 Placer JavaScript- eller TypeScript-filer i plugin-mappen.
 
-- `.opencode/plugins/` - Plugins på projektniveau
+- `.mimocode/plugins/` - Plugins på projektniveau
 - `~/.config/opencode/plugins/` - Globale plugins
 
 Filer i disse mapper indlæses automatisk ved opstart.
@@ -30,9 +30,9 @@ Filer i disse mapper indlæses automatisk ved opstart.
 
 Angiv npm-pakker i din konfigurationsfil.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ Gennemse tilgængelige plugins i [ecosystem](/docs/ecosystem#plugins).
 
 Plugins indlæses fra alle kilder, og alle hooks kører i rækkefølge. Indlæsningsrækkefølgen er:
 
-1. Global konfiguration (`~/.config/opencode/opencode.json`)
-2. Projektkonfiguration (`opencode.json`)
+1. Global konfiguration (`~/.config/opencode/mimocode.jsonc`)
+2. Projektkonfiguration (`mimocode.jsonc`)
 3. Global plugin-mappe (`~/.config/opencode/plugins/`)
-4. Projekt plugin bibliotek (`.opencode/plugins/`)
+4. Projekt plugin bibliotek (`.mimocode/plugins/`)
 
 Dublerede npm-pakker med samme navn og version indlæses én gang. Et lokalt plugin og et npm plugin med lignende navne indlæses dog hver for sig.
 
@@ -75,7 +75,7 @@ funktioner. Hver funktion modtager et kontekstobjekt og returnerer et hooks-obje
 
 Lokale plugins og brugerdefinerede værktøjer kan bruge eksterne npm-pakker. Tilføj en `package.json` til din konfigurationsmappe med de afhængigheder, du har brug for.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -85,7 +85,7 @@ Lokale plugins og brugerdefinerede værktøjer kan bruge eksterne npm-pakker. Ti
 
 OpenCode kører `bun install` ved opstart for at installere disse. Dine plugins og værktøjer kan derefter importere dem.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -103,7 +103,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Grundlæggende struktur
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -218,7 +218,7 @@ Her er nogle eksempler på plugins, du kan bruge til at udvide opencode.
 
 Send meddelelser, når visse hændelser indtræffer:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -243,7 +243,7 @@ Hvis du bruger OpenCode desktop-appen, kan den sende systemmeddelelser automatis
 
 Undgå opencode i at læse `.env` filer:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -261,7 +261,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Injicer miljøvariabler i al shell-udførelse (AI-værktøjer og brugerterminaler):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -278,7 +278,7 @@ export const InjectEnvPlugin = async () => {
 
 Plugins kan også tilføje brugerdefinerede værktøjer til opencode:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -317,7 +317,7 @@ Hvis et plugin-værktøj bruger samme navn som et indbygget værktøj, har plugi
 
 Brug `client.app.log()` i stedet for `console.log` til struktureret logning:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -330,7 +330,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Niveauer: `debug`, `info`, `warn`, `error`. Se [SDK documentation](https://opencode.ai/docs/sdk) for detaljer.
+Niveauer: `debug`, `info`, `warn`, `error`. Se [SDK documentation](https://mimocode.ai/docs/sdk) for detaljer.
 
 ---
 
@@ -338,7 +338,7 @@ Niveauer: `debug`, `info`, `warn`, `error`. Se [SDK documentation](https://openc
 
 Tilpas konteksten inkluderet, når en session komprimeres:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -362,7 +362,7 @@ Include any state that should persist across compaction:
 
 Du kan også erstatte komprimeringsprompten helt ved at indstille `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/de/cli.mdx
+++ b/packages/web/src/content/docs/de/cli.mdx
@@ -360,7 +360,7 @@ Starten Sie einen Headless-OpenCode-Server für den API-Zugriff. Sehen Sie sich 
 opencode serve
 ```
 
-Dadurch wird ein HTTP-Server gestartet, der API-Zugriff auf OpenCode-Funktionalität ohne die TUI-Schnittstelle bietet. Legen Sie `OPENCODE_SERVER_PASSWORD` fest, um die HTTP-Basisauthentifizierung zu aktivieren (Benutzername ist standardmäßig `opencode`).
+Dadurch wird ein HTTP-Server gestartet, der API-Zugriff auf OpenCode-Funktionalität ohne die TUI-Schnittstelle bietet. Legen Sie `MIMOCODE_SERVER_PASSWORD` fest, um die HTTP-Basisauthentifizierung zu aktivieren (Benutzername ist standardmäßig `opencode`).
 
 #### Optionen
 
@@ -456,7 +456,7 @@ Starten Sie einen Headless-OpenCode-Server mit einer Weboberfläche.
 opencode web
 ```
 
-Dadurch wird ein HTTP-Server gestartet und ein Webbrowser geöffnet, um über eine Webschnittstelle auf OpenCode zuzugreifen. Legen Sie `OPENCODE_SERVER_PASSWORD` fest, um die HTTP-Basisauthentifizierung zu aktivieren (Benutzername ist standardmäßig `opencode`).
+Dadurch wird ein HTTP-Server gestartet und ein Webbrowser geöffnet, um über eine Webschnittstelle auf OpenCode zuzugreifen. Legen Sie `MIMOCODE_SERVER_PASSWORD` fest, um die HTTP-Basisauthentifizierung zu aktivieren (Benutzername ist standardmäßig `opencode`).
 
 #### Optionen
 
@@ -555,29 +555,29 @@ OpenCode kann mithilfe von Umgebungsvariablen konfiguriert werden.
 
 | Variable                              | Typ             | Beschreibung                                                                     |
 | ------------------------------------- | --------------- | -------------------------------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolescher Wert | Sitzungen automatisch teilen                                                     |
-| `OPENCODE_GIT_BASH_PATH`              | Zeichenfolge    | Pfad zur ausführbaren Git Bash-Datei unter Windows                               |
-| `OPENCODE_CONFIG`                     | Zeichenfolge    | Pfad zur Konfigurationsdatei                                                     |
-| `OPENCODE_CONFIG_DIR`                 | Zeichenfolge    | Pfad zum Konfigurationsverzeichnis                                               |
-| `OPENCODE_CONFIG_CONTENT`             | Zeichenfolge    | Inline-JSON-Konfigurationsinhalt                                                 |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolescher Wert | Automatische Update-Prüfungen deaktivieren                                       |
-| `OPENCODE_DISABLE_PRUNE`              | boolescher Wert | Bereinigung alter Daten deaktivieren                                             |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolescher Wert | Deaktivieren Sie die automatische Aktualisierung von Terminaltiteln              |
-| `OPENCODE_PERMISSION`                 | Zeichenfolge    | Inline-JSON-Berechtigungskonfiguration                                           |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolescher Wert | Standard-Plugins deaktivieren                                                    |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolescher Wert | Automatische LSP-Server-Downloads deaktivieren                                   |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolescher Wert | Experimentelle Modelle aktivieren                                                |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolescher Wert | Automatische Kontextkomprimierung deaktivieren                                   |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolescher Wert | Deaktivieren Sie das Lesen von `.claude` (Prompt + Skills)                       |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolescher Wert | Deaktivieren Sie das Lesen von `~/.claude/CLAUDE.md`                             |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolescher Wert | Deaktivieren Sie das Laden von `.claude/skills`                                  |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolescher Wert | Deaktivieren Sie das Abrufen von Modellen aus Remote-Quellen                     |
-| `OPENCODE_FAKE_VCS`                   | Zeichenfolge    | Gefälschter VCS-Anbieter zu Testzwecken                                          |
-| `OPENCODE_CLIENT`                     | Zeichenfolge    | Client-ID (standardmäßig `cli`)                                                  |
-| `OPENCODE_ENABLE_EXA`                 | boolescher Wert | Exa-Websuchtools aktivieren                                                      |
-| `OPENCODE_SERVER_PASSWORD`            | Zeichenfolge    | Aktivieren Sie die Basisauthentifizierung für `serve`/`web`                      |
-| `OPENCODE_SERVER_USERNAME`            | Zeichenfolge    | Benutzernamen für die Basisauthentifizierung überschreiben (Standard `opencode`) |
-| `OPENCODE_MODELS_URL`                 | Zeichenfolge    | Benutzerdefinierte URL zum Abrufen der Modellkonfiguration                       |
+| `MIMOCODE_AUTO_SHARE`                 | boolescher Wert | Sitzungen automatisch teilen                                                     |
+| `MIMOCODE_GIT_BASH_PATH`              | Zeichenfolge    | Pfad zur ausführbaren Git Bash-Datei unter Windows                               |
+| `MIMOCODE_CONFIG`                     | Zeichenfolge    | Pfad zur Konfigurationsdatei                                                     |
+| `MIMOCODE_CONFIG_DIR`                 | Zeichenfolge    | Pfad zum Konfigurationsverzeichnis                                               |
+| `MIMOCODE_CONFIG_CONTENT`             | Zeichenfolge    | Inline-JSON-Konfigurationsinhalt                                                 |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolescher Wert | Automatische Update-Prüfungen deaktivieren                                       |
+| `MIMOCODE_DISABLE_PRUNE`              | boolescher Wert | Bereinigung alter Daten deaktivieren                                             |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolescher Wert | Deaktivieren Sie die automatische Aktualisierung von Terminaltiteln              |
+| `MIMOCODE_PERMISSION`                 | Zeichenfolge    | Inline-JSON-Berechtigungskonfiguration                                           |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolescher Wert | Standard-Plugins deaktivieren                                                    |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolescher Wert | Automatische LSP-Server-Downloads deaktivieren                                   |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolescher Wert | Experimentelle Modelle aktivieren                                                |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolescher Wert | Automatische Kontextkomprimierung deaktivieren                                   |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolescher Wert | Deaktivieren Sie das Lesen von `.claude` (Prompt + Skills)                       |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolescher Wert | Deaktivieren Sie das Lesen von `~/.claude/CLAUDE.md`                             |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolescher Wert | Deaktivieren Sie das Laden von `.claude/skills`                                  |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolescher Wert | Deaktivieren Sie das Abrufen von Modellen aus Remote-Quellen                     |
+| `MIMOCODE_FAKE_VCS`                   | Zeichenfolge    | Gefälschter VCS-Anbieter zu Testzwecken                                          |
+| `MIMOCODE_CLIENT`                     | Zeichenfolge    | Client-ID (standardmäßig `cli`)                                                  |
+| `MIMOCODE_ENABLE_EXA`                 | boolescher Wert | Exa-Websuchtools aktivieren                                                      |
+| `MIMOCODE_SERVER_PASSWORD`            | Zeichenfolge    | Aktivieren Sie die Basisauthentifizierung für `serve`/`web`                      |
+| `MIMOCODE_SERVER_USERNAME`            | Zeichenfolge    | Benutzernamen für die Basisauthentifizierung überschreiben (Standard `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | Zeichenfolge    | Benutzerdefinierte URL zum Abrufen der Modellkonfiguration                       |
 
 ---
 
@@ -587,16 +587,16 @@ Diese Umgebungsvariablen ermöglichen experimentelle Funktionen, die sich änder
 
 | Variable                                        | Typ             | Beschreibung                                            |
 | ----------------------------------------------- | --------------- | ------------------------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | boolescher Wert | Alle experimentellen Funktionen aktivieren              |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolescher Wert | Symbolerkennung aktivieren                              |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolescher Wert | Kopieren bei Auswahl in TUI deaktivieren                |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | Zahl            | Standard-Timeout für Bash-Befehle in ms                 |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | Zahl            | Maximale Ausgabetokens für LLM-Antworten                |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolescher Wert | Dateiüberwachung für das gesamte Verzeichnis aktivieren |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolescher Wert | Oxfmt-Formatierer aktivieren                            |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolescher Wert | Experimentelles LSP-Tool aktivieren                     |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolescher Wert | Dateiüberwachung deaktivieren                           |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolescher Wert | Experimentelle Exa-Funktionen aktivieren                |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolescher Wert | TY LSP für Python-Dateien aktivieren                    |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolescher Wert | Experimentelle Markdown-Funktionen aktivieren           |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolescher Wert | Planmodus aktivieren                                    |
+| `MIMOCODE_EXPERIMENTAL`                         | boolescher Wert | Alle experimentellen Funktionen aktivieren              |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolescher Wert | Symbolerkennung aktivieren                              |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolescher Wert | Kopieren bei Auswahl in TUI deaktivieren                |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | Zahl            | Standard-Timeout für Bash-Befehle in ms                 |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | Zahl            | Maximale Ausgabetokens für LLM-Antworten                |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolescher Wert | Dateiüberwachung für das gesamte Verzeichnis aktivieren |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolescher Wert | Oxfmt-Formatierer aktivieren                            |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolescher Wert | Experimentelles LSP-Tool aktivieren                     |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolescher Wert | Dateiüberwachung deaktivieren                           |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolescher Wert | Experimentelle Exa-Funktionen aktivieren                |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolescher Wert | TY LSP für Python-Dateien aktivieren                    |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolescher Wert | Experimentelle Markdown-Funktionen aktivieren           |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolescher Wert | Planmodus aktivieren                                    |

--- a/packages/web/src/content/docs/de/config.mdx
+++ b/packages/web/src/content/docs/de/config.mdx
@@ -11,9 +11,9 @@ Sie können OpenCode mithilfe einer JSON-Konfigurationsdatei konfigurieren.
 
 OpenCode unterstützt die Formate **JSON** und **JSONC** (JSON mit Kommentaren).
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   // Theme configuration
   "theme": "opencode",
   "model": "anthropic/claude-sonnet-4-5",
@@ -43,11 +43,11 @@ Wenn Ihre globale Konfiguration beispielsweise `theme: "opencode"` und `autoupda
 Konfigurationsquellen werden in dieser Reihenfolge geladen (spätere Quellen überschreiben frühere):
 
 1. **Remote-Konfiguration** (von `.well-known/opencode`) – Organisationsstandards
-2. **Globale Konfiguration** (`~/.config/opencode/opencode.json`) – Benutzereinstellungen
-3. **Benutzerdefinierte Konfiguration** (`OPENCODE_CONFIG` env var) – benutzerdefinierte Überschreibungen
-4. **Projektkonfiguration** (`opencode.json` im Projekt) – projektspezifische Einstellungen
+2. **Globale Konfiguration** (`~/.config/opencode/mimocode.jsonc`) – Benutzereinstellungen
+3. **Benutzerdefinierte Konfiguration** (`MIMOCODE_CONFIG` env var) – benutzerdefinierte Überschreibungen
+4. **Projektkonfiguration** (`mimocode.jsonc` im Projekt) – projektspezifische Einstellungen
 5. **`.opencode` Verzeichnisse** – Agenten, Befehle, Plugins
-6. **Inline-Konfiguration** (`OPENCODE_CONFIG_CONTENT` env var) – Laufzeitüberschreibungen
+6. **Inline-Konfiguration** (`MIMOCODE_CONFIG_CONTENT` env var) – Laufzeitüberschreibungen
 
 Dies bedeutet, dass Projektkonfigurationen globale Standardeinstellungen überschreiben können und globale Konfigurationen Remote-Organisationsstandards überschreiben können.
 
@@ -79,7 +79,7 @@ Wenn Ihre Organisation beispielsweise MCP-Server bereitstellt, sind die standard
 
 Sie können bestimmte Server in Ihrer lokalen Konfiguration aktivieren:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ Sie können bestimmte Server in Ihrer lokalen Konfiguration aktivieren:
 
 ### Global
 
-Platzieren Sie Ihre globale OpenCode-Konfiguration in `~/.config/opencode/opencode.json`. Verwenden Sie die globale Konfiguration für benutzerweite Einstellungen wie Themen, Anbieter oder Tastenkombinationen.
+Platzieren Sie Ihre globale OpenCode-Konfiguration in `~/.config/opencode/mimocode.jsonc`. Verwenden Sie die globale Konfiguration für benutzerweite Einstellungen wie Themen, Anbieter oder Tastenkombinationen.
 
 Die globale Konfiguration überschreibt die Standardeinstellungen der Remote-Organisation.
 
@@ -103,7 +103,7 @@ Die globale Konfiguration überschreibt die Standardeinstellungen der Remote-Org
 
 ### Pro Projekt
 
-Fügen Sie `opencode.json` in Ihrem Projektstamm hinzu. Die Projektkonfiguration hat unter den Standardkonfigurationsdateien die höchste Priorität – sie überschreibt sowohl globale als auch Remote-Konfigurationen.
+Fügen Sie `mimocode.jsonc` in Ihrem Projektstamm hinzu. Die Projektkonfiguration hat unter den Standardkonfigurationsdateien die höchste Priorität – sie überschreibt sowohl globale als auch Remote-Konfigurationen.
 
 :::tip
 Platzieren Sie die projektspezifische Konfiguration im Stammverzeichnis Ihres Projekts.
@@ -117,10 +117,10 @@ Dies kann auch sicher in Git eingecheckt werden und dasselbe Schema wie das glob
 
 ### Benutzerdefinierter Pfad
 
-Geben Sie mithilfe der Umgebungsvariablen `OPENCODE_CONFIG` einen benutzerdefinierten Konfigurationsdateipfad an.
+Geben Sie mithilfe der Umgebungsvariablen `MIMOCODE_CONFIG` einen benutzerdefinierten Konfigurationsdateipfad an.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -130,13 +130,13 @@ Die benutzerdefinierte Konfiguration wird in der Rangfolge zwischen globalen und
 
 ### Benutzerdefiniertes Verzeichnis
 
-Geben Sie mit `OPENCODE_CONFIG_DIR` ein benutzerdefiniertes Konfigurationsverzeichnis an.
+Geben Sie mit `MIMOCODE_CONFIG_DIR` ein benutzerdefiniertes Konfigurationsverzeichnis an.
 Umgebungsvariable. Dieses Verzeichnis wird nach Agenten, Befehlen,
 Modi und Plugins genau wie das Standardverzeichnis `.opencode` und sollten
 folgen der gleichen Struktur.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -146,7 +146,7 @@ Das benutzerdefinierte Verzeichnis wird nach den Verzeichnissen global config un
 
 ## Schema
 
-Die Konfigurationsdatei verfügt über ein Schema, das in [**`opencode.ai/config.json`**](https://opencode.ai/config.json) definiert ist.
+Die Konfigurationsdatei verfügt über ein Schema, das in [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json) definiert ist.
 
 Ihr Editor sollte in der Lage sein, basierend auf dem Schema zu validieren und automatisch zu vervollständigen.
 
@@ -156,9 +156,9 @@ Ihr Editor sollte in der Lage sein, basierend auf dem Schema zu validieren und a
 
 Sie können TUI-spezifische Einstellungen über die Option `tui` konfigurieren.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tui": {
     "scroll_speed": 3,
     "scroll_acceleration": {
@@ -183,9 +183,9 @@ Verfügbare Optionen:
 
 Sie können Servereinstellungen für die Befehle `opencode serve` und `opencode web` über die Option `server` konfigurieren.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -212,9 +212,9 @@ Verfügbare Optionen:
 
 Sie können die Tools, die ein LLM verwenden kann, über die Option `tools` verwalten.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -230,9 +230,9 @@ Sie können die Tools, die ein LLM verwenden kann, über die Option `tools` verw
 
 Sie können die Anbieter und Modelle, die Sie in Ihrer OpenCode-Konfiguration verwenden möchten, über die Optionen `provider`, `model` und `small_model` konfigurieren.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -243,9 +243,9 @@ Die Option `small_model` konfiguriert ein separates Modell für einfache Aufgabe
 
 Zu den Anbieteroptionen können `timeout` und `setCacheKey` gehören:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -272,9 +272,9 @@ Einige Anbieter unterstützen zusätzliche Konfigurationsoptionen über die allg
 
 Amazon Bedrock unterstützt AWS-spezifische Konfigurationen:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -303,9 +303,9 @@ Inhabertoken (`AWS_BEARER_TOKEN_BEDROCK` oder `/connect`) haben Vorrang vor der 
 
 Sie können das Thema, das Sie in Ihrer OpenCode-Konfiguration verwenden möchten, über die Option `theme` konfigurieren.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "theme": ""
 }
 ```
@@ -318,9 +318,9 @@ Sie können das Thema, das Sie in Ihrer OpenCode-Konfiguration verwenden möchte
 
 Über die Option `agent` können Sie spezielle Agenten für bestimmte Aufgaben konfigurieren.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -336,7 +336,7 @@ Sie können das Thema, das Sie in Ihrer OpenCode-Konfiguration verwenden möchte
 }
 ```
 
-Sie können Agenten auch mithilfe von Markdown-Dateien in `~/.config/opencode/agents/` oder `.opencode/agents/` definieren. [Mehr erfahren](/docs/agents).
+Sie können Agenten auch mithilfe von Markdown-Dateien in `~/.config/opencode/agents/` oder `.mimocode/agents/` definieren. [Mehr erfahren](/docs/agents).
 
 ---
 
@@ -344,9 +344,9 @@ Sie können Agenten auch mithilfe von Markdown-Dateien in `~/.config/opencode/ag
 
 Sie können den Standardagenten mit der Option `default_agent` festlegen. Dadurch wird bestimmt, welcher Agent verwendet wird, wenn keiner explizit angegeben wird.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -361,9 +361,9 @@ Diese Einstellung gilt für alle Schnittstellen: TUI, CLI (`opencode run`), Desk
 
 Sie können die Funktion [share](/docs/share) über die Option `share` konfigurieren.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -382,9 +382,9 @@ Standardmäßig ist die Freigabe auf den manuellen Modus eingestellt, in dem Sie
 
 Sie können benutzerdefinierte Befehle für sich wiederholende Aufgaben über die Option `command` konfigurieren.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -400,7 +400,7 @@ Sie können benutzerdefinierte Befehle für sich wiederholende Aufgaben über di
 }
 ```
 
-Sie können Befehle auch mithilfe von Markdown-Dateien in `~/.config/opencode/commands/` oder `.opencode/commands/` definieren. [Mehr erfahren](/docs/commands).
+Sie können Befehle auch mithilfe von Markdown-Dateien in `~/.config/opencode/commands/` oder `.mimocode/commands/` definieren. [Mehr erfahren](/docs/commands).
 
 ---
 
@@ -408,9 +408,9 @@ Sie können Befehle auch mithilfe von Markdown-Dateien in `~/.config/opencode/co
 
 Sie können Ihre Tastenkombinationen über die Option `keybinds` anpassen.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "keybinds": {}
 }
 ```
@@ -423,9 +423,9 @@ Sie können Ihre Tastenkombinationen über die Option `keybinds` anpassen.
 
 OpenCode lädt beim Start automatisch alle neuen Updates herunter. Sie können dies mit der Option `autoupdate` deaktivieren.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -439,9 +439,9 @@ Beachten Sie, dass dies nur funktioniert, wenn es nicht mit einem Paketmanager w
 
 Sie können Codeformatierer über die Option `formatter` konfigurieren.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -467,9 +467,9 @@ OpenCode erlaubt standardmäßig alle Vorgänge, ohne dass eine ausdrückliche G
 
 Um beispielsweise sicherzustellen, dass die Tools `edit` und `bash` eine Benutzergenehmigung erfordern:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -485,9 +485,9 @@ Um beispielsweise sicherzustellen, dass die Tools `edit` und `bash` eine Benutze
 
 Sie können das Verhalten der Kontextkomprimierung über die Option `compaction` steuern.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true
@@ -504,9 +504,9 @@ Sie können das Verhalten der Kontextkomprimierung über die Option `compaction`
 
 Sie können Datei-Watcher-Ignoriermuster über die Option `watcher` konfigurieren.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -521,9 +521,9 @@ Muster folgen der Glob-Syntax. Verwenden Sie diese Option, um verrauschte Verzei
 
 Sie können den MCP-Server, den Sie verwenden möchten, über die Option `mcp` konfigurieren.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -536,11 +536,11 @@ Sie können den MCP-Server, den Sie verwenden möchten, über die Option `mcp` k
 
 [Plugins](/docs/plugins) erweitert OpenCode mit benutzerdefinierten Tools, Hooks und Integrationen.
 
-Platzieren Sie Ihre Plugin-Dateien in `.opencode/plugins/` oder `~/.config/opencode/plugins/`. Sie können Plugins auch über die Option `plugin` von npm laden.
+Platzieren Sie Ihre Plugin-Dateien in `.mimocode/plugins/` oder `~/.config/opencode/plugins/`. Sie können Plugins auch über die Option `plugin` von npm laden.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -553,9 +553,9 @@ Platzieren Sie Ihre Plugin-Dateien in `.opencode/plugins/` oder `~/.config/openc
 
 Sie können die Anweisungen für das von Ihnen verwendete Modell über die Option `instructions` konfigurieren.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -568,9 +568,9 @@ Dies erfordert eine Reihe von Pfaden und Glob-Mustern zu Anweisungsdateien. [Erf
 
 Sie können Anbieter, die automatisch geladen werden, über die Option `disabled_providers` deaktivieren. Dies ist nützlich, wenn Sie verhindern möchten, dass bestimmte Anbieter geladen werden, selbst wenn deren Anmeldeinformationen verfügbar sind.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -591,9 +591,9 @@ Die Option `disabled_providers` akzeptiert ein Array des Anbieters IDs. Wenn ein
 
 Sie können über die Option `enabled_providers` eine Zulassungsliste für Anbieter angeben. Wenn diese Option festgelegt ist, werden nur die angegebenen Anbieter aktiviert und alle anderen werden ignoriert.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -612,9 +612,9 @@ Wenn ein Anbieter sowohl in `enabled_providers` als auch in `disabled_providers`
 
 Der Schlüssel `experimental` enthält Optionen, die sich in der aktiven Entwicklung befinden.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -635,10 +635,10 @@ Sie können die Variablenersetzung in Ihren Konfigurationsdateien verwenden, um 
 
 Verwenden Sie `{env:VARIABLE_NAME}`, um Umgebungsvariablen zu ersetzen:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -658,9 +658,9 @@ Wenn die Umgebungsvariable nicht gesetzt ist, wird sie durch eine leere Zeichenf
 
 Verwenden Sie `{file:path/to/file}`, um den Inhalt einer Datei zu ersetzen:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/de/plugins.mdx
+++ b/packages/web/src/content/docs/de/plugins.mdx
@@ -19,7 +19,7 @@ Es gibt zwei Möglichkeiten, Plugins zu laden.
 
 Platzieren Sie JavaScript- oder TypeScript-Dateien im Plugin-Verzeichnis.
 
-- `.opencode/plugins/` – Plugins auf Projektebene
+- `.mimocode/plugins/` – Plugins auf Projektebene
 - `~/.config/opencode/plugins/` – Globale Plugins
 
 Dateien in diesen Verzeichnissen werden beim Start automatisch geladen.
@@ -30,9 +30,9 @@ Dateien in diesen Verzeichnissen werden beim Start automatisch geladen.
 
 Geben Sie npm-Pakete in Ihrer Konfigurationsdatei an.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ Durchsuchen Sie die verfügbaren Plugins im [ecosystem](/docs/ecosystem#plugins)
 
 Plugins werden aus allen Quellen geladen und alle Hooks werden nacheinander ausgeführt. Die Ladereihenfolge lautet:
 
-1. Globale Konfiguration (`~/.config/opencode/opencode.json`)
-2. Projektkonfiguration (`opencode.json`)
+1. Globale Konfiguration (`~/.config/opencode/mimocode.jsonc`)
+2. Projektkonfiguration (`mimocode.jsonc`)
 3. Globales Plugin-Verzeichnis (`~/.config/opencode/plugins/`)
-4. Projekt-Plugin-Verzeichnis (`.opencode/plugins/`)
+4. Projekt-Plugin-Verzeichnis (`.mimocode/plugins/`)
 
 Doppelte npm-Pakete mit demselben Namen und derselben Version werden einmal geladen. Allerdings werden ein lokales Plugin und ein NPM-Plugin mit ähnlichen Namen beide separat geladen.
 
@@ -74,7 +74,7 @@ Ein Plugin ist ein **JavaScript/TypeScript-Modul**, das eine oder mehrere Plugin
 
 Lokale Plugins und benutzerdefinierte Tools können externe npm-Pakete verwenden. Fügen Sie Ihrem Konfigurationsverzeichnis ein `package.json` mit den benötigten Abhängigkeiten hinzu.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -84,7 +84,7 @@ Lokale Plugins und benutzerdefinierte Tools können externe npm-Pakete verwenden
 
 OpenCode führt beim Start `bun install` aus, um diese zu installieren. Ihre Plugins und Tools können sie dann importieren.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -102,7 +102,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Grundstruktur
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -217,7 +217,7 @@ Hier sind einige Beispiele für Plugins, mit denen Sie OpenCode erweitern könne
 
 Senden Sie Benachrichtigungen, wenn bestimmte Ereignisse eintreten:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -242,7 +242,7 @@ Wenn Sie die OpenCode-Desktop-App verwenden, kann diese automatisch Systembenach
 
 Verhindern Sie, dass OpenCode `.env`-Dateien liest:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -260,7 +260,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Fügen Sie Umgebungsvariablen in alle Shell-Ausführungen ein (AI-Tools und Benutzerterminals):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -277,7 +277,7 @@ export const InjectEnvPlugin = async () => {
 
 Plugins können OpenCode auch benutzerdefinierte Tools hinzufügen:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -312,7 +312,7 @@ Ihre benutzerdefinierten Tools stehen neben den integrierten Tools für OpenCode
 
 Verwenden Sie `client.app.log()` anstelle von `console.log` für die strukturierte Protokollierung:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -325,7 +325,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Ebenen: `debug`, `info`, `warn`, `error`. Weitere Informationen finden Sie unter [SDK documentation](https://opencode.ai/docs/sdk).
+Ebenen: `debug`, `info`, `warn`, `error`. Weitere Informationen finden Sie unter [SDK documentation](https://mimocode.ai/docs/sdk).
 
 ---
 
@@ -333,7 +333,7 @@ Ebenen: `debug`, `info`, `warn`, `error`. Weitere Informationen finden Sie unter
 
 Passen Sie den Kontext an, der beim Komprimieren einer Sitzung einbezogen wird:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -357,7 +357,7 @@ Der Hook `experimental.session.compacting` wird ausgelöst, bevor der Hook LLM e
 
 Sie können die Komprimierungsaufforderung auch vollständig ersetzen, indem Sie `output.prompt` festlegen:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/es/cli.mdx
+++ b/packages/web/src/content/docs/es/cli.mdx
@@ -360,7 +360,7 @@ Inicie un servidor OpenCode sin cabeza para acceso API. Consulte los [documentos
 opencode serve
 ```
 
-Esto inicia un servidor HTTP que proporciona acceso API a la funcionalidad opencode sin la interfaz TUI. Configure `OPENCODE_SERVER_PASSWORD` para habilitar la autenticación básica HTTP (el nombre de usuario predeterminado es `opencode`).
+Esto inicia un servidor HTTP que proporciona acceso API a la funcionalidad opencode sin la interfaz TUI. Configure `MIMOCODE_SERVER_PASSWORD` para habilitar la autenticación básica HTTP (el nombre de usuario predeterminado es `opencode`).
 
 #### Opciones
 
@@ -456,7 +456,7 @@ Inicie un servidor OpenCode sin cabeza con una interfaz web.
 opencode web
 ```
 
-Esto inicia un servidor HTTP y abre un navegador web para acceder a OpenCode a través de una interfaz web. Configure `OPENCODE_SERVER_PASSWORD` para habilitar la autenticación básica HTTP (el nombre de usuario predeterminado es `opencode`).
+Esto inicia un servidor HTTP y abre un navegador web para acceder a OpenCode a través de una interfaz web. Configure `MIMOCODE_SERVER_PASSWORD` para habilitar la autenticación básica HTTP (el nombre de usuario predeterminado es `opencode`).
 
 #### Opciones
 
@@ -555,29 +555,29 @@ OpenCode se puede configurar mediante variables de entorno.
 
 | Variable                              | Type     | Description                                                                     |
 | ------------------------------------- | -------- | ------------------------------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | booleano | Compartir sesiones automáticamente                                              |
-| `OPENCODE_GIT_BASH_PATH`              | cadena   | Ruta al ejecutable de Git Bash en Windows                                       |
-| `OPENCODE_CONFIG`                     | cadena   | Ruta al archivo de configuración                                                |
-| `OPENCODE_CONFIG_DIR`                 | cadena   | Ruta al directorio de configuración                                             |
-| `OPENCODE_CONFIG_CONTENT`             | cadena   | Contenido de configuración json en línea                                        |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | booleano | Deshabilitar las comprobaciones automáticas de actualizaciones                  |
-| `OPENCODE_DISABLE_PRUNE`              | booleano | Deshabilitar la poda de datos antiguos                                          |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | booleano | Deshabilitar las actualizaciones automáticas de títulos de terminal             |
-| `OPENCODE_PERMISSION`                 | cadena   | Configuración de permisos json incorporados                                     |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | booleano | Deshabilitar complementos predeterminados                                       |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | booleano | Deshabilitar las descargas automáticas del servidor LSP                         |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | booleano | Habilitar modelos experimentales                                                |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | booleano | Deshabilitar la compactación automática de contexto                             |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | booleano | Deshabilitar la lectura desde `.claude` (mensaje + habilidades)                 |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | booleano | Desactivar lectura `~/.claude/CLAUDE.md`                                        |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | booleano | Deshabilitar la carga `.claude/skills`                                          |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | booleano | Deshabilitar la recuperación de modelos desde fuentes remotas                   |
-| `OPENCODE_FAKE_VCS`                   | cadena   | Proveedor de VCS falso para fines de prueba                                     |
-| `OPENCODE_CLIENT`                     | cadena   | Identificador de cliente (por defecto `cli`)                                    |
-| `OPENCODE_ENABLE_EXA`                 | booleano | Habilitar las herramientas de búsqueda web de Exa                               |
-| `OPENCODE_SERVER_PASSWORD`            | cadena   | Habilite la autenticación básica para `serve`/`web`                             |
-| `OPENCODE_SERVER_USERNAME`            | cadena   | Anular el nombre de usuario de autenticación básica (predeterminado `opencode`) |
-| `OPENCODE_MODELS_URL`                 | cadena   | URL personalizada para buscar la configuración de modelos                       |
+| `MIMOCODE_AUTO_SHARE`                 | booleano | Compartir sesiones automáticamente                                              |
+| `MIMOCODE_GIT_BASH_PATH`              | cadena   | Ruta al ejecutable de Git Bash en Windows                                       |
+| `MIMOCODE_CONFIG`                     | cadena   | Ruta al archivo de configuración                                                |
+| `MIMOCODE_CONFIG_DIR`                 | cadena   | Ruta al directorio de configuración                                             |
+| `MIMOCODE_CONFIG_CONTENT`             | cadena   | Contenido de configuración json en línea                                        |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | booleano | Deshabilitar las comprobaciones automáticas de actualizaciones                  |
+| `MIMOCODE_DISABLE_PRUNE`              | booleano | Deshabilitar la poda de datos antiguos                                          |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | booleano | Deshabilitar las actualizaciones automáticas de títulos de terminal             |
+| `MIMOCODE_PERMISSION`                 | cadena   | Configuración de permisos json incorporados                                     |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | booleano | Deshabilitar complementos predeterminados                                       |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | booleano | Deshabilitar las descargas automáticas del servidor LSP                         |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | booleano | Habilitar modelos experimentales                                                |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | booleano | Deshabilitar la compactación automática de contexto                             |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | booleano | Deshabilitar la lectura desde `.claude` (mensaje + habilidades)                 |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | booleano | Desactivar lectura `~/.claude/CLAUDE.md`                                        |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | booleano | Deshabilitar la carga `.claude/skills`                                          |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | booleano | Deshabilitar la recuperación de modelos desde fuentes remotas                   |
+| `MIMOCODE_FAKE_VCS`                   | cadena   | Proveedor de VCS falso para fines de prueba                                     |
+| `MIMOCODE_CLIENT`                     | cadena   | Identificador de cliente (por defecto `cli`)                                    |
+| `MIMOCODE_ENABLE_EXA`                 | booleano | Habilitar las herramientas de búsqueda web de Exa                               |
+| `MIMOCODE_SERVER_PASSWORD`            | cadena   | Habilite la autenticación básica para `serve`/`web`                             |
+| `MIMOCODE_SERVER_USERNAME`            | cadena   | Anular el nombre de usuario de autenticación básica (predeterminado `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | cadena   | URL personalizada para buscar la configuración de modelos                       |
 
 ---
 
@@ -587,16 +587,16 @@ Estas variables de entorno habilitan funciones experimentales que pueden cambiar
 
 | Variable                                        | Type     | Description                                                |
 | ----------------------------------------------- | -------- | ---------------------------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | booleano | Habilitar todas las funciones experimentales               |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | booleano | Habilitar descubrimiento de íconos                         |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | booleano | Deshabilitar copia al seleccionar en TUI                   |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | número   | Tiempo de espera predeterminado para comandos bash en ms   |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | número   | Tokens de salida máximos para respuestas LLM               |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | booleano | Habilite el observador de archivos para todo el directorio |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | booleano | Habilitar el formateador oxfmt                             |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | booleano | Habilitar herramienta experimental LSP                     |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | booleano | Deshabilitar el observador de archivos                     |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | booleano | Habilitar funciones experimentales de Exa                  |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | booleano | Habilitar Habilitar TY LSP para archivos python            |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | booleano | Habilitar funciones de Markdown experimentales             |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | booleano | Habilitar modo de plan                                     |
+| `MIMOCODE_EXPERIMENTAL`                         | booleano | Habilitar todas las funciones experimentales               |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | booleano | Habilitar descubrimiento de íconos                         |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | booleano | Deshabilitar copia al seleccionar en TUI                   |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | número   | Tiempo de espera predeterminado para comandos bash en ms   |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | número   | Tokens de salida máximos para respuestas LLM               |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | booleano | Habilite el observador de archivos para todo el directorio |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | booleano | Habilitar el formateador oxfmt                             |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | booleano | Habilitar herramienta experimental LSP                     |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | booleano | Deshabilitar el observador de archivos                     |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | booleano | Habilitar funciones experimentales de Exa                  |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | booleano | Habilitar Habilitar TY LSP para archivos python            |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | booleano | Habilitar funciones de Markdown experimentales             |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | booleano | Habilitar modo de plan                                     |

--- a/packages/web/src/content/docs/es/config.mdx
+++ b/packages/web/src/content/docs/es/config.mdx
@@ -11,9 +11,9 @@ Puede configurar OpenCode usando un archivo de configuración JSON.
 
 OpenCode admite los formatos **JSON** y **JSONC** (JSON con comentarios).
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   // Theme configuration
   "theme": "opencode",
   "model": "anthropic/claude-sonnet-4-5",
@@ -43,11 +43,11 @@ Por ejemplo, si su configuración global establece `theme: "opencode"` y `autoup
 Las fuentes de configuración se cargan en este orden (las fuentes posteriores anulan las anteriores):
 
 1. **Configuración remota** (de `.well-known/opencode`): valores predeterminados de la organización
-2. **Configuración global** (`~/.config/opencode/opencode.json`) - preferencias del usuario
-3. **Configuración personalizada** (`OPENCODE_CONFIG` env var): anulaciones personalizadas
-4. **Configuración del proyecto** (`opencode.json` en el proyecto): configuración específica del proyecto
+2. **Configuración global** (`~/.config/opencode/mimocode.jsonc`) - preferencias del usuario
+3. **Configuración personalizada** (`MIMOCODE_CONFIG` env var): anulaciones personalizadas
+4. **Configuración del proyecto** (`mimocode.jsonc` en el proyecto): configuración específica del proyecto
 5. Directorios **`.opencode`** - agentes, comandos, complementos
-6. **Configuración en línea** (`OPENCODE_CONFIG_CONTENT` env var): anulaciones del tiempo de ejecución
+6. **Configuración en línea** (`MIMOCODE_CONFIG_CONTENT` env var): anulaciones del tiempo de ejecución
 
 Esto significa que las configuraciones del proyecto pueden anular los valores predeterminados globales y las configuraciones globales pueden anular los valores predeterminados de la organización remota.
 
@@ -79,7 +79,7 @@ Por ejemplo, si su organización proporciona servidores MCP que están deshabili
 
 Puede habilitar servidores específicos en su configuración local:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ Puede habilitar servidores específicos en su configuración local:
 
 ### Global
 
-Coloque su configuración global OpenCode en `~/.config/opencode/opencode.json`. Utilice la configuración global para las preferencias de todo el usuario, como temas, proveedores o combinaciones de teclas.
+Coloque su configuración global OpenCode en `~/.config/opencode/mimocode.jsonc`. Utilice la configuración global para las preferencias de todo el usuario, como temas, proveedores o combinaciones de teclas.
 
 La configuración global anula los valores predeterminados de la organización remota.
 
@@ -103,7 +103,7 @@ La configuración global anula los valores predeterminados de la organización r
 
 ### Por proyecto
 
-Agregue `opencode.json` en la raíz de su proyecto. La configuración del proyecto tiene la mayor prioridad entre los archivos de configuración estándar: anula las configuraciones globales y remotas.
+Agregue `mimocode.jsonc` en la raíz de su proyecto. La configuración del proyecto tiene la mayor prioridad entre los archivos de configuración estándar: anula las configuraciones globales y remotas.
 
 :::tip
 Coloque la configuración específica del proyecto en la raíz de su proyecto.
@@ -117,10 +117,10 @@ Esto también es seguro para registrarlo en Git y utiliza el mismo esquema que e
 
 ### Ruta personalizada
 
-Especifique una ruta de archivo de configuración personalizada utilizando la variable de entorno `OPENCODE_CONFIG`.
+Especifique una ruta de archivo de configuración personalizada utilizando la variable de entorno `MIMOCODE_CONFIG`.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -130,13 +130,13 @@ La configuración personalizada se carga entre las configuraciones globales y de
 
 ### Directorio personalizado
 
-Especifique un directorio de configuración personalizado usando `OPENCODE_CONFIG_DIR`
+Especifique un directorio de configuración personalizado usando `MIMOCODE_CONFIG_DIR`
 variable de entorno. En este directorio se buscarán agentes, comandos,
 modos y complementos como el directorio estándar `.opencode`, y debería
 Sigue la misma estructura.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -146,7 +146,7 @@ El directorio personalizado se carga después de los directorios global config y
 
 ## Esquema
 
-El archivo de configuración tiene un esquema definido en [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+El archivo de configuración tiene un esquema definido en [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
 Su editor debería poder validar y autocompletar según el esquema.
 
@@ -156,9 +156,9 @@ Su editor debería poder validar y autocompletar según el esquema.
 
 Puede configurar ajustes específicos de TUI a través de la opción `tui`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tui": {
     "scroll_speed": 3,
     "scroll_acceleration": {
@@ -183,9 +183,9 @@ Opciones disponibles:
 
 Puede configurar los ajustes del servidor para los comandos `opencode serve` y `opencode web` a través de la opción `server`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -212,9 +212,9 @@ Opciones disponibles:
 
 Puede administrar las herramientas que un LLM puede usar a través de la opción `tools`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -230,9 +230,9 @@ Puede administrar las herramientas que un LLM puede usar a través de la opción
 
 Puede configurar los proveedores y modelos que desea utilizar en su configuración OpenCode a través de las opciones `provider`, `model` y `small_model`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -243,9 +243,9 @@ La opción `small_model` configura un modelo separado para tareas livianas como 
 
 Las opciones de proveedores pueden incluir `timeout` y `setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -272,9 +272,9 @@ Algunos proveedores admiten opciones de configuración adicionales más allá de
 
 Amazon Bedrock admite la configuración específica de AWS:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -303,9 +303,9 @@ Los tokens de portador (`AWS_BEARER_TOKEN_BEDROCK` o `/connect`) tienen priorida
 
 Puede configurar el tema que desea usar en su configuración OpenCode a través de la opción `theme`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "theme": ""
 }
 ```
@@ -318,9 +318,9 @@ Puede configurar el tema que desea usar en su configuración OpenCode a través 
 
 Puedes configurar agentes especializados para tareas específicas a través de la opción `agent`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -336,7 +336,7 @@ Puedes configurar agentes especializados para tareas específicas a través de l
 }
 ```
 
-También puede definir agentes utilizando archivos de Markdown en `~/.config/opencode/agents/` o `.opencode/agents/`. [Más información aquí](/docs/agents).
+También puede definir agentes utilizando archivos de Markdown en `~/.config/opencode/agents/` o `.mimocode/agents/`. [Más información aquí](/docs/agents).
 
 ---
 
@@ -344,9 +344,9 @@ También puede definir agentes utilizando archivos de Markdown en `~/.config/ope
 
 Puede configurar el agente predeterminado usando la opción `default_agent`. Esto determina qué agente se utiliza cuando no se especifica ninguno explícitamente.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -361,9 +361,9 @@ Esta configuración se aplica en todas las interfaces: TUI, CLI (`opencode run`)
 
 Puede configurar la función [compartir](/docs/share) a través de la opción `share`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -382,9 +382,9 @@ De forma predeterminada, el uso compartido está configurado en modo manual, don
 
 Puede configurar comandos personalizados para tareas repetitivas a través de la opción `command`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -400,7 +400,7 @@ Puede configurar comandos personalizados para tareas repetitivas a través de la
 }
 ```
 
-También puede definir comandos utilizando archivos de Markdown en `~/.config/opencode/commands/` o `.opencode/commands/`. [Más información aquí](/docs/commands).
+También puede definir comandos utilizando archivos de Markdown en `~/.config/opencode/commands/` o `.mimocode/commands/`. [Más información aquí](/docs/commands).
 
 ---
 
@@ -408,9 +408,9 @@ También puede definir comandos utilizando archivos de Markdown en `~/.config/op
 
 Puede personalizar sus combinaciones de teclas a través de la opción `keybinds`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "keybinds": {}
 }
 ```
@@ -423,9 +423,9 @@ Puede personalizar sus combinaciones de teclas a través de la opción `keybinds
 
 OpenCode descargará automáticamente cualquier actualización nueva cuando se inicie. Puede desactivar esto con la opción `autoupdate`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -439,9 +439,9 @@ Tenga en cuenta que esto sólo funciona si no se instaló mediante un administra
 
 Puede configurar formateadores de código a través de la opción `formatter`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -467,9 +467,9 @@ De forma predeterminada, opencode **permite todas las operaciones** sin requerir
 
 Por ejemplo, para garantizar que las herramientas `edit` y `bash` requieran la aprobación del usuario:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -485,9 +485,9 @@ Por ejemplo, para garantizar que las herramientas `edit` y `bash` requieran la a
 
 Puede controlar el comportamiento de compactación del contexto a través de la opción `compaction`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true
@@ -504,9 +504,9 @@ Puede controlar el comportamiento de compactación del contexto a través de la 
 
 Puede configurar patrones de ignorancia del observador de archivos a través de la opción `watcher`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -521,9 +521,9 @@ Los patrones siguen la sintaxis global. Utilice esto para excluir directorios ru
 
 Puede configurar los servidores MCP que desee utilizar a través de la opción `mcp`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -536,11 +536,11 @@ Puede configurar los servidores MCP que desee utilizar a través de la opción `
 
 Los [complementos](/docs/plugins) amplían OpenCode con herramientas, enlaces e integraciones personalizados.
 
-Coloque los archivos de complemento en `.opencode/plugins/` o `~/.config/opencode/plugins/`. También puedes cargar complementos desde npm a través de la opción `plugin`.
+Coloque los archivos de complemento en `.mimocode/plugins/` o `~/.config/opencode/plugins/`. También puedes cargar complementos desde npm a través de la opción `plugin`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -553,9 +553,9 @@ Coloque los archivos de complemento en `.opencode/plugins/` o `~/.config/opencod
 
 Puedes configurar las instrucciones para el modelo que estás usando a través de la opción `instructions`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -569,9 +569,9 @@ sobre las reglas aquí](/docs/rules).
 
 Puede deshabilitar proveedores que se cargan automáticamente a través de la opción `disabled_providers`. Esto es útil cuando desea evitar que se carguen ciertos proveedores incluso si sus credenciales están disponibles.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -592,9 +592,9 @@ La opción `disabled_providers` acepta una variedad de ID de proveedores. Cuando
 
 Puede especificar una lista de proveedores permitidos a través de la opción `enabled_providers`. Cuando se establece, solo se habilitarán los proveedores especificados y se ignorarán todos los demás.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -613,9 +613,9 @@ Si un proveedor aparece tanto en `enabled_providers` como en `disabled_providers
 
 La clave `experimental` contiene opciones que se encuentran en desarrollo activo.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -636,10 +636,10 @@ Puede utilizar la sustitución de variables en sus archivos de configuración pa
 
 Utilice `{env:VARIABLE_NAME}` para sustituir variables de entorno:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -659,9 +659,9 @@ Si la variable de entorno no está configurada, se reemplazará con una cadena v
 
 Utilice `{file:path/to/file}` para sustituir el contenido de un archivo:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/es/plugins.mdx
+++ b/packages/web/src/content/docs/es/plugins.mdx
@@ -19,7 +19,7 @@ Hay dos formas de cargar complementos.
 
 Coloque los archivos JavaScript o TypeScript en el directorio del complemento.
 
-- `.opencode/plugins/` - Complementos a nivel de proyecto
+- `.mimocode/plugins/` - Complementos a nivel de proyecto
 - `~/.config/opencode/plugins/` - Complementos globales
 
 Los archivos en estos directorios se cargan automáticamente al inicio.
@@ -30,9 +30,9 @@ Los archivos en estos directorios se cargan automáticamente al inicio.
 
 Especifique paquetes npm en su archivo de configuración.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ Los **complementos npm** se instalan automáticamente usando Bun al inicio. Los 
 
 Los complementos se cargan desde todas las fuentes y todos los enlaces se ejecutan en secuencia. El orden de carga es:
 
-1. Configuración global (`~/.config/opencode/opencode.json`)
-2. Configuración del proyecto (`opencode.json`)
+1. Configuración global (`~/.config/opencode/mimocode.jsonc`)
+2. Configuración del proyecto (`mimocode.jsonc`)
 3. Directorio global de complementos (`~/.config/opencode/plugins/`)
-4. Directorio de complementos del proyecto (`.opencode/plugins/`)
+4. Directorio de complementos del proyecto (`.mimocode/plugins/`)
 
 Los paquetes npm duplicados con el mismo nombre y versión se cargan una vez. Sin embargo, un complemento local y un complemento npm con nombres similares se cargan por separado.
 
@@ -75,7 +75,7 @@ funciones. Cada función recibe un objeto de contexto y devuelve un objeto de en
 
 Los complementos locales y las herramientas personalizadas pueden utilizar paquetes npm externos. Agregue un `package.json` a su directorio de configuración con las dependencias que necesita.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -85,7 +85,7 @@ Los complementos locales y las herramientas personalizadas pueden utilizar paque
 
 OpenCode ejecuta `bun install` al inicio para instalarlos. Luego, sus complementos y herramientas pueden importarlos.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -103,7 +103,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Estructura básica
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -218,7 +218,7 @@ A continuación se muestran algunos ejemplos de complementos que puede utilizar 
 
 Enviar notificaciones cuando ocurran ciertos eventos:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -243,7 +243,7 @@ Si está utilizando la aplicación de escritorio OpenCode, puede enviar notifica
 
 Evite que opencode lea archivos `.env`:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -261,7 +261,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Inyecte variables de entorno en toda la ejecución del shell (herramientas de inteligencia artificial y terminales de usuario):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -278,7 +278,7 @@ export const InjectEnvPlugin = async () => {
 
 Los complementos también pueden agregar herramientas personalizadas a opencode:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -317,7 +317,7 @@ Si una herramienta de complemento utiliza el mismo nombre que una herramienta in
 
 Utilice `client.app.log()` en lugar de `console.log` para el registro estructurado:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -330,7 +330,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Niveles: `debug`, `info`, `warn`, `error`. Consulte la [documentación del SDK](https://opencode.ai/docs/sdk) para obtener más detalles.
+Niveles: `debug`, `info`, `warn`, `error`. Consulte la [documentación del SDK](https://mimocode.ai/docs/sdk) para obtener más detalles.
 
 ---
 
@@ -338,7 +338,7 @@ Niveles: `debug`, `info`, `warn`, `error`. Consulte la [documentación del SDK](
 
 Personalice el contexto incluido cuando se compacta una sesión:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -362,7 +362,7 @@ El hook `experimental.session.compacting` se activa antes de que LLM genere un r
 
 También puede reemplazar completamente el mensaje de compactación configurando `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/fr/cli.mdx
+++ b/packages/web/src/content/docs/fr/cli.mdx
@@ -360,7 +360,7 @@ Démarrez un serveur OpenCode sans interface graphique pour un accès API. Consu
 opencode serve
 ```
 
-Cela démarre un serveur HTTP qui fournit un accès API aux fonctionnalités d'OpenCode sans l'interface TUI. Définissez `OPENCODE_SERVER_PASSWORD` pour activer l'authentification de base HTTP (le nom d'utilisateur par défaut est `opencode`).
+Cela démarre un serveur HTTP qui fournit un accès API aux fonctionnalités d'OpenCode sans l'interface TUI. Définissez `MIMOCODE_SERVER_PASSWORD` pour activer l'authentification de base HTTP (le nom d'utilisateur par défaut est `opencode`).
 
 #### Options
 
@@ -456,7 +456,7 @@ Démarrez un serveur OpenCode sans interface graphique avec une interface Web.
 opencode web
 ```
 
-Cela démarre un serveur HTTP et ouvre un navigateur Web pour accéder à OpenCode via une interface Web. Définissez `OPENCODE_SERVER_PASSWORD` pour activer l'authentification de base HTTP (le nom d'utilisateur par défaut est `opencode`).
+Cela démarre un serveur HTTP et ouvre un navigateur Web pour accéder à OpenCode via une interface Web. Définissez `MIMOCODE_SERVER_PASSWORD` pour activer l'authentification de base HTTP (le nom d'utilisateur par défaut est `opencode`).
 
 #### Options
 
@@ -555,30 +555,30 @@ OpenCode peut être configuré à l'aide de variables d'environnement.
 
 | Variables                             | Type    | Description                                                                       |
 | ------------------------------------- | ------- | --------------------------------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | booléen | Partager automatiquement des sessions                                             |
-| `OPENCODE_GIT_BASH_PATH`              | chaîne  | Chemin vers l'exécutable Git Bash sur Windows                                     |
-| `OPENCODE_CONFIG`                     | chaîne  | Chemin d'accès au fichier de configuration                                        |
-| `OPENCODE_TUI_CONFIG`                 | chaîne  | Chemin d'accès au fichier de configuration TUI                                    |
-| `OPENCODE_CONFIG_DIR`                 | chaîne  | Chemin d'accès au répertoire de configuration                                     |
-| `OPENCODE_CONFIG_CONTENT`             | chaîne  | Contenu de configuration JSON en ligne                                            |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | booléen | Désactiver les vérifications automatiques des mises à jour                        |
-| `OPENCODE_DISABLE_PRUNE`              | booléen | Désactiver le nettoyage des anciennes données                                     |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | booléen | Désactiver les mises à jour automatiques des titres du terminal                   |
-| `OPENCODE_PERMISSION`                 | chaîne  | Configuration des autorisations JSON intégrées                                    |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | booléen | Désactiver les plugins par défaut                                                 |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | booléen | Désactiver les téléchargements automatiques du serveur LSP                        |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | booléen | Activer les modèles expérimentaux                                                 |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | booléen | Désactiver le compactage automatique du contexte                                  |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | booléen | Désactiver la lecture de `.claude` (prompt + compétences)                         |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | booléen | Désactiver la lecture `~/.claude/CLAUDE.md`                                       |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | booléen | Désactiver le chargement de `.claude/skills`                                      |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | booléen | Désactiver la récupération de modèles à partir de sources distantes               |
-| `OPENCODE_FAKE_VCS`                   | chaîne  | Faux fournisseur VCS à des fins de test                                           |
-| `OPENCODE_CLIENT`                     | chaîne  | Identifiant du client (par défaut `cli`)                                          |
-| `OPENCODE_ENABLE_EXA`                 | booléen | Activer les outils de recherche Web Exa                                           |
-| `OPENCODE_SERVER_PASSWORD`            | chaîne  | Activer l'authentification de base pour `serve`/`web`                             |
-| `OPENCODE_SERVER_USERNAME`            | chaîne  | Remplacer le nom d'utilisateur d'authentification de base (par défaut `opencode`) |
-| `OPENCODE_MODELS_URL`                 | chaîne  | URL personnalisé pour récupérer la configuration des modèles                      |
+| `MIMOCODE_AUTO_SHARE`                 | booléen | Partager automatiquement des sessions                                             |
+| `MIMOCODE_GIT_BASH_PATH`              | chaîne  | Chemin vers l'exécutable Git Bash sur Windows                                     |
+| `MIMOCODE_CONFIG`                     | chaîne  | Chemin d'accès au fichier de configuration                                        |
+| `MIMOCODE_TUI_CONFIG`                 | chaîne  | Chemin d'accès au fichier de configuration TUI                                    |
+| `MIMOCODE_CONFIG_DIR`                 | chaîne  | Chemin d'accès au répertoire de configuration                                     |
+| `MIMOCODE_CONFIG_CONTENT`             | chaîne  | Contenu de configuration JSON en ligne                                            |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | booléen | Désactiver les vérifications automatiques des mises à jour                        |
+| `MIMOCODE_DISABLE_PRUNE`              | booléen | Désactiver le nettoyage des anciennes données                                     |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | booléen | Désactiver les mises à jour automatiques des titres du terminal                   |
+| `MIMOCODE_PERMISSION`                 | chaîne  | Configuration des autorisations JSON intégrées                                    |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | booléen | Désactiver les plugins par défaut                                                 |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | booléen | Désactiver les téléchargements automatiques du serveur LSP                        |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | booléen | Activer les modèles expérimentaux                                                 |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | booléen | Désactiver le compactage automatique du contexte                                  |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | booléen | Désactiver la lecture de `.claude` (prompt + compétences)                         |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | booléen | Désactiver la lecture `~/.claude/CLAUDE.md`                                       |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | booléen | Désactiver le chargement de `.claude/skills`                                      |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | booléen | Désactiver la récupération de modèles à partir de sources distantes               |
+| `MIMOCODE_FAKE_VCS`                   | chaîne  | Faux fournisseur VCS à des fins de test                                           |
+| `MIMOCODE_CLIENT`                     | chaîne  | Identifiant du client (par défaut `cli`)                                          |
+| `MIMOCODE_ENABLE_EXA`                 | booléen | Activer les outils de recherche Web Exa                                           |
+| `MIMOCODE_SERVER_PASSWORD`            | chaîne  | Activer l'authentification de base pour `serve`/`web`                             |
+| `MIMOCODE_SERVER_USERNAME`            | chaîne  | Remplacer le nom d'utilisateur d'authentification de base (par défaut `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | chaîne  | URL personnalisé pour récupérer la configuration des modèles                      |
 
 ---
 
@@ -588,16 +588,16 @@ Ces variables d'environnement activent des fonctionnalités expérimentales qui 
 
 | Variables                                       | Type    | Description                                                     |
 | ----------------------------------------------- | ------- | --------------------------------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | booléen | Activer toutes les fonctionnalités expérimentales               |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | booléen | Activer la découverte d'icônes                                  |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | booléen | Désactiver la copie lors de la sélection dans TUI               |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | numéro  | Délai d'expiration par défaut pour les commandes bash en ms     |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | numéro  | Nombre maximum de jetons de sortie pour les réponses LLM        |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | booléen | Activer l'observateur de fichiers pour l'ensemble du répertoire |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | booléen | Activer le formateur oxfmt                                      |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | booléen | Activer l'outil expérimental LSP                                |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | booléen | Désactiver l'observateur de fichiers                            |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | booléen | Activer les fonctionnalités Exa expérimentales                  |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | booléen | Activer TY LSP pour les fichiers python                         |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | booléen | Activer les fonctionnalités Markdown expérimentales             |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | booléen | Activer le mode plan                                            |
+| `MIMOCODE_EXPERIMENTAL`                         | booléen | Activer toutes les fonctionnalités expérimentales               |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | booléen | Activer la découverte d'icônes                                  |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | booléen | Désactiver la copie lors de la sélection dans TUI               |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | numéro  | Délai d'expiration par défaut pour les commandes bash en ms     |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | numéro  | Nombre maximum de jetons de sortie pour les réponses LLM        |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | booléen | Activer l'observateur de fichiers pour l'ensemble du répertoire |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | booléen | Activer le formateur oxfmt                                      |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | booléen | Activer l'outil expérimental LSP                                |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | booléen | Désactiver l'observateur de fichiers                            |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | booléen | Activer les fonctionnalités Exa expérimentales                  |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | booléen | Activer TY LSP pour les fichiers python                         |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | booléen | Activer les fonctionnalités Markdown expérimentales             |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | booléen | Activer le mode plan                                            |

--- a/packages/web/src/content/docs/fr/config.mdx
+++ b/packages/web/src/content/docs/fr/config.mdx
@@ -11,9 +11,9 @@ Vous pouvez configurer OpenCode à l'aide d'un fichier de configuration JSON.
 
 OpenCode prend en charge les formats **JSON** et **JSONC** (JSON avec commentaires).
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -44,11 +44,11 @@ Par exemple, si votre configuration globale définit `autoupdate: true` et que l
 Les sources de configuration sont chargées dans cet ordre (les sources ultérieures remplacent les précédentes) :
 
 1. **Configuration distante** (à partir de `.well-known/opencode`) - paramètres par défaut de l'organisation
-2. **Configuration globale** (`~/.config/opencode/opencode.json`) - préférences utilisateur
-3. **Configuration personnalisée** (`OPENCODE_CONFIG` env var) - remplacements personnalisés
-4. **Configuration du projet** (`opencode.json` dans le projet) - paramètres spécifiques au projet
+2. **Configuration globale** (`~/.config/opencode/mimocode.jsonc`) - préférences utilisateur
+3. **Configuration personnalisée** (`MIMOCODE_CONFIG` env var) - remplacements personnalisés
+4. **Configuration du projet** (`mimocode.jsonc` dans le projet) - paramètres spécifiques au projet
 5. **Répertoires `.opencode`** - agents, commandes, plugins
-6. **Configuration en ligne** (`OPENCODE_CONFIG_CONTENT` env var) - remplacements d'exécution
+6. **Configuration en ligne** (`MIMOCODE_CONFIG_CONTENT` env var) - remplacements d'exécution
 
 Cela signifie que les configurations de projet peuvent remplacer les valeurs par défaut globales, et que les configurations globales peuvent remplacer les valeurs par défaut de l'organisation distante.
 
@@ -80,7 +80,7 @@ Par exemple, si votre organisation fournit des serveurs MCP qui sont désactivé
 
 Vous pouvez activer des serveurs spécifiques dans votre configuration locale :
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -96,7 +96,7 @@ Vous pouvez activer des serveurs spécifiques dans votre configuration locale :
 
 ### Globale
 
-Placez votre configuration globale OpenCode dans `~/.config/opencode/opencode.json`. Utilisez la configuration globale pour les préférences de l'utilisateur telles que les fournisseurs, les modèles et les autorisations.
+Placez votre configuration globale OpenCode dans `~/.config/opencode/mimocode.jsonc`. Utilisez la configuration globale pour les préférences de l'utilisateur telles que les fournisseurs, les modèles et les autorisations.
 
 Pour les paramètres spécifiques à TUI, utilisez `~/.config/opencode/tui.json`.
 
@@ -106,7 +106,7 @@ La configuration globale remplace les paramètres par défaut de l'organisation 
 
 ### Par projet
 
-Ajoutez `opencode.json` à la racine de votre projet. La configuration du projet a la priorité la plus élevée parmi les fichiers de configuration standard : elle remplace les configurations globales et distantes.
+Ajoutez `mimocode.jsonc` à la racine de votre projet. La configuration du projet a la priorité la plus élevée parmi les fichiers de configuration standard : elle remplace les configurations globales et distantes.
 
 Pour les paramètres TUI spécifiques au projet, ajoutez `tui.json` à côté.
 
@@ -122,10 +122,10 @@ Il peut également être archivé en toute sécurité dans Git et utilise le mê
 
 ### Chemin personnalisé
 
-Spécifiez un chemin de fichier de configuration personnalisé à l'aide de la variable d'environnement `OPENCODE_CONFIG`.
+Spécifiez un chemin de fichier de configuration personnalisé à l'aide de la variable d'environnement `MIMOCODE_CONFIG`.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -135,10 +135,10 @@ La configuration personnalisée est chargée entre les configurations globales e
 
 ### Répertoire personnalisé
 
-Spécifiez un répertoire de configuration personnalisé à l'aide de `OPENCODE_CONFIG_DIR` variable d'environnement. Ce répertoire sera recherché pour les agents, les commandes, modes et plugins tout comme le répertoire standard `.opencode`, et devrait suivre la même structure.
+Spécifiez un répertoire de configuration personnalisé à l'aide de `MIMOCODE_CONFIG_DIR` variable d'environnement. Ce répertoire sera recherché pour les agents, les commandes, modes et plugins tout comme le répertoire standard `.opencode`, et devrait suivre la même structure.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -148,9 +148,9 @@ Le répertoire personnalisé est chargé après les répertoires de configuratio
 
 ## Schéma
 
-Le fichier de configuration a un schéma défini dans [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+Le fichier de configuration a un schéma défini dans [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
-La configuration TUI utilise [**`opencode.ai/tui.json`**](https://opencode.ai/tui.json).
+La configuration TUI utilise [**`mimocode.ai/tui.json`**](https://mimocode.ai/tui.json).
 
 Votre éditeur doit être capable de valider et de compléter automatiquement en fonction du schéma.
 
@@ -162,7 +162,7 @@ Utilisez un fichier dédié `tui.json` (ou `tui.jsonc`) pour les paramètres sp�
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "scroll_speed": 3,
   "scroll_acceleration": {
     "enabled": true
@@ -171,9 +171,9 @@ Utilisez un fichier dédié `tui.json` (ou `tui.jsonc`) pour les paramètres sp�
 }
 ```
 
-Utilisez `OPENCODE_TUI_CONFIG` pour pointer vers un fichier de configuration TUI personnalisé.
+Utilisez `MIMOCODE_TUI_CONFIG` pour pointer vers un fichier de configuration TUI personnalisé.
 
-Les anciennes clés `theme`, `keybinds` et `tui` dans `opencode.json` sont obsolètes et migrées automatiquement lorsque cela est possible.
+Les anciennes clés `theme`, `keybinds` et `tui` dans `mimocode.jsonc` sont obsolètes et migrées automatiquement lorsque cela est possible.
 
 [En savoir plus sur l'utilisation du TUI ici](/docs/tui#configure).
 
@@ -183,9 +183,9 @@ Les anciennes clés `theme`, `keybinds` et `tui` dans `opencode.json` sont obsol
 
 Vous pouvez configurer les paramètres du serveur pour les commandes `opencode serve` et `opencode web` via l'option `server`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -212,9 +212,9 @@ Options disponibles :
 
 Vous pouvez gérer les outils qu'un LLM peut utiliser via l'option `tools`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -230,9 +230,9 @@ Vous pouvez gérer les outils qu'un LLM peut utiliser via l'option `tools`.
 
 Vous pouvez configurer les fournisseurs et les modèles que vous souhaitez utiliser dans votre configuration OpenCode via les options `provider`, `model` et `small_model`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -243,9 +243,9 @@ L'option `small_model` configure un modèle distinct pour les tâches légères 
 
 Les options du fournisseur peuvent inclure `timeout` et `setCacheKey` :
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -272,9 +272,9 @@ Certains fournisseurs prennent en charge des options de configuration supplémen
 
 Amazon Bedrock prend en charge la configuration spécifique à AWS :
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -305,7 +305,7 @@ Définissez votre thème d'interface utilisateur dans `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -318,9 +318,9 @@ Définissez votre thème d'interface utilisateur dans `tui.json`.
 
 Vous pouvez configurer des agents spécialisés pour des tâches spécifiques via l'option `agent`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -336,7 +336,7 @@ Vous pouvez configurer des agents spécialisés pour des tâches spécifiques vi
 }
 ```
 
-Vous pouvez également définir des agents à l'aide de fichiers markdown dans `~/.config/opencode/agents/` ou `.opencode/agents/`. [En savoir plus ici](/docs/agents).
+Vous pouvez également définir des agents à l'aide de fichiers markdown dans `~/.config/opencode/agents/` ou `.mimocode/agents/`. [En savoir plus ici](/docs/agents).
 
 ---
 
@@ -344,9 +344,9 @@ Vous pouvez également définir des agents à l'aide de fichiers markdown dans `
 
 Vous pouvez définir l'agent par défaut à l'aide de l'option `default_agent`. Ceci détermine quel agent est utilisé lorsqu'aucun n'est explicitement spécifié.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -361,9 +361,9 @@ Ce paramètre s'applique à toutes les interfaces : TUI, CLI (`opencode run`), a
 
 Vous pouvez configurer la fonctionnalité [share](/docs/share) via l'option `share`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -382,9 +382,9 @@ Par défaut, le partage est défini en mode manuel où vous devez partager expli
 
 Vous pouvez configurer des commandes personnalisées pour les tâches répétitives via l'option `command`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -400,7 +400,7 @@ Vous pouvez configurer des commandes personnalisées pour les tâches répétiti
 }
 ```
 
-Vous pouvez également définir des commandes à l'aide de fichiers markdown dans `~/.config/opencode/commands/` ou `.opencode/commands/`. [En savoir plus ici](/docs/commands).
+Vous pouvez également définir des commandes à l'aide de fichiers markdown dans `~/.config/opencode/commands/` ou `.mimocode/commands/`. [En savoir plus ici](/docs/commands).
 
 ---
 
@@ -410,7 +410,7 @@ Personnalisez les raccourcis clavier dans `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -423,9 +423,9 @@ Personnalisez les raccourcis clavier dans `tui.json`.
 
 OpenCode téléchargera automatiquement toutes les nouvelles mises à jour au démarrage. Vous pouvez désactiver cela avec l'option `autoupdate`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -439,9 +439,9 @@ Notez que cela ne fonctionne que s'il n'a pas été installé à l'aide d'un ges
 
 Vous pouvez configurer les formateurs de code via l'option `formatter`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -467,9 +467,9 @@ Par défaut, opencode **autorise toutes les opérations** sans nécessiter d'app
 
 Par exemple, pour garantir que les outils `edit` et `bash` nécessitent l'approbation de l'utilisateur :
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -485,9 +485,9 @@ Par exemple, pour garantir que les outils `edit` et `bash` nécessitent l'approb
 
 Vous pouvez contrôler le comportement de compactage du contexte via l'option `compaction`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -506,9 +506,9 @@ Vous pouvez contrôler le comportement de compactage du contexte via l'option `c
 
 Vous pouvez configurer les modèles d'ignorance de l'observateur de fichiers via l'option `watcher`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -523,9 +523,9 @@ Les modèles suivent la syntaxe glob. Utilisez ceci pour exclure les répertoire
 
 Vous pouvez configurer les serveurs MCP que vous souhaitez utiliser via l'option `mcp`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -538,11 +538,11 @@ Vous pouvez configurer les serveurs MCP que vous souhaitez utiliser via l'option
 
 [Plugins](/docs/plugins) étendent OpenCode avec des outils, des hooks et des intégrations personnalisés.
 
-Placez les fichiers du plugin dans `.opencode/plugins/` ou `~/.config/opencode/plugins/`. Vous pouvez également charger des plugins depuis npm via l'option `plugin`.
+Placez les fichiers du plugin dans `.mimocode/plugins/` ou `~/.config/opencode/plugins/`. Vous pouvez également charger des plugins depuis npm via l'option `plugin`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -555,9 +555,9 @@ Placez les fichiers du plugin dans `.opencode/plugins/` ou `~/.config/opencode/p
 
 Vous pouvez configurer les instructions pour le modèle que vous utilisez via l'option `instructions`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -570,9 +570,9 @@ Cela prend un tableau de chemins et de modèles globaux vers les fichiers d'inst
 
 Vous pouvez désactiver les fournisseurs chargés automatiquement via l'option `disabled_providers`. Ceci est utile lorsque vous souhaitez empêcher le chargement de certains fournisseurs même si leurs informations d'identification sont disponibles.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -593,9 +593,9 @@ L'option `disabled_providers` accepte un tableau d'ID de fournisseur. Lorsqu'un 
 
 Vous pouvez spécifier une liste autorisée de fournisseurs via l'option `enabled_providers`. Une fois défini, seuls les fournisseurs spécifiés seront activés et tous les autres seront ignorés.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -614,9 +614,9 @@ Si un fournisseur apparaît à la fois dans `enabled_providers` et `disabled_pro
 
 La clé `experimental` contient des options en cours de développement actif.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -637,10 +637,10 @@ Vous pouvez utiliser la substitution de variables dans vos fichiers de configura
 
 Utilisez `{env:VARIABLE_NAME}` pour remplacer les variables d'environnement :
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -660,9 +660,9 @@ Si la variable d'environnement n'est pas définie, elle sera remplacée par une 
 
 Utilisez `{file:path/to/file}` pour remplacer le contenu d'un fichier :
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/fr/plugins.mdx
+++ b/packages/web/src/content/docs/fr/plugins.mdx
@@ -19,7 +19,7 @@ Il existe deux manières de charger des plugins.
 
 Placez les fichiers JavaScript ou TypeScript dans le répertoire du plugin.
 
-- `.opencode/plugins/` - Plugins au niveau du projet
+- `.mimocode/plugins/` - Plugins au niveau du projet
 - `~/.config/opencode/plugins/` - Plugins globaux
 
 Les fichiers de ces répertoires sont automatiquement chargés au démarrage.
@@ -30,9 +30,9 @@ Les fichiers de ces répertoires sont automatiquement chargés au démarrage.
 
 Spécifiez les packages npm dans votre fichier de configuration.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ Les **plugins locaux** sont chargés directement depuis le répertoire des plugi
 
 Les plugins sont chargés à partir de toutes les sources et tous les hooks s'exécutent dans l'ordre. L'ordre de chargement est le suivant :
 
-1. Configuration globale (`~/.config/opencode/opencode.json`)
-2. Configuration du projet (`opencode.json`)
+1. Configuration globale (`~/.config/opencode/mimocode.jsonc`)
+2. Configuration du projet (`mimocode.jsonc`)
 3. Répertoire global des plugins (`~/.config/opencode/plugins/`)
-4. Répertoire des plugins du projet (`.opencode/plugins/`)
+4. Répertoire des plugins du projet (`.mimocode/plugins/`)
 
 Les packages npm en double avec le même nom et la même version sont chargés une fois. Cependant, un plugin local et un plugin npm portant des noms similaires sont tous deux chargés séparément.
 
@@ -74,7 +74,7 @@ Un plugin est un **module JavaScript/TypeScript** qui exporte une ou plusieurs f
 
 Les plugins locaux et les outils personnalisés peuvent utiliser des packages npm externes. Ajoutez un `package.json` à votre répertoire de configuration avec les dépendances dont vous avez besoin.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -84,7 +84,7 @@ Les plugins locaux et les outils personnalisés peuvent utiliser des packages np
 
 OpenCode exécute `bun install` au démarrage pour les installer. Vos plugins et outils peuvent ensuite les importer.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -102,7 +102,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Structure de base
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -217,7 +217,7 @@ Voici quelques exemples de plugins que vous pouvez utiliser pour étendre openco
 
 Envoyez des notifications lorsque certains événements se produisent :
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -242,7 +242,7 @@ Si vous utilisez l'application de bureau OpenCode, elle peut envoyer automatique
 
 Empêchez opencode de lire les fichiers `.env` :
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -260,7 +260,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Injectez des variables d'environnement dans toutes les exécutions du shell (outils d'IA et terminal utilisateur) :
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -277,7 +277,7 @@ export const InjectEnvPlugin = async () => {
 
 Les plugins peuvent également ajouter des outils personnalisés à opencode :
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -312,7 +312,7 @@ Vos outils personnalisés seront disponibles pour opencode aux côtés des outil
 
 Utilisez `client.app.log()` au lieu de `console.log` pour la journalisation structurée :
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -325,7 +325,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Niveaux : `debug`, `info`, `warn`, `error`. Voir la [documentation du SDK](https://opencode.ai/docs/sdk) pour plus de détails.
+Niveaux : `debug`, `info`, `warn`, `error`. Voir la [documentation du SDK](https://mimocode.ai/docs/sdk) pour plus de détails.
 
 ---
 
@@ -333,7 +333,7 @@ Niveaux : `debug`, `info`, `warn`, `error`. Voir la [documentation du SDK](https
 
 Personnalisez le contexte inclus lorsqu'une session est compactée :
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -357,7 +357,7 @@ Le hook `experimental.session.compacting` se déclenche avant que le LLM ne gén
 
 Vous pouvez également remplacer entièrement le prompt de compactage en définissant `output.prompt` :
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/it/cli.mdx
+++ b/packages/web/src/content/docs/it/cli.mdx
@@ -360,7 +360,7 @@ Avvia un server OpenCode headless per accesso via API. Vedi le [server docs](/do
 opencode serve
 ```
 
-Avvia un server HTTP che espone accesso API alle funzionalità di opencode senza la TUI. Imposta `OPENCODE_SERVER_PASSWORD` per abilitare HTTP basic auth (username di default `opencode`).
+Avvia un server HTTP che espone accesso API alle funzionalità di opencode senza la TUI. Imposta `MIMOCODE_SERVER_PASSWORD` per abilitare HTTP basic auth (username di default `opencode`).
 
 #### Flag
 
@@ -456,7 +456,7 @@ Avvia un server OpenCode headless con interfaccia web.
 opencode web
 ```
 
-Avvia un server HTTP e apre un browser per accedere a OpenCode tramite interfaccia web. Imposta `OPENCODE_SERVER_PASSWORD` per abilitare HTTP basic auth (username di default `opencode`).
+Avvia un server HTTP e apre un browser per accedere a OpenCode tramite interfaccia web. Imposta `MIMOCODE_SERVER_PASSWORD` per abilitare HTTP basic auth (username di default `opencode`).
 
 #### Flag
 
@@ -555,30 +555,30 @@ OpenCode può essere configurato tramite variabili d'ambiente.
 
 | Variabile                             | Tipo    | Descrizione                                                 |
 | ------------------------------------- | ------- | ----------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | Condivide automaticamente le sessioni                       |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Percorso all'eseguibile Git Bash su Windows                 |
-| `OPENCODE_CONFIG`                     | string  | Percorso al file di configurazione                          |
-| `OPENCODE_TUI_CONFIG`                 | string  | Percorso al file di configurazione TUI                      |
-| `OPENCODE_CONFIG_DIR`                 | string  | Percorso alla directory di configurazione                   |
-| `OPENCODE_CONFIG_CONTENT`             | string  | Contenuto JSON di config inline                             |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disabilita i controlli automatici di aggiornamento          |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | Disabilita la potatura dei dati vecchi                      |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disabilita aggiornamenti automatici del titolo terminale    |
-| `OPENCODE_PERMISSION`                 | string  | Config permessi JSON inline                                 |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disabilita i plugin di default                              |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disabilita download automatico dei server LSP               |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Abilita modelli sperimentali                                |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Disabilita compaction automatica del contesto               |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Disabilita lettura da `.claude` (prompt + skill)            |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disabilita lettura di `~/.claude/CLAUDE.md`                 |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disabilita caricamento di `.claude/skills`                  |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Disabilita fetch dei modelli da fonti remote                |
-| `OPENCODE_FAKE_VCS`                   | string  | Provider VCS finto per scopi di test                        |
-| `OPENCODE_CLIENT`                     | string  | Identificatore client (default `cli`)                       |
-| `OPENCODE_ENABLE_EXA`                 | boolean | Abilita gli strumenti di web search Exa                     |
-| `OPENCODE_SERVER_PASSWORD`            | string  | Abilita basic auth per `serve`/`web`                        |
-| `OPENCODE_SERVER_USERNAME`            | string  | Sovrascrive lo username basic auth (default `opencode`)     |
-| `OPENCODE_MODELS_URL`                 | string  | URL personalizzato per recuperare la configurazione modelli |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | Condivide automaticamente le sessioni                       |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | Percorso all'eseguibile Git Bash su Windows                 |
+| `MIMOCODE_CONFIG`                     | string  | Percorso al file di configurazione                          |
+| `MIMOCODE_TUI_CONFIG`                 | string  | Percorso al file di configurazione TUI                      |
+| `MIMOCODE_CONFIG_DIR`                 | string  | Percorso alla directory di configurazione                   |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | Contenuto JSON di config inline                             |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | Disabilita i controlli automatici di aggiornamento          |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | Disabilita la potatura dei dati vecchi                      |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disabilita aggiornamenti automatici del titolo terminale    |
+| `MIMOCODE_PERMISSION`                 | string  | Config permessi JSON inline                                 |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disabilita i plugin di default                              |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disabilita download automatico dei server LSP               |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Abilita modelli sperimentali                                |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | Disabilita compaction automatica del contesto               |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | Disabilita lettura da `.claude` (prompt + skill)            |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disabilita lettura di `~/.claude/CLAUDE.md`                 |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disabilita caricamento di `.claude/skills`                  |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | Disabilita fetch dei modelli da fonti remote                |
+| `MIMOCODE_FAKE_VCS`                   | string  | Provider VCS finto per scopi di test                        |
+| `MIMOCODE_CLIENT`                     | string  | Identificatore client (default `cli`)                       |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | Abilita gli strumenti di web search Exa                     |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | Abilita basic auth per `serve`/`web`                        |
+| `MIMOCODE_SERVER_USERNAME`            | string  | Sovrascrive lo username basic auth (default `opencode`)     |
+| `MIMOCODE_MODELS_URL`                 | string  | URL personalizzato per recuperare la configurazione modelli |
 
 ---
 
@@ -588,16 +588,16 @@ Queste variabili d'ambiente abilitano funzionalità sperimentali che potrebbero 
 
 | Variabile                                       | Tipo    | Descrizione                                |
 | ----------------------------------------------- | ------- | ------------------------------------------ |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | Abilita tutte le funzionalità sperimentali |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Abilita icon discovery                     |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Disabilita copy on select nella TUI        |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Timeout di default per comandi bash in ms  |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Massimo token di output per risposte LLM   |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Abilita file watcher per l'intera dir      |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | Abilita formatter oxfmt                    |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Abilita strumento LSP sperimentale         |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Disabilita file watcher                    |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Abilita funzionalità Exa sperimentali      |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Abilita Abilita TY LSP per i file python   |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Abilita markdown sperimentale              |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Abilita plan mode                          |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | Abilita tutte le funzionalità sperimentali |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Abilita icon discovery                     |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Disabilita copy on select nella TUI        |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Timeout di default per comandi bash in ms  |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Massimo token di output per risposte LLM   |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Abilita file watcher per l'intera dir      |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | Abilita formatter oxfmt                    |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Abilita strumento LSP sperimentale         |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Disabilita file watcher                    |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | Abilita funzionalità Exa sperimentali      |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Abilita Abilita TY LSP per i file python   |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Abilita markdown sperimentale              |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Abilita plan mode                          |

--- a/packages/web/src/content/docs/it/config.mdx
+++ b/packages/web/src/content/docs/it/config.mdx
@@ -11,9 +11,9 @@ Puoi configurare OpenCode usando un file di configurazione JSON.
 
 OpenCode supporta sia **JSON** sia **JSONC** (JSON con commenti).
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -43,11 +43,11 @@ Per esempio, se la tua configurazione globale imposta `autoupdate: true` e la co
 Le sorgenti di configurazione vengono caricate in questo ordine (le successive sovrascrivono le precedenti):
 
 1. **Config remota** (da `.well-known/opencode`) - default dell'organizzazione
-2. **Config globale** (`~/.config/opencode/opencode.json`) - preferenze utente
-3. **Config personalizzata** (variabile d'ambiente `OPENCODE_CONFIG`) - sovrascritture personalizzate
-4. **Config di progetto** (`opencode.json` nel progetto) - impostazioni specifiche del progetto
+2. **Config globale** (`~/.config/opencode/mimocode.jsonc`) - preferenze utente
+3. **Config personalizzata** (variabile d'ambiente `MIMOCODE_CONFIG`) - sovrascritture personalizzate
+4. **Config di progetto** (`mimocode.jsonc` nel progetto) - impostazioni specifiche del progetto
 5. **Directory `.opencode`** - agenti, comandi, plugin
-6. **Config inline** (variabile d'ambiente `OPENCODE_CONFIG_CONTENT`) - sovrascritture a runtime
+6. **Config inline** (variabile d'ambiente `MIMOCODE_CONFIG_CONTENT`) - sovrascritture a runtime
 
 Questo significa che la configurazione di progetto puo sovrascrivere i default globali, e la configurazione globale puo sovrascrivere i default remoti dell'organizzazione.
 
@@ -79,7 +79,7 @@ Per esempio, se la tua organizzazione fornisce server MCP disabilitati per impos
 
 Puoi abilitare server specifici nella tua configurazione locale:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ Puoi abilitare server specifici nella tua configurazione locale:
 
 ### Configurazione globale
 
-Metti la configurazione globale di OpenCode in `~/.config/opencode/opencode.json`. Usa la configurazione globale per preferenze server/runtime valide per l'utente come provider, modelli e permessi.
+Metti la configurazione globale di OpenCode in `~/.config/opencode/mimocode.jsonc`. Usa la configurazione globale per preferenze server/runtime valide per l'utente come provider, modelli e permessi.
 
 Per le impostazioni specifiche della TUI, usa `~/.config/opencode/tui.json`.
 
@@ -105,7 +105,7 @@ La configurazione globale sovrascrive i default remoti dell'organizzazione.
 
 ### Configurazione di progetto
 
-Aggiungi `opencode.json` nella root del progetto. La configurazione di progetto ha la precedenza piu alta tra i file standard: sovrascrive sia la configurazione globale sia quella remota.
+Aggiungi `mimocode.jsonc` nella root del progetto. La configurazione di progetto ha la precedenza piu alta tra i file standard: sovrascrive sia la configurazione globale sia quella remota.
 
 Per le impostazioni TUI specifiche del progetto, aggiungi `tui.json` nella stessa posizione.
 
@@ -121,10 +121,10 @@ Questo file puo essere tranquillamente versionato in Git e usa lo stesso schema 
 
 ### Percorso personalizzato
 
-Specifica un percorso personalizzato per il file di configurazione usando la variabile d'ambiente `OPENCODE_CONFIG`.
+Specifica un percorso personalizzato per il file di configurazione usando la variabile d'ambiente `MIMOCODE_CONFIG`.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -134,10 +134,10 @@ La configurazione personalizzata viene caricata tra quella globale e quella di p
 
 ### Directory personalizzata
 
-Specifica una directory di configurazione personalizzata usando la variabile d'ambiente `OPENCODE_CONFIG_DIR`. Questa directory verra usata per cercare agenti, comandi, modalita e plugin proprio come la directory standard `.opencode` e dovrebbe seguire la stessa struttura.
+Specifica una directory di configurazione personalizzata usando la variabile d'ambiente `MIMOCODE_CONFIG_DIR`. Questa directory verra usata per cercare agenti, comandi, modalita e plugin proprio come la directory standard `.opencode` e dovrebbe seguire la stessa struttura.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -147,9 +147,9 @@ La directory personalizzata viene caricata dopo la configurazione globale e le d
 
 ## Schema
 
-Il file di configurazione ha uno schema definito in [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+Il file di configurazione ha uno schema definito in [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
-La configurazione TUI usa [**`opencode.ai/tui.json`**](https://opencode.ai/tui.json).
+La configurazione TUI usa [**`mimocode.ai/tui.json`**](https://mimocode.ai/tui.json).
 
 Il tuo editor dovrebbe poter validare e suggerire l'autocompletamento in base allo schema.
 
@@ -161,7 +161,7 @@ Usa un file dedicato `tui.json` (o `tui.jsonc`) per le impostazioni specifiche d
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "scroll_speed": 3,
   "scroll_acceleration": {
     "enabled": true
@@ -170,9 +170,9 @@ Usa un file dedicato `tui.json` (o `tui.jsonc`) per le impostazioni specifiche d
 }
 ```
 
-Usa `OPENCODE_TUI_CONFIG` per puntare a un file di configurazione TUI personalizzato.
+Usa `MIMOCODE_TUI_CONFIG` per puntare a un file di configurazione TUI personalizzato.
 
-Le chiavi legacy `theme`, `keybinds` e `tui` in `opencode.json` sono deprecate e vengono migrate automaticamente quando possibile.
+Le chiavi legacy `theme`, `keybinds` e `tui` in `mimocode.jsonc` sono deprecate e vengono migrate automaticamente quando possibile.
 
 [Scopri di piu sulla configurazione TUI](/docs/tui#configure).
 
@@ -182,9 +182,9 @@ Le chiavi legacy `theme`, `keybinds` e `tui` in `opencode.json` sono deprecate e
 
 Puoi configurare le impostazioni del server per i comandi `opencode serve` e `opencode web` tramite l'opzione `server`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -211,9 +211,9 @@ Opzioni disponibili:
 
 Puoi gestire gli strumenti che un LLM puo usare tramite l'opzione `tools`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -229,9 +229,9 @@ Puoi gestire gli strumenti che un LLM puo usare tramite l'opzione `tools`.
 
 Puoi configurare provider e modelli da usare in OpenCode tramite le opzioni `provider`, `model` e `small_model`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -242,9 +242,9 @@ L'opzione `small_model` configura un modello separato per task leggeri come la g
 
 Le opzioni del provider possono includere `timeout` e `setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -271,9 +271,9 @@ Alcuni provider supportano opzioni di configurazione aggiuntive oltre alle impos
 
 Amazon Bedrock supporta una configurazione specifica per AWS:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -304,7 +304,7 @@ Imposta il tuo tema UI in `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -317,9 +317,9 @@ Imposta il tuo tema UI in `tui.json`.
 
 Puoi configurare agenti specializzati per task specifici tramite l'opzione `agent`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -335,7 +335,7 @@ Puoi configurare agenti specializzati per task specifici tramite l'opzione `agen
 }
 ```
 
-Puoi anche definire agenti usando file markdown in `~/.config/opencode/agents/` o `.opencode/agents/`. [Scopri di piu](/docs/agents).
+Puoi anche definire agenti usando file markdown in `~/.config/opencode/agents/` o `.mimocode/agents/`. [Scopri di piu](/docs/agents).
 
 ---
 
@@ -343,9 +343,9 @@ Puoi anche definire agenti usando file markdown in `~/.config/opencode/agents/` 
 
 Puoi impostare l'agente predefinito usando l'opzione `default_agent`. Questo determina quale agente viene usato quando non ne specifichi uno esplicitamente.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -360,9 +360,9 @@ Questa impostazione si applica a tutte le interfacce: TUI, CLI (`opencode run`),
 
 Puoi configurare la funzione di [condivisione](/docs/share) tramite l'opzione `share`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -381,9 +381,9 @@ Per impostazione predefinita, la condivisione e in modalita manuale e devi condi
 
 Puoi configurare comandi personalizzati per task ripetitivi tramite l'opzione `command`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -399,7 +399,7 @@ Puoi configurare comandi personalizzati per task ripetitivi tramite l'opzione `c
 }
 ```
 
-Puoi anche definire comandi usando file markdown in `~/.config/opencode/commands/` o `.opencode/commands/`. [Scopri di piu](/docs/commands).
+Puoi anche definire comandi usando file markdown in `~/.config/opencode/commands/` o `.mimocode/commands/`. [Scopri di piu](/docs/commands).
 
 ---
 
@@ -409,7 +409,7 @@ Personalizza i keybind in `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -422,9 +422,9 @@ Personalizza i keybind in `tui.json`.
 
 OpenCode scarichera automaticamente eventuali aggiornamenti quando si avvia. Puoi disabilitare questa funzione con l'opzione `autoupdate`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -438,9 +438,9 @@ Nota che questo funziona solo se non e stato installato con un package manager c
 
 Puoi configurare i formatter di codice tramite l'opzione `formatter`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -466,9 +466,9 @@ Per impostazione predefinita, opencode **consente tutte le operazioni** senza ri
 
 Per esempio, per fare in modo che gli strumenti `edit` e `bash` richiedano l'approvazione dell'utente:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -484,9 +484,9 @@ Per esempio, per fare in modo che gli strumenti `edit` e `bash` richiedano l'app
 
 Puoi controllare il comportamento di compattazione del contesto tramite l'opzione `compaction`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -505,9 +505,9 @@ Puoi controllare il comportamento di compattazione del contesto tramite l'opzion
 
 Puoi configurare i pattern di ignoramento del file watcher tramite l'opzione `watcher`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -522,9 +522,9 @@ I pattern seguono la sintassi glob. Usali per escludere directory rumorose dal m
 
 Puoi configurare i server MCP che vuoi usare tramite l'opzione `mcp`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -537,11 +537,11 @@ Puoi configurare i server MCP che vuoi usare tramite l'opzione `mcp`.
 
 [I plugin](/docs/plugins) estendono OpenCode con strumenti personalizzati, hook e integrazioni.
 
-Metti i file dei plugin in `.opencode/plugins/` o `~/.config/opencode/plugins/`. Puoi anche caricare plugin da npm tramite l'opzione `plugin`.
+Metti i file dei plugin in `.mimocode/plugins/` o `~/.config/opencode/plugins/`. Puoi anche caricare plugin da npm tramite l'opzione `plugin`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -554,9 +554,9 @@ Metti i file dei plugin in `.opencode/plugins/` o `~/.config/opencode/plugins/`.
 
 Puoi configurare le istruzioni per il modello che stai usando tramite l'opzione `instructions`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -569,9 +569,9 @@ Accetta un array di percorsi e pattern glob verso file di istruzioni. [Scopri di
 
 Puoi disabilitare i provider caricati automaticamente tramite l'opzione `disabled_providers`. E utile quando vuoi impedire il caricamento di alcuni provider anche se le credenziali sono disponibili.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -592,9 +592,9 @@ L'opzione `disabled_providers` accetta un array di ID provider. Quando un provid
 
 Puoi specificare un'allowlist di provider tramite l'opzione `enabled_providers`. Se impostata, solo i provider indicati verranno abilitati e tutti gli altri saranno ignorati.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -613,9 +613,9 @@ Se un provider appare sia in `enabled_providers` sia in `disabled_providers`, `d
 
 La chiave `experimental` contiene opzioni in sviluppo attivo.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -636,10 +636,10 @@ Puoi usare la sostituzione di variabili nei file di configurazione per referenzi
 
 Usa `{env:VARIABLE_NAME}` per sostituire variabili d'ambiente:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -659,9 +659,9 @@ Se la variabile d'ambiente non e impostata, verra sostituita con una stringa vuo
 
 Usa `{file:path/to/file}` per sostituire il contenuto di un file:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/it/plugins.mdx
+++ b/packages/web/src/content/docs/it/plugins.mdx
@@ -19,7 +19,7 @@ Ci sono due modi per caricare i plugin.
 
 Metti file JavaScript o TypeScript nella directory dei plugin.
 
-- `.opencode/plugins/` - plugin a livello progetto
+- `.mimocode/plugins/` - plugin a livello progetto
 - `~/.config/opencode/plugins/` - plugin globali
 
 I file in queste directory vengono caricati automaticamente all'avvio.
@@ -30,9 +30,9 @@ I file in queste directory vengono caricati automaticamente all'avvio.
 
 Specifica i pacchetti npm nel tuo file di configurazione.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ I **plugin locali** vengono caricati direttamente dalla directory dei plugin. Pe
 
 I plugin vengono caricati da tutte le sorgenti e tutti gli hook vengono eseguiti in sequenza. L'ordine di caricamento è:
 
-1. Config globale (`~/.config/opencode/opencode.json`)
-2. Config di progetto (`opencode.json`)
+1. Config globale (`~/.config/opencode/mimocode.jsonc`)
+2. Config di progetto (`mimocode.jsonc`)
 3. Directory plugin globale (`~/.config/opencode/plugins/`)
-4. Directory plugin di progetto (`.opencode/plugins/`)
+4. Directory plugin di progetto (`.mimocode/plugins/`)
 
 I pacchetti npm duplicati con lo stesso nome e versione vengono caricati una sola volta. Tuttavia, un plugin locale e un plugin npm con nomi simili vengono entrambi caricati separatamente.
 
@@ -74,7 +74,7 @@ Un plugin è un **modulo JavaScript/TypeScript** che esporta una o più funzioni
 
 I plugin locali e gli strumenti personalizzati possono usare pacchetti npm esterni. Aggiungi un `package.json` alla tua directory di configurazione con le dipendenze di cui hai bisogno.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -84,7 +84,7 @@ I plugin locali e gli strumenti personalizzati possono usare pacchetti npm ester
 
 OpenCode esegue `bun install` all'avvio per installarle. I tuoi plugin e strumenti potranno poi importarle.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -102,7 +102,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Struttura base
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -217,7 +217,7 @@ Ecco alcuni esempi di plugin che puoi usare per estendere opencode.
 
 Invia notifiche quando avvengono certi eventi:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -242,7 +242,7 @@ Se usi l'app desktop di OpenCode, può inviare automaticamente notifiche di sist
 
 Impedisci a opencode di leggere i file `.env`:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -260,7 +260,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Inietta variabili d'ambiente in tutte le esecuzioni di shell (strumenti AI e terminale utente):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -277,7 +277,7 @@ export const InjectEnvPlugin = async () => {
 
 I plugin possono anche aggiungere strumenti personalizzati a opencode:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -316,7 +316,7 @@ Se uno strumento di un plugin usa lo stesso nome di uno strumento integrato, lo 
 
 Usa `client.app.log()` invece di `console.log` per logging strutturato:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -329,7 +329,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Livelli: `debug`, `info`, `warn`, `error`. Vedi la [documentazione SDK](https://opencode.ai/docs/sdk) per i dettagli.
+Livelli: `debug`, `info`, `warn`, `error`. Vedi la [documentazione SDK](https://mimocode.ai/docs/sdk) per i dettagli.
 
 ---
 
@@ -337,7 +337,7 @@ Livelli: `debug`, `info`, `warn`, `error`. Vedi la [documentazione SDK](https://
 
 Personalizza il contesto incluso quando una sessione viene compattata:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -361,7 +361,7 @@ L'hook `experimental.session.compacting` scatta prima che l'LLM generi un riassu
 
 Puoi anche sostituire completamente il prompt di compaction impostando `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/ja/cli.mdx
+++ b/packages/web/src/content/docs/ja/cli.mdx
@@ -360,7 +360,7 @@ API アクセスのためにヘッドレス OpenCode サーバーを起動しま
 opencode serve
 ```
 
-これにより、TUI インターフェイスを使用せずに opencode 機能への API アクセスを提供する HTTP サーバーが起動します。 `OPENCODE_SERVER_PASSWORD` を設定して HTTP 基本認証を有効にします (ユーザー名のデフォルトは `opencode`)。
+これにより、TUI インターフェイスを使用せずに opencode 機能への API アクセスを提供する HTTP サーバーが起動します。 `MIMOCODE_SERVER_PASSWORD` を設定して HTTP 基本認証を有効にします (ユーザー名のデフォルトは `opencode`)。
 
 #### フラグ
 
@@ -456,7 +456,7 @@ Web インターフェイスを使用してヘッドレス OpenCode サーバー
 opencode web
 ```
 
-これにより、HTTP サーバーが起動し、Web ブラウザが開き、Web インターフェイスを通じて OpenCode にアクセスします。 `OPENCODE_SERVER_PASSWORD` を設定して HTTP 基本認証を有効にします (ユーザー名のデフォルトは `opencode`)。
+これにより、HTTP サーバーが起動し、Web ブラウザが開き、Web インターフェイスを通じて OpenCode にアクセスします。 `MIMOCODE_SERVER_PASSWORD` を設定して HTTP 基本認証を有効にします (ユーザー名のデフォルトは `opencode`)。
 
 #### フラグ
 
@@ -555,29 +555,29 @@ OpenCode は環境変数を使用して構成できます。
 
 | 変数                                  | タイプ   | 説明                                                                |
 | ------------------------------------- | -------- | ------------------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | ブール値 | セッションを自動的に共有する                                        |
-| `OPENCODE_GIT_BASH_PATH`              | 文字列   | Windows 上で実行可能な Git Bash へのパス                            |
-| `OPENCODE_CONFIG`                     | 文字列   | 構成ファイルへのパス                                                |
-| `OPENCODE_CONFIG_DIR`                 | 文字列   | config ディレクトリへのパス                                         |
-| `OPENCODE_CONFIG_CONTENT`             | 文字列   | インライン JSON 構成コンテンツ                                      |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | ブール値 | 自動更新チェックを無効にする                                        |
-| `OPENCODE_DISABLE_PRUNE`              | ブール値 | 古いデータのプルーニングを無効にする                                |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | ブール値 | ターミナルタイトルの自動更新を無効にする                            |
-| `OPENCODE_PERMISSION`                 | 文字列   | インライン化された json 権限設定                                    |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | ブール値 | デフォルトのプラグインを無効にする                                  |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | ブール値 | LSP サーバーの自動ダウンロードを無効にする                          |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | ブール値 | 実験モデルを有効にする                                              |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | ブール値 | 自動コンテキスト圧縮を無効にする                                    |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | ブール値 | `.claude` からの読み取りを無効にする (プロンプト + スキル)          |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | ブール値 | `~/.claude/CLAUDE.md` の読み取りを無効にする                        |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | ブール値 | `.claude/skills` のロードを無効にする                               |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | ブール値 | リモートソースからのモデルの取得を無効にする                        |
-| `OPENCODE_FAKE_VCS`                   | 文字列   | テスト目的の偽の VCS プロバイダー                                   |
-| `OPENCODE_CLIENT`                     | 文字列   | クライアント識別子 (デフォルトは `cli`)                             |
-| `OPENCODE_ENABLE_EXA`                 | ブール値 | Exa Web 検索ツールを有効にする                                      |
-| `OPENCODE_SERVER_PASSWORD`            | 文字列   | `serve`/`web` の基本認証を有効にする                                |
-| `OPENCODE_SERVER_USERNAME`            | 文字列   | 基本認証ユーザー名 (デフォルト `opencode`) をオーバーライドします。 |
-| `OPENCODE_MODELS_URL`                 | 文字列   | モデル設定を取得するためのカスタム URL                              |
+| `MIMOCODE_AUTO_SHARE`                 | ブール値 | セッションを自動的に共有する                                        |
+| `MIMOCODE_GIT_BASH_PATH`              | 文字列   | Windows 上で実行可能な Git Bash へのパス                            |
+| `MIMOCODE_CONFIG`                     | 文字列   | 構成ファイルへのパス                                                |
+| `MIMOCODE_CONFIG_DIR`                 | 文字列   | config ディレクトリへのパス                                         |
+| `MIMOCODE_CONFIG_CONTENT`             | 文字列   | インライン JSON 構成コンテンツ                                      |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | ブール値 | 自動更新チェックを無効にする                                        |
+| `MIMOCODE_DISABLE_PRUNE`              | ブール値 | 古いデータのプルーニングを無効にする                                |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | ブール値 | ターミナルタイトルの自動更新を無効にする                            |
+| `MIMOCODE_PERMISSION`                 | 文字列   | インライン化された json 権限設定                                    |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | ブール値 | デフォルトのプラグインを無効にする                                  |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | ブール値 | LSP サーバーの自動ダウンロードを無効にする                          |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | ブール値 | 実験モデルを有効にする                                              |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | ブール値 | 自動コンテキスト圧縮を無効にする                                    |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | ブール値 | `.claude` からの読み取りを無効にする (プロンプト + スキル)          |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | ブール値 | `~/.claude/CLAUDE.md` の読み取りを無効にする                        |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | ブール値 | `.claude/skills` のロードを無効にする                               |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | ブール値 | リモートソースからのモデルの取得を無効にする                        |
+| `MIMOCODE_FAKE_VCS`                   | 文字列   | テスト目的の偽の VCS プロバイダー                                   |
+| `MIMOCODE_CLIENT`                     | 文字列   | クライアント識別子 (デフォルトは `cli`)                             |
+| `MIMOCODE_ENABLE_EXA`                 | ブール値 | Exa Web 検索ツールを有効にする                                      |
+| `MIMOCODE_SERVER_PASSWORD`            | 文字列   | `serve`/`web` の基本認証を有効にする                                |
+| `MIMOCODE_SERVER_USERNAME`            | 文字列   | 基本認証ユーザー名 (デフォルト `opencode`) をオーバーライドします。 |
+| `MIMOCODE_MODELS_URL`                 | 文字列   | モデル設定を取得するためのカスタム URL                              |
 
 ---
 
@@ -587,16 +587,16 @@ OpenCode は環境変数を使用して構成できます。
 
 | 変数                                            | タイプ   | 説明                                             |
 | ----------------------------------------------- | -------- | ------------------------------------------------ |
-| `OPENCODE_EXPERIMENTAL`                         | ブール値 | すべての実験的機能を有効にする                   |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | ブール値 | アイコン検出を有効にする                         |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | ブール値 | TUI で選択時のコピーを無効にする                 |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | 数値     | bash コマンドのデフォルトのタイムアウト (ミリ秒) |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | 数値     | LLM 応答の最大出力トークン                       |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | ブール値 | ディレクトリ全体のファイル監視を有効にする       |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | ブール値 | oxfmt フォーマッタを有効にする                   |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | ブール値 | 実験的な LSP ツールを有効にする                  |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | ブール値 | ファイルウォッチャーを無効にする                 |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | ブール値 | 実験的な Exa 機能を有効にする                    |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | ブール値 | python ファイルの TY LSP を有効にする            |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | ブール値 | 試験的な Markdown 機能を有効にする               |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | ブール値 | プランモードを有効にする                         |
+| `MIMOCODE_EXPERIMENTAL`                         | ブール値 | すべての実験的機能を有効にする                   |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | ブール値 | アイコン検出を有効にする                         |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | ブール値 | TUI で選択時のコピーを無効にする                 |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | 数値     | bash コマンドのデフォルトのタイムアウト (ミリ秒) |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | 数値     | LLM 応答の最大出力トークン                       |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | ブール値 | ディレクトリ全体のファイル監視を有効にする       |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | ブール値 | oxfmt フォーマッタを有効にする                   |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | ブール値 | 実験的な LSP ツールを有効にする                  |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | ブール値 | ファイルウォッチャーを無効にする                 |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | ブール値 | 実験的な Exa 機能を有効にする                    |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | ブール値 | python ファイルの TY LSP を有効にする            |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | ブール値 | 試験的な Markdown 機能を有効にする               |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | ブール値 | プランモードを有効にする                         |

--- a/packages/web/src/content/docs/ja/config.mdx
+++ b/packages/web/src/content/docs/ja/config.mdx
@@ -11,9 +11,9 @@ JSON 設定ファイルを使用して OpenCode を構成できます。
 
 OpenCode は、**JSON** と **JSONC** (コメント付きの JSON) 形式の両方をサポートしています。
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -43,11 +43,11 @@ OpenCode は、**JSON** と **JSONC** (コメント付きの JSON) 形式の両�
 設定ソースは次の順序でロードされます (後のソースは前のソースをオーバーライドします)。
 
 1. **リモート設定** (`.well-known/opencode` から) - 組織のデフォルト
-2. **グローバル設定** (`~/.config/opencode/opencode.json`) - ユーザー設定
-3. **カスタム設定** (`OPENCODE_CONFIG` 環境変数) - カスタムオーバーライド
-4. **プロジェクト設定** (プロジェクト内の `opencode.json`) - プロジェクト固有の設定
+2. **グローバル設定** (`~/.config/opencode/mimocode.jsonc`) - ユーザー設定
+3. **カスタム設定** (`MIMOCODE_CONFIG` 環境変数) - カスタムオーバーライド
+4. **プロジェクト設定** (プロジェクト内の `mimocode.jsonc`) - プロジェクト固有の設定
 5. **`.opencode` ディレクトリ** - エージェント、コマンド、プラグイン
-6. **インライン設定** (`OPENCODE_CONFIG_CONTENT` 環境変数) - ランタイムオーバーライド
+6. **インライン設定** (`MIMOCODE_CONFIG_CONTENT` 環境変数) - ランタイムオーバーライド
 
 つまり、プロジェクト設定はグローバルのデフォルトをオーバーライドでき、グローバル設定はリモート組織のデフォルトをオーバーライドできます。
 
@@ -79,7 +79,7 @@ OpenCode は、**JSON** と **JSONC** (コメント付きの JSON) 形式の両�
 
 ローカル設定で特定のサーバーを有効にすることができます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ OpenCode は、**JSON** と **JSONC** (コメント付きの JSON) 形式の両�
 
 ### グローバル
 
-グローバル OpenCode 設定を `~/.config/opencode/opencode.json` に配置します。プロバイダー、モデル、権限などのユーザー全体の設定にはグローバル設定を使用します。
+グローバル OpenCode 設定を `~/.config/opencode/mimocode.jsonc` に配置します。プロバイダー、モデル、権限などのユーザー全体の設定にはグローバル設定を使用します。
 
 TUI 固有の設定には、`~/.config/opencode/tui.json` を使用します。
 
@@ -105,7 +105,7 @@ TUI 固有の設定には、`~/.config/opencode/tui.json` を使用します。
 
 ### プロジェクトごと
 
-プロジェクトのルートに `opencode.json` を追加します。プロジェクト設定は、標準設定ファイルの中で最も高い優先順位を持ち、グローバル設定とリモート設定の両方をオーバーライドします。
+プロジェクトのルートに `mimocode.jsonc` を追加します。プロジェクト設定は、標準設定ファイルの中で最も高い優先順位を持ち、グローバル設定とリモート設定の両方をオーバーライドします。
 
 プロジェクト固有の TUI 設定については、その横に `tui.json` を追加します。
 
@@ -121,10 +121,10 @@ OpenCode が起動すると、現在のディレクトリで設定ファイル�
 
 ### カスタムパス
 
-`OPENCODE_CONFIG` 環境変数を使用してカスタム設定ファイルのパスを指定します。
+`MIMOCODE_CONFIG` 環境変数を使用してカスタム設定ファイルのパスを指定します。
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -134,13 +134,13 @@ opencode run "Hello world"
 
 ### カスタムディレクトリ
 
-`OPENCODE_CONFIG_DIR` を使用してカスタム設定ディレクトリを指定します。
+`MIMOCODE_CONFIG_DIR` を使用してカスタム設定ディレクトリを指定します。
 環境変数。このディレクトリでは、エージェント、コマンド、
 モードとプラグインは標準の `.opencode` ディレクトリと同様であり、次のようにする必要があります。
 同じ構造に従います。
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -150,9 +150,9 @@ opencode run "Hello world"
 
 ## スキーマ
 
-サーバー/ランタイム構成スキーマは [**`opencode.ai/config.json`**](https://opencode.ai/config.json) で定義されています。
+サーバー/ランタイム構成スキーマは [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json) で定義されています。
 
-TUI 設定は [**`opencode.ai/tui.json`**](https://opencode.ai/tui.json) を使用します。
+TUI 設定は [**`mimocode.ai/tui.json`**](https://mimocode.ai/tui.json) を使用します。
 
 エディターはスキーマに基づいて検証し、オートコンプリートできる必要があります。
 
@@ -164,7 +164,7 @@ TUI 固有の設定には、専用の `tui.json` (または `tui.jsonc`) ファ�
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "scroll_speed": 3,
   "scroll_acceleration": {
     "enabled": true
@@ -173,9 +173,9 @@ TUI 固有の設定には、専用の `tui.json` (または `tui.jsonc`) ファ�
 }
 ```
 
-カスタム TUI 設定ファイルを指定するには、`OPENCODE_TUI_CONFIG` を使用します。
+カスタム TUI 設定ファイルを指定するには、`MIMOCODE_TUI_CONFIG` を使用します。
 
-`opencode.json` 内の従来の `theme`、`keybinds`、および `tui` キーは非推奨となり、可能であれば自動的に移行されます。
+`mimocode.jsonc` 内の従来の `theme`、`keybinds`、および `tui` キーは非推奨となり、可能であれば自動的に移行されます。
 
 [TUI の設定の詳細については、こちら](/docs/tui#configure) をご覧ください。
 
@@ -185,9 +185,9 @@ TUI 固有の設定には、専用の `tui.json` (または `tui.jsonc`) ファ�
 
 `opencode serve` オプションを使用して、`opencode web` および `server` コマンドのサーバー設定を構成できます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -214,9 +214,9 @@ TUI 固有の設定には、専用の `tui.json` (または `tui.jsonc`) ファ�
 
 LLM が使用できるツールは、`tools` オプションを通じて管理できます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -232,9 +232,9 @@ LLM が使用できるツールは、`tools` オプションを通じて管理�
 
 `provider`、`model`、および `small_model` オプションを使用して、OpenCode 設定で使用するプロバイダーとモデルを構成できます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -245,9 +245,9 @@ LLM が使用できるツールは、`tools` オプションを通じて管理�
 
 プロバイダーオプションには、`timeout` および `setCacheKey` を含めることができます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -274,9 +274,9 @@ LLM が使用できるツールは、`tools` オプションを通じて管理�
 
 Amazon Bedrock は、AWS 固有の設定をサポートしています。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -307,7 +307,7 @@ UI テーマを `tui.json` で設定します。
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -320,9 +320,9 @@ UI テーマを `tui.json` で設定します。
 
 `agent` オプションを使用して、特定のタスクに特化したエージェントを構成できます。
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -338,7 +338,7 @@ UI テーマを `tui.json` で設定します。
 }
 ```
 
-`~/.config/opencode/agents/` または `.opencode/agents/` の Markdown ファイルを使用してエージェントを定義することもできます。 [詳細はこちら](/docs/agents)。
+`~/.config/opencode/agents/` または `.mimocode/agents/` の Markdown ファイルを使用してエージェントを定義することもできます。 [詳細はこちら](/docs/agents)。
 
 ---
 
@@ -346,9 +346,9 @@ UI テーマを `tui.json` で設定します。
 
 `default_agent` オプションを使用してデフォルトのエージェントを設定できます。これにより、明示的に何も指定されていない場合にどのエージェントが使用されるかが決まります。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -363,9 +363,9 @@ UI テーマを `tui.json` で設定します。
 
 `share` オプションを使用して [share](/docs/share) 機能を設定できます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -384,9 +384,9 @@ UI テーマを `tui.json` で設定します。
 
 `command` オプションを使用して、反復タスク用のカスタムコマンドを構成できます。
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -402,7 +402,7 @@ UI テーマを `tui.json` で設定します。
 }
 ```
 
-`~/.config/opencode/commands/` または `.opencode/commands/` の Markdown ファイルを使用してコマンドを定義することもできます。 [詳細はこちら](/docs/commands)。
+`~/.config/opencode/commands/` または `.mimocode/commands/` の Markdown ファイルを使用してコマンドを定義することもできます。 [詳細はこちら](/docs/commands)。
 
 ---
 
@@ -412,7 +412,7 @@ UI テーマを `tui.json` で設定します。
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -425,9 +425,9 @@ UI テーマを `tui.json` で設定します。
 
 OpenCode は起動時に新しいアップデートを自動的にダウンロードします。 `autoupdate` オプションを使用してこれを無効にできます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -441,9 +441,9 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 `formatter` オプションを使用してコードフォーマッタを設定できます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -469,9 +469,9 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 たとえば、`edit` ツールと `bash` ツールにユーザーの承認が必要であることを確認するには、次のようにします。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -487,9 +487,9 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 `compaction` オプションを使用してコンテキストの圧縮動作を制御できます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true
@@ -506,9 +506,9 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 `watcher` オプションを使用して、ファイルウォッチャーの無視パターンを構成できます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -523,9 +523,9 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 `mcp` オプションを使用して、使用する MCP サーバーを構成できます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -538,11 +538,11 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 [Plugins](/docs/plugins) は、カスタムツール、フック、統合を使用して OpenCode を拡張します。
 
-プラグインファイルを `.opencode/plugins/` または `~/.config/opencode/plugins/` に配置します。 `plugin` オプションを使用して npm からプラグインをロードすることもできます。
+プラグインファイルを `.mimocode/plugins/` または `~/.config/opencode/plugins/` に配置します。 `plugin` オプションを使用して npm からプラグインをロードすることもできます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -555,9 +555,9 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 `instructions` オプションを使用して、使用しているモデルの指示を構成できます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -570,9 +570,9 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 `disabled_providers` オプションを使用して、自動的にロードされるプロバイダーを無効にすることができます。これは、認証情報が利用可能な場合でも、特定のプロバイダーが読み込まれないようにしたい場合に便利です。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -592,9 +592,9 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 `enabled_providers` オプションを使用してプロバイダーの許可リストを指定できます。設定すると、指定されたプロバイダーのみが有効になり、その他はすべて無視されます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -612,9 +612,9 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 `experimental` キーには、現在開発中のオプションが含まれています。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -635,10 +635,10 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 `{env:VARIABLE_NAME}` を使用して環境変数を置き換えます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -658,9 +658,9 @@ OpenCode は起動時に新しいアップデートを自動的にダウンロ�
 
 `{file:path/to/file}` を使用してファイルの内容を置き換えます。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/ja/plugins.mdx
+++ b/packages/web/src/content/docs/ja/plugins.mdx
@@ -19,7 +19,7 @@ description: OpenCode を拡張する独自のプラグインを作成します�
 
 JavaScript または TypeScript ファイルをプラグインディレクトリに配置します。
 
-- `.opencode/plugins/` - プロジェクトレベルのプラグイン
+- `.mimocode/plugins/` - プロジェクトレベルのプラグイン
 - `~/.config/opencode/plugins/` - グローバルプラグイン
 
 これらのディレクトリ内のファイルは起動時に自動的にロードされます。
@@ -30,9 +30,9 @@ JavaScript または TypeScript ファイルをプラグインディレクトリ
 
 設定ファイルで npm パッケージを指定します。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ JavaScript または TypeScript ファイルをプラグインディレクトリ
 
 プラグインはすべてのソースからロードされ、すべてのフックが順番に実行されます。ロード順序は次のとおりです。
 
-1. グローバル設定 (`~/.config/opencode/opencode.json`)
-2. プロジェクト設定 (`opencode.json`)
+1. グローバル設定 (`~/.config/opencode/mimocode.jsonc`)
+2. プロジェクト設定 (`mimocode.jsonc`)
 3. グローバルプラグインディレクトリ (`~/.config/opencode/plugins/`)
-4. プロジェクトプラグインディレクトリ (`.opencode/plugins/`)
+4. プロジェクトプラグインディレクトリ (`.mimocode/plugins/`)
 
 同じ名前とバージョンを持つ重複した npm パッケージは 1 回ロードされます。ただし、似た名前のローカルプラグインと npm プラグインは両方とも別々にロードされます。
 
@@ -75,7 +75,7 @@ JavaScript または TypeScript ファイルをプラグインディレクトリ
 
 ローカルプラグインとカスタムツールは外部の npm パッケージを使用できます。必要な依存関係を含む `package.json` を config ディレクトリに追加します。
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -85,7 +85,7 @@ JavaScript または TypeScript ファイルをプラグインディレクトリ
 
 OpenCode は起動時に `bun install` を実行してこれらをインストールします。プラグインとツールはそれらをインポートできるようになります。
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -103,7 +103,7 @@ export const MyPlugin = async (ctx) => {
 
 ### 基本構造
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -218,7 +218,7 @@ export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree
 
 特定のイベントが発生したときに通知を送信します。
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -243,7 +243,7 @@ macOS 上で AppleScript を実行するために `osascript` を使用してい
 
 構造化ログには `console.log` の代わりに `client.app.log()` を使用します。
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -256,7 +256,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-レベル: `debug`、`info`、`warn`、`error`。詳細については、[SDK ドキュメント](https://opencode.ai/docs/sdk) を参照してください。
+レベル: `debug`、`info`、`warn`、`error`。詳細については、[SDK ドキュメント](https://mimocode.ai/docs/sdk) を参照してください。
 
 ---
 
@@ -264,7 +264,7 @@ export const MyPlugin = async ({ client }) => {
 
 セッションが圧縮されたときに含まれるコンテキストをカスタマイズします。
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -288,7 +288,7 @@ Include any state that should persist across compaction:
 
 `output.prompt` を設定することで、圧縮プロンプトを完全に置き換えることもできます。
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {
@@ -319,7 +319,7 @@ Format as a structured prompt that a new agent can use to resume work.
 
 OpenCode が `.env` ファイルを読み取らないようにします。
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -337,7 +337,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 すべてのシェル実行 (AI ツールとユーザーターミナル) に環境変数を挿入します。
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -354,7 +354,7 @@ export const InjectEnvPlugin = async () => {
 
 プラグインは OpenCode にカスタムツールを追加することもできます。
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -389,7 +389,7 @@ export const CustomToolsPlugin: Plugin = async (ctx) => {
 
 構造化ログには `client.app.log()` の代わりに `console.log` を使用します。
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -402,7 +402,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-レベル: `debug`、`info`、`warn`、`error`。詳細については、[SDK ドキュメント](https://opencode.ai/docs/sdk) を参照してください。
+レベル: `debug`、`info`、`warn`、`error`。詳細については、[SDK ドキュメント](https://mimocode.ai/docs/sdk) を参照してください。
 
 ---
 
@@ -410,7 +410,7 @@ export const MyPlugin = async ({ client }) => {
 
 セッションが圧縮されたときに含まれるコンテキストをカスタマイズします。
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -434,7 +434,7 @@ Include any state that should persist across compaction:
 
 `output.prompt` を設定することで、圧縮プロンプトを完全に置き換えることもできます。
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/ko/cli.mdx
+++ b/packages/web/src/content/docs/ko/cli.mdx
@@ -360,7 +360,7 @@ API 접근용 headless OpenCode 서버를 시작합니다. 전체 HTTP 인터페
 opencode serve
 ```
 
-이 명령은 TUI 없이 opencode 기능에 접근할 수 있는 HTTP 서버를 시작합니다. `OPENCODE_SERVER_PASSWORD`를 설정하면 HTTP basic auth가 활성화됩니다(기본 사용자명: `opencode`).
+이 명령은 TUI 없이 opencode 기능에 접근할 수 있는 HTTP 서버를 시작합니다. `MIMOCODE_SERVER_PASSWORD`를 설정하면 HTTP basic auth가 활성화됩니다(기본 사용자명: `opencode`).
 
 #### 플래그
 
@@ -456,7 +456,7 @@ opencode import https://opncd.ai/s/abc123
 opencode web
 ```
 
-이 명령은 HTTP 서버를 시작하고 웹 브라우저를 열어 웹 인터페이스로 OpenCode에 접속합니다. `OPENCODE_SERVER_PASSWORD`를 설정하면 HTTP basic auth가 활성화됩니다(기본 사용자명: `opencode`).
+이 명령은 HTTP 서버를 시작하고 웹 브라우저를 열어 웹 인터페이스로 OpenCode에 접속합니다. `MIMOCODE_SERVER_PASSWORD`를 설정하면 HTTP basic auth가 활성화됩니다(기본 사용자명: `opencode`).
 
 #### 플래그
 
@@ -555,29 +555,29 @@ OpenCode는 환경 변수로도 구성할 수 있습니다.
 
 | 변수                                  | 타입    | 설명                                           |
 | ------------------------------------- | ------- | ---------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | 세션 자동 공유                                 |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Windows에서 Git Bash 실행 파일 경로            |
-| `OPENCODE_CONFIG`                     | string  | 설정 파일 경로                                 |
-| `OPENCODE_CONFIG_DIR`                 | string  | 설정 디렉터리 경로                             |
-| `OPENCODE_CONFIG_CONTENT`             | string  | 인라인 JSON 설정 내용                          |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | 자동 업데이트 확인 비활성화                    |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | 오래된 데이터 정리(prune) 비활성화             |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | 터미널 제목 자동 업데이트 비활성화             |
-| `OPENCODE_PERMISSION`                 | string  | 인라인 JSON 권한 설정                          |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | 기본 플러그인 비활성화                         |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | LSP 서버 자동 다운로드 비활성화                |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | 실험적 모델 활성화                             |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | 자동 컨텍스트 컴팩션 비활성화                  |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | `.claude`(프롬프트 + 스킬) 읽기 비활성화       |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | `~/.claude/CLAUDE.md` 읽기 비활성화            |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | `.claude/skills` 로드 비활성화                 |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | 원격 소스에서 모델 목록 가져오기 비활성화      |
-| `OPENCODE_FAKE_VCS`                   | string  | 테스트용 가짜 VCS provider                     |
-| `OPENCODE_CLIENT`                     | string  | 클라이언트 식별자(기본값: `cli`)               |
-| `OPENCODE_ENABLE_EXA`                 | boolean | Exa 웹 검색 도구 활성화                        |
-| `OPENCODE_SERVER_PASSWORD`            | string  | `serve`/`web` 기본 인증 활성화                 |
-| `OPENCODE_SERVER_USERNAME`            | string  | 기본 인증 사용자명 오버라이드(기본 `opencode`) |
-| `OPENCODE_MODELS_URL`                 | string  | 모델 설정을 가져올 사용자 지정 URL             |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | 세션 자동 공유                                 |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | Windows에서 Git Bash 실행 파일 경로            |
+| `MIMOCODE_CONFIG`                     | string  | 설정 파일 경로                                 |
+| `MIMOCODE_CONFIG_DIR`                 | string  | 설정 디렉터리 경로                             |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | 인라인 JSON 설정 내용                          |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | 자동 업데이트 확인 비활성화                    |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | 오래된 데이터 정리(prune) 비활성화             |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | 터미널 제목 자동 업데이트 비활성화             |
+| `MIMOCODE_PERMISSION`                 | string  | 인라인 JSON 권한 설정                          |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | 기본 플러그인 비활성화                         |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | LSP 서버 자동 다운로드 비활성화                |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | 실험적 모델 활성화                             |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | 자동 컨텍스트 컴팩션 비활성화                  |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | `.claude`(프롬프트 + 스킬) 읽기 비활성화       |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | `~/.claude/CLAUDE.md` 읽기 비활성화            |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | `.claude/skills` 로드 비활성화                 |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | 원격 소스에서 모델 목록 가져오기 비활성화      |
+| `MIMOCODE_FAKE_VCS`                   | string  | 테스트용 가짜 VCS provider                     |
+| `MIMOCODE_CLIENT`                     | string  | 클라이언트 식별자(기본값: `cli`)               |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | Exa 웹 검색 도구 활성화                        |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | `serve`/`web` 기본 인증 활성화                 |
+| `MIMOCODE_SERVER_USERNAME`            | string  | 기본 인증 사용자명 오버라이드(기본 `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | string  | 모델 설정을 가져올 사용자 지정 URL             |
 
 ---
 
@@ -587,16 +587,16 @@ OpenCode는 환경 변수로도 구성할 수 있습니다.
 
 | 변수                                            | 타입    | 설명                             |
 | ----------------------------------------------- | ------- | -------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | 모든 실험 기능 활성화            |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | 아이콘 탐색 활성화               |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | TUI에서 선택 시 복사 비활성화    |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | bash 명령 기본 타임아웃(ms)      |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | LLM 응답 최대 출력 토큰 수       |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | 전체 디렉터리 파일 감시 활성화   |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | oxfmt 포매터 활성화              |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | 실험적 LSP 도구 활성화           |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | 파일 감시 비활성화               |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | 실험적 Exa 기능 활성화           |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | python 파일에 대해 TY LSP 활성화 |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | 실험적 Markdown 기능 활성화      |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Plan mode 활성화                 |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | 모든 실험 기능 활성화            |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | 아이콘 탐색 활성화               |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | TUI에서 선택 시 복사 비활성화    |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | bash 명령 기본 타임아웃(ms)      |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | LLM 응답 최대 출력 토큰 수       |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | 전체 디렉터리 파일 감시 활성화   |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | oxfmt 포매터 활성화              |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | 실험적 LSP 도구 활성화           |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | 파일 감시 비활성화               |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | 실험적 Exa 기능 활성화           |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | python 파일에 대해 TY LSP 활성화 |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolean | 실험적 Markdown 기능 활성화      |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Plan mode 활성화                 |

--- a/packages/web/src/content/docs/ko/config.mdx
+++ b/packages/web/src/content/docs/ko/config.mdx
@@ -11,9 +11,9 @@ JSON config 파일로 OpenCode를 설정할 수 있습니다.
 
 OpenCode는 **JSON**과 **JSONC**(주석이 포함된 JSON) 형식을 모두 지원합니다.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -43,11 +43,11 @@ config 파일은 서로 대체되는 방식이 아니라 병합됩니다. 아래
 config source는 다음 순서로 로드됩니다(나중 source가 앞선 source를 override).
 
 1. **Remote config**(`.well-known/opencode`) - 조직 기본값
-2. **Global config**(`~/.config/opencode/opencode.json`) - 사용자 기본 설정
-3. **Custom config**(`OPENCODE_CONFIG` env var) - custom override
-4. **Project config**(프로젝트의 `opencode.json`) - 프로젝트별 설정
+2. **Global config**(`~/.config/opencode/mimocode.jsonc`) - 사용자 기본 설정
+3. **Custom config**(`MIMOCODE_CONFIG` env var) - custom override
+4. **Project config**(프로젝트의 `mimocode.jsonc`) - 프로젝트별 설정
 5. **`.opencode` directories** - agents, commands, plugins
-6. **Inline config**(`OPENCODE_CONFIG_CONTENT` env var) - 런타임 override
+6. **Inline config**(`MIMOCODE_CONFIG_CONTENT` env var) - 런타임 override
 
 즉, 프로젝트 config는 전역 기본값을 override할 수 있고, 전역 config는 조직의 Remote 기본값을 override할 수 있습니다.
 
@@ -79,7 +79,7 @@ Remote config는 가장 먼저 로드되어 기본 레이어 역할을 합니다
 
 로컬 config에서 특정 서버를 활성화할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ Remote config는 가장 먼저 로드되어 기본 레이어 역할을 합니다
 
 ### Global
 
-전역 OpenCode config는 `~/.config/opencode/opencode.json`에 두세요. provider, model, permissions 같은 사용자 전체 기본 설정은 전역 config로 관리하세요.
+전역 OpenCode config는 `~/.config/opencode/mimocode.jsonc`에 두세요. provider, model, permissions 같은 사용자 전체 기본 설정은 전역 config로 관리하세요.
 
 TUI 관련 설정은 `~/.config/opencode/tui.json`을 사용하세요.
 
@@ -105,7 +105,7 @@ TUI 관련 설정은 `~/.config/opencode/tui.json`을 사용하세요.
 
 ### Per project
 
-프로젝트 루트에 `opencode.json`을 추가하세요. 프로젝트 config는 표준 config 파일 중 우선순위가 가장 높아 전역 및 Remote config를 모두 override합니다.
+프로젝트 루트에 `mimocode.jsonc`을 추가하세요. 프로젝트 config는 표준 config 파일 중 우선순위가 가장 높아 전역 및 Remote config를 모두 override합니다.
 
 프로젝트별 TUI 설정은 `tui.json`을 함께 추가하세요.
 
@@ -121,10 +121,10 @@ OpenCode 시작 시 현재 디렉토리에서 config 파일을 찾고, 없으면
 
 ### Custom path
 
-`OPENCODE_CONFIG` 환경 변수로 custom config 파일 경로를 지정하세요.
+`MIMOCODE_CONFIG` 환경 변수로 custom config 파일 경로를 지정하세요.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -134,10 +134,10 @@ Custom config는 우선순위상 전역 config와 프로젝트 config 사이에�
 
 ### Custom directory
 
-`OPENCODE_CONFIG_DIR` 환경 변수로 custom config 디렉토리를 지정할 수 있습니다. 이 디렉토리는 표준 `.opencode` 디렉토리와 동일하게 agents, commands, modes, plugins를 검색하며, 동일한 구조를 따라야 합니다.
+`MIMOCODE_CONFIG_DIR` 환경 변수로 custom config 디렉토리를 지정할 수 있습니다. 이 디렉토리는 표준 `.opencode` 디렉토리와 동일하게 agents, commands, modes, plugins를 검색하며, 동일한 구조를 따라야 합니다.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -147,9 +147,9 @@ custom 디렉토리는 전역 config와 `.opencode` 디렉토리 뒤에 로드�
 
 ## Schema
 
-server/runtime config schema는 [**`opencode.ai/config.json`**](https://opencode.ai/config.json)에 정의되어 있습니다.
+server/runtime config schema는 [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json)에 정의되어 있습니다.
 
-TUI config는 [**`opencode.ai/tui.json`**](https://opencode.ai/tui.json)을 사용합니다.
+TUI config는 [**`mimocode.ai/tui.json`**](https://mimocode.ai/tui.json)을 사용합니다.
 
 편집기에서 이 schema를 기반으로 validation과 autocomplete를 사용할 수 있습니다.
 
@@ -161,7 +161,7 @@ TUI 관련 설정에는 전용 `tui.json` (또는 `tui.jsonc`) 파일을 사용�
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "scroll_speed": 3,
   "scroll_acceleration": {
     "enabled": true
@@ -170,9 +170,9 @@ TUI 관련 설정에는 전용 `tui.json` (또는 `tui.jsonc`) 파일을 사용�
 }
 ```
 
-`OPENCODE_TUI_CONFIG`를 사용하여 사용자 지정 TUI 설정 파일을 가리킬 수 있습니다.
+`MIMOCODE_TUI_CONFIG`를 사용하여 사용자 지정 TUI 설정 파일을 가리킬 수 있습니다.
 
-`opencode.json`의 기존 `theme`, `keybinds`, `tui` 키는 더 이상 사용되지 않으며(deprecated) 가능한 경우 자동으로 마이그레이션됩니다.
+`mimocode.jsonc`의 기존 `theme`, `keybinds`, `tui` 키는 더 이상 사용되지 않으며(deprecated) 가능한 경우 자동으로 마이그레이션됩니다.
 
 [TUI 구성에 대해 더 알아보기](/docs/tui#configure).
 
@@ -182,9 +182,9 @@ TUI 관련 설정에는 전용 `tui.json` (또는 `tui.jsonc`) 파일을 사용�
 
 `server` 옵션으로 `opencode serve`와 `opencode web` 명령의 server 설정을 구성할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -211,9 +211,9 @@ TUI 관련 설정에는 전용 `tui.json` (또는 `tui.jsonc`) 파일을 사용�
 
 `tools` 옵션으로 LLM이 사용할 수 있는 tool을 관리할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -229,9 +229,9 @@ TUI 관련 설정에는 전용 `tui.json` (또는 `tui.jsonc`) 파일을 사용�
 
 OpenCode config의 `provider`, `model`, `small_model` 옵션으로 사용할 provider와 model을 설정할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -242,9 +242,9 @@ OpenCode config의 `provider`, `model`, `small_model` 옵션으로 사용할 pro
 
 provider 옵션에는 `timeout`, `setCacheKey`를 포함할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -271,9 +271,9 @@ provider 옵션에는 `timeout`, `setCacheKey`를 포함할 수 있습니다.
 
 Amazon Bedrock은 AWS 전용 config를 지원합니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -304,7 +304,7 @@ Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -317,9 +317,9 @@ Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인
 
 `agent` 옵션으로 특정 작업용 전문 agent를 구성할 수 있습니다.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -335,7 +335,7 @@ Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인
 }
 ```
 
-`~/.config/opencode/agents/` 또는 `.opencode/agents/`의 Markdown 파일로 agent를 정의할 수도 있습니다. [더 알아보기](/docs/agents).
+`~/.config/opencode/agents/` 또는 `.mimocode/agents/`의 Markdown 파일로 agent를 정의할 수도 있습니다. [더 알아보기](/docs/agents).
 
 ---
 
@@ -343,9 +343,9 @@ Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인
 
 `default_agent` 옵션으로 기본 agent를 설정할 수 있습니다. 별도 지정이 없을 때 어떤 agent를 사용할지 결정합니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -360,9 +360,9 @@ Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인
 
 `share` 옵션으로 [share](/docs/share) 기능을 설정할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -381,9 +381,9 @@ Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인
 
 `command` 옵션으로 반복 작업용 custom command를 구성할 수 있습니다.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -399,7 +399,7 @@ Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인
 }
 ```
 
-`~/.config/opencode/commands/` 또는 `.opencode/commands/`의 Markdown 파일로 command를 정의할 수도 있습니다. [더 알아보기](/docs/commands).
+`~/.config/opencode/commands/` 또는 `.mimocode/commands/`의 Markdown 파일로 command를 정의할 수도 있습니다. [더 알아보기](/docs/commands).
 
 ---
 
@@ -409,7 +409,7 @@ Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -422,9 +422,9 @@ Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인
 
 OpenCode는 시작 시 새 업데이트를 자동으로 다운로드합니다. `autoupdate` 옵션으로 비활성화할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -438,9 +438,9 @@ OpenCode는 시작 시 새 업데이트를 자동으로 다운로드합니다. `
 
 `formatter` 옵션으로 코드 formatter를 설정할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -466,9 +466,9 @@ OpenCode는 시작 시 새 업데이트를 자동으로 다운로드합니다. `
 
 예를 들어 `edit`, `bash` tool이 사용자 승인을 요구하게 하려면:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -484,9 +484,9 @@ OpenCode는 시작 시 새 업데이트를 자동으로 다운로드합니다. `
 
 `compaction` 옵션으로 context compaction 동작을 제어할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -505,9 +505,9 @@ OpenCode는 시작 시 새 업데이트를 자동으로 다운로드합니다. `
 
 `watcher` 옵션으로 파일 watcher ignore 패턴을 설정할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -522,9 +522,9 @@ OpenCode는 시작 시 새 업데이트를 자동으로 다운로드합니다. `
 
 `mcp` 옵션으로 사용할 MCP server를 설정할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -537,11 +537,11 @@ OpenCode는 시작 시 새 업데이트를 자동으로 다운로드합니다. `
 
 [Plugins](/docs/plugins)는 custom tool, hook, integration으로 OpenCode를 확장합니다.
 
-plugin 파일은 `.opencode/plugins/` 또는 `~/.config/opencode/plugins/`에 두세요. `plugin` 옵션으로 npm plugin을 로드할 수도 있습니다.
+plugin 파일은 `.mimocode/plugins/` 또는 `~/.config/opencode/plugins/`에 두세요. `plugin` 옵션으로 npm plugin을 로드할 수도 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -554,9 +554,9 @@ plugin 파일은 `.opencode/plugins/` 또는 `~/.config/opencode/plugins/`에 �
 
 `instructions` 옵션으로 사용 중인 model에 제공할 지침 파일을 설정할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -569,9 +569,9 @@ plugin 파일은 `.opencode/plugins/` 또는 `~/.config/opencode/plugins/`에 �
 
 `disabled_providers` 옵션으로 자동 로드되는 provider를 비활성화할 수 있습니다. credential이 있어도 특정 provider를 로드하지 않게 하고 싶을 때 유용합니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -592,9 +592,9 @@ plugin 파일은 `.opencode/plugins/` 또는 `~/.config/opencode/plugins/`에 �
 
 `enabled_providers` 옵션으로 provider allowlist를 지정할 수 있습니다. 이 값을 설정하면 지정한 provider만 활성화되고 나머지는 무시됩니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -613,9 +613,9 @@ provider를 하나씩 비활성화하는 대신, OpenCode가 특정 provider만 
 
 `experimental` key에는 현재 활발히 개발 중인 옵션이 포함됩니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -636,10 +636,10 @@ config 파일에서 환경 변수와 파일 내용을 참조할 수 있도록 �
 
 `{env:VARIABLE_NAME}` 형식으로 환경 변수를 치환할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -659,9 +659,9 @@ config 파일에서 환경 변수와 파일 내용을 참조할 수 있도록 �
 
 `{file:path/to/file}` 형식으로 파일 내용을 치환할 수 있습니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/ko/plugins.mdx
+++ b/packages/web/src/content/docs/ko/plugins.mdx
@@ -19,7 +19,7 @@ description: OpenCode를 확장하기 위해 자신만의 플러그인을 작성
 
 플러그인 디렉토리에 JavaScript 또는 TypeScript 파일을 배치합니다.
 
-- `.opencode/plugins/` - 프로젝트 레벨 플러그인
+- `.mimocode/plugins/` - 프로젝트 레벨 플러그인
 - `~/.config/opencode/plugins/` - 글로벌 플러그인
 
 이 디렉토리의 파일은 시작 시 자동으로 로드됩니다.
@@ -30,9 +30,9 @@ description: OpenCode를 확장하기 위해 자신만의 플러그인을 작성
 
 config 파일에 npm 패키지를 지정합니다.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ config 파일에 npm 패키지를 지정합니다.
 
 플러그인은 모든 소스에서 로드되며 모든 후크는 순서대로 실행됩니다. 로드 순서는 다음과 같습니다:
 
-1. 글로벌 구성 (`~/.config/opencode/opencode.json`)
-2. 프로젝트 구성 (`opencode.json`)
+1. 글로벌 구성 (`~/.config/opencode/mimocode.jsonc`)
+2. 프로젝트 구성 (`mimocode.jsonc`)
 3. 글로벌 플러그인 디렉토리 (`~/.config/opencode/plugins/`)
-4. 프로젝트 플러그인 디렉토리 (`.opencode/plugins/`)
+4. 프로젝트 플러그인 디렉토리 (`.mimocode/plugins/`)
 
 중복된 이름과 버전의 npm 패키지는 한 번만 로드됩니다. 하지만 로컬 플러그인과 npm 플러그인의 이름이 비슷하더라도 둘 다 별도로 로드됩니다.
 
@@ -74,7 +74,7 @@ config 파일에 npm 패키지를 지정합니다.
 
 로컬 플러그인 및 사용자 정의 도구는 외부 npm 패키지를 사용할 수 있습니다. config 디렉토리에 `package.json`을 추가하고 필요한 의존성을 명시하십시오.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -84,7 +84,7 @@ config 파일에 npm 패키지를 지정합니다.
 
 opencode는 시작 시 `bun install`을 실행하여 이를 설치합니다. 이후 플러그인 및 도구에서 가져올 수 있습니다.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -102,7 +102,7 @@ export const MyPlugin = async (ctx) => {
 
 ### 기본 구조
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -217,7 +217,7 @@ opencode를 확장하기 위해 사용할 수 있는 플러그인 예제입니�
 
 특정 이벤트가 발생할 때 알림을 전송:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -242,7 +242,7 @@ opencode 데스크톱 앱을 사용하는 경우 응답이 준비되어 있거�
 
 opencode가 `.env` 파일을 읽지 못하도록 방지:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -260,7 +260,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 모든 shell 실행(AI 도구 및 사용자 terminal)에 환경 변수 주입:
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -277,7 +277,7 @@ export const InjectEnvPlugin = async () => {
 
 플러그인은 opencode에 사용자 정의 도구를 추가할 수 있습니다:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -316,7 +316,7 @@ export const CustomToolsPlugin: Plugin = async (ctx) => {
 
 구조화된 로깅을 위해 `console.log` 대신 `client.app.log()`를 사용하십시오:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -329,7 +329,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-레벨: `debug`, `info`, `warn`, `error`. [SDK 문서](https://opencode.ai/docs/sdk)를 참고하세요.
+레벨: `debug`, `info`, `warn`, `error`. [SDK 문서](https://mimocode.ai/docs/sdk)를 참고하세요.
 
 ---
 
@@ -337,7 +337,7 @@ export const MyPlugin = async ({ client }) => {
 
 세션이 압축될 때 포함되는 컨텍스트를 사용자 지정할 수 있습니다:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -361,7 +361,7 @@ Include any state that should persist across compaction:
 
 또한 `output.prompt`를 설정하여 압축 프롬프트를 완전히 대체할 수도 있습니다:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/nb/cli.mdx
+++ b/packages/web/src/content/docs/nb/cli.mdx
@@ -360,7 +360,7 @@ Start en headless OpenCode-server for API-tilgang. Sjekk ut [server-dokumentene]
 opencode serve
 ```
 
-Dette starter en HTTP-server som gir API tilgang til OpenCode-funksjonalitet uten TUI-grensesnittet. Sett `OPENCODE_SERVER_PASSWORD` for å aktivere HTTP grunnleggende autentisering (brukernavn er standard til `opencode`).
+Dette starter en HTTP-server som gir API tilgang til OpenCode-funksjonalitet uten TUI-grensesnittet. Sett `MIMOCODE_SERVER_PASSWORD` for å aktivere HTTP grunnleggende autentisering (brukernavn er standard til `opencode`).
 
 #### Flagg
 
@@ -456,7 +456,7 @@ Start en headless OpenCode-server med et webgrensesnitt.
 opencode web
 ```
 
-Dette starter en HTTP-server og åpner en nettleser for å få tilgang til OpenCode via et nettgrensesnitt. Sett `OPENCODE_SERVER_PASSWORD` for å aktivere HTTP grunnleggende autentisering (brukernavn er standard til `opencode`).
+Dette starter en HTTP-server og åpner en nettleser for å få tilgang til OpenCode via et nettgrensesnitt. Sett `MIMOCODE_SERVER_PASSWORD` for å aktivere HTTP grunnleggende autentisering (brukernavn er standard til `opencode`).
 
 #### Flagg
 
@@ -555,30 +555,30 @@ OpenCode kan konfigureres ved hjelp av miljøvariabler.
 
 | Variabel                              | Type   | Beskrivelse                                                           |
 | ------------------------------------- | ------ | --------------------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolsk | Del økter automatisk                                                  |
-| `OPENCODE_GIT_BASH_PATH`              | streng | Bane til Git Bash-kjørbar på Windows                                  |
-| `OPENCODE_CONFIG`                     | streng | Bane til konfigurasjonsfil                                            |
-| `OPENCODE_TUI_CONFIG`                 | streng | Bane til TUI-konfigurasjonsfil                                        |
-| `OPENCODE_CONFIG_DIR`                 | streng | Bane til konfigurasjonskatalog                                        |
-| `OPENCODE_CONFIG_CONTENT`             | streng | Innebygd json-konfigurasjonsinnhold                                   |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolsk | Deaktiver automatiske oppdateringskontroller                          |
-| `OPENCODE_DISABLE_PRUNE`              | boolsk | Deaktiver beskjæring av gamle data                                    |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolsk | Deaktiver automatiske terminaltitteloppdateringer                     |
-| `OPENCODE_PERMISSION`                 | streng | Innebygd json-tillatelseskonfigurasjon                                |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolsk | Deaktiver standard plugins                                            |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolsk | Deaktiver automatiske LSP servernedlastinger                          |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolsk | Aktiver eksperimentelle modeller                                      |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolsk | Deaktiver automatisk kontekstkomprimering                             |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolsk | Deaktiver lesing fra `.claude` (spørsmål + ferdigheter)               |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolsk | Deaktiver lesing `~/.claude/CLAUDE.md`                                |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolsk | Deaktiver innlasting av `.claude/skills`                              |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolsk | Deaktiver henting av modeller fra eksterne kilder                     |
-| `OPENCODE_FAKE_VCS`                   | streng | Falsk VCS-leverandør for testformål                                   |
-| `OPENCODE_CLIENT`                     | streng | Klientidentifikator (standard til `cli`)                              |
-| `OPENCODE_ENABLE_EXA`                 | boolsk | Aktiver Exa-nettsøkeverktøy                                           |
-| `OPENCODE_SERVER_PASSWORD`            | streng | Aktiver grunnleggende autentisering for `serve`/`web`                 |
-| `OPENCODE_SERVER_USERNAME`            | streng | Overstyr grunnleggende autentiseringsbrukernavn (standard `opencode`) |
-| `OPENCODE_MODELS_URL`                 | streng | Egendefinert URL for henting av modellkonfigurasjon                   |
+| `MIMOCODE_AUTO_SHARE`                 | boolsk | Del økter automatisk                                                  |
+| `MIMOCODE_GIT_BASH_PATH`              | streng | Bane til Git Bash-kjørbar på Windows                                  |
+| `MIMOCODE_CONFIG`                     | streng | Bane til konfigurasjonsfil                                            |
+| `MIMOCODE_TUI_CONFIG`                 | streng | Bane til TUI-konfigurasjonsfil                                        |
+| `MIMOCODE_CONFIG_DIR`                 | streng | Bane til konfigurasjonskatalog                                        |
+| `MIMOCODE_CONFIG_CONTENT`             | streng | Innebygd json-konfigurasjonsinnhold                                   |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolsk | Deaktiver automatiske oppdateringskontroller                          |
+| `MIMOCODE_DISABLE_PRUNE`              | boolsk | Deaktiver beskjæring av gamle data                                    |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolsk | Deaktiver automatiske terminaltitteloppdateringer                     |
+| `MIMOCODE_PERMISSION`                 | streng | Innebygd json-tillatelseskonfigurasjon                                |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolsk | Deaktiver standard plugins                                            |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolsk | Deaktiver automatiske LSP servernedlastinger                          |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolsk | Aktiver eksperimentelle modeller                                      |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolsk | Deaktiver automatisk kontekstkomprimering                             |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolsk | Deaktiver lesing fra `.claude` (spørsmål + ferdigheter)               |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolsk | Deaktiver lesing `~/.claude/CLAUDE.md`                                |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolsk | Deaktiver innlasting av `.claude/skills`                              |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolsk | Deaktiver henting av modeller fra eksterne kilder                     |
+| `MIMOCODE_FAKE_VCS`                   | streng | Falsk VCS-leverandør for testformål                                   |
+| `MIMOCODE_CLIENT`                     | streng | Klientidentifikator (standard til `cli`)                              |
+| `MIMOCODE_ENABLE_EXA`                 | boolsk | Aktiver Exa-nettsøkeverktøy                                           |
+| `MIMOCODE_SERVER_PASSWORD`            | streng | Aktiver grunnleggende autentisering for `serve`/`web`                 |
+| `MIMOCODE_SERVER_USERNAME`            | streng | Overstyr grunnleggende autentiseringsbrukernavn (standard `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | streng | Egendefinert URL for henting av modellkonfigurasjon                   |
 
 ---
 
@@ -588,16 +588,16 @@ Disse miljøvariablene muliggjør eksperimentelle funksjoner som kan endres elle
 
 | Variabel                                        | Type   | Beskrivelse                                   |
 | ----------------------------------------------- | ------ | --------------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | boolsk | Aktiver alle eksperimentelle funksjoner       |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolsk | Aktiver ikonoppdagelse                        |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolsk | Deaktiver kopi ved valg i TUI                 |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | tall   | Standard tidsavbrudd for bash-kommandoer i ms |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | tall   | Maks Output Tokens for LLM-svar               |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolsk | Aktiver filovervåker for hele dir             |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolsk | Aktiver oxfmt formatter                       |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolsk | Aktiver eksperimentelt LSP-verktøy            |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolsk | Deaktiver filovervåking                       |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolsk | Aktiver eksperimentelle Exa-funksjoner        |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolsk | Aktiver TY LSP for python-filer               |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolsk | Aktiver eksperimentelle Markdown-funksjoner   |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolsk | Aktiver planmodus                             |
+| `MIMOCODE_EXPERIMENTAL`                         | boolsk | Aktiver alle eksperimentelle funksjoner       |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolsk | Aktiver ikonoppdagelse                        |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolsk | Deaktiver kopi ved valg i TUI                 |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | tall   | Standard tidsavbrudd for bash-kommandoer i ms |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | tall   | Maks Output Tokens for LLM-svar               |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolsk | Aktiver filovervåker for hele dir             |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolsk | Aktiver oxfmt formatter                       |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolsk | Aktiver eksperimentelt LSP-verktøy            |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolsk | Deaktiver filovervåking                       |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolsk | Aktiver eksperimentelle Exa-funksjoner        |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolsk | Aktiver TY LSP for python-filer               |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolsk | Aktiver eksperimentelle Markdown-funksjoner   |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolsk | Aktiver planmodus                             |

--- a/packages/web/src/content/docs/nb/config.mdx
+++ b/packages/web/src/content/docs/nb/config.mdx
@@ -11,9 +11,9 @@ Du kan konfigurere OpenCode ved å bruke en JSON konfigurasjonsfil.
 
 OpenCode støtter både **JSON** og **JSONC** (JSON med kommentarer) formater.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -44,11 +44,11 @@ For eksempel, hvis din globale konfigurasjon setter `theme: "opencode"` og `auto
 Konfigurasjonskilder lastes inn i denne rekkefølgen (senere kilder overstyrer tidligere):
 
 1. **Ekstern konfigurasjon** (fra `.well-known/opencode`) - organisasjonsstandarder
-2. **Global konfigurasjon** (`~/.config/opencode/opencode.json`) - brukerinnstillinger
-3. **Egendefinert konfigurasjon** (`OPENCODE_CONFIG` env var) - egendefinerte overstyringer
-4. **Prosjektkonfigurasjon** (`opencode.json` i prosjekt) - prosjektspesifikke innstillinger
+2. **Global konfigurasjon** (`~/.config/opencode/mimocode.jsonc`) - brukerinnstillinger
+3. **Egendefinert konfigurasjon** (`MIMOCODE_CONFIG` env var) - egendefinerte overstyringer
+4. **Prosjektkonfigurasjon** (`mimocode.jsonc` i prosjekt) - prosjektspesifikke innstillinger
 5. **`.opencode` kataloger** - agenter, kommandoer, plugins
-6. **Inline config** (`OPENCODE_CONFIG_CONTENT` env var) - kjøretidsoverstyringer
+6. **Inline config** (`MIMOCODE_CONFIG_CONTENT` env var) - kjøretidsoverstyringer
 
 Dette betyr at prosjektkonfigurasjoner kan overstyre globale standardinnstillinger, og globale konfigurasjoner kan overstyre eksterne organisasjonsstandarder.
 
@@ -80,7 +80,7 @@ For eksempel, hvis organisasjonen din tilbyr MCP servere som er deaktivert som s
 
 Du kan aktivere spesifikke servere i din lokale konfigurasjon:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -96,7 +96,7 @@ Du kan aktivere spesifikke servere i din lokale konfigurasjon:
 
 ### Global konfigurasjon
 
-Plasser din globale OpenCode-konfigurasjon i `~/.config/opencode/opencode.json`. Bruk global konfigurasjon for brukerspesifikke preferanser som temaer, leverandører eller nøkkelbindinger.
+Plasser din globale OpenCode-konfigurasjon i `~/.config/opencode/mimocode.jsonc`. Bruk global konfigurasjon for brukerspesifikke preferanser som temaer, leverandører eller nøkkelbindinger.
 
 Global konfigurasjon overstyrer eksterne organisasjonsstandarder.
 
@@ -104,7 +104,7 @@ Global konfigurasjon overstyrer eksterne organisasjonsstandarder.
 
 ### Per prosjekt
 
-Legg til `opencode.json` i prosjektroten din. Prosjektkonfigurasjon har den høyeste prioritet blant standard config-filer - den overstyrer både globale og eksterne konfigurasjoner.
+Legg til `mimocode.jsonc` i prosjektroten din. Prosjektkonfigurasjon har den høyeste prioritet blant standard config-filer - den overstyrer både globale og eksterne konfigurasjoner.
 
 :::tip
 Plasser prosjektspesifikk konfigurasjon i roten til prosjektet ditt.
@@ -118,10 +118,10 @@ Det er også trygt å sjekke inn dette i Git og bruker samme skjema som det glob
 
 ### Egendefinert bane
 
-Spesifiser en tilpasset konfigurasjonsfilbane ved å bruke miljøvariabelen `OPENCODE_CONFIG`.
+Spesifiser en tilpasset konfigurasjonsfilbane ved å bruke miljøvariabelen `MIMOCODE_CONFIG`.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -131,13 +131,13 @@ Egendefinert konfigurasjon lastes inn mellom globale og prosjektkonfigurasjoner 
 
 ### Egendefinert katalog
 
-Spesifiser en tilpasset konfigurasjonskatalog ved å bruke `OPENCODE_CONFIG_DIR`
+Spesifiser en tilpasset konfigurasjonskatalog ved å bruke `MIMOCODE_CONFIG_DIR`
 miljøvariabel. Denne katalogen vil bli søkt etter agenter, kommandoer,
 moduser og plugins akkurat som standard `.opencode` katalog, og bør
 følge samme struktur.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -147,7 +147,7 @@ Den egendefinerte katalogen lastes inn etter den globale konfigurasjonen og `.op
 
 ## Skjema
 
-Konfigurasjonsfilen har et skjema som er definert i [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+Konfigurasjonsfilen har et skjema som er definert i [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
 Redaktøren din skal kunne validere og autofullføre basert på skjemaet.
 
@@ -157,9 +157,9 @@ Redaktøren din skal kunne validere og autofullføre basert på skjemaet.
 
 Du kan konfigurere TUI-spesifikke innstillinger gjennom alternativet `tui`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tui": {
     "scroll_speed": 3,
     "scroll_acceleration": {
@@ -184,9 +184,9 @@ Tilgjengelige alternativer:
 
 Du kan konfigurere serverinnstillinger for kommandoene `opencode serve` og `opencode web` gjennom alternativet `server`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -213,9 +213,9 @@ Tilgjengelige alternativer:
 
 Du kan administrere verktøyene en LLM kan bruke gjennom alternativet `tools`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -231,9 +231,9 @@ Du kan administrere verktøyene en LLM kan bruke gjennom alternativet `tools`.
 
 Du kan konfigurere leverandørene og modellene du vil bruke i OpenCode-konfigurasjonen gjennom alternativene `provider`, `model` og `small_model`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -244,9 +244,9 @@ Alternativet `small_model` konfigurerer en egen modell for lette oppgaver som ti
 
 Leverandøralternativer kan inkludere `timeout` og `setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -273,9 +273,9 @@ Noen leverandører støtter flere konfigurasjonsalternativer utover de generiske
 
 Amazon Bedrock støtter AWS-spesifikk konfigurasjon:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -306,7 +306,7 @@ Angi UI-temaet ditt i `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -319,9 +319,9 @@ Angi UI-temaet ditt i `tui.json`.
 
 Du kan konfigurere spesialiserte agenter for spesifikke oppgaver gjennom alternativet `agent`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -337,7 +337,7 @@ Du kan konfigurere spesialiserte agenter for spesifikke oppgaver gjennom alterna
 }
 ```
 
-Du kan også definere agenter ved å bruke markdown-filer i `~/.config/opencode/agents/` eller `.opencode/agents/`. [Les mer her](/docs/agents).
+Du kan også definere agenter ved å bruke markdown-filer i `~/.config/opencode/agents/` eller `.mimocode/agents/`. [Les mer her](/docs/agents).
 
 ---
 
@@ -345,9 +345,9 @@ Du kan også definere agenter ved å bruke markdown-filer i `~/.config/opencode/
 
 Du kan angi standard agent ved å bruke alternativet `default_agent`. Dette bestemmer hvilken agent som brukes når ingen er eksplisitt spesifisert.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -362,9 +362,9 @@ Denne innstillingen gjelder for alle grensesnitt: TUI, CLI (`opencode run`), skr
 
 Du kan konfigurere [share](/docs/share)-funksjonen gjennom alternativet `share`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -383,9 +383,9 @@ Som standard er deling satt til manuell modus der du eksplisitt må dele samtale
 
 Du kan konfigurere egendefinerte kommandoer for repeterende oppgaver gjennom alternativet `command`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -401,7 +401,7 @@ Du kan konfigurere egendefinerte kommandoer for repeterende oppgaver gjennom alt
 }
 ```
 
-Du kan også definere kommandoer ved å bruke markdown-filer i `~/.config/opencode/commands/` eller `.opencode/commands/`. [Les mer her](/docs/commands).
+Du kan også definere kommandoer ved å bruke markdown-filer i `~/.config/opencode/commands/` eller `.mimocode/commands/`. [Les mer her](/docs/commands).
 
 ---
 
@@ -411,7 +411,7 @@ Tilpass tastebindinger i `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -424,9 +424,9 @@ Tilpass tastebindinger i `tui.json`.
 
 OpenCode vil automatisk laste ned eventuelle nye oppdateringer når den starter opp. Du kan deaktivere dette med alternativet `autoupdate`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -440,9 +440,9 @@ Legg merke til at dette bare fungerer hvis det ikke ble installert med en pakkeb
 
 Du kan konfigurere kodeformatere gjennom alternativet `formatter`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -468,9 +468,9 @@ Som standard **tillater OpenCode alle operasjoner** uten å kreve eksplisitt god
 
 Slik sikrer du at verktøyene `edit` og `bash` krever brukergodkjenning:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -486,9 +486,9 @@ Slik sikrer du at verktøyene `edit` og `bash` krever brukergodkjenning:
 
 Du kan styre kontekstkomprimering gjennom alternativet `compaction`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -507,9 +507,9 @@ Du kan styre kontekstkomprimering gjennom alternativet `compaction`.
 
 Du kan konfigurere ignoreringsmønstre for filovervåking gjennom alternativet `watcher`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -524,9 +524,9 @@ Mønstre følger glob-syntaks. Bruk dette for å ekskludere støyende kataloger 
 
 Du kan konfigurere MCP-servere du vil bruke gjennom alternativet `mcp`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -539,11 +539,11 @@ Du kan konfigurere MCP-servere du vil bruke gjennom alternativet `mcp`.
 
 [Plugins](/docs/plugins) utvider OpenCode med tilpassede verktøy, kroker og integrasjoner.
 
-Plasser plugin-filer i `.opencode/plugins/` eller `~/.config/opencode/plugins/`. Du kan også laste inn plugins fra npm gjennom alternativet `plugin`.
+Plasser plugin-filer i `.mimocode/plugins/` eller `~/.config/opencode/plugins/`. Du kan også laste inn plugins fra npm gjennom alternativet `plugin`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -556,9 +556,9 @@ Plasser plugin-filer i `.opencode/plugins/` eller `~/.config/opencode/plugins/`.
 
 Du kan konfigurere instruksjoner for modellen du bruker gjennom alternativet `instructions`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -572,9 +572,9 @@ om regler her](/docs/rules).
 
 Du kan deaktivere leverandører som lastes automatisk gjennom alternativet `disabled_providers`. Dette er nyttig når du vil forhindre at enkelte leverandører lastes inn selv om deres legitimasjon er tilgjengelig.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -595,9 +595,9 @@ Alternativet `disabled_providers` godtar en rekke leverandør-ID-er. Når en lev
 
 Du kan spesifisere en godkjenningsliste over leverandører gjennom alternativet `enabled_providers`. Når angitt, vil bare de angitte leverandørene være aktivert og alle andre vil bli ignorert.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -616,9 +616,9 @@ Hvis en leverandør vises i både `enabled_providers` og `disabled_providers`, h
 
 `experimental`-nøkkelen inneholder alternativer som er under aktiv utvikling.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -639,10 +639,10 @@ Du kan bruke variabelerstatning i konfigurasjonsfilene dine for å referere til 
 
 Bruk `{env:VARIABLE_NAME}` for å erstatte miljøvariabler:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -662,9 +662,9 @@ Hvis miljøvariabelen ikke er angitt, vil den bli erstattet med en tom streng.
 
 Bruk `{file:path/to/file}` for å erstatte innholdet i en fil:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/nb/plugins.mdx
+++ b/packages/web/src/content/docs/nb/plugins.mdx
@@ -19,7 +19,7 @@ Det er to måter å laste inn plugins.
 
 Plasser JavaScript- eller TypeScript-filer i plugin-katalogen.
 
-- `.opencode/plugins/` - Programtillegg på prosjektnivå
+- `.mimocode/plugins/` - Programtillegg på prosjektnivå
 - `~/.config/opencode/plugins/` - Globale plugins
 
 Filer i disse katalogene lastes automatisk ved oppstart.
@@ -30,9 +30,9 @@ Filer i disse katalogene lastes automatisk ved oppstart.
 
 Spesifiser npm-pakker i konfigurasjonsfilen.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ Bla gjennom tilgjengelige plugins i [økosystemet](/docs/ecosystem#plugins).
 
 Plugins lastes inn fra alle kilder og alle kroker kjøres i rekkefølge. Lastrekkefølgen er:
 
-1. Global konfigurasjon (`~/.config/opencode/opencode.json`)
-2. Prosjektkonfigurasjon (`opencode.json`)
+1. Global konfigurasjon (`~/.config/opencode/mimocode.jsonc`)
+2. Prosjektkonfigurasjon (`mimocode.jsonc`)
 3. Global plugin-katalog (`~/.config/opencode/plugins/`)
-4. Prosjektpluginkatalog (`.opencode/plugins/`)
+4. Prosjektpluginkatalog (`.mimocode/plugins/`)
 
 Dupliserte npm-pakker med samme navn og versjon lastes inn én gang. Imidlertid lastes en lokal plugin og en npm plugin med lignende navn begge separat.
 
@@ -75,7 +75,7 @@ funksjoner. Hver funksjon mottar et kontekstobjekt og returnerer et krokobjekt.
 
 Lokale plugins og tilpassede verktøy kan bruke eksterne npm-pakker. Legg til en `package.json` til konfigurasjonskatalogen med avhengighetene du trenger.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -85,7 +85,7 @@ Lokale plugins og tilpassede verktøy kan bruke eksterne npm-pakker. Legg til en
 
 OpenCode kjører `bun install` ved oppstart for å installere disse. Programtilleggene og verktøyene dine kan deretter importere dem.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -103,7 +103,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Grunnleggende struktur
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -218,7 +218,7 @@ Her er noen eksempler på plugins du kan bruke for å utvide OpenCode.
 
 Send varsler når visse hendelser inntreffer:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -243,7 +243,7 @@ Hvis du bruker OpenCode-skrivebordsappen, kan den sende systemvarsler automatisk
 
 Hindre OpenCode fra å lese `.env` filer:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -261,7 +261,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Injiser miljøvariabler i all shell-utførelse (AI-verktøy og brukerterminaler):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -278,7 +278,7 @@ export const InjectEnvPlugin = async () => {
 
 Plugins kan også legge til egendefinerte verktøy til OpenCode:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -317,7 +317,7 @@ Hvis et plugin-verktøy bruker samme navn som et innebygd verktøy, vil plugin-v
 
 Bruk `client.app.log()` i stedet for `console.log` for strukturert logging:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -330,7 +330,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Nivåer: `debug`, `info`, `warn`, `error`. Se [SDK dokumentasjon](https://opencode.ai/docs/sdk) for detaljer.
+Nivåer: `debug`, `info`, `warn`, `error`. Se [SDK dokumentasjon](https://mimocode.ai/docs/sdk) for detaljer.
 
 ---
 
@@ -338,7 +338,7 @@ Nivåer: `debug`, `info`, `warn`, `error`. Se [SDK dokumentasjon](https://openco
 
 Tilpass konteksten inkludert når en økt komprimeres:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -362,7 +362,7 @@ Include any state that should persist across compaction:
 
 Du kan også erstatte komprimeringsprompten helt ved å stille inn `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/pl/cli.mdx
+++ b/packages/web/src/content/docs/pl/cli.mdx
@@ -360,7 +360,7 @@ Uruchom serwer OpenCode (bez interfejsu) w celu uzyskania dostępu do API. Pełn
 opencode serve
 ```
 
-Uruchamia to serwer HTTP, który zapewnia dostęp do API OpenCode bez interfejsu TUI. Ustaw `OPENCODE_SERVER_PASSWORD`, aby włączyć podstawowe uwierzytelnianie HTTP (domyślna nazwa użytkownika to `opencode`).
+Uruchamia to serwer HTTP, który zapewnia dostęp do API OpenCode bez interfejsu TUI. Ustaw `MIMOCODE_SERVER_PASSWORD`, aby włączyć podstawowe uwierzytelnianie HTTP (domyślna nazwa użytkownika to `opencode`).
 
 #### Flagi
 
@@ -456,7 +456,7 @@ Uruchom serwer OpenCode z interfejsem internetowym.
 opencode web
 ```
 
-Uruchamia to serwer HTTP i udostępnia OpenCode przez interfejs przeglądarkowy. Ustaw `OPENCODE_SERVER_PASSWORD`, aby włączyć podstawowe uwierzytelnianie HTTP (domyślna nazwa użytkownika to `opencode`).
+Uruchamia to serwer HTTP i udostępnia OpenCode przez interfejs przeglądarkowy. Ustaw `MIMOCODE_SERVER_PASSWORD`, aby włączyć podstawowe uwierzytelnianie HTTP (domyślna nazwa użytkownika to `opencode`).
 
 #### Flagi
 
@@ -555,30 +555,30 @@ OpenCode można skonfigurować za pomocą zmiennych środowiskowych.
 
 | Zmienna                               | Typ     | Opis                                                       |
 | ------------------------------------- | ------- | ---------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | Automatycznie udostępniaj sesje                            |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Ścieżka do pliku wykonywalnego Git Bash w systemie Windows |
-| `OPENCODE_CONFIG`                     | string  | Ścieżka do pliku konfiguracyjnego                          |
-| `OPENCODE_TUI_CONFIG`                 | string  | Ścieżka do pliku konfiguracyjnego TUI                      |
-| `OPENCODE_CONFIG_DIR`                 | string  | Ścieżka do katalogu konfiguracyjnego                       |
-| `OPENCODE_CONFIG_CONTENT`             | string  | Treść konfiguracji JSON (inline)                           |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Wyłącz automatyczne sprawdzanie aktualizacji               |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | Wyłącz czyszczenie starych wyników (pruning)               |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Wyłącz automatyczne ustawianie tytułu terminala            |
-| `OPENCODE_PERMISSION`                 | string  | Konfiguracja uprawnień w JSON (inline)                     |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Wyłącz domyślne wtyczki                                    |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Wyłącz automatyczne pobieranie serwerów LSP                |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Włącz modele eksperymentalne                               |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Wyłącz automatyczne kompaktowanie kontekstu                |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Wyłącz integrację z `.claude` (prompt + skills)            |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Wyłącz czytanie `~/.claude/CLAUDE.md`                      |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Wyłącz ładowanie `.claude/skills`                          |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Wyłącz pobieranie modeli ze źródeł zewnętrznych            |
-| `OPENCODE_FAKE_VCS`                   | string  | Fałszywy dostawca VCS do celów testowych                   |
-| `OPENCODE_CLIENT`                     | string  | Identyfikator klienta (domyślnie `cli`)                    |
-| `OPENCODE_ENABLE_EXA`                 | boolean | Włącz narzędzie wyszukiwania internetowego Exa             |
-| `OPENCODE_SERVER_PASSWORD`            | string  | Włącz uwierzytelnianie podstawowe dla `serve`/`web`        |
-| `OPENCODE_SERVER_USERNAME`            | string  | Nazwa użytkownika do autoryzacji (domyślnie `opencode`)    |
-| `OPENCODE_MODELS_URL`                 | string  | Niestandardowy adres URL do pobierania konfiguracji modeli |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | Automatycznie udostępniaj sesje                            |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | Ścieżka do pliku wykonywalnego Git Bash w systemie Windows |
+| `MIMOCODE_CONFIG`                     | string  | Ścieżka do pliku konfiguracyjnego                          |
+| `MIMOCODE_TUI_CONFIG`                 | string  | Ścieżka do pliku konfiguracyjnego TUI                      |
+| `MIMOCODE_CONFIG_DIR`                 | string  | Ścieżka do katalogu konfiguracyjnego                       |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | Treść konfiguracji JSON (inline)                           |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | Wyłącz automatyczne sprawdzanie aktualizacji               |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | Wyłącz czyszczenie starych wyników (pruning)               |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | Wyłącz automatyczne ustawianie tytułu terminala            |
+| `MIMOCODE_PERMISSION`                 | string  | Konfiguracja uprawnień w JSON (inline)                     |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Wyłącz domyślne wtyczki                                    |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Wyłącz automatyczne pobieranie serwerów LSP                |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Włącz modele eksperymentalne                               |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | Wyłącz automatyczne kompaktowanie kontekstu                |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | Wyłącz integrację z `.claude` (prompt + skills)            |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Wyłącz czytanie `~/.claude/CLAUDE.md`                      |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Wyłącz ładowanie `.claude/skills`                          |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | Wyłącz pobieranie modeli ze źródeł zewnętrznych            |
+| `MIMOCODE_FAKE_VCS`                   | string  | Fałszywy dostawca VCS do celów testowych                   |
+| `MIMOCODE_CLIENT`                     | string  | Identyfikator klienta (domyślnie `cli`)                    |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | Włącz narzędzie wyszukiwania internetowego Exa             |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | Włącz uwierzytelnianie podstawowe dla `serve`/`web`        |
+| `MIMOCODE_SERVER_USERNAME`            | string  | Nazwa użytkownika do autoryzacji (domyślnie `opencode`)    |
+| `MIMOCODE_MODELS_URL`                 | string  | Niestandardowy adres URL do pobierania konfiguracji modeli |
 
 ---
 
@@ -588,16 +588,16 @@ Te zmienne włączają funkcje eksperymentalne, które mogą ulec zmianie lub zo
 
 | Zmienna                                         | Typ     | Opis                                         |
 | ----------------------------------------------- | ------- | -------------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | Włącz wszystkie funkcje eksperymentalne      |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Włącz wykrywanie ikon                        |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Wyłącz kopiowanie przy zaznaczaniu w TUI     |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Domyślny limit czasu dla narzędzia bash w ms |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Maksymalne tokeny wyjściowe dla LLM          |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Włącz obserwatora plików dla całego katalogu |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | Włącz formater oxfmt                         |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Włącz eksperymentalne narzędzie LSP          |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Wyłącz obserwatora plików                    |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Włącz funkcje eksperymentalne Exa            |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Włącz TY LSP dla plików python               |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Włącz funkcje eksperymentalne Markdown       |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Włącz tryb planowania                        |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | Włącz wszystkie funkcje eksperymentalne      |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Włącz wykrywanie ikon                        |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Wyłącz kopiowanie przy zaznaczaniu w TUI     |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Domyślny limit czasu dla narzędzia bash w ms |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Maksymalne tokeny wyjściowe dla LLM          |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Włącz obserwatora plików dla całego katalogu |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | Włącz formater oxfmt                         |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Włącz eksperymentalne narzędzie LSP          |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Wyłącz obserwatora plików                    |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | Włącz funkcje eksperymentalne Exa            |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Włącz TY LSP dla plików python               |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Włącz funkcje eksperymentalne Markdown       |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Włącz tryb planowania                        |

--- a/packages/web/src/content/docs/pl/config.mdx
+++ b/packages/web/src/content/docs/pl/config.mdx
@@ -11,9 +11,9 @@ Możesz dostosować OpenCode za pomocą pliku konfiguracyjnego JSON.
 
 OpenCode obsługuje formaty **JSON** i **JSONC** (JSON z komentarzami).
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   // Theme configuration
   "theme": "opencode",
   "model": "anthropic/claude-sonnet-4-5",
@@ -42,11 +42,11 @@ Na przykład, jeśli konfiguracja globalna ustawi `theme: "opencode"` i `autoupd
 Źródła konfiguracji są ładowane w następującej kolejności (źródła występujące później mają pierwszeństwo):
 
 1. **Konfiguracja zdalna** (z `.well-known/opencode`) – ustawienia wymuszane przez organizację
-2. **Konfiguracja globalna** (`~/.config/opencode/opencode.json`) – preferencje użytkownika
-3. **Konfiguracja niestandardowa** (zmienna `OPENCODE_CONFIG`) — jawne nadpisanie
-4. **Konfiguracja projektu** (`opencode.json` w projekcie) - ustawienia specyficzne dla projektu
+2. **Konfiguracja globalna** (`~/.config/opencode/mimocode.jsonc`) – preferencje użytkownika
+3. **Konfiguracja niestandardowa** (zmienna `MIMOCODE_CONFIG`) — jawne nadpisanie
+4. **Konfiguracja projektu** (`mimocode.jsonc` w projekcie) - ustawienia specyficzne dla projektu
 5. **Katalogi `.opencode`** - agenci, polecenia, umiejętności
-6. **Konfiguracja wbudowana** (zmienna `OPENCODE_CONFIG_CONTENT`) — nadpisanie środowiska uruchomieniowego
+6. **Konfiguracja wbudowana** (zmienna `MIMOCODE_CONFIG_CONTENT`) — nadpisanie środowiska uruchomieniowego
 
 Oznacza to, że konfiguracje projektu mogą nadpisywać konfiguracje globalne, a konfiguracje globalne mogą nadpisywać konfiguracje zdalne.
 
@@ -78,7 +78,7 @@ Na przykład, jeśli Twoja organizacja udostępnia serwery MCP, które są domy�
 
 Możesz włączyć serwer w konfiguracji projektu:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -94,7 +94,7 @@ Możesz włączyć serwer w konfiguracji projektu:
 
 ### Globalna
 
-Umieść swoją globalną konfigurację OpenCode w `~/.config/opencode/opencode.json`. Użyj jej do ustawień ogólnych dla użytkownika, takich jak dostawcy, modele i uprawnienia.
+Umieść swoją globalną konfigurację OpenCode w `~/.config/opencode/mimocode.jsonc`. Użyj jej do ustawień ogólnych dla użytkownika, takich jak dostawcy, modele i uprawnienia.
 
 Dla ustawień specyficznych dla TUI, użyj `~/.config/opencode/tui.json`.
 
@@ -104,7 +104,7 @@ Konfiguracja globalna ma pierwszeństwo przed konfiguracją zdalną.
 
 ### Projekt
 
-Dodaj `opencode.json` w katalogu głównym projektu. Konfiguracja projektu ma najwyższy priorytet wśród plików konfiguracyjnych — nadpisuje konfiguracje globalne i zdalne.
+Dodaj `mimocode.jsonc` w katalogu głównym projektu. Konfiguracja projektu ma najwyższy priorytet wśród plików konfiguracyjnych — nadpisuje konfiguracje globalne i zdalne.
 
 Dla ustawień TUI specyficznych dla projektu, dodaj plik `tui.json` obok niego.
 
@@ -120,10 +120,10 @@ Może on być przechowywany w Git i mieć ten sam schemat, co konfiguracja globa
 
 ### Niestandardowa ścieżka
 
-Możesz załadować niestandardowy plik konfiguracyjny, ustawiając zmienną środowiskową `OPENCODE_CONFIG`.
+Możesz załadować niestandardowy plik konfiguracyjny, ustawiając zmienną środowiskową `MIMOCODE_CONFIG`.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -133,10 +133,10 @@ Konfiguracja niestandardowa jest ładowana po konfiguracji globalnej i przed kon
 
 ### Niestandardowy katalog
 
-Możesz ustawić niestandardowy katalog konfiguracyjny za pomocą zmiennej środowiskowej `OPENCODE_CONFIG_DIR`. Katalog ten będzie przeszukiwany pod kątem agentów, poleceń, trybów i wtyczek, tak jak standardowy katalog `.opencode` i powinien zachować tę samą strukturę.
+Możesz ustawić niestandardowy katalog konfiguracyjny za pomocą zmiennej środowiskowej `MIMOCODE_CONFIG_DIR`. Katalog ten będzie przeszukiwany pod kątem agentów, poleceń, trybów i wtyczek, tak jak standardowy katalog `.opencode` i powinien zachować tę samą strukturę.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -146,7 +146,7 @@ Katalog niestandardowy jest ładowany po globalnej konfiguracji i katalogach `.o
 
 ## Schemat
 
-Plik konfiguracyjny ma schemat JSON dostępny pod adresem [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+Plik konfiguracyjny ma schemat JSON dostępny pod adresem [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
 Twój edytor powinien zapewniać walidację i autouzupełnianie na podstawie tego schematu.
 
@@ -158,7 +158,7 @@ Użyj dedykowanego pliku `tui.json` (lub `tui.jsonc`) dla ustawień specyficznyc
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "scroll_speed": 3,
   "scroll_acceleration": {
     "enabled": true
@@ -167,9 +167,9 @@ Użyj dedykowanego pliku `tui.json` (lub `tui.jsonc`) dla ustawień specyficznyc
 }
 ```
 
-Użyj `OPENCODE_TUI_CONFIG`, aby wskazać niestandardowy plik konfiguracyjny TUI.
+Użyj `MIMOCODE_TUI_CONFIG`, aby wskazać niestandardowy plik konfiguracyjny TUI.
 
-Przestarzałe klucze `theme`, `keybinds` i `tui` w `opencode.json` są wycofywane i automatycznie migrowane, gdy to możliwe.
+Przestarzałe klucze `theme`, `keybinds` i `tui` w `mimocode.jsonc` są wycofywane i automatycznie migrowane, gdy to możliwe.
 
 [Dowiedz się więcej o konfiguracji TUI tutaj](/docs/tui#configure).
 
@@ -179,9 +179,9 @@ Przestarzałe klucze `theme`, `keybinds` i `tui` w `opencode.json` są wycofywan
 
 Możesz skonfigurować serwer dla `opencode serve` i `opencode web` za pomocą opcji `server`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -208,9 +208,9 @@ Dostępne opcje:
 
 Kontroluj, które narzędzia są dostępne dla LLM, za pomocą opcji `tools`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -226,9 +226,9 @@ Kontroluj, które narzędzia są dostępne dla LLM, za pomocą opcji `tools`.
 
 Możesz skonfigurować dostawców i modele, których chcesz używać, za pomocą opcji `provider`, `model` i `small_model`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -239,9 +239,9 @@ Opcja `small_model` konfiguruje oddzielny model do lżejszych zadań, takich jak
 
 Opcje dostawcy mogą zawierać `timeout` i `setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -268,9 +268,9 @@ Niektórzy dostawcy obsługują dodatkowe opcje konfiguracji poza `timeout` i `a
 
 Amazon Bedrock umożliwia konfigurację połączenia z AWS:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -301,7 +301,7 @@ Ustaw motyw interfejsu użytkownika w `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -314,9 +314,9 @@ Ustaw motyw interfejsu użytkownika w `tui.json`.
 
 Możesz zdefiniować i skonfigurować agentów za pomocą opcji `agent`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -332,7 +332,7 @@ Możesz zdefiniować i skonfigurować agentów za pomocą opcji `agent`.
 }
 ```
 
-Możesz także definiować agentów przy użyciu plików markdown w `~/.config/opencode/agents/` lub `.opencode/agents/`. [Dowiedz się więcej o agentach](/docs/agents).
+Możesz także definiować agentów przy użyciu plików markdown w `~/.config/opencode/agents/` lub `.mimocode/agents/`. [Dowiedz się więcej o agentach](/docs/agents).
 
 ---
 
@@ -340,9 +340,9 @@ Możesz także definiować agentów przy użyciu plików markdown w `~/.config/o
 
 Domyślnego agenta można ustawić za pomocą opcji `default_agent`. Określa to agenta, który jest używany, jeśli nie wybrano żadnego innego.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -357,9 +357,9 @@ Dotyczy to wszystkich interfejsów: TUI, CLI (`opencode run`), aplikacji desktop
 
 Możesz skonfigurować [udostępnianie](/docs/share) za pomocą opcji `share`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -378,9 +378,9 @@ Domyślnie ustawiony jest tryb ręczny, w którym należy jawnie udostępniać r
 
 Możesz zdefiniować niestandardowe polecenia dla powtarzalnych zadań za pomocą opcji `command`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -396,7 +396,7 @@ Możesz zdefiniować niestandardowe polecenia dla powtarzalnych zadań za pomoc�
 }
 ```
 
-Możesz także definiować polecenia przy użyciu plików Markdown w `~/.config/opencode/commands/` lub `.opencode/commands/`. [Dowiedz się więcej o poleceniach](/docs/commands).
+Możesz także definiować polecenia przy użyciu plików Markdown w `~/.config/opencode/commands/` lub `.mimocode/commands/`. [Dowiedz się więcej o poleceniach](/docs/commands).
 
 ---
 
@@ -406,7 +406,7 @@ Dostosuj skróty klawiszowe w `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -419,9 +419,9 @@ Dostosuj skróty klawiszowe w `tui.json`.
 
 OpenCode może automatycznie pobierać nowe wersje. Możesz to kontrolować za pomocą opcji `autoupdate`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -435,9 +435,9 @@ Działa to tylko wtedy, gdy OpenCode nie został zainstalowany przez menedżera 
 
 Możesz skonfigurować formatery kodu za pomocą opcji `formatter`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -463,9 +463,9 @@ Domyślnie OpenCode **zezwala na wszystkie działania** bez konieczności zatwie
 
 Na przykład, aby wymagać zatwierdzenia dla narzędzi `edit` i `bash`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -481,9 +481,9 @@ Na przykład, aby wymagać zatwierdzenia dla narzędzi `edit` i `bash`:
 
 Możesz kontrolować zachowanie kompaktowania kontekstu za pomocą opcji `compaction`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true
@@ -500,9 +500,9 @@ Możesz kontrolować zachowanie kompaktowania kontekstu za pomocą opcji `compac
 
 Skonfiguruj ignorowane wzorce plików dla obserwatora plików za pomocą `watcher`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -517,9 +517,9 @@ Wzorce są zgodne ze składnią glob. Użyj tej opcji, aby wykluczyć często zm
 
 Skonfiguruj serwery MCP, których chcesz używać, za pomocą opcji `mcp`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -532,11 +532,11 @@ Skonfiguruj serwery MCP, których chcesz używać, za pomocą opcji `mcp`.
 
 [Wtyczki](/docs/plugins) rozszerzają OpenCode o niestandardowe narzędzia, hooki i integracje.
 
-Umieść pliki wtyczek w `.opencode/plugins/` lub `~/.config/opencode/plugins/`. Możesz także załadować wtyczkę z npm za pomocą opcji `plugin`.
+Umieść pliki wtyczek w `.mimocode/plugins/` lub `~/.config/opencode/plugins/`. Możesz także załadować wtyczkę z npm za pomocą opcji `plugin`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -549,9 +549,9 @@ Umieść pliki wtyczek w `.opencode/plugins/` lub `~/.config/opencode/plugins/`.
 
 Określ pliki instrukcji dla modelu, używając opcji `instructions`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -564,9 +564,9 @@ Załadowane pliki są dołączane do promptu systemowego. Obsługuje wzorce glob
 
 Zapobiegaj automatycznemu ładowaniu dostawców za pomocą opcji `disabled_providers`. Jest to przydatne, gdy chcesz wyłączyć niektórych dostawców, nawet jeśli masz dla nich dane uwierzytelniające.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -587,9 +587,9 @@ Opcja `disabled_providers` przyjmuje tablicę identyfikatorów dostawców. Gdy d
 
 Możesz określić listę dozwolonych dostawców za pomocą `enabled_providers`. Po ustawieniu, tylko wymienieni dostawcy będą ładowani.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -608,9 +608,9 @@ Jeśli dostawca jest wymieniony zarówno w `enabled_providers`, jak i `disabled_
 
 Klucz `experimental` zawiera opcje, które są we wczesnej fazie rozwoju.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -631,10 +631,10 @@ Możesz używać specjalnej składni w plikach konfiguracyjnych, aby odwoływać
 
 Użyj `{env:VARIABLE_NAME}`, aby wstawić wartość zmiennej środowiskowej:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -654,9 +654,9 @@ Jeśli zmienna środowiskowa nie jest ustawiona, zostanie zastąpiona pustym ci�
 
 Użyj `{file:path/to/file}`, aby wstawić zawartość pliku:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/pl/plugins.mdx
+++ b/packages/web/src/content/docs/pl/plugins.mdx
@@ -19,7 +19,7 @@ Istnieją dwa sposoby ładowania wtyczek.
 
 Miejsce plików JavaScript lub TypeScript w katalogu wtyczki.
 
-- `.opencode/plugins/` - Wtyczki na poziomie projektu
+- `.mimocode/plugins/` - Wtyczki na poziomie projektu
 - `~/.config/opencode/plugins/` - Wtyczki globalne
 
 Pliki w tych katalogach są automatycznie ładowane podczas uruchamiania.
@@ -30,9 +30,9 @@ Pliki w tych katalogach są automatycznie ładowane podczas uruchamiania.
 
 szczegółowy pakiet npm w pliku konfiguracyjnym.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ Przeglądaj dostępną wtyczkę w [ekosystemie](/docs/ecosystem#plugins).
 
 Wtyczki są ładowane ze wszystkich źródeł, a wszystkie hooki napisane po kolei. Kolejność ładowania do:
 
-1. Konfiguracja globalna (`~/.config/opencode/opencode.json`)
-2. Konfiguracja projektu (`opencode.json`)
+1. Konfiguracja globalna (`~/.config/opencode/mimocode.jsonc`)
+2. Konfiguracja projektu (`mimocode.jsonc`)
 3. Globalny katalog wtyczek (`~/.config/opencode/plugins/`)
-4. Katalog wtyczek projektu (`.opencode/plugins/`)
+4. Katalog wtyczek projektu (`.mimocode/plugins/`)
 
 Zduplikowane pakiety npm o tej samej nazwie i wersji są ładowane raz. Równie ważny jest dostęp lokalny i zewnętrzny npm o dodatkowych nazwach, które są zewnętrzne.
 
@@ -75,7 +75,7 @@ funkcje. dostępna funkcja korzystania z obiektu kontekstu i głównego obiektu 
 
 Lokalne narzędzie i narzędzie, które można wykorzystać z zewnętrznych pakietów npm. Dodaj `package.json` do swojego katalogu konfiguracyjnego z zależnościami.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -85,7 +85,7 @@ Lokalne narzędzie i narzędzie, które można wykorzystać z zewnętrznych paki
 
 opencode uruchomienie `bun install` przy uruchomieniu, aby je uruchomić. Twoje dodatkowe funkcje będą dostępne po zaimportowaniu.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -103,7 +103,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Podstawowa struktura
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -218,7 +218,7 @@ Oto kilka dostępnych wtyczek, które można udostępnić do opencode.
 
 Wysyłaj powiadomienia, gdy wystąpią określone zdarzenia:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -243,7 +243,7 @@ Jeśli korzystasz z aplikacji komputerowej opencode, może ona automatycznie wys
 
 Zablokuj opencode czytanie plików `.env`:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -261,7 +261,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Wstrzyknij zmienne konsekwencje dla wszystkich wykonań (narzędzia AI i terminale użytkownika):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -278,7 +278,7 @@ export const InjectEnvPlugin = async () => {
 
 Wtyczki mogą również dodawać niestandardowe narzędzia do opencode:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -313,7 +313,7 @@ Twoje narzędzie będzie dostępne dla otwartego kodu wraz z narzędziami użytk
 
 użyj `client.app.log()` zamiast `console.log` do rejestracji strukturalnego:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -326,7 +326,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Poziomy: `debug`, `info`, `warn`, `error`. Aby uzyskać szczegółowe informacje, zobacz [dokumentację pakietu SDK](https://opencode.ai/docs/sdk).
+Poziomy: `debug`, `info`, `warn`, `error`. Aby uzyskać szczegółowe informacje, zobacz [dokumentację pakietu SDK](https://mimocode.ai/docs/sdk).
 
 ---
 
@@ -334,7 +334,7 @@ Poziomy: `debug`, `info`, `warn`, `error`. Aby uzyskać szczegółowe informacje
 
 Dostosuj kontekst dołączony podczas kompaktowania sesji:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -358,7 +358,7 @@ Hak `experimental.session.compacting` jest uruchamiany, zanim LLM wygeneruje pod
 
 Można także umieścić kompletny monit o zagęszczenie, ustawiając `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -19,7 +19,7 @@ There are two ways to load plugins.
 
 Place JavaScript or TypeScript files in the plugin directory.
 
-- `.opencode/plugins/` - Project-level plugins
+- `.mimocode/plugins/` - Project-level plugins
 - `~/.config/opencode/plugins/` - Global plugins
 
 Files in these directories are automatically loaded at startup.
@@ -30,9 +30,9 @@ Files in these directories are automatically loaded at startup.
 
 Specify npm packages in your config file.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ Browse available plugins in the [ecosystem](/docs/ecosystem#plugins).
 
 Plugins are loaded from all sources and all hooks run in sequence. The load order is:
 
-1. Global config (`~/.config/opencode/opencode.json`)
-2. Project config (`opencode.json`)
+1. Global config (`~/.config/opencode/mimocode.jsonc`)
+2. Project config (`mimocode.jsonc`)
 3. Global plugin directory (`~/.config/opencode/plugins/`)
-4. Project plugin directory (`.opencode/plugins/`)
+4. Project plugin directory (`.mimocode/plugins/`)
 
 Duplicate npm packages with the same name and version are loaded once. However, a local plugin and an npm plugin with similar names are both loaded separately.
 
@@ -75,7 +75,7 @@ functions. Each function receives a context object and returns a hooks object.
 
 Local plugins and custom tools can use external npm packages. Add a `package.json` to your config directory with the dependencies you need.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -85,7 +85,7 @@ Local plugins and custom tools can use external npm packages. Add a `package.jso
 
 OpenCode runs `bun install` at startup to install these. Your plugins and tools can then import them.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -103,7 +103,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Basic structure
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -218,7 +218,7 @@ Here are some examples of plugins you can use to extend opencode.
 
 Send notifications when certain events occur:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -243,7 +243,7 @@ If you’re using the OpenCode desktop app, it can send system notifications aut
 
 Prevent opencode from reading `.env` files:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -261,7 +261,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Inject environment variables into all shell execution (AI tools and user terminals):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -278,7 +278,7 @@ export const InjectEnvPlugin = async () => {
 
 Plugins can also add custom tools to opencode:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -317,7 +317,7 @@ If a plugin tool uses the same name as a built-in tool, the plugin tool takes pr
 
 Use `client.app.log()` instead of `console.log` for structured logging:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -330,7 +330,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Levels: `debug`, `info`, `warn`, `error`. See [SDK documentation](https://opencode.ai/docs/sdk) for details.
+Levels: `debug`, `info`, `warn`, `error`. See [SDK documentation](https://mimocode.ai/docs/sdk) for details.
 
 ---
 
@@ -338,7 +338,7 @@ Levels: `debug`, `info`, `warn`, `error`. See [SDK documentation](https://openco
 
 Customize the context included when a session is compacted:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -362,7 +362,7 @@ The `experimental.session.compacting` hook fires before the LLM generates a cont
 
 You can also replace the compaction prompt entirely by setting `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/pt-br/cli.mdx
+++ b/packages/web/src/content/docs/pt-br/cli.mdx
@@ -360,7 +360,7 @@ Inicie um servidor opencode sem cabeça para acesso à API. Confira a [documenta
 opencode serve
 ```
 
-Isso inicia um servidor HTTP que fornece acesso à funcionalidade do opencode sem a interface TUI. Defina `OPENCODE_SERVER_PASSWORD` para habilitar a autenticação básica HTTP (o nome de usuário padrão é `opencode`).
+Isso inicia um servidor HTTP que fornece acesso à funcionalidade do opencode sem a interface TUI. Defina `MIMOCODE_SERVER_PASSWORD` para habilitar a autenticação básica HTTP (o nome de usuário padrão é `opencode`).
 
 #### Opções
 
@@ -456,7 +456,7 @@ Inicie um servidor opencode sem cabeça com uma interface web.
 opencode web
 ```
 
-Isso inicia um servidor HTTP e abre um navegador para acessar o opencode através de uma interface web. Defina `OPENCODE_SERVER_PASSWORD` para habilitar a autenticação básica HTTP (o nome de usuário padrão é `opencode`).
+Isso inicia um servidor HTTP e abre um navegador para acessar o opencode através de uma interface web. Defina `MIMOCODE_SERVER_PASSWORD` para habilitar a autenticação básica HTTP (o nome de usuário padrão é `opencode`).
 
 #### Opções
 
@@ -555,29 +555,29 @@ O opencode pode ser configurado usando variáveis de ambiente.
 
 | Variável                              | Tipo    | Descrição                                                             |
 | ------------------------------------- | ------- | --------------------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | Compartilhar sessões automaticamente                                  |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Caminho para o executável do Git Bash no Windows                      |
-| `OPENCODE_CONFIG`                     | string  | Caminho para o arquivo de configuração                                |
-| `OPENCODE_CONFIG_DIR`                 | string  | Caminho para o diretório de configuração                              |
-| `OPENCODE_CONFIG_CONTENT`             | string  | Conteúdo de configuração json inline                                  |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Desabilitar verificações de atualização automática                    |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | Desabilitar a poda de dados antigos                                   |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Desabilitar atualizações automáticas do título do terminal            |
-| `OPENCODE_PERMISSION`                 | string  | Configuração de permissões json inline                                |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Desabilitar plugins padrão                                            |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Desabilitar downloads automáticos do servidor LSP                     |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Habilitar modelos experimentais                                       |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Desabilitar compactação automática de contexto                        |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Desabilitar leitura de `.claude` (prompt + habilidades)               |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Desabilitar leitura de `~/.claude/CLAUDE.md`                          |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Desabilitar carregamento de `.claude/skills`                          |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Desabilitar busca de modelos de fontes remotas                        |
-| `OPENCODE_FAKE_VCS`                   | string  | Provedor VCS falso para fins de teste                                 |
-| `OPENCODE_CLIENT`                     | string  | Identificador do cliente (padrão é `cli`)                             |
-| `OPENCODE_ENABLE_EXA`                 | boolean | Habilitar ferramentas de busca web Exa                                |
-| `OPENCODE_SERVER_PASSWORD`            | string  | Habilitar autenticação básica para `serve`/`web`                      |
-| `OPENCODE_SERVER_USERNAME`            | string  | Substituir nome de usuário de autenticação básica (padrão `opencode`) |
-| `OPENCODE_MODELS_URL`                 | string  | URL personalizada para buscar configuração de modelos                 |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | Compartilhar sessões automaticamente                                  |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | Caminho para o executável do Git Bash no Windows                      |
+| `MIMOCODE_CONFIG`                     | string  | Caminho para o arquivo de configuração                                |
+| `MIMOCODE_CONFIG_DIR`                 | string  | Caminho para o diretório de configuração                              |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | Conteúdo de configuração json inline                                  |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | Desabilitar verificações de atualização automática                    |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | Desabilitar a poda de dados antigos                                   |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | Desabilitar atualizações automáticas do título do terminal            |
+| `MIMOCODE_PERMISSION`                 | string  | Configuração de permissões json inline                                |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Desabilitar plugins padrão                                            |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Desabilitar downloads automáticos do servidor LSP                     |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Habilitar modelos experimentais                                       |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | Desabilitar compactação automática de contexto                        |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | Desabilitar leitura de `.claude` (prompt + habilidades)               |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Desabilitar leitura de `~/.claude/CLAUDE.md`                          |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Desabilitar carregamento de `.claude/skills`                          |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | Desabilitar busca de modelos de fontes remotas                        |
+| `MIMOCODE_FAKE_VCS`                   | string  | Provedor VCS falso para fins de teste                                 |
+| `MIMOCODE_CLIENT`                     | string  | Identificador do cliente (padrão é `cli`)                             |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | Habilitar ferramentas de busca web Exa                                |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | Habilitar autenticação básica para `serve`/`web`                      |
+| `MIMOCODE_SERVER_USERNAME`            | string  | Substituir nome de usuário de autenticação básica (padrão `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | string  | URL personalizada para buscar configuração de modelos                 |
 
 ---
 
@@ -587,16 +587,16 @@ Essas variáveis de ambiente habilitam recursos experimentais que podem mudar ou
 
 | Variável                                        | Tipo    | Descrição                                                 |
 | ----------------------------------------------- | ------- | --------------------------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | Habilitar todos os recursos experimentais                 |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Habilitar descoberta de ícones                            |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Desabilitar cópia ao selecionar no TUI                    |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Tempo limite padrão para comandos bash em ms              |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Máximo de tokens de saída para respostas LLM              |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Habilitar monitoramento de arquivos para todo o diretório |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | Habilitar formatador oxfmt                                |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Habilitar ferramenta LSP experimental                     |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Desabilitar monitoramento de arquivos                     |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Habilitar recursos experimentais do Exa                   |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Habilitar TY LSP para arquivos python                     |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Habilitar recursos experimentais de markdown              |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Habilitar modo de plano                                   |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | Habilitar todos os recursos experimentais                 |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Habilitar descoberta de ícones                            |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Desabilitar cópia ao selecionar no TUI                    |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Tempo limite padrão para comandos bash em ms              |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Máximo de tokens de saída para respostas LLM              |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Habilitar monitoramento de arquivos para todo o diretório |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | Habilitar formatador oxfmt                                |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Habilitar ferramenta LSP experimental                     |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Desabilitar monitoramento de arquivos                     |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | Habilitar recursos experimentais do Exa                   |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Habilitar TY LSP para arquivos python                     |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Habilitar recursos experimentais de markdown              |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Habilitar modo de plano                                   |

--- a/packages/web/src/content/docs/pt-br/config.mdx
+++ b/packages/web/src/content/docs/pt-br/config.mdx
@@ -11,9 +11,9 @@ Você pode configurar o opencode usando um arquivo de configuração JSON.
 
 O opencode suporta os formatos **JSON** e **JSONC** (JSON com Comentários).
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -44,11 +44,11 @@ Por exemplo, se sua configuração global define `autoupdate: true` e sua config
 As fontes de configuração são carregadas nesta ordem (fontes posteriores substituem as anteriores):
 
 1. **Configuração remota** (de `.well-known/opencode`) - padrões organizacionais
-2. **Configuração global** (`~/.config/opencode/opencode.json`) - preferências do usuário
-3. **Configuração personalizada** (`OPENCODE_CONFIG` var de ambiente) - substituições personalizadas
-4. **Configuração do projeto** (`opencode.json` no projeto) - configurações específicas do projeto
+2. **Configuração global** (`~/.config/opencode/mimocode.jsonc`) - preferências do usuário
+3. **Configuração personalizada** (`MIMOCODE_CONFIG` var de ambiente) - substituições personalizadas
+4. **Configuração do projeto** (`mimocode.jsonc` no projeto) - configurações específicas do projeto
 5. **Diretórios `.opencode`** - agentes, comandos, plugins
-6. **Configuração inline** (`OPENCODE_CONFIG_CONTENT` var de ambiente) - substituições em tempo de execução
+6. **Configuração inline** (`MIMOCODE_CONFIG_CONTENT` var de ambiente) - substituições em tempo de execução
 
 Isso significa que as configurações do projeto podem substituir os padrões globais, e as configurações globais podem substituir os padrões organizacionais remotos.
 
@@ -80,7 +80,7 @@ Por exemplo, se sua organização fornece servidores MCP que estão desativados 
 
 Você pode habilitar servidores específicos em sua configuração local:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -96,7 +96,7 @@ Você pode habilitar servidores específicos em sua configuração local:
 
 ### Global
 
-Coloque sua configuração global do opencode em `~/.config/opencode/opencode.json`. Use a configuração global para preferências de todo o usuário, como provedores, modelos e permissões.
+Coloque sua configuração global do opencode em `~/.config/opencode/mimocode.jsonc`. Use a configuração global para preferências de todo o usuário, como provedores, modelos e permissões.
 
 Para configurações específicas do TUI, use `~/.config/opencode/tui.json`.
 
@@ -106,7 +106,7 @@ A configuração global substitui os padrões organizacionais remotos.
 
 ### Por projeto
 
-Adicione `opencode.json` na raiz do seu projeto. A configuração do projeto tem a maior precedência entre os arquivos de configuração padrão - ela substitui tanto as configurações globais quanto as remotas.
+Adicione `mimocode.jsonc` na raiz do seu projeto. A configuração do projeto tem a maior precedência entre os arquivos de configuração padrão - ela substitui tanto as configurações globais quanto as remotas.
 
 Para configurações específicas do TUI do projeto, adicione `tui.json` junto a ele.
 
@@ -122,10 +122,10 @@ Isso também é seguro para ser verificado no Git e usa o mesmo esquema que o gl
 
 ### Caminho personalizado
 
-Especifique um caminho de arquivo de configuração personalizado usando a variável de ambiente `OPENCODE_CONFIG`.
+Especifique um caminho de arquivo de configuração personalizado usando a variável de ambiente `MIMOCODE_CONFIG`.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -135,10 +135,10 @@ A configuração personalizada é carregada entre as configurações globais e d
 
 ### Diretório personalizado
 
-Especifique um diretório de configuração personalizado usando a variável de ambiente `OPENCODE_CONFIG_DIR`. Este diretório será pesquisado por agentes, comandos, modos e plugins, assim como o diretório padrão `.opencode`, e deve seguir a mesma estrutura.
+Especifique um diretório de configuração personalizado usando a variável de ambiente `MIMOCODE_CONFIG_DIR`. Este diretório será pesquisado por agentes, comandos, modos e plugins, assim como o diretório padrão `.opencode`, e deve seguir a mesma estrutura.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -148,9 +148,9 @@ O diretório personalizado é carregado após a configuração global e os diret
 
 ## Esquema
 
-O esquema de configuração do servidor/tempo de execução é definido em [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+O esquema de configuração do servidor/tempo de execução é definido em [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
-A configuração do TUI usa [**`opencode.ai/tui.json`**](https://opencode.ai/tui.json).
+A configuração do TUI usa [**`mimocode.ai/tui.json`**](https://mimocode.ai/tui.json).
 
 Seu editor deve ser capaz de validar e autocompletar com base no esquema.
 
@@ -162,7 +162,7 @@ Use um arquivo `tui.json` (ou `tui.jsonc`) dedicado para configurações especí
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "scroll_speed": 3,
   "scroll_acceleration": {
     "enabled": true
@@ -171,9 +171,9 @@ Use um arquivo `tui.json` (ou `tui.jsonc`) dedicado para configurações especí
 }
 ```
 
-Use `OPENCODE_TUI_CONFIG` para apontar para um arquivo de configuração TUI personalizado.
+Use `MIMOCODE_TUI_CONFIG` para apontar para um arquivo de configuração TUI personalizado.
 
-Chaves legadas `theme`, `keybinds` e `tui` em `opencode.json` estão obsoletas e são migradas automaticamente quando possível.
+Chaves legadas `theme`, `keybinds` e `tui` em `mimocode.jsonc` estão obsoletas e são migradas automaticamente quando possível.
 
 [Saiba mais sobre a configuração do TUI aqui](/docs/tui#configure).
 
@@ -183,9 +183,9 @@ Chaves legadas `theme`, `keybinds` e `tui` em `opencode.json` estão obsoletas e
 
 Você pode configurar as configurações do servidor para os comandos `opencode serve` e `opencode web` através da opção `server`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -212,9 +212,9 @@ Opções disponíveis:
 
 Você pode gerenciar as ferramentas que um LLM pode usar através da opção `tools`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -230,9 +230,9 @@ Você pode gerenciar as ferramentas que um LLM pode usar através da opção `to
 
 Você pode configurar os provedores e modelos que deseja usar em sua configuração do opencode através das opções `provider`, `model` e `small_model`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -243,9 +243,9 @@ A opção `small_model` configura um modelo separado para tarefas leves, como ge
 
 As opções do provedor podem incluir `timeout` e `setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -272,9 +272,9 @@ Alguns provedores suportam opções de configuração adicionais além das confi
 
 Amazon Bedrock suporta configuração específica da AWS:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -305,7 +305,7 @@ Defina seu tema de interface em `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -318,9 +318,9 @@ Defina seu tema de interface em `tui.json`.
 
 Você pode configurar agentes especializados para tarefas específicas através da opção `agent`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Revisa código para melhores práticas e potenciais problemas",
@@ -336,7 +336,7 @@ Você pode configurar agentes especializados para tarefas específicas através 
 }
 ```
 
-Você também pode definir agentes usando arquivos markdown em `~/.config/opencode/agents/` ou `.opencode/agents/`. [Saiba mais aqui](/docs/agents).
+Você também pode definir agentes usando arquivos markdown em `~/.config/opencode/agents/` ou `.mimocode/agents/`. [Saiba mais aqui](/docs/agents).
 
 ---
 
@@ -344,9 +344,9 @@ Você também pode definir agentes usando arquivos markdown em `~/.config/openco
 
 Você pode definir o agente padrão usando a opção `default_agent`. Isso determina qual agente é usado quando nenhum é explicitamente especificado.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -361,9 +361,9 @@ Essa configuração se aplica a todas as interfaces: TUI, CLI (`opencode run`), 
 
 Você pode configurar o recurso [share](/docs/share) através da opção `share`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -382,9 +382,9 @@ Por padrão, o compartilhamento é definido para o modo manual, onde você preci
 
 Você pode configurar comandos personalizados para tarefas repetitivas através da opção `command`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Execute a suíte de testes completa com relatório de cobertura e mostre quaisquer falhas.\nConcentre-se nos testes com falha e sugira correções.",
@@ -400,7 +400,7 @@ Você pode configurar comandos personalizados para tarefas repetitivas através 
 }
 ```
 
-Você também pode definir comandos usando arquivos markdown em `~/.config/opencode/commands/` ou `.opencode/commands/`. [Saiba mais aqui](/docs/commands).
+Você também pode definir comandos usando arquivos markdown em `~/.config/opencode/commands/` ou `.mimocode/commands/`. [Saiba mais aqui](/docs/commands).
 
 ---
 
@@ -410,7 +410,7 @@ Personalize atalhos de teclado em `tui.json`.
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -423,9 +423,9 @@ Personalize atalhos de teclado em `tui.json`.
 
 O opencode fará o download automaticamente de quaisquer novas atualizações quando for iniciado. Você pode desabilitar isso com a opção `autoupdate`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -439,9 +439,9 @@ Observe que isso só funciona se não foi instalado usando um gerenciador de pac
 
 Você pode configurar formatadores de código através da opção `formatter`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -467,9 +467,9 @@ Por padrão, o opencode **permite todas as operações** sem exigir aprovação 
 
 Por exemplo, para garantir que as ferramentas `edit` e `bash` exijam aprovação do usuário:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -485,9 +485,9 @@ Por exemplo, para garantir que as ferramentas `edit` e `bash` exijam aprovação
 
 Você pode controlar o comportamento de compactação de contexto através da opção `compaction`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -506,9 +506,9 @@ Você pode controlar o comportamento de compactação de contexto através da op
 
 Você pode configurar padrões de ignorar do observador de arquivos através da opção `watcher`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -523,9 +523,9 @@ Os padrões seguem a sintaxe glob. Use isso para excluir diretórios barulhentos
 
 Você pode configurar servidores MCP que deseja usar através da opção `mcp`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -538,11 +538,11 @@ Você pode configurar servidores MCP que deseja usar através da opção `mcp`.
 
 [Plugins](/docs/plugins) estendem o opencode com ferramentas, hooks e integrações personalizadas.
 
-Coloque arquivos de plugin em `.opencode/plugins/` ou `~/.config/opencode/plugins/`. Você também pode carregar plugins do npm através da opção `plugin`.
+Coloque arquivos de plugin em `.mimocode/plugins/` ou `~/.config/opencode/plugins/`. Você também pode carregar plugins do npm através da opção `plugin`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -555,9 +555,9 @@ Coloque arquivos de plugin em `.opencode/plugins/` ou `~/.config/opencode/plugin
 
 Você pode configurar as instruções para o modelo que está usando através da opção `instructions`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -570,9 +570,9 @@ Isso aceita um array de caminhos e padrões glob para arquivos de instrução. [
 
 Você pode desabilitar provedores que são carregados automaticamente através da opção `disabled_providers`. Isso é útil quando você deseja impedir que certos provedores sejam carregados, mesmo que suas credenciais estejam disponíveis.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -593,9 +593,9 @@ A opção `disabled_providers` aceita um array de IDs de provedores. Quando um p
 
 Você pode especificar uma lista de permissão de provedores através da opção `enabled_providers`. Quando definida, apenas os provedores especificados serão habilitados e todos os outros serão ignorados.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -614,9 +614,9 @@ Se um provedor aparecer em `enabled_providers` e `disabled_providers`, a `disabl
 
 A chave `experimental` contém opções que estão em desenvolvimento ativo.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -637,10 +637,10 @@ Você pode usar substituição de variáveis em seus arquivos de configuração 
 
 Use `{env:VARIABLE_NAME}` para substituir variáveis de ambiente:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -660,9 +660,9 @@ Se a variável de ambiente não estiver definida, ela será substituída por uma
 
 Use `{file:path/to/file}` para substituir o conteúdo de um arquivo:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/pt-br/plugins.mdx
+++ b/packages/web/src/content/docs/pt-br/plugins.mdx
@@ -19,7 +19,7 @@ Existem duas maneiras de carregar plugins.
 
 Coloque arquivos JavaScript ou TypeScript no diretório de plugins.
 
-- `.opencode/plugins/` - Plugins em nível de projeto
+- `.mimocode/plugins/` - Plugins em nível de projeto
 - `~/.config/opencode/plugins/` - Plugins globais
 
 Os arquivos nesses diretórios são carregados automaticamente na inicialização.
@@ -30,9 +30,9 @@ Os arquivos nesses diretórios são carregados automaticamente na inicializaçã
 
 Especifique pacotes npm no seu arquivo de configuração.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ Navegue pelos plugins disponíveis no [ecossistema](/docs/ecosystem#plugins).
 
 Os plugins são carregados de todas as fontes e todos os hooks são executados em sequência. A ordem de carregamento é:
 
-1. Configuração global (`~/.config/opencode/opencode.json`)
-2. Configuração do projeto (`opencode.json`)
+1. Configuração global (`~/.config/opencode/mimocode.jsonc`)
+2. Configuração do projeto (`mimocode.jsonc`)
 3. Diretório de plugins global (`~/.config/opencode/plugins/`)
-4. Diretório de plugins do projeto (`.opencode/plugins/`)
+4. Diretório de plugins do projeto (`.mimocode/plugins/`)
 
 Pacotes npm duplicados com o mesmo nome e versão são carregados uma vez. No entanto, um plugin local e um plugin npm com nomes semelhantes são carregados separadamente.
 
@@ -74,7 +74,7 @@ Um plugin é um **módulo JavaScript/TypeScript** que exporta uma ou mais funç�
 
 Plugins locais e ferramentas personalizadas podem usar pacotes npm externos. Adicione um `package.json` ao seu diretório de configuração com as dependências necessárias.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -84,7 +84,7 @@ Plugins locais e ferramentas personalizadas podem usar pacotes npm externos. Adi
 
 O opencode executa `bun install` na inicialização para instalar esses pacotes. Seus plugins e ferramentas podem então importá-los.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -102,7 +102,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Estrutura básica
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -217,7 +217,7 @@ Aqui estão alguns exemplos de plugins que você pode usar para estender o openc
 
 Envie notificações quando certos eventos ocorrerem:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -242,7 +242,7 @@ Se você estiver usando o aplicativo desktop opencode, ele pode enviar notifica�
 
 Impeça o opencode de ler arquivos `.env`:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -260,7 +260,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Injete variáveis de ambiente em todas as execuções de shell (ferramentas de AI e terminais de usuário):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -277,7 +277,7 @@ export const InjectEnvPlugin = async () => {
 
 Plugins também podem adicionar ferramentas personalizadas ao opencode:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -316,7 +316,7 @@ Se uma ferramenta de plugin usar o mesmo nome que uma ferramenta integrada, a fe
 
 Use `client.app.log()` em vez de `console.log` para registro estruturado:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -329,7 +329,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Níveis: `debug`, `info`, `warn`, `error`. Veja a [documentação do SDK](https://opencode.ai/docs/sdk) para detalhes.
+Níveis: `debug`, `info`, `warn`, `error`. Veja a [documentação do SDK](https://mimocode.ai/docs/sdk) para detalhes.
 
 ---
 
@@ -337,7 +337,7 @@ Níveis: `debug`, `info`, `warn`, `error`. Veja a [documentação do SDK](https:
 
 Personalize o contexto incluído quando uma sessão é compactada:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -361,7 +361,7 @@ O hook `experimental.session.compacting` é acionado antes que o LLM gere um res
 
 Você também pode substituir o prompt de compactação completamente definindo `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/ru/cli.mdx
+++ b/packages/web/src/content/docs/ru/cli.mdx
@@ -360,7 +360,7 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 opencode serve
 ```
 
-При этом запускается HTTP-сервер, который обеспечивает доступ API к функциям opencode без интерфейса TUI. Установите `OPENCODE_SERVER_PASSWORD`, чтобы включить базовую аутентификацию HTTP (имя пользователя по умолчанию — `opencode`).
+При этом запускается HTTP-сервер, который обеспечивает доступ API к функциям opencode без интерфейса TUI. Установите `MIMOCODE_SERVER_PASSWORD`, чтобы включить базовую аутентификацию HTTP (имя пользователя по умолчанию — `opencode`).
 
 #### Флаги
 
@@ -456,7 +456,7 @@ opencode import https://opncd.ai/s/abc123
 opencode web
 ```
 
-При этом запускается HTTP-сервер и открывается веб-браузер для доступа к opencode через веб-интерфейс. Установите `OPENCODE_SERVER_PASSWORD`, чтобы включить базовую аутентификацию HTTP (имя пользователя по умолчанию — `opencode`).
+При этом запускается HTTP-сервер и открывается веб-браузер для доступа к opencode через веб-интерфейс. Установите `MIMOCODE_SERVER_PASSWORD`, чтобы включить базовую аутентификацию HTTP (имя пользователя по умолчанию — `opencode`).
 
 #### Флаги
 
@@ -555,30 +555,30 @@ opencode можно настроить с помощью переменных с
 
 | Переменная                            | Тип                 | Описание                                                                         |
 | ------------------------------------- | ------------------- | -------------------------------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | логическое значение | Автоматически делиться сеансами                                                  |
-| `OPENCODE_GIT_BASH_PATH`              | строка              | Путь к исполняемому файлу Git Bash в Windows                                     |
-| `OPENCODE_CONFIG`                     | строка              | Путь к файлу конфигурации                                                        |
-| `OPENCODE_TUI_CONFIG`                 | строка              | Путь к файлу конфигурации TUI                                                    |
-| `OPENCODE_CONFIG_DIR`                 | строка              | Путь к каталогу конфигурации                                                     |
-| `OPENCODE_CONFIG_CONTENT`             | строка              | Встроенное содержимое конфигурации json                                          |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | логическое значение | Отключить автоматическую проверку обновлений                                     |
-| `OPENCODE_DISABLE_PRUNE`              | логическое значение | Отключить удаление старых данных                                                 |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | логическое значение | Отключить автоматическое обновление заголовка терминала                          |
-| `OPENCODE_PERMISSION`                 | строка              | Встроенная конфигурация разрешений json                                          |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | логическое значение | Отключить плагины по умолчанию                                                   |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | логическое значение | Отключить автоматическую загрузку LSP-сервера                                    |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | логическое значение | Включить экспериментальные модели                                                |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | логическое значение | Отключить автоматическое сжатие контекста                                        |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | логическое значение | Отключить чтение из `.claude` (подсказка + навыки)                               |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | логическое значение | Отключить чтение `~/.claude/CLAUDE.md`                                           |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | логическое значение | Отключить загрузку `.claude/skills`                                              |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | логическое значение | Отключить получение моделей из удаленных источников                              |
-| `OPENCODE_FAKE_VCS`                   | строка              | Поддельный поставщик VCS для целей тестирования                                  |
-| `OPENCODE_CLIENT`                     | строка              | Идентификатор клиента (по умолчанию `cli`)                                       |
-| `OPENCODE_ENABLE_EXA`                 | логическое значение | Включить инструменты веб-поиска Exa                                              |
-| `OPENCODE_SERVER_PASSWORD`            | строка              | Включить базовую аутентификацию для `serve`/`web`                                |
-| `OPENCODE_SERVER_USERNAME`            | строка              | Переопределить имя пользователя базовой аутентификации (по умолчанию `opencode`) |
-| `OPENCODE_MODELS_URL`                 | строка              | Пользовательский URL-адрес для получения конфигурации модели                     |
+| `MIMOCODE_AUTO_SHARE`                 | логическое значение | Автоматически делиться сеансами                                                  |
+| `MIMOCODE_GIT_BASH_PATH`              | строка              | Путь к исполняемому файлу Git Bash в Windows                                     |
+| `MIMOCODE_CONFIG`                     | строка              | Путь к файлу конфигурации                                                        |
+| `MIMOCODE_TUI_CONFIG`                 | строка              | Путь к файлу конфигурации TUI                                                    |
+| `MIMOCODE_CONFIG_DIR`                 | строка              | Путь к каталогу конфигурации                                                     |
+| `MIMOCODE_CONFIG_CONTENT`             | строка              | Встроенное содержимое конфигурации json                                          |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | логическое значение | Отключить автоматическую проверку обновлений                                     |
+| `MIMOCODE_DISABLE_PRUNE`              | логическое значение | Отключить удаление старых данных                                                 |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | логическое значение | Отключить автоматическое обновление заголовка терминала                          |
+| `MIMOCODE_PERMISSION`                 | строка              | Встроенная конфигурация разрешений json                                          |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | логическое значение | Отключить плагины по умолчанию                                                   |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | логическое значение | Отключить автоматическую загрузку LSP-сервера                                    |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | логическое значение | Включить экспериментальные модели                                                |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | логическое значение | Отключить автоматическое сжатие контекста                                        |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | логическое значение | Отключить чтение из `.claude` (подсказка + навыки)                               |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | логическое значение | Отключить чтение `~/.claude/CLAUDE.md`                                           |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | логическое значение | Отключить загрузку `.claude/skills`                                              |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | логическое значение | Отключить получение моделей из удаленных источников                              |
+| `MIMOCODE_FAKE_VCS`                   | строка              | Поддельный поставщик VCS для целей тестирования                                  |
+| `MIMOCODE_CLIENT`                     | строка              | Идентификатор клиента (по умолчанию `cli`)                                       |
+| `MIMOCODE_ENABLE_EXA`                 | логическое значение | Включить инструменты веб-поиска Exa                                              |
+| `MIMOCODE_SERVER_PASSWORD`            | строка              | Включить базовую аутентификацию для `serve`/`web`                                |
+| `MIMOCODE_SERVER_USERNAME`            | строка              | Переопределить имя пользователя базовой аутентификации (по умолчанию `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | строка              | Пользовательский URL-адрес для получения конфигурации модели                     |
 
 ---
 
@@ -588,16 +588,16 @@ opencode можно настроить с помощью переменных с
 
 | Переменная                                      | Тип                 | Описание                                               |
 | ----------------------------------------------- | ------------------- | ------------------------------------------------------ |
-| `OPENCODE_EXPERIMENTAL`                         | логическое значение | Включить все экспериментальные функции                 |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | логическое значение | Включить обнаружение значков                           |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | логическое значение | Отключить копирование при выборе в TUI                 |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | число               | Таймаут по умолчанию для команд bash в мс              |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | число               | Максимальное количество токенов вывода для ответов LLM |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | логическое значение | Включить просмотр файлов для всего каталога            |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | логическое значение | Включить форматтер oxfmt                               |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | логическое значение | Включить экспериментальный инструмент LSP              |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | логическое значение | Отключить просмотрщик файлов                           |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | логическое значение | Включить экспериментальные функции Exa                 |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | логическое значение | Включить TY LSP для файлов python                      |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | логическое значение | Включить экспериментальные функции Markdown            |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | логическое значение | Включить режим плана                                   |
+| `MIMOCODE_EXPERIMENTAL`                         | логическое значение | Включить все экспериментальные функции                 |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | логическое значение | Включить обнаружение значков                           |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | логическое значение | Отключить копирование при выборе в TUI                 |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | число               | Таймаут по умолчанию для команд bash в мс              |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | число               | Максимальное количество токенов вывода для ответов LLM |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | логическое значение | Включить просмотр файлов для всего каталога            |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | логическое значение | Включить форматтер oxfmt                               |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | логическое значение | Включить экспериментальный инструмент LSP              |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | логическое значение | Отключить просмотрщик файлов                           |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | логическое значение | Включить экспериментальные функции Exa                 |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | логическое значение | Включить TY LSP для файлов python                      |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | логическое значение | Включить экспериментальные функции Markdown            |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | логическое значение | Включить режим плана                                   |

--- a/packages/web/src/content/docs/ru/config.mdx
+++ b/packages/web/src/content/docs/ru/config.mdx
@@ -11,9 +11,9 @@ description: Использование конфигурации opencode JSON.
 
 opencode поддерживает форматы **JSON** и **JSONC** (JSON с комментариями).
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   // Theme configuration
   "theme": "opencode",
   "model": "anthropic/claude-sonnet-4-5",
@@ -43,11 +43,11 @@ opencode поддерживает форматы **JSON** и **JSONC** (JSON с 
 Источники конфигурации загружаются в следующем порядке (более поздние источники переопределяют более ранние):
 
 1. **Удаленная конфигурация** (от `.well-known/opencode`) – организационные настройки по умолчанию.
-2. **Глобальная конфигурация** (`~/.config/opencode/opencode.json`) — настройки пользователя.
-3. **Пользовательская конфигурация** (`OPENCODE_CONFIG` env var) – пользовательские переопределения
-4. **Конфигурация проекта** (`opencode.json` в проекте) — настройки, специфичные для проекта.
+2. **Глобальная конфигурация** (`~/.config/opencode/mimocode.jsonc`) — настройки пользователя.
+3. **Пользовательская конфигурация** (`MIMOCODE_CONFIG` env var) – пользовательские переопределения
+4. **Конфигурация проекта** (`mimocode.jsonc` в проекте) — настройки, специфичные для проекта.
 5. **Каталоги `.opencode`** — агенты, команды, плагины
-6. **Встроенная конфигурация** (`OPENCODE_CONFIG_CONTENT` env var) – переопределяет время выполнения
+6. **Встроенная конфигурация** (`MIMOCODE_CONFIG_CONTENT` env var) – переопределяет время выполнения
 
 Это означает, что конфигурации проекта могут переопределять глобальные настройки по умолчанию, а глобальные конфигурации могут переопределять настройки по умолчанию для удаленной организации.
 
@@ -79,7 +79,7 @@ opencode поддерживает форматы **JSON** и **JSONC** (JSON с 
 
 Вы можете включить определенные серверы в локальной конфигурации:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ opencode поддерживает форматы **JSON** и **JSONC** (JSON с 
 
 ### Глобальная
 
-Поместите глобальную конфигурацию opencode в `~/.config/opencode/opencode.json`. Используйте глобальную конфигурацию для общепользовательских настроек, таких как темы, поставщики или привязки клавиш.
+Поместите глобальную конфигурацию opencode в `~/.config/opencode/mimocode.jsonc`. Используйте глобальную конфигурацию для общепользовательских настроек, таких как темы, поставщики или привязки клавиш.
 
 Для настроек, специфичных для TUI, используйте `~/.config/opencode/tui.json`.
 
@@ -105,7 +105,7 @@ opencode поддерживает форматы **JSON** и **JSONC** (JSON с 
 
 ### Проектная
 
-Добавьте `opencode.json` в корень вашего проекта. Конфигурация проекта имеет наивысший приоритет среди стандартных файлов конфигурации — она переопределяет как глобальные, так и удаленные конфигурации.
+Добавьте `mimocode.jsonc` в корень вашего проекта. Конфигурация проекта имеет наивысший приоритет среди стандартных файлов конфигурации — она переопределяет как глобальные, так и удаленные конфигурации.
 
 Для настроек TUI, специфичных для проекта, добавьте `tui.json` рядом с ним.
 
@@ -121,10 +121,10 @@ opencode поддерживает форматы **JSON** и **JSONC** (JSON с 
 
 ### Пользовательский путь
 
-Укажите собственный путь к файлу конфигурации, используя переменную среды `OPENCODE_CONFIG`.
+Укажите собственный путь к файлу конфигурации, используя переменную среды `MIMOCODE_CONFIG`.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -134,10 +134,10 @@ opencode run "Hello world"
 
 ### Пользовательский каталог
 
-Укажите пользовательский каталог конфигурации, используя переменную среды `OPENCODE_CONFIG_DIR`. В этом каталоге будет выполняться поиск агентов, команд, режимов и плагинов (аналогично стандартному каталогу `.opencode`), и он должен иметь ту же структуру.
+Укажите пользовательский каталог конфигурации, используя переменную среды `MIMOCODE_CONFIG_DIR`. В этом каталоге будет выполняться поиск агентов, команд, режимов и плагинов (аналогично стандартному каталогу `.opencode`), и он должен иметь ту же структуру.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -147,9 +147,9 @@ opencode run "Hello world"
 
 ## Схема
 
-Файл конфигурации имеет схему, определенную в [**`opencode.ai/config.json`**](https://opencode.ai/config.json).
+Файл конфигурации имеет схему, определенную в [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json).
 
-Конфигурация TUI использует [**`opencode.ai/tui.json`**](https://opencode.ai/tui.json).
+Конфигурация TUI использует [**`mimocode.ai/tui.json`**](https://mimocode.ai/tui.json).
 
 Ваш редактор должен иметь возможность проверять и автозаполнять данные на основе схемы.
 
@@ -161,7 +161,7 @@ opencode run "Hello world"
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "scroll_speed": 3,
   "scroll_acceleration": {
     "enabled": true
@@ -170,9 +170,9 @@ opencode run "Hello world"
 }
 ```
 
-Используйте `OPENCODE_TUI_CONFIG`, чтобы указать на пользовательский файл конфигурации TUI.
+Используйте `MIMOCODE_TUI_CONFIG`, чтобы указать на пользовательский файл конфигурации TUI.
 
-Устаревшие ключи `theme`, `keybinds` и `tui` в `opencode.json` устарели и автоматически переносятся, когда это возможно.
+Устаревшие ключи `theme`, `keybinds` и `tui` в `mimocode.jsonc` устарели и автоматически переносятся, когда это возможно.
 
 [Подробнее об использовании TUI можно узнать здесь](/docs/tui#configure).
 
@@ -182,9 +182,9 @@ opencode run "Hello world"
 
 Вы можете настроить параметры сервера для команд `opencode serve` и `opencode web` с помощью опции `server`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -211,9 +211,9 @@ opencode run "Hello world"
 
 Вы можете управлять инструментами, которые LLM может использовать, с помощью опции `tools`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -229,9 +229,9 @@ opencode run "Hello world"
 
 Вы можете настроить поставщиков и модели, которые хотите использовать в своей конфигурации opencode, с помощью параметров `provider`, `model` и `small_model`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -242,9 +242,9 @@ opencode run "Hello world"
 
 Опции провайдера могут включать `timeout` и `setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -271,9 +271,9 @@ opencode run "Hello world"
 
 Amazon Bedrock поддерживает конфигурацию, специфичную для AWS:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -304,7 +304,7 @@ Amazon Bedrock поддерживает конфигурацию, специфи
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -317,9 +317,9 @@ Amazon Bedrock поддерживает конфигурацию, специфи
 
 Вы можете настроить специализированные агенты для конкретных задач с помощью опции `agent`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -335,7 +335,7 @@ Amazon Bedrock поддерживает конфигурацию, специфи
 }
 ```
 
-Вы также можете определить агентов, используя файлы Markdown в `~/.config/opencode/agents/` или `.opencode/agents/`. [Подробнее здесь](/docs/agents).
+Вы также можете определить агентов, используя файлы Markdown в `~/.config/opencode/agents/` или `.mimocode/agents/`. [Подробнее здесь](/docs/agents).
 
 ---
 
@@ -343,9 +343,9 @@ Amazon Bedrock поддерживает конфигурацию, специфи
 
 Вы можете установить агента по умолчанию, используя опцию `default_agent`. Это определяет, какой агент используется, если ни один из них не указан явно.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -360,9 +360,9 @@ Amazon Bedrock поддерживает конфигурацию, специфи
 
 Функцию [share](/docs/share) можно настроить с помощью опции `share`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -381,9 +381,9 @@ Amazon Bedrock поддерживает конфигурацию, специфи
 
 Вы можете настроить собственные команды для повторяющихся задач с помощью опции `command`.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -399,7 +399,7 @@ Amazon Bedrock поддерживает конфигурацию, специфи
 }
 ```
 
-Вы также можете определять команды, используя файлы Markdown в `~/.config/opencode/commands/` или `.opencode/commands/`. [Подробнее здесь](/docs/commands).
+Вы также можете определять команды, используя файлы Markdown в `~/.config/opencode/commands/` или `.mimocode/commands/`. [Подробнее здесь](/docs/commands).
 
 ---
 
@@ -409,7 +409,7 @@ Amazon Bedrock поддерживает конфигурацию, специфи
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -422,9 +422,9 @@ Amazon Bedrock поддерживает конфигурацию, специфи
 
 opencode автоматически загрузит все новые обновления при запуске. Вы можете отключить это с помощью опции `autoupdate`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -438,9 +438,9 @@ opencode автоматически загрузит все новые обно�
 
 Вы можете настроить форматировщики кода с помощью опции `formatter`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -466,9 +466,9 @@ opencode автоматически загрузит все новые обно�
 
 Например, чтобы гарантировать, что инструменты `edit` и `bash` требуют одобрения пользователя:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -484,9 +484,9 @@ opencode автоматически загрузит все новые обно�
 
 Вы можете управлять поведением сжатия контекста с помощью опции `compaction`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -505,9 +505,9 @@ opencode автоматически загрузит все новые обно�
 
 Вы можете настроить шаблоны игнорирования средства отслеживания файлов с помощью опции `watcher`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -522,9 +522,9 @@ opencode автоматически загрузит все новые обно�
 
 Вы можете настроить серверы MCP, которые хотите использовать, с помощью опции `mcp`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -537,11 +537,11 @@ opencode автоматически загрузит все новые обно�
 
 [Плагины](/docs/plugins) расширяют opencode с помощью пользовательских инструментов, перехватчиков и интеграций.
 
-Поместите файлы плагина в `.opencode/plugins/` или `~/.config/opencode/plugins/`. Вы также можете загружать плагины из npm с помощью опции `plugin`.
+Поместите файлы плагина в `.mimocode/plugins/` или `~/.config/opencode/plugins/`. Вы также можете загружать плагины из npm с помощью опции `plugin`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -554,9 +554,9 @@ opencode автоматически загрузит все новые обно�
 
 Вы можете настроить инструкции для используемой вами модели с помощью опции `instructions`.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -569,9 +569,9 @@ opencode автоматически загрузит все новые обно�
 
 Вы можете отключить поставщиков, которые загружаются автоматически, с помощью опции `disabled_providers`. Это полезно, если вы хотите запретить загрузку определенных поставщиков, даже если их учетные данные доступны.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -592,9 +592,9 @@ opencode автоматически загрузит все новые обно�
 
 Вы можете указать белый список поставщиков с помощью опции `enabled_providers`. Если этот параметр установлен, будут включены только указанные поставщики, а все остальные будут игнорироваться.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -613,9 +613,9 @@ opencode автоматически загрузит все новые обно�
 
 Ключ `experimental` содержит параметры, находящиеся в активной разработке.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -636,10 +636,10 @@ opencode автоматически загрузит все новые обно�
 
 Используйте `{env:VARIABLE_NAME}` для замены переменных среды:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -659,9 +659,9 @@ opencode автоматически загрузит все новые обно�
 
 Используйте `{file:path/to/file}` для замены содержимого файла:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/ru/plugins.mdx
+++ b/packages/web/src/content/docs/ru/plugins.mdx
@@ -19,7 +19,7 @@ description: Напишите свои собственные плагины д�
 
 Поместите файлы JavaScript или TypeScript в каталог плагина.
 
-- `.opencode/plugins/` – плагины уровня проекта.
+- `.mimocode/plugins/` – плагины уровня проекта.
 - `~/.config/opencode/plugins/` — глобальные плагины
 
 Файлы в этих каталогах автоматически загружаются при запуске.
@@ -30,9 +30,9 @@ description: Напишите свои собственные плагины д�
 
 Укажите пакеты npm в файле конфигурации.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ description: Напишите свои собственные плагины д�
 
 Плагины загружаются из всех источников, и все хуки запускаются последовательно. Порядок загрузки следующий:
 
-1. Глобальная конфигурация (`~/.config/opencode/opencode.json`)
-2. Конфигурация проекта (`opencode.json`)
+1. Глобальная конфигурация (`~/.config/opencode/mimocode.jsonc`)
+2. Конфигурация проекта (`mimocode.jsonc`)
 3. Глобальный каталог плагинов (`~/.config/opencode/plugins/`)
-4. Каталог плагинов проекта (`.opencode/plugins/`)
+4. Каталог плагинов проекта (`.mimocode/plugins/`)
 
 Дубликаты пакетов npm с тем же именем и версией загружаются один раз. Однако локальный плагин и плагин npm со схожими именами загружаются отдельно.
 
@@ -75,7 +75,7 @@ description: Напишите свои собственные плагины д�
 
 Локальные плагины и специальные инструменты могут использовать внешние пакеты npm. Добавьте `package.json` в каталог конфигурации с необходимыми вам зависимостями.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -85,7 +85,7 @@ description: Напишите свои собственные плагины д�
 
 opencode запускает `bun install` при запуске для их установки. Затем ваши плагины и инструменты смогут импортировать их.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -103,7 +103,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Базовая структура
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -218,7 +218,7 @@ export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree
 
 Отправляйте уведомления при возникновении определенных событий:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -243,7 +243,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
 
 Запретите открытому коду читать файлы `.env`:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -261,7 +261,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Внедряйте переменные среды во все shell-процессы выполнения (инструменты искусственного интеллекта и пользовательские terminal):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -278,7 +278,7 @@ export const InjectEnvPlugin = async () => {
 
 Плагины также могут добавлять в opencode собственные инструменты:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -313,7 +313,7 @@ export const CustomToolsPlugin: Plugin = async (ctx) => {
 
 Используйте `client.app.log()` вместо `console.log` для структурированного ведения журнала:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -326,7 +326,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Уровни: `debug`, `info`, `warn`, `error`. Подробности см. в документации SDK](https://opencode.ai/docs/sdk).
+Уровни: `debug`, `info`, `warn`, `error`. Подробности см. в документации SDK](https://mimocode.ai/docs/sdk).
 
 ---
 
@@ -334,7 +334,7 @@ export const MyPlugin = async ({ client }) => {
 
 Настройте контекст, включаемый при сжатии сеанса:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -358,7 +358,7 @@ Include any state that should persist across compaction:
 
 Вы также можете полностью заменить запрос на уплотнение, установив `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/th/cli.mdx
+++ b/packages/web/src/content/docs/th/cli.mdx
@@ -361,7 +361,7 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 opencode serve
 ```
 
-คำสั่งนี้จะเริ่มต้นเซิร์ฟเวอร์ HTTP ให้ API เข้าถึงฟังก์ชันการทำงานของ OpenCode ได้โดยไม่ต้องมี TUI นอกจากนี้ยังรองรับการตรวจสอบสิทธิ์พื้นฐาน HTTP (ชื่อผู้ใช้เริ่มต้นคือ `opencode` และรหัสผ่านระบุโดย `OPENCODE_SERVER_PASSWORD`)
+คำสั่งนี้จะเริ่มต้นเซิร์ฟเวอร์ HTTP ให้ API เข้าถึงฟังก์ชันการทำงานของ OpenCode ได้โดยไม่ต้องมี TUI นอกจากนี้ยังรองรับการตรวจสอบสิทธิ์พื้นฐาน HTTP (ชื่อผู้ใช้เริ่มต้นคือ `opencode` และรหัสผ่านระบุโดย `MIMOCODE_SERVER_PASSWORD`)
 
 #### แฟล็ก
 
@@ -457,7 +457,7 @@ opencode import https://opncd.ai/s/abc123
 opencode web
 ```
 
-คำสั่งนี้จะเริ่มต้นเซิร์ฟเวอร์ HTTP และเปิดเว็บเบราว์เซอร์เพื่อเข้าถึง OpenCode ผ่านทางเว็บอินเตอร์เฟส รองรับการตรวจสอบสิทธิ์พื้นฐาน HTTP (ชื่อผู้ใช้เริ่มต้นคือ `opencode` และรหัสผ่านระบุโดย `OPENCODE_SERVER_PASSWORD`)
+คำสั่งนี้จะเริ่มต้นเซิร์ฟเวอร์ HTTP และเปิดเว็บเบราว์เซอร์เพื่อเข้าถึง OpenCode ผ่านทางเว็บอินเตอร์เฟส รองรับการตรวจสอบสิทธิ์พื้นฐาน HTTP (ชื่อผู้ใช้เริ่มต้นคือ `opencode` และรหัสผ่านระบุโดย `MIMOCODE_SERVER_PASSWORD`)
 
 #### แฟล็ก
 
@@ -556,30 +556,30 @@ OpenCode สามารถกำหนดค่าโดยใช้ตัว�
 
 | ตัวแปร                                | ชนิด    | คำอธิบาย                                                         |
 | ------------------------------------- | ------- | ---------------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | Boolean | แชร์เซสชันอัตโนมัติเมื่อสร้าง                                    |
-| `OPENCODE_GIT_BASH_PATH`              | String  | เส้นทางไปยัง Git Bash บน Windows                                 |
-| `OPENCODE_CONFIG`                     | String  | เส้นทางไปยังไฟล์การกำหนดค่า                                      |
-| `OPENCODE_TUI_CONFIG`                 | String  | เส้นทางไปยังไฟล์การกำหนดค่า TUI                                  |
-| `OPENCODE_CONFIG_DIR`                 | String  | เส้นทางไปยังไดเร็กทอรีการกำหนดค่า                                |
-| `OPENCODE_CONFIG_CONTENT`             | String  | เนื้อหาการกำหนดค่าแบบ inline JSON                                |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | Boolean | ปิดใช้งานการอัปเดตอัตโนมัติ                                      |
-| `OPENCODE_DISABLE_PRUNE`              | Boolean | ปิดใช้งานการลบข้อมูลเซสชันเก่า                                   |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | Boolean | ปิดใช้งานการตั้งชื่อหน้าต่าง terminal                            |
-| `OPENCODE_PERMISSION`                 | String  | การกำหนดค่าสิทธิ์แบบ inline JSON                                 |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | Boolean | ปิดใช้งานปลั๊กอินเริ่มต้น                                        |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | Boolean | ปิดใช้งานการดาวน์โหลด LSP อัตโนมัติ                              |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | Boolean | เปิดใช้งานโมเดลทดลอง                                             |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | Boolean | ปิดใช้งานการบีบอัดบริบทอัตโนมัติ                                 |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | Boolean | ปิดใช้งานการนำเข้าจาก `.claude` (prompt + skills)                |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | Boolean | ปิดใช้งานการนำเข้า `~/.claude/CLAUDE.md`                         |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | Boolean | ปิดใช้งานการนำเข้า `.claude/skills`                              |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | Boolean | ปิดใช้งานการดึงรายการโมเดลจากระยะไกล                             |
-| `OPENCODE_FAKE_VCS`                   | String  | เปิดใช้งาน VCS จำลองสำหรับการทดสอบ                               |
-| `OPENCODE_CLIENT`                     | String  | ตัวระบุไคลเอนต์ (ค่าเริ่มต้นคือ `cli`)                           |
-| `OPENCODE_ENABLE_EXA`                 | Boolean | เปิดใช้งานการใช้ Exa แทน ls หากมี                                |
-| `OPENCODE_SERVER_PASSWORD`            | String  | รหัสผ่านสำหรับการตรวจสอบสิทธิ์พื้นฐาน `serve`/`web`              |
-| `OPENCODE_SERVER_USERNAME`            | String  | ชื่อผู้ใช้สำหรับการตรวจสอบสิทธิ์พื้นฐาน (ค่าเริ่มต้น `opencode`) |
-| `OPENCODE_MODELS_URL`                 | String  | URL ที่กำหนดเองสำหรับการดึงรายการโมเดล                           |
+| `MIMOCODE_AUTO_SHARE`                 | Boolean | แชร์เซสชันอัตโนมัติเมื่อสร้าง                                    |
+| `MIMOCODE_GIT_BASH_PATH`              | String  | เส้นทางไปยัง Git Bash บน Windows                                 |
+| `MIMOCODE_CONFIG`                     | String  | เส้นทางไปยังไฟล์การกำหนดค่า                                      |
+| `MIMOCODE_TUI_CONFIG`                 | String  | เส้นทางไปยังไฟล์การกำหนดค่า TUI                                  |
+| `MIMOCODE_CONFIG_DIR`                 | String  | เส้นทางไปยังไดเร็กทอรีการกำหนดค่า                                |
+| `MIMOCODE_CONFIG_CONTENT`             | String  | เนื้อหาการกำหนดค่าแบบ inline JSON                                |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | Boolean | ปิดใช้งานการอัปเดตอัตโนมัติ                                      |
+| `MIMOCODE_DISABLE_PRUNE`              | Boolean | ปิดใช้งานการลบข้อมูลเซสชันเก่า                                   |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | Boolean | ปิดใช้งานการตั้งชื่อหน้าต่าง terminal                            |
+| `MIMOCODE_PERMISSION`                 | String  | การกำหนดค่าสิทธิ์แบบ inline JSON                                 |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | Boolean | ปิดใช้งานปลั๊กอินเริ่มต้น                                        |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | Boolean | ปิดใช้งานการดาวน์โหลด LSP อัตโนมัติ                              |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | Boolean | เปิดใช้งานโมเดลทดลอง                                             |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | Boolean | ปิดใช้งานการบีบอัดบริบทอัตโนมัติ                                 |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | Boolean | ปิดใช้งานการนำเข้าจาก `.claude` (prompt + skills)                |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | Boolean | ปิดใช้งานการนำเข้า `~/.claude/CLAUDE.md`                         |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | Boolean | ปิดใช้งานการนำเข้า `.claude/skills`                              |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | Boolean | ปิดใช้งานการดึงรายการโมเดลจากระยะไกล                             |
+| `MIMOCODE_FAKE_VCS`                   | String  | เปิดใช้งาน VCS จำลองสำหรับการทดสอบ                               |
+| `MIMOCODE_CLIENT`                     | String  | ตัวระบุไคลเอนต์ (ค่าเริ่มต้นคือ `cli`)                           |
+| `MIMOCODE_ENABLE_EXA`                 | Boolean | เปิดใช้งานการใช้ Exa แทน ls หากมี                                |
+| `MIMOCODE_SERVER_PASSWORD`            | String  | รหัสผ่านสำหรับการตรวจสอบสิทธิ์พื้นฐาน `serve`/`web`              |
+| `MIMOCODE_SERVER_USERNAME`            | String  | ชื่อผู้ใช้สำหรับการตรวจสอบสิทธิ์พื้นฐาน (ค่าเริ่มต้น `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | String  | URL ที่กำหนดเองสำหรับการดึงรายการโมเดล                           |
 
 ---
 
@@ -589,16 +589,16 @@ OpenCode สามารถกำหนดค่าโดยใช้ตัว�
 
 | ตัวแปร                                          | ชนิด    | คำอธิบาย                                       |
 | ----------------------------------------------- | ------- | ---------------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | Boolean | เปิดใช้งานฟีเจอร์ทดลองทั้งหมด                  |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | Boolean | การค้นหาไอคอนทดลอง                             |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | Boolean | ปิดใช้งานการคัดลอกเมื่อเลือกใน TUI             |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | Number  | การหมดเวลาเริ่มต้นสำหรับคำสั่ง bash ในหน่วย ms |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | Number  | ขีดจำกัดสูงสุดสำหรับโทเค็นเอาต์พุต LLM         |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | Boolean | เปิดใช้งานตัวเฝ้าดูไฟล์สำหรับไดเร็กทอรีทั้งหมด |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | Boolean | ใช้ oxfmt เป็นตัวจัดรูปแบบ                     |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | Boolean | เปิดใช้งานเครื่องมือ LSP ทดลอง                 |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | Boolean | ปิดใช้งานตัวเฝ้าดูไฟล์                         |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | Boolean | ฟีเจอร์ Exa ทดลอง                              |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | Boolean | เปิดใช้งาน TY LSP สำหรับไฟล์ python            |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | Boolean | ใช้ Markdown renderer แบบทดลอง                 |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | Boolean | เปิดใช้งาน Plan mode                           |
+| `MIMOCODE_EXPERIMENTAL`                         | Boolean | เปิดใช้งานฟีเจอร์ทดลองทั้งหมด                  |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | Boolean | การค้นหาไอคอนทดลอง                             |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | Boolean | ปิดใช้งานการคัดลอกเมื่อเลือกใน TUI             |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | Number  | การหมดเวลาเริ่มต้นสำหรับคำสั่ง bash ในหน่วย ms |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | Number  | ขีดจำกัดสูงสุดสำหรับโทเค็นเอาต์พุต LLM         |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | Boolean | เปิดใช้งานตัวเฝ้าดูไฟล์สำหรับไดเร็กทอรีทั้งหมด |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | Boolean | ใช้ oxfmt เป็นตัวจัดรูปแบบ                     |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | Boolean | เปิดใช้งานเครื่องมือ LSP ทดลอง                 |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | Boolean | ปิดใช้งานตัวเฝ้าดูไฟล์                         |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | Boolean | ฟีเจอร์ Exa ทดลอง                              |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | Boolean | เปิดใช้งาน TY LSP สำหรับไฟล์ python            |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | Boolean | ใช้ Markdown renderer แบบทดลอง                 |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | Boolean | เปิดใช้งาน Plan mode                           |

--- a/packages/web/src/content/docs/th/config.mdx
+++ b/packages/web/src/content/docs/th/config.mdx
@@ -11,9 +11,9 @@ description: การใช้การกำหนดค่า OpenCode JSON
 
 OpenCode รองรับทั้งรูปแบบ **JSON** และ **JSONC** (JSON พร้อมความคิดเห็น)
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -44,11 +44,11 @@ OpenCode รองรับทั้งรูปแบบ **JSON** และ **J
 แหล่งที่มาของการกำหนดค่าถูกโหลดตามลำดับนี้ (แหล่งที่มาภายหลังจะแทนที่แหล่งที่มาก่อนหน้า):
 
 1. **การกำหนดค่าระยะไกล** (จาก `.well-known/opencode`) - ค่าเริ่มต้นขององค์กร
-2. **การกำหนดค่าสากล** (`~/.config/opencode/opencode.json`) - การตั้งค่าของผู้ใช้
-3. **การกำหนดค่าแบบกำหนดเอง** (`OPENCODE_CONFIG` env var) - การแทนที่แบบกำหนดเอง
-4. **การกำหนดค่าโครงการ** (`opencode.json` ในโครงการ) - การตั้งค่าเฉพาะโครงการ
+2. **การกำหนดค่าสากล** (`~/.config/opencode/mimocode.jsonc`) - การตั้งค่าของผู้ใช้
+3. **การกำหนดค่าแบบกำหนดเอง** (`MIMOCODE_CONFIG` env var) - การแทนที่แบบกำหนดเอง
+4. **การกำหนดค่าโครงการ** (`mimocode.jsonc` ในโครงการ) - การตั้งค่าเฉพาะโครงการ
 5. **`.opencode` ไดเรกทอรี** - ตัวแทน คำสั่ง ปลั๊กอิน
-6. **การกำหนดค่าแบบอินไลน์** (`OPENCODE_CONFIG_CONTENT` env var) - การแทนที่รันไทม์
+6. **การกำหนดค่าแบบอินไลน์** (`MIMOCODE_CONFIG_CONTENT` env var) - การแทนที่รันไทม์
 
 ซึ่งหมายความว่าการกำหนดค่าโปรเจ็กต์สามารถแทนที่ค่าเริ่มต้นส่วนกลางได้ และการกำหนดค่าส่วนกลางสามารถแทนที่ค่าเริ่มต้นขององค์กรระยะไกลได้
 
@@ -80,7 +80,7 @@ OpenCode รองรับทั้งรูปแบบ **JSON** และ **J
 
 คุณสามารถเปิดใช้งานเซิร์ฟเวอร์เฉพาะในการกำหนดค่าภายในเครื่องของคุณได้:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -96,7 +96,7 @@ OpenCode รองรับทั้งรูปแบบ **JSON** และ **J
 
 ### ทั่วโลก
 
-วางการกำหนดค่า OpenCode ส่วนกลางของคุณใน `~/.config/opencode/opencode.json` ใช้การกำหนดค่าส่วนกลางสำหรับการตั้งค่าทั้งผู้ใช้ เช่น ผู้ให้บริการ รุ่น และสิทธิ์
+วางการกำหนดค่า OpenCode ส่วนกลางของคุณใน `~/.config/opencode/mimocode.jsonc` ใช้การกำหนดค่าส่วนกลางสำหรับการตั้งค่าทั้งผู้ใช้ เช่น ผู้ให้บริการ รุ่น และสิทธิ์
 
 สำหรับการตั้งค่าเฉพาะ TUI ให้ใช้ `~/.config/opencode/tui.json`
 
@@ -106,7 +106,7 @@ OpenCode รองรับทั้งรูปแบบ **JSON** และ **J
 
 ### ต่อโครงการ
 
-เพิ่ม `opencode.json` ในรูทโปรเจ็กต์ของคุณ การกำหนดค่าโปรเจ็กต์มีความสำคัญสูงสุดในบรรดาไฟล์กำหนดค่ามาตรฐาน โดยจะแทนที่การกำหนดค่าทั้งส่วนกลางและระยะไกล
+เพิ่ม `mimocode.jsonc` ในรูทโปรเจ็กต์ของคุณ การกำหนดค่าโปรเจ็กต์มีความสำคัญสูงสุดในบรรดาไฟล์กำหนดค่ามาตรฐาน โดยจะแทนที่การกำหนดค่าทั้งส่วนกลางและระยะไกล
 
 สำหรับการตั้งค่า TUI เฉพาะโครงการ ให้เพิ่ม `tui.json` ควบคู่ไปกับมัน
 
@@ -122,10 +122,10 @@ OpenCode รองรับทั้งรูปแบบ **JSON** และ **J
 
 ### เส้นทางที่กำหนดเอง
 
-ระบุเส้นทางไฟล์กำหนดค่าที่กำหนดเองโดยใช้ตัวแปรสภาพแวดล้อม `OPENCODE_CONFIG`
+ระบุเส้นทางไฟล์กำหนดค่าที่กำหนดเองโดยใช้ตัวแปรสภาพแวดล้อม `MIMOCODE_CONFIG`
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -135,13 +135,13 @@ opencode run "Hello world"
 
 ### ไดเรกทอรีที่กำหนดเอง
 
-ระบุไดเร็กทอรีการกำหนดค่าที่กำหนดเองโดยใช้ `OPENCODE_CONFIG_DIR`
+ระบุไดเร็กทอรีการกำหนดค่าที่กำหนดเองโดยใช้ `MIMOCODE_CONFIG_DIR`
 ตัวแปรสภาพแวดล้อม ไดเร็กทอรีนี้จะถูกค้นหาตัวแทน, คำสั่ง,
 โหมดและปลั๊กอินเหมือนกับไดเร็กทอรี `.opencode` มาตรฐานและควร
 เป็นไปตามโครงสร้างเดียวกัน
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -151,9 +151,9 @@ opencode run "Hello world"
 
 ## สคีมา
 
-ไฟล์กำหนดค่ามีสคีมาที่กำหนดไว้ใน [**`opencode.ai/config.json`**](https://opencode.ai/config.json)
+ไฟล์กำหนดค่ามีสคีมาที่กำหนดไว้ใน [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json)
 
-การกำหนดค่า TUI ใช้ [**`opencode.ai/tui.json`**](https://opencode.ai/tui.json)
+การกำหนดค่า TUI ใช้ [**`mimocode.ai/tui.json`**](https://mimocode.ai/tui.json)
 
 ผู้แก้ไขของคุณควรสามารถตรวจสอบและเติมข้อความอัตโนมัติตามสคีมาได้
 
@@ -165,7 +165,7 @@ opencode run "Hello world"
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "scroll_speed": 3,
   "scroll_acceleration": {
     "enabled": true
@@ -174,9 +174,9 @@ opencode run "Hello world"
 }
 ```
 
-ใช้ `OPENCODE_TUI_CONFIG` เพื่อชี้ไปยังไฟล์กำหนดค่า TUI ที่กำหนดเอง
+ใช้ `MIMOCODE_TUI_CONFIG` เพื่อชี้ไปยังไฟล์กำหนดค่า TUI ที่กำหนดเอง
 
-คีย์ `theme`, `keybinds` และ `tui` แบบเดิมใน `opencode.json` เลิกใช้แล้วและจะถูกย้ายโดยอัตโนมัติเมื่อเป็นไปได้
+คีย์ `theme`, `keybinds` และ `tui` แบบเดิมใน `mimocode.jsonc` เลิกใช้แล้วและจะถูกย้ายโดยอัตโนมัติเมื่อเป็นไปได้
 
 [เรียนรู้เพิ่มเติมเกี่ยวกับการใช้ TUI ที่นี่](/docs/tui#configure)
 
@@ -186,9 +186,9 @@ opencode run "Hello world"
 
 คุณสามารถกำหนดการตั้งค่าเซิร์ฟเวอร์สำหรับคำสั่ง `opencode serve` และ `opencode web` ผ่านตัวเลือก `server`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -215,9 +215,9 @@ opencode run "Hello world"
 
 คุณสามารถจัดการเครื่องมือที่ LLM สามารถใช้ได้ผ่านตัวเลือก `tools`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -233,9 +233,9 @@ opencode run "Hello world"
 
 คุณสามารถกำหนดค่าผู้ให้บริการและรุ่นที่คุณต้องการใช้ในการกำหนดค่า OpenCode ของคุณได้ผ่านตัวเลือก `provider`, `model` และ `small_model`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -246,9 +246,9 @@ opencode run "Hello world"
 
 ตัวเลือกผู้ให้บริการอาจรวมถึง `timeout` และ `setCacheKey`:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -275,9 +275,9 @@ opencode run "Hello world"
 
 Amazon Bedrock รองรับ AWS-การกำหนดค่าเฉพาะ:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -308,7 +308,7 @@ Bearer Token (`AWS_BEARER_TOKEN_BEDROCK` หรือ `/connect`) มีคว�
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -321,9 +321,9 @@ Bearer Token (`AWS_BEARER_TOKEN_BEDROCK` หรือ `/connect`) มีคว�
 
 คุณสามารถกำหนดค่าตัวแทนเฉพาะสำหรับงานเฉพาะผ่านตัวเลือก `agent`
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -339,7 +339,7 @@ Bearer Token (`AWS_BEARER_TOKEN_BEDROCK` หรือ `/connect`) มีคว�
 }
 ```
 
-คุณยังสามารถกำหนดตัวแทนโดยใช้ไฟล์ Markdown ใน `~/.config/opencode/agents/` หรือ `.opencode/agents/` [เรียนรู้เพิ่มเติมที่นี่](/docs/agents)
+คุณยังสามารถกำหนดตัวแทนโดยใช้ไฟล์ Markdown ใน `~/.config/opencode/agents/` หรือ `.mimocode/agents/` [เรียนรู้เพิ่มเติมที่นี่](/docs/agents)
 
 ---
 
@@ -347,9 +347,9 @@ Bearer Token (`AWS_BEARER_TOKEN_BEDROCK` หรือ `/connect`) มีคว�
 
 คุณสามารถตั้งค่าตัวแทนเริ่มต้นได้โดยใช้ตัวเลือก `default_agent` ซึ่งจะกำหนดว่าเอเจนต์ใดที่จะใช้เมื่อไม่มีการระบุอย่างชัดเจน
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -364,9 +364,9 @@ Bearer Token (`AWS_BEARER_TOKEN_BEDROCK` หรือ `/connect`) มีคว�
 
 คุณสามารถกำหนดค่าคุณสมบัติ [แบ่งปัน](/docs/share) ได้ผ่านทางตัวเลือก `share`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -385,9 +385,9 @@ Bearer Token (`AWS_BEARER_TOKEN_BEDROCK` หรือ `/connect`) มีคว�
 
 คุณสามารถกำหนดค่าคำสั่งที่กำหนดเองสำหรับงานซ้ำๆ ได้ผ่านตัวเลือก `command`
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -403,7 +403,7 @@ Bearer Token (`AWS_BEARER_TOKEN_BEDROCK` หรือ `/connect`) มีคว�
 }
 ```
 
-คุณยังสามารถกำหนดคำสั่งโดยใช้ไฟล์ Markdown ใน `~/.config/opencode/commands/` หรือ `.opencode/commands/` [เรียนรู้เพิ่มเติมที่นี่](/docs/commands)
+คุณยังสามารถกำหนดคำสั่งโดยใช้ไฟล์ Markdown ใน `~/.config/opencode/commands/` หรือ `.mimocode/commands/` [เรียนรู้เพิ่มเติมที่นี่](/docs/commands)
 
 ---
 
@@ -413,7 +413,7 @@ Bearer Token (`AWS_BEARER_TOKEN_BEDROCK` หรือ `/connect`) มีคว�
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -426,9 +426,9 @@ Bearer Token (`AWS_BEARER_TOKEN_BEDROCK` หรือ `/connect`) มีคว�
 
 OpenCode จะดาวน์โหลดการอัปเดตใหม่โดยอัตโนมัติเมื่อเริ่มต้นระบบ คุณสามารถปิดการใช้งานนี้ได้โดยใช้ตัวเลือก `autoupdate`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -442,9 +442,9 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 คุณสามารถกำหนดค่าตัวจัดรูปแบบโค้ดผ่านตัวเลือก `formatter`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -470,9 +470,9 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 ตัวอย่างเช่น เพื่อให้แน่ใจว่าเครื่องมือ `edit` และ `bash` ต้องได้รับการอนุมัติจากผู้ใช้:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -488,9 +488,9 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 คุณสามารถควบคุมลักษณะการทำงานของการบีบอัดบริบทได้โดยใช้ตัวเลือก `compaction`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -509,9 +509,9 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 คุณสามารถกำหนดค่ารูปแบบการละเว้นตัวเฝ้าดูไฟล์ได้ผ่านตัวเลือก `watcher`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -526,9 +526,9 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 คุณสามารถกำหนดค่าเซิร์ฟเวอร์ MCP ที่คุณต้องการใช้ผ่านตัวเลือก `mcp`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -541,11 +541,11 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 [ปลั๊กอิน](/docs/plugins) ขยาย OpenCode ด้วยเครื่องมือที่กำหนดเอง hooks และการผสานรวม
 
-วางไฟล์ปลั๊กอินใน `.opencode/plugins/` หรือ `~/.config/opencode/plugins/` คุณยังสามารถโหลดปลั๊กอินจาก npm ผ่านตัวเลือก `plugin`
+วางไฟล์ปลั๊กอินใน `.mimocode/plugins/` หรือ `~/.config/opencode/plugins/` คุณยังสามารถโหลดปลั๊กอินจาก npm ผ่านตัวเลือก `plugin`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -558,9 +558,9 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 คุณสามารถกำหนดค่าคำแนะนำสำหรับรุ่นที่คุณใช้ผ่านตัวเลือก `instructions`
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -574,9 +574,9 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 คุณสามารถปิดการใช้งานผู้ให้บริการที่โหลดโดยอัตโนมัติผ่านตัวเลือก `disabled_providers` สิ่งนี้มีประโยชน์เมื่อคุณต้องการป้องกันไม่ให้โหลดผู้ให้บริการบางรายแม้ว่าจะมีข้อมูลประจำตัวอยู่ก็ตาม
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -597,9 +597,9 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 คุณสามารถระบุรายชื่อผู้ให้บริการที่อนุญาตได้ผ่านตัวเลือก `enabled_providers` เมื่อตั้งค่าแล้ว เฉพาะผู้ให้บริการที่ระบุเท่านั้นที่จะเปิดใช้งาน และผู้ให้บริการอื่นๆ ทั้งหมดจะถูกละเว้น
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -618,9 +618,9 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 ปุ่ม `experimental` มีตัวเลือกที่อยู่ระหว่างการพัฒนา
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -641,10 +641,10 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 ใช้ `{env:VARIABLE_NAME}` เพื่อทดแทนตัวแปรสภาพแวดล้อม:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -664,9 +664,9 @@ OpenCode จะดาวน์โหลดการอัปเดตใหม�
 
 ใช้ `{file:path/to/file}` เพื่อทดแทนเนื้อหาของไฟล์:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/th/plugins.mdx
+++ b/packages/web/src/content/docs/th/plugins.mdx
@@ -19,7 +19,7 @@ description: เขียนปลั๊กอินของคุณเอง�
 
 วางไฟล์ JavaScript หรือ TypeScript ในไดเร็กทอรีปลั๊กอิน
 
-- `.opencode/plugins/` - ​​ปลั๊กอินระดับโครงการ
+- `.mimocode/plugins/` - ​​ปลั๊กอินระดับโครงการ
 - `~/.config/opencode/plugins/` - ​​ปลั๊กอินทั่วโลก
 
 ไฟล์ในไดเร็กทอรีเหล่านี้จะถูกโหลดโดยอัตโนมัติเมื่อเริ่มต้นระบบ
@@ -30,9 +30,9 @@ description: เขียนปลั๊กอินของคุณเอง�
 
 ระบุแพ็คเกจ npm ในไฟล์ปรับแต่งของคุณ
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ description: เขียนปลั๊กอินของคุณเอง�
 
 ปลั๊กอินถูกโหลดจากทุกแหล่งและ hooks ทั้งหมดทำงานตามลำดับ ลำดับการโหลดคือ:
 
-1. การกำหนดค่าส่วนกลาง (`~/.config/opencode/opencode.json`)
-2. การกำหนดค่าโครงการ (`opencode.json`)
+1. การกำหนดค่าส่วนกลาง (`~/.config/opencode/mimocode.jsonc`)
+2. การกำหนดค่าโครงการ (`mimocode.jsonc`)
 3. ไดเร็กทอรีปลั๊กอินสากล (`~/.config/opencode/plugins/`)
-4. ไดเรกทอรีปลั๊กอินโครงการ (`.opencode/plugins/`)
+4. ไดเรกทอรีปลั๊กอินโครงการ (`.mimocode/plugins/`)
 
 แพ็กเกจ npm ที่ซ้ำกันซึ่งมีชื่อและเวอร์ชันเดียวกันจะถูกโหลดหนึ่งครั้ง อย่างไรก็ตาม ทั้งปลั๊กอินในเครื่องและปลั๊กอิน npm ที่มีชื่อคล้ายกันจะโหลดแยกกัน
 
@@ -75,7 +75,7 @@ description: เขียนปลั๊กอินของคุณเอง�
 
 ปลั๊กอินท้องถิ่นและเครื่องมือแบบกำหนดเองสามารถใช้แพ็คเกจ npm ภายนอกได้ เพิ่ม `package.json` ลงในไดเร็กทอรี config ของคุณด้วยการอ้างอิงที่คุณต้องการ
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -85,7 +85,7 @@ description: เขียนปลั๊กอินของคุณเอง�
 
 OpenCode รัน `bun install` เมื่อเริ่มต้นเพื่อติดตั้งสิ่งเหล่านี้ ปลั๊กอินและเครื่องมือของคุณสามารถนำเข้าได้
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -103,7 +103,7 @@ export const MyPlugin = async (ctx) => {
 
 ### โครงสร้างพื้นฐาน
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -218,7 +218,7 @@ export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree
 
 ส่งการแจ้งเตือนเมื่อมีเหตุการณ์บางอย่างเกิดขึ้น:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -243,7 +243,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
 
 ป้องกันไม่ให้ opencode อ่านไฟล์ `.env`:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -261,7 +261,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 แทรกตัวแปรสภาพแวดล้อมลงในการดำเนินการ shell ทั้งหมด (เครื่องมือ AI และ terminal ผู้ใช้):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -278,7 +278,7 @@ export const InjectEnvPlugin = async () => {
 
 ปลั๊กอินยังสามารถเพิ่มเครื่องมือที่กำหนดเองให้กับ opencode:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -317,7 +317,7 @@ export const CustomToolsPlugin: Plugin = async (ctx) => {
 
 ใช้ `client.app.log()` แทน `console.log` สำหรับการบันทึกแบบมีโครงสร้าง:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -330,7 +330,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-ระดับ: `debug`, `info`, `warn`, `error` ดู[SDKเอกสารประกอบ](https://opencode.ai/docs/sdk)สำหรับรายละเอียด
+ระดับ: `debug`, `info`, `warn`, `error` ดู[SDKเอกสารประกอบ](https://mimocode.ai/docs/sdk)สำหรับรายละเอียด
 
 ---
 
@@ -338,7 +338,7 @@ export const MyPlugin = async ({ client }) => {
 
 ปรับแต่งบริบทที่รวมไว้เมื่อมีการกระชับเซสชัน:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -362,7 +362,7 @@ Include any state that should persist across compaction:
 
 คุณยังสามารถแทนที่พรอมต์การกระชับข้อมูลทั้งหมดได้โดยตั้งค่า `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/tr/cli.mdx
+++ b/packages/web/src/content/docs/tr/cli.mdx
@@ -360,7 +360,7 @@ API erişimi için headless bir opencode sunucusu başlatır. Tam HTTP arayüzü
 opencode serve
 ```
 
-Bu, TUI arayüzü olmadan opencode işlevselliğine API erişimi sağlayan bir HTTP sunucusunu başlatır. HTTP temel kimlik doğrulamasını etkinleştirmek için `OPENCODE_SERVER_PASSWORD` öğesini ayarlayın (kullanıcı adı varsayılan olarak `opencode` şeklindedir).
+Bu, TUI arayüzü olmadan opencode işlevselliğine API erişimi sağlayan bir HTTP sunucusunu başlatır. HTTP temel kimlik doğrulamasını etkinleştirmek için `MIMOCODE_SERVER_PASSWORD` öğesini ayarlayın (kullanıcı adı varsayılan olarak `opencode` şeklindedir).
 
 #### Bayraklar
 
@@ -456,7 +456,7 @@ Web arayüzüyle başsız bir opencode sunucusu başlatın.
 opencode web
 ```
 
-Bu, bir HTTP sunucusunu başlatır ve bir web arayüzü aracılığıyla opencode'a erişmek için bir web tarayıcısı açar. HTTP temel kimlik doğrulamasını etkinleştirmek için `OPENCODE_SERVER_PASSWORD` öğesini ayarlayın (kullanıcı adı varsayılan olarak `opencode` şeklindedir).
+Bu, bir HTTP sunucusunu başlatır ve bir web arayüzü aracılığıyla opencode'a erişmek için bir web tarayıcısı açar. HTTP temel kimlik doğrulamasını etkinleştirmek için `MIMOCODE_SERVER_PASSWORD` öğesini ayarlayın (kullanıcı adı varsayılan olarak `opencode` şeklindedir).
 
 #### Bayraklar
 
@@ -555,30 +555,30 @@ opencode ortam değişkenleri kullanılarak yapılandırılabilir.
 
 | Değişken                              | Tip     | Açıklama                                                                    |
 | ------------------------------------- | ------- | --------------------------------------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | Oturumları otomatik olarak paylaş                                           |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Windows'ta yürütülebilir Git Bash'in Yolu                                   |
-| `OPENCODE_CONFIG`                     | string  | Yapılandırma dosyasının yolu                                                |
-| `OPENCODE_TUI_CONFIG`                 | string  | TUI yapılandırma dosyasının yolu                                            |
-| `OPENCODE_CONFIG_DIR`                 | string  | Yapılandırma dizinine giden yol                                             |
-| `OPENCODE_CONFIG_CONTENT`             | string  | Satır içi JSON config içeriği                                               |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Otomatik güncelleme kontrollerini devre dışı bırak                          |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | Eski verilerin temizlenmesini devre dışı bırak                              |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Otomatik terminal başlığı güncellemelerini devre dışı bırakın               |
-| `OPENCODE_PERMISSION`                 | string  | Satır içi JSON izin config'i                                                |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Varsayılan eklentileri devre dışı bırakın                                   |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Otomatik LSP sunucu indirmelerini devre dışı bırakın                        |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Deneysel modelleri etkinleştir                                              |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Otomatik context sıkıştırmayı devre dışı bırak                              |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | `.claude`'den okumayı devre dışı bırak (istem + beceriler)                  |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | `~/.claude/CLAUDE.md` dosyasını okumayı devre dışı bırak                    |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | `.claude/skills` yüklemesini devre dışı bırak                               |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Uzak kaynaklardan model getirmeyi devre dışı bırakın                        |
-| `OPENCODE_FAKE_VCS`                   | string  | Test amaçlı sahte VCS sağlayıcısı                                           |
-| `OPENCODE_CLIENT`                     | string  | Client kimliği (varsayılan: `cli`)                                          |
-| `OPENCODE_ENABLE_EXA`                 | boolean | Exa web arama araçlarını etkinleştir                                        |
-| `OPENCODE_SERVER_PASSWORD`            | string  | `serve`/`web` için temel kimlik doğrulamayı etkinleştirin                   |
-| `OPENCODE_SERVER_USERNAME`            | string  | Temel kimlik doğrulama kullanıcı adını geçersiz kıl (varsayılan `opencode`) |
-| `OPENCODE_MODELS_URL`                 | string  | Model yapılandırmasını almak için özel URL                                  |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | Oturumları otomatik olarak paylaş                                           |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | Windows'ta yürütülebilir Git Bash'in Yolu                                   |
+| `MIMOCODE_CONFIG`                     | string  | Yapılandırma dosyasının yolu                                                |
+| `MIMOCODE_TUI_CONFIG`                 | string  | TUI yapılandırma dosyasının yolu                                            |
+| `MIMOCODE_CONFIG_DIR`                 | string  | Yapılandırma dizinine giden yol                                             |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | Satır içi JSON config içeriği                                               |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | Otomatik güncelleme kontrollerini devre dışı bırak                          |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | Eski verilerin temizlenmesini devre dışı bırak                              |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | Otomatik terminal başlığı güncellemelerini devre dışı bırakın               |
+| `MIMOCODE_PERMISSION`                 | string  | Satır içi JSON izin config'i                                                |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Varsayılan eklentileri devre dışı bırakın                                   |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Otomatik LSP sunucu indirmelerini devre dışı bırakın                        |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Deneysel modelleri etkinleştir                                              |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | Otomatik context sıkıştırmayı devre dışı bırak                              |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | `.claude`'den okumayı devre dışı bırak (istem + beceriler)                  |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | `~/.claude/CLAUDE.md` dosyasını okumayı devre dışı bırak                    |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | `.claude/skills` yüklemesini devre dışı bırak                               |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | Uzak kaynaklardan model getirmeyi devre dışı bırakın                        |
+| `MIMOCODE_FAKE_VCS`                   | string  | Test amaçlı sahte VCS sağlayıcısı                                           |
+| `MIMOCODE_CLIENT`                     | string  | Client kimliği (varsayılan: `cli`)                                          |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | Exa web arama araçlarını etkinleştir                                        |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | `serve`/`web` için temel kimlik doğrulamayı etkinleştirin                   |
+| `MIMOCODE_SERVER_USERNAME`            | string  | Temel kimlik doğrulama kullanıcı adını geçersiz kıl (varsayılan `opencode`) |
+| `MIMOCODE_MODELS_URL`                 | string  | Model yapılandırmasını almak için özel URL                                  |
 
 ---
 
@@ -588,16 +588,16 @@ Bu ortam değişkenleri değişebilecek veya kaldırılabilecek deneysel özelli
 
 | Değişken                                        | Tip     | Tanım                                                   |
 | ----------------------------------------------- | ------- | ------------------------------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | Tüm deneysel özellikleri etkinleştir                    |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Simge bulmayı etkinleştir                               |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | TUI'da seçim yapıldığında kopyalamayı devre dışı bırak  |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | MS cinsinden bash komutları için varsayılan zaman aşımı |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | LLM yanıtları için maksimum çıktı belirteçleri          |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Tüm dizin için dosya izleyiciyi etkinleştir             |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | Oxfmt biçimlendiriciyi etkinleştir                      |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Deneysel LSP aracını etkinleştir                        |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Dosya izleyiciyi devre dışı bırak                       |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Deneysel Exa özelliklerini etkinleştirin                |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | python dosyaları için TY LSP'yi etkinleştir             |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Deneysel işaretleme özelliklerini etkinleştir           |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Plan modunu etkinleştir                                 |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | Tüm deneysel özellikleri etkinleştir                    |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Simge bulmayı etkinleştir                               |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | TUI'da seçim yapıldığında kopyalamayı devre dışı bırak  |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | MS cinsinden bash komutları için varsayılan zaman aşımı |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | LLM yanıtları için maksimum çıktı belirteçleri          |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Tüm dizin için dosya izleyiciyi etkinleştir             |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | Oxfmt biçimlendiriciyi etkinleştir                      |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Deneysel LSP aracını etkinleştir                        |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Dosya izleyiciyi devre dışı bırak                       |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | Deneysel Exa özelliklerini etkinleştirin                |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | python dosyaları için TY LSP'yi etkinleştir             |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Deneysel işaretleme özelliklerini etkinleştir           |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Plan modunu etkinleştir                                 |

--- a/packages/web/src/content/docs/tr/config.mdx
+++ b/packages/web/src/content/docs/tr/config.mdx
@@ -11,9 +11,9 @@ opencode'u JSON yapılandırma dosyası kullanarak yapılandırabilirsiniz.
 
 opencode hem **JSON** hem de **JSONC** (JSON Yorumlarla birlikte) formatlarını destekler.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   // Theme configuration
   "theme": "opencode",
   "model": "anthropic/claude-sonnet-4-5",
@@ -43,11 +43,11 @@ Yapılandırma dosyaları değiştirilmez, birleştirilir. Aşağıdaki yapılan
 Yapılandırma kaynakları bu sırayla yüklenir (sonraki kaynaklar öncekileri geçersiz kılar):
 
 1. **Uzak yapılandırma** (`.well-known/opencode`'dan) - kurumsal varsayılanlar
-2. **Genel yapılandırma** (`~/.config/opencode/opencode.json`) - kullanıcı tercihleri
-3. **Özel yapılandırma** (`OPENCODE_CONFIG` env var) - özel geçersiz kılmalar
-4. **Proje yapılandırması** (projedeki `opencode.json`) - projeye özgü ayarlar
+2. **Genel yapılandırma** (`~/.config/opencode/mimocode.jsonc`) - kullanıcı tercihleri
+3. **Özel yapılandırma** (`MIMOCODE_CONFIG` env var) - özel geçersiz kılmalar
+4. **Proje yapılandırması** (projedeki `mimocode.jsonc`) - projeye özgü ayarlar
 5. **`.opencode` dizinleri** - agent'lar, komutlar, eklentiler
-6. **Satır içi yapılandırma** (`OPENCODE_CONFIG_CONTENT` env var) - çalışma zamanı geçersiz kılmaları
+6. **Satır içi yapılandırma** (`MIMOCODE_CONFIG_CONTENT` env var) - çalışma zamanı geçersiz kılmaları
 
 Bu, proje yapılandırmalarının genel varsayılanları geçersiz kılabileceği ve genel yapılandırmaların uzak organizasyonel varsayılanları geçersiz kılabileceği anlamına gelir.
 
@@ -79,7 +79,7 @@ Uzak yapılandırma ilk olarak yüklenir ve temel katman görevi görür. Diğer
 
 Yerel yapılandırmanızda belirli sunucuları etkinleştirebilirsiniz:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ Yerel yapılandırmanızda belirli sunucuları etkinleştirebilirsiniz:
 
 ### Global
 
-Global opencode yapılandırmanızı `~/.config/opencode/opencode.json` içine yerleştirin. Temalar, sağlayıcılar veya tuş atamaları gibi kullanıcı çapındaki tercihler için genel yapılandırmayı kullanın.
+Global opencode yapılandırmanızı `~/.config/opencode/mimocode.jsonc` içine yerleştirin. Temalar, sağlayıcılar veya tuş atamaları gibi kullanıcı çapındaki tercihler için genel yapılandırmayı kullanın.
 
 Genel yapılandırma, uzak kurumsal varsayılanları geçersiz kılar.
 
@@ -103,7 +103,7 @@ Genel yapılandırma, uzak kurumsal varsayılanları geçersiz kılar.
 
 ### Proje başına
 
-Proje kökünüze `opencode.json` ekleyin. Proje yapılandırması, standart yapılandırma dosyaları arasında en yüksek önceliğe sahiptir; hem genel hem de uzak yapılandırmaları geçersiz kılar.
+Proje kökünüze `mimocode.jsonc` ekleyin. Proje yapılandırması, standart yapılandırma dosyaları arasında en yüksek önceliğe sahiptir; hem genel hem de uzak yapılandırmaları geçersiz kılar.
 
 :::tip
 Projeye özel yapılandırmayı projenizin köküne yerleştirin.
@@ -117,10 +117,10 @@ Bunun Git'te kontrol edilmesi de güvenlidir ve global olanla aynı şemayı kul
 
 ### Özel yol
 
-`OPENCODE_CONFIG` ortam değişkenini kullanarak özel bir yapılandırma dosyası yolu belirtin.
+`MIMOCODE_CONFIG` ortam değişkenini kullanarak özel bir yapılandırma dosyası yolu belirtin.
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -130,13 +130,13 @@ opencode run "Hello world"
 
 ### Özel dizin
 
-`OPENCODE_CONFIG_DIR` kullanarak özel bir yapılandırma dizini belirtin
+`MIMOCODE_CONFIG_DIR` kullanarak özel bir yapılandırma dizini belirtin
 ortam değişkeni. Bu dizin agent'lar, komutlar için aranacaktır.
 modlar ve eklentiler tıpkı standart `.opencode` dizini gibi olmalıdır ve
 aynı yapıyı takip edin.
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -146,7 +146,7 @@ opencode run "Hello world"
 
 ## Şema
 
-Yapılandırma dosyası [**`opencode.ai/config.json`**](https://opencode.ai/config.json)'da tanımlanan bir şemaya sahiptir.
+Yapılandırma dosyası [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json)'da tanımlanan bir şemaya sahiptir.
 
 Editörünüz şemaya göre doğrulama ve otomatik tamamlama yapabilmelidir.
 
@@ -156,9 +156,9 @@ Editörünüz şemaya göre doğrulama ve otomatik tamamlama yapabilmelidir.
 
 TUI'ye özgü ayarları `tui` seçeneği aracılığıyla yapılandırabilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tui": {
     "scroll_speed": 3,
     "scroll_acceleration": {
@@ -183,9 +183,9 @@ Mevcut seçenekler:
 
 `opencode serve` ve `opencode web` komutları için sunucu ayarlarını `server` seçeneği aracılığıyla yapılandırabilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -212,9 +212,9 @@ Mevcut seçenekler:
 
 Bir LLM'nin kullanabileceği araçları `tools` seçeneği aracılığıyla yönetebilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -230,9 +230,9 @@ Bir LLM'nin kullanabileceği araçları `tools` seçeneği aracılığıyla yön
 
 opencode yapılandırmanızda kullanmak istediğiniz sağlayıcıları ve modelleri `provider`, `model` ve `small_model` seçenekleri aracılığıyla yapılandırabilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -243,9 +243,9 @@ opencode yapılandırmanızda kullanmak istediğiniz sağlayıcıları ve modell
 
 Sağlayıcı seçenekleri `timeout` ve `setCacheKey` içerebilir:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -272,9 +272,9 @@ Bazı sağlayıcılar genel `timeout` ve `apiKey` ayarlarının ötesinde ek yap
 
 Amazon Bedrock, AWS'a özgü yapılandırmayı destekler:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -303,9 +303,9 @@ Taşıyıcı belirteçleri (`AWS_BEARER_TOKEN_BEDROCK` veya `/connect`) profil t
 
 opencode yapılandırmanızda kullanmak istediğiniz temayı `theme` seçeneği aracılığıyla yapılandırabilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "theme": ""
 }
 ```
@@ -318,9 +318,9 @@ opencode yapılandırmanızda kullanmak istediğiniz temayı `theme` seçeneği 
 
 `agent` seçeneği aracılığıyla özel görevlere yönelik özel agent'ları yapılandırabilirsiniz.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -337,7 +337,7 @@ opencode yapılandırmanızda kullanmak istediğiniz temayı `theme` seçeneği 
 }
 ```
 
-Agent'ları `~/.config/opencode/agents/` veya `.opencode/agents/` içindeki Markdown dosyalarıyla da tanımlayabilirsiniz. [Daha fazla bilgi](/docs/agents).
+Agent'ları `~/.config/opencode/agents/` veya `.mimocode/agents/` içindeki Markdown dosyalarıyla da tanımlayabilirsiniz. [Daha fazla bilgi](/docs/agents).
 
 ---
 
@@ -345,9 +345,9 @@ Agent'ları `~/.config/opencode/agents/` veya `.opencode/agents/` içindeki Mark
 
 `default_agent` seçeneğini kullanarak varsayılan agent'ı ayarlayabilirsiniz. Bu, hiçbiri açıkça belirtilmediğinde hangi agent'ın kullanılacağını belirler.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -362,9 +362,9 @@ Bu ayar tüm arayüzler için geçerlidir: TUI, CLI (`opencode run`), masaüstü
 
 [share](/docs/share) özelliğini `share` seçeneği aracılığıyla yapılandırabilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -383,9 +383,9 @@ Varsayılan olarak paylaşım, `/share` komutunu kullanarak konuşmaları açık
 
 `command` seçeneği aracılığıyla tekrarlanan görevler için özel komutlar yapılandırabilirsiniz.
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -401,7 +401,7 @@ Varsayılan olarak paylaşım, `/share` komutunu kullanarak konuşmaları açık
 }
 ```
 
-Komutları `~/.config/opencode/commands/` veya `.opencode/commands/` içindeki Markdown dosyalarıyla da tanımlayabilirsiniz. [Daha fazla bilgi](/docs/commands).
+Komutları `~/.config/opencode/commands/` veya `.mimocode/commands/` içindeki Markdown dosyalarıyla da tanımlayabilirsiniz. [Daha fazla bilgi](/docs/commands).
 
 ---
 
@@ -409,9 +409,9 @@ Komutları `~/.config/opencode/commands/` veya `.opencode/commands/` içindeki M
 
 Tuş atamalarınızı `keybinds` seçeneği aracılığıyla özelleştirebilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "keybinds": {}
 }
 ```
@@ -424,9 +424,9 @@ Tuş atamalarınızı `keybinds` seçeneği aracılığıyla özelleştirebilirs
 
 opencode başlatıldığında yeni güncellemeleri otomatik olarak indirecektir. Bunu `autoupdate` seçeneğiyle devre dışı bırakabilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -440,9 +440,9 @@ Bunun yalnızca Homebrew gibi bir paket yöneticisi kullanılarak yüklenmemişs
 
 Kod formatlayıcılarını `formatter` seçeneği aracılığıyla yapılandırabilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -468,9 +468,9 @@ Varsayılan olarak, opencode açık bir onay gerektirmeden **tüm işlemlere izi
 
 Örneğin, `edit` ve `bash` araçlarının kullanıcı onayı gerektirdiğinden emin olmak için:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -486,9 +486,9 @@ Varsayılan olarak, opencode açık bir onay gerektirmeden **tüm işlemlere izi
 
 Bağlam sıkıştırma davranışını `compaction` seçeneği aracılığıyla kontrol edebilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -507,9 +507,9 @@ Bağlam sıkıştırma davranışını `compaction` seçeneği aracılığıyla 
 
 Dosya izleyicinin yok sayma kalıplarını `watcher` seçeneği aracılığıyla yapılandırabilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -524,9 +524,9 @@ Desenler glob sözdizimini takip eder. Gürültülü dizinleri dosya izlemenin d
 
 Kullanmak istediğiniz MCP sunucularını `mcp` seçeneği aracılığıyla yapılandırabilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -539,11 +539,11 @@ Kullanmak istediğiniz MCP sunucularını `mcp` seçeneği aracılığıyla yap�
 
 [Eklentiler](/docs/plugins) opencode'u özel araçlar, kancalar ve entegrasyonlarla genişletin.
 
-Eklenti dosyalarını `.opencode/plugins/` veya `~/.config/opencode/plugins/` içine yerleştirin. Ayrıca eklentileri `plugin` seçeneği aracılığıyla npm'den de yükleyebilirsiniz.
+Eklenti dosyalarını `.mimocode/plugins/` veya `~/.config/opencode/plugins/` içine yerleştirin. Ayrıca eklentileri `plugin` seçeneği aracılığıyla npm'den de yükleyebilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -556,9 +556,9 @@ Eklenti dosyalarını `.opencode/plugins/` veya `~/.config/opencode/plugins/` i�
 
 Kullandığınız modele ilişkin talimatları `instructions` seçeneği aracılığıyla yapılandırabilirsiniz.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -571,9 +571,9 @@ Bu, talimat dosyalarına giden bir dizi yolu ve glob desenini alır. [Kurallar h
 
 `disabled_providers` seçeneği aracılığıyla otomatik olarak yüklenen sağlayıcıları devre dışı bırakabilirsiniz. Bu, belirli sağlayıcıların kimlik bilgileri mevcut olsa bile yüklenmesini engellemek istediğinizde kullanışlıdır.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -594,9 +594,9 @@ Bu, talimat dosyalarına giden bir dizi yolu ve glob desenini alır. [Kurallar h
 
 `enabled_providers` seçeneğini kullanarak sağlayıcıların izin verilenler listesini belirtebilirsiniz. Ayarlandığında yalnızca belirtilen sağlayıcılar etkinleştirilecek ve diğerleri göz ardı edilecektir.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -615,9 +615,9 @@ Bir sağlayıcı hem `enabled_providers` hem de `disabled_providers`'de görün�
 
 `experimental` anahtarı aktif olarak geliştirilmekte olan seçenekleri içerir.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -638,10 +638,10 @@ Ortam değişkenlerine ve dosya içeriklerine referans vermek için yapılandır
 
 Ortam değişkenlerini değiştirmek için `{env:VARIABLE_NAME}` kullanın:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -661,9 +661,9 @@ Ortam değişkeni ayarlanmamışsa boş bir dizeyle değiştirilecektir.
 
 Bir dosyanın biçimini değiştirmek için `{file:path/to/file}` kullanın:
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/tr/plugins.mdx
+++ b/packages/web/src/content/docs/tr/plugins.mdx
@@ -19,7 +19,7 @@ Eklentileri yüklemenin iki yolu vardır.
 
 JavaScript veya TypeScript dosyalarını eklenti dizinine yerleştirin.
 
-- `.opencode/plugins/` - Proje düzeyinde eklentiler
+- `.mimocode/plugins/` - Proje düzeyinde eklentiler
 - `~/.config/opencode/plugins/` - Genel eklentiler
 
 Bu dizinlerdeki dosyalar başlangıçta otomatik olarak yüklenir.
@@ -30,9 +30,9 @@ Bu dizinlerdeki dosyalar başlangıçta otomatik olarak yüklenir.
 
 Yapılandırma dosyanızda npm paketlerini belirtin.
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ Hem normal hem de kapsamlı npm paketleri desteklenir.
 
 Eklentiler tüm kaynaklardan yüklenir ve tüm kancalar sırayla çalışır. Yükleme sırası şöyledir:
 
-1. Global config (`~/.config/opencode/opencode.json`)
-2. Project config (`opencode.json`)
+1. Global config (`~/.config/opencode/mimocode.jsonc`)
+2. Project config (`mimocode.jsonc`)
 3. Global eklenti dizini (`~/.config/opencode/plugins/`)
-4. Proje eklenti dizini (`.opencode/plugins/`)
+4. Proje eklenti dizini (`.mimocode/plugins/`)
 
 Aynı ad ve sürüme sahip yinelenen npm paketleri bir kez yüklenir. Ancak benzer adlara sahip bir yerel eklenti ve bir npm eklentisinin her ikisi de ayrı ayrı yüklenir.
 
@@ -74,7 +74,7 @@ Eklenti, bir veya daha fazla eklenti işlevini dışa aktaran bir **JavaScript/T
 
 Yerel eklentiler ve özel araçlar harici npm paketlerini kullanabilir. İhtiyacınız olan bağımlılıkları içeren config dizininize bir `package.json` ekleyin.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -84,7 +84,7 @@ Yerel eklentiler ve özel araçlar harici npm paketlerini kullanabilir. İhtiyac
 
 OpenCode bunları yüklemek için başlangıçta `bun install` komutunu çalıştırır. Eklentileriniz ve araçlarınız daha sonra bunları içe aktarabilir.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -102,7 +102,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Temel yapı
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -217,7 +217,7 @@ OpenCode'u genişletmek için kullanabileceğiniz bazı eklenti örneklerini bur
 
 Belirli olaylar meydana geldiğinde bildirim gönderin:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -242,7 +242,7 @@ OpenCode masaüstü uygulamasını kullanıyorsanız yanıt hazır olduğunda ve
 
 OpenCode'un `.env` dosyalarını okumasını önleyin:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -260,7 +260,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Ortam değişkenlerini tüm kabuk yürütmeye (AI araçları ve kullanıcı terminalleri) enjekte edin:
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -277,7 +277,7 @@ export const InjectEnvPlugin = async () => {
 
 Eklentiler ayrıca OpenCode'a özel araçlar da ekleyebilir:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -316,7 +316,7 @@ Eğer bir eklenti aracı yerleşik bir araçla aynı adı kullanırsa, eklenti a
 
 Yapılandırılmış günlük kaydı için `console.log` yerine `client.app.log()` kullanın:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -329,7 +329,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-Seviyeler: `debug`, `info`, `warn`, `error`. Ayrıntılar için [SDK belgelerine](https://opencode.ai/docs/sdk) bakın.
+Seviyeler: `debug`, `info`, `warn`, `error`. Ayrıntılar için [SDK belgelerine](https://mimocode.ai/docs/sdk) bakın.
 
 ---
 
@@ -337,7 +337,7 @@ Seviyeler: `debug`, `info`, `warn`, `error`. Ayrıntılar için [SDK belgelerine
 
 Bir oturum sıkıştırıldığında içerilen bağlamı özelleştirin:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -361,7 +361,7 @@ Include any state that should persist across compaction:
 
 Ayrıca `output.prompt` ayarını yaparak sıkıştırma istemini tamamen değiştirebilirsiniz:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/zh-cn/cli.mdx
+++ b/packages/web/src/content/docs/zh-cn/cli.mdx
@@ -360,7 +360,7 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 opencode serve
 ```
 
-此命令启动一个 HTTP 服务器，提供对 OpenCode 功能的 API 访问，无需 TUI 界面。设置 `OPENCODE_SERVER_PASSWORD` 可启用 HTTP 基本认证（用户名默认为 `opencode`）。
+此命令启动一个 HTTP 服务器，提供对 OpenCode 功能的 API 访问，无需 TUI 界面。设置 `MIMOCODE_SERVER_PASSWORD` 可启用 HTTP 基本认证（用户名默认为 `opencode`）。
 
 #### 标志
 
@@ -456,7 +456,7 @@ opencode import https://opncd.ai/s/abc123
 opencode web
 ```
 
-此命令启动一个 HTTP 服务器并打开浏览器，通过 Web 界面访问 OpenCode。设置 `OPENCODE_SERVER_PASSWORD` 可启用 HTTP 基本认证（用户名默认为 `opencode`）。
+此命令启动一个 HTTP 服务器并打开浏览器，通过 Web 界面访问 OpenCode。设置 `MIMOCODE_SERVER_PASSWORD` 可启用 HTTP 基本认证（用户名默认为 `opencode`）。
 
 #### 标志
 
@@ -555,30 +555,30 @@ OpenCode 可以通过环境变量进行配置。
 
 | 变量                                  | 类型    | 描述                                    |
 | ------------------------------------- | ------- | --------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | 自动分享会话                            |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Windows 上 Git Bash 可执行文件的路径    |
-| `OPENCODE_CONFIG`                     | string  | 配置文件路径                            |
-| `OPENCODE_TUI_CONFIG`                 | string  | TUI 配置文件路径                        |
-| `OPENCODE_CONFIG_DIR`                 | string  | 配置目录路径                            |
-| `OPENCODE_CONFIG_CONTENT`             | string  | 内联 JSON 配置内容                      |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | 禁用自动更新检查                        |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | 禁用旧数据清理                          |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | 禁用自动终端标题更新                    |
-| `OPENCODE_PERMISSION`                 | string  | 内联 JSON 权限配置                      |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | 禁用默认插件                            |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | 禁用 LSP 服务器自动下载                 |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | 启用实验性模型                          |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | 禁用自动上下文压缩                      |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | 禁用读取 `.claude`（提示词 + 技能）     |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | 禁用读取 `~/.claude/CLAUDE.md`          |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | 禁用加载 `.claude/skills`               |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | 禁用从远程源获取模型                    |
-| `OPENCODE_FAKE_VCS`                   | string  | 用于测试目的的模拟 VCS 提供商           |
-| `OPENCODE_CLIENT`                     | string  | 客户端标识符（默认为 `cli`）            |
-| `OPENCODE_ENABLE_EXA`                 | boolean | 启用 Exa 网络搜索工具                   |
-| `OPENCODE_SERVER_PASSWORD`            | string  | 为 `serve`/`web` 启用基本认证           |
-| `OPENCODE_SERVER_USERNAME`            | string  | 覆盖基本认证用户名（默认为 `opencode`） |
-| `OPENCODE_MODELS_URL`                 | string  | 自定义模型配置获取 URL                  |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | 自动分享会话                            |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | Windows 上 Git Bash 可执行文件的路径    |
+| `MIMOCODE_CONFIG`                     | string  | 配置文件路径                            |
+| `MIMOCODE_TUI_CONFIG`                 | string  | TUI 配置文件路径                        |
+| `MIMOCODE_CONFIG_DIR`                 | string  | 配置目录路径                            |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | 内联 JSON 配置内容                      |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | 禁用自动更新检查                        |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | 禁用旧数据清理                          |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | 禁用自动终端标题更新                    |
+| `MIMOCODE_PERMISSION`                 | string  | 内联 JSON 权限配置                      |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | 禁用默认插件                            |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | 禁用 LSP 服务器自动下载                 |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | 启用实验性模型                          |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | 禁用自动上下文压缩                      |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | 禁用读取 `.claude`（提示词 + 技能）     |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | 禁用读取 `~/.claude/CLAUDE.md`          |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | 禁用加载 `.claude/skills`               |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | 禁用从远程源获取模型                    |
+| `MIMOCODE_FAKE_VCS`                   | string  | 用于测试目的的模拟 VCS 提供商           |
+| `MIMOCODE_CLIENT`                     | string  | 客户端标识符（默认为 `cli`）            |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | 启用 Exa 网络搜索工具                   |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | 为 `serve`/`web` 启用基本认证           |
+| `MIMOCODE_SERVER_USERNAME`            | string  | 覆盖基本认证用户名（默认为 `opencode`） |
+| `MIMOCODE_MODELS_URL`                 | string  | 自定义模型配置获取 URL                  |
 
 ---
 
@@ -588,15 +588,15 @@ OpenCode 可以通过环境变量进行配置。
 
 | 变量                                            | 类型    | 描述                            |
 | ----------------------------------------------- | ------- | ------------------------------- | --- | -------------------------------- | ------- | ------------------------ |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | 启用所有实验性功能              |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | 启用图标发现                    |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | 禁用 TUI 中的选中即复制         |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | bash 命令的默认超时时间（毫秒） |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | LLM 响应的最大输出 Token 数     |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | 启用整个目录的文件监听器        |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | 启用 oxfmt 格式化器             |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | 启用实验性 LSP 工具             |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | 禁用文件监听器                  |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | 启用实验性 Exa 功能             |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | 为 python 文件启用 TY LSP       |     | `OPENCODE_EXPERIMENTAL_MARKDOWN` | boolean | 启用实验性 Markdown 功能 |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | 启用计划模式                    |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | 启用所有实验性功能              |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | 启用图标发现                    |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | 禁用 TUI 中的选中即复制         |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | bash 命令的默认超时时间（毫秒） |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | LLM 响应的最大输出 Token 数     |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | 启用整个目录的文件监听器        |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | 启用 oxfmt 格式化器             |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | 启用实验性 LSP 工具             |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | 禁用文件监听器                  |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | 启用实验性 Exa 功能             |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | 为 python 文件启用 TY LSP       |     | `MIMOCODE_EXPERIMENTAL_MARKDOWN` | boolean | 启用实验性 Markdown 功能 |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | 启用计划模式                    |

--- a/packages/web/src/content/docs/zh-cn/config.mdx
+++ b/packages/web/src/content/docs/zh-cn/config.mdx
@@ -11,9 +11,9 @@ description: 使用 OpenCode JSON 配置。
 
 OpenCode 支持 **JSON** 和 **JSONC**（带注释的 JSON）格式。
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -43,11 +43,11 @@ OpenCode 支持 **JSON** 和 **JSONC**（带注释的 JSON）格式。
 配置源按以下顺序加载（后面的源覆盖前面的源）：
 
 1. **远程配置**（来自 `.well-known/opencode`）- 组织默认值
-2. **全局配置**（`~/.config/opencode/opencode.json`）- 用户偏好
-3. **自定义配置**（`OPENCODE_CONFIG` 环境变量）- 自定义覆盖
-4. **项目配置**（项目中的 `opencode.json`）- 项目特定设置
+2. **全局配置**（`~/.config/opencode/mimocode.jsonc`）- 用户偏好
+3. **自定义配置**（`MIMOCODE_CONFIG` 环境变量）- 自定义覆盖
+4. **项目配置**（项目中的 `mimocode.jsonc`）- 项目特定设置
 5. **`.opencode` 目录** - 代理、命令、插件
-6. **内联配置**（`OPENCODE_CONFIG_CONTENT` 环境变量）- 运行时覆盖
+6. **内联配置**（`MIMOCODE_CONFIG_CONTENT` 环境变量）- 运行时覆盖
 
 这意味着项目配置可以覆盖全局默认值，全局配置可以覆盖远程组织默认值。
 
@@ -79,7 +79,7 @@ OpenCode 支持 **JSON** 和 **JSONC**（带注释的 JSON）格式。
 
 您可以在本地配置中启用特定服务器：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ OpenCode 支持 **JSON** 和 **JSONC**（带注释的 JSON）格式。
 
 ### 全局
 
-将全局 OpenCode 配置放在 `~/.config/opencode/opencode.json` 中。使用全局配置来设置用户级别的偏好，例如主题、提供商或快捷键。
+将全局 OpenCode 配置放在 `~/.config/opencode/mimocode.jsonc` 中。使用全局配置来设置用户级别的偏好，例如主题、提供商或快捷键。
 
 全局配置覆盖远程组织默认值。
 
@@ -103,7 +103,7 @@ OpenCode 支持 **JSON** 和 **JSONC**（带注释的 JSON）格式。
 
 ### 项目级
 
-在项目根目录中添加 `opencode.json`。项目配置在标准配置文件中具有最高优先级——它会覆盖全局配置和远程配置。
+在项目根目录中添加 `mimocode.jsonc`。项目配置在标准配置文件中具有最高优先级——它会覆盖全局配置和远程配置。
 
 :::tip
 将项目特定配置放在项目的根目录中。
@@ -117,10 +117,10 @@ OpenCode 支持 **JSON** 和 **JSONC**（带注释的 JSON）格式。
 
 ### 自定义路径
 
-使用 `OPENCODE_CONFIG` 环境变量指定自定义配置文件路径。
+使用 `MIMOCODE_CONFIG` 环境变量指定自定义配置文件路径。
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -130,10 +130,10 @@ opencode run "Hello world"
 
 ### 自定义目录
 
-使用 `OPENCODE_CONFIG_DIR` 环境变量指定自定义配置目录。该目录会像标准 `.opencode` 目录一样被搜索代理、命令、模式和插件，并且应遵循相同的结构。
+使用 `MIMOCODE_CONFIG_DIR` 环境变量指定自定义配置目录。该目录会像标准 `.opencode` 目录一样被搜索代理、命令、模式和插件，并且应遵循相同的结构。
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -143,7 +143,7 @@ opencode run "Hello world"
 
 ## Schema
 
-配置文件具有在 [**`opencode.ai/config.json`**](https://opencode.ai/config.json) 中定义的 Schema。
+配置文件具有在 [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json) 中定义的 Schema。
 
 您的编辑器应该能够基于该 Schema 进行验证和自动补全。
 
@@ -153,9 +153,9 @@ opencode run "Hello world"
 
 您可以通过 `tui` 选项配置 TUI 相关设置。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tui": {
     "scroll_speed": 3,
     "scroll_acceleration": {
@@ -180,9 +180,9 @@ opencode run "Hello world"
 
 您可以通过 `server` 选项为 `opencode serve` 和 `opencode web` 命令配置服务器设置。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -209,9 +209,9 @@ opencode run "Hello world"
 
 您可以通过 `tools` 选项管理 LLM 可以使用的工具。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -227,9 +227,9 @@ opencode run "Hello world"
 
 您可以通过 `provider`、`model` 和 `small_model` 选项在 OpenCode 配置中设置要使用的提供商和模型。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -240,9 +240,9 @@ opencode run "Hello world"
 
 提供商选项可以包括 `timeout` 和 `setCacheKey`：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -269,9 +269,9 @@ opencode run "Hello world"
 
 Amazon Bedrock 支持 AWS 特定配置：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -300,9 +300,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）优先于基于配置
 
 您可以通过 OpenCode 配置中的 `theme` 选项设置要使用的主题。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "theme": ""
 }
 ```
@@ -315,9 +315,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）优先于基于配置
 
 您可以通过 `agent` 选项为特定任务配置专用代理。
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -333,7 +333,7 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）优先于基于配置
 }
 ```
 
-您还可以使用 `~/.config/opencode/agents/` 或 `.opencode/agents/` 中的 Markdown 文件定义代理。[在此了解更多](/docs/agents)。
+您还可以使用 `~/.config/opencode/agents/` 或 `.mimocode/agents/` 中的 Markdown 文件定义代理。[在此了解更多](/docs/agents)。
 
 ---
 
@@ -341,9 +341,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）优先于基于配置
 
 您可以使用 `default_agent` 选项设置默认代理。当未明确指定代理时，将使用该默认代理。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -358,9 +358,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）优先于基于配置
 
 您可以通过 `share` 选项配置[分享](/docs/share)功能。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -379,9 +379,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）优先于基于配置
 
 您可以通过 `command` 选项为重复任务配置自定义命令。
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -397,7 +397,7 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）优先于基于配置
 }
 ```
 
-您还可以使用 `~/.config/opencode/commands/` 或 `.opencode/commands/` 中的 Markdown 文件定义命令。[在此了解更多](/docs/commands)。
+您还可以使用 `~/.config/opencode/commands/` 或 `.mimocode/commands/` 中的 Markdown 文件定义命令。[在此了解更多](/docs/commands)。
 
 ---
 
@@ -405,9 +405,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）优先于基于配置
 
 您可以通过 `keybinds` 选项自定义快捷键。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "keybinds": {}
 }
 ```
@@ -420,9 +420,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）优先于基于配置
 
 OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项禁用此功能。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -436,9 +436,9 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 您可以通过 `formatter` 选项配置代码格式化程序。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -464,9 +464,9 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 例如，要让 `edit` 和 `bash` 工具需要用户确认：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -482,9 +482,9 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 您可以通过 `compaction` 选项控制上下文压缩行为。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -503,9 +503,9 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 您可以通过 `watcher` 选项配置文件监视器的忽略模式。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -520,9 +520,9 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 您可以通过 `mcp` 选项配置要使用的 MCP 服务器。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -535,11 +535,11 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 [插件](/docs/plugins)通过自定义工具、钩子和集成来扩展 OpenCode。
 
-将插件文件放置在 `.opencode/plugins/` 或 `~/.config/opencode/plugins/` 中。您还可以通过 `plugin` 选项从 npm 加载插件。
+将插件文件放置在 `.mimocode/plugins/` 或 `~/.config/opencode/plugins/` 中。您还可以通过 `plugin` 选项从 npm 加载插件。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -552,9 +552,9 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 您可以通过 `instructions` 选项为所使用的模型配置指令。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -567,9 +567,9 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 您可以通过 `disabled_providers` 选项禁用自动加载的提供商。当您希望阻止某些提供商被加载（即使其凭据可用）时，此选项非常有用。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -590,9 +590,9 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 您可以通过 `enabled_providers` 选项指定允许使用的提供商白名单。设置后，仅启用指定的提供商，所有其他提供商将被忽略。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -611,9 +611,9 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 `experimental` 键包含正在积极开发中的选项。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -634,10 +634,10 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 使用 `{env:VARIABLE_NAME}` 来替换环境变量：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -657,9 +657,9 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 使用 `{file:path/to/file}` 来替换文件内容：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/zh-cn/plugins.mdx
+++ b/packages/web/src/content/docs/zh-cn/plugins.mdx
@@ -19,7 +19,7 @@ description: 编写自己的插件来扩展 OpenCode。
 
 将 JavaScript 或 TypeScript 文件放置在插件目录中。
 
-- `.opencode/plugins/` - 项目级插件
+- `.mimocode/plugins/` - 项目级插件
 - `~/.config/opencode/plugins/` - 全局插件
 
 这些目录中的文件会在启动时自动加载。
@@ -30,9 +30,9 @@ description: 编写自己的插件来扩展 OpenCode。
 
 在配置文件中指定 npm 包。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ description: 编写自己的插件来扩展 OpenCode。
 
 插件从所有来源加载，所有钩子按顺序执行。加载顺序为：
 
-1. 全局配置 (`~/.config/opencode/opencode.json`)
-2. 项目配置 (`opencode.json`)
+1. 全局配置 (`~/.config/opencode/mimocode.jsonc`)
+2. 项目配置 (`mimocode.jsonc`)
 3. 全局插件目录 (`~/.config/opencode/plugins/`)
-4. 项目插件目录 (`.opencode/plugins/`)
+4. 项目插件目录 (`.mimocode/plugins/`)
 
 名称和版本相同的重复 npm 包只会加载一次。但本地插件和名称相似的 npm 插件会分别独立加载。
 
@@ -74,7 +74,7 @@ description: 编写自己的插件来扩展 OpenCode。
 
 本地插件和自定义工具可以使用外部 npm 包。在配置目录中添加一个 `package.json`，列出所需的依赖项。
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -84,7 +84,7 @@ description: 编写自己的插件来扩展 OpenCode。
 
 OpenCode 会在启动时运行 `bun install` 来安装这些依赖项。之后你的插件和工具就可以导入它们了。
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -102,7 +102,7 @@ export const MyPlugin = async (ctx) => {
 
 ### 基本结构
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -217,7 +217,7 @@ export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree
 
 在特定事件发生时发送通知：
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -242,7 +242,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
 
 阻止 OpenCode 读取 `.env` 文件：
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -260,7 +260,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 将环境变量注入所有 Shell 执行（AI 工具和用户终端）：
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -277,7 +277,7 @@ export const InjectEnvPlugin = async () => {
 
 插件还可以为 OpenCode 添加自定义工具：
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -316,7 +316,7 @@ export const CustomToolsPlugin: Plugin = async (ctx) => {
 
 使用 `client.app.log()` 代替 `console.log` 进行结构化日志记录：
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -329,7 +329,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-日志级别：`debug`、`info`、`warn`、`error`。详情请参阅 [SDK 文档](https://opencode.ai/docs/sdk)。
+日志级别：`debug`、`info`、`warn`、`error`。详情请参阅 [SDK 文档](https://mimocode.ai/docs/sdk)。
 
 ---
 
@@ -337,7 +337,7 @@ export const MyPlugin = async ({ client }) => {
 
 自定义会话压缩时包含的上下文：
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -361,7 +361,7 @@ Include any state that should persist across compaction:
 
 你还可以通过设置 `output.prompt` 来完全替换压缩提示词：
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {

--- a/packages/web/src/content/docs/zh-tw/cli.mdx
+++ b/packages/web/src/content/docs/zh-tw/cli.mdx
@@ -360,7 +360,7 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 opencode serve
 ```
 
-此指令啟動一個 HTTP 伺服器，提供對 OpenCode 功能的 API 存取，無需 TUI 介面。設定 `OPENCODE_SERVER_PASSWORD` 可啟用 HTTP 基本認證（使用者名稱預設為 `opencode`）。
+此指令啟動一個 HTTP 伺服器，提供對 OpenCode 功能的 API 存取，無需 TUI 介面。設定 `MIMOCODE_SERVER_PASSWORD` 可啟用 HTTP 基本認證（使用者名稱預設為 `opencode`）。
 
 #### 旗標
 
@@ -456,7 +456,7 @@ opencode import https://opncd.ai/s/abc123
 opencode web
 ```
 
-此指令啟動一個 HTTP 伺服器並開啟瀏覽器，透過 Web 介面存取 OpenCode。設定 `OPENCODE_SERVER_PASSWORD` 可啟用 HTTP 基本認證（使用者名稱預設為 `opencode`）。
+此指令啟動一個 HTTP 伺服器並開啟瀏覽器，透過 Web 介面存取 OpenCode。設定 `MIMOCODE_SERVER_PASSWORD` 可啟用 HTTP 基本認證（使用者名稱預設為 `opencode`）。
 
 #### 旗標
 
@@ -555,30 +555,30 @@ OpenCode 可以透過環境變數進行設定。
 
 | 變數                                  | 類型    | 說明                                        |
 | ------------------------------------- | ------- | ------------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | 自動分享工作階段                            |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Windows 上 Git Bash 可執行檔的路徑          |
-| `OPENCODE_CONFIG`                     | string  | 設定檔路徑                                  |
-| `OPENCODE_TUI_CONFIG`                 | string  | TUI 設定檔路徑                              |
-| `OPENCODE_CONFIG_DIR`                 | string  | 設定目錄路徑                                |
-| `OPENCODE_CONFIG_CONTENT`             | string  | 內嵌 JSON 設定內容                          |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | 停用自動更新檢查                            |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | 停用舊資料清理                              |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | 停用自動終端機標題更新                      |
-| `OPENCODE_PERMISSION`                 | string  | 內嵌 JSON 權限設定                          |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | 停用預設外掛程式                            |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | 停用 LSP 伺服器自動下載                     |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | 啟用實驗性模型                              |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | 停用自動上下文壓縮                          |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | 停用讀取 `.claude`（提示詞 + 技能）         |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | 停用讀取 `~/.claude/CLAUDE.md`              |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | 停用載入 `.claude/skills`                   |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | 停用從遠端來源擷取模型                      |
-| `OPENCODE_FAKE_VCS`                   | string  | 用於測試目的的模擬 VCS 供應商               |
-| `OPENCODE_CLIENT`                     | string  | 用戶端識別碼（預設為 `cli`）                |
-| `OPENCODE_ENABLE_EXA`                 | boolean | 啟用 Exa 網路搜尋工具                       |
-| `OPENCODE_SERVER_PASSWORD`            | string  | 為 `serve`/`web` 啟用基本認證               |
-| `OPENCODE_SERVER_USERNAME`            | string  | 覆寫基本認證使用者名稱（預設為 `opencode`） |
-| `OPENCODE_MODELS_URL`                 | string  | 自訂模型設定擷取 URL                        |
+| `MIMOCODE_AUTO_SHARE`                 | boolean | 自動分享工作階段                            |
+| `MIMOCODE_GIT_BASH_PATH`              | string  | Windows 上 Git Bash 可執行檔的路徑          |
+| `MIMOCODE_CONFIG`                     | string  | 設定檔路徑                                  |
+| `MIMOCODE_TUI_CONFIG`                 | string  | TUI 設定檔路徑                              |
+| `MIMOCODE_CONFIG_DIR`                 | string  | 設定目錄路徑                                |
+| `MIMOCODE_CONFIG_CONTENT`             | string  | 內嵌 JSON 設定內容                          |
+| `MIMOCODE_DISABLE_AUTOUPDATE`         | boolean | 停用自動更新檢查                            |
+| `MIMOCODE_DISABLE_PRUNE`              | boolean | 停用舊資料清理                              |
+| `MIMOCODE_DISABLE_TERMINAL_TITLE`     | boolean | 停用自動終端機標題更新                      |
+| `MIMOCODE_PERMISSION`                 | string  | 內嵌 JSON 權限設定                          |
+| `MIMOCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | 停用預設外掛程式                            |
+| `MIMOCODE_DISABLE_LSP_DOWNLOAD`       | boolean | 停用 LSP 伺服器自動下載                     |
+| `MIMOCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | 啟用實驗性模型                              |
+| `MIMOCODE_DISABLE_AUTOCOMPACT`        | boolean | 停用自動上下文壓縮                          |
+| `MIMOCODE_DISABLE_CLAUDE_CODE`        | boolean | 停用讀取 `.claude`（提示詞 + 技能）         |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | 停用讀取 `~/.claude/CLAUDE.md`              |
+| `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | 停用載入 `.claude/skills`                   |
+| `MIMOCODE_DISABLE_MODELS_FETCH`       | boolean | 停用從遠端來源擷取模型                      |
+| `MIMOCODE_FAKE_VCS`                   | string  | 用於測試目的的模擬 VCS 供應商               |
+| `MIMOCODE_CLIENT`                     | string  | 用戶端識別碼（預設為 `cli`）                |
+| `MIMOCODE_ENABLE_EXA`                 | boolean | 啟用 Exa 網路搜尋工具                       |
+| `MIMOCODE_SERVER_PASSWORD`            | string  | 為 `serve`/`web` 啟用基本認證               |
+| `MIMOCODE_SERVER_USERNAME`            | string  | 覆寫基本認證使用者名稱（預設為 `opencode`） |
+| `MIMOCODE_MODELS_URL`                 | string  | 自訂模型設定擷取 URL                        |
 
 ---
 
@@ -588,16 +588,16 @@ OpenCode 可以透過環境變數進行設定。
 
 | 變數                                            | 類型    | 說明                            |
 | ----------------------------------------------- | ------- | ------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | boolean | 啟用所有實驗性功能              |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | 啟用圖示探索                    |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | 停用 TUI 中的選取即複製         |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | bash 指令的預設逾時時間（毫秒） |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | LLM 回應的最大輸出 Token 數     |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | 啟用整個目錄的檔案監看器        |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | 啟用 oxfmt 格式化器             |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | 啟用實驗性 LSP 工具             |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | 停用檔案監看器                  |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | 啟用實驗性 Exa 功能             |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | 為 python 檔案啟用 TY LSP       |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | 啟用實驗性 Markdown 功能        |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | 啟用計畫模式                    |
+| `MIMOCODE_EXPERIMENTAL`                         | boolean | 啟用所有實驗性功能              |
+| `MIMOCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | 啟用圖示探索                    |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | 停用 TUI 中的選取即複製         |
+| `MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | bash 指令的預設逾時時間（毫秒） |
+| `MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | LLM 回應的最大輸出 Token 數     |
+| `MIMOCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | 啟用整個目錄的檔案監看器        |
+| `MIMOCODE_EXPERIMENTAL_OXFMT`                   | boolean | 啟用 oxfmt 格式化器             |
+| `MIMOCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | 啟用實驗性 LSP 工具             |
+| `MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | 停用檔案監看器                  |
+| `MIMOCODE_EXPERIMENTAL_EXA`                     | boolean | 啟用實驗性 Exa 功能             |
+| `MIMOCODE_EXPERIMENTAL_LSP_TY`                  | boolean | 為 python 檔案啟用 TY LSP       |
+| `MIMOCODE_EXPERIMENTAL_MARKDOWN`                | boolean | 啟用實驗性 Markdown 功能        |
+| `MIMOCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | 啟用計畫模式                    |

--- a/packages/web/src/content/docs/zh-tw/config.mdx
+++ b/packages/web/src/content/docs/zh-tw/config.mdx
@@ -11,9 +11,9 @@ description: 使用 OpenCode JSON 設定。
 
 OpenCode 支援 **JSON** 和 **JSONC**（帶註解的 JSON）格式。
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "model": "anthropic/claude-sonnet-4-5",
   "autoupdate": true,
   "server": {
@@ -43,11 +43,11 @@ OpenCode 支援 **JSON** 和 **JSONC**（帶註解的 JSON）格式。
 設定來源按以下順序載入（後面的來源覆寫前面的來源）：
 
 1. **遠端設定**（來自 `.well-known/opencode`）- 組織預設值
-2. **全域設定**（`~/.config/opencode/opencode.json`）- 使用者偏好
-3. **自訂設定**（`OPENCODE_CONFIG` 環境變數）- 自訂覆寫
-4. **專案設定**（專案中的 `opencode.json`）- 專案特定設定
+2. **全域設定**（`~/.config/opencode/mimocode.jsonc`）- 使用者偏好
+3. **自訂設定**（`MIMOCODE_CONFIG` 環境變數）- 自訂覆寫
+4. **專案設定**（專案中的 `mimocode.jsonc`）- 專案特定設定
 5. **`.opencode` 目錄** - 代理、指令、外掛程式
-6. **內嵌設定**（`OPENCODE_CONFIG_CONTENT` 環境變數）- 執行時覆寫
+6. **內嵌設定**（`MIMOCODE_CONFIG_CONTENT` 環境變數）- 執行時覆寫
 
 這意味著專案設定可以覆寫全域預設值，全域設定可以覆寫遠端組織預設值。
 
@@ -79,7 +79,7 @@ OpenCode 支援 **JSON** 和 **JSONC**（帶註解的 JSON）格式。
 
 您可以在本地設定中啟用特定伺服器：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
   "mcp": {
     "jira": {
@@ -95,7 +95,7 @@ OpenCode 支援 **JSON** 和 **JSONC**（帶註解的 JSON）格式。
 
 ### 全域
 
-將全域 OpenCode 設定放在 `~/.config/opencode/opencode.json` 中。使用全域設定來設定使用者層級的偏好，例如主題、供應商或快捷鍵。
+將全域 OpenCode 設定放在 `~/.config/opencode/mimocode.jsonc` 中。使用全域設定來設定使用者層級的偏好，例如主題、供應商或快捷鍵。
 
 全域設定覆寫遠端組織預設值。
 
@@ -103,7 +103,7 @@ OpenCode 支援 **JSON** 和 **JSONC**（帶註解的 JSON）格式。
 
 ### 專案層級
 
-在專案根目錄中新增 `opencode.json`。專案設定在標準設定檔中具有最高優先級——它會覆寫全域設定和遠端設定。
+在專案根目錄中新增 `mimocode.jsonc`。專案設定在標準設定檔中具有最高優先級——它會覆寫全域設定和遠端設定。
 
 :::tip
 將專案特定設定放在專案的根目錄中。
@@ -117,10 +117,10 @@ OpenCode 支援 **JSON** 和 **JSONC**（帶註解的 JSON）格式。
 
 ### 自訂路徑
 
-使用 `OPENCODE_CONFIG` 環境變數指定自訂設定檔路徑。
+使用 `MIMOCODE_CONFIG` 環境變數指定自訂設定檔路徑。
 
 ```bash
-export OPENCODE_CONFIG=/path/to/my/custom-config.json
+export MIMOCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
@@ -130,10 +130,10 @@ opencode run "Hello world"
 
 ### 自訂目錄
 
-使用 `OPENCODE_CONFIG_DIR` 環境變數指定自訂設定目錄。該目錄會像標準 `.opencode` 目錄一樣被搜尋代理、指令、模式和外掛程式，並且應遵循相同的結構。
+使用 `MIMOCODE_CONFIG_DIR` 環境變數指定自訂設定目錄。該目錄會像標準 `.opencode` 目錄一樣被搜尋代理、指令、模式和外掛程式，並且應遵循相同的結構。
 
 ```bash
-export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+export MIMOCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
@@ -143,7 +143,7 @@ opencode run "Hello world"
 
 ## Schema
 
-設定檔具有在 [**`opencode.ai/config.json`**](https://opencode.ai/config.json) 中定義的 Schema。
+設定檔具有在 [**`mimocode.ai/config.json`**](https://mimocode.ai/config.json) 中定義的 Schema。
 
 您的編輯器應該能夠基於該 Schema 進行驗證和自動補全。
 
@@ -153,9 +153,9 @@ opencode run "Hello world"
 
 您可以透過 `tui` 選項設定 TUI 相關設定。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tui": {
     "scroll_speed": 3,
     "scroll_acceleration": {
@@ -172,9 +172,9 @@ opencode run "Hello world"
 - `scroll_speed` - 自訂捲動速度倍率（預設值：`3`，最小值：`1`）。如果 `scroll_acceleration.enabled` 為 `true`，則忽略此選項。
 - `diff_style` - 控制差異呈現方式。`"auto"` 根據終端機寬度自適應，`"stacked"` 始終顯示單列。
 
-使用 `OPENCODE_TUI_CONFIG` 指向自訂 TUI 設定檔。
+使用 `MIMOCODE_TUI_CONFIG` 指向自訂 TUI 設定檔。
 
-`opencode.json` 中的舊版 `theme`、`keybinds` 和 `tui` 鍵已被棄用，並將在可能的情況下自動遷移。
+`mimocode.jsonc` 中的舊版 `theme`、`keybinds` 和 `tui` 鍵已被棄用，並將在可能的情況下自動遷移。
 
 [在此了解更多關於 TUI 的資訊](/docs/tui)。
 
@@ -184,9 +184,9 @@ opencode run "Hello world"
 
 您可以透過 `server` 選項為 `opencode serve` 和 `opencode web` 指令設定伺服器設定。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
@@ -213,9 +213,9 @@ opencode run "Hello world"
 
 您可以透過 `tools` 選項管理 LLM 可以使用的工具。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "tools": {
     "write": false,
     "bash": false
@@ -231,9 +231,9 @@ opencode run "Hello world"
 
 您可以透過 `provider`、`model` 和 `small_model` 選項在 OpenCode 設定中設定要使用的供應商和模型。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {},
   "model": "anthropic/claude-sonnet-4-5",
   "small_model": "anthropic/claude-haiku-4-5"
@@ -244,9 +244,9 @@ opencode run "Hello world"
 
 供應商選項可以包括 `timeout` 和 `setCacheKey`：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "anthropic": {
       "options": {
@@ -273,9 +273,9 @@ opencode run "Hello world"
 
 Amazon Bedrock 支援 AWS 特定設定：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "provider": {
     "amazon-bedrock": {
       "options": {
@@ -306,7 +306,7 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）優先於基於設定
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "theme": "tokyonight"
 }
 ```
@@ -319,9 +319,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）優先於基於設定
 
 您可以透過 `agent` 選項為特定任務設定專用代理。
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
@@ -337,7 +337,7 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）優先於基於設定
 }
 ```
 
-您還可以使用 `~/.config/opencode/agents/` 或 `.opencode/agents/` 中的 Markdown 檔案定義代理。[在此了解更多](/docs/agents)。
+您還可以使用 `~/.config/opencode/agents/` 或 `.mimocode/agents/` 中的 Markdown 檔案定義代理。[在此了解更多](/docs/agents)。
 
 ---
 
@@ -345,9 +345,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）優先於基於設定
 
 您可以使用 `default_agent` 選項設定預設代理。當未明確指定代理時，將使用該預設代理。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "default_agent": "plan"
 }
 ```
@@ -362,9 +362,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）優先於基於設定
 
 您可以透過 `share` 選項設定[分享](/docs/share)功能。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "share": "manual"
 }
 ```
@@ -383,9 +383,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）優先於基於設定
 
 您可以透過 `command` 選項為重複任務設定自訂指令。
 
-```jsonc title="opencode.jsonc"
+```jsonc title="mimocode.jsoncc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "command": {
     "test": {
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
@@ -401,7 +401,7 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）優先於基於設定
 }
 ```
 
-您還可以使用 `~/.config/opencode/commands/` 或 `.opencode/commands/` 中的 Markdown 檔案定義指令。[在此了解更多](/docs/commands)。
+您還可以使用 `~/.config/opencode/commands/` 或 `.mimocode/commands/` 中的 Markdown 檔案定義指令。[在此了解更多](/docs/commands)。
 
 ---
 
@@ -411,7 +411,7 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）優先於基於設定
 
 ```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/tui.json",
+  "$schema": "https://mimocode.ai/tui.json",
   "keybinds": {}
 }
 ```
@@ -424,9 +424,9 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）優先於基於設定
 
 OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項停用此功能。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "autoupdate": false
 }
 ```
@@ -440,9 +440,9 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 您可以透過 `formatter` 選項設定程式碼格式化器。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "formatter": {
     "prettier": {
       "disabled": true
@@ -468,9 +468,9 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 例如，要讓 `edit` 和 `bash` 工具需要使用者確認：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "permission": {
     "edit": "ask",
     "bash": "ask"
@@ -486,9 +486,9 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 您可以透過 `compaction` 選項控制上下文壓縮行為。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "compaction": {
     "auto": true,
     "prune": true,
@@ -507,9 +507,9 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 您可以透過 `watcher` 選項設定檔案監看器的忽略模式。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]
   }
@@ -524,9 +524,9 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 您可以透過 `mcp` 選項設定要使用的 MCP 伺服器。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "mcp": {}
 }
 ```
@@ -539,11 +539,11 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 [外掛程式](/docs/plugins)透過自訂工具、掛鉤和整合來擴展 OpenCode。
 
-將外掛程式檔案放置在 `.opencode/plugins/` 或 `~/.config/opencode/plugins/` 中。您還可以透過 `plugin` 選項從 npm 載入外掛程式。
+將外掛程式檔案放置在 `.mimocode/plugins/` 或 `~/.config/opencode/plugins/` 中。您還可以透過 `plugin` 選項從 npm 載入外掛程式。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
 }
 ```
@@ -556,9 +556,9 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 您可以透過 `instructions` 選項為所使用的模型設定指示。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
 }
 ```
@@ -571,9 +571,9 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 您可以透過 `disabled_providers` 選項停用自動載入的供應商。當您希望阻止某些供應商被載入（即使其憑證可用）時，此選項非常有用。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "disabled_providers": ["openai", "gemini"]
 }
 ```
@@ -594,9 +594,9 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 您可以透過 `enabled_providers` 選項指定允許使用的供應商白名單。設定後，僅啟用指定的供應商，所有其他供應商將被忽略。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "enabled_providers": ["anthropic", "openai"]
 }
 ```
@@ -615,9 +615,9 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 `experimental` 鍵包含正在積極開發中的選項。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "experimental": {}
 }
 ```
@@ -638,10 +638,10 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 使用 `{env:VARIABLE_NAME}` 來替換環境變數：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "{env:OPENCODE_MODEL}",
+  "$schema": "https://mimocode.ai/config.json",
+  "model": "{env:MIMOCODE_MODEL}",
   "provider": {
     "anthropic": {
       "models": {},
@@ -661,9 +661,9 @@ OpenCode 啟動時會自動下載新版本。您可以使用 `autoupdate` 選項
 
 使用 `{file:path/to/file}` 來替換檔案內容：
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {

--- a/packages/web/src/content/docs/zh-tw/plugins.mdx
+++ b/packages/web/src/content/docs/zh-tw/plugins.mdx
@@ -19,7 +19,7 @@ description: 編寫自己的外掛來擴展 OpenCode。
 
 將 JavaScript 或 TypeScript 檔案放置在外掛目錄中。
 
-- `.opencode/plugins/` - 專案級外掛
+- `.mimocode/plugins/` - 專案級外掛
 - `~/.config/opencode/plugins/` - 全域外掛
 
 這些目錄中的檔案會在啟動時自動載入。
@@ -30,9 +30,9 @@ description: 編寫自己的外掛來擴展 OpenCode。
 
 在設定檔中指定 npm 套件。
 
-```json title="opencode.json"
+```json title="mimocode.jsonc"
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimocode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
 }
 ```
@@ -55,10 +55,10 @@ description: 編寫自己的外掛來擴展 OpenCode。
 
 外掛從所有來源載入，所有鉤子按順序執行。載入順序為：
 
-1. 全域設定 (`~/.config/opencode/opencode.json`)
-2. 專案設定 (`opencode.json`)
+1. 全域設定 (`~/.config/opencode/mimocode.jsonc`)
+2. 專案設定 (`mimocode.jsonc`)
 3. 全域外掛目錄 (`~/.config/opencode/plugins/`)
-4. 專案外掛目錄 (`.opencode/plugins/`)
+4. 專案外掛目錄 (`.mimocode/plugins/`)
 
 名稱和版本相同的重複 npm 套件只會載入一次。但本地外掛和名稱相似的 npm 外掛會分別獨立載入。
 
@@ -74,7 +74,7 @@ description: 編寫自己的外掛來擴展 OpenCode。
 
 本地外掛和自訂工具可以使用外部 npm 套件。在設定目錄中新增一個 `package.json`，列出所需的相依套件。
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -84,7 +84,7 @@ description: 編寫自己的外掛來擴展 OpenCode。
 
 OpenCode 會在啟動時執行 `bun install` 來安裝這些相依套件。之後您的外掛和工具就可以匯入它們了。
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -102,7 +102,7 @@ export const MyPlugin = async (ctx) => {
 
 ### 基本結構
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -217,7 +217,7 @@ export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree
 
 在特定事件發生時傳送通知：
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
@@ -242,7 +242,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
 
 阻止 OpenCode 讀取 `.env` 檔案：
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -260,7 +260,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 將環境變數注入所有 Shell 執行（AI 工具和使用者終端機）：
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -277,7 +277,7 @@ export const InjectEnvPlugin = async () => {
 
 外掛還可以為 OpenCode 新增自訂工具：
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -316,7 +316,7 @@ export const CustomToolsPlugin: Plugin = async (ctx) => {
 
 使用 `client.app.log()` 代替 `console.log` 進行結構化日誌記錄：
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -329,7 +329,7 @@ export const MyPlugin = async ({ client }) => {
 }
 ```
 
-日誌層級：`debug`、`info`、`warn`、`error`。詳情請參閱 [SDK 文件](https://opencode.ai/docs/sdk)。
+日誌層級：`debug`、`info`、`warn`、`error`。詳情請參閱 [SDK 文件](https://mimocode.ai/docs/sdk)。
 
 ---
 
@@ -337,7 +337,7 @@ export const MyPlugin = async ({ client }) => {
 
 自訂工作階段壓縮時包含的上下文：
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -361,7 +361,7 @@ Include any state that should persist across compaction:
 
 您還可以透過設定 `output.prompt` 來完全替換壓縮提示詞：
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {


### PR DESCRIPTION
This PR fixes two issues:
1. Adds a skip_claude_md configuration option to bypass loading ~/.claude/CLAUDE.md during initialization. Fixes #1138
2. Modifies textarea rendering components to explicitly set selectionFg and selectionBg props to dynamically use the theme's text color. This ensures IME uncommitted text inherits the correct color in light themes. Fixes #1141