### PR TITLE
feat(checkpoint): preserve verbatim user input in rebuild context

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -300,6 +300,12 @@ const InfoSchema = Schema.Struct({
           open_notes: Schema.optional(PositiveInt).annotate({
             description: "Token cap for §11 Open notes section of checkpoint.md (writer-side budget validation). Default: 800.",
           }),
+          recent_user: Schema.optional(NonNegativeInt).annotate({
+            description: "Token cap for the recent user input section (verbatim user messages from the live DB, FIFO eviction). Default: 16000. Set 0 to disable.",
+          }),
+          recent_user_per_msg: Schema.optional(PositiveInt).annotate({
+            description: "Per-message cap inside recent user input section; oversized messages get head/tail truncation with messageID elision marker. Default: 2000.",
+          }),
         }),
       ).annotate({
         description:

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -1113,17 +1113,19 @@ export const layer: Layer.Layer<
       const recentUserPerMsg = caps.recent_user_per_msg ?? 2_000
       const recentUserEntries: string[] = []
       if (recentUserCap > 0) {
-        // Pull a window large enough that the token budget (not the page limit)
-        // is what bounds the section. Floor of 200; otherwise scale to the cap
-        // assuming a conservative ~50 tokens/msg so a long session of many tiny
-        // prompts still lets FIFO evict on the budget rather than the page edge.
-        const pageLimit = Math.max(200, Math.ceil(recentUserCap / 50))
+        // Fixed page ceiling sized comfortably above the token budget: at the
+        // 2K per-msg cap, 200 msgs ≈ 400K tokens, far past any recent_user cap,
+        // so the token loop below — not this limit — is what bounds the section.
+        // The only way 200 msgs could underflow the budget is hundreds of sub-
+        // 80-token prompts ("ok"/"continue"), which carry no anchors worth
+        // paging deeper for. Keeping a constant avoids a magic tokens/msg
+        // heuristic and a larger fetch+hydrate on every checkpoint.
         // Exclude rebuild/compaction boundary messages: insertRebuildBoundary
         // writes a role:"user" row carrying a checkpoint part + synthetic text
         // holding the *previous* rebuild context. Re-ingesting it would fold
         // each prior rebuild back in recursively (fractal bloat). userMsgText
         // also drops synthetic text parts as a second guard.
-        const userMsgs = MessageV2.page({ sessionID, agentID: "main", limit: pageLimit }).items.filter(
+        const userMsgs = MessageV2.page({ sessionID, agentID: "main", limit: 200 }).items.filter(
           (m) =>
             m.info.role === "user" &&
             !m.parts.some((p) => p.type === "tool" || p.type === "checkpoint" || p.type === "compaction"),

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -55,8 +55,11 @@ function truncate(s: string, max: number): string {
  */
 function truncateVerbatimUserMsg(text: string, capTokens: number, messageID: string): string {
   if (Token.estimate(text) <= capTokens) return text
-  const head = text.slice(0, Math.floor(capTokens * 0.6) * 4)
-  const tail = text.slice(-Math.floor(capTokens * 0.3) * 4)
+  // slice() cuts on UTF-16 code units, which can split a surrogate pair at the
+  // boundary; trim a dangling high surrogate off the head and a leading low
+  // surrogate off the tail so emoji / non-BMP chars don't render as garbage.
+  const head = text.slice(0, Math.floor(capTokens * 0.6) * 4).replace(/[\uD800-\uDBFF]$/, "")
+  const tail = text.slice(-Math.floor(capTokens * 0.3) * 4).replace(/^[\uDC00-\uDFFF]/, "")
   const elidedTokens = Token.estimate(text) - Token.estimate(head) - Token.estimate(tail)
   return [
     head,
@@ -67,11 +70,12 @@ function truncateVerbatimUserMsg(text: string, capTokens: number, messageID: str
 
 /**
  * Concatenate text-typed parts of a user message into a single string. Skips
- * tool/file/image/etc. parts — only true user prose contributes.
+ * tool/file/image/etc. parts and synthetic text (e.g. rebuild-boundary content
+ * injected by insertRebuildBoundary) — only true user prose contributes.
  */
-function userMsgText(parts: Array<{ type: string; text?: string }>): string {
+function userMsgText(parts: Array<{ type: string; text?: string; synthetic?: boolean }>): string {
   return parts
-    .filter((p) => p.type === "text" && typeof p.text === "string" && p.text.length > 0)
+    .filter((p) => p.type === "text" && !p.synthetic && typeof p.text === "string" && p.text.length > 0)
     .map((p) => p.text!)
     .join("\n")
 }
@@ -1109,18 +1113,27 @@ export const layer: Layer.Layer<
       const recentUserPerMsg = caps.recent_user_per_msg ?? 2_000
       const recentUserEntries: string[] = []
       if (recentUserCap > 0) {
-        // page() with limit=200 + agentID:"main" returns asc-time main slice.
-        // 200 covers the 16K budget at 2K/msg max; total token guard kicks in
-        // first in practice.
-        const userMsgs = MessageV2.page({ sessionID, agentID: "main", limit: 200 }).items.filter(
-          (m) => m.info.role === "user" && !m.parts.some((p) => p.type === "tool"),
+        // Pull a window large enough that the token budget (not the page limit)
+        // is what bounds the section. Floor of 200; otherwise scale to the cap
+        // assuming a conservative ~50 tokens/msg so a long session of many tiny
+        // prompts still lets FIFO evict on the budget rather than the page edge.
+        const pageLimit = Math.max(200, Math.ceil(recentUserCap / 50))
+        // Exclude rebuild/compaction boundary messages: insertRebuildBoundary
+        // writes a role:"user" row carrying a checkpoint part + synthetic text
+        // holding the *previous* rebuild context. Re-ingesting it would fold
+        // each prior rebuild back in recursively (fractal bloat). userMsgText
+        // also drops synthetic text parts as a second guard.
+        const userMsgs = MessageV2.page({ sessionID, agentID: "main", limit: pageLimit }).items.filter(
+          (m) =>
+            m.info.role === "user" &&
+            !m.parts.some((p) => p.type === "tool" || p.type === "checkpoint" || p.type === "compaction"),
         )
         // Iterate most-recent backward so FIFO drops oldest when total cap hits.
         let remaining = recentUserCap
         for (let i = userMsgs.length - 1; i >= 0; i--) {
           const rawText = userMsgText(userMsgs[i].parts)
           if (!rawText.trim()) continue
-          const entry = `[U${i + 1}] ${truncateVerbatimUserMsg(rawText, recentUserPerMsg, userMsgs[i].info.id)}`
+          const entry = truncateVerbatimUserMsg(rawText, recentUserPerMsg, userMsgs[i].info.id)
           const cost = Token.estimate(entry)
           if (remaining - cost < 0) break
           recentUserEntries.unshift(entry)

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -47,6 +47,35 @@ function truncate(s: string, max: number): string {
   return s.length <= max ? s : s.slice(0, max - 60) + "\n... (truncated, full body at file)"
 }
 
+/**
+ * Truncate verbatim user input that exceeds per-message cap. Keeps head (~60%)
+ * + tail (~30%) with an elision marker pointing at messageID for full recall
+ * via the history tool's operation=around. ~4 chars/token approximation matches
+ * Token.estimate.
+ */
+function truncateVerbatimUserMsg(text: string, capTokens: number, messageID: string): string {
+  if (Token.estimate(text) <= capTokens) return text
+  const head = text.slice(0, Math.floor(capTokens * 0.6) * 4)
+  const tail = text.slice(-Math.floor(capTokens * 0.3) * 4)
+  const elidedTokens = Token.estimate(text) - Token.estimate(head) - Token.estimate(tail)
+  return [
+    head,
+    `[…elided ${elidedTokens} tokens; messageID=${messageID}; use the history tool with operation=around to fetch full content]`,
+    tail,
+  ].join("\n")
+}
+
+/**
+ * Concatenate text-typed parts of a user message into a single string. Skips
+ * tool/file/image/etc. parts — only true user prose contributes.
+ */
+function userMsgText(parts: Array<{ type: string; text?: string }>): string {
+  return parts
+    .filter((p) => p.type === "text" && typeof p.text === "string" && p.text.length > 0)
+    .map((p) => p.text!)
+    .join("\n")
+}
+
 function autonomousLoopReminder(): string {
   return [
     "<system-reminder>",
@@ -1073,13 +1102,41 @@ export const layer: Layer.Layer<
 
       const actors = yield* actorRegistry.listActive()
 
-      // Bail early if absolutely nothing to push: no tasks, no memory content, no live actors.
+      // Pull recent user messages (verbatim, FIFO-bounded). Done before the
+      // early-bail check so a session whose only signal is "user typed N
+      // prompts" still emits the section.
+      const recentUserCap = caps.recent_user ?? 16_000
+      const recentUserPerMsg = caps.recent_user_per_msg ?? 2_000
+      const recentUserEntries: string[] = []
+      if (recentUserCap > 0) {
+        // page() with limit=200 + agentID:"main" returns asc-time main slice.
+        // 200 covers the 16K budget at 2K/msg max; total token guard kicks in
+        // first in practice.
+        const userMsgs = MessageV2.page({ sessionID, agentID: "main", limit: 200 }).items.filter(
+          (m) => m.info.role === "user" && !m.parts.some((p) => p.type === "tool"),
+        )
+        // Iterate most-recent backward so FIFO drops oldest when total cap hits.
+        let remaining = recentUserCap
+        for (let i = userMsgs.length - 1; i >= 0; i--) {
+          const rawText = userMsgText(userMsgs[i].parts)
+          if (!rawText.trim()) continue
+          const entry = `[U${i + 1}] ${truncateVerbatimUserMsg(rawText, recentUserPerMsg, userMsgs[i].info.id)}`
+          const cost = Token.estimate(entry)
+          if (remaining - cost < 0) break
+          recentUserEntries.unshift(entry)
+          remaining -= cost
+        }
+      }
+
+      // Bail early if absolutely nothing to push: no tasks, no memory content, no live actors,
+      // no user messages.
       if (
         tasks.length === 0 &&
         !checkpointText.trim() &&
         !memoryText.trim() &&
         !globalText.trim() &&
-        actors.length === 0
+        actors.length === 0 &&
+        recentUserEntries.length === 0
       ) {
         return ""
       }
@@ -1140,6 +1197,16 @@ export const layer: Layer.Layer<
           lines.push(line)
           actorBudget -= cost
         }
+        lines.push("")
+      }
+
+      // Section 6.5: recent user input (verbatim, FIFO, budget-bounded).
+      // Preserves original user prose from the live DB — writer summaries
+      // paraphrase user commands, losing anchors like exact flags or pasted
+      // content. (entries computed earlier so the early-bail guard sees them.)
+      if (recentUserEntries.length > 0) {
+        lines.push("## Recent user input (verbatim)")
+        lines.push(...recentUserEntries)
         lines.push("")
       }
 

--- a/packages/opencode/test/session/checkpoint-rebuild-unify.test.ts
+++ b/packages/opencode/test/session/checkpoint-rebuild-unify.test.ts
@@ -70,31 +70,36 @@ async function seedUserMessage(sessionID: SessionID, text: string) {
 describe("SessionCheckpoint.insertRebuildBoundary", () => {
   it.live(
     "insertRebuildBoundary returns false and inserts nothing when rebuild context is empty",
-    provideTmpdirInstance(() =>
-      Effect.gen(function* () {
-        const ssn = yield* SessionNs.Service
-        const cp = yield* SessionCheckpoint.Service
-        const info = yield* ssn.create({})
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const ssn = yield* SessionNs.Service
+          const cp = yield* SessionCheckpoint.Service
+          const info = yield* ssn.create({})
 
-        const m1 = yield* Effect.promise(() => seedUserMessage(info.id, "turn one"))
-        const _m2 = yield* Effect.promise(() => seedUserMessage(info.id, "turn two"))
-        const m3 = yield* Effect.promise(() => seedUserMessage(info.id, "turn three"))
+          const m1 = yield* Effect.promise(() => seedUserMessage(info.id, "turn one"))
+          const _m2 = yield* Effect.promise(() => seedUserMessage(info.id, "turn two"))
+          const m3 = yield* Effect.promise(() => seedUserMessage(info.id, "turn three"))
 
-        // No checkpoint file → renderRebuildContext is empty → helper returns false, inserts nothing.
-        const insertedNoCtx = yield* cp.insertRebuildBoundary({
-          sessionID: info.id,
-          boundary: m3.id,
-          agent: "build",
-          model: { providerID: "anthropic", modelID: "claude" },
-        })
-        expect(insertedNoCtx).toBe(false)
+          // No checkpoint file → renderRebuildContext is empty → helper returns false, inserts nothing.
+          // recent_user disabled here: the verbatim-user-input section's whole point is to make a
+          // user-only-signal session emit non-empty context, so it must be opted out to assert the
+          // "nothing to push" semantics this test targets.
+          const insertedNoCtx = yield* cp.insertRebuildBoundary({
+            sessionID: info.id,
+            boundary: m3.id,
+            agent: "build",
+            model: { providerID: "anthropic", modelID: "claude" },
+          })
+          expect(insertedNoCtx).toBe(false)
 
-        const after = yield* ssn.messages({ sessionID: info.id })
-        // Every original message still present — nothing deleted.
-        expect(after.some((m) => m.info.id === m1.id)).toBe(true)
-        expect(after.some((m) => m.info.id === m3.id)).toBe(true)
-        expect(after.length).toBe(3)
-      }),
+          const after = yield* ssn.messages({ sessionID: info.id })
+          // Every original message still present — nothing deleted.
+          expect(after.some((m) => m.info.id === m1.id)).toBe(true)
+          expect(after.some((m) => m.info.id === m3.id)).toBe(true)
+          expect(after.length).toBe(3)
+        }),
+      { config: { checkpoint: { push_caps: { recent_user: 0 } } } },
     ),
   )
 })

--- a/packages/opencode/test/session/recent-user-msg.test.ts
+++ b/packages/opencode/test/session/recent-user-msg.test.ts
@@ -11,6 +11,8 @@ import { Instance } from "../../src/project/instance"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { checkpointPath } from "../../src/session/checkpoint-paths"
+import * as fs from "node:fs/promises"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { Log } from "../../src/util"
@@ -113,6 +115,29 @@ describe("renderRebuildContext — recent user input section", () => {
   )
 
   it.live(
+    "per-message overflow keeps surrogate pairs intact at truncation boundary",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const cp = yield* SessionCheckpoint.Service
+        const ssn = yield* SessionNs.Service
+        const sess = yield* ssn.create({})
+        // Emoji are non-BMP (surrogate pairs). A code-unit slice would land
+        // inside a pair unless the truncator trims it. cap=2000 → head cut at
+        // ~4800 chars, which falls mid-pair for a solid run of "👍".
+        const m = yield* Effect.promise(() =>
+          seedUserMessage(sess.id, "👍".repeat(6000) + " TAIL-AFTER-EMOJI"),
+        )
+
+        const out = yield* cp.renderRebuildContext(sess.id)
+        expect(out).toContain("…elided")
+        expect(out).toContain(m.id)
+        // A split pair would surface the replacement char; it must not.
+        expect(out).not.toContain("\uFFFD")
+      }),
+    ),
+  )
+
+  it.live(
     "total-budget FIFO eviction: oldest dropped when over cap",
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
@@ -148,6 +173,47 @@ describe("renderRebuildContext — recent user input section", () => {
           expect(out).not.toContain("this should not appear")
         }),
       { config: { checkpoint: { push_caps: { recent_user: 0 } } } },
+    ),
+  )
+
+  it.live(
+    "does not re-ingest a prior rebuild boundary's synthetic content as user input",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const cp = yield* SessionCheckpoint.Service
+        const ssn = yield* SessionNs.Service
+        const sess = yield* ssn.create({})
+        // checkpoint.md so the first renderRebuildContext is non-empty and the
+        // boundary actually gets inserted.
+        yield* Effect.promise(async () => {
+          await fs.mkdir(checkpointPath(sess.id).replace(/\/[^/]+$/, ""), { recursive: true })
+          await Bun.write(checkpointPath(sess.id), "## §1 Active intent\n\nUNIQUE-CHECKPOINT-SENTINEL\n")
+        })
+        const m = yield* Effect.promise(() => seedUserMessage(sess.id, "REAL-HUMAN-PROMPT-ZZZ"))
+
+        // Round 1: insert a rebuild boundary. The boundary is a role:"user"
+        // message carrying a checkpoint part + synthetic text parts holding the
+        // full rebuild context (which itself includes the recent-user section).
+        const inserted = yield* cp.insertRebuildBoundary({
+          sessionID: sess.id,
+          boundary: m.id,
+          agent: "build",
+          model: { providerID: "anthropic", modelID: "claude" },
+        })
+        expect(inserted).toBe(true)
+
+        // Round 2: re-render. The boundary message must NOT be picked up as
+        // verbatim user input — otherwise each compaction recursively folds the
+        // prior rebuild context back in (fractal bloat). The genuine human
+        // prompt must still appear exactly once.
+        const out = yield* cp.renderRebuildContext(sess.id)
+        const section = out.slice(out.indexOf("## Recent user input (verbatim)"))
+        expect(section).toContain("REAL-HUMAN-PROMPT-ZZZ")
+        expect(section).not.toContain("UNIQUE-CHECKPOINT-SENTINEL")
+        expect(section).not.toContain("## Session checkpoint")
+        // The human prompt appears once, not duplicated via the boundary echo.
+        expect(out.split("REAL-HUMAN-PROMPT-ZZZ").length - 1).toBe(1)
+      }),
     ),
   )
 })

--- a/packages/opencode/test/session/recent-user-msg.test.ts
+++ b/packages/opencode/test/session/recent-user-msg.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config"
+import { Memory } from "../../src/memory"
+import { Session as SessionNs } from "../../src/session"
+import { SessionCheckpoint } from "../../src/session/checkpoint"
+import { TaskRegistry } from "../../src/task/registry"
+import { ActorRegistry } from "../../src/actor/registry"
+import { Instance } from "../../src/project/instance"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { Log } from "../../src/util"
+
+void Log.init({ print: false })
+
+const ref = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("test-model"),
+}
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const it = testEffect(
+  Layer.mergeAll(
+    CrossSpawnSpawner.defaultLayer,
+    Bus.defaultLayer,
+    Config.defaultLayer,
+    Memory.defaultLayer,
+    SessionNs.defaultLayer,
+    TaskRegistry.defaultLayer,
+    ActorRegistry.defaultLayer,
+    SessionCheckpoint.defaultLayer,
+  ),
+)
+
+async function seedUserMessage(sessionID: SessionID, text: string) {
+  const msg = await Effect.runPromise(
+    SessionNs.Service.use((s) =>
+      s.updateMessage({
+        id: MessageID.ascending(),
+        role: "user",
+        sessionID,
+        agent: "build",
+        model: ref,
+        time: { created: Date.now() },
+      }),
+    ).pipe(Effect.provide(SessionNs.defaultLayer)),
+  )
+  await Effect.runPromise(
+    SessionNs.Service.use((s) =>
+      s.updatePart({
+        id: PartID.ascending(),
+        messageID: msg.id,
+        sessionID,
+        type: "text",
+        text,
+      }),
+    ).pipe(Effect.provide(SessionNs.defaultLayer)),
+  )
+  return msg
+}
+
+describe("renderRebuildContext — recent user input section", () => {
+  it.live(
+    "under-budget passthrough: small messages all appear verbatim",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const cp = yield* SessionCheckpoint.Service
+        const ssn = yield* SessionNs.Service
+        const sess = yield* ssn.create({})
+        yield* Effect.promise(() => seedUserMessage(sess.id, "first prompt about authentication"))
+        yield* Effect.promise(() => seedUserMessage(sess.id, "second prompt asking for tests"))
+        yield* Effect.promise(() => seedUserMessage(sess.id, "third prompt — please commit"))
+
+        const out = yield* cp.renderRebuildContext(sess.id)
+        expect(out).toContain("## Recent user input (verbatim)")
+        expect(out).toContain("first prompt about authentication")
+        expect(out).toContain("second prompt asking for tests")
+        expect(out).toContain("third prompt — please commit")
+        expect(out).not.toContain("…elided")
+      }),
+    ),
+  )
+
+  it.live(
+    "per-message overflow truncation emits messageID-bearing marker",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const cp = yield* SessionCheckpoint.Service
+        const ssn = yield* SessionNs.Service
+        const sess = yield* ssn.create({})
+        const head = "HEAD-MARKER-XYZZY " + "padding ".repeat(800)
+        const tail = "padding ".repeat(800) + " TAIL-MARKER-PLUGH"
+        const middle = "middle-noise ".repeat(2000)
+        const m = yield* Effect.promise(() => seedUserMessage(sess.id, head + "\n" + middle + "\n" + tail))
+
+        const out = yield* cp.renderRebuildContext(sess.id)
+        expect(out).toContain("## Recent user input (verbatim)")
+        expect(out).toContain("HEAD-MARKER-XYZZY")
+        expect(out).toContain("TAIL-MARKER-PLUGH")
+        expect(out).not.toContain("middle-noise middle-noise middle-noise")
+        expect(out).toContain("…elided")
+        expect(out).toContain(m.id)
+        expect(out).toContain("history tool")
+      }),
+    ),
+  )
+
+  it.live(
+    "total-budget FIFO eviction: oldest dropped when over cap",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const cp = yield* SessionCheckpoint.Service
+        const ssn = yield* SessionNs.Service
+        const sess = yield* ssn.create({})
+        const tag = (i: number) => `MARKER-MSG-${i.toString().padStart(2, "0")}`
+        const body = "x ".repeat(2500)
+        for (let i = 0; i < 20; i++) {
+          yield* Effect.promise(() => seedUserMessage(sess.id, `${tag(i)} ${body}`))
+        }
+
+        const out = yield* cp.renderRebuildContext(sess.id)
+        expect(out).toContain("## Recent user input (verbatim)")
+        expect(out).toContain("MARKER-MSG-19")
+        expect(out).not.toContain("MARKER-MSG-00")
+      }),
+    ),
+  )
+
+  it.live(
+    "disabled when recent_user cap = 0",
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const cp = yield* SessionCheckpoint.Service
+          const ssn = yield* SessionNs.Service
+          const sess = yield* ssn.create({})
+          yield* Effect.promise(() => seedUserMessage(sess.id, "this should not appear"))
+
+          const out = yield* cp.renderRebuildContext(sess.id)
+          expect(out).not.toContain("Recent user input")
+          expect(out).not.toContain("this should not appear")
+        }),
+      { config: { checkpoint: { push_caps: { recent_user: 0 } } } },
+    ),
+  )
+})


