### PR TITLE
feat(release): publish and install release artifacts via Xiaomi FDS

### DIFF
--- a/install
+++ b/install
@@ -180,35 +180,33 @@ else
         fi
     fi
 
-    if [ -z "$requested_version" ]; then
-        url="https://github.com/XiaomiMiMo/MiMo-Code/releases/latest/download/$filename"
+    # Download from Xiaomi FDS (fast in mainland China). Layout:
+    #   $MIMO_FDS_BASE/releases/latest          -> text file containing the latest version (e.g. 0.1.0)
+    #   $MIMO_FDS_BASE/releases/v<version>/<filename>
+    fds_base="${MIMO_FDS_BASE:-https://mimocode.cnbj1.mi-fds.com/mimocode/mimocode}"
+    fds_base="${fds_base%/}"
 
-        # Resolve the latest version from the redirect of the "latest" page
-        # (.../releases/latest -> .../releases/tag/vX.Y.Z). This avoids
-        # api.github.com, which rate-limits anonymous requests to 60/hour per IP
-        # and breaks installs on shared/CI/corporate networks.
-        specific_version=$(curl -sI "https://github.com/XiaomiMiMo/MiMo-Code/releases/latest" \
-            | grep -i '^location:' | head -1 | tr -d '\r' \
-            | sed -n 's#.*/tag/v\([0-9][^/[:space:]]*\).*#\1#p')
+    if [ -z "$requested_version" ]; then
+        specific_version=$(curl -fsSL "${fds_base}/releases/latest" 2>/dev/null | tr -d '[:space:]' | sed 's/^v//')
 
         if [ -z "$specific_version" ]; then
             echo -e "${RED}Failed to fetch version information${NC}"
-            echo -e "${MUTED}Could not resolve the latest release. Please check your network and retry,${NC}"
+            echo -e "${MUTED}Could not resolve the latest release from FDS. Please check your network and retry,${NC}"
             echo -e "${MUTED}or install a specific version, e.g.: bash -s -- --version 0.1.0${NC}"
-            echo -e "${MUTED}Available releases: https://github.com/XiaomiMiMo/MiMo-Code/releases${NC}"
             exit 1
         fi
+        url="${fds_base}/releases/v${specific_version}/$filename"
     else
         # Strip leading 'v' if present
         requested_version="${requested_version#v}"
-        url="https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v${requested_version}/$filename"
         specific_version=$requested_version
+        url="${fds_base}/releases/v${requested_version}/$filename"
 
-        # Verify the release exists before downloading
-        http_status=$(curl -sI -o /dev/null -w "%{http_code}" "https://github.com/XiaomiMiMo/MiMo-Code/releases/tag/v${requested_version}")
+        # Verify the artifact exists before downloading
+        http_status=$(curl -sI -o /dev/null -w "%{http_code}" "$url")
         if [ "$http_status" = "404" ]; then
             echo -e "${RED}Error: Release v${requested_version} not found${NC}"
-            echo -e "${MUTED}Available releases: https://github.com/XiaomiMiMo/MiMo-Code/releases${NC}"
+            echo -e "${MUTED}Checked: ${url}${NC}"
             exit 1
         fi
     fi

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -310,6 +310,24 @@ if (Script.release) {
     }
   }
   await $`gh release upload v${Script.version} ./dist/*.zip ./dist/*.tar.gz --clobber --repo ${process.env.GH_REPO}`
+
+  // Also publish to Xiaomi FDS (fast download in mainland China; the install
+  // script reads from there). Skipped when credentials are absent so local
+  // release builds still work.
+  if (process.env.MIMO_FDS_AK && process.env.MIMO_FDS_SK) {
+    const { uploadFile } = await import("./fds-upload.ts")
+    const archives = fs.readdirSync("dist").filter((f) => f.endsWith(".zip") || f.endsWith(".tar.gz"))
+    for (const file of archives) {
+      await uploadFile(`dist/${file}`, `releases/v${Script.version}/${file}`)
+      console.log(`Uploaded to FDS: releases/v${Script.version}/${file}`)
+    }
+    const tmpLatest = "dist/_latest.txt"
+    await Bun.write(tmpLatest, Script.version)
+    await uploadFile(tmpLatest, "releases/latest", "text/plain")
+    console.log(`Uploaded to FDS: releases/latest -> ${Script.version}`)
+  } else {
+    console.log("Skipping FDS upload (MIMO_FDS_AK / MIMO_FDS_SK not set)")
+  }
 }
 
 export { binaries }

