### PR TITLE
Revert "fix(tui): show provider/model id as title in model dialog"

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -52,7 +52,7 @@ export function DialogModel(props: { providerID?: string }) {
           {
             key: item,
             value: { providerID: provider.id, modelID: model.id },
-            title: `${provider.id}/${item.modelID}`,
+            title: model.name ?? item.modelID,
             description: provider.name,
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
@@ -87,7 +87,7 @@ export function DialogModel(props: { providerID?: string }) {
           filter(([_, info]) => (props.providerID ? info.providerID === props.providerID : true)),
           map(([model, info]) => ({
             value: { providerID: provider.id, modelID: model },
-            title: `${provider.id}/${model}`,
+            title: info.name ?? model,
             description: favorites.some((item) => item.providerID === provider.id && item.modelID === model)
               ? "(Favorite)"
               : undefined,


### PR DESCRIPTION
## Summary / 概要

Reverts #1169

## Reason / 原因

PR #1169 将模型选择对话框中的标题从模型名称改为 provider/modelID 格式，导致以下问题：

1. **显示效果不佳**：选择界面本就显示 Provider 信息，现在变成了 provider/modelid Provider 这样的重复格式
2. **忽略了模型的 name 字段**：原改动忽略了模型设置的 name 字段，该字段提供了更友好的显示名称

The PR #1169 changed the model selection dialog title from model name to provider/modelID format, causing:

1. **Poor display effect**: The selection interface already shows Provider info, now it becomes redundant provider/modelid Provider format
2. **Ignores model name field**: The original change ignores the model name field which provides a more user-friendly display name