### PR DESCRIPTION
## Summary

Adds a new `## Recent user input (verbatim)` section to the checkpoint rebuild context. Writer summaries paraphrase user commands, so anchors like exact flags or pasted content get rewritten to prose and lost across compactions. This section preserves the originals straight from the live message DB (no new files).

Ported from opencode (`c9a7e8661f`, `c8e1dc55ba`) into mimocode.

## Behavior

- Populated from the live message DB, bounded by **16K total + 2K per-message** budgets.
- **Per-message overflow:** head + tail kept, with an elision marker carrying the `messageID` so the full body is recallable via the `history` tool's `operation=around`.
- **Total overflow:** FIFO eviction of oldest user messages; each rebuild re-queries the DB so old messages age out across compactions.
- Tool-bearing user rows and subagent slices are excluded.
- Configurable via `checkpoint.push_caps.recent_user` (default 16000, `0` disables) and `recent_user_per_msg` (default 2000).

## Implementation notes

- Reuses the existing `MessageV2.get` instead of porting opencode's `byID` helper.
- The new section is computed before the early-bail guard so a session whose only signal is "user typed N prompts" still emits a non-empty context.
- Updated `checkpoint-rebuild-unify.test.ts` to opt out via `recent_user: 0` when asserting empty-rebuild-context semantics (the section's whole point is to make such sessions non-empty).

## Tests

- 4 new tests in `recent-user-msg.test.ts`: under-budget passthrough, per-message overflow truncation, total-budget FIFO eviction, disable-via-cap. All pass.
- `bun typecheck` clean.
- The one `insertRebuildBoundary returns false` failure seen only in multi-file runs is a **pre-existing `Instance.provide` cross-file race** (reproduced on the unmodified baseline), not a regression from this change.