### PR TITLE
fix(dev): inject local src/ext overlay when present so dev matches release

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "bun@1.3.11",
   "scripts": {
-    "dev": "MIMOCODE_HOME=$PWD/.dev-home bun run --cwd packages/opencode --conditions=browser src/index.ts",
+    "dev": "bun run --cwd packages/opencode script/dev.ts",
     "dev:desktop": "bun --cwd packages/desktop dev",
     "dev:web": "bun --cwd packages/app dev",
     "dev:console": "ulimit -n 10240 2>/dev/null; bun run --cwd packages/console/app dev",

--- a/packages/opencode/script/dev.ts
+++ b/packages/opencode/script/dev.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env bun
+// Dev launcher. If an optional local extension overlay is available next to this
+// checkout (at ../../mimoapi/packages/opencode/src/ext), it is copied into
+// src/ext/ before starting the dev server and removed on exit, so the dev run
+// picks up those modules while the working tree stays clean. When no overlay is
+// present (e.g. an open-source checkout) this just runs the dev server.
+import fs from "fs"
+import path from "path"
+
+const pkgDir = path.resolve(import.meta.dir, "..")
+const extDir = path.join(pkgDir, "src", "ext")
+const overlaySrc = path.resolve(pkgDir, "../../mimoapi/packages/opencode/src/ext")
+
+let injected = false
+if (!fs.existsSync(extDir) && fs.existsSync(overlaySrc)) {
+  fs.cpSync(overlaySrc, extDir, { recursive: true })
+  injected = true
+  console.log(`Injected local extensions from ${overlaySrc}`)
+}
+
+function cleanup() {
+  if (injected) fs.rmSync(extDir, { recursive: true, force: true })
+}
+process.on("exit", cleanup)
+
+const proc = Bun.spawn(["bun", "run", "--conditions=browser", "src/index.ts", ...process.argv.slice(2)], {
+  cwd: pkgDir,
+  stdio: ["inherit", "inherit", "inherit"],
+  env: { ...process.env, MIMOCODE_HOME: process.env.MIMOCODE_HOME ?? path.resolve(pkgDir, "../../.dev-home") },
+})
+
+const onSignal = () => proc.kill()
+process.on("SIGINT", onSignal)
+process.on("SIGTERM", onSignal)
+
+const code = await proc.exited
+cleanup()
+process.exit(code ?? 0)


### PR DESCRIPTION
## 问题

`packages/opencode` 支持可选的本地扩展模块(`src/ext/`)。release 构建会自动把这些模块纳入产物,但 `bun run dev` 直接跑 `src/index.ts`,不做任何注入——开源 checkout 里 `src/ext/` 不存在时没问题,但当扩展源放在相邻目录时,dev 看不到它们,导致 **dev 与 release 行为不一致**。

## 改动

新增 `packages/opencode/script/dev.ts` 作为 dev 启动器:

- 启动前,若 `src/ext/` 不存在且相邻目录存在扩展源,则拷入 `src/ext/`,进程退出(含 Ctrl-C)时自动清理,保持工作树干净。
- 没有扩展源时(纯开源 checkout)直接启动 dev,行为不变。
- `package.json` 的 `dev` 脚本指向该启动器。

## 验证

- ✅ 有扩展源时:`bun run dev` 自动注入,退出后 `src/ext/` 已清理
- ✅ 无扩展源时:dev 正常启动,模型列表正常,无注入、无残留
- ✅ 与 release 构建行为一致

## Test plan

- [ ] `bun run dev` 在有/无扩展源两种情况下都能正常启动
- [ ] 退出后工作树干净(无 `src/ext/` 残留)