### PR TITLE
feat(tool): add notebook-edit tool and read-state validation

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -18,6 +18,7 @@ import { Instance } from "../project/instance"
 import { SessionCwd } from "./session-cwd"
 import { Snapshot } from "@/snapshot"
 import { assertWriteAllowed, askEditUnlessMemory } from "./external-directory"
+import { assertFileRead } from "./read-state"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 
 function normalizeLineEndings(text: string): string {
@@ -77,6 +78,13 @@ export const EditTool = Tool.define(
             ? params.filePath
             : path.join(SessionCwd.get(ctx.sessionID), params.filePath)
           yield* assertWriteAllowed(ctx, filePath)
+
+          // The "create new file" branch (oldString === "") is effectively a
+          // write, so a prior Read isn't meaningful there. For real edits we
+          // require Read first so the model is operating on current contents.
+          if (params.oldString !== "") {
+            assertFileRead(ctx, filePath, "edit")
+          }
 
           let diff = ""
           let contentOld = ""

--- a/packages/opencode/src/tool/edit.txt
+++ b/packages/opencode/src/tool/edit.txt
@@ -1,7 +1,7 @@
 Performs exact string replacements in files. 
 
 Usage:
-- You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. 
+- You must use your `Read` tool at least once in the conversation before editing — this tool will error with a recoverable failure if you attempt an edit on a file that has not been Read in this session. Creating a brand-new file with `oldString=""` is exempt.
 - When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: line number + colon + space (e.g., `1: `). Everything after that space is the actual file content to match. Never include any part of the line number prefix in the oldString or newString.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.

--- a/packages/opencode/src/tool/notebook-edit.ts
+++ b/packages/opencode/src/tool/notebook-edit.ts
@@ -1,0 +1,225 @@
+import z from "zod"
+import * as path from "path"
+import { Effect } from "effect"
+import { createTwoFilesPatch } from "diff"
+import * as Tool from "./tool"
+import DESCRIPTION from "./notebook-edit.txt"
+import { AppFileSystem } from "@mimo-ai/shared/filesystem"
+import { Bus } from "../bus"
+import { File } from "../file"
+import { FileWatcher } from "../file/watcher"
+import { Instance } from "../project/instance"
+import { SessionCwd } from "./session-cwd"
+import { assertWriteAllowed, askEditUnlessMemory } from "./external-directory"
+import { assertFileRead } from "./read-state"
+import { trimDiff } from "./edit"
+
+const Parameters = z.object({
+  notebookPath: z.string().describe("The absolute path to the .ipynb file to modify"),
+  cellId: z
+    .string()
+    .optional()
+    .describe(
+      "Cell id from the Read tool's <cell id=\"...\"> output. Required for replace/delete; for insert, the new cell is added after this cell (or at the beginning if omitted).",
+    ),
+  newSource: z.string().optional().describe("The cell's new content. Required for replace and insert; ignored for delete."),
+  cellType: z
+    .enum(["code", "markdown"])
+    .optional()
+    .describe("Cell type. Required for insert; for replace, defaults to the existing cell's type."),
+  editMode: z
+    .enum(["replace", "insert", "delete"])
+    .optional()
+    .describe("Operation to perform. Defaults to replace."),
+})
+
+type NotebookCell = {
+  cell_type: "code" | "markdown" | "raw"
+  id?: string
+  source: string | string[]
+  metadata?: Record<string, unknown>
+  outputs?: unknown[]
+  execution_count?: number | null
+}
+
+type Notebook = {
+  cells: NotebookCell[]
+  metadata?: Record<string, unknown>
+  nbformat?: number
+  nbformat_minor?: number
+}
+
+function stringToCellSource(content: string): string[] {
+  if (content === "") return []
+  const lines = content.split("\n")
+  return lines.map((line, i) => (i < lines.length - 1 ? line + "\n" : line)).filter((line) => line !== "")
+}
+
+function generateCellId(existing: Set<string>): string {
+  for (let i = 0; i < 1000; i++) {
+    const id = crypto.randomUUID().slice(0, 8)
+    if (!existing.has(id)) return id
+  }
+  return crypto.randomUUID()
+}
+
+function buildCell(cellType: "code" | "markdown", source: string, id: string): NotebookCell {
+  const sourceLines = stringToCellSource(source)
+  if (cellType === "code") {
+    return {
+      cell_type: "code",
+      id,
+      source: sourceLines,
+      metadata: {},
+      outputs: [],
+      execution_count: null,
+    }
+  }
+  return {
+    cell_type: "markdown",
+    id,
+    source: sourceLines,
+    metadata: {},
+  }
+}
+
+export const NotebookEditTool = Tool.define(
+  "notebook_edit",
+  Effect.gen(function* () {
+    const fs = yield* AppFileSystem.Service
+    const bus = yield* Bus.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: z.infer<typeof Parameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const editMode = params.editMode ?? "replace"
+
+          if (!params.notebookPath) throw new Error("notebookPath is required")
+          if (path.extname(params.notebookPath) !== ".ipynb") {
+            throw new Error("notebookPath must point to a .ipynb file")
+          }
+
+          const notebookPath = path.isAbsolute(params.notebookPath)
+            ? params.notebookPath
+            : path.join(SessionCwd.get(ctx.sessionID), params.notebookPath)
+
+          if (editMode !== "insert" && !params.cellId) {
+            throw new Error(`cellId is required when editMode is "${editMode}"`)
+          }
+          if ((editMode === "replace" || editMode === "insert") && params.newSource === undefined) {
+            throw new Error(`newSource is required when editMode is "${editMode}"`)
+          }
+          if (editMode === "insert" && !params.cellType) {
+            throw new Error('cellType is required when editMode is "insert"')
+          }
+
+          yield* assertWriteAllowed(ctx, notebookPath)
+          assertFileRead(ctx, notebookPath, "notebook_edit")
+
+          const exists = yield* fs.existsSafe(notebookPath)
+          if (!exists) throw new Error(`Notebook not found: ${notebookPath}`)
+
+          const contentOld = yield* fs.readFileString(notebookPath)
+          const notebook = ((): Notebook => {
+            try {
+              return JSON.parse(contentOld) as Notebook
+            } catch (err) {
+              throw new Error(`Failed to parse notebook JSON: ${(err as Error).message}`)
+            }
+          })()
+
+          if (!Array.isArray(notebook.cells)) {
+            throw new Error("Notebook is missing a `cells` array — file does not look like a valid Jupyter notebook")
+          }
+
+          // Older notebooks (nbformat_minor < 5) have no cell ids. Backfill UUIDs
+          // for any cell missing one so cellId lookup is stable, and bump
+          // nbformat_minor to 5 to match what Jupyter does on save.
+          const existingIds = new Set<string>()
+          for (const cell of notebook.cells) if (cell.id) existingIds.add(cell.id)
+          let backfilled = false
+          for (const cell of notebook.cells) {
+            if (cell.id) continue
+            const id = generateCellId(existingIds)
+            cell.id = id
+            existingIds.add(id)
+            backfilled = true
+          }
+          if (backfilled && (notebook.nbformat_minor ?? 0) < 5) {
+            notebook.nbformat_minor = 5
+          }
+
+          // Accept either the real cell id or a positional reference like "#0".
+          const findIndex = (ref: string) => {
+            if (ref.startsWith("#")) {
+              const idx = Number.parseInt(ref.slice(1), 10)
+              if (Number.isInteger(idx) && idx >= 0 && idx < notebook.cells.length) return idx
+              return -1
+            }
+            return notebook.cells.findIndex((c) => c.id === ref)
+          }
+          const cellNotFound = (ref: string) => {
+            const ids = notebook.cells.map((c, i) => c.id ?? `#${i}`).join(", ")
+            return new Error(`Cell not found: ${ref}. Available cells: ${ids || "(none)"}`)
+          }
+
+          let title = ""
+
+          if (editMode === "replace") {
+            const idx = findIndex(params.cellId!)
+            if (idx === -1) throw cellNotFound(params.cellId!)
+            const target = notebook.cells[idx]
+            const nextType = params.cellType ?? (target.cell_type === "raw" ? "code" : target.cell_type)
+            const replaced = buildCell(nextType, params.newSource ?? "", target.id ?? params.cellId!)
+            if (target.cell_type === "code" && nextType === "code") {
+              replaced.outputs = target.outputs ?? []
+              replaced.execution_count = target.execution_count ?? null
+              replaced.metadata = target.metadata ?? {}
+            } else {
+              replaced.metadata = target.metadata ?? {}
+            }
+            notebook.cells[idx] = replaced
+            title = `replace cell ${target.id ?? `#${idx}`}`
+          } else if (editMode === "delete") {
+            const idx = findIndex(params.cellId!)
+            if (idx === -1) throw cellNotFound(params.cellId!)
+            notebook.cells.splice(idx, 1)
+            title = `delete cell ${params.cellId}`
+          } else {
+            // insert
+            const newId = generateCellId(existingIds)
+            const cell = buildCell(params.cellType!, params.newSource ?? "", newId)
+            if (!params.cellId) {
+              notebook.cells.unshift(cell)
+              title = `insert cell at start`
+            } else {
+              const idx = findIndex(params.cellId)
+              if (idx === -1) throw cellNotFound(params.cellId)
+              notebook.cells.splice(idx + 1, 0, cell)
+              title = `insert cell after ${params.cellId}`
+            }
+          }
+
+          const contentNew = JSON.stringify(notebook, null, 1) + (contentOld.endsWith("\n") ? "\n" : "")
+
+          const diff = trimDiff(createTwoFilesPatch(notebookPath, notebookPath, contentOld, contentNew))
+          yield* askEditUnlessMemory(ctx, notebookPath, {
+            patterns: [path.relative(Instance.worktree, notebookPath)],
+            diff,
+          })
+
+          yield* fs.writeWithDirs(notebookPath, contentNew)
+          yield* bus.publish(File.Event.Edited, { file: notebookPath })
+          yield* bus.publish(FileWatcher.Event.Updated, { file: notebookPath, event: "change" })
+
+          return {
+            title: `${path.relative(Instance.worktree, notebookPath)} — ${title}`,
+            metadata: { diff, editMode, cellId: params.cellId },
+            output: `Notebook updated: ${editMode} on ${path.relative(Instance.worktree, notebookPath)}.`,
+          }
+        }).pipe(Effect.orDie),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/notebook-edit.txt
+++ b/packages/opencode/src/tool/notebook-edit.txt
@@ -1,0 +1,10 @@
+Replaces, inserts, or deletes a single cell in a Jupyter notebook (.ipynb file).
+
+Usage:
+- You must use your `read` tool on the notebook in this conversation before editing — this tool will fail with a recoverable error if the file has not been Read in this session.
+- `notebookPath` should be an absolute path to a `.ipynb` file.
+- `cellId` is the `id` attribute shown in the read tool's `<cell id="...">` output. It is required for `replace` and `delete`. For older notebooks (nbformat_minor < 5) where cells have no real `id`, you can pass a positional reference like `#0`, `#1`, etc. (0-based index). On first edit, missing ids are auto-generated and the notebook is upgraded to nbformat_minor 5.
+- `editMode` defaults to `replace`. Use `insert` to add a new cell after the cell with the given `cellId` (or at the beginning of the notebook if `cellId` is omitted) — `cellType` is required when inserting. Use `delete` to remove the cell.
+- For `replace`, the cell type is preserved unless `cellType` is explicitly provided.
+- `newSource` is the cell's full new content (required for `replace` and `insert`, ignored for `delete`).
+- This tool understands the Jupyter notebook cell structure and modifies cells in place — prefer it over `write`/`edit` for `.ipynb` files so the surrounding JSON, outputs, and metadata stay intact.

--- a/packages/opencode/src/tool/read-state.ts
+++ b/packages/opencode/src/tool/read-state.ts
@@ -1,0 +1,44 @@
+import path from "path"
+import type * as Tool from "./tool"
+import { SessionCwd } from "./session-cwd"
+import { AppFileSystem } from "@mimo-ai/shared/filesystem"
+import { RecoverableError } from "./recoverable"
+import type { SessionID } from "../session/schema"
+
+// Same normalization both sides of the comparison go through so a Read on
+// a relative path lines up with an Edit on the absolute one.
+function canon(sessionID: SessionID, p: string): string {
+  const abs = path.isAbsolute(p) ? p : path.resolve(SessionCwd.get(sessionID), p)
+  if (process.platform === "win32") return AppFileSystem.normalizePath(abs).toLowerCase()
+  return abs
+}
+
+/**
+ * Throws RecoverableError if the given file was not previously read by the
+ * `read` tool in this conversation. Writes/edits to existing files must be
+ * preceded by a Read so the model sees the current contents — this turns the
+ * usage note in edit.txt into actual enforcement.
+ *
+ * RecoverableError is intentional: the failure is surfaced to the agent as a
+ * tool result it can act on (call Read, then retry) rather than as a hard
+ * system fault.
+ */
+export function assertFileRead(ctx: Tool.Context, targetPath: string, toolId: string): void {
+  const target = canon(ctx.sessionID, targetPath)
+
+  for (const msg of ctx.messages) {
+    for (const part of msg.parts) {
+      if (part.type !== "tool") continue
+      if (part.tool !== "read") continue
+      if (part.state.status !== "completed") continue
+      const input = part.state.input as { filePath?: unknown } | undefined
+      const fp = input?.filePath
+      if (typeof fp !== "string") continue
+      if (canon(ctx.sessionID, fp) === target) return
+    }
+  }
+
+  throw new RecoverableError(
+    `${toolId}: ${targetPath} has not been read in this conversation. Call the read tool on this file first, then retry.`,
+  )
+}

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -13,6 +13,7 @@ import { TaskTool } from "./task"
 import { WorkflowTool } from "./workflow"
 import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
+import { NotebookEditTool } from "./notebook-edit"
 import { InvalidTool } from "./invalid"
 import { SkillTool } from "./skill"
 import * as Tool from "./tool"
@@ -132,6 +133,7 @@ export const layer = Layer.effect(
     const codesearch = yield* CodeSearchTool
     const globtool = yield* GlobTool
     const writetool = yield* WriteTool
+    const notebookedit = yield* NotebookEditTool
     const edit = yield* EditTool
     const greptool = yield* GrepTool
     const patchtool = yield* ApplyPatchTool
@@ -212,6 +214,7 @@ export const layer = Layer.effect(
           grep: Tool.init(greptool),
           edit: Tool.init(edit),
           write: Tool.init(writetool),
+          notebookedit: Tool.init(notebookedit),
           actor: Tool.init(actor),
           fetch: Tool.init(webfetch),
           search: Tool.init(websearch),
@@ -240,6 +243,7 @@ export const layer = Layer.effect(
             tool.grep,
             tool.edit,
             tool.write,
+            tool.notebookedit,
             tool.actor,
             tool.fetch,
             tool.search,


### PR DESCRIPTION
## Summary
- Add `NotebookEditTool` for Jupyter notebook cell operations (replace/insert/delete)
- Add `read-state` module to track which files have been Read in a session
- Edit tool now enforces Read-before-Edit for existing files (new files exempt)
- Register notebook-edit tool in the tool registry