### PR TITLE
fix(test): fix CI test failures on main

### DIFF
--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2638,12 +2638,13 @@ test("opencode and opencode-go providers are disabled by MimoFreeAuthPlugin", as
 
   // MimoFreeAuthPlugin always pushes opencode/opencode-go into disabled_providers,
   // so they should not appear even when the user supplies an apiKey or auth record.
-  expect(opencodeProviderPresent(providers)).toBe(false)
-  expect(providers[ProviderID.make("opencode-go")]).toBeUndefined()
-  // The replacement free provider is registered by a private plugin (src/private/)
-  // that only exists in the internal build. Skip these assertions in open-source.
+  // However, MimoFreeAuthPlugin is part of the private overlay (src/ext/) that only
+  // exists in the internal build. In the open-source build the plugin is absent and
+  // opencode/opencode-go remain loaded. Gate these assertions on mimo provider presence.
   const mimo = providers[ProviderID.make("mimo")]
   if (mimo) {
+    expect(opencodeProviderPresent(providers)).toBe(false)
+    expect(providers[ProviderID.make("opencode-go")]).toBeUndefined()
     expect(mimo.models[ModelID.make("mimo-auto")]).toBeDefined()
     expect(mimo.models[ModelID.make("mimo-auto")].limit.context).toBe(1_000_000)
     expect(mimo.models[ModelID.make("mimo-auto")].limit.output).toBe(128_000)

--- a/packages/opencode/test/tool/whitelist.test.ts
+++ b/packages/opencode/test/tool/whitelist.test.ts
@@ -292,7 +292,9 @@ describe("Tool whitelist (Task 14)", () => {
         })
 
         // Locate the bash tool part in the persisted message stream.
-        const msgs = yield* MessageV2.filterCompactedEffect(session.id)
+        // Use agentID="*" to include the subagent slice (actorID="build-1"),
+        // since filterCompactedEffect defaults to the "main" slice only.
+        const msgs = yield* MessageV2.filterCompactedEffect(session.id, { agentID: "*" })
         const tool = msgs
           .flatMap((msg) => msg.parts)
           .find(
@@ -350,7 +352,9 @@ describe("Tool whitelist (Task 14)", () => {
           parts: [{ type: "text", text: "no tool call needed" }],
         })
 
-        const msgs = yield* MessageV2.filterCompactedEffect(session.id)
+        // Use agentID="*" to include the subagent slice (actorID="build-2"),
+        // since filterCompactedEffect defaults to the "main" slice only.
+        const msgs = yield* MessageV2.filterCompactedEffect(session.id, { agentID: "*" })
         const rejected = msgs
           .flatMap((msg) => msg.parts)
           .find((part) => part.type === "tool" && part.state.status === "completed" && (part.state.metadata?.rejected as unknown) === true)


### PR DESCRIPTION
## Summary
- Fix provider.test.ts: MimoFreeAuthPlugin only exists in internal overlay, skip opencode disable assertions when mimo provider absent
- Fix whitelist.test.ts: filterCompactedEffect defaults to main slice, subagent messages live in their actorID slice; use agentID='*'