### PR TITLE
fix(mcp): keep Claude imports pending until connect

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -524,6 +524,11 @@ export const layer = Layer.effect(
                 return
               }
 
+              if (cfg.mcp_origins?.[key]?.type === "claude") {
+                s.status[key] = { status: "pending" }
+                return
+              }
+
               const result = yield* create(key, mcp).pipe(Effect.catch(() => Effect.void))
               if (!result) return
 


### PR DESCRIPTION

## Summary

Keep MCP servers imported from Claude config in `pending` status during MCP service initialization. They should not eagerly connect until the user explicitly calls `connect()`.

## Root Cause

The MCP initialization path iterates every configured MCP server and immediately calls `create()`. Claude-origin servers are imported into config with origin metadata, but that metadata was not used to preserve the expected lazy connection behavior.

## Changes

- Detect `cfg.mcp_origins?.[key]?.type === "claude"` during MCP state initialization.
- Set those servers to `{ status: "pending" }` and skip eager `create()`.
- Existing explicit `connect()` behavior remains unchanged.

## Validation

- `bun typecheck`
- `bun test --timeout 60000 test/mcp/lifecycle.test.ts`

## CI Status Note

- `lint` and `typecheck` pass on this PR.
- Full `unit` currently fails, but `upstream/main@ee4ddd2` already has a failing `test` workflow (run `28071223407`).
- This PR fixes its target failure: `Claude Code local MCP server is pending until explicitly connected` is absent from this PR unit failure list.
- The remaining `failed subtask preserves metadata on error tool state` failure is covered by companion PR #1268, not this MCP change.
- The `CheckpointContext producer`, `parentSessionID end-to-end`, and `session.llm.stream` failures are also present on current `upstream/main` and are outside this diff.
