### PR TITLE
feat(tui): free-channel model UX + Token Plan rate-limit dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-mimo-login.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-mimo-login.tsx
@@ -45,31 +45,6 @@ export function DialogMimoLogin() {
           ))
         },
       },
-      // Free "mimo-auto" channel: only offered when its provider is actually
-      // loaded (i.e. the private src/private/ overlay is present). In the
-      // open-source build the provider never loads, so this option is hidden.
-      ...(sync.data.provider.some((p) => p.id === "mimo")
-        ? [
-            {
-              title: t("tui.dialog.login.mimo_free"),
-              value: "mimo-free",
-              description: t("tui.dialog.login.mimo_free.desc"),
-              category: "Recommended",
-              onSelect: async () => {
-                await sync.bootstrap()
-                const mimo = sync.data.provider.find((p) => p.id === "mimo")
-                if (!mimo || !("mimo-auto" in mimo.models)) {
-                  toast.show({ message: t("tui.dialog.login.mimo_free.unavailable"), variant: "error" })
-                  dialog.clear()
-                  return
-                }
-                local.model.set({ providerID: "mimo", modelID: "mimo-auto" }, { recent: true })
-                toast.show({ message: t("tui.dialog.login.mimo_free.success"), variant: "info" })
-                dialog.clear()
-              },
-            },
-          ]
-        : []),
       {
         title: t("tui.dialog.login.import_claude"),
         value: "import_claude",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -10,6 +10,8 @@ import { useKeybind } from "../context/keybind"
 import { useSDK } from "../context/sdk"
 import { useToast, type ToastContext } from "../ui/toast"
 import { DialogPrompt } from "../ui/dialog-prompt"
+import { useLanguage } from "@tui/context/language"
+import * as Model from "../util/model"
 import * as fuzzysort from "fuzzysort"
 
 const ADD_MODEL_SENTINEL = "__add_model__"
@@ -32,6 +34,8 @@ export function DialogModel(props: { providerID?: string }) {
 
   const connected = useConnected()
   const providers = createDialogProviderOptions()
+  const t = useLanguage().t
+  const providerName = (p: { id: string; name: string }) => t("provider.name." + p.id) || p.name
 
   const showExtra = createMemo(() => connected() && !props.providerID)
 
@@ -52,8 +56,7 @@ export function DialogModel(props: { providerID?: string }) {
           {
             key: item,
             value: { providerID: provider.id, modelID: model.id },
-            title: model.name ?? item.modelID,
-            description: provider.name,
+            title: Model.name(sync.data.provider, provider.id, model.id),
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
             footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
@@ -80,6 +83,9 @@ export function DialogModel(props: { providerID?: string }) {
         (provider) => provider.name,
       ),
       flatMap((provider) => {
+        // The free mimo-auto model is surfaced as the top entry of the Xiaomi
+        // group below, so the mimo provider never renders its own section.
+        if (provider.id === "mimo") return []
         const models = pipe(
           provider.models,
           entries(),
@@ -91,35 +97,47 @@ export function DialogModel(props: { providerID?: string }) {
             description: favorites.some((item) => item.providerID === provider.id && item.modelID === model)
               ? "(Favorite)"
               : undefined,
-            category: connected() ? provider.name : undefined,
+            category: connected() ? providerName(provider) : undefined,
             disabled: provider.id === "opencode" && model.includes("-nano"),
             footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
             onSelect() {
               onSelect(provider.id, model)
             },
           })),
-          filter((x) => {
-            if (!showSections) return true
-            if (favorites.some((item) => item.providerID === x.value.providerID && item.modelID === x.value.modelID))
-              return false
-            if (recents.some((item) => item.providerID === x.value.providerID && item.modelID === x.value.modelID))
-              return false
-            return true
-          }),
           sortBy(
             (x) => x.footer !== "Free",
             (x) => x.title,
           ),
         )
-        if (provider.source !== "config") return models
-        if (props.providerID && props.providerID !== provider.id) return models
+        // Prepend the free mimo-auto model to the Xiaomi group when it's loaded.
+        const free =
+          provider.id === "xiaomi" &&
+          (!props.providerID || props.providerID === provider.id) &&
+          sync.data.provider.some((p) => p.id === "mimo" && "mimo-auto" in p.models)
+            ? [
+                {
+                  value: { providerID: "mimo", modelID: "mimo-auto" },
+                  title: Model.name(sync.data.provider, "mimo", "mimo-auto"),
+                  description: undefined as string | undefined,
+                  category: connected() ? providerName(provider) : undefined,
+                  disabled: false,
+                  footer: undefined as "Free" | undefined,
+                  onSelect() {
+                    onSelect("mimo", "mimo-auto")
+                  },
+                },
+              ]
+            : []
+        if (provider.source !== "config") return [...free, ...models]
+        if (props.providerID && props.providerID !== provider.id) return [...free, ...models]
         return [
+          ...free,
           ...models,
           {
             value: { providerID: provider.id, modelID: ADD_MODEL_SENTINEL },
             title: "+ Add model",
             description: undefined,
-            category: connected() ? provider.name : undefined,
+            category: connected() ? providerName(provider) : undefined,
             disabled: false,
             footer: undefined as "Free" | undefined,
             onSelect() {
@@ -158,7 +176,7 @@ export function DialogModel(props: { providerID?: string }) {
   const title = createMemo(() => {
     const value = provider()
     if (!value) return "Select model"
-    return value.name
+    return providerName(value)
   })
 
   function onSelect(providerID: string, modelID: string) {
@@ -201,6 +219,7 @@ export function DialogModel(props: { providerID?: string }) {
       onFilter={setQuery}
       flat={true}
       title={title()}
+      hint={t("tui.dialog.model.login_hint")}
       current={local.model.current()}
     />
   )

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -12,6 +12,7 @@ import { useToast, type ToastContext } from "../ui/toast"
 import { DialogPrompt } from "../ui/dialog-prompt"
 import { useLanguage } from "@tui/context/language"
 import * as Model from "../util/model"
+import { PROVIDER_PRIORITY } from "@/util/provider-priority"
 import * as fuzzysort from "fuzzysort"
 
 const ADD_MODEL_SENTINEL = "__add_model__"
@@ -36,6 +37,8 @@ export function DialogModel(props: { providerID?: string }) {
   const providers = createDialogProviderOptions()
   const t = useLanguage().t
   const providerName = (p: { id: string; name: string }) => t("provider.name." + p.id) || p.name
+  const modelName = (providerID: string, modelID: string) =>
+    modelID === "mimo-auto" ? t("tui.model.mimo_auto.name") : Model.name(sync.data.provider, providerID, modelID)
 
   const showExtra = createMemo(() => connected() && !props.providerID)
 
@@ -56,7 +59,7 @@ export function DialogModel(props: { providerID?: string }) {
           {
             key: item,
             value: { providerID: provider.id, modelID: model.id },
-            title: Model.name(sync.data.provider, provider.id, model.id),
+            title: modelName(provider.id, model.id),
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
             footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
@@ -80,7 +83,8 @@ export function DialogModel(props: { providerID?: string }) {
       sync.data.provider,
       sortBy(
         (provider) => provider.id !== "opencode",
-        (provider) => provider.name,
+        (provider) => PROVIDER_PRIORITY[provider.id] ?? 99,
+        (provider) => providerName(provider),
       ),
       flatMap((provider) => {
         // The free mimo-auto model is surfaced as the top entry of the Xiaomi
@@ -94,9 +98,7 @@ export function DialogModel(props: { providerID?: string }) {
           map(([model, info]) => ({
             value: { providerID: provider.id, modelID: model },
             title: info.name ?? model,
-            description: favorites.some((item) => item.providerID === provider.id && item.modelID === model)
-              ? "(Favorite)"
-              : undefined,
+            description: undefined as string | undefined,
             category: connected() ? providerName(provider) : undefined,
             disabled: provider.id === "opencode" && model.includes("-nano"),
             footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
@@ -104,6 +106,14 @@ export function DialogModel(props: { providerID?: string }) {
               onSelect(provider.id, model)
             },
           })),
+          // Favorites live in their own section, so don't repeat them here.
+          // Recents intentionally still appear in their provider group.
+          filter((x) => {
+            if (!showSections) return true
+            return !favorites.some(
+              (item) => item.providerID === x.value.providerID && item.modelID === x.value.modelID,
+            )
+          }),
           sortBy(
             (x) => x.footer !== "Free",
             (x) => x.title,
@@ -117,7 +127,7 @@ export function DialogModel(props: { providerID?: string }) {
             ? [
                 {
                   value: { providerID: "mimo", modelID: "mimo-auto" },
-                  title: Model.name(sync.data.provider, "mimo", "mimo-auto"),
+                  title: modelName("mimo", "mimo-auto"),
                   description: undefined as string | undefined,
                   category: connected() ? providerName(provider) : undefined,
                   disabled: false,

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -47,6 +47,11 @@ export function DialogModel(props: { providerID?: string }) {
     const showSections = showExtra() && needle.length === 0
     const favorites = connected() ? local.model.favorite() : []
     const recents = local.model.recent()
+    // A model already shown in the Favorites/Recent shortcut sections must not
+    // appear again in its provider group (show each model at most once).
+    const inShortcuts = (providerID: string, modelID: string) =>
+      favorites.some((item) => item.providerID === providerID && item.modelID === modelID) ||
+      recents.some((item) => item.providerID === providerID && item.modelID === modelID)
 
     function toOptions(items: typeof favorites, category: string) {
       if (!showSections) return []
@@ -106,23 +111,22 @@ export function DialogModel(props: { providerID?: string }) {
               onSelect(provider.id, model)
             },
           })),
-          // Favorites live in their own section, so don't repeat them here.
-          // Recents intentionally still appear in their provider group.
+          // Favorites/recents live in their own sections; don't repeat them here.
           filter((x) => {
             if (!showSections) return true
-            return !favorites.some(
-              (item) => item.providerID === x.value.providerID && item.modelID === x.value.modelID,
-            )
+            return !inShortcuts(x.value.providerID, x.value.modelID)
           }),
           sortBy(
             (x) => x.footer !== "Free",
             (x) => x.title,
           ),
         )
-        // Prepend the free mimo-auto model to the Xiaomi group when it's loaded.
+        // Prepend the free mimo-auto model to the Xiaomi group when it's loaded
+        // and not already surfaced in the Favorites/Recent sections.
         const free =
           provider.id === "xiaomi" &&
           (!props.providerID || props.providerID === provider.id) &&
+          (!showSections || !inShortcuts("mimo", "mimo-auto")) &&
           sync.data.provider.some((p) => p.id === "mimo" && "mimo-auto" in p.models)
             ? [
                 {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -15,6 +15,7 @@ import * as Clipboard from "@tui/util/clipboard"
 import { useToast, type ToastContext } from "../ui/toast"
 import { isConsoleManagedProvider } from "@tui/util/provider-origin"
 import { isPopularProvider, PROVIDER_PRIORITY } from "@/util/provider-priority"
+import { useLanguage } from "@tui/context/language"
 
 export function createDialogProviderOptions() {
   const sync = useSync()
@@ -22,6 +23,7 @@ export function createDialogProviderOptions() {
   const sdk = useSDK()
   const toast = useToast()
   const { theme } = useTheme()
+  const t = useLanguage().t
   const options = createMemo(() => {
     const list = pipe(
       sync.data.provider_next.all,
@@ -31,7 +33,7 @@ export function createDialogProviderOptions() {
         const connected = sync.data.provider_next.connected.includes(provider.id)
 
         return {
-          title: provider.name,
+          title: t("provider.name." + provider.id) || provider.name,
           value: provider.id,
           description: {
             anthropic: "(API key)",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-token-plan.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-token-plan.tsx
@@ -1,0 +1,67 @@
+import { TextAttributes } from "@opentui/core"
+import open from "open"
+import { useKeyboard } from "@opentui/solid"
+import { useTheme } from "@tui/context/theme"
+import { useLanguage } from "@tui/context/language"
+import { useDialog, type DialogContext } from "@tui/ui/dialog"
+
+const TOKEN_PLAN_URL = "https://platform.xiaomimimo.com/token-plan"
+
+// Shown once per 24h when the free "mimo-auto" channel hits a rate limit /
+// queue ("too many requests"). Modeled on DialogAgreement (same medium width).
+export function DialogTokenPlan(props: { onClose?: () => void }) {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+  const t = useLanguage().t
+
+  const close = () => {
+    dialog.clear()
+    props.onClose?.()
+  }
+
+  useKeyboard((evt) => {
+    if (evt.name === "return") close()
+  })
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          {t("tui.dialog.token_plan.title")}
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => close()}>
+          {t("tui.dialog.close_hint")}
+        </text>
+      </box>
+      <box gap={0} paddingBottom={1}>
+        <text fg={theme.textMuted}>{t("tui.dialog.token_plan.line1")}</text>
+        <box flexDirection="row" flexWrap="wrap">
+          <text fg={theme.textMuted}>{t("tui.dialog.token_plan.subscribe")}</text>
+          <text
+            fg={theme.primary}
+            attributes={TextAttributes.UNDERLINE}
+            onMouseUp={() => open(TOKEN_PLAN_URL).catch(() => {})}
+          >
+            {t("tui.dialog.token_plan.link")}
+          </text>
+          <text fg={theme.textMuted}>{t("tui.dialog.token_plan.link_suffix")}</text>
+        </box>
+        <text fg={theme.textMuted}>{t("tui.dialog.token_plan.line3")}</text>
+      </box>
+      <box flexDirection="row" justifyContent="center" paddingBottom={1}>
+        <box paddingLeft={2} paddingRight={2} backgroundColor={theme.primary} onMouseUp={() => close()}>
+          <text fg={theme.selectedListItemText}>{t("tui.dialog.token_plan.confirm")}</text>
+        </box>
+      </box>
+    </box>
+  )
+}
+
+DialogTokenPlan.show = (dialog: DialogContext) => {
+  return new Promise<void>((resolve) => {
+    dialog.replace(
+      () => <DialogTokenPlan onClose={() => resolve()} />,
+      () => resolve(),
+    )
+  })
+}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-token-plan.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-token-plan.tsx
@@ -3,6 +3,8 @@ import open from "open"
 import { useKeyboard } from "@opentui/solid"
 import { useTheme } from "@tui/context/theme"
 import { useLanguage } from "@tui/context/language"
+import { useToast } from "@tui/ui/toast"
+import * as Clipboard from "@tui/util/clipboard"
 import { useDialog, type DialogContext } from "@tui/ui/dialog"
 
 const TOKEN_PLAN_URL = "https://platform.xiaomimimo.com/token-plan"
@@ -13,14 +15,22 @@ export function DialogTokenPlan(props: { onClose?: () => void }) {
   const dialog = useDialog()
   const { theme } = useTheme()
   const t = useLanguage().t
+  const toast = useToast()
 
   const close = () => {
     dialog.clear()
     props.onClose?.()
   }
 
+  const openLink = () => {
+    open(TOKEN_PLAN_URL).catch(() => {
+      Clipboard.copy(TOKEN_PLAN_URL).catch(() => {})
+      toast.show({ message: TOKEN_PLAN_URL, variant: "info" })
+    })
+  }
+
   useKeyboard((evt) => {
-    if (evt.name === "return") close()
+    if (evt.name === "return" || evt.name === "escape") close()
   })
 
   return (
@@ -40,7 +50,7 @@ export function DialogTokenPlan(props: { onClose?: () => void }) {
           <text
             fg={theme.primary}
             attributes={TextAttributes.UNDERLINE}
-            onMouseUp={() => open(TOKEN_PLAN_URL).catch(() => {})}
+            onMouseUp={() => openLink()}
           >
             {t("tui.dialog.token_plan.link")}
           </text>

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -12,6 +12,7 @@ import { useArgs } from "./args"
 import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
 import { Filesystem } from "@/util"
+import * as Model from "../util/model"
 
 export function parseModel(model: string) {
   const [providerID, ...rest] = model.split("/")
@@ -231,8 +232,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const provider = sync.data.provider.find((x) => x.id === value.providerID)
           const info = provider?.models[value.modelID]
           return {
-            provider: provider?.name ?? value.providerID,
-            model: value.modelID === "mimo-auto" ? "MiMo Auto（MiMo-V2.5 限免中）" : (info?.name ?? value.modelID),
+            provider: value.providerID === "mimo" ? "MiMo" : (provider?.name ?? value.providerID),
+            model: Model.name(sync.data.provider, value.providerID, value.modelID),
             reasoning: info?.capabilities?.reasoning ?? false,
           }
         }),

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -13,6 +13,7 @@ import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
 import { Filesystem } from "@/util"
 import * as Model from "../util/model"
+import { useLanguage } from "@tui/context/language"
 
 export function parseModel(model: string) {
   const [providerID, ...rest] = model.split("/")
@@ -28,6 +29,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sync = useSync()
     const sdk = useSDK()
     const toast = useToast()
+    const t = useLanguage().t
 
     function isModelValid(model: { providerID: string; modelID: string }) {
       const provider = sync.data.provider.find((x) => x.id === model.providerID)
@@ -232,8 +234,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const provider = sync.data.provider.find((x) => x.id === value.providerID)
           const info = provider?.models[value.modelID]
           return {
-            provider: value.providerID === "mimo" ? "MiMo" : (provider?.name ?? value.providerID),
-            model: Model.name(sync.data.provider, value.providerID, value.modelID),
+            provider: t("provider.name." + value.providerID) || provider?.name || value.providerID,
+            model:
+              value.modelID === "mimo-auto"
+                ? t("tui.model.mimo_auto.name")
+                : Model.name(sync.data.provider, value.providerID, value.modelID),
             reasoning: info?.capabilities?.reasoning ?? false,
           }
         }),

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -264,6 +264,8 @@ export const dict: Record<string, string> = {
   "tui.consent.revoked": "Free-model agreement revoked — you'll be asked to agree again",
   "tui.dialog.select.placeholder": "Search",
   "tui.dialog.model.login_hint": "Tip: run /login to sign in before switching models",
+  "provider.name.mimo": "MiMo",
+  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, limited-time free)",
   "tui.dialog.token_plan.title": "Subscribe to a Token Plan or wait in queue",
   "tui.dialog.token_plan.line1": "In free mode, requests are currently queued. For stable, high-quality service,",
   "tui.dialog.token_plan.subscribe": "subscribe to ",

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -18,6 +18,9 @@ export const dict: Record<string, string> = {
   "language.th": "ไทย",
   "language.tr": "Türkçe",
 
+  // Provider display names (override server-provided names per locale)
+  "provider.name.xiaomi": "Xiaomi",
+
   // Prompt placeholders
   "tui.prompt.placeholder.normal": "Type your message... (type / for commands)",
   "tui.prompt.placeholder.shell": 'Run a command... "{{example}}"',
@@ -73,7 +76,7 @@ export const dict: Record<string, string> = {
     "Press {highlight}Ctrl+X X{/highlight} or {highlight}/export{/highlight} to save the conversation as Markdown",
   "tui.tips.copy_last": "Press {highlight}Ctrl+X Y{/highlight} to copy the assistant's last message to clipboard",
   "tui.tips.command_palette": "Press {highlight}Ctrl+P{/highlight} to see all available actions and commands",
-  "tui.tips.login": "Run {highlight}/login{/highlight} to sign in and use your token plan",
+  "tui.tips.login": "Run {highlight}/login{/highlight} to sign in and use a Token Plan or configure your own API key",
   "tui.tips.connect": "Run {highlight}/connect{/highlight} to choose your LLM provider and add API keys",
   "tui.tips.leader": "The leader key is {highlight}Ctrl+X{/highlight}; combine with other keys for quick actions",
   "tui.tips.f2": "Press {highlight}F2{/highlight} to quickly switch between recently used models",
@@ -260,6 +263,14 @@ export const dict: Record<string, string> = {
   "tui.command.consent.revoke.title": "Revoke free-model agreement",
   "tui.consent.revoked": "Free-model agreement revoked — you'll be asked to agree again",
   "tui.dialog.select.placeholder": "Search",
+  "tui.dialog.model.login_hint": "Tip: run /login to sign in before switching models",
+  "tui.dialog.token_plan.title": "Subscribe to a Token Plan or wait in queue",
+  "tui.dialog.token_plan.line1": "In free mode, requests are currently queued. For stable, high-quality service,",
+  "tui.dialog.token_plan.subscribe": "subscribe to ",
+  "tui.dialog.token_plan.link": "MiMo Token Plan",
+  "tui.dialog.token_plan.link_suffix": ".",
+  "tui.dialog.token_plan.line3": "You can also run /login to configure your own API key.",
+  "tui.dialog.token_plan.confirm": "Got it",
   "tui.dialog.select.no_results": "No results found",
   "tui.dialog.prompt.placeholder": "Enter text",
   "tui.dialog.prompt.busy": "Working...",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -327,6 +327,8 @@ export const dict = {
   "tui.consent.revoked": "Acuerdo de modelo gratuito revocado: se te pedirá aceptarlo de nuevo",
   "tui.dialog.select.placeholder": "Buscar",
   "tui.dialog.model.login_hint": "Consejo: ejecuta /login para iniciar sesión antes de cambiar de modelo",
+  "provider.name.mimo": "MiMo",
+  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, gratis por tiempo limitado)",
   "tui.dialog.token_plan.title": "Suscríbete a un Token Plan o espera en la cola",
   "tui.dialog.token_plan.line1":
     "En el modo gratuito, las solicitudes están en cola. Para un servicio estable y de calidad,",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -87,7 +87,7 @@ export const dict = {
   "tui.tips.command_palette":
     "Pulsa {highlight}Ctrl+P{/highlight} para ver todas las acciones y comandos disponibles",
   "tui.tips.login":
-    "Ejecuta {highlight}/login{/highlight} para iniciar sesión y usar tu plan de tokens",
+    "Ejecuta {highlight}/login{/highlight} para iniciar sesión y usar un Token Plan o configurar tu propia API key",
   "tui.tips.connect":
     "Ejecuta {highlight}/connect{/highlight} para elegir tu proveedor LLM y añadir claves API",
   "tui.tips.leader":
@@ -326,6 +326,15 @@ export const dict = {
   "tui.command.consent.revoke.title": "Revocar el acuerdo de modelo gratuito",
   "tui.consent.revoked": "Acuerdo de modelo gratuito revocado: se te pedirá aceptarlo de nuevo",
   "tui.dialog.select.placeholder": "Buscar",
+  "tui.dialog.model.login_hint": "Consejo: ejecuta /login para iniciar sesión antes de cambiar de modelo",
+  "tui.dialog.token_plan.title": "Suscríbete a un Token Plan o espera en la cola",
+  "tui.dialog.token_plan.line1":
+    "En el modo gratuito, las solicitudes están en cola. Para un servicio estable y de calidad,",
+  "tui.dialog.token_plan.subscribe": "suscríbete a ",
+  "tui.dialog.token_plan.link": "MiMo Token Plan",
+  "tui.dialog.token_plan.link_suffix": ".",
+  "tui.dialog.token_plan.line3": "También puedes ejecutar /login para configurar tu propia clave API.",
+  "tui.dialog.token_plan.confirm": "Entendido",
   "tui.dialog.select.no_results": "No se encontraron resultados",
   "tui.dialog.prompt.placeholder": "Introduce texto",
   "tui.dialog.prompt.busy": "Trabajando...",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -316,6 +316,8 @@ export const dict = {
   "tui.consent.revoked": "Accord du modèle gratuit révoqué — vous devrez l'accepter à nouveau",
   "tui.dialog.select.placeholder": "Rechercher",
   "tui.dialog.model.login_hint": "Astuce : exécutez /login pour vous connecter avant de changer de modèle",
+  "provider.name.mimo": "MiMo",
+  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, gratuit pour une durée limitée)",
   "tui.dialog.token_plan.title": "Abonnez-vous à un Token Plan ou patientez dans la file",
   "tui.dialog.token_plan.line1":
     "En mode gratuit, les requêtes sont mises en file d'attente. Pour un service stable et de qualité,",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -85,7 +85,7 @@ export const dict = {
   "tui.tips.command_palette":
     "Appuyez sur {highlight}Ctrl+P{/highlight} pour voir toutes les actions et commandes disponibles",
   "tui.tips.login":
-    "Exécutez {highlight}/login{/highlight} pour vous connecter et utiliser votre forfait de tokens",
+    "Exécutez {highlight}/login{/highlight} pour vous connecter et utiliser un Token Plan ou configurer votre propre clé API",
   "tui.tips.connect":
     "Exécutez {highlight}/connect{/highlight} pour choisir votre fournisseur LLM et ajouter des clés API",
   "tui.tips.leader":
@@ -315,6 +315,15 @@ export const dict = {
   "tui.command.consent.revoke.title": "Révoquer l'accord du modèle gratuit",
   "tui.consent.revoked": "Accord du modèle gratuit révoqué — vous devrez l'accepter à nouveau",
   "tui.dialog.select.placeholder": "Rechercher",
+  "tui.dialog.model.login_hint": "Astuce : exécutez /login pour vous connecter avant de changer de modèle",
+  "tui.dialog.token_plan.title": "Abonnez-vous à un Token Plan ou patientez dans la file",
+  "tui.dialog.token_plan.line1":
+    "En mode gratuit, les requêtes sont mises en file d'attente. Pour un service stable et de qualité,",
+  "tui.dialog.token_plan.subscribe": "abonnez-vous à ",
+  "tui.dialog.token_plan.link": "MiMo Token Plan",
+  "tui.dialog.token_plan.link_suffix": ".",
+  "tui.dialog.token_plan.line3": "Vous pouvez aussi exécuter /login pour configurer votre propre clé API.",
+  "tui.dialog.token_plan.confirm": "Compris",
   "tui.dialog.select.no_results": "Aucun résultat trouvé",
   "tui.dialog.prompt.placeholder": "Saisir du texte",
   "tui.dialog.prompt.busy": "Traitement...",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -22,6 +22,9 @@ export const dict = {
   "language.th": "ไทย",
   "language.tr": "Türkçe",
 
+  // Provider display names
+  "provider.name.xiaomi": "シャオミ",
+
   // Prompt placeholders
   "tui.prompt.placeholder.normal": '何でも聞いてください... "{{example}}"',
   "tui.prompt.placeholder.shell": 'コマンドを実行... "{{example}}"',
@@ -77,7 +80,7 @@ export const dict = {
   "tui.tips.copy_last":
     "{highlight}Ctrl+X Y{/highlight} でアシスタントの最後のメッセージをクリップボードにコピーします",
   "tui.tips.command_palette": "{highlight}Ctrl+P{/highlight} で利用可能なすべてのコマンドを表示します",
-  "tui.tips.login": "{highlight}/login{/highlight} でサインインしてトークンプランを利用します",
+  "tui.tips.login": "{highlight}/login{/highlight} でサインインして Token Plan を利用するか、独自の API キーを設定します",
   "tui.tips.connect": "{highlight}/connect{/highlight} で LLM プロバイダを選択して API キーを追加します",
   "tui.tips.leader": "リーダーキーは {highlight}Ctrl+X{/highlight}。他のキーと組み合わせてクイック操作ができます",
   "tui.tips.f2": "{highlight}F2{/highlight} で最近使ったモデルを素早く切り替えます",
@@ -263,6 +266,15 @@ export const dict = {
   "tui.command.consent.revoke.title": "無料モデルの同意を取り消す",
   "tui.consent.revoked": "無料モデルの同意を取り消しました — 次回利用時に再度同意を求めます",
   "tui.dialog.select.placeholder": "検索",
+  "tui.dialog.model.login_hint": "ヒント：モデルを切り替える前に /login でログインしてください",
+  "tui.dialog.token_plan.title": "Token Plan を購読するか順番待ち",
+  "tui.dialog.token_plan.line1":
+    "無料モードでは現在順番待ちが必要です。安定した高品質なサービスをご利用いただくには、",
+  "tui.dialog.token_plan.subscribe": "",
+  "tui.dialog.token_plan.link": "MiMo Token Plan",
+  "tui.dialog.token_plan.link_suffix": " のご購読をおすすめします。",
+  "tui.dialog.token_plan.line3": "/login で独自の API キーを設定することもできます。",
+  "tui.dialog.token_plan.confirm": "了解",
   "tui.dialog.select.no_results": "結果が見つかりません",
   "tui.dialog.prompt.placeholder": "テキストを入力",
   "tui.dialog.prompt.busy": "処理中...",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -267,6 +267,8 @@ export const dict = {
   "tui.consent.revoked": "無料モデルの同意を取り消しました — 次回利用時に再度同意を求めます",
   "tui.dialog.select.placeholder": "検索",
   "tui.dialog.model.login_hint": "ヒント：モデルを切り替える前に /login でログインしてください",
+  "provider.name.mimo": "MiMo",
+  "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 期間限定無料）",
   "tui.dialog.token_plan.title": "Token Plan を購読するか順番待ち",
   "tui.dialog.token_plan.line1":
     "無料モードでは現在順番待ちが必要です。安定した高品質なサービスをご利用いただくには、",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -334,6 +334,8 @@ export const dict = {
   "tui.consent.revoked": "Согласие на бесплатную модель отозвано — потребуется принять снова",
   "tui.dialog.select.placeholder": "Поиск",
   "tui.dialog.model.login_hint": "Подсказка: выполните /login для входа перед сменой модели",
+  "provider.name.mimo": "MiMo",
+  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, временно бесплатно)",
   "tui.dialog.token_plan.title": "Оформите Token Plan или подождите в очереди",
   "tui.dialog.token_plan.line1":
     "В бесплатном режиме запросы сейчас в очереди. Для стабильного и качественного сервиса",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -22,6 +22,9 @@ export const dict = {
   "language.th": "ไทย",
   "language.tr": "Türkçe",
 
+  // Provider display names
+  "provider.name.xiaomi": "Сяоми",
+
   // Prompt placeholders
   "tui.prompt.placeholder.normal": 'Спросите что угодно... "{{example}}"',
   "tui.prompt.placeholder.shell": 'Выполните команду... "{{example}}"',
@@ -87,7 +90,7 @@ export const dict = {
   "tui.tips.command_palette":
     "Нажмите {highlight}Ctrl+P{/highlight}, чтобы посмотреть все доступные действия и команды",
   "tui.tips.login":
-    "Выполните {highlight}/login{/highlight}, чтобы войти и использовать ваш тарифный план токенов",
+    "Выполните {highlight}/login{/highlight}, чтобы войти и использовать Token Plan или настроить собственный API-ключ",
   "tui.tips.connect":
     "Выполните {highlight}/connect{/highlight}, чтобы выбрать LLM-провайдера и добавить API-ключи",
   "tui.tips.leader":
@@ -330,6 +333,15 @@ export const dict = {
   "tui.command.consent.revoke.title": "Отозвать согласие на бесплатную модель",
   "tui.consent.revoked": "Согласие на бесплатную модель отозвано — потребуется принять снова",
   "tui.dialog.select.placeholder": "Поиск",
+  "tui.dialog.model.login_hint": "Подсказка: выполните /login для входа перед сменой модели",
+  "tui.dialog.token_plan.title": "Оформите Token Plan или подождите в очереди",
+  "tui.dialog.token_plan.line1":
+    "В бесплатном режиме запросы сейчас в очереди. Для стабильного и качественного сервиса",
+  "tui.dialog.token_plan.subscribe": "оформите ",
+  "tui.dialog.token_plan.link": "MiMo Token Plan",
+  "tui.dialog.token_plan.link_suffix": ".",
+  "tui.dialog.token_plan.line3": "Вы также можете выполнить /login, чтобы настроить собственный API-ключ.",
+  "tui.dialog.token_plan.confirm": "Понятно",
   "tui.dialog.select.no_results": "Ничего не найдено",
   "tui.dialog.prompt.placeholder": "Введите текст",
   "tui.dialog.prompt.busy": "Выполняется...",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -253,6 +253,8 @@ export const dict = {
   "tui.consent.revoked": "已撤销免费模型协议 — 下次使用时将再次请求同意",
   "tui.dialog.select.placeholder": "搜索",
   "tui.dialog.model.login_hint": "提示：先 /login 登录再切换模型",
+  "provider.name.mimo": "MiMo",
+  "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 限免中）",
   "tui.dialog.token_plan.title": "订阅token plan或排队等待",
   "tui.dialog.token_plan.line1": "免费模式下当前需要排队等待，如果想要稳定获取高质量服务，",
   "tui.dialog.token_plan.subscribe": "欢迎订阅 ",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -22,6 +22,9 @@ export const dict = {
   "language.th": "ไทย",
   "language.tr": "Türkçe",
 
+  // Provider display names
+  "provider.name.xiaomi": "小米",
+
   // Prompt placeholders
   "tui.prompt.placeholder.normal": "输入消息...(输入/唤起命令)",
   "tui.prompt.placeholder.shell": '执行命令…… "{{example}}"',
@@ -69,7 +72,7 @@ export const dict = {
   "tui.tips.export": "按 {highlight}Ctrl+X X{/highlight} 或 {highlight}/export{/highlight} 把会话保存为 Markdown",
   "tui.tips.copy_last": "按 {highlight}Ctrl+X Y{/highlight} 把助手最后一条消息复制到剪贴板",
   "tui.tips.command_palette": "按 {highlight}Ctrl+P{/highlight} 查看所有可用动作和命令",
-  "tui.tips.login": "运行 {highlight}/login{/highlight} 登录使用 Token 套餐",
+  "tui.tips.login": "运行 {highlight}/login{/highlight} 登录使用Token Plan或配置自己的API key",
   "tui.tips.connect": "运行 {highlight}/connect{/highlight} 选择 LLM 服务商并添加 API key",
   "tui.tips.leader": "前导键是 {highlight}Ctrl+X{/highlight}，搭配其他键可快速触发动作",
   "tui.tips.f2": "按 {highlight}F2{/highlight} 在最近使用的模型之间快速切换",
@@ -249,6 +252,14 @@ export const dict = {
   "tui.command.consent.revoke.title": "撤销免费模型协议",
   "tui.consent.revoked": "已撤销免费模型协议 — 下次使用时将再次请求同意",
   "tui.dialog.select.placeholder": "搜索",
+  "tui.dialog.model.login_hint": "提示：先 /login 登录再切换模型",
+  "tui.dialog.token_plan.title": "订阅token plan或排队等待",
+  "tui.dialog.token_plan.line1": "免费模式下当前需要排队等待，如果想要稳定获取高质量服务，",
+  "tui.dialog.token_plan.subscribe": "欢迎订阅 ",
+  "tui.dialog.token_plan.link": "MiMo Token Plan",
+  "tui.dialog.token_plan.link_suffix": "。",
+  "tui.dialog.token_plan.line3": "你也可以通过 /login 来配置自己的 API key。",
+  "tui.dialog.token_plan.confirm": "知道了",
   "tui.dialog.select.no_results": "未找到结果",
   "tui.dialog.prompt.placeholder": "输入文本",
   "tui.dialog.prompt.busy": "处理中...",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -253,6 +253,8 @@ export const dict = {
   "tui.consent.revoked": "已撤銷免費模型協議 — 下次使用時將再次請求同意",
   "tui.dialog.select.placeholder": "搜尋",
   "tui.dialog.model.login_hint": "提示：先 /login 登入再切換模型",
+  "provider.name.mimo": "MiMo",
+  "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 限免中）",
   "tui.dialog.token_plan.title": "訂閱token plan或排隊等待",
   "tui.dialog.token_plan.line1": "免費模式下目前需要排隊等待，若想穩定取得高品質服務，",
   "tui.dialog.token_plan.subscribe": "歡迎訂閱 ",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -22,6 +22,9 @@ export const dict = {
   "language.th": "ไทย",
   "language.tr": "Türkçe",
 
+  // Provider display names
+  "provider.name.xiaomi": "小米",
+
   // Prompt placeholders
   "tui.prompt.placeholder.normal": '問點什麼…… "{{example}}"',
   "tui.prompt.placeholder.shell": '執行指令…… "{{example}}"',
@@ -69,7 +72,7 @@ export const dict = {
   "tui.tips.export": "按 {highlight}Ctrl+X X{/highlight} 或 {highlight}/export{/highlight} 把對話儲存為 Markdown",
   "tui.tips.copy_last": "按 {highlight}Ctrl+X Y{/highlight} 將助理最後一條訊息複製到剪貼簿",
   "tui.tips.command_palette": "按 {highlight}Ctrl+P{/highlight} 檢視所有可用動作與指令",
-  "tui.tips.login": "執行 {highlight}/login{/highlight} 登入使用 Token 套餐",
+  "tui.tips.login": "執行 {highlight}/login{/highlight} 登入使用 Token Plan或配置自己的API key",
   "tui.tips.connect": "執行 {highlight}/connect{/highlight} 選擇 LLM 服務商並新增 API 金鑰",
   "tui.tips.leader": "前導鍵是 {highlight}Ctrl+X{/highlight}，搭配其他按鍵可快速觸發動作",
   "tui.tips.f2": "按 {highlight}F2{/highlight} 在最近使用的模型之間快速切換",
@@ -249,6 +252,14 @@ export const dict = {
   "tui.command.consent.revoke.title": "撤銷免費模型協議",
   "tui.consent.revoked": "已撤銷免費模型協議 — 下次使用時將再次請求同意",
   "tui.dialog.select.placeholder": "搜尋",
+  "tui.dialog.model.login_hint": "提示：先 /login 登入再切換模型",
+  "tui.dialog.token_plan.title": "訂閱token plan或排隊等待",
+  "tui.dialog.token_plan.line1": "免費模式下目前需要排隊等待，若想穩定取得高品質服務，",
+  "tui.dialog.token_plan.subscribe": "歡迎訂閱 ",
+  "tui.dialog.token_plan.link": "MiMo Token Plan",
+  "tui.dialog.token_plan.link_suffix": "。",
+  "tui.dialog.token_plan.line3": "你也可以透過 /login 來設定自己的 API key。",
+  "tui.dialog.token_plan.confirm": "知道了",
   "tui.dialog.select.no_results": "找不到結果",
   "tui.dialog.prompt.placeholder": "輸入文字",
   "tui.dialog.prompt.busy": "處理中...",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -375,8 +375,11 @@ export function Session() {
     const seen = kv.get(QUEUE_TOKEN_PLAN_LAST_SEEN_AT)
     if (typeof seen === "number" && Date.now() - seen < QUEUE_TOKEN_PLAN_WINDOW) return
 
-    kv.set(QUEUE_TOKEN_PLAN_LAST_SEEN_AT, Date.now())
-    void DialogTokenPlan.show(dialog)
+    // Record the 24h cooldown only after the user dismisses, so a show() that
+    // fails (or never reaches the user) doesn't silently burn the whole day.
+    void DialogTokenPlan.show(dialog).then(() => {
+      kv.set(QUEUE_TOKEN_PLAN_LAST_SEEN_AT, Date.now())
+    })
   })
 
   function moveFirstChild() {
@@ -1367,7 +1370,11 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const t = useLanguage().t
   const [copyHover, setCopyHover] = createSignal(false)
   const messages = createMemo(() => sync.data.message[props.message.sessionID]?.[props.message.agentID ?? "main"] ?? [])
-  const model = createMemo(() => Model.name(ctx.providers(), props.message.providerID, props.message.modelID))
+  const model = createMemo(() =>
+    props.message.modelID === "mimo-auto"
+      ? t("tui.model.mimo_auto.name")
+      : Model.name(ctx.providers(), props.message.providerID, props.message.modelID),
+  )
 
   const final = createMemo(() => {
     return props.message.finish && props.message.finish !== "tool-calls"

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -90,6 +90,7 @@ import { getScrollAcceleration } from "../../util/scroll"
 import { nextThinkingMode, reasoningSummary, useThinkingMode, type ThinkingMode } from "../../context/thinking"
 import { TuiPluginRuntime } from "../../plugin"
 import { DialogGoUpsell } from "../../component/dialog-go-upsell"
+import { DialogTokenPlan } from "../../component/dialog-token-plan"
 import { SessionRetry } from "@/session/retry"
 import { getRevertDiffFiles } from "../../util/revert-diff"
 
@@ -98,6 +99,9 @@ addDefaultParsers(parsers.parsers)
 const GO_UPSELL_LAST_SEEN_AT = "go_upsell_last_seen_at"
 const GO_UPSELL_DONT_SHOW = "go_upsell_dont_show"
 const GO_UPSELL_WINDOW = 86_400_000 // 24 hrs
+
+const QUEUE_TOKEN_PLAN_LAST_SEEN_AT = "queue_token_plan_last_seen_at"
+const QUEUE_TOKEN_PLAN_WINDOW = 86_400_000 // 24 hrs
 
 const context = createContext<{
   width: number
@@ -357,6 +361,23 @@ export function Session() {
   }
 
   const local = useLocal()
+
+  // Free "mimo-auto" channel: on a rate-limit / queue ("too many requests"),
+  // nudge the user toward a Token Plan — at most once per 24h.
+  event.on("session.status", (evt) => {
+    if (evt.properties.sessionID !== route.sessionID) return
+    if (evt.properties.status.type !== "retry") return
+    if (!SessionRetry.isRateLimitMessage(evt.properties.status.message)) return
+    const model = local.model.current()
+    if (!model || model.providerID !== "mimo" || model.modelID !== "mimo-auto") return
+    if (dialog.stack.length > 0) return
+
+    const seen = kv.get(QUEUE_TOKEN_PLAN_LAST_SEEN_AT)
+    if (typeof seen === "number" && Date.now() - seen < QUEUE_TOKEN_PLAN_WINDOW) return
+
+    kv.set(QUEUE_TOKEN_PLAN_LAST_SEEN_AT, Date.now())
+    void DialogTokenPlan.show(dialog)
+  })
 
   function moveFirstChild() {
     const list = actors().filter((a) => a.mode === "subagent")

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -33,6 +33,8 @@ export interface DialogSelectProps<T> {
     onTrigger: (option: DialogSelectOption<T>) => void
   }[]
   current?: T
+  /** Optional muted subtitle shown under the title (e.g. a usage hint). */
+  hint?: string
 }
 
 export interface DialogSelectOption<T = any> {
@@ -183,9 +185,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     const option = selected()
     if (option) props.onMove?.(option)
     if (!scroll) return
-    const target = scroll.getChildren().find((child) => {
-      return child.id === JSON.stringify(selected()?.value)
-    })
+    const target = scroll.getChildren().find((child) => child.id === String(next))
     if (!target) return
     const y = target.y - scroll.y
     if (center) {
@@ -197,7 +197,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
       }
       if (y < 0) {
         scroll.scrollBy(y)
-        if (isDeepEqual(flat()[0].value, selected()?.value)) {
+        if (next === 0) {
           scroll.scrollTo(0)
         }
       }
@@ -263,6 +263,11 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
             {t("tui.dialog.close_hint")}
           </text>
         </box>
+        <Show when={props.hint}>
+          <box paddingTop={1} alignItems="center">
+            <text fg={theme.textMuted}>{props.hint}</text>
+          </box>
+        </Show>
         <Show when={!props.skipFilter}>
           <box paddingTop={1}>
             <input
@@ -325,11 +330,12 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                 </Show>
                 <For each={options}>
                   {(option) => {
-                    const active = createMemo(() => isDeepEqual(option.value, selected()?.value))
+                    const rowIndex = createMemo(() => flat().indexOf(option))
+                    const active = createMemo(() => rowIndex() === store.selected)
                     const current = createMemo(() => isDeepEqual(option.value, props.current))
                     return (
                       <box
-                        id={JSON.stringify(option.value)}
+                        id={String(rowIndex())}
                         flexDirection="row"
                         position="relative"
                         onMouseMove={() => {
@@ -341,14 +347,12 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                         }}
                         onMouseOver={() => {
                           if (store.input !== "mouse") return
-                          const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
-                          if (index === -1) return
-                          moveTo(index)
+                          if (rowIndex() === -1) return
+                          moveTo(rowIndex())
                         }}
                         onMouseDown={() => {
-                          const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
-                          if (index === -1) return
-                          moveTo(index)
+                          if (rowIndex() === -1) return
+                          moveTo(rowIndex())
                         }}
                         backgroundColor={active() ? (option.bg ?? theme.primary) : RGBA.fromInts(0, 0, 0, 0)}
                         paddingLeft={current() || option.gutter ? 1 : 3}

--- a/packages/opencode/src/cli/cmd/tui/util/model.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/model.ts
@@ -19,5 +19,6 @@ export function name(
   providerID: string,
   modelID: string,
 ) {
+  if (modelID === "mimo-auto") return "MiMo Auto（MiMo-V2.5 限免中）"
   return get(list, providerID, modelID)?.name ?? modelID
 }

--- a/packages/opencode/src/cli/cmd/tui/util/model.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/model.ts
@@ -19,6 +19,5 @@ export function name(
   providerID: string,
   modelID: string,
 ) {
-  if (modelID === "mimo-auto") return "MiMo Auto（MiMo-V2.5 限免中）"
   return get(list, providerID, modelID)?.name ?? modelID
 }

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -9,6 +9,18 @@ export type Err = ReturnType<NamedError["toObject"]>
 // literal error string kind of sucks, but it is the simplest for now.
 export const GO_UPSELL_MESSAGE = "Free usage exceeded, subscribe to Go https://opencode.ai/go"
 
+// Shared with the TUI: does this retry status message indicate a rate-limit /
+// queue ("too many requests" / HTTP 429) condition? retryable() normalizes
+// every 429 variant into a message containing one of these substrings.
+export function isRateLimitMessage(message: string): boolean {
+  const lower = message.toLowerCase()
+  return (
+    lower.includes("too many requests") ||
+    lower.includes("rate limit") ||
+    lower.includes("rate increased too quickly")
+  )
+}
+
 export const RETRY_INITIAL_DELAY = 2000
 export const RETRY_BACKOFF_FACTOR = 2
 export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds

--- a/packages/opencode/src/util/provider-priority.ts
+++ b/packages/opencode/src/util/provider-priority.ts
@@ -1,4 +1,4 @@
-const HEAD_POPULAR_PROVIDERS = ["openai", "anthropic"] as const
+const HEAD_POPULAR_PROVIDERS = ["xiaomi", "openai", "anthropic"] as const
 
 const CHINA_POPULAR_BEFORE_ALIBABA = [
   "deepseek",


### PR DESCRIPTION
- provider-priority: surface Xiaomi at the top of popular providers
- i18n (7 locales): Xiaomi display name, /login tip, Token Plan dialog copy
- /login: drop the standalone "MiMo Auto (free)" entry
- /models: model-name-only in Recent/Favorites; fold the free mimo-auto model into the Xiaomi group; also list recent/favorite models in their provider sections; add a "/login first" hint subtitle
- dialog-select: match selection/scroll by row index so duplicate models no longer double-highlight or jump the cursor
- status bar shows "MiMo" for the free provider; centralize the mimo-auto display name in Model.name()
- add DialogTokenPlan: shown once per 24h when the free channel hits a rate limit ("too many requests"), with a clickable MiMo Token Plan link

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