--- a/packages/opencode/script/fds-upload.ts
+++ b/packages/opencode/script/fds-upload.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env bun
+// Xiaomi FDS upload for release artifacts. Galaxy-V2 signing reimplemented with
+// Node's built-in crypto (no Python/SDK), matching galaxy-fds-sdk's
+// fds/auth/signature/signer.py. Pure signing logic is unit-testable; HTTP PUT is
+// the IO shell.
+//
+// Upload host (path-style, with /bucket) differs from the public download host
+// (CDN, bucket already in the subdomain). install reads from the CDN host.
+//
+// Env:
+//   MIMO_FDS_AK / MIMO_FDS_SK            credentials (required to upload)
+//   MIMO_FDS_ENDPOINT                    upload+signing host (default cnbj1 prod)
+//   MIMO_FDS_BUCKET / MIMO_FDS_PREFIX    object layout (default mimocode/mimocode)
+//
+// CLI: bun script/fds-upload.ts <localFile> <objectSubPath> [--content-type=...]
+//   objectSubPath is relative to "<bucket>/<prefix>/", e.g. "releases/latest".
+import crypto from "node:crypto"
+
+export const FDS_ENDPOINT = process.env.MIMO_FDS_ENDPOINT || "cnbj1-fds.api.xiaomi.net"
+export const FDS_BUCKET = process.env.MIMO_FDS_BUCKET || "mimocode"
+export const FDS_PREFIX = process.env.MIMO_FDS_PREFIX || "mimocode"
+
+// signer.py SubResource.get_all_subresource: only these query keys are signed.
+const SUBRESOURCES = new Set(["acl", "quota", "uploads", "partNumber", "uploadId", "storageAccessToken", "metadata"])
+
+// signer._canonicalize_resource: path + sorted signed sub-resource query.
+export function canonicalizeResource(urlStr: string) {
+  const u = new URL(urlStr)
+  let result = decodeURIComponent(u.pathname)
+  const raw = u.search.startsWith("?") ? u.search.slice(1) : u.search
+  const parts = raw ? raw.split("&") : []
+  let i = 0
+  for (const q of [...parts].sort()) {
+    const [k, v] = q.split("=")
+    if (SUBRESOURCES.has(k!)) {
+      result += i === 0 ? "?" : "&"
+      result += v === undefined ? k : `${k}=${v}`
+      i++
+    }
+  }
+  return result
+}
+
+// signer._construct_string_to_sign: method\n md5\n type\n date\n + canonical resource.
+export function buildStringToSign(input: {
+  method: string
+  url: string
+  contentType?: string
+  date: string
+  contentMd5?: string
+}) {
+  return `${input.method}\n${input.contentMd5 ?? ""}\n${input.contentType ?? ""}\n${input.date}\n${canonicalizeResource(input.url)}`
+}
+
+export function authHeader(input: {
+  accessKey: string
+  secret: string
+  method: string
+  url: string
+  contentType?: string
+  date: string
+  contentMd5?: string
+}) {
+  const sig = crypto.createHmac("sha1", input.secret).update(buildStringToSign(input), "utf8").digest("base64")
+  return `Galaxy-V2 ${input.accessKey}:${sig}`
+}
+
+// galaxy_fds_client._acl_to_acp: public READ for ALL_USERS group. Not added by
+// put_object automatically, so anonymous download returns 403 without it.
+function publicReadAclBody(accessKey: string) {
+  return {
+    owner: { id: accessKey },
+    accessControlList: [{ grantee: { id: "ALL_USERS" }, type: "GROUP", permission: "READ" }],
+  }
+}
+
+// Full object name under the bucket, e.g. "mimocode/releases/latest".
+export function objectName(subPath: string) {
+  return `${FDS_PREFIX}/${subPath.replace(/^\/+/, "")}`
+}
+
+// Upload host, path-style: endpoint/bucket/object. Used for PUT and signing.
+function uploadUrl(name: string) {
+  return `https://${FDS_ENDPOINT}/${FDS_BUCKET}/${name}`
+}
+
+async function safeText(res: Response) {
+  try {
+    return await res.text()
+  } catch {
+    return "<no body>"
+  }
+}
+
+// Upload one object and set public-read ACL.
+export async function putObject(input: {
+  accessKey: string
+  secret: string
+  name: string
+  body: Uint8Array | string
+  contentType: string
+}) {
+  const url = uploadUrl(input.name)
+  const date1 = new Date().toUTCString()
+  const putRes = await fetch(url, {
+    method: "PUT",
+    headers: {
+      date: date1,
+      "content-type": input.contentType,
+      "cache-control": "no-cache",
+      authorization: authHeader({ ...input, method: "PUT", url, contentType: input.contentType, date: date1 }),
+    },
+    body: input.body as BodyInit,
+  })
+  if (!putRes.ok) throw new Error(`FDS put failed ${putRes.status}: ${await safeText(putRes)}`)
+
+  const aclUrl = `${url}?acl=true`
+  const date2 = new Date().toUTCString()
+  const aclRes = await fetch(aclUrl, {
+    method: "PUT",
+    headers: {
+      date: date2,
+      "content-type": "application/json",
+      authorization: authHeader({
+        ...input,
+        method: "PUT",
+        url: aclUrl,
+        contentType: "application/json",
+        date: date2,
+      }),
+    },
+    body: JSON.stringify(publicReadAclBody(input.accessKey)),
+  })
+  if (!aclRes.ok) throw new Error(`FDS set acl failed ${aclRes.status}: ${await safeText(aclRes)}`)
+}
+
+function contentTypeFor(file: string) {
+  if (file.endsWith(".zip")) return "application/zip"
+  if (file.endsWith(".tar.gz") || file.endsWith(".tgz")) return "application/gzip"
+  if (file.endsWith(".json")) return "application/json"
+  return "application/octet-stream"
+}
+
+// Upload a local file to "<prefix>/<subPath>". Returns the object name.
+export async function uploadFile(localFile: string, subPath: string, contentType?: string) {
+  const accessKey = process.env.MIMO_FDS_AK
+  const secret = process.env.MIMO_FDS_SK
+  if (!accessKey || !secret) throw new Error("MIMO_FDS_AK / MIMO_FDS_SK must be set to upload to FDS")
+  const name = objectName(subPath)
+  await putObject({
+    accessKey,
+    secret,
+    name,
+    body: new Uint8Array(await Bun.file(localFile).arrayBuffer()),
+    contentType: contentType ?? contentTypeFor(localFile),
+  })
+  return name
+}
+
+if (import.meta.main) {
+  const args = process.argv.slice(2).filter((a) => !a.startsWith("--"))
+  const ctFlag = process.argv.find((a) => a.startsWith("--content-type="))?.split("=")[1]
+  const [localFile, subPath] = args
+  if (!localFile || !subPath) {
+    console.error("Usage: bun script/fds-upload.ts <localFile> <objectSubPath> [--content-type=...]")
+    process.exit(1)
+  }
+  const name = await uploadFile(localFile, subPath, ctFlag)
+  console.log(`Uploaded ${localFile} -> ${FDS_BUCKET}/${name}`)
+}


