### PR TITLE
fix(security): skip FORBIDDEN_ROOTS check on Windows in assertSafeDir…

### DIFF
--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -28,6 +28,7 @@ function assertSafeDirectory(directory: string): void {
   if (directory === pathParse(directory).root) {
     throw new Error("Access denied: filesystem root is not a valid project directory")
   }
+  if (process.platform === "win32") return
   for (const forbidden of FORBIDDEN_ROOTS) {
     if (directory === forbidden || AppFileSystem.contains(forbidden, directory)) {
       throw new Error("Access denied: target is a protected system directory")


### PR DESCRIPTION
### Issue for this PR

Closes #1264

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, any project path containing `\dev\` (e.g. `C:\dev\test`) falsely triggers "Access denied: target is a protected system directory".

`assertSafeDirectory` checks `FORBIDDEN_ROOTS` which only contains Unix paths (`/dev`, `/etc`, etc.). On Windows, `path.relative("/dev", "C:\\dev\\test")` returns `"test"` (not starting with `..`), so `AppFileSystem.contains()` incorrectly returns `true`.

This fix skips the `FORBIDDEN_ROOTS` check when `process.platform === "win32"` since those Unix paths don't exist on Windows.

### How did you verify your code works?

- Ran `bun dev C:\dev\test` before fix: error occurs
- Ran `bun dev C:\dev\test` after fix: works correctly
- Change is 1 line, no type changes needed

### Screenshots / recordings

_N/A — not a UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR