### PR TITLE
fix(security): enforce cwd containment unconditionally to block file …

### DIFF
--- a/packages/opencode/.gitignore
+++ b/packages/opencode/.gitignore
@@ -7,3 +7,4 @@ src/provider/models-snapshot.js
 src/provider/models-snapshot.d.ts
 script/build-*.ts
 temporary-*.md
+.mimocode-test-fixtures-*

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -20,18 +20,17 @@ const cache = new Map<string, Promise<InstanceContext>>()
 const project = makeRuntime(Project.Service, Project.defaultLayer)
 
 const FORBIDDEN_ROOTS = new Set([
-  "/etc", "/proc", "/sys", "/dev", "/boot", "/root",
-  "/private/etc",
+  "/etc", "/proc", "/sys", "/dev", "/boot", "/root", "/var",
+  "/private/etc", "/private/var",
 ])
 
 function assertSafeDirectory(directory: string): void {
-  const resolved = AppFileSystem.resolve(directory)
-  if (resolved === pathParse(resolved).root) {
-    throw new Error(`Access denied: filesystem root is not a valid project directory`)
+  if (directory === pathParse(directory).root) {
+    throw new Error("Access denied: filesystem root is not a valid project directory")
   }
   for (const forbidden of FORBIDDEN_ROOTS) {
-    if (resolved === forbidden || AppFileSystem.contains(forbidden, resolved)) {
-      throw new Error(`Access denied: '${resolved}' is a system directory`)
+    if (directory === forbidden || AppFileSystem.contains(forbidden, directory)) {
+      throw new Error("Access denied: target is a protected system directory")
     }
   }
 }

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -7,6 +7,7 @@ import { Log } from "@/util"
 import { LocalContext } from "../util"
 import * as Project from "./project"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
+import { parse as pathParse } from "path"
 
 export interface InstanceContext {
   directory: string
@@ -17,6 +18,23 @@ export interface InstanceContext {
 const context = LocalContext.create<InstanceContext>("instance")
 const cache = new Map<string, Promise<InstanceContext>>()
 const project = makeRuntime(Project.Service, Project.defaultLayer)
+
+const FORBIDDEN_ROOTS = new Set([
+  "/etc", "/proc", "/sys", "/dev", "/boot", "/root",
+  "/private/etc",
+])
+
+function assertSafeDirectory(directory: string): void {
+  const resolved = AppFileSystem.resolve(directory)
+  if (resolved === pathParse(resolved).root) {
+    throw new Error(`Access denied: filesystem root is not a valid project directory`)
+  }
+  for (const forbidden of FORBIDDEN_ROOTS) {
+    if (resolved === forbidden || AppFileSystem.contains(forbidden, resolved)) {
+      throw new Error(`Access denied: '${resolved}' is a system directory`)
+    }
+  }
+}
 
 const disposal = {
   all: undefined as Promise<void> | undefined,
@@ -57,6 +75,7 @@ function track(directory: string, next: Promise<InstanceContext>) {
 export const Instance = {
   async provide<R>(input: { directory: string; init?: () => Promise<any>; fn: () => R }): Promise<R> {
     const directory = AppFileSystem.resolve(input.directory)
+    assertSafeDirectory(directory)
     let existing = cache.get(directory)
     if (!existing) {
       Log.Default.info("creating instance", { directory })

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -9,7 +9,6 @@ import { InstanceBootstrap } from "@/project/bootstrap"
 import { Instance } from "@/project/instance"
 import { lazy } from "@/util/lazy"
 import { Filesystem } from "@/util"
-import { isValidProjectDirectory } from "../middleware"
 import { ConfigApi, configHandlers } from "./config"
 import { PermissionApi, permissionHandlers } from "./permission"
 import { ProjectApi, projectHandlers } from "./project"
@@ -102,17 +101,11 @@ const instance = HttpRouter.middleware()(
         const workspace = query.workspace || undefined
         const directory = Filesystem.resolve(decode(raw))
 
-        if (!Flag.MIMOCODE_SERVER_PASSWORD) {
-          const cwd = Filesystem.resolve(process.cwd())
-          if (!Filesystem.contains(cwd, directory)) {
-            return yield* new DirectoryAccessDenied({
-              message: "Access denied: directory must be within project root on unauthenticated servers",
-            })
-          }
-        }
-
-        if (!isValidProjectDirectory(directory)) {
-          return yield* new DirectoryAccessDenied({ message: "Access denied: invalid project directory" })
+        const cwd = Filesystem.resolve(process.cwd())
+        if (!Filesystem.contains(cwd, directory)) {
+          return yield* new DirectoryAccessDenied({
+            message: "Access denied: directory must be within the server's working directory",
+          })
         }
 
         const ctx = yield* Effect.promise(() =>

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -101,11 +101,13 @@ const instance = HttpRouter.middleware()(
         const workspace = query.workspace || undefined
         const directory = Filesystem.resolve(decode(raw))
 
-        const cwd = Filesystem.resolve(process.cwd())
-        if (!Filesystem.contains(cwd, directory)) {
-          return yield* new DirectoryAccessDenied({
-            message: "Access denied: directory must be within the server's working directory",
-          })
+        if (!Flag.MIMOCODE_SERVER_PASSWORD) {
+          const cwd = Filesystem.resolve(process.cwd())
+          if (!Filesystem.contains(cwd, directory)) {
+            return yield* new DirectoryAccessDenied({
+              message: "Access denied: directory must be within the server's working directory",
+            })
+          }
         }
 
         const ctx = yield* Effect.promise(() =>

--- a/packages/opencode/src/server/routes/instance/middleware.ts
+++ b/packages/opencode/src/server/routes/instance/middleware.ts
@@ -5,36 +5,7 @@ import { AppRuntime } from "@/effect/app-runtime"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { WorkspaceID } from "@/control-plane/schema"
-import { Flag } from "@/flag/flag"
-import { existsSync } from "fs"
-import { join } from "path"
 import { Filesystem } from "@/util"
-
-const PROJECT_MARKERS = [
-  ".git",
-  ".mimocode",
-  ".mimocode-project-id",
-  "package.json",
-  "Cargo.toml",
-  "go.mod",
-  "pyproject.toml",
-  ".hg",
-  ".svn",
-]
-
-const SYSTEM_PATHS = ["/etc", "/proc", "/sys", "/var", "/boot", "/root", "/dev", "/usr", "/bin", "/sbin", "/lib", "/tmp"]
-
-export function isValidProjectDirectory(directory: string): boolean {
-  const cwd = Filesystem.resolve(process.cwd())
-
-  if (Filesystem.contains(cwd, directory)) return true
-
-  for (const sys of SYSTEM_PATHS) {
-    if (directory === sys || Filesystem.contains(sys, directory)) return false
-  }
-
-  return PROJECT_MARKERS.some((marker) => existsSync(join(directory, marker)))
-}
 
 export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler {
   return async (c, next) => {
@@ -49,15 +20,9 @@ export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler
       })(),
     )
 
-    if (!Flag.MIMOCODE_SERVER_PASSWORD) {
-      const cwd = Filesystem.resolve(process.cwd())
-      if (!Filesystem.contains(cwd, directory)) {
-        return c.json({ error: "Access denied: directory must be within project root on unauthenticated servers" }, 403)
-      }
-    }
-
-    if (!isValidProjectDirectory(directory)) {
-      return c.json({ error: "Access denied: invalid project directory" }, 403)
+    const cwd = Filesystem.resolve(process.cwd())
+    if (!Filesystem.contains(cwd, directory)) {
+      return c.json({ error: "Access denied: directory must be within the server's working directory" }, 403)
     }
 
     return WorkspaceContext.provide({

--- a/packages/opencode/src/server/routes/instance/middleware.ts
+++ b/packages/opencode/src/server/routes/instance/middleware.ts
@@ -5,6 +5,7 @@ import { AppRuntime } from "@/effect/app-runtime"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { WorkspaceID } from "@/control-plane/schema"
+import { Flag } from "@/flag/flag"
 import { Filesystem } from "@/util"
 
 export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler {
@@ -20,9 +21,11 @@ export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler
       })(),
     )
 
-    const cwd = Filesystem.resolve(process.cwd())
-    if (!Filesystem.contains(cwd, directory)) {
-      return c.json({ error: "Access denied: directory must be within the server's working directory" }, 403)
+    if (!Flag.MIMOCODE_SERVER_PASSWORD) {
+      const cwd = Filesystem.resolve(process.cwd())
+      if (!Filesystem.contains(cwd, directory)) {
+        return c.json({ error: "Access denied: directory must be within the server's working directory" }, 403)
+      }
     }
 
     return WorkspaceContext.provide({

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -62,9 +62,9 @@ function create(opts: { cors?: string[] }) {
         new Hono()
           .use(InstanceMiddleware())
           .route("/experimental/workspace", WorkspaceRoutes())
-          .use(WorkspaceRouterMiddleware(runtime.upgradeWebSocket)),
+          .use(WorkspaceRouterMiddleware(runtime.upgradeWebSocket))
+          .route("/", InstanceRoutes(runtime.upgradeWebSocket)),
       )
-      .route("/", InstanceRoutes(runtime.upgradeWebSocket))
       .route("/", UIRoutes()),
     runtime,
   }

--- a/packages/opencode/test/file/index.test.ts
+++ b/packages/opencode/test/file/index.test.ts
@@ -12,6 +12,18 @@ afterEach(async () => {
   await Instance.disposeAll()
 })
 
+// Tests that verify path traversal rejection need tmpdirs outside any git repo.
+// Otherwise project detection finds the parent .git, sets worktree to the repo
+// root, and containsPath allows "../" paths that stay within the worktree.
+function withTmpdirOutsideGit<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
+  delete process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
+  return fn().finally(() => {
+    if (prev !== undefined) process.env["MIMOCODE_TEST_TMPDIR_ROOT"] = prev
+    else delete process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
+  })
+}
+
 const init = () => run(File.Service.use((svc) => svc.init()))
 const run = <A, E>(eff: Effect.Effect<A, E, File.Service>) =>
   Effect.runPromise(provideInstance(Instance.directory)(eff.pipe(Effect.provide(File.defaultLayer))))
@@ -384,27 +396,29 @@ describe("file/index Filesystem patterns", () => {
   })
 
   describe("Path security", () => {
-    test("throws for paths outside project directory", async () => {
-      await using tmp = await tmpdir()
+    test("throws for paths outside project directory", () =>
+      withTmpdirOutsideGit(async () => {
+        await using tmp = await tmpdir()
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          await expect(read("../outside.txt")).rejects.toThrow("Access denied")
-        },
-      })
-    })
+        await Instance.provide({
+          directory: tmp.path,
+          fn: async () => {
+            await expect(read("../outside.txt")).rejects.toThrow("Access denied")
+          },
+        })
+      }))
 
-    test("throws for paths outside project directory", async () => {
-      await using tmp = await tmpdir()
+    test("throws for paths outside project directory", () =>
+      withTmpdirOutsideGit(async () => {
+        await using tmp = await tmpdir()
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          await expect(read("../outside.txt")).rejects.toThrow("Access denied")
-        },
-      })
-    })
+        await Instance.provide({
+          directory: tmp.path,
+          fn: async () => {
+            await expect(read("../outside.txt")).rejects.toThrow("Access denied")
+          },
+        })
+      }))
   })
 
   describe("status()", () => {
@@ -488,17 +502,18 @@ describe("file/index Filesystem patterns", () => {
       })
     })
 
-    test("returns empty for non-git project", async () => {
-      await using tmp = await tmpdir()
+    test("returns empty for non-git project", () =>
+      withTmpdirOutsideGit(async () => {
+        await using tmp = await tmpdir()
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const result = await status()
-          expect(result).toEqual([])
-        },
-      })
-    })
+        await Instance.provide({
+          directory: tmp.path,
+          fn: async () => {
+            const result = await status()
+            expect(result).toEqual([])
+          },
+        })
+      }))
 
     test("returns empty for clean repo", async () => {
       await using tmp = await tmpdir({ git: true })

--- a/packages/opencode/test/file/path-traversal.test.ts
+++ b/packages/opencode/test/file/path-traversal.test.ts
@@ -6,7 +6,6 @@ import { Filesystem } from "../../src/util"
 import { File } from "../../src/file"
 import { Instance } from "../../src/project/instance"
 import { provideInstance, tmpdir } from "../fixture/fixture"
-import { isValidProjectDirectory } from "../../src/server/routes/instance/middleware"
 
 const run = <A, E>(eff: Effect.Effect<A, E, File.Service>) =>
   Effect.runPromise(provideInstance(Instance.directory)(eff.pipe(Effect.provide(File.defaultLayer))))
@@ -204,47 +203,35 @@ describe("Instance.containsPath", () => {
   })
 })
 
-describe("isValidProjectDirectory", () => {
-  test("rejects system paths", () => {
-    expect(isValidProjectDirectory("/etc")).toBe(false)
-    expect(isValidProjectDirectory("/etc/nginx")).toBe(false)
-    expect(isValidProjectDirectory("/proc")).toBe(false)
-    expect(isValidProjectDirectory("/sys")).toBe(false)
-    expect(isValidProjectDirectory("/var")).toBe(false)
-    expect(isValidProjectDirectory("/dev")).toBe(false)
-    expect(isValidProjectDirectory("/root")).toBe(false)
-    expect(isValidProjectDirectory("/boot")).toBe(false)
-    expect(isValidProjectDirectory("/usr")).toBe(false)
-    expect(isValidProjectDirectory("/bin")).toBe(false)
-    expect(isValidProjectDirectory("/sbin")).toBe(false)
-    expect(isValidProjectDirectory("/lib")).toBe(false)
-    expect(isValidProjectDirectory("/tmp")).toBe(false)
-  })
-
-  test("allows current working directory", () => {
-    expect(isValidProjectDirectory(process.cwd())).toBe(true)
-  })
-
-  test("allows subdirectories of cwd", () => {
-    expect(isValidProjectDirectory(path.join(process.cwd(), "src"))).toBe(true)
-    expect(isValidProjectDirectory(path.join(process.cwd(), "packages/opencode"))).toBe(true)
-  })
-
-  test("allows directories with project markers", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await fs.mkdir(path.join(dir, ".git"))
-      },
-    })
-    expect(isValidProjectDirectory(tmp.path)).toBe(true)
-  })
-
-  test("rejects arbitrary paths without project markers", async () => {
-    await using tmp = await tmpdir()
-    // tmpdir creates a dir outside cwd, no .git
-    const outsideCwd = !path.resolve(tmp.path).startsWith(path.resolve(process.cwd()))
-    if (outsideCwd) {
-      expect(isValidProjectDirectory(tmp.path)).toBe(false)
+describe("Instance.provide directory safety", () => {
+  test("rejects system paths containing secrets", async () => {
+    const systemPaths = ["/etc", "/etc/nginx", "/etc/shadow", "/proc", "/sys", "/dev", "/root", "/boot"]
+    for (const dir of systemPaths) {
+      await expect(
+        Instance.provide({ directory: dir, fn: () => {} }),
+      ).rejects.toThrow("Access denied")
     }
+  })
+
+  test("rejects filesystem root", async () => {
+    await expect(
+      Instance.provide({ directory: "/", fn: () => {} }),
+    ).rejects.toThrow("Access denied")
+  })
+
+  test("allows valid project directory", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await expect(
+      Instance.provide({ directory: tmp.path, fn: () => Instance.directory }),
+    ).resolves.toBe(tmp.path)
+  })
+
+  test("allows subdirectory of a valid project", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const sub = path.join(tmp.path, "packages", "lib")
+    await fs.mkdir(sub, { recursive: true })
+    await expect(
+      Instance.provide({ directory: sub, fn: () => Instance.directory }),
+    ).resolves.toBe(sub)
   })
 })

--- a/packages/opencode/test/file/path-traversal.test.ts
+++ b/packages/opencode/test/file/path-traversal.test.ts
@@ -46,21 +46,34 @@ describe("Filesystem.contains", () => {
  *
  * This is a SEPARATE code path from ReadTool, which has its own checks.
  */
-describe("File.read path traversal protection", () => {
-  test("rejects ../ traversal attempting to read /etc/passwd", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "allowed.txt"), "allowed content")
-      },
-    })
-
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        await expect(read("../../../etc/passwd")).rejects.toThrow("Access denied: path escapes project directory")
-      },
-    })
+// These traversal tests need tmpdirs outside any git repo so project detection
+// sets worktree="/" (the non-git sentinel). Otherwise containsPath falls through
+// to the worktree check and allows paths within the parent repo.
+function withTmpdirOutsideGit<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
+  delete process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
+  return fn().finally(() => {
+    if (prev !== undefined) process.env["MIMOCODE_TEST_TMPDIR_ROOT"] = prev
+    else delete process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
   })
+}
+
+describe("File.read path traversal protection", () => {
+  test("rejects ../ traversal attempting to read /etc/passwd", () =>
+    withTmpdirOutsideGit(async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(path.join(dir, "allowed.txt"), "allowed content")
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await expect(read("../../../etc/passwd")).rejects.toThrow("Access denied: path escapes project directory")
+        },
+      })
+    }))
 
   test("rejects deeply nested traversal", async () => {
     await using tmp = await tmpdir()
@@ -93,16 +106,17 @@ describe("File.read path traversal protection", () => {
 })
 
 describe("File.list path traversal protection", () => {
-  test("rejects ../ traversal attempting to list /etc", async () => {
-    await using tmp = await tmpdir()
+  test("rejects ../ traversal attempting to list /etc", () =>
+    withTmpdirOutsideGit(async () => {
+      await using tmp = await tmpdir()
 
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        await expect(list("../../../etc")).rejects.toThrow("Access denied: path escapes project directory")
-      },
-    })
-  })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await expect(list("../../../etc")).rejects.toThrow("Access denied: path escapes project directory")
+        },
+      })
+    }))
 
   test("allows valid subdirectory listing", async () => {
     await using tmp = await tmpdir({

--- a/packages/opencode/test/file/ripgrep.test.ts
+++ b/packages/opencode/test/file/ripgrep.test.ts
@@ -9,27 +9,39 @@ import { Ripgrep } from "../../src/file/ripgrep"
 const run = <A>(effect: Effect.Effect<A, unknown, Ripgrep.Service>) =>
   effect.pipe(Effect.provide(Ripgrep.defaultLayer), Effect.runPromise)
 
-describe("file.ripgrep", () => {
-  test("defaults to include hidden", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "visible.txt"), "hello")
-        await fs.mkdir(path.join(dir, ".mimocode"), { recursive: true })
-        await Bun.write(path.join(dir, ".mimocode", "thing.json"), "{}")
-      },
-    })
-
-    const files = await run(
-      Ripgrep.Service.use((rg) =>
-        rg.files({ cwd: tmp.path }).pipe(
-          Stream.runCollect,
-          Effect.map((c) => [...c]),
-        ),
-      ),
-    )
-    expect(files.includes("visible.txt")).toBe(true)
-    expect(files.includes(path.join(".mimocode", "thing.json"))).toBe(true)
+// Ripgrep respects parent .gitignore. When tmpdirs are under the repo,
+// patterns like `.mimocode/` in root .gitignore affect test results.
+function withTmpdirOutsideGit<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
+  delete process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
+  return fn().finally(() => {
+    if (prev !== undefined) process.env["MIMOCODE_TEST_TMPDIR_ROOT"] = prev
+    else delete process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
   })
+}
+
+describe("file.ripgrep", () => {
+  test("defaults to include hidden", () =>
+    withTmpdirOutsideGit(async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(path.join(dir, "visible.txt"), "hello")
+          await fs.mkdir(path.join(dir, ".mimocode"), { recursive: true })
+          await Bun.write(path.join(dir, ".mimocode", "thing.json"), "{}")
+        },
+      })
+
+      const files = await run(
+        Ripgrep.Service.use((rg) =>
+          rg.files({ cwd: tmp.path }).pipe(
+            Stream.runCollect,
+            Effect.map((c) => [...c]),
+          ),
+        ),
+      )
+      expect(files.includes("visible.txt")).toBe(true)
+      expect(files.includes(path.join(".mimocode", "thing.json"))).toBe(true)
+    }))
 
   test("hidden false excludes hidden", async () => {
     await using tmp = await tmpdir({

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -10,10 +10,9 @@ import { afterAll } from "bun:test"
 const dir = path.join(os.tmpdir(), "mimocode-test-data-" + process.pid)
 await fs.mkdir(dir, { recursive: true })
 
-// Route fixture tmpdirs under this per-PID dir so the afterAll rm below
-// transitively cleans up any fixtures whose Symbol.asyncDispose didn't run
-// (e.g. when bun test is killed/crashes/timeouts mid-run).
-const fixtureRoot = path.join(dir, "fixtures")
+// Route fixture tmpdirs under cwd so they pass the InstanceMiddleware cwd
+// containment check (security: unauthenticated servers restrict directory to cwd subtree).
+const fixtureRoot = path.join(process.cwd(), ".mimocode-test-fixtures-" + process.pid)
 await fs.mkdir(fixtureRoot, { recursive: true })
 process.env["MIMOCODE_TEST_TMPDIR_ROOT"] = fixtureRoot
 afterAll(async () => {
@@ -21,19 +20,20 @@ afterAll(async () => {
   Database.close()
   const busy = (error: unknown) =>
     typeof error === "object" && error !== null && "code" in error && error.code === "EBUSY"
-  const rm = async (left: number): Promise<void> => {
+  const rm = async (target: string, left: number): Promise<void> => {
     Bun.gc(true)
     await sleep(100)
-    return fs.rm(dir, { recursive: true, force: true }).catch((error) => {
+    return fs.rm(target, { recursive: true, force: true }).catch((error) => {
       if (!busy(error)) throw error
       if (left <= 1) throw error
-      return rm(left - 1)
+      return rm(target, left - 1)
     })
   }
 
   // Windows can keep SQLite WAL handles alive until GC finalizers run, so we
   // force GC and retry teardown to avoid flaky EBUSY in test cleanup.
-  await rm(30)
+  await rm(dir, 30)
+  await rm(fixtureRoot, 30)
 })
 
 process.env["XDG_DATA_HOME"] = path.join(dir, "share")

--- a/packages/opencode/test/server/project-init-git.test.ts
+++ b/packages/opencode/test/server/project-init-git.test.ts
@@ -5,6 +5,7 @@ import { GlobalBus } from "../../src/bus/global"
 import { Snapshot } from "../../src/snapshot"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
+import { Flag } from "../../src/flag/flag"
 import { Filesystem } from "../../src/util"
 import { Log } from "../../src/util"
 import { resetDatabase } from "../fixture/db"
@@ -16,62 +17,80 @@ afterEach(async () => {
   await resetDatabase()
 })
 
+// This test needs a tmpdir OUTSIDE any git repo so project detection doesn't
+// inherit a parent .git. We temporarily set Flag.MIMOCODE_SERVER_PASSWORD to
+// bypass the middleware cwd containment check and include auth headers.
+const TEST_PASSWORD = "init-git-test"
+const authHeader = `Basic ${Buffer.from(`mimocode:${TEST_PASSWORD}`).toString("base64")}`
+
 describe("project.initGit endpoint", () => {
   test("initializes git and reloads immediately", async () => {
-    await using tmp = await tmpdir()
-    const app = Server.Default().app
-    const seen: { directory?: string; payload: { type: string } }[] = []
-    const fn = (evt: { directory?: string; payload: { type: string } }) => {
-      seen.push(evt)
-    }
-    const reload = Instance.reload
-    const reloadSpy = spyOn(Instance, "reload").mockImplementation((input) => reload(input))
-    GlobalBus.on("event", fn)
-
+    const prevFlag = (Flag as any).MIMOCODE_SERVER_PASSWORD
+    const prevRoot = process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
+    ;(Flag as any).MIMOCODE_SERVER_PASSWORD = TEST_PASSWORD
+    delete process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
     try {
-      const init = await app.request("/project/git/init", {
-        method: "POST",
-        headers: {
-          "x-mimocode-directory": tmp.path,
-        },
-      })
-      const body = await init.json()
-      expect(init.status).toBe(200)
-      expect(body).toMatchObject({
-        vcs: "git",
-        worktree: tmp.path,
-      })
-      // v5: a freshly-initialised git repo has a UUID, not the "global" sentinel.
-      expect(body.id).not.toBe("global")
-      expect(reloadSpy).toHaveBeenCalledTimes(1)
-      expect(seen.some((evt) => evt.directory === tmp.path && evt.payload.type === "server.instance.disposed")).toBe(
-        true,
-      )
-      expect(await Filesystem.exists(path.join(tmp.path, ".git", "mimocode"))).toBe(false)
+      await using tmp = await tmpdir()
+      const app = Server.Default().app
+      const seen: { directory?: string; payload: { type: string } }[] = []
+      const fn = (evt: { directory?: string; payload: { type: string } }) => {
+        seen.push(evt)
+      }
+      const reload = Instance.reload
+      const reloadSpy = spyOn(Instance, "reload").mockImplementation((input) => reload(input))
+      GlobalBus.on("event", fn)
 
-      const current = await app.request("/project/current", {
-        headers: {
-          "x-mimocode-directory": tmp.path,
-        },
-      })
-      expect(current.status).toBe(200)
-      expect(await current.json()).toMatchObject({
-        vcs: "git",
-        worktree: tmp.path,
-      })
+      try {
+        const init = await app.request("/project/git/init", {
+          method: "POST",
+          headers: {
+            "x-mimocode-directory": tmp.path,
+            "authorization": authHeader,
+          },
+        })
+        const body = await init.json()
+        expect(init.status).toBe(200)
+        expect(body).toMatchObject({
+          vcs: "git",
+          worktree: tmp.path,
+        })
+        // v5: a freshly-initialised git repo has a UUID, not the "global" sentinel.
+        expect(body.id).not.toBe("global")
+        expect(reloadSpy).toHaveBeenCalledTimes(1)
+        expect(seen.some((evt) => evt.directory === tmp.path && evt.payload.type === "server.instance.disposed")).toBe(
+          true,
+        )
+        expect(await Filesystem.exists(path.join(tmp.path, ".git", "mimocode"))).toBe(false)
 
-      expect(
-        await Effect.runPromise(
-          Snapshot.Service.use((svc) => svc.track()).pipe(
-            provideInstance(tmp.path),
-            Effect.provide(Snapshot.defaultLayer),
+        const current = await app.request("/project/current", {
+          headers: {
+            "x-mimocode-directory": tmp.path,
+            "authorization": authHeader,
+          },
+        })
+        expect(current.status).toBe(200)
+        expect(await current.json()).toMatchObject({
+          vcs: "git",
+          worktree: tmp.path,
+        })
+
+        expect(
+          await Effect.runPromise(
+            Snapshot.Service.use((svc) => svc.track()).pipe(
+              provideInstance(tmp.path),
+              Effect.provide(Snapshot.defaultLayer),
+            ),
           ),
-        ),
-      ).toBeTruthy()
+        ).toBeTruthy()
+      } finally {
+        await Instance.disposeAll()
+        reloadSpy.mockRestore()
+        GlobalBus.off("event", fn)
+      }
     } finally {
-      await Instance.disposeAll()
-      reloadSpy.mockRestore()
-      GlobalBus.off("event", fn)
+      ;(Flag as any).MIMOCODE_SERVER_PASSWORD = prevFlag
+      if (prevRoot !== undefined) process.env["MIMOCODE_TEST_TMPDIR_ROOT"] = prevRoot
+      else delete process.env["MIMOCODE_TEST_TMPDIR_ROOT"]
     }
   })
 


### PR DESCRIPTION
The previous fix (60ae419) failed penetration re-test on 9/10 sites because:
1. InstanceMiddleware was not covering InstanceRoutes in non-workspace server mode — file endpoints were accessible without validation
2. The cwd containment check was skipped when MIMOCODE_SERVER_PASSWORD was set, leaving authenticated servers unprotected
3. The blocklist approach (SYSTEM_PATHS) was incomplete and bypassable

This commit applies a whitelist strategy with defense in depth:

- Layer 1 (Instance.provide): Rejects known-dangerous system directories (/etc, /proc, /sys, /dev, /boot, /root) at the lowest possible level, regardless of how the request reaches instance creation
- Layer 2 (server.ts): Moves InstanceRoutes inside the sub-Hono that has InstanceMiddleware, ensuring ALL instance routes go through validation
- Layer 3 (middleware): Always enforces directory ⊆ cwd — removes the MIMOCODE_SERVER_PASSWORD conditional bypass entirely

