### PR TITLE
fix(session): align last-step handling with provider requirements

### DIFF
--- a/docs/compose/plans/2026-06-17-align-last-step-handling.md
+++ b/docs/compose/plans/2026-06-17-align-last-step-handling.md
@@ -1,0 +1,185 @@
+# Align Last-Step Handling With Provider Requirements Implementation Plan
+
+> [!NOTE]
+> This document may not reflect the current implementation.
+> See the final report for up-to-date state:
+> [Final Report](../reports/align-last-step-handling.md)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use compose:subagent (recommended) or compose:execute to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop ending the conversation on an assistant message when the agent reaches its step cap, so Bedrock-routed Claude no longer returns a 400 (`This model does not support assistant message prefill`), while restoring the step-cap enforcement that the effectify refactor accidentally gutted.
+
+**Architecture:** At `step >= agent.steps` (`isLastStep`), both LLM send sites in `prompt.ts` currently append `{ role: "assistant", content: MAX_STEPS }` — an assistant prefill that Bedrock rejects. Replace it with a provider-agnostic pattern: deliver the MAX_STEPS instruction on a **user**-role message (conversation ends on a user turn → accepted by all providers) and set `toolChoice: "none"` on the last step so tools are physically disabled (the cap is enforced, not merely requested).
+
+**Tech Stack:** TypeScript, Effect, Bun, the `ai` SDK (`ModelMessage`, `toolChoice`).
+
+---
+
+## Background (verified facts)
+
+- The original feature (upstream PR #4062, `feat: add max steps`) had **three** last-step layers: `system.push(MAX_STEPS)`, `toolChoice: isLastStep ? "none"`, and the assistant prefill.
+- The effectify refactor (upstream PR #19483) **dropped** the first two. Today only the assistant prefill remains — so naively deleting it would silently disable step-cap enforcement.
+- The provider-agnostic alternative is to never end on an assistant turn for this purpose: deliver the instruction via a prompt-text/user message plus turn-bounding, since models behind providers that don't support prefill reject conversations ending with an assistant turn.
+- `toolChoice?: "auto" | "required" | "none"` is valid in both `llm.ts:195` (StreamInput) and `max-mode.ts:61` (max-mode path). `"none"` is accepted.
+- Both send sites already have `isLastStep` (computed at `prompt.ts:2573`) in scope.
+
+## File Structure
+
+- Modify: `packages/opencode/src/session/prompt.ts`
+  - Main-loop send site (`messages` at `:2720`, `toolChoice` at `:2723`)
+  - Fork-loop send site (`messages` at `:2850`, `toolChoice` at `:2853`)
+- Test: `packages/opencode/src/session/classify.test.ts` is unrelated; the build of the messages array is inline in `prompt.ts` and not independently exported, so verification is via typecheck + a targeted assertion in a new/existing prompt-level test if one exists. If no prompt-level unit harness exists, verification is typecheck + manual reasoning (documented in Task 3).
+
+No new files. `max-steps.txt` content reused verbatim. No `system.ts` change (the instruction now rides on the last-step user message).
+
+---
+
+### Task 1: Replace prefill with a user-role MAX_STEPS message + restore `toolChoice:"none"` at the main-loop send site
+
+**Covers:** core fix (main loop)
+
+**Files:**
+- Modify: `packages/opencode/src/session/prompt.ts:2720` (messages) and `:2723` (toolChoice)
+
+- [ ] **Step 1: Edit the `messages` line (main loop, `:2720`)**
+
+Replace the assistant prefill with a user-role message so the conversation ends on a user turn.
+
+Old:
+```ts
+                messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
+```
+
+New:
+```ts
+                messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
+```
+
+- [ ] **Step 2: Edit the `toolChoice` line (main loop, `:2723`)**
+
+Restore last-step tool disabling. Last-step takes precedence over the `json_schema` "required" form — the step cap is the harder constraint and a closing summary turn must not be forced into a tool call.
+
+Old:
+```ts
+                toolChoice: format.type === "json_schema" ? "required" : undefined,
+```
+
+New:
+```ts
+                toolChoice: isLastStep ? "none" : format.type === "json_schema" ? "required" : undefined,
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run from `packages/opencode`:
+```bash
+bun typecheck
+```
+Expected: PASS (no new errors). `"none"` is a valid `toolChoice` literal per `llm.ts:195`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/opencode/src/session/prompt.ts
+git commit -m "fix(session): use user-role MAX_STEPS message + toolChoice none on last step (main loop)
+
+The assistant-prefill MAX_STEPS message made the conversation end on an
+assistant turn, which Bedrock-routed Claude rejects (400, no prefill
+support). Deliver the instruction on a user turn instead and restore
+toolChoice:\"none\" (lost in the effectify refactor) so the step cap is
+enforced rather than merely requested."
+```
+
+---
+
+### Task 2: Apply the identical fix at the fork-loop send site
+
+**Covers:** core fix (fork / subagent loop)
+
+**Files:**
+- Modify: `packages/opencode/src/session/prompt.ts:2850` (messages) and `:2853` (toolChoice)
+
+- [ ] **Step 1: Edit the `messages` line (fork loop, `:2850`)**
+
+Old:
+```ts
+              messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
+```
+
+New:
+```ts
+              messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
+```
+
+- [ ] **Step 2: Edit the `toolChoice` line (fork loop, `:2853`)**
+
+Note this site annotates the literal with `as const`; keep that on the `json_schema` branch.
+
+Old:
+```ts
+              toolChoice: format.type === "json_schema" ? ("required" as const) : undefined,
+```
+
+New:
+```ts
+              toolChoice: isLastStep ? ("none" as const) : format.type === "json_schema" ? ("required" as const) : undefined,
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run from `packages/opencode`:
+```bash
+bun typecheck
+```
+Expected: PASS. The fork path's `processArgs` flows into both `handle.process` and `MaxMode.runMaxStep`; `max-mode.ts:61` also types `toolChoice?: "auto" | "required" | "none"`, so `"none"` is accepted on both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/opencode/src/session/prompt.ts
+git commit -m "fix(session): apply user-role MAX_STEPS + toolChoice none on fork last step
+
+Mirror the main-loop fix on the fork/subagent send site so subagents that
+hit agent.steps also end on a user turn (Bedrock-safe) with tools disabled."
+```
+
+---
+
+### Task 3: Verify the fix end-to-end
+
+**Covers:** verification
+
+**Files:**
+- Read-only inspection of `packages/opencode/src/session/prompt.ts`
+
+- [ ] **Step 1: Confirm no assistant-prefill remains**
+
+Run:
+```bash
+cd /root/projects/.vibe-board-workspaces/41f7-/opencode && grep -n 'role: "assistant" as const, content: MAX_STEPS' packages/opencode/src/session/prompt.ts
+```
+Expected: no output (zero matches).
+
+- [ ] **Step 2: Confirm both sites now use the user-role form + last-step toolChoice**
+
+Run:
+```bash
+cd /root/projects/.vibe-board-workspaces/41f7-/opencode && grep -n 'role: "user" as const, content: MAX_STEPS' packages/opencode/src/session/prompt.ts; grep -n 'isLastStep ?' packages/opencode/src/session/prompt.ts | grep -i none
+```
+Expected: two matches for the user-role messages line; two matches for the `isLastStep ? ... none` toolChoice lines.
+
+- [ ] **Step 3: Final typecheck**
+
+Run from `packages/opencode`:
+```bash
+bun typecheck
+```
+Expected: PASS, no new errors.
+
+- [ ] **Step 4: Reasoning check (no behavioral regression)**
+
+Confirm by inspection:
+- When `isLastStep` is false, both lines are byte-identical to before except the (false) ternary branch — no behavior change on normal steps.
+- When `isLastStep` is true, the appended message is `role:"user"` (conversation ends on user turn) and `toolChoice` is `"none"` (model cannot emit tool calls). This matches the intended provider-agnostic design.
+
+No commit (verification only).

--- a/docs/compose/reports/align-last-step-handling.md
+++ b/docs/compose/reports/align-last-step-handling.md
@@ -1,0 +1,64 @@
+---
+feature: align-last-step-handling
+status: delivered
+specs: []
+plans:
+  - docs/compose/plans/2026-06-17-align-last-step-handling.md
+branch: 41f7-
+commits: e9fa96ac83..5fd4316a5e
+---
+
+# Align Last-Step Handling With Provider Requirements — Final Report
+
+## What Was Built
+
+When an agent reaches its configured step cap (`agent.steps`), the session loop sends one final "wrap up and summarize" request to the model. That final request is now constructed so it ends on a **user** turn with tools disabled, instead of ending on a pre-filled **assistant** turn.
+
+This fixes a hard failure on Bedrock-routed Claude, which rejects any conversation that ends on an assistant message (`400 — This model does not support assistant message prefill. The conversation must end with a user message.`). It also restores step-cap enforcement that had silently regressed: the model can no longer emit tool calls on the final step, so `agent.steps` is an actual hard stop rather than a suggestion.
+
+## Architecture
+
+The change lives entirely in `packages/opencode/src/session/prompt.ts`, at the two sites that build the per-step LLM request inside the run loop:
+
+- **Main-loop send site** (~line 2720/2723)
+- **Fork/subagent send site** (~line 2850/2853)
+
+`isLastStep` is computed once per iteration at `prompt.ts:2573` (`step >= (agent.steps ?? Infinity)`) and is in scope at both sites.
+
+At each site, when `isLastStep` is true:
+
+- **Messages** — a message carrying the `MAX_STEPS` instruction (from `src/session/prompt/max-steps.txt`) is appended with `role: "user"`, so `messages` ends on a user turn. Previously this was `role: "assistant"` (a prefill).
+- **toolChoice** — set to `"none"`, physically preventing tool calls on the final turn. On non-last steps the prior behavior is unchanged (`"required"` for `json_schema` format, otherwise `undefined`). Last-step `"none"` takes precedence over the `json_schema` `"required"` branch.
+
+`toolChoice: "none"` is a valid value on both code paths: `StreamInput` (`src/session/llm.ts:195`) and the max-mode step (`src/session/max-mode.ts:61`) both type it as `"auto" | "required" | "none"`. Setting `toolChoice` does not alter the tools schema, so the cached request prefix (system prompt + tool definitions) is unaffected.
+
+### Design Decisions
+
+- **User message, not provider detection.** We deliver `MAX_STEPS` on a user-role message rather than branching on provider capability (e.g. a `supportsPrefill` flag). The user-role form is valid on every provider including Anthropic-direct, so per-provider branching would be dead complexity.
+- **Provider-agnostic by ending on a user turn.** Rather than using assistant prefill to force a final turn, the instruction rides on a prompt-text/user message with turn bounding. Conversations that end on an assistant turn are rejected by providers that don't support prefill (e.g. Bedrock-routed Claude), so ending on a user turn is the portable choice.
+- **Restored `toolChoice: "none"` deliberately.** The original max-steps feature (upstream PR #4062) disabled tools on the last step; the effectify refactor (upstream PR #19483) dropped it, leaving the assistant prefill as the only last-step control. Removing the prefill alone would have made the step cap a no-op, so tool disabling was restored alongside.
+
+## Usage
+
+No user-facing API or config change. Behavior triggers automatically when an agent with a finite `steps` value (e.g. fork subagents at `maxTurns`/`steps` limits) reaches its cap. On that final step the model receives the `max-steps.txt` instruction (announce limit reached, summarize work done, list remaining tasks, recommend next steps) and cannot call tools.
+
+## Verification
+
+- `bun typecheck` (from `packages/opencode`) — exits 0 after both edits.
+- Grep assertions: zero `role: "assistant" ... MAX_STEPS` matches; two `role: "user" ... MAX_STEPS` matches; two `isLastStep ? "none"` toolChoice lines.
+- Test suites `test/session/prompt.test.ts`, `prompt-sweep.test.ts`, `max-mode.test.ts`, `test/agent/agent.test.ts` — 62 pass, 1 fail. The single failure (`general agent denies todo tools`) is **pre-existing and unrelated**: confirmed by reproducing it on the pre-change `prompt.ts` (it fails identically without this change).
+- Reasoning: on non-last steps both edited lines reduce to the prior behavior (the `isLastStep` ternary takes its false branch), so normal turns are byte-for-byte unchanged.
+
+## Journey Log
+
+> Brief notes on what informed the final design. Not required reading.
+
+- [lesson] The 400 was not a fork bug — the assistant-prefill last-step pattern is upstream-native (PR #4062). This fork only widened its reach by copying it into the fork/subagent loop.
+- [lesson] The effectify refactor (PR #19483) silently dropped two of three original last-step controls (`system.push(MAX_STEPS)` and `toolChoice: "none"`), leaving only the prefill — so a naive "just delete the prefill" fix would have quietly disabled step-cap enforcement.
+- [pivot] The robust pattern is to avoid assistant-final turns entirely for non-prefill providers. That confirmed the user-message + tool-disable approach over any provider-detection scheme.
+
+## Source Materials
+
+| File | Role | Notes |
+|------|------|-------|
+| `docs/compose/plans/2026-06-17-align-last-step-handling.md` | Implementation plan | Complete (3 tasks) |

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3051,10 +3051,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               // MessageV2.User.system for logging/replay); llm.stream itself uses prebuiltSystem.
               system: additions,
               prebuiltSystem,
-              messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
+              messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
               tools,
               model,
-              toolChoice: format.type === "json_schema" ? ("required" as const) : undefined,
+              toolChoice: isLastStep ? ("none" as const) : format.type === "json_schema" ? ("required" as const) : undefined,
               agentID: lastUser.agentID,
             }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2892,10 +2892,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   parentSessionID: session.parentID,
                   system: additions,
                   prebuiltSystem,
-                  messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
+                  messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
                   tools,
                   model,
-                  toolChoice: format.type === "json_schema" ? "required" : undefined,
+                  toolChoice: isLastStep ? "none" : format.type === "json_schema" ? "required" : undefined,
                   agentID: lastUser.agentID,
                 })
                 .pipe(


### PR DESCRIPTION
## Summary

When an agent reaches its configured step cap (`agent.steps`), the session loop sends one final "wrap up and summarize" request. That request previously ended on a pre-filled **assistant** turn, which Bedrock-routed Claude rejects with `400 — This model does not support assistant message prefill. The conversation must end with a user message.`

This PR makes the final request end on a **user** turn with tools disabled:

- Deliver the `MAX_STEPS` instruction on a `role: "user"` message instead of an assistant prefill — accepted by all providers.
- Set `toolChoice: "none"` on the last step, restoring step-cap enforcement that the effectify refactor (upstream PR #19483) had silently dropped, so `agent.steps` is a hard stop rather than a suggestion.

Applied at **both** LLM send sites in `packages/opencode/src/session/prompt.ts`: the main run loop and the fork/subagent loop.

## Why

The original max-steps feature had three last-step controls (`system.push(MAX_STEPS)`, `toolChoice: "none"`, and the assistant prefill). The effectify refactor dropped the first two, leaving the prefill as the only — and provider-broken — control. Naively deleting the prefill would have made the step cap a no-op, so tool disabling is restored alongside the user-message switch.

`toolChoice: "none"` is type-valid on both paths (`llm.ts` `StreamInput` and `max-mode.ts`, both `"auto" | "required" | "none"`) and does not alter the tools schema, so the cached request prefix is unaffected.

## Changes

- `packages/opencode/src/session/prompt.ts` — 4 lines across the two send sites (user-role MAX_STEPS message + last-step `toolChoice: "none"`).
- `docs/compose/plans/2026-06-17-align-last-step-handling.md` — implementation plan.
- `docs/compose/reports/align-last-step-handling.md` — final report.

## Verification

- On non-last steps both edited lines reduce to prior behavior (the `isLastStep` ternary takes its false branch), so normal turns are byte-for-byte unchanged.
- Grep assertions: zero assistant-prefill MAX_STEPS, two user-role MAX_STEPS, two last-step `toolChoice: "none"`.

## Known behavior change (intentional trade-off)

On the **last step**, `toolChoice: "none"` takes precedence over the `json_schema` `"required"` branch. If an agent is configured with a finite `steps` **and** the final step is one that would produce structured output, the `StructuredOutput` tool cannot be invoked: the structured-output auto-retry re-enters the same loop where `step >= maxSteps` keeps `isLastStep` true, so retries are exhausted and a `StructuredOutputError` is recorded.

This is an accepted trade-off — the step cap is treated as the harder constraint (a closing summary turn must not be forced into a tool call). It does **not** affect default agents (the `general` agent has no `steps`, so `isLastStep` is never reached) or the default workflow path; it only surfaces when a user explicitly configures `steps` on an agent that is also invoked with a `json_schema` format. Flagged here for transparency.
