### PR TITLE
fix(tui): restore provider hint on model picker favorites/recent rows

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -65,6 +65,7 @@ export function DialogModel(props: { providerID?: string }) {
             key: item,
             value: { providerID: provider.id, modelID: model.id },
             title: modelName(provider.id, model.id),
+            description: providerName(provider),
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
             footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,


### PR DESCRIPTION
## Summary

The model picker shows the provider next to each model when searching, but the default-page **Favorites** and **Recent** rows lost theirs. #1241 refactored the `toOptions` builder and dropped the `description: provider.name` line, so those rows rendered without a provider hint.

Fix is one line: re-add `description: providerName(provider)` to the Favorites/Recent option builder. Small change but important — without it users can't tell which provider a favorited/recent model belongs to.

Verified manually: provider hint restored on Favorites/Recent rows.