### PR TITLE
docs: migrate remaining OpenCode references to MiMoCode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to OpenCode
+# Contributing to MiMoCode
 
-We want to make it easy for you to contribute to OpenCode. Here are the most common type of changes that get merged:
+We want to make it easy for you to contribute to MiMoCode. Here are the most common type of changes that get merged:
 
 - Bug fixes
 - Additional LSPs / Formatters
@@ -14,10 +14,10 @@ However, any UI or core product feature must go through a design review with the
 
 If you are unsure if a PR would be accepted, feel free to ask a maintainer or look for issues with any of the following labels:
 
-- [`help wanted`](https://github.com/anomalyco/opencode/issues?q=is%3Aissue%20state%3Aopen%20label%3Ahelp-wanted)
-- [`good first issue`](https://github.com/anomalyco/opencode/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
-- [`bug`](https://github.com/anomalyco/opencode/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug)
-- [`perf`](https://github.com/anomalyco/opencode/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22perf%22)
+- [`help wanted`](https://github.com/XiaomiMiMo/MiMo-Code/issues?q=is%3Aissue%20state%3Aopen%20label%3Ahelp-wanted)
+- [`good first issue`](https://github.com/XiaomiMiMo/MiMo-Code/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
+- [`bug`](https://github.com/XiaomiMiMo/MiMo-Code/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug)
+- [`perf`](https://github.com/XiaomiMiMo/MiMo-Code/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22perf%22)
 
 > [!NOTE]
 > PRs that ignore these guardrails will likely be closed.
@@ -29,7 +29,7 @@ Want to take on an issue? Leave a comment and a maintainer may assign it to you 
 New providers shouldn't require many if ANY code changes, but if you want to add support for a new provider first make a PR to:
 https://github.com/anomalyco/models.dev
 
-## Developing OpenCode
+## Developing MiMoCode
 
 - Requirements: Bun 1.3+
 - Install dependencies and start the dev server from the repo root:
@@ -41,13 +41,13 @@ https://github.com/anomalyco/models.dev
 
 ### Running against a different directory
 
-By default, `bun dev` runs OpenCode in the `packages/opencode` directory. To run it against a different directory or repository:
+By default, `bun dev` runs MiMoCode in the `packages/opencode` directory. To run it against a different directory or repository:
 
 ```bash
 bun dev <directory>
 ```
 
-To run OpenCode in the root of the opencode repo itself:
+To run MiMoCode in the root of the MiMo-Code repo itself:
 
 ```bash
 bun dev .
@@ -64,21 +64,21 @@ To compile a standalone executable:
 Then run it with:
 
 ```bash
-./packages/opencode/dist/opencode-<platform>/bin/opencode
+./packages/opencode/dist/mimocode-<platform>/bin/mimo
 ```
 
 Replace `<platform>` with your platform (e.g., `darwin-arm64`, `linux-x64`).
 
 - Core pieces:
-  - `packages/opencode`: OpenCode core business logic & server.
+  - `packages/opencode`: MiMoCode core business logic & server.
   - `packages/opencode/src/cli/cmd/tui/`: The TUI code, written in SolidJS with [opentui](https://github.com/sst/opentui)
   - `packages/app`: The shared web UI components, written in SolidJS
   - `packages/desktop`: The native desktop app, built with Tauri (wraps `packages/app`)
   - `packages/plugin`: Source for `@mimo-ai/plugin`
 
-### Understanding bun dev vs opencode
+### Understanding bun dev vs mimo
 
-During development, `bun dev` is the local equivalent of the built `opencode` command. Both run the same CLI interface:
+During development, `bun dev` is the local equivalent of the built `mimo` command. Both run the same CLI interface:
 
 ```bash
 # Development (from project root)
@@ -88,15 +88,15 @@ bun dev web              # Start server + open web interface
 bun dev <directory>      # Start TUI in specific directory
 
 # Production
-opencode --help          # Show all available commands
-opencode serve           # Start headless API server
-opencode web             # Start server + open web interface
-opencode <directory>     # Start TUI in specific directory
+mimo --help          # Show all available commands
+mimo serve           # Start headless API server
+mimo web             # Start server + open web interface
+mimo <directory>     # Start TUI in specific directory
 ```
 
 ### Running the API Server
 
-To start the OpenCode headless API server:
+To start the MiMoCode headless API server:
 
 ```bash
 bun dev serve
@@ -112,7 +112,7 @@ bun dev serve --port 8080
 
 To test UI changes during development:
 
-1. **First, start the OpenCode server** (see [Running the API Server](#running-the-api-server) section above)
+1. **First, start the MiMoCode server** (see [Running the API Server](#running-the-api-server) section above)
 2. **Then run the web app:**
 
 ```bash
@@ -159,16 +159,16 @@ Please try to follow the [style guide](./AGENTS.md)
 
 Bun debugging is currently rough around the edges. We hope this guide helps you get set up and avoid some pain points.
 
-The most reliable way to debug OpenCode is to run it manually in a terminal via `bun run --inspect=<url> dev ...` and attach
+The most reliable way to debug MiMoCode is to run it manually in a terminal via `bun run --inspect=<url> dev ...` and attach
 your debugger via that URL. Other methods can result in breakpoints being mapped incorrectly, at least in VSCode (YMMV).
 
 Caveats:
 
-- If you want to run the OpenCode TUI and have breakpoints triggered in the server code, you might need to run `bun dev spawn` instead of
+- If you want to run the MiMoCode TUI and have breakpoints triggered in the server code, you might need to run `bun dev spawn` instead of
   the usual `bun dev`. This is because `bun dev` runs the server in a worker thread and breakpoints might not work there.
 - If `spawn` does not work for you, you can debug the server separately:
   - Debug server: `bun run --inspect=ws://localhost:6499/ --cwd packages/opencode ./src/index.ts serve --port 4096`,
-    then attach TUI with `opencode attach http://localhost:4096`
+    then attach TUI with `mimo attach http://localhost:4096`
   - Debug TUI: `bun run --inspect=ws://localhost:6499/ --cwd packages/opencode --conditions=browser ./src/index.ts`
 
 Other tips and tricks:
@@ -183,7 +183,7 @@ If you use VSCode, you can use our example configurations [.vscode/settings.exam
 Some debug methods that can be problematic:
 
 - Debug configurations with `"request": "launch"` can have breakpoints incorrectly mapped and thus unusable
-- The same problem arises when running OpenCode in the VSCode `JavaScript Debug Terminal`
+- The same problem arises when running MiMoCode in the VSCode `JavaScript Debug Terminal`
 
 With that said, you may want to try these methods, as they might work for you.
 
@@ -262,7 +262,7 @@ These are not strictly enforced, they are just general guidelines:
 
 ## Feature Requests
 
-For net-new functionality, start with a design conversation. Open an issue describing the problem, your proposed approach (optional), and why it belongs in OpenCode. The core team will help decide whether it should move forward; please wait for that approval instead of opening a feature PR directly.
+For net-new functionality, start with a design conversation. Open an issue describing the problem, your proposed approach (optional), and why it belongs in MiMoCode. The core team will help decide whether it should move forward; please wait for that approval instead of opening a feature PR directly.
 
 ## Trust & Vouch System
 
@@ -271,7 +271,7 @@ This project uses [vouch](https://github.com/mitchellh/vouch) to manage contribu
 ### How it works
 
 - **Vouched users** are explicitly trusted contributors.
-- **Denounced users** are explicitly blocked. Issues and pull requests from denounced users are automatically closed. If you have been denounced, you can request to be unvouched by reaching out to a maintainer on [Discord](https://opencode.ai/discord)
+- **Denounced users** are explicitly blocked. Issues and pull requests from denounced users are automatically closed. If you have been denounced, you can request to be unvouched by reaching out to a maintainer on [GitHub Discussions](https://github.com/XiaomiMiMo/MiMo-Code/discussions)
 - **Everyone else** can participate normally — you don't need to be vouched to open issues or PRs.
 
 ### For maintainers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,13 +10,13 @@ submit one that will be an automatic ban from the project.
 
 ### Overview
 
-OpenCode is an AI-powered coding assistant that runs locally on your machine. It provides an agent system with access to powerful tools including shell execution, file operations, and web access.
+MiMoCode is an AI-powered coding assistant that runs locally on your machine. It provides an agent system with access to powerful tools including shell execution, file operations, and web access.
 
 ### No Sandbox
 
-OpenCode does **not** sandbox the agent. The permission system exists as a UX feature to help users stay aware of what actions the agent is taking - it prompts for confirmation before executing commands, writing files, etc. However, it is not designed to provide security isolation.
+MiMoCode does **not** sandbox the agent. The permission system exists as a UX feature to help users stay aware of what actions the agent is taking - it prompts for confirmation before executing commands, writing files, etc. However, it is not designed to provide security isolation.
 
-If you need true isolation, run OpenCode inside a Docker container or VM.
+If you need true isolation, run MiMoCode inside a Docker container or VM.
 
 ### Server Mode
 
@@ -38,7 +38,7 @@ Server mode is opt-in only. When enabled, set `OPENCODE_SERVER_PASSWORD` to requ
 
 We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/anomalyco/opencode/security/advisories/new) tab.
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/XiaomiMiMo/MiMo-Code/security/advisories/new) tab.
 
 The team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -31,7 +31,7 @@ Your app is ready to be deployed!
 
 ## E2E Testing
 
-Playwright starts the Vite dev server automatically via `webServer`, and UI tests expect an opencode backend at `localhost:4096` by default.
+Playwright starts the Vite dev server automatically via `webServer`, and UI tests expect a MiMoCode backend at `localhost:4096` by default.
 
 ```bash
 bunx playwright install chromium

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -1,6 +1,6 @@
-# OpenCode Desktop
+# MiMoCode Desktop
 
-The OpenCode Desktop app, built with Electron.
+The MiMoCode Desktop app, built with Electron.
 
 ## Development
 

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -1,15 +1,114 @@
-# js
+# @mimo-ai/cli
 
-To install dependencies:
+The core package of MiMoCode — a terminal-native AI coding assistant. This package contains the CLI, TUI, session engine, provider system, tool system, plugin framework, and HTTP server.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) 1.3+
+
+## Development
 
 ```bash
+# From the repository root
 bun install
+bun dev                # Run TUI in packages/opencode
+bun dev <directory>    # Run TUI in a specific directory
+bun dev .              # Run TUI in the repository root
 ```
 
-To run:
+### CLI Commands
 
 ```bash
-bun run index.ts
+bun dev --help              # Show all available commands
+bun dev serve               # Start headless API server (default port 4096)
+bun dev serve --port 8080   # Start server on a custom port
+bun dev web                 # Start server + open web interface
+bun dev models              # List available models
+bun dev providers           # List available providers
 ```
 
-This project was created using `bun init` in bun v1.2.12. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.
+### Type Checking & Linting
+
+```bash
+bun typecheck               # Run TypeScript type checker (tsgo)
+bun run lint                # Run oxlint from repository root
+```
+
+### Testing
+
+Tests must be run from within this package directory, not the repository root.
+
+```bash
+bun test                    # Run all tests
+bun test --timeout 30000    # Run with extended timeout
+```
+
+Test infrastructure lives in `test/`:
+
+- `test/fixture/` — temp directory factories and Effect-based test helpers
+- `test/lib/llm-server.ts` — mock LLM server (OpenAI-compatible SSE)
+- `test/lib/mock-llm.ts` — lightweight in-process LLM mock
+- `test/preload.ts` — test environment bootstrap (isolated DB, env vars, XDG dirs)
+
+### Building
+
+```bash
+# Build a standalone executable
+./script/build.ts --single
+
+# Output location
+./dist/opencode-<platform>/bin/opencode
+```
+
+## Architecture
+
+```
+src/
+├── cli/              # CLI entry point (yargs) and commands
+│   └── cmd/tui/      # TUI application (SolidJS + OpenTUI)
+├── session/          # Session engine: LLM streaming, prompts, checkpoints
+├── provider/         # LLM provider abstraction (20+ SDKs)
+├── tool/             # Agent tools (bash, edit, read, write, grep, glob, etc.)
+├── agent/            # Agent definitions and configuration
+├── actor/            # Sub-agent spawning and lifecycle
+├── plugin/           # Plugin framework (internal + external + file hooks)
+├── server/           # HTTP/WebSocket server (Hono)
+├── config/           # Configuration system (24 modules)
+├── storage/          # SQLite storage (Drizzle ORM)
+├── memory/           # Persistent memory (FTS5 full-text search)
+├── task/             # Tree-shaped task tracking
+├── workflow/         # Workflow engine (inline JS orchestration)
+├── effect/           # Effect-TS runtime and DI infrastructure
+├── bus/              # Event bus (pub/sub)
+├── mcp/              # Model Context Protocol client
+├── lsp/              # Language Server Protocol client
+├── permission/       # Tool execution permissions
+├── format/           # Code formatter integration
+├── file/             # Filesystem utilities (ignore, watcher, ripgrep)
+├── util/             # Shared utilities (30+ modules)
+└── index.ts          # Main CLI entry point
+```
+
+### Key Dependencies
+
+| Dependency | Purpose |
+|-----------|---------|
+| [Effect-TS](https://effect.website) | DI, error handling, concurrency |
+| [SolidJS](https://www.solidjs.com) | TUI component framework |
+| [OpenTUI](https://github.com/sst/opentui) | Terminal UI primitives |
+| [Hono](https://hono.dev) | HTTP server |
+| [Drizzle ORM](https://orm.drizzle.team) | SQLite storage |
+| [AI SDK](https://sdk.vercel.ai) | LLM provider abstraction |
+| [Tree-sitter](https://tree-sitter.github.io) | Shell parsing |
+
+## Configuration
+
+Configuration is loaded from `.mimocode/mimocode.json` in the project directory or `~/.config/mimocode/mimocode.json` globally. See the main [MiMoCode README](../../README.md) for available options.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines. All PRs must reference an existing issue.
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -57,7 +57,7 @@ Test infrastructure lives in `test/`:
 ./script/build.ts --single
 
 # Output location
-./dist/opencode-<platform>/bin/opencode
+./dist/mimocode-<platform>/bin/mimo
 ```
 
 ## Architecture

--- a/packages/opencode/src/acp/README.md
+++ b/packages/opencode/src/acp/README.md
@@ -1,6 +1,6 @@
 # ACP (Agent Client Protocol) Implementation
 
-This directory contains a clean, protocol-compliant implementation of the [Agent Client Protocol](https://agentclientprotocol.com/) for opencode.
+This directory contains a clean, protocol-compliant implementation of the [Agent Client Protocol](https://agentclientprotocol.com/) for MiMoCode.
 
 ## Architecture
 
@@ -21,7 +21,7 @@ The implementation follows a clean separation of concerns:
 
 - **`session.ts`** - Session state management
   - Creates and tracks ACP sessions
-  - Maps ACP sessions to internal opencode sessions
+  - Maps ACP sessions to internal MiMoCode sessions
   - Maintains working directory context
   - Handles MCP server configurations
 
@@ -38,10 +38,10 @@ The implementation follows a clean separation of concerns:
 
 ```bash
 # Start the ACP server in the current directory
-opencode acp
+mimo acp
 
 # Start in a specific directory
-opencode acp --cwd /path/to/project
+mimo acp --cwd /path/to/project
 ```
 
 ### Question Tool Opt-In
@@ -49,7 +49,7 @@ opencode acp --cwd /path/to/project
 ACP excludes `QuestionTool` by default.
 
 ```bash
-OPENCODE_ENABLE_QUESTION_TOOL=1 opencode acp
+MIMOCODE_ENABLE_QUESTION_TOOL=1 mimo acp
 ```
 
 Enable this only for ACP clients that support interactive question prompts.
@@ -70,7 +70,7 @@ Add to your Zed configuration (`~/.config/zed/settings.json`):
 {
   "agent_servers": {
     "OpenCode": {
-      "command": "opencode",
+      "command": "mimo",
       "args": ["acp"]
     }
   }
@@ -124,7 +124,7 @@ This implementation follows the ACP specification v1:
 - **Session Persistence**: Save and restore full conversation history
 - **Mode Support**: Implement different operational modes (ask, code, etc.)
 - **Enhanced Permissions**: More sophisticated permission handling
-- **Terminal Integration**: Full terminal support via opencode's bash tool
+- **Terminal Integration**: Full terminal support via MiMoCode's bash tool
 
 ## Testing
 
@@ -133,7 +133,7 @@ This implementation follows the ACP specification v1:
 bun test test/acp.test.ts
 
 # Test manually with stdio
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}' | opencode acp
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}' | mimo acp
 ```
 
 ## Design Decisions
@@ -160,7 +160,7 @@ This makes the codebase maintainable and testable.
 
 ### Mapping to OpenCode
 
-ACP sessions map cleanly to opencode's internal session model:
+ACP sessions map cleanly to MiMoCode's internal session model:
 
 - ACP `session/new` → creates internal Session
 - ACP `session/prompt` → uses SessionPrompt.prompt()

--- a/packages/opencode/test/AGENTS.md
+++ b/packages/opencode/test/AGENTS.md
@@ -19,7 +19,7 @@ test("example", async () => {
 ### Options
 
 - `git?: boolean` - Initialize a git repo with a root commit
-- `config?: Partial<Config.Info>` - Write an `opencode.json` config file
+- `config?: Partial<Config.Info>` - Write an `mimocode.json` config file
 - `init?: (dir: string) => Promise<T>` - Custom setup function, returns value accessible as `tmp.extra`
 - `dispose?: (dir: string) => Promise<T>` - Custom cleanup function
 
@@ -76,7 +76,7 @@ await using tmp = await tmpdir({
 
 ### Notes
 
-- Directories are created in the system temp folder with prefix `opencode-test-`
+- Directories are created in the system temp folder with prefix `mimocode-test-`
 - Use `await using` for automatic cleanup when the variable goes out of scope
 - Paths are sanitized to strip null bytes (defensive fix for CI environments)
 

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -1,6 +1,6 @@
 # @mimo-ai/slack
 
-Slack bot integration for opencode that creates threaded conversations.
+Slack bot integration for MiMoCode that creates threaded conversations.
 
 ## Setup
 
@@ -24,4 +24,4 @@ Slack bot integration for opencode that creates threaded conversations.
 bun dev
 ```
 
-The bot will respond to messages in channels where it's added, creating separate opencode sessions for each thread.
+The bot will respond to messages in channels where it's added, creating separate MiMoCode sessions for each thread.

--- a/sdks/vscode/README.md
+++ b/sdks/vscode/README.md
@@ -1,21 +1,21 @@
-# opencode VS Code Extension
+# MiMoCode VS Code Extension
 
-A Visual Studio Code extension that integrates [opencode](https://opencode.ai) directly into your development workflow.
+A Visual Studio Code extension that integrates [MiMoCode](https://mimo.xiaomi.com/coder) directly into your development workflow.
 
 ## Prerequisites
 
-This extension requires the [opencode CLI](https://opencode.ai) to be installed on your system. Visit [opencode.ai](https://opencode.ai) for installation instructions.
+This extension requires the [MiMoCode CLI](https://mimo.xiaomi.com/coder) to be installed on your system. Visit [mimo.xiaomi.com](https://mimo.xiaomi.com/coder) for installation instructions.
 
 ## Features
 
-- **Quick Launch**: Use `Cmd+Esc` (Mac) or `Ctrl+Esc` (Windows/Linux) to open opencode in a split terminal view, or focus an existing terminal session if one is already running.
-- **New Session**: Use `Cmd+Shift+Esc` (Mac) or `Ctrl+Shift+Esc` (Windows/Linux) to start a new opencode terminal session, even if one is already open. You can also click the opencode button in the UI.
-- **Context Awareness**: Automatically share your current selection or tab with opencode.
+- **Quick Launch**: Use `Cmd+Esc` (Mac) or `Ctrl+Esc` (Windows/Linux) to open MiMoCode in a split terminal view, or focus an existing terminal session if one is already running.
+- **New Session**: Use `Cmd+Shift+Esc` (Mac) or `Ctrl+Shift+Esc` (Windows/Linux) to start a new MiMoCode terminal session, even if one is already open. You can also click the MiMoCode button in the UI.
+- **Context Awareness**: Automatically share your current selection or tab with MiMoCode.
 - **File Reference Shortcuts**: Use `Cmd+Option+K` (Mac) or `Alt+Ctrl+K` (Linux/Windows) to insert file references. For example, `@File#L37-42`.
 
 ## Support
 
-This is an early release. If you encounter issues or have feedback, please create an issue at https://github.com/anomalyco/opencode/issues.
+This is an early release. If you encounter issues or have feedback, please create an issue at https://github.com/XiaomiMiMo/MiMo-Code/issues.
 
 ## Development
 


### PR DESCRIPTION
Fixes #1219

## Summary

Updated documentation files to replace OpenCode references with MiMoCode, ensuring consistency across the project.

## Changes

- **CONTRIBUTING.md**: title, content, GitHub links, CLI commands
- **SECURITY.md**: threat model description, security report link
- **packages/desktop/README.md**: title and description
- **sdks/vscode/README.md**: all content and links
- **packages/opencode/src/acp/README.md**: commands, env vars, config examples
- **packages/app/README.md**: backend reference
- **packages/opencode/test/AGENTS.md**: config filename, test prefix
- **packages/slack/README.md**: integration description
- **packages/opencode/README.md**: fixed build output path

## Verification

- Verified environment variable names against source code (e.g., \MIMOCODE_ENABLE_QUESTION_TOOL\)
- Verified build output path matches actual build script (\mimocode-<platform>/bin/mimo\)
- Verified GitHub repository link is valid
- Verified mimo.xiaomi.com/coder link is valid

## Related PRs

- #1148: Rewrites packages/opencode/README.md
- #1155: Migrates config.mdx and cli.mdx