### PR TITLE
docs: fix OpenCode plugin paths to MiMoCode in plugins.mdx

### DIFF
--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -1,9 +1,9 @@
 ---
 title: Plugins
-description: Write your own plugins to extend OpenCode.
+description: Write your own plugins to extend MiMo Code.
 ---
 
-Plugins allow you to extend OpenCode by hooking into various events and customizing behavior. You can create plugins to add new features, integrate with external services, or modify OpenCode's default behavior.
+Plugins allow you to extend MiMo Code by hooking into various events and customizing behavior. You can create plugins to add new features, integrate with external services, or modify MiMo Code's default behavior.
 
 For examples, check out the [plugins](/docs/ecosystem#plugins) created by the community.
 
@@ -19,8 +19,8 @@ There are two ways to load plugins.
 
 Place JavaScript or TypeScript files in the plugin directory.
 
-- `.opencode/plugins/` - Project-level plugins
-- `~/.config/opencode/plugins/` - Global plugins
+- `.mimocode/plugins/` - Project-level plugins
+- `~/.config/mimocode/plugins/` - Global plugins
 
 Files in these directories are automatically loaded at startup.
 
@@ -30,7 +30,7 @@ Files in these directories are automatically loaded at startup.
 
 Specify npm packages in your config file.
 
-```json title="opencode.json"
+```json title="mimocode.json"
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
@@ -45,7 +45,7 @@ Browse available plugins in the [ecosystem](/docs/ecosystem#plugins).
 
 ### How plugins are installed
 
-**npm plugins** are installed automatically using Bun at startup. Packages and their dependencies are cached in `~/.cache/opencode/node_modules/`.
+**npm plugins** are installed automatically using Bun at startup. Packages and their dependencies are cached in `~/.cache/mimocode/node_modules/`.
 
 **Local plugins** are loaded directly from the plugin directory. To use external packages, you must create a `package.json` within your config directory (see [Dependencies](#dependencies)), or publish the plugin to npm and [add it to your config](/docs/config#plugins).
 
@@ -55,10 +55,10 @@ Browse available plugins in the [ecosystem](/docs/ecosystem#plugins).
 
 Plugins are loaded from all sources and all hooks run in sequence. The load order is:
 
-1. Global config (`~/.config/opencode/opencode.json`)
-2. Project config (`opencode.json`)
-3. Global plugin directory (`~/.config/opencode/plugins/`)
-4. Project plugin directory (`.opencode/plugins/`)
+1. Global config (`~/.config/mimocode/mimocode.json`)
+2. Project config (`mimocode.json`)
+3. Global plugin directory (`~/.config/mimocode/plugins/`)
+4. Project plugin directory (`.mimocode/plugins/`)
 
 Duplicate npm packages with the same name and version are loaded once. However, a local plugin and an npm plugin with similar names are both loaded separately.
 
@@ -75,7 +75,7 @@ functions. Each function receives a context object and returns a hooks object.
 
 Local plugins and custom tools can use external npm packages. Add a `package.json` to your config directory with the dependencies you need.
 
-```json title=".opencode/package.json"
+```json title=".mimocode/package.json"
 {
   "dependencies": {
     "shescape": "^2.1.0"
@@ -83,9 +83,9 @@ Local plugins and custom tools can use external npm packages. Add a `package.jso
 }
 ```
 
-OpenCode runs `bun install` at startup to install these. Your plugins and tools can then import them.
+MiMo Code runs `bun install` at startup to install these. Your plugins and tools can then import them.
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 import { escape } from "shescape"
 
 export const MyPlugin = async (ctx) => {
@@ -103,7 +103,7 @@ export const MyPlugin = async (ctx) => {
 
 ### Basic structure
 
-```js title=".opencode/plugins/example.js"
+```js title=".mimocode/plugins/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
   console.log("Plugin initialized!")
 
@@ -118,7 +118,7 @@ The plugin function receives:
 - `project`: The current project information.
 - `directory`: The current working directory.
 - `worktree`: The git worktree path.
-- `client`: An opencode SDK client for interacting with the AI.
+- `client`: A MiMo Code SDK client for interacting with the AI.
 - `$`: Bun's [shell API](https://bun.com/docs/runtime/shell) for executing commands.
 
 ---
@@ -210,7 +210,7 @@ Plugins can subscribe to events as seen below in the Examples section. Here is a
 
 ## Examples
 
-Here are some examples of plugins you can use to extend opencode.
+Here are some examples of plugins you can use to extend MiMo Code.
 
 ---
 
@@ -218,13 +218,13 @@ Here are some examples of plugins you can use to extend opencode.
 
 Send notifications when certain events occur:
 
-```js title=".opencode/plugins/notification.js"
+```js title=".mimocode/plugins/notification.js"
 export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
   return {
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'display notification "Session completed!" with title "MiMo Code"'`
       }
     },
   }
@@ -234,16 +234,16 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
 We are using `osascript` to run AppleScript on macOS. Here we are using it to send notifications.
 
 :::note
-If you’re using the OpenCode desktop app, it can send system notifications automatically when a response is ready or when a session errors.
+If you’re using the MiMo Code desktop app, it can send system notifications automatically when a response is ready or when a session errors.
 :::
 
 ---
 
 ### .env protection
 
-Prevent opencode from reading `.env` files:
+Prevent MiMo Code from reading `.env` files:
 
-```javascript title=".opencode/plugins/env-protection.js"
+```javascript title=".mimocode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
   return {
     "tool.execute.before": async (input, output) => {
@@ -261,7 +261,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 Inject environment variables into all shell execution (AI tools and user terminals):
 
-```javascript title=".opencode/plugins/inject-env.js"
+```javascript title=".mimocode/plugins/inject-env.js"
 export const InjectEnvPlugin = async () => {
   return {
     "shell.env": async (input, output) => {
@@ -276,9 +276,9 @@ export const InjectEnvPlugin = async () => {
 
 ### Custom tools
 
-Plugins can also add custom tools to opencode:
+Plugins can also add custom tools to MiMo Code:
 
-```ts title=".opencode/plugins/custom-tools.ts"
+```ts title=".mimocode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@mimo-ai/plugin"
 
 export const CustomToolsPlugin: Plugin = async (ctx) => {
@@ -299,13 +299,13 @@ export const CustomToolsPlugin: Plugin = async (ctx) => {
 }
 ```
 
-The `tool` helper creates a custom tool that opencode can call. It takes a Zod schema function and returns a tool definition with:
+The `tool` helper creates a custom tool that MiMo Code can call. It takes a Zod schema function and returns a tool definition with:
 
 - `description`: What the tool does
 - `args`: Zod schema for the tool's arguments
 - `execute`: Function that runs when the tool is called
 
-Your custom tools will be available to opencode alongside built-in tools.
+Your custom tools will be available to MiMo Code alongside built-in tools.
 
 :::note
 If a plugin tool uses the same name as a built-in tool, the plugin tool takes precedence.
@@ -317,7 +317,7 @@ If a plugin tool uses the same name as a built-in tool, the plugin tool takes pr
 
 Use `client.app.log()` instead of `console.log` for structured logging:
 
-```ts title=".opencode/plugins/my-plugin.ts"
+```ts title=".mimocode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
     body: {
@@ -338,7 +338,7 @@ Levels: `debug`, `info`, `warn`, `error`. See [SDK documentation](https://openco
 
 Customize the context included when a session is compacted:
 
-```ts title=".opencode/plugins/compaction.ts"
+```ts title=".mimocode/plugins/compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
@@ -362,7 +362,7 @@ The `experimental.session.compacting` hook fires before the LLM generates a cont
 
 You can also replace the compaction prompt entirely by setting `output.prompt`:
 
-```ts title=".opencode/plugins/custom-compaction.ts"
+```ts title=".mimocode/plugins/custom-compaction.ts"
 import type { Plugin } from "@mimo-ai/plugin"
 
 export const CustomCompactionPlugin: Plugin = async (ctx) => {


### PR DESCRIPTION
## Problem

The plugin docs (`packages/web/src/content/docs/plugins.mdx`) still reference `.opencode/plugins/` directories. MiMoCode's plugin loader only scans `.mimocode/` directories — users who follow the docs create plugins in directories that are silently ignored.

Verified against current `main`:
- `packages/opencode/src/config/plugin.ts:33` — scans `Glob.scan("{plugin,plugins}/*.{ts,js}", { cwd: dir })` on dirs from `paths.ts`
- `packages/opencode/src/config/paths.ts:25` — `directories()` looks for `.mimocode` (not `.opencode`)
- `packages/shared/src/global.ts:6` — `const APP = "mimocode"`
- The repo's own sample plugins live in `.mimocode/plugins/`

## Changes

All references to directory paths, config files, and "OpenCode"/"opencode" prose updated to MiMoCode equivalents:
- `.opencode/plugins/` → `.mimocode/plugins/`
- `~/.config/opencode/` → `~/.config/mimocode/`
- All `.opencode/` code block titles → `.mimocode/`
- "OpenCode"/"opencode" prose → "MiMo Code"

Schema URLs (`opencode.ai/config.json`) and npm package names left unchanged — those are real external references.

Closes: #1151
