### PR TITLE
feat(tool): make plan_enter/plan_exit always visible across modes

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -96,8 +96,6 @@ export const layer = Layer.effect(
             ...Object.fromEntries(whitelistedDirs.map((dir) => [dir, "allow"])),
           },
           question: "deny",
-          plan_enter: "deny",
-          plan_exit: "deny",
           // mirrors github.com/github/gitignore Node.gitignore pattern for .env files
           read: {
             "*": "allow",
@@ -119,7 +117,6 @@ export const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 question: "allow",
-                plan_enter: "allow",
               }),
               user,
             ),
@@ -141,7 +138,6 @@ export const layer = Layer.effect(
                     defaults,
                     Permission.fromConfig({
                       question: "allow",
-                      plan_enter: "allow",
                     }),
                     user,
                   ),
@@ -159,7 +155,6 @@ export const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 question: "allow",
-                plan_exit: "allow",
                 external_directory: {
                   [path.join(Global.Path.data, "plans", "*")]: "allow",
                 },
@@ -183,7 +178,6 @@ export const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 question: "allow",
-                skill: "allow",
               }),
               user,
             ),

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -419,6 +419,14 @@ export const dict: Record<string, string> = {
   "tui.dialog.login.flow.invalid_code": "Invalid Code, please retry",
   "tui.dialog.login.flow.copied": "Copied",
 
+  // Question i18n — plan_enter
+  "tui.question.plan_enter.question": "Would you like to switch to plan mode for structured planning?",
+  "tui.question.plan_enter.header": "Plan",
+  "tui.question.plan_enter.option.0.label": "Yes",
+  "tui.question.plan_enter.option.0.description": "Switch to plan agent for read-only planning",
+  "tui.question.plan_enter.option.1.label": "No",
+  "tui.question.plan_enter.option.1.description": "Stay in current mode",
+
   // Question i18n — plan_exit
   "tui.question.plan_exit.question": "Plan at {{plan}} is complete. Would you like to switch to the build agent and start implementing?",
   "tui.question.plan_exit.header": "Plan",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -454,6 +454,14 @@ export const dict = {
   "tui.command.plugins.list.title": "Plugins",
   "tui.command.plugins.install.title": "Instalar plugin",
 
+  // Question i18n — plan_enter
+  "tui.question.plan_enter.question": "¿Desea cambiar al modo plan para una planificación estructurada?",
+  "tui.question.plan_enter.header": "Entrar al plan",
+  "tui.question.plan_enter.option.0.label": "Sí",
+  "tui.question.plan_enter.option.0.description": "Cambiar al agente plan para planificación de solo lectura",
+  "tui.question.plan_enter.option.1.label": "No",
+  "tui.question.plan_enter.option.1.description": "Permanecer en el modo actual",
+
   // Question i18n — plan_exit
   "tui.question.plan_exit.question": "El plan en {{plan}} está completo. ¿Desea cambiar al agente build para comenzar la implementación?",
   "tui.question.plan_exit.header": "Salir del plan",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -468,6 +468,14 @@ export const dict = {
   "cli.providers.mimo_login.decrypt_retry": "Échec du déchiffrement, veuillez réessayer ({remaining} tentatives restantes)",
   "cli.providers.mimo_login.decrypt_exhausted": "Échec du déchiffrement, nombre maximal de tentatives atteint",
 
+  // Question i18n — plan_enter
+  "tui.question.plan_enter.question": "Voulez-vous basculer en mode plan pour une planification structurée ?",
+  "tui.question.plan_enter.header": "Entrer dans le plan",
+  "tui.question.plan_enter.option.0.label": "Oui",
+  "tui.question.plan_enter.option.0.description": "Basculer vers l'agent plan pour une planification en lecture seule",
+  "tui.question.plan_enter.option.1.label": "Non",
+  "tui.question.plan_enter.option.1.description": "Rester dans le mode actuel",
+
   // Question i18n — plan_exit
   "tui.question.plan_exit.question": "Le plan {{plan}} est terminé. Voulez-vous basculer vers l'agent build pour commencer l'implémentation ?",
   "tui.question.plan_exit.header": "Quitter le plan",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -416,6 +416,14 @@ export const dict = {
   "cli.providers.mimo_login.decrypt_retry": "復号に失敗しました、再試行してください（残り {remaining} 回）",
   "cli.providers.mimo_login.decrypt_exhausted": "復号に失敗しました、最大再試行回数に達しました",
 
+  // Question i18n — plan_enter
+  "tui.question.plan_enter.question": "構造化された計画のために plan モードに切り替えますか？",
+  "tui.question.plan_enter.header": "計画開始",
+  "tui.question.plan_enter.option.0.label": "はい",
+  "tui.question.plan_enter.option.0.description": "読み取り専用の計画のために plan エージェントに切り替え",
+  "tui.question.plan_enter.option.1.label": "いいえ",
+  "tui.question.plan_enter.option.1.description": "現在のモードにとどまる",
+
   // Question i18n — plan_exit
   "tui.question.plan_exit.question": "{{plan}} の計画が完了しました。build エージェントに切り替えて実装を開始しますか？",
   "tui.question.plan_exit.header": "計画終了",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -480,6 +480,14 @@ export const dict = {
   "cli.providers.mimo_login.decrypt_retry": "Ошибка расшифровки, повторите попытку (осталось попыток: {remaining})",
   "cli.providers.mimo_login.decrypt_exhausted": "Ошибка расшифровки, превышено максимальное число попыток",
 
+  // Question i18n — plan_enter
+  "tui.question.plan_enter.question": "Переключиться в режим plan для структурированного планирования?",
+  "tui.question.plan_enter.header": "Вход в план",
+  "tui.question.plan_enter.option.0.label": "Да",
+  "tui.question.plan_enter.option.0.description": "Переключиться на агента plan для планирования в режиме чтения",
+  "tui.question.plan_enter.option.1.label": "Нет",
+  "tui.question.plan_enter.option.1.description": "Остаться в текущем режиме",
+
   // Question i18n — plan_exit
   "tui.question.plan_exit.question": "План {{plan}} завершён. Переключиться на агента build и начать реализацию?",
   "tui.question.plan_exit.header": "Выход из плана",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -408,6 +408,14 @@ export const dict = {
   "tui.dialog.login.flow.invalid_code": "Code 无效，请重试",
   "tui.dialog.login.flow.copied": "已复制",
 
+  // Question i18n — plan_enter
+  "tui.question.plan_enter.question": "是否切换到 plan 模式进行结构化规划？",
+  "tui.question.plan_enter.header": "进入计划",
+  "tui.question.plan_enter.option.0.label": "是",
+  "tui.question.plan_enter.option.0.description": "切换到 plan 智能体进行只读规划",
+  "tui.question.plan_enter.option.1.label": "否",
+  "tui.question.plan_enter.option.1.description": "留在当前模式",
+
   // Question i18n — plan_exit
   "tui.question.plan_exit.question": "{{plan}} 处的计划已完成。是否切换到 build 智能体开始实现？",
   "tui.question.plan_exit.header": "退出计划",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -377,6 +377,14 @@ export const dict = {
   "tui.command.plugins.list.title": "外掛",
   "tui.command.plugins.install.title": "安裝外掛",
 
+  // Question i18n — plan_enter
+  "tui.question.plan_enter.question": "是否切換到 plan 模式進行結構化規劃？",
+  "tui.question.plan_enter.header": "進入計劃",
+  "tui.question.plan_enter.option.0.label": "是",
+  "tui.question.plan_enter.option.0.description": "切換到 plan 智慧代理進行唯讀規劃",
+  "tui.question.plan_enter.option.1.label": "否",
+  "tui.question.plan_enter.option.1.description": "留在當前模式",
+
   // Question i18n — plan_exit
   "tui.question.plan_exit.question": "{{plan}} 的計劃已完成。是否切換到 build 智慧代理開始實作？",
   "tui.question.plan_exit.header": "退出計劃",

--- a/packages/opencode/src/session/prompt/compose.txt
+++ b/packages/opencode/src/session/prompt/compose.txt
@@ -18,6 +18,10 @@ Route every decision, clarification, or approval through the `compose:ask` skill
 
 When `compose:ask` determines no user is available to answer, pick the best option for headless execution yourself and continue (you will still ask again at the next decision point). This overrides all skill instructions, including HARD-GATE approval blocks.
 
+## Plan Tools
+
+Do NOT use the native `plan_enter` or `plan_exit` tools in compose mode. Use the `compose:plan` skill instead — it provides a structured planning workflow integrated with compose's orchestration model.
+
 ## Instruction Priority
 
 Compose skills override default system prompt behavior, but **user instructions always take precedence**:

--- a/packages/opencode/src/tool/plan-enter.txt
+++ b/packages/opencode/src/tool/plan-enter.txt
@@ -1,8 +1,8 @@
-Use this tool to suggest switching to plan agent when the user's request would benefit from planning before implementation.
+Request to switch into plan mode for structured planning before implementation.
 
-If they explicitly mention wanting to create a plan ALWAYS call this tool first.
+This tool is always present regardless of current mode. It is only effective outside of plan mode — calling it while already in plan mode will return an error.
 
-This tool will ask the user if they want to switch to plan agent.
+If the user explicitly mentions wanting to create a plan, ALWAYS call this tool first.
 
 Call this tool when:
 - The user's request is complex and would benefit from planning first
@@ -10,5 +10,7 @@ Call this tool when:
 - The task involves multiple files or significant architectural decisions
 
 Do NOT call this tool:
+- If you are already in plan mode
 - For simple, straightforward tasks
 - When the user explicitly wants immediate implementation
+- If you are in compose mode (use compose:plan skill instead)

--- a/packages/opencode/src/tool/plan-exit.txt
+++ b/packages/opencode/src/tool/plan-exit.txt
@@ -1,6 +1,6 @@
-Use this tool when you have completed the planning phase and are ready to exit plan agent.
+Request to exit plan mode and switch to build agent for implementation.
 
-This tool will ask the user if they want to switch to build agent to start implementing the plan.
+This tool is always present regardless of current mode. It is only effective in plan mode — calling it from any other mode will return an error.
 
 Call this tool:
 - After you have written a complete plan to the plan file
@@ -8,6 +8,7 @@ Call this tool:
 - When you are confident the plan is ready for implementation
 
 Do NOT call this tool:
+- If you are not currently in plan mode
 - Before you have created or finalized the plan
 - If you still have unanswered questions about the implementation
 - If the user has indicated they want to continue planning

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -8,6 +8,7 @@ import { MessageV2 } from "../session/message-v2"
 import { Provider } from "../provider"
 import { Instance } from "../project/instance"
 import { type SessionID, MessageID, PartID } from "../session/schema"
+import ENTER_DESCRIPTION from "./plan-enter.txt"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 
 function getLastModel(sessionID: SessionID) {
@@ -16,6 +17,86 @@ function getLastModel(sessionID: SessionID) {
   }
   return undefined
 }
+
+export const PlanEnterTool = Tool.define(
+  "plan_enter",
+  Effect.gen(function* () {
+    const session = yield* Session.Service
+    const question = yield* Question.Service
+    const provider = yield* Provider.Service
+
+    return {
+      description: ENTER_DESCRIPTION,
+      parameters: z.object({}),
+      execute: (_params: {}, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          if (ctx.agent === "plan") {
+            return {
+              title: "Already in plan mode",
+              output: "You are already in plan mode. This tool is only effective outside of plan mode.",
+              metadata: { switched: false, feedback: "" },
+            }
+          }
+
+          const info = yield* session.get(ctx.sessionID)
+          const plan = path.relative(Instance.worktree, Session.plan(info))
+          const answers = yield* question.ask({
+            sessionID: ctx.sessionID,
+            questions: [
+              {
+                key: "plan_enter",
+                params: { plan },
+                question: `Would you like to switch to plan mode for structured planning?`,
+                header: "Plan",
+                options: [
+                  { label: "Yes", description: "Switch to plan agent for read-only planning" },
+                  { label: "No", description: "Stay in current mode" },
+                ],
+              },
+            ],
+            tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
+          })
+
+          const answer = answers[0]?.[0]
+          if (answer === "No") return yield* new Question.RejectedError()
+
+          if (answer !== "Yes") {
+            return {
+              title: "User provided feedback",
+              output: `User chose not to switch yet and provided feedback: ${answer}`,
+              metadata: { switched: false, feedback: answer },
+            }
+          }
+
+          const model = getLastModel(ctx.sessionID) ?? (yield* provider.defaultModel())
+
+          const msg: MessageV2.User = {
+            id: MessageID.ascending(),
+            sessionID: ctx.sessionID,
+            role: "user",
+            time: { created: Date.now() },
+            agent: "plan",
+            model,
+          }
+          yield* session.updateMessage(msg)
+          yield* session.updatePart({
+            id: PartID.ascending(),
+            messageID: msg.id,
+            sessionID: ctx.sessionID,
+            type: "text",
+            text: `Switched to plan mode. Create a plan at ${plan}`,
+            synthetic: true,
+          } satisfies MessageV2.TextPart)
+
+          return {
+            title: "Switching to plan agent",
+            output: "User approved switching to plan agent. Wait for further instructions.",
+            metadata: { switched: true, feedback: "" },
+          }
+        }).pipe(Effect.orDie),
+    }
+  }),
+)
 
 export const PlanExitTool = Tool.define(
   "plan_exit",
@@ -29,6 +110,14 @@ export const PlanExitTool = Tool.define(
       parameters: z.object({}),
       execute: (_params: {}, ctx: Tool.Context) =>
         Effect.gen(function* () {
+          if (ctx.agent !== "plan") {
+            return {
+              title: "Not in plan mode",
+              output: "You are not in plan mode. This tool is only effective in plan mode.",
+              metadata: { switched: false, feedback: "" },
+            }
+          }
+
           const info = yield* session.get(ctx.sessionID)
           const plan = path.relative(Instance.worktree, Session.plan(info))
           const answers = yield* question.ask({

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -124,7 +124,7 @@ export const layer = Layer.effect(
     const read = yield* ReadTool
     const question = yield* QuestionTool
     const lsptool = yield* LspTool
-    const plan = yield* PlanExitTool
+    const planexit = yield* PlanExitTool
     const planenter = yield* PlanEnterTool
     const webfetch = yield* WebFetchTool
     const websearch = yield* WebSearchTool
@@ -221,7 +221,7 @@ export const layer = Layer.effect(
           changedir: Tool.init(changedirtool),
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
-          plan: Tool.init(plan),
+          planexit: Tool.init(planexit),
           planenter: Tool.init(planenter),
           memory: Tool.init(memorytool),
           history: Tool.init(historytool),
@@ -248,7 +248,7 @@ export const layer = Layer.effect(
             tool.patch,
             tool.changedir,
             ...(Flag.MIMOCODE_EXPERIMENTAL_LSP_TOOL ? [tool.lsp] : []),
-            tool.plan,
+            tool.planexit,
             tool.planenter,
             tool.memory,
             tool.history,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -1,4 +1,4 @@
-import { PlanExitTool } from "./plan"
+import { PlanEnterTool, PlanExitTool } from "./plan"
 import { Session } from "../session"
 import { QuestionTool } from "./question"
 import { BashTool } from "./bash"
@@ -125,6 +125,7 @@ export const layer = Layer.effect(
     const question = yield* QuestionTool
     const lsptool = yield* LspTool
     const plan = yield* PlanExitTool
+    const planenter = yield* PlanEnterTool
     const webfetch = yield* WebFetchTool
     const websearch = yield* WebSearchTool
     const bash = yield* BashTool
@@ -221,6 +222,7 @@ export const layer = Layer.effect(
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
+          planenter: Tool.init(planenter),
           memory: Tool.init(memorytool),
           history: Tool.init(historytool),
           task: Tool.init(tasktool),
@@ -247,6 +249,7 @@ export const layer = Layer.effect(
             tool.changedir,
             ...(Flag.MIMOCODE_EXPERIMENTAL_LSP_TOOL ? [tool.lsp] : []),
             tool.plan,
+            tool.planenter,
             tool.memory,
             tool.history,
             tool.task,

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -75,6 +75,23 @@ test("plan agent denies edits except .mimocode/plans/*", async () => {
   })
 })
 
+test("plan_enter and plan_exit are allowed (not hidden) for all primary agents", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agents = await load(tmp.path, (svc) => svc.list())
+      const primaryAgents = agents.filter((a) => a.mode === "primary")
+      expect(primaryAgents.length).toBeGreaterThanOrEqual(3)
+      for (const agent of primaryAgents) {
+        const disabled = Permission.disabled(["plan_enter", "plan_exit"], agent.permission)
+        expect(disabled.has("plan_enter")).toBe(false)
+        expect(disabled.has("plan_exit")).toBe(false)
+      }
+    },
+  })
+})
+
 test("explore agent denies edit and write", async () => {
   await using tmp = await tmpdir()
   await Instance.provide({

--- a/packages/opencode/test/permission/disabled.test.ts
+++ b/packages/opencode/test/permission/disabled.test.ts
@@ -49,3 +49,20 @@ test("*: deny with no edit/write rule — write disabled (wildcard-match)", () =
   expect(disabled.has("write")).toBe(true)
   expect(disabled.has("edit")).toBe(true)
 })
+
+test("plan_enter/plan_exit are not disabled under default *: allow", () => {
+  const rs = ruleset({ "*": "allow", question: "deny" })
+  const disabled = Permission.disabled(["plan_enter", "plan_exit", "question", "bash"], rs)
+  expect(disabled.has("plan_enter")).toBe(false)
+  expect(disabled.has("plan_exit")).toBe(false)
+  expect(disabled.has("question")).toBe(true)
+  expect(disabled.has("bash")).toBe(false)
+})
+
+test("plan_enter/plan_exit disabled only by explicit deny", () => {
+  const rs = ruleset({ "*": "allow", plan_enter: "deny", plan_exit: "deny" })
+  const disabled = Permission.disabled(["plan_enter", "plan_exit", "bash"], rs)
+  expect(disabled.has("plan_enter")).toBe(true)
+  expect(disabled.has("plan_exit")).toBe(true)
+  expect(disabled.has("bash")).toBe(false)
+})


### PR DESCRIPTION
## Summary

- **plan_enter** and **plan_exit** tools are now always present in the tool list regardless of current mode, eliminating tool list mutations on mode switch that caused context instability
- Mode enforcement moved from permission-based hiding to runtime handler checks (plan_exit rejects if not in plan mode, plan_enter rejects if already in plan mode)
- Added new `PlanEnterTool` implementation that allows the model to request switching into plan mode
- Removed redundant `skill: "allow"` from compose agent (already covered by `"*": "allow"` default)
- Added compose prompt guidance to use `compose:plan` skill instead of native plan tools
- All 7 i18n locales updated with plan_enter question entries
- `run` (non-interactive CLI) mode still hides both tools via session-level deny rules
- Registry keys renamed: `plan` → `planexit` to align with `planenter`

## How it works

Previously the `disabled()` function hid `plan_exit` from non-plan agents and `plan_enter` from the plan agent via default deny permissions. Now:

1. Default permissions no longer contain `plan_enter: "deny"` / `plan_exit: "deny"`
2. Both tools fall through to `"*": "allow"` and appear in every agent's tool list
3. The handler itself checks `ctx.agent` and returns an informative error if called from the wrong mode
4. The TUI question component uses original untranslated labels (`props.request.questions[...].options[...].label`) for answer matching, so `answer === "Yes"` is locale-safe

## Automated tests (passing)

- `test/permission/disabled.test.ts` — verifies plan_enter/plan_exit are NOT disabled under default `*: allow`, and only disabled by explicit deny
- `test/agent/agent.test.ts` — verifies all primary agents have both tools visible (not in disabled set)

## Manual verification completed

- [x] In TUI, switch between build/plan/compose modes — tool list stable (both plan_enter and plan_exit always present)
- [x] In plan mode, plan_exit works: model calls plan_exit → question prompt appears → approve → switches to build
- [x] In build mode, plan_enter works: model calls plan_enter → question prompt appears → approve → switches to plan
- [x] In build mode, plan_exit returns "Not in plan mode" error without prompting user
- [x] In plan mode, plan_enter returns "Already in plan mode" error without prompting user

## CI note

The 16 test failures in CI are all pre-existing flaky tests on main (15 identical failures on main's latest run). The extra 1 (`WorkflowRuntime worktree isolation > two concurrent isolated agents`) is a timing-sensitive test unrelated to this PR — it races `git worktree add` with concurrent mock LLM calls and sporadically fails on 2-vCPU CI runners.