### PR TITLE
fix(plan): resolve model from build agent config before falling back to session

### DIFF
--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -6,6 +6,7 @@ import { Question } from "../question"
 import { Session } from "../session"
 import { MessageV2 } from "../session/message-v2"
 import { Provider } from "../provider"
+import { Agent } from "../agent/agent"
 import { Instance } from "../project/instance"
 import { type SessionID, MessageID, PartID } from "../session/schema"
 import ENTER_DESCRIPTION from "./plan-enter.txt"
@@ -104,6 +105,7 @@ export const PlanExitTool = Tool.define(
     const session = yield* Session.Service
     const question = yield* Question.Service
     const provider = yield* Provider.Service
+    const agents = yield* Agent.Service
 
     return {
       description: EXIT_DESCRIPTION,
@@ -148,7 +150,15 @@ export const PlanExitTool = Tool.define(
             }
           }
 
-          const model = getLastModel(ctx.sessionID) ?? (yield* provider.defaultModel())
+          // Resolve model from build agent config first, then fall back to last session model
+          const buildAgent = yield* agents.get("build").pipe(Effect.catch(() => Effect.succeed(undefined)))
+          const agentModel = buildAgent?.modelRef
+            ? yield* provider.resolveModelRef(buildAgent.modelRef).pipe(
+                Effect.map((m) => ({ providerID: m.providerID, modelID: m.id })),
+                Effect.catch(() => Effect.succeed(undefined)),
+              )
+            : buildAgent?.model ?? undefined
+          const model = agentModel ?? getLastModel(ctx.sessionID) ?? (yield* provider.defaultModel())
 
           const msg: MessageV2.User = {
             id: MessageID.ascending(),


### PR DESCRIPTION
When the plan-exit tool creates the handoff message for the build agent, it now resolves the model from the build agent's configuration first, before falling back to the last session model or the global default.

Previously it skipped the agent-configured model entirely, which caused the build agent to be prompted with the wrong model.