### PR TITLE
fix(tui): add missing space between icon and children in GenericTool and PlanExit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1790,7 +1790,7 @@ function PlanExit(props: ToolProps<any>) {
   return (
     <>
       <InlineTool icon="⚙" pending="Asking..." complete={true} part={props.part} dismissed={dismissed()}>
-        plan_exit
+        {" "}plan_exit
       </InlineTool>
       <Show when={feedback()}>
         <box paddingLeft={6}>
@@ -1819,7 +1819,7 @@ function GenericTool(props: ToolProps<any>) {
       when={props.output && ctx.showGenericToolOutput()}
       fallback={
         <InlineTool icon="⚙" pending="Writing command..." complete={true} part={props.part}>
-          {props.tool} {input(props.input)}
+          {" "}{props.tool} {input(props.input)}
         </InlineTool>
       }
     >


### PR DESCRIPTION
## Problem

TUI 中 `GenericTool` 和 `PlanExit` 组件渲染时，icon（⚙）和 children 之间缺少空格。

- **GenericTool**: `⚙memory [operation=search, ...]` → 应为 `⚙ memory [operation=search, ...]`
- **PlanExit**: `⚙plan_exit` → 应为 `⚙ plan_exit`

## Root Cause

opentui 的 JSX 实现没有保留表达式之间的空白字符。其他 `InlineTool` 组件（如 `Skill`、`Glob`、`Grep` 等）不受影响，因为它们的 children 本身包含前导文本（如 `"Skill "`、`"Glob "`）。而 `GenericTool` 和 `PlanExit` 的 children 以 JSX 表达式开头，导致空格丢失。

## Fix

在两个组件的 children 前添加 `{" "}` 表达式，确保空格始终被渲染。

Closes: #1233
