### PR TITLE
fix: skip FORBIDDEN_PREFIXES check on Windows

### DIFF
--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -33,9 +33,11 @@ function assertSafeDirectory(directory: string): void {
   if (resolved === pathParse(resolved).root) {
     throw new Error("Access denied: filesystem root is not a valid project directory")
   }
-  for (const prefix of FORBIDDEN_PREFIXES) {
-    if (resolved === prefix || resolved.startsWith(`${prefix}/`)) {
-      throw new Error("Access denied: target is a protected system directory")
+  if (process.platform !== "win32") {
+    for (const prefix of FORBIDDEN_PREFIXES) {
+      if (resolved === prefix || resolved.startsWith(`${prefix}/`)) {
+        throw new Error("Access denied: target is a protected system directory")
+      }
     }
   }
 }


### PR DESCRIPTION
Unix system paths like /dev match Windows directories such as D:\dev after path normalization. These prefixes are meaningless on Windows, so skip the check entirely on that platform.