### PR TITLE
fix(api): update upgrade route description from opencode to MiMoCode

### DIFF
--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -225,8 +225,8 @@ export const GlobalRoutes = lazy(() =>
     .post(
       "/upgrade",
       describeRoute({
-        summary: "Upgrade opencode",
-        description: "Upgrade opencode to the specified version or latest if not specified.",
+        summary: "Upgrade MiMoCode",
+        description: "Upgrade MiMoCode to the specified version or latest if not specified.",
         operationId: "global.upgrade",
         responses: {
           200: {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -389,9 +389,9 @@ export class Global extends HeyApiClient {
   }
 
   /**
-   * Upgrade opencode
+   * Upgrade MiMoCode
    *
-   * Upgrade opencode to the specified version or latest if not specified.
+   * Upgrade MiMoCode to the specified version or latest if not specified.
    */
   public upgrade<ThrowOnError extends boolean = false>(
     parameters?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -161,8 +161,8 @@
     "/global/upgrade": {
       "post": {
         "operationId": "global.upgrade",
-        "summary": "Upgrade opencode",
-        "description": "Upgrade opencode to the specified version or latest if not specified.",
+        "summary": "Upgrade MiMoCode",
+        "description": "Upgrade MiMoCode to the specified version or latest if not specified.",
         "responses": {
           "200": {
             "description": "Upgrade result",


### PR DESCRIPTION
The upgrade route summary and description in the OpenAPI spec and generated SDK types still referenced "opencode" instead of "MiMoCode".

Updated:
- Source route definition in `packages/opencode/src/server/routes/global.ts`
- OpenAPI spec in `packages/sdk/openapi.json`
- Generated SDK types in `packages/sdk/js/src/v2/gen/sdk.gen.ts`

Fixes #1232