### PR TITLE
fix(upgrade): resolve latest version from FDS to match install download source

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -218,14 +218,16 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
         // }
 
         if (detectedMethod === "curl") {
-          const headers = yield* text([
-            "curl",
-            "-sI",
-            "https://github.com/XiaomiMiMo/MiMo-Code/releases/latest",
-          ])
-          const match = headers.match(/^location:.*\/tag\/v([0-9][^\s/]*)/im)
-          if (match) return match[1]
-          return yield* Effect.die(new Error("failed to resolve latest version from GitHub releases redirect"))
+          // Resolve the latest version from FDS, matching the source the install
+          // script downloads from (fast in mainland China). Override base via
+          // MIMO_FDS_BASE to mirror the install script.
+          const base = (process.env.MIMO_FDS_BASE || "https://mimocode.cnbj1.mi-fds.com/mimocode/mimocode").replace(
+            /\/+$/,
+            "",
+          )
+          const version = (yield* text(["curl", "-fsSL", `${base}/releases/latest`])).trim().replace(/^v/, "")
+          if (version) return version
+          return yield* Effect.die(new Error("failed to resolve latest version from FDS"))
         }
 
         if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm") {


### PR DESCRIPTION
## 背景

`mimo upgrade`(curl 安装方式)分两步:
1. **检查最新版本** —— 之前请求 GitHub `releases/latest` 重定向取版本号
2. **下载安装** —— 跑 `https://mimo.xiaomi.com/install`,该脚本已改为从 FDS 下载(#1212)

两步来源不一致:版本检查走 GitHub(国内慢/可能不可达),下载走 FDS。

## 改动

把 curl 方式的版本检查也改为读 FDS 的 `releases/latest`(install 脚本写入、下载时读取的同一文件),与下载源统一。基址可用 `MIMO_FDS_BASE` 覆盖,与 install 脚���对齐。

其他安装方式(npm/pnpm/bun)不变,仍走各自 registry。

## Test plan

- [ ] curl 安装的客户端 `mimo upgrade` 能从 FDS 解析到最新版本并升级
- [ ] `bun typecheck` 通过(已验证)