### PR TITLE
fix(tui): prevent stale model override when switching agents

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -521,7 +521,10 @@ export function Prompt(props: PromptProps) {
       if (msg.agent && isPrimaryAgent) {
         // Keep command line --agent if specified.
         if (!args.agent) local.agent.set(msg.agent)
-        if (msg.model) {
+        // Only restore model from history if the agent has no configured model.
+        // The agent-change effect in local.tsx handles the agent.model case.
+        const currentAgent = local.agent.current()
+        if (msg.model && !currentAgent?.model) {
           local.model.set(msg.model)
           local.model.variant.set(msg.model.variant)
         }

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -310,6 +310,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             }
           })
         },
+        clear(agentName: string) {
+          setModelStore("model", agentName, undefined!)
+          save()
+        },
         toggleFavorite(model: { providerID: string; modelID: string }) {
           batch(() => {
             if (!isModelValid(model)) {
@@ -441,6 +445,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             message: `Agent ${value.name}'s configured model ${value.model.providerID}/${value.model.modelID} is not valid`,
             duration: 3000,
           })
+      } else {
+        // Clear stale per-agent override so memo falls through to
+        // agent.config or global fallback instead of a stale value
+        model.clear(value.name)
       }
     })
 


### PR DESCRIPTION
Two changes fix a bug where switching TUI agents could retain or overwrite a stale model selection:

1. **prompt/index.tsx**: Skip restoring model from conversation history when the current agent already has a configured model
2. **local.tsx**: Add `model.clear()` and call it when an agent's configured model is invalid, so stale overrides fall through to the correct fallback