### PR TITLE
fix(test): use Flag mutation for server tests instead of moving fixtu…

### DIFF
--- a/packages/opencode/.gitignore
+++ b/packages/opencode/.gitignore
@@ -7,4 +7,3 @@ src/provider/models-snapshot.js
 src/provider/models-snapshot.d.ts
 script/build-*.ts
 temporary-*.md
-.mimocode-test-fixtures-*

--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -9,6 +9,7 @@ import type * as Scope from "effect/Scope"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import type { Config } from "../../src/config"
 import { InstanceRef } from "../../src/effect/instance-ref"
+import { Flag } from "../../src/flag/flag"
 import { Instance } from "../../src/project/instance"
 import { TestLLMServer } from "../lib/llm-server"
 
@@ -186,5 +187,23 @@ export function provideTmpdirServer<A, E, R>(
       git: options?.git,
       config: options?.config?.(llm.url),
     })
+  })
+}
+
+/**
+ * Temporarily sets Flag.MIMOCODE_SERVER_PASSWORD so that the InstanceMiddleware
+ * cwd containment check is bypassed. Use in server tests that pass a directory
+ * (via query param or header) pointing to a tmpdir outside process.cwd().
+ *
+ * Returns the auth header string to include in app.request() calls.
+ */
+const SERVER_TEST_PASSWORD = "server-test"
+const SERVER_TEST_AUTH = `Basic ${Buffer.from(`mimocode:${SERVER_TEST_PASSWORD}`).toString("base64")}`
+
+export function withServerAuth<T>(fn: (auth: string) => Promise<T>): Promise<T> {
+  const prev = (Flag as any).MIMOCODE_SERVER_PASSWORD
+  ;(Flag as any).MIMOCODE_SERVER_PASSWORD = SERVER_TEST_PASSWORD
+  return fn(SERVER_TEST_AUTH).finally(() => {
+    ;(Flag as any).MIMOCODE_SERVER_PASSWORD = prev
   })
 }

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -10,11 +10,6 @@ import { afterAll } from "bun:test"
 const dir = path.join(os.tmpdir(), "mimocode-test-data-" + process.pid)
 await fs.mkdir(dir, { recursive: true })
 
