### PR TITLE
ci: split tests into 4 shards with fail-fast disabled

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,53 +1,19 @@
 name: "Setup Bun"
-description: "Setup Bun with caching and install dependencies"
+description: "Setup Bun, cache dependencies, and install"
 runs:
   using: "composite"
   steps:
-    - name: Get baseline download URL
-      id: bun-url
-      shell: bash
-      run: |
-        if [ "$RUNNER_ARCH" = "X64" ]; then
-          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
-          case "$RUNNER_OS" in
-            macOS)   OS=darwin ;;
-            Linux)   OS=linux ;;
-            Windows) OS=windows ;;
-          esac
-          echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
-      with:
-        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
-        bun-download-url: ${{ steps.bun-url.outputs.url }}
-
-    - name: Get cache directory
-      id: cache
-      shell: bash
-      run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
 
     - name: Cache Bun dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
-        path: ${{ steps.cache.outputs.dir }}
+        path: ~/.bun/install/cache
         key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
         restore-keys: |
           ${{ runner.os }}-bun-
 
-    - name: Install setuptools for distutils compatibility
-      run: python3 -m pip install setuptools || pip install setuptools || true
-      shell: bash
-
     - name: Install dependencies
-      run: |
-        # Workaround for patched peer variants
-        # e.g. ./patches/ for standard-openapi
-        # https://github.com/oven-sh/bun/issues/28147
-        if [ "$RUNNER_OS" = "Windows" ]; then
-          bun install --linker hoisted
-        else
-          bun install
-        fi
+      run: bun install
       shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,14 @@ permissions:
 jobs:
   unit:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ["1/4", "2/4", "3/4", "4/4"]
+    name: unit (shard ${{ matrix.shard }})
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
@@ -29,15 +34,14 @@ jobs:
           git config --global user.email "ci@mimo.ai"
           git config --global user.name "mimo-ci"
 
-      - name: Cache Turbo
-        uses: actions/cache@v4
-        with:
-          path: node_modules/.cache/turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-
-            turbo-${{ runner.os }}-
+      - name: Run unit tests (shard ${{ matrix.shard }})
+        timeout-minutes: 8
+        working-directory: packages/opencode
+        run: bun run test:ci --shard ${{ matrix.shard }}
 
-      - name: Run unit tests
-        timeout-minutes: 20
-        run: bun turbo test --output-logs=errors-only --log-order=grouped --log-prefix=task
+      - name: Upload JUnit
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit-shard-${{ strategy.job-index }}
+          path: packages/opencode/.artifacts/unit/junit.xml

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.11",
+  "packageManager": "bun@1.3.14",
   "scripts": {
     "dev": "bun run --cwd packages/opencode script/dev.ts",
     "dev:desktop": "bun --cwd packages/desktop dev",

--- a/turbo.json
+++ b/turbo.json
@@ -3,29 +3,6 @@
   "globalEnv": ["CI", "OPENCODE_DISABLE_SHARE"],
   "globalPassThroughEnv": ["CI", "OPENCODE_DISABLE_SHARE"],
   "tasks": {
-    "typecheck": {},
-    "build": {
-      "dependsOn": [],
-      "outputs": ["dist/**"]
-    },
-    "@mimo-ai/cli#test": {
-      "dependsOn": ["^build"],
-      "outputs": [],
-      "passThroughEnv": ["*"]
-    },
-    "@mimo-ai/cli#test:ci": {
-      "dependsOn": ["^build"],
-      "outputs": [".artifacts/unit/junit.xml"],
-      "passThroughEnv": ["*"]
-    },
-    "@mimo-ai/app#test": {
-      "dependsOn": ["^build"],
-      "outputs": []
-    },
-    "@mimo-ai/app#test:ci": {
-      "dependsOn": ["^build"],
-      "outputs": [".artifacts/unit/junit.xml"],
-      "passThroughEnv": ["*"]
-    }
+    "typecheck": {}
   }
 }


### PR DESCRIPTION
## Summary

- Split unit tests into 4 parallel shards using `bun test --shard`
- Set `fail-fast: false` so all shards complete even if one fails
- Run tests directly in `packages/opencode` via `test:ci` script with JUnit reporter
- Upload JUnit XML artifact per shard
- Simplify `setup-bun` action: remove baseline URL construction, setuptools, Windows hoisted workaround
- Bump actions: `checkout@v6`, `cache@v5`, `upload-artifact@v7` (fix Node.js 20 deprecation warnings)
- `turbo.json`: only keep `typecheck` (remove `build` + `@mimo-ai/cli` / `@mimo-ai/app` test tasks)
- Bump bun to 1.3.14 via `packageManager`

## Changes

| File | Change |
|---|---|
| `test.yml` | 4 shards, fail-fast=false, 8min timeout, JUnit artifacts |
| `lint.yml` / `typecheck.yml` | checkout v6 |
| `setup-bun/action.yml` | 53→19 lines, simplified |
| `turbo.json` | only `typecheck` |
| `package.json` | bun 1.3.14 |