### PR TITLE
fix(test): replace sleep(50) with condition-based wait in cancel shell TERM test

### DIFF
--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1287,12 +1287,18 @@ unix(
       provideTmpdirInstance(
         (_dir) =>
           Effect.gen(function* () {
-            const { prompt, chat } = yield* boot()
+            const { prompt, sessions, chat } = yield* boot()
 
             const sh = yield* prompt
               .shell({ sessionID: chat.id, agent: "build", command: "trap '' TERM; sleep 30" })
               .pipe(Effect.forkChild)
-            yield* Effect.sleep(50)
+            yield* Effect.gen(function* () {
+              while (true) {
+                const msgs = yield* sessions.messages({ sessionID: chat.id })
+                if (msgs.some((m) => m.info.role === "assistant")) return
+                yield* Effect.sleep(10)
+              }
+            }).pipe(Effect.timeout(5000))
 
             yield* prompt.cancel(chat.id)
 


### PR DESCRIPTION
## Summary / 概述

Follow-up to #1189. Same race condition in the sibling test `cancel persists aborted shell result when shell ignores TERM`.

#1189 的后续修复。兄弟测试 `cancel persists aborted shell result when shell ignores TERM` 存在完全相同的竞态条件。

## Root Cause / 根因

Identical to #1189: `Effect.sleep(50)` is insufficient for shell setup (context fetch, agent/model resolution, user+assistant message creation) when SDK loading is present. When `cancel` fires during setup, `lastAssistant` throws `"Impossible"` because the assistant message hasn't been created yet.

与 #1189 完全相同：本地 SDK 加载导致 shell setup（context 获取、agent/model 解析、user+assistant message 创建）超过 50ms。cancel 在 setup 期间触发时，`lastAssistant` 因 assistant message 尚未创建而抛出 `"Impossible"`。

CI failure: [job/82680823412](https://github.com/XiaomiMiMo/MiMo-Code/actions/runs/27943044755/job/82680823412?pr=1198)

## Fix / 修复

Same approach as #1189: poll for the assistant message to exist before calling `cancel`.

与 #1189 相同方案：轮询等待 assistant message 出现后再调用 `cancel`。

## Test / 验证

- [x] 3/3 local runs pass (previously 3/3 fail)
- [x] `bun typecheck` passes
- [x] Full test file: 33 pass / 1 fail (pre-existing, same as #911)