-// Route fixture tmpdirs under cwd so they pass the InstanceMiddleware cwd
-// containment check (security: unauthenticated servers restrict directory to cwd subtree).
-const fixtureRoot = path.join(process.cwd(), ".mimocode-test-fixtures-" + process.pid)
-await fs.mkdir(fixtureRoot, { recursive: true })
-process.env["MIMOCODE_TEST_TMPDIR_ROOT"] = fixtureRoot
 afterAll(async () => {
   const { Database } = await import("../src/storage")
   Database.close()
@@ -33,7 +28,6 @@ afterAll(async () => {
   // Windows can keep SQLite WAL handles alive until GC finalizers run, so we
   // force GC and retry teardown to avoid flaky EBUSY in test cleanup.
   await rm(dir, 30)
-  await rm(fixtureRoot, 30)
 })
 
 process.env["XDG_DATA_HOME"] = path.join(dir, "share")

--- a/packages/opencode/test/server/project-init-git.test.ts
+++ b/packages/opencode/test/server/project-init-git.test.ts
@@ -9,7 +9,7 @@ import { Flag } from "../../src/flag/flag"
 import { Filesystem } from "../../src/util"
 import { Log } from "../../src/util"
 import { resetDatabase } from "../fixture/db"
-import { provideInstance, tmpdir } from "../fixture/fixture"
+import { provideInstance, tmpdir, withServerAuth } from "../fixture/fixture"
 
 void Log.init({ print: false })
 
@@ -94,48 +94,51 @@ describe("project.initGit endpoint", () => {
     }
   })
 
-  test("does not reload when the project is already git", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const app = Server.Default().app
-    const seen: { directory?: string; payload: { type: string } }[] = []
-    const fn = (evt: { directory?: string; payload: { type: string } }) => {
-      seen.push(evt)
-    }
-    const reload = Instance.reload
-    const reloadSpy = spyOn(Instance, "reload").mockImplementation((input) => reload(input))
-    GlobalBus.on("event", fn)
+  test("does not reload when the project is already git", () =>
+    withServerAuth(async (auth) => {
+      await using tmp = await tmpdir({ git: true })
+      const app = Server.Default().app
+      const seen: { directory?: string; payload: { type: string } }[] = []
+      const fn = (evt: { directory?: string; payload: { type: string } }) => {
+        seen.push(evt)
+      }
+      const reload = Instance.reload
+      const reloadSpy = spyOn(Instance, "reload").mockImplementation((input) => reload(input))
+      GlobalBus.on("event", fn)
 
-    try {
-      const init = await app.request("/project/git/init", {
-        method: "POST",
-        headers: {
-          "x-mimocode-directory": tmp.path,
-        },
-      })
-      expect(init.status).toBe(200)
-      expect(await init.json()).toMatchObject({
-        vcs: "git",
-        worktree: tmp.path,
-      })
-      expect(
-        seen.filter((evt) => evt.directory === tmp.path && evt.payload.type === "server.instance.disposed").length,
-      ).toBe(0)
-      expect(reloadSpy).toHaveBeenCalledTimes(0)
+      try {
+        const init = await app.request("/project/git/init", {
+          method: "POST",
+          headers: {
+            "x-mimocode-directory": tmp.path,
+            "authorization": auth,
+          },
+        })
+        expect(init.status).toBe(200)
+        expect(await init.json()).toMatchObject({
+          vcs: "git",
+          worktree: tmp.path,
+        })
+        expect(
+          seen.filter((evt) => evt.directory === tmp.path && evt.payload.type === "server.instance.disposed").length,
+        ).toBe(0)
+        expect(reloadSpy).toHaveBeenCalledTimes(0)
 
-      const current = await app.request("/project/current", {
-        headers: {
-          "x-mimocode-directory": tmp.path,
-        },
-      })
-      expect(current.status).toBe(200)
-      expect(await current.json()).toMatchObject({
-        vcs: "git",
-        worktree: tmp.path,
-      })
-    } finally {
-      await Instance.disposeAll()
-      reloadSpy.mockRestore()
-      GlobalBus.off("event", fn)
-    }
-  })
+        const current = await app.request("/project/current", {
+          headers: {
+            "x-mimocode-directory": tmp.path,
+            "authorization": auth,
+          },
+        })
+        expect(current.status).toBe(200)
+        expect(await current.json()).toMatchObject({
+          vcs: "git",
+          worktree: tmp.path,
+        })
+      } finally {
+        await Instance.disposeAll()
+        reloadSpy.mockRestore()
+        GlobalBus.off("event", fn)
+      }
+    }))
 })

--- a/packages/opencode/test/server/session-prompt-busy.test.ts
+++ b/packages/opencode/test/server/session-prompt-busy.test.ts
@@ -8,7 +8,7 @@ import { Session } from "../../src/session"
 import { SessionRunState } from "../../src/session/run-state"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Log } from "../../src/util"
-import { tmpdir } from "../fixture/fixture"
+import { tmpdir, withServerAuth } from "../fixture/fixture"
 
 void Log.init({ print: false })
 
@@ -32,115 +32,106 @@ describe("ErrorMiddleware → BusyError mapping", () => {
 })
 
 describe("POST /session/:sessionID/message busy-runner behavior", () => {
-  test("returns 409 when session main runner is already busy", async () => {
-    await using tmp = await tmpdir({})
+  test("returns 409 when session main runner is already busy", () =>
+    withServerAuth(async (auth) => {
+      await using tmp = await tmpdir({})
 
-    const status = await Instance.provide({
-      directory: tmp.path,
-      fn: async () =>
-        AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const sessions = yield* Session.Service
-            const sess = yield* sessions.create({ title: "busy-runner test" })
-            const state = yield* SessionRunState.Service
+      const status = await Instance.provide({
+        directory: tmp.path,
+        fn: async () =>
+          AppRuntime.runPromise(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const sess = yield* sessions.create({ title: "busy-runner test" })
+              const state = yield* SessionRunState.Service
 
-            // Occupy the main runner with an Effect that never resolves.
-            // Forked so we can continue and issue the conflicting POST.
-            yield* state
-              .startShell(
-                sess.id,
-                Effect.succeed({ info: {}, parts: [] } as never),
-                Effect.never as never,
-              )
-              .pipe(Effect.forkChild)
+              yield* state
+                .startShell(
+                  sess.id,
+                  Effect.succeed({ info: {}, parts: [] } as never),
+                  Effect.never as never,
+                )
+                .pipe(Effect.forkChild)
 
-            // Give the scheduler a tick so the occupant marks the runner busy.
-            yield* Effect.sleep("50 millis")
+              yield* Effect.sleep("50 millis")
 
-            // Pass ?directory= so InstanceMiddleware resolves to the same instance
-            // the test created. Without this, the route handler would land in a
-            // different Instance (process.cwd()) whose SessionRunState has no busy
-            // runner, defeating the test.
-            const app = Server.Default().app
-            const res = yield* Effect.promise(async () =>
-              app.request(`/session/${sess.id}/message?directory=${encodeURIComponent(tmp.path)}`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  parts: [{ type: "text", text: "should be rejected" }],
+              const app = Server.Default().app
+              const res = yield* Effect.promise(async () =>
+                app.request(`/session/${sess.id}/message?directory=${encodeURIComponent(tmp.path)}`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json", "authorization": auth },
+                  body: JSON.stringify({
+                    parts: [{ type: "text", text: "should be rejected" }],
+                  }),
                 }),
-              }),
-            )
-
-            // Best-effort: stop the occupant so afterEach disposal is clean.
-            yield* state.cancel(sess.id)
-
-            return res.status
-          }),
-        ),
-    })
-
-    expect(status).toBe(409)
-  })
-
-  test("POST /:sessionID/abort frees runner; subsequent POST is no longer rejected with 409", async () => {
-    await using tmp = await tmpdir({})
-
-    const result = await Instance.provide({
-      directory: tmp.path,
-      fn: async () =>
-        AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const sessions = yield* Session.Service
-            const sess = yield* sessions.create({ title: "busy-recover test" })
-            const state = yield* SessionRunState.Service
-
-            yield* state
-              .startShell(
-                sess.id,
-                Effect.succeed({ info: {}, parts: [] } as never),
-                Effect.never as never,
               )
-              .pipe(Effect.forkChild)
-            yield* Effect.sleep("50 millis")
 
-            const app = Server.Default().app
-            const dirQuery = `?directory=${encodeURIComponent(tmp.path)}`
+              yield* state.cancel(sess.id)
 
-            // 1. confirm busy → 409
-            const first = yield* Effect.promise(async () =>
-              app.request(`/session/${sess.id}/message${dirQuery}`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ parts: [{ type: "text", text: "first" }] }),
-              }),
-            )
+              return res.status
+            }),
+          ),
+      })
 
-            // 2. abort frees the runner
-            const abort = yield* Effect.promise(async () =>
-              app.request(`/session/${sess.id}/abort${dirQuery}`, { method: "POST" }),
-            )
+      expect(status).toBe(409)
+    }))
 
-            // Wait for runner.cancel to take effect.
-            yield* Effect.sleep("100 millis")
+  test("POST /:sessionID/abort frees runner; subsequent POST is no longer rejected with 409", () =>
+    withServerAuth(async (auth) => {
+      await using tmp = await tmpdir({})
 
-            // 3. subsequent POST is no longer 409 — assert just status != 409.
-            //    (full success requires a real LLM; we only verify the contention
-            //    is gone, not the prompt outcome.)
-            const second = yield* Effect.promise(async () =>
-              app.request(`/session/${sess.id}/message${dirQuery}`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ parts: [{ type: "text", text: "second" }] }),
-              }),
-            )
-            return { firstStatus: first.status, abortStatus: abort.status, secondStatus: second.status }
-          }),
-        ),
-    })
+      const result = await Instance.provide({
+        directory: tmp.path,
+        fn: async () =>
+          AppRuntime.runPromise(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const sess = yield* sessions.create({ title: "busy-recover test" })
+              const state = yield* SessionRunState.Service
 
-    expect(result.firstStatus).toBe(409)
-    expect(result.abortStatus).toBe(200)
-    expect(result.secondStatus).not.toBe(409)
-  })
+              yield* state
+                .startShell(
+                  sess.id,
+                  Effect.succeed({ info: {}, parts: [] } as never),
+                  Effect.never as never,
+                )
+                .pipe(Effect.forkChild)
+              yield* Effect.sleep("50 millis")
+
+              const app = Server.Default().app
+              const dirQuery = `?directory=${encodeURIComponent(tmp.path)}`
+
+              const first = yield* Effect.promise(async () =>
+                app.request(`/session/${sess.id}/message${dirQuery}`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json", "authorization": auth },
+                  body: JSON.stringify({ parts: [{ type: "text", text: "first" }] }),
+                }),
+              )
+
+              const abort = yield* Effect.promise(async () =>
+                app.request(`/session/${sess.id}/abort${dirQuery}`, {
+                  method: "POST",
+                  headers: { "authorization": auth },
+                }),
+              )
+
+              yield* Effect.sleep("100 millis")
+
+              const second = yield* Effect.promise(async () =>
+                app.request(`/session/${sess.id}/message${dirQuery}`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json", "authorization": auth },
+                  body: JSON.stringify({ parts: [{ type: "text", text: "second" }] }),
+                }),
+              )
+              return { firstStatus: first.status, abortStatus: abort.status, secondStatus: second.status }
+            }),
+          ),
+      })
+
+      expect(result.firstStatus).toBe(409)
+      expect(result.abortStatus).toBe(200)
+      expect(result.secondStatus).not.toBe(409)
+    }))
 })

--- a/packages/opencode/test/server/workflows-route.test.ts
+++ b/packages/opencode/test/server/workflows-route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeAll, afterAll, describe, expect, test } from "bun:test"
 import { Effect, Exit, Cause } from "effect"
 import { Log } from "../../src/util"
 import { Instance } from "../../src/project/instance"
@@ -8,6 +8,7 @@ import { WorkflowPersistence } from "../../src/workflow/persistence"
 import { WorkflowRuntime } from "../../src/workflow/runtime"
 import { workflowRef } from "../../src/workflow/runtime-ref"
 import { provideTmpdirServer, tmpdir } from "../fixture/fixture"
+import { Flag } from "../../src/flag/flag"
 import { testEffect } from "../lib/effect"
 import { makeLayer, ref, providerCfg } from "../workflow/lib"
 
@@ -198,27 +199,29 @@ const it = testEffect(makeLayer())
 // cached replay, zero-spawn resume) are covered in the warmed-up
 // test/workflow/runtime.test.ts suite.
 describe("workflows routes — live runtime", () => {
+  const TEST_PASSWORD = "wf-live-test"
+  const auth = `Basic ${Buffer.from(`mimocode:${TEST_PASSWORD}`).toString("base64")}`
+  let prevFlag: any
+  beforeAll(() => {
+    prevFlag = (Flag as any).MIMOCODE_SERVER_PASSWORD
+    ;(Flag as any).MIMOCODE_SERVER_PASSWORD = TEST_PASSWORD
+  })
+  afterAll(() => {
+    ;(Flag as any).MIMOCODE_SERVER_PASSWORD = prevFlag
+  })
+
   it.live("POST /workflows/:runID/resume reaches the LIVE runtime (resumed: false for an unknown run)", () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ dir }) {
-        // #given the workflow runtime IS live (the layer set the late-bound ref) —
-        // this is what distinguishes this from the degenerate test above, where the
-        // ref is undefined and the route returns early without calling resume().
         expect(workflowRef.current).toBeDefined()
 
-        // #when — POST resume over the REAL route for a runID with no persisted run.
-        // Use a valid minted-shape runID (wf_ + 26 base62) so it passes the param
-        // validator and genuinely reaches the live runtime.resume(), which loads no
-        // row and returns { resumed: false }. (async wrapper normalizes Hono's
-        // `Promise<Response> | Response` overload for Effect.promise.)
         const response = yield* Effect.promise(async () =>
           Server.Default().app.request(`/workflows/wf_00000000000000000000000000/resume`, {
             method: "POST",
-            headers: { "x-mimocode-directory": dir },
+            headers: { "x-mimocode-directory": dir, "authorization": auth },
           }),
         )
 
-        // #then — the live runtime's real verdict flows back through the HTTP route.
         expect(response.status).toBe(200)
         expect(yield* Effect.promise(() => response.json())).toEqual({
           runID: "wf_00000000000000000000000000",
@@ -252,7 +255,7 @@ describe("workflows routes — live runtime", () => {
         const response = yield* Effect.promise(async () =>
           Server.Default().app.request(`/workflows?sessionID=${parent.id}`, {
             method: "GET",
-            headers: { "x-mimocode-directory": dir },
+            headers: { "x-mimocode-directory": dir, "authorization": auth },
           }),
         )
         expect(response.status).toBe(200)


### PR DESCRIPTION
Revert preload.ts change that moved all test tmpdirs under cwd — this
broke 80+ tests that depend on non-git tmpdir behavior.

Instead, server tests that pass a directory via query/header now
temporarily set Flag.MIMOCODE_SERVER_PASSWORD to bypass the cwd
containment check and include auth headers in requests. Added
withServerAuth() helper to test fixtures.