### PR TITLE
fix(test): replace sleep(50) with condition-based wait in cancel shell test

### DIFF
--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1244,12 +1244,18 @@ unix(
       provideTmpdirInstance(
         (_dir) =>
           Effect.gen(function* () {
-            const { prompt, run, chat } = yield* boot()
+            const { prompt, run, sessions, chat } = yield* boot()
 
             const sh = yield* prompt
               .shell({ sessionID: chat.id, agent: "build", command: "sleep 30" })
               .pipe(Effect.forkChild)
-            yield* Effect.sleep(50)
+            yield* Effect.gen(function* () {
+              while (true) {
+                const msgs = yield* sessions.messages({ sessionID: chat.id })
+                if (msgs.some((m) => m.info.role === "assistant")) return
+                yield* Effect.sleep(10)
+              }
+            }).pipe(Effect.timeout(5000))
 
             yield* prompt.cancel(chat.id)
 


### PR DESCRIPTION
## Summary / 概述

Fix the consistently failing test `cancel interrupts shell and resolves cleanly` by replacing an arbitrary `sleep(50)` with a condition-based wait.

修复测试 `cancel interrupts shell and resolves cleanly` 的稳定失败，将固定的 `sleep(50)` 替换为基于条件的等待。

## Root Cause / 根因

The test forks a shell (`sleep 30`), sleeps 50ms, then cancels. The shell setup (`shellImpl`) does significant IO before spawning the process: fetching context, resolving agent/model, creating user+assistant messages. When local SDK loading is present, this setup exceeds 50ms.

When `cancel` fires during setup, the runner interrupts the shell fiber. The `onInterrupt` callback (`lastAssistant`) tries to find the last assistant message — but it hasn't been created yet, so it throws `"Impossible"`, making the fiber exit as a failure instead of success.

**Race:** `sleep(50)` < shell setup time → interrupt fires before assistant message exists → `lastAssistant` throws → test fails.

## Fix / 修复

Replace `sleep(50)` with a polling loop that waits for the assistant message to appear in the session before calling `cancel`. This guarantees the shell has completed its message creation phase, making `lastAssistant` safe to call on interrupt.

将 `sleep(50)` 替换为轮询循环，等待 session 中出现 assistant message 后再调用 `cancel`。这保证了 shell 已完成消息创建阶段，`lastAssistant` 在 interrupt 时可以安全调用。

```ts
// Before
yield* Effect.sleep(50)

// After
yield* Effect.gen(function* () {
  while (true) {
    const msgs = yield* sessions.messages({ sessionID: chat.id })
    if (msgs.some((m) => m.info.role === "assistant")) return
    yield* Effect.sleep(10)
  }
}).pipe(Effect.timeout(5000))
```

## Note / 备注

There is a deeper design issue: `runner.ts:startShell`'s `onInterrupt` callback assumes an assistant message always exists. A more robust fix would make `lastAssistant` handle empty sessions gracefully. This is left as a follow-up.

`runner.ts:startShell` 的 `onInterrupt` 回调假设 assistant message 始终存在，更彻底的修复应让 `lastAssistant` 优雅处理空 session。留作后续。

## Test / 验证

- [x] 3/3 local runs pass (previously 3/3 fail)
- [x] `bun typecheck` passes