### PR DESCRIPTION
## 背景

GitHub Release 在中国大陆下载慢。改为发布到小米 FDS 对象存储(国内 CDN 快),并让安装脚本从 FDS 下载。GitHub Release 仍照常上传(双份,作为存档/海外来源)。

## 改动

- **`script/fds-upload.ts`(新)**:FDS 上传库 + CLI。Galaxy-V2 签名用 Node `crypto` 实现(无 SDK / Python),上传后设公开读 ACL。凭证经 `MIMO_FDS_AK` / `MIMO_FDS_SK` 环境变量读取,不硬编码。
- **`script/build.ts`**:发版段在 `gh release upload` 之后,新增把所有 `dist/*.{zip,tar.gz}` 上传到 FDS `releases/v<version>/`,并写 `releases/latest`(版本号)。无凭证时跳过,本地 release 构建不受影响。
- **`install`**:从 FDS 下载——`releases/latest` 解析最新版本,`releases/v<version>/<filename>` 取包。基址可用 `MIMO_FDS_BASE` 覆盖。

布局自洽:上传写什么路径,install 就读什么路径。

## 验证

- ✅ 实测上传:签名 PUT 成功,公开读 ACL 生效,匿名 CDN 下载返回 200、内容正确
- ✅ `bun typecheck` 通过
- ✅ 签名算法与参考实现(galaxy-fds-sdk)对齐

## 备注

- FDS 凭证仅在发版环境注入,不进二进制(已扫描确认)。
- 发版机需设置 `MIMO_FDS_AK` / `MIMO_FDS_SK`(对目标 bucket 有写权限)。

## Test plan

- [ ] 发版后确认 FDS `releases/latest` 与 `releases/v<version>/` 产物就位
- [ ] `curl -fsSL https://mimo.xiaomi.com/install | bash` 端到端安装
- [ ] 无 FDS 凭证的本地 release 构建仍正常(跳过 FDS 上传)