### PR TITLE
fix(tool): tolerate quoted/<<- heredoc delimiters and rescue JSON-escaped newlines

### DIFF
--- a/packages/opencode/src/tool/shell-tokenize.ts
+++ b/packages/opencode/src/tool/shell-tokenize.ts
@@ -17,6 +17,32 @@ function heredocPlaceholder(n: number) {
   return `\x00HD${n}\x00`
 }
 
+// Parse a heredoc opener at `start` (where script[start] and start+1 are `<<`).
+// Tolerates the common bash forms a model naturally reaches for — an optional
+// `-`, surrounding whitespace, and a quoted delimiter:
+//   <<EOF   <<-EOF   << EOF   <<'EOF'   <<"EOF"   <<-'EOF'
+// The quotes are stripped; the closing line still matches the bare marker (as in
+// bash). Returns the marker name and the index just past it (after the closing
+// quote, if any), or null when there is no valid marker — in which case the
+// caller falls through to the operator-reject path. Rejecting <<'EOF' here was
+// the original "unsupported shell operator: <" failure.
+function parseHeredocMarker(script: string, start: number): { marker: string; end: number } | null {
+  let j = start + 2
+  if (script[j] === "-") j++
+  while (script[j] === " " || script[j] === "\t") j++
+  const quote = script[j] === "'" || script[j] === '"' ? script[j] : null
+  if (quote) j++
+  const markerStart = j
+  if (!(j < script.length && /[A-Za-z_]/.test(script[j]))) return null
+  while (j < script.length && /[A-Za-z0-9_]/.test(script[j])) j++
+  const marker = script.slice(markerStart, j)
+  if (quote) {
+    if (script[j] !== quote) return null
+    j++
+  }
+  return { marker, end: j }
+}
+
 type HeredocResult =
   | { ok: true; stripped: string; bodies: string[] }
   | { ok: false; error: ParseError }
@@ -71,16 +97,14 @@ function extractHeredocs(script: string): HeredocResult {
         continue
       }
 
