### PR TITLE
feat(compose): configurable docs directory

### DIFF
--- a/packages/opencode/src/config/compose.ts
+++ b/packages/opencode/src/config/compose.ts
@@ -6,6 +6,10 @@ export const Info = Schema.Struct({
   docs: Schema.optional(Schema.String).annotate({
     description: "Directory where compose skills save specs, plans, and reports. Relative paths resolve against the project root. Defaults to docs/compose.",
   }),
+  docs_absolute: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "Whether the docs directory injected into the compose prompt is an absolute path. When true (default), a relative `docs` is resolved against the active worktree root so it is unambiguous regardless of the agent's working directory. When false, the relative `docs` value is passed through verbatim. Ignored when `docs` is already absolute.",
+  }),
 }).pipe(withStatics((s) => ({ zod: zod(s) })))
 
 export type Info = Schema.Schema.Type<typeof Info>

--- a/packages/opencode/src/config/compose.ts
+++ b/packages/opencode/src/config/compose.ts
@@ -8,7 +8,7 @@ export const Info = Schema.Struct({
   }),
   docs_absolute: Schema.optional(Schema.Boolean).annotate({
     description:
-      "Whether the docs directory injected into the compose prompt is an absolute path. When true (default), a relative `docs` is resolved against the active worktree root so it is unambiguous regardless of the agent's working directory. When false, the relative `docs` value is passed through verbatim. Ignored when `docs` is already absolute.",
+      "Whether the docs directory injected into the compose prompt is an absolute path. When false (default), a relative `docs` value is passed through verbatim. When true, a relative `docs` is resolved against the active worktree root so it is unambiguous regardless of the agent's working directory. Ignored when `docs` is already absolute.",
   }),
 }).pipe(withStatics((s) => ({ zod: zod(s) })))
 

--- a/packages/opencode/src/config/compose.ts
+++ b/packages/opencode/src/config/compose.ts
@@ -1,0 +1,15 @@
+import { Schema } from "effect"
+import { zod } from "@/util/effect-zod"
+import { withStatics } from "@/util/schema"
+
+export const Info = Schema.Struct({
+  docs: Schema.optional(Schema.String).annotate({
+    description: "Directory where compose skills save specs, plans, and reports. Relative paths resolve against the project root. Defaults to docs/compose.",
+  }),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
+
+export type Info = Schema.Schema.Type<typeof Info>
+
+export const DEFAULT_DOCS_DIR = "docs/compose"
+
+export * as ConfigCompose from "./compose"

--- a/packages/opencode/src/config/compose.ts
+++ b/packages/opencode/src/config/compose.ts
@@ -1,10 +1,11 @@
 import { Schema } from "effect"
+import path from "path"
 import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
 export const Info = Schema.Struct({
   docs: Schema.optional(Schema.String).annotate({
-    description: "Directory where compose skills save specs, plans, and reports. Relative paths resolve against the project root. Defaults to docs/compose.",
+    description: "Directory where compose skills save specs, plans, and reports. Relative paths are passed to the agent prompt verbatim; set docs_absolute: true to anchor them to the project root. Defaults to docs/compose.",
   }),
   docs_absolute: Schema.optional(Schema.Boolean).annotate({
     description:
@@ -15,5 +16,11 @@ export const Info = Schema.Struct({
 export type Info = Schema.Schema.Type<typeof Info>
 
 export const DEFAULT_DOCS_DIR = "docs/compose"
+
+export function resolveDocsDir(worktree: string, cfg?: Info) {
+  const configured = cfg?.docs ?? DEFAULT_DOCS_DIR
+  if (path.isAbsolute(configured) || cfg?.docs_absolute === true) return path.resolve(worktree, configured)
+  return configured
+}
 
 export * as ConfigCompose from "./compose"

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -27,6 +27,7 @@ import { InstanceRef } from "@/effect/instance-ref"
 import { zod, ZodOverride } from "@/util/effect-zod"
 import { ConfigAgent } from "./agent"
 import { ConfigCommand } from "./command"
+import { ConfigCompose } from "./compose"
 import { ConfigFormatter } from "./formatter"
 import { ConfigHistory } from "./history"
 import { ConfigLayout } from "./layout"
@@ -104,6 +105,7 @@ const InfoSchema = Schema.Struct({
     description: "Command configuration, see https://opencode.ai/docs/commands",
   }),
   skills: Schema.optional(ConfigSkills.Info).annotate({ description: "Additional skill folder paths" }),
+  compose: Schema.optional(ConfigCompose.Info).annotate({ description: "Compose mode configuration" }),
   watcher: Schema.optional(
     Schema.Struct({
       ignore: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),

--- a/packages/opencode/src/config/index.ts
+++ b/packages/opencode/src/config/index.ts
@@ -1,6 +1,7 @@
 export * as Config from "./config"
 export * as ConfigAgent from "./agent"
 export * as ConfigCommand from "./command"
+export * as ConfigCompose from "./compose"
 export * as ConfigError from "./error"
 export * as ConfigFormatter from "./formatter"
 export * as ConfigLSP from "./lsp"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -485,10 +485,12 @@ export const layer = Layer.effect(
       if (composeModeMsg) {
         const composeModeBlock = composeSkillsBlock()
         const ctx = yield* InstanceState.context
-        const docsConfigured = (yield* config.get()).compose?.docs ?? ConfigCompose.DEFAULT_DOCS_DIR
-        const docsDir = path.isAbsolute(docsConfigured)
-          ? docsConfigured
-          : path.join(ctx.worktree, docsConfigured)
+        const composeCfg = (yield* config.get()).compose
+        const docsConfigured = composeCfg?.docs ?? ConfigCompose.DEFAULT_DOCS_DIR
+        const docsDir =
+          path.isAbsolute(docsConfigured) || composeCfg?.docs_absolute !== false
+            ? path.resolve(ctx.worktree, docsConfigured)
+            : docsConfigured
         const composeDocsBlock = [
           "<compose_docs_dir>",
           `Save compose skill outputs: specs in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -488,7 +488,7 @@ export const layer = Layer.effect(
         const composeCfg = (yield* config.get()).compose
         const docsConfigured = composeCfg?.docs ?? ConfigCompose.DEFAULT_DOCS_DIR
         const docsDir =
-          path.isAbsolute(docsConfigured) || composeCfg?.docs_absolute !== false
+          path.isAbsolute(docsConfigured) || composeCfg?.docs_absolute === true
             ? path.resolve(ctx.worktree, docsConfigured)
             : docsConfigured
         const composeDocsBlock = [

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -491,8 +491,7 @@ export const layer = Layer.effect(
           : path.join(ctx.worktree, docsConfigured)
         const composeDocsBlock = [
           "<compose_docs_dir>",
-          `Save compose skill outputs (specs, plans, reports) under this directory instead of the default \`docs/compose\`:`,
-          `  ${docsDir}`,
+          `Save compose skill outputs under this directory: ${docsDir}`,
           `Specs go in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`,
           "</compose_docs_dir>",
         ].join("\n")

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -54,7 +54,7 @@ import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import * as Stream from "effect/Stream"
 import { Command } from "../command"
 import { pathToFileURL, fileURLToPath } from "url"
-import { ConfigMarkdown } from "../config"
+import { ConfigMarkdown, ConfigCompose } from "../config"
 import { SessionSummary } from "./summary"
 import { NamedError } from "@mimo-ai/shared/util/error"
 import { SessionProcessor } from "./processor"
@@ -484,12 +484,28 @@ export const layer = Layer.effect(
       )
       if (composeModeMsg) {
         const composeModeBlock = composeSkillsBlock()
+        const ctx = yield* InstanceState.context
+        const docsConfigured = (yield* config.get()).compose?.docs ?? ConfigCompose.DEFAULT_DOCS_DIR
+        const docsDir = path.isAbsolute(docsConfigured)
+          ? docsConfigured
+          : path.join(ctx.worktree, docsConfigured)
+        const composeDocsBlock = [
+          "<compose_docs_dir>",
+          `Save compose skill outputs (specs, plans, reports) under this directory instead of the default \`docs/compose\`:`,
+          `  ${docsDir}`,
+          `Specs go in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`,
+          "</compose_docs_dir>",
+        ].join("\n")
         composeModeMsg.parts.unshift({
           id: PartID.ascending(),
           messageID: composeModeMsg.info.id,
           sessionID: composeModeMsg.info.sessionID,
           type: "text",
-          text: PROMPT_COMPOSE + (composeModeBlock ? "\n\n" + composeModeBlock : ""),
+          text:
+            PROMPT_COMPOSE +
+            (composeModeBlock ? "\n\n" + composeModeBlock : "") +
+            "\n\n" +
+            composeDocsBlock,
           synthetic: true,
         })
       }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -486,11 +486,7 @@ export const layer = Layer.effect(
         const composeModeBlock = composeSkillsBlock()
         const ctx = yield* InstanceState.context
         const composeCfg = (yield* config.get()).compose
-        const docsConfigured = composeCfg?.docs ?? ConfigCompose.DEFAULT_DOCS_DIR
-        const docsDir =
-          path.isAbsolute(docsConfigured) || composeCfg?.docs_absolute === true
-            ? path.resolve(ctx.worktree, docsConfigured)
-            : docsConfigured
+        const docsDir = ConfigCompose.resolveDocsDir(ctx.worktree, composeCfg)
         const composeDocsBlock = [
           "<compose_docs_dir>",
           `Save compose skill outputs: specs in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -491,8 +491,7 @@ export const layer = Layer.effect(
           : path.join(ctx.worktree, docsConfigured)
         const composeDocsBlock = [
           "<compose_docs_dir>",
-          `Save compose skill outputs under this directory: ${docsDir}`,
-          `Specs go in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`,
+          `Save compose skill outputs: specs in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`,
           "</compose_docs_dir>",
         ].join("\n")
         composeModeMsg.parts.unshift({

--- a/packages/opencode/src/skill/compose/.bundle/brainstorm/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/brainstorm/SKILL.md
@@ -33,7 +33,7 @@ You MUST create a task for each of these items and complete them in order:
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** (optional, multi-step features only) — save to `<docs-dir>/specs/YYYY-MM-DD-<topic>-design.md` (where `<docs-dir>` is the compose docs directory from the `<compose_docs_dir>` block in your prompt, default `docs/compose`) and commit. For single-step fixes or small changes, keep the design in conversation context only.
+6. **Write design doc** (optional, multi-step features only) — save to the `specs/` directory given in the `<compose_docs_dir>` block of your prompt, as `YYYY-MM-DD-<topic>-design.md`, and commit. For single-step fixes or small changes, keep the design in conversation context only.
 7. **Spec self-review** (if doc written) — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** (if doc written) — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke compose:plan to create implementation plan
@@ -105,7 +105,7 @@ You MUST create a task for each of these items and complete them in order:
 **Documentation (optional, multi-step features only):**
 
 For features with multiple tasks or significant architectural decisions:
-- Write the validated design (spec) to `<docs-dir>/specs/YYYY-MM-DD-<topic>-design.md` (`<docs-dir>` = the compose docs directory from `<compose_docs_dir>`, default `docs/compose`)
+- Write the validated design (spec) to the `specs/` directory given in `<compose_docs_dir>`, as `YYYY-MM-DD-<topic>-design.md`
   - (User preferences for spec location override this default)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git

--- a/packages/opencode/src/skill/compose/.bundle/brainstorm/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/brainstorm/SKILL.md
@@ -33,7 +33,7 @@ You MUST create a task for each of these items and complete them in order:
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** (optional, multi-step features only) — save to `docs/compose/specs/YYYY-MM-DD-<topic>-design.md` and commit. For single-step fixes or small changes, keep the design in conversation context only.
+6. **Write design doc** (optional, multi-step features only) — save to `<docs-dir>/specs/YYYY-MM-DD-<topic>-design.md` (where `<docs-dir>` is the compose docs directory from the `<compose_docs_dir>` block in your prompt, default `docs/compose`) and commit. For single-step fixes or small changes, keep the design in conversation context only.
 7. **Spec self-review** (if doc written) — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** (if doc written) — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke compose:plan to create implementation plan
@@ -105,7 +105,7 @@ You MUST create a task for each of these items and complete them in order:
 **Documentation (optional, multi-step features only):**
 
 For features with multiple tasks or significant architectural decisions:
-- Write the validated design (spec) to `docs/compose/specs/YYYY-MM-DD-<topic>-design.md`
+- Write the validated design (spec) to `<docs-dir>/specs/YYYY-MM-DD-<topic>-design.md` (`<docs-dir>` = the compose docs directory from `<compose_docs_dir>`, default `docs/compose`)
   - (User preferences for spec location override this default)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git

--- a/packages/opencode/src/skill/compose/.bundle/brainstorm/spec-document-reviewer-prompt.md
+++ b/packages/opencode/src/skill/compose/.bundle/brainstorm/spec-document-reviewer-prompt.md
@@ -4,7 +4,7 @@ Use this template when dispatching a spec document reviewer subagent.
 
 **Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
 
-**Dispatch after:** Spec document is written to the compose docs `specs/` directory (the `<docs-dir>/specs/` path from the `<compose_docs_dir>` block, default `docs/compose/specs/`)
+**Dispatch after:** Spec document is written to the `specs/` directory given in the `<compose_docs_dir>` block
 
 Dispatch a `general` subagent via the `actor` tool, following the syntax in that
 tool's own description. Use a short title like "Review spec document" and this prompt:

--- a/packages/opencode/src/skill/compose/.bundle/brainstorm/spec-document-reviewer-prompt.md
+++ b/packages/opencode/src/skill/compose/.bundle/brainstorm/spec-document-reviewer-prompt.md
@@ -4,7 +4,7 @@ Use this template when dispatching a spec document reviewer subagent.
 
 **Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
 
-**Dispatch after:** Spec document is written to docs/compose/specs/
+**Dispatch after:** Spec document is written to the compose docs `specs/` directory (the `<docs-dir>/specs/` path from the `<compose_docs_dir>` block, default `docs/compose/specs/`)
 
 Dispatch a `general` subagent via the `actor` tool, following the syntax in that
 tool's own description. Use a short title like "Review spec document" and this prompt:

--- a/packages/opencode/src/skill/compose/.bundle/plan/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/plan/SKILL.md
@@ -16,7 +16,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Context:** If working in an isolated worktree, it should have been created via the `compose:worktree` skill at execution time.
 
-**Save plans to:** `docs/compose/plans/YYYY-MM-DD-<feature-name>.md`
+**Save plans to:** `<docs-dir>/plans/YYYY-MM-DD-<feature-name>.md`, where `<docs-dir>` is the compose docs directory given in the `<compose_docs_dir>` block of your prompt (defaults to `docs/compose`).
 - (User preferences for plan location override this default)
 
 ## Scope Check

--- a/packages/opencode/src/skill/compose/.bundle/plan/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/plan/SKILL.md
@@ -16,7 +16,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Context:** If working in an isolated worktree, it should have been created via the `compose:worktree` skill at execution time.
 
-**Save plans to:** `<docs-dir>/plans/YYYY-MM-DD-<feature-name>.md`, where `<docs-dir>` is the compose docs directory given in the `<compose_docs_dir>` block of your prompt (defaults to `docs/compose`).
+**Save plans to:** the `plans/` directory given in the `<compose_docs_dir>` block of your prompt, as `YYYY-MM-DD-<feature-name>.md`.
 - (User preferences for plan location override this default)
 
 ## Scope Check

--- a/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
@@ -54,10 +54,10 @@ Every report MUST use this structure:
 feature: <feature-name>
 status: delivered
 specs:
-  - <docs-dir>/specs/<spec-1>.md
-  - <docs-dir>/specs/<spec-2>.md
+  - <path to spec file, in the specs/ dir from <compose_docs_dir>>
+  - <path to another spec file>
 plans:
-  - <docs-dir>/plans/<plan>.md
+  - <path to plan file, in the plans/ dir from <compose_docs_dir>>
 branch: <branch-name>
 commits: <first-sha>..<last-sha>
 ---

--- a/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
@@ -14,7 +14,7 @@ Consolidate a feature's spec history into a single human-readable final report. 
 
 **Announce at start:** "I'm using the report skill to write the final report for this feature."
 
-**Save reports to:** `<docs-dir>/reports/<feature-name>.md`, where `<docs-dir>` is the compose docs directory from the `<compose_docs_dir>` block in your prompt (defaults to `docs/compose`)
+**Save reports to:** the `reports/` directory given in the `<compose_docs_dir>` block of your prompt, as `<feature-name>.md`
 - No date in filename — the report is overwritten in place when the feature evolves
 - Git history tracks revisions
 - User preferences for report location override this default

--- a/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
@@ -14,7 +14,7 @@ Consolidate a feature's spec history into a single human-readable final report. 
 
 **Announce at start:** "I'm using the report skill to write the final report for this feature."
 
-**Save reports to:** `docs/compose/reports/<feature-name>.md`
+**Save reports to:** `<docs-dir>/reports/<feature-name>.md`, where `<docs-dir>` is the compose docs directory from the `<compose_docs_dir>` block in your prompt (defaults to `docs/compose`)
 - No date in filename — the report is overwritten in place when the feature evolves
 - Git history tracks revisions
 - User preferences for report location override this default
@@ -54,10 +54,10 @@ Every report MUST use this structure:
 feature: <feature-name>
 status: delivered
 specs:
-  - docs/compose/specs/<spec-1>.md
-  - docs/compose/specs/<spec-2>.md
+  - <docs-dir>/specs/<spec-1>.md
+  - <docs-dir>/specs/<spec-2>.md
 plans:
-  - docs/compose/plans/<plan>.md
+  - <docs-dir>/plans/<plan>.md
 branch: <branch-name>
 commits: <first-sha>..<last-sha>
 ---

--- a/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
@@ -54,10 +54,10 @@ Every report MUST use this structure:
 feature: <feature-name>
 status: delivered
 specs:
-  - <path to spec file, in the specs/ dir from <compose_docs_dir>>
-  - <path to another spec file>
+  - <spec-1-path>
+  - <spec-2-path>
 plans:
-  - <path to plan file, in the plans/ dir from <compose_docs_dir>>
+  - <plan-path>
 branch: <branch-name>
 commits: <first-sha>..<last-sha>
 ---

--- a/packages/opencode/src/skill/compose/.bundle/review/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/review/SKILL.md
@@ -58,7 +58,7 @@ HEAD_SHA=$(git rev-parse HEAD)
 
 [Dispatch code reviewer subagent]
   DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types
-  PLAN_OR_REQUIREMENTS: Task 2 from docs/compose/plans/deployment-plan.md
+  PLAN_OR_REQUIREMENTS: Task 2 from plans/deployment-plan.md
   BASE_SHA: a7981ec
   HEAD_SHA: 3df7661
 

--- a/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
@@ -150,7 +150,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 ```
 You: I'm using Subagent-Driven Development to execute this plan.
 
-[Read plan file once: docs/compose/plans/feature-plan.md]
+[Read plan file once: plans/feature-plan.md]
 [Extract all 5 tasks with full text and context]
 [Create a task per plan task with `task create`, capturing each TID]
 

--- a/packages/opencode/test/skill/compose-review.test.ts
+++ b/packages/opencode/test/skill/compose-review.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { loadComposeBundle } from "../../src/skill/compose/bundle.macro"
+import { ConfigCompose } from "../../src/config"
 
 const bundle = loadComposeBundle()
 
@@ -137,5 +138,37 @@ describe("compose spec-anchored review contract", () => {
         expect(md).not.toMatch(/operation:\s*run/)
       }
     })
+  })
+})
+
+describe("compose docs dir resolution", () => {
+  const worktree = "/repo/root"
+
+  test("relative docs is passed through verbatim by default", () => {
+    expect(ConfigCompose.resolveDocsDir(worktree, { docs: "docs/compose" })).toBe("docs/compose")
+  })
+
+  test("relative docs is anchored to worktree when docs_absolute is true", () => {
+    expect(ConfigCompose.resolveDocsDir(worktree, { docs: "docs/compose", docs_absolute: true })).toBe(
+      "/repo/root/docs/compose",
+    )
+  })
+
+  test("absolute docs ignores worktree regardless of docs_absolute", () => {
+    expect(ConfigCompose.resolveDocsDir(worktree, { docs: "/abs/docs" })).toBe("/abs/docs")
+    expect(ConfigCompose.resolveDocsDir(worktree, { docs: "/abs/docs", docs_absolute: true })).toBe("/abs/docs")
+  })
+
+  test("default docs dir is used when config is absent", () => {
+    expect(ConfigCompose.resolveDocsDir(worktree, undefined)).toBe(ConfigCompose.DEFAULT_DOCS_DIR)
+  })
+
+  test("skill example workflows do not hardcode the default docs/compose prefix", () => {
+    const offenders = Object.entries(bundle).flatMap(([skill, files]) =>
+      Object.entries(files)
+        .filter(([, content]) => content.includes("docs/compose"))
+        .map(([rel]) => `${skill}/${rel}`),
+    )
+    expect(offenders).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Add a `compose` config section with a `docs` field so compose skills can save specs, plans, and reports to a configurable directory (defaults to `docs/compose`). Relative paths resolve against the project root.
- Add a `docs_absolute` knob controlling whether the docs path injected into the compose prompt is absolute or passed through verbatim. Defaults to `false` (relative).
- Inject a `<compose_docs_dir>` block into the compose prompt so skills reference output locations by role rather than hardcoded paths.
- Update compose skill docs (brainstorm, plan, report) to reference the dynamic docs dir and remove the orphaned `<docs-dir>` token.

## Changes
- `config/compose.ts` (new): `Info` schema with `docs` + `docs_absolute`, `DEFAULT_DOCS_DIR`.
- `config/config.ts`, `config/index.ts`: wire `ConfigCompose` into the config tree.
- `session/prompt.ts`: resolve the docs dir (honoring `docs_absolute`) and inject the `<compose_docs_dir>` block.
- `skill/compose/.bundle/{brainstorm,plan,report}`: reference the injected docs dir by role.

## Verification
- `tsgo --noEmit` typecheck: exit 0
- `test/skill/compose-review.test.ts`: 19/19 pass
- pre-push hook typecheck across workspace: 12/12 tasks pass