### PR TITLE
fix(ui): preserve time_updated when renaming session title

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -640,7 +640,8 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
     })
 
     const setTitle = Effect.fn("Session.setTitle")(function* (input: { sessionID: SessionID; title: string }) {
-      yield* patch(input.sessionID, { title: input.title })
+      const session = yield* get(input.sessionID)
+      yield* patch(input.sessionID, { title: input.title, time: { updated: session.time.updated } })
     })
 
     const setArchived = Effect.fn("Session.setArchived")(function* (input: { sessionID: SessionID; time?: number }) {


### PR DESCRIPTION
The Drizzle ORM Timestamps definition uses `$onUpdate(() => Date.now())`, which automatically bumps `time_updated` on every row update. When renaming a session via the sessions dialog (ctrl+R), this caused the renamed session to move to "Today" in the session list because `setTitle` only passed the new title without preserving the original timestamp.

## Root Cause

`time_updated` in `packages/opencode/src/storage/schema.sql.ts` has `.$onUpdate(() => Date.now())`, which fires on every UPDATE to any table using `Timestamps`. The `setTitle` method only patched `{ title }`, allowing the ORM to auto-set `time_updated` to the current time.

## Fix

`setTitle` now reads the session first and explicitly passes the original `time_updated` value in the patch. Drizzle ORM's `$onUpdate` only fires when no explicit value is provided, so this preserves the original timestamp.

## Reproduction

1. Open the sessions dialog (`/sessions`)
2. Select a session from a previous day
3. Press `ctrl+R` to rename it
4. The renamed session no longer moves to Today

Fixes #1257