-      // Try to read a marker name starting at i+2
-      let j = i + 2
-      const markerStart = j
-      // Marker must start with letter or underscore
-      if (j < script.length && /[A-Za-z_]/.test(script[j])) {
-        while (j < script.length && /[A-Za-z0-9_]/.test(script[j])) j++
-        const marker = script.slice(markerStart, j)
+      // Read the heredoc marker, tolerating optional `-`, surrounding whitespace,
+      // and a quoted delimiter (<<'EOF' / <<"EOF" / <<-EOF / << EOF).
+      const opener = parseHeredocMarker(script, i)
+      if (opener) {
+        const marker = opener.marker
 
         // After marker: only optional whitespace, then newline (or EOF)
-        let k = j
+        let k = opener.end
         while (k < script.length && (script[k] === " " || script[k] === "\t")) k++
 
         if (k < script.length && script[k] !== "\n") {

--- a/packages/opencode/src/tool/shell-tokenize.ts
+++ b/packages/opencode/src/tool/shell-tokenize.ts
@@ -26,6 +26,10 @@ function heredocPlaceholder(n: number) {
 // quote, if any), or null when there is no valid marker — in which case the
 // caller falls through to the operator-reject path. Rejecting <<'EOF' here was
 // the original "unsupported shell operator: <" failure.
+// Heredoc marker name: starts with a letter/underscore, then word chars (bash-like).
+const HEREDOC_MARKER_HEAD = /[A-Za-z_]/
+const HEREDOC_MARKER_TAIL = /[A-Za-z0-9_]/
+
 function parseHeredocMarker(script: string, start: number): { marker: string; end: number } | null {
   let j = start + 2
   if (script[j] === "-") j++
@@ -33,8 +37,8 @@ function parseHeredocMarker(script: string, start: number): { marker: string; en
   const quote = script[j] === "'" || script[j] === '"' ? script[j] : null
   if (quote) j++
   const markerStart = j
-  if (!(j < script.length && /[A-Za-z_]/.test(script[j]))) return null
-  while (j < script.length && /[A-Za-z0-9_]/.test(script[j])) j++
+  if (!(j < script.length && HEREDOC_MARKER_HEAD.test(script[j]))) return null
+  while (j < script.length && HEREDOC_MARKER_TAIL.test(script[j])) j++
   const marker = script.slice(markerStart, j)
   if (quote) {
     if (script[j] !== quote) return null

--- a/packages/opencode/src/tool/shell-wrap.ts
+++ b/packages/opencode/src/tool/shell-wrap.ts
@@ -7,7 +7,8 @@ export const shellInputSchema = z.object({
     [
       "Multi-line shell-style script. Each non-blank line is one command; commands run sequentially and stop on first failure.",
       'Quoting: "..." preserves literal newlines and processes \\" \\\\ escapes; \'...\' is verbatim.',
-      "<<EOF heredoc bodies are fully verbatim (no escape, no $vars).",
+      "<<EOF heredoc bodies are fully verbatim (no escape, no $vars); the delimiter may be quoted (<<'EOF', <<\"EOF\") or use <<-.",
+      "Use REAL line breaks between commands and inside heredoc bodies — a literal \\n (backslash-n) is not a newline.",
       "# starts a line comment to end-of-line (quoted # is literal).",
       "Variables ($VAR, ${VAR}) are preserved as literal text — no expansion.",
       "See the tool description for the verb table.",
@@ -69,7 +70,25 @@ export function shellWrap<P extends z.ZodType, M extends Tool.Metadata>(
             metadata: { commands: 0, success: 0 } as Tool.Metadata,
           }
         }
-        const parseExit = yield* Effect.exit(shell.parse(args.script))
+        // Strict parse first. If it fails, try a best-effort rescue: a script
+        // authored as a JSON string sometimes arrives with a DOUBLED backslash
+        // (JSON `\\n`) where a real newline was meant (JSON `\n`), collapsing a
+        // multi-line script onto one physical line so the parser can't see its
+        // structure. Repair literal \n / \t back to real control chars and
+        // re-parse; only adopt the result if THAT succeeds. A notice then teaches
+        // the model to emit real newlines next time.
+        let rescued = false
+        let parseExit = yield* Effect.exit(shell.parse(args.script))
+        if (parseExit._tag === "Failure") {
+          const repaired = repairJsonEscapes(args.script)
+          if (repaired !== undefined) {
+            const retry = yield* Effect.exit(shell.parse(repaired))
+            if (retry._tag === "Success") {
+              parseExit = retry
+              rescued = true
+            }
+          }
+        }
         if (parseExit._tag === "Failure") {
           const err = Cause.squash(parseExit.cause)
           const body = formatParseError(def.id, err)
@@ -88,6 +107,7 @@ export function shellWrap<P extends z.ZodType, M extends Tool.Metadata>(
           }
         }
         const blocks: string[] = []
+        if (rescued) blocks.push(formatNotice(rescueNoticeBody(def.id)))
         let lastMetadata: Tool.Metadata = {}
         let success = 0
         for (let i = 0; i < parsedList.length; i++) {
@@ -161,6 +181,30 @@ function describeFailure(cause: Cause.Cause<unknown>): string {
 
 function formatFailedCommandNoVerb(body: string): string {
   return `<command failed="true">\n${body}\n</command>`
+}
+
+function formatNotice(body: string): string {
+  return `<notice>\n${body}\n</notice>`
+}
+
+// Best-effort repair of the JSON double-escape: the model meant a real newline
+// (JSON `\n`) but emitted a doubled backslash (JSON `\\n`), which arrives here as
+// the literal two characters backslash-n. Turn literal \n / \t back into real
+// control chars so a script collapsed onto one physical line can re-parse.
+// Returns undefined when there's nothing to repair, so the caller skips the retry
+// and reports the original error. Only ever used when the strict parse FAILED and
+// the repaired re-parse SUCCEEDS — that bounds the blast radius: a heredoc body's
+// intentional literal \n is left alone whenever the strict parse already succeeds.
+function repairJsonEscapes(script: string): string | undefined {
+  if (!/\\[nt]/.test(script)) return undefined
+  return script.replace(/\\n/g, "\n").replace(/\\t/g, "\t")
+}
+
+function rescueNoticeBody(toolId: string): string {
+  return [
+    `${toolId}: your script had no real line breaks — literal \\n / \\t were read as newlines/tabs.`,
+    `Emit REAL line breaks in the JSON string (JSON \\n), not a doubled backslash (\\\\n).`,
+  ].join("\n")
 }
 
 function shellTeachingBody(toolId: string): string {

--- a/packages/opencode/src/tool/shell-wrap.ts
+++ b/packages/opencode/src/tool/shell-wrap.ts
@@ -204,6 +204,7 @@ function rescueNoticeBody(toolId: string): string {
   return [
     `${toolId}: your script had no real line breaks — literal \\n / \\t were read as newlines/tabs.`,
     `Emit REAL line breaks in the JSON string (JSON \\n), not a doubled backslash (\\\\n).`,
+    `If you meant a LITERAL \\n / \\t inside a quoted string, it was rewritten too — double-escape it (\\\\\\\\n) so it survives.`,
   ].join("\n")
 }
 

--- a/packages/opencode/test/tool/actor.shell.test.ts
+++ b/packages/opencode/test/tool/actor.shell.test.ts
@@ -40,6 +40,22 @@ describe("actor.shell.parse: spawn variants", () => {
     expect(cmd.operation.prompt).toContain("C:\\Users")
     expect(cmd.operation.prompt).toContain("$foo")
   })
+
+  test("run with quoted heredoc delimiter <<'PROMPT' parses (original parse-error repro)", async () => {
+    const script = [
+      `actor run general "Implement Task 1" <<'PROMPT'`,
+      `Add submodule fields to workspace_repos.`,
+      `Columns: parent_workspace_repo_id, submodule_path.`,
+      `PROMPT`,
+    ].join("\n")
+    const out = await parse(script)
+    const cmd = out[0] as { operation: { action: string; subagent_type: string; prompt: string } }
+    expect(cmd.operation.action).toBe("run")
+    expect(cmd.operation.subagent_type).toBe("general")
+    expect(cmd.operation.prompt).toBe(
+      "Add submodule fields to workspace_repos.\nColumns: parent_workspace_repo_id, submodule_path.",
+    )
+  })
 })
 
 describe("actor.shell.parse: --model flag", () => {

--- a/packages/opencode/test/tool/shell-tokenize.test.ts
+++ b/packages/opencode/test/tool/shell-tokenize.test.ts
@@ -270,4 +270,40 @@ describe("shell-tokenize: heredoc", () => {
     const out = await tokenizeOk(script)
     expect(out[0].tokens.at(-1)).toBe("")
   })
+
+  test("single-quoted delimiter <<'EOF' parses, body verbatim", async () => {
+    const script = ["task revise T1 <<'EOF'", "line 1", "$x and 'quotes'", "EOF"].join("\n")
+    const out = await tokenizeOk(script)
+    expect(out).toEqual([{ line: 1, tokens: ["task", "revise", "T1", "line 1\n$x and 'quotes'"] }])
+  })
+
+  test('double-quoted delimiter <<"EOF" parses', async () => {
+    const script = ['task revise T1 <<"EOF"', "body", "EOF"].join("\n")
+    const out = await tokenizeOk(script)
+    expect(out[0].tokens.at(-1)).toBe("body")
+  })
+
+  test("<<-EOF dash form parses", async () => {
+    const script = ["task revise T1 <<-EOF", "body", "EOF"].join("\n")
+    const out = await tokenizeOk(script)
+    expect(out[0].tokens.at(-1)).toBe("body")
+  })
+
+  test("<< EOF leading whitespace before marker parses", async () => {
+    const script = ["task revise T1 << EOF", "body", "EOF"].join("\n")
+    const out = await tokenizeOk(script)
+    expect(out[0].tokens.at(-1)).toBe("body")
+  })
+
+  test("combined <<-'EOF' parses", async () => {
+    const script = ["task revise T1 <<-'EOF'", "body", "EOF"].join("\n")
+    const out = await tokenizeOk(script)
+    expect(out[0].tokens.at(-1)).toBe("body")
+  })
+
+  test("closing marker matches the bare name even when the delimiter was quoted", async () => {
+    const script = ["task revise T1 <<'END'", "keep 'END' inside", "END"].join("\n")
+    const out = await tokenizeOk(script)
+    expect(out[0].tokens.at(-1)).toBe("keep 'END' inside")
+  })
 })

--- a/packages/opencode/test/tool/shell-wrap.test.ts
+++ b/packages/opencode/test/tool/shell-wrap.test.ts
@@ -255,3 +255,81 @@ describe("shellWrap: nested discriminator (task-style)", () => {
     expect(result.output).not.toContain("[object Object]")
   })
 })
+
+describe("shellWrap: JSON double-escape rescue", () => {
+  // A parser that chokes when the script arrives collapsed onto one physical line
+  // via literal backslash-n (the JSON double-escape), but parses fine once real
+  // newlines are restored — mirroring how the real tokenizer behaves.
+  function makeNewlineSensitiveTool(record: { calls: z.infer<typeof params>[] }): Tool.Def<typeof params> {
+    return {
+      ...makeRecordingTool(record),
+      shell: {
+        description: "shell description",
+        parse: (script) => {
+          if (/\\n/.test(script))
+            return Effect.fail({ kind: "unsupported-operator", line: 1, detail: "literal backslash-n" })
+          return Effect.succeed(
+            script
+              .split("\n")
+              .filter((l) => l.trim() !== "")
+              .map((line) => {
+                const tokens = line.trim().split(/\s+/)
+                return { operation: tokens[1], value: tokens[2] } as z.infer<typeof params>
+              }),
+          )
+        },
+      },
+    }
+  }
+
+  test("literal \\n collapsed script is repaired, re-parsed, and runs with a notice", async () => {
+    const record = { calls: [] as z.infer<typeof params>[] }
+    const wrapped = shellWrap(makeNewlineSensitiveTool(record))
+    const result = await runtime.runPromise(
+      wrapped.execute({ script: "synthetic create A\\nsynthetic update B" }, stubCtx()),
+    )
+    expect(record.calls).toEqual([
+      { operation: "create", value: "A" },
+      { operation: "update", value: "B" },
+    ])
+    expect(result.output).toContain("<notice>")
+    expect(result.output).toContain("REAL line breaks")
+    expect(result.output.match(/<command/g)?.length).toBe(2)
+    expect(result.metadata).toEqual({ operation: "update", commands: 2, success: 2 })
+  })
+
+  test("nothing to repair → original parse error, no notice", async () => {
+    const record = { calls: [] as z.infer<typeof params>[] }
+    const wrapped = shellWrap({
+      ...makeRecordingTool(record),
+      shell: {
+        description: "shell description",
+        parse: () => Effect.fail({ kind: "unsupported-operator", line: 1, detail: "always fails" }),
+      },
+    })
+    const result = await runtime.runPromise(wrapped.execute({ script: "synthetic create A" }, stubCtx()))
+    expect(record.calls).toEqual([])
+    expect(result.output).toContain('<command failed="true">')
+    expect(result.output).not.toContain("<notice>")
+    expect(result.output).toContain("always fails")
+  })
+
+  test("repair attempted but re-parse still fails → original error, no notice", async () => {
+    const record = { calls: [] as z.infer<typeof params>[] }
+    const wrapped = shellWrap({
+      ...makeRecordingTool(record),
+      shell: {
+        description: "shell description",
+        parse: () => Effect.fail({ kind: "unsupported-operator", line: 1, detail: "still broken" }),
+      },
+    })
+    // Script carries literal \n so repair runs, but parse fails regardless.
+    const result = await runtime.runPromise(
+      wrapped.execute({ script: "synthetic create A\\nsynthetic update B" }, stubCtx()),
+    )
+    expect(record.calls).toEqual([])
+    expect(result.output).toContain('<command failed="true">')
+    expect(result.output).not.toContain("<notice>")
+    expect(result.output).toContain("still broken")
+  })
+})

--- a/packages/opencode/test/tool/shell-wrap.test.ts
+++ b/packages/opencode/test/tool/shell-wrap.test.ts
@@ -314,6 +314,16 @@ describe("shellWrap: JSON double-escape rescue", () => {
     expect(result.output).toContain("always fails")
   })
 
+  test("rescue notice warns that a literal \\n inside a string may have been rewritten", async () => {
+    const record = { calls: [] as z.infer<typeof params>[] }
+    const wrapped = shellWrap(makeNewlineSensitiveTool(record))
+    const result = await runtime.runPromise(
+      wrapped.execute({ script: "synthetic create A\\nsynthetic update B" }, stubCtx()),
+    )
+    expect(result.output).toContain("<notice>")
+    expect(result.output).toContain("LITERAL")
+  })
+
   test("repair attempted but re-parse still fails → original error, no notice", async () => {
     const record = { calls: [] as z.infer<typeof params>[] }
     const wrapped = shellWrap({


### PR DESCRIPTION
## Summary

The shell-style tool parser rejected `<<'PROMPT'` (and `<<"X"`, `<<-X`, `<< X`) with `unsupported shell operator: <`: the heredoc marker had to start immediately with `[A-Za-z_]` right after `<<`. Models naturally reach for the quoted-delimiter bash form, so this failed often.

Two infra-level fixes, shared by `actor`, `task`, and every shell tool:

- **`shell-tokenize`** — `parseHeredocMarker` now accepts an optional `-`, surrounding whitespace, and a quoted delimiter; quotes are stripped and the closing line still matches the bare marker.
- **`shell-wrap`** — on parse failure, repair the JSON double-escape (literal `\n` / `\t` where a real newline was meant) and re-parse, adopting the result only if the re-parse succeeds, with a `<notice>` teaching the model to emit real newlines. The script param description now states the newline rule and that quoted delimiters are accepted.

## Behavior notes / known limitations

- **`<<-` is accepted but does NOT strip leading tabs** from the body (or the closing marker) the way bash does. This is intentional — the heredoc body is collected verbatim. The `<<-` form parses; just don't expect bash's tab-stripping semantics.
- **The rescue can rewrite an intentional literal `\n` / `\t`.** It replaces every literal `\n`/`\t` in the script, so a deliberate literal inside a quoted string is rewritten too. It's bounded — the repair is adopted only when the re-parse succeeds (it never yields unparseable output) — but a model that meant a literal must double-escape it (`\\n`). The rescue `<notice>` now says this explicitly.

## Verification

- `bun typecheck` clean
- 90 tool tests pass across the affected files (delimiter variants, the quoted-delimiter actor repro, rescue success/no-op/still-fails, and the new "notice warns about literal rewrite" case)