### PR TITLE
fix: improve provider auth method fallback logic and rebrand to MiMoCode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -44,12 +44,16 @@ export function createDialogProviderOptions() {
           async onSelect() {
             if (consoleManaged) return
 
-            const methods = sync.data.provider_auth[provider.id] ?? [
-              {
-                type: "api",
-                label: "API key",
-              },
-            ]
+            const stored = sync.data.provider_auth[provider.id]
+            const methods: ProviderAuthMethod[] =
+              stored && stored.length > 0
+                ? stored
+                : [
+                    {
+                      type: "api",
+                      label: "API key",
+                    },
+                  ]
             let index: number | null = 0
             if (methods.length > 1) {
               index = await new Promise<number | null>((resolve) => {

--- a/packages/opencode/src/session/prompt/codex.txt
+++ b/packages/opencode/src/session/prompt/codex.txt
@@ -1,4 +1,4 @@
-You are OpenCode, the best coding agent on the planet.
+You are MiMoCode, the best coding agent on the planet.
 
 You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 

--- a/packages/opencode/src/session/prompt/gemini.txt
+++ b/packages/opencode/src/session/prompt/gemini.txt
@@ -1,4 +1,4 @@
-You are opencode, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
+You are MiMoCode, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
 
 # Core Mandates
 


### PR DESCRIPTION
## Summary
- Fix dialog-provider to explicitly check for empty auth methods array before falling back to default API key method
- Add explicit ProviderAuthMethod[] typing for type safety
- Rebrand system prompts from OpenCode to MiMoCode

## Changes
- : Improved auth method selection logic with explicit empty array check and proper typing
- : Updated system prompt branding from OpenCode to MiMoCode
- : Updated system prompt branding from opencode to MiMoCode