### PR TITLE
feat(tui): remove provider name i18n, pin mimo models at top

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -84,17 +84,60 @@ export function DialogModel(props: { providerID?: string }) {
       "Recent",
     )
 
+    // Xiaomi provider and mimo-free pinned at top (after favorites/recents)
+    const xiaomiProvider = sync.data.provider.find((p) => p.id === "xiaomi")
+    const mimoFreeAvailable = sync.data.provider.some((p) => p.id === "mimo" && "mimo-auto" in p.models)
+    const pinnedOptions = xiaomiProvider && connected() && showSections
+      ? [
+          // mimo-free model
+          ...((!props.providerID || props.providerID === "mimo") &&
+          (!showSections || !inShortcuts("mimo", "mimo-auto")) &&
+          mimoFreeAvailable
+            ? [
+                {
+                  value: { providerID: "mimo", modelID: "mimo-auto" },
+                  title: modelName("mimo", "mimo-auto"),
+                  description: undefined as string | undefined,
+                  category: xiaomiProvider.name,
+                  disabled: false,
+                  footer: undefined as "Free" | undefined,
+                  onSelect() {
+                    onSelect("mimo", "mimo-auto")
+                  },
+                },
+              ]
+            : []),
+          // xiaomi provider models
+          ...pipe(
+            xiaomiProvider.models,
+            entries(),
+            filter(([_, info]) => info.status !== "deprecated"),
+            filter(([_, info]) => (props.providerID ? info.providerID === props.providerID : true)),
+            map(([model, info]) => ({
+              value: { providerID: xiaomiProvider.id, modelID: model },
+              title: info.name ?? model,
+              description: undefined as string | undefined,
+              category: xiaomiProvider.name,
+              disabled: false,
+              footer: undefined as "Free" | undefined,
+              onSelect() {
+                onSelect(xiaomiProvider.id, model)
+              },
+            })),
+            filter((x) => !showSections || !inShortcuts(x.value.providerID, x.value.modelID)),
+          ),
+        ]
+      : []
+
     const providerOptions = pipe(
       sync.data.provider,
+      filter((provider) => provider.id !== "xiaomi" && provider.id !== "mimo"),
       sortBy(
         (provider) => provider.id !== "opencode",
         (provider) => PROVIDER_PRIORITY[provider.id] ?? 99,
         (provider) => provider.name,
       ),
       flatMap((provider) => {
-        // The free mimo-auto model is surfaced as the top entry of the Xiaomi
-        // group below, so the mimo provider never renders its own section.
-        if (provider.id === "mimo") return []
         const models = pipe(
           provider.models,
           entries(),
@@ -121,31 +164,9 @@ export function DialogModel(props: { providerID?: string }) {
             (x) => x.title,
           ),
         )
-        // Prepend the free mimo-auto model to the Xiaomi group when it's loaded
-        // and not already surfaced in the Favorites/Recent sections.
-        const free =
-          provider.id === "xiaomi" &&
-          (!props.providerID || props.providerID === provider.id) &&
-          (!showSections || !inShortcuts("mimo", "mimo-auto")) &&
-          sync.data.provider.some((p) => p.id === "mimo" && "mimo-auto" in p.models)
-            ? [
-                {
-                  value: { providerID: "mimo", modelID: "mimo-auto" },
-                  title: modelName("mimo", "mimo-auto"),
-                  description: undefined as string | undefined,
-                  category: connected() ? provider.name : undefined,
-                  disabled: false,
-                  footer: undefined as "Free" | undefined,
-                  onSelect() {
-                    onSelect("mimo", "mimo-auto")
-                  },
-                },
-              ]
-            : []
-        if (provider.source !== "config") return [...free, ...models]
-        if (props.providerID && props.providerID !== provider.id) return [...free, ...models]
+        if (provider.source !== "config") return models
+        if (props.providerID && props.providerID !== provider.id) return models
         return [
-          ...free,
           ...models,
           {
             value: { providerID: provider.id, modelID: ADD_MODEL_SENTINEL },
@@ -180,7 +201,7 @@ export function DialogModel(props: { providerID?: string }) {
       ]
     }
 
-    return [...favoriteOptions, ...recentOptions, ...providerOptions, ...popularProviders]
+    return [...favoriteOptions, ...recentOptions, ...pinnedOptions, ...providerOptions, ...popularProviders]
   })
 
   const provider = createMemo(() =>

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -89,12 +89,13 @@ export function DialogModel(props: { providerID?: string }) {
     const mimoProvider = sync.data.provider.find((p) => p.id === "mimo")
     const xiaomiProvider = sync.data.provider.find((p) => p.id === "xiaomi")
     const pinnedCategory = xiaomiProvider?.name ?? "MiMo"
-    const showPinned = connected() && showSections && !props.providerID
+    // Show pinned section when not scoped to a specific provider
+    const showPinned = connected() && !props.providerID
 
     const pinnedOptions = showPinned
       ? [
           // mimo-free model
-          ...(mimoProvider && "mimo-auto" in mimoProvider.models && !inShortcuts("mimo", "mimo-auto")
+          ...(mimoProvider && "mimo-auto" in mimoProvider.models && (!showSections || !inShortcuts("mimo", "mimo-auto"))
             ? [
                 {
                   value: { providerID: "mimo", modelID: "mimo-auto" },
@@ -126,7 +127,7 @@ export function DialogModel(props: { providerID?: string }) {
                     onSelect(xiaomiProvider.id, model)
                   },
                 })),
-                filter((x) => !inShortcuts(x.value.providerID, x.value.modelID)),
+                filter((x) => !showSections || !inShortcuts(x.value.providerID, x.value.modelID)),
               )
             : []),
         ]
@@ -134,7 +135,8 @@ export function DialogModel(props: { providerID?: string }) {
 
     const providerOptions = pipe(
       sync.data.provider,
-      filter((provider) => provider.id !== "xiaomi" && provider.id !== "mimo"),
+      // Exclude xiaomi/mimo from regular list only when pinned section is shown
+      filter((provider) => !showPinned || (provider.id !== "xiaomi" && provider.id !== "mimo")),
       sortBy(
         (provider) => provider.id !== "opencode",
         (provider) => PROVIDER_PRIORITY[provider.id] ?? 99,
@@ -199,6 +201,7 @@ export function DialogModel(props: { providerID?: string }) {
 
     if (needle) {
       return [
+        ...fuzzysort.go(needle, pinnedOptions, { keys: ["title", "category"] }).map((x) => x.obj),
         ...fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
         ...fuzzysort.go(needle, popularProviders, { keys: ["title"] }).map((x) => x.obj),
       ]

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -87,6 +87,7 @@ export function DialogModel(props: { providerID?: string }) {
     // mimo-free and xiaomi provider pinned at top (after favorites/recents)
     const mimoProvider = sync.data.provider.find((p) => p.id === "mimo")
     const xiaomiProvider = sync.data.provider.find((p) => p.id === "xiaomi")
+    const pinnedCategory = xiaomiProvider?.name ?? "MiMo"
     const showPinned = connected() && showSections && !props.providerID
 
     const pinnedOptions = showPinned
@@ -98,7 +99,7 @@ export function DialogModel(props: { providerID?: string }) {
                   value: { providerID: "mimo", modelID: "mimo-auto" },
                   title: modelName("mimo", "mimo-auto"),
                   description: undefined as string | undefined,
-                  category: "Xiaomi",
+                  category: pinnedCategory,
                   disabled: false,
                   footer: undefined as "Free" | undefined,
                   onSelect() {
@@ -117,7 +118,7 @@ export function DialogModel(props: { providerID?: string }) {
                   value: { providerID: xiaomiProvider.id, modelID: model },
                   title: info.name ?? model,
                   description: undefined as string | undefined,
-                  category: xiaomiProvider.name,
+                  category: pinnedCategory,
                   disabled: false,
                   footer: undefined as "Free" | undefined,
                   onSelect() {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -166,6 +166,10 @@ export function DialogModel(props: { providerID?: string }) {
           provider.models,
           entries(),
           filter(([_, info]) => info.status !== "deprecated"),
+          // Scoped views ("you just connected provider X, pick a model from X")
+          // intentionally show only that provider's own models. The free
+          // mimo-auto belongs to the `mimo` provider, so it is NOT surfaced
+          // here — it stays pinned in the unscoped picker. Don't re-add it.
           filter(([_, info]) => (props.providerID ? info.providerID === props.providerID : true)),
           map(([model, info]) => ({
             value: { providerID: provider.id, modelID: model },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -95,7 +95,7 @@ export function DialogModel(props: { providerID?: string }) {
     const pinnedOptions = showPinned
       ? [
           // mimo-free model
-          ...(mimoProvider && "mimo-auto" in mimoProvider.models && (!showSections || !inShortcuts("mimo", "mimo-auto"))
+          ...(mimoProvider && "mimo-auto" in mimoProvider.models && mimoProvider.models["mimo-auto"].status !== "deprecated" && (!showSections || !inShortcuts("mimo", "mimo-auto"))
             ? [
                 {
                   value: { providerID: "mimo", modelID: "mimo-auto" },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -84,21 +84,21 @@ export function DialogModel(props: { providerID?: string }) {
       "Recent",
     )
 
-    // Xiaomi provider and mimo-free pinned at top (after favorites/recents)
+    // mimo-free and xiaomi provider pinned at top (after favorites/recents)
+    const mimoProvider = sync.data.provider.find((p) => p.id === "mimo")
     const xiaomiProvider = sync.data.provider.find((p) => p.id === "xiaomi")
-    const mimoFreeAvailable = sync.data.provider.some((p) => p.id === "mimo" && "mimo-auto" in p.models)
-    const pinnedOptions = xiaomiProvider && connected() && showSections
+    const showPinned = connected() && showSections && !props.providerID
+
+    const pinnedOptions = showPinned
       ? [
           // mimo-free model
-          ...((!props.providerID || props.providerID === "mimo") &&
-          (!showSections || !inShortcuts("mimo", "mimo-auto")) &&
-          mimoFreeAvailable
+          ...(mimoProvider && "mimo-auto" in mimoProvider.models && !inShortcuts("mimo", "mimo-auto")
             ? [
                 {
                   value: { providerID: "mimo", modelID: "mimo-auto" },
                   title: modelName("mimo", "mimo-auto"),
                   description: undefined as string | undefined,
-                  category: xiaomiProvider.name,
+                  category: "Xiaomi",
                   disabled: false,
                   footer: undefined as "Free" | undefined,
                   onSelect() {
@@ -108,24 +108,25 @@ export function DialogModel(props: { providerID?: string }) {
               ]
             : []),
           // xiaomi provider models
-          ...pipe(
-            xiaomiProvider.models,
-            entries(),
-            filter(([_, info]) => info.status !== "deprecated"),
-            filter(([_, info]) => (props.providerID ? info.providerID === props.providerID : true)),
-            map(([model, info]) => ({
-              value: { providerID: xiaomiProvider.id, modelID: model },
-              title: info.name ?? model,
-              description: undefined as string | undefined,
-              category: xiaomiProvider.name,
-              disabled: false,
-              footer: undefined as "Free" | undefined,
-              onSelect() {
-                onSelect(xiaomiProvider.id, model)
-              },
-            })),
-            filter((x) => !showSections || !inShortcuts(x.value.providerID, x.value.modelID)),
-          ),
+          ...(xiaomiProvider
+            ? pipe(
+                xiaomiProvider.models,
+                entries(),
+                filter(([_, info]) => info.status !== "deprecated"),
+                map(([model, info]) => ({
+                  value: { providerID: xiaomiProvider.id, modelID: model },
+                  title: info.name ?? model,
+                  description: undefined as string | undefined,
+                  category: xiaomiProvider.name,
+                  disabled: false,
+                  footer: undefined as "Free" | undefined,
+                  onSelect() {
+                    onSelect(xiaomiProvider.id, model)
+                  },
+                })),
+                filter((x) => !inShortcuts(x.value.providerID, x.value.modelID)),
+              )
+            : []),
         ]
       : []
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -4,7 +4,8 @@ import { useSync } from "@tui/context/sync"
 import { map, pipe, flatMap, entries, filter, sortBy, take } from "remeda"
 import { DialogSelect } from "@tui/ui/dialog-select"
 import { useDialog, type DialogContext } from "@tui/ui/dialog"
-import { createDialogProviderOptions, DialogProvider } from "./dialog-provider"
+import { createDialogProviderOptions } from "./dialog-provider"
+import { DialogMimoLogin } from "./dialog-mimo-login"
 import { DialogVariant } from "./dialog-variant"
 import { useKeybind } from "../context/keybind"
 import { useSDK } from "../context/sdk"
@@ -259,9 +260,9 @@ export function DialogModel(props: { providerID?: string }) {
       keybind={[
         {
           keybind: keybind.all.model_provider_list?.[0],
-          title: connected() ? "Connect provider" : "View all providers",
+          title: "Connect provider",
           onTrigger() {
-            dialog.replace(() => <DialogProvider />)
+            dialog.replace(() => <DialogMimoLogin />)
           },
         },
         {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -64,7 +64,8 @@ export function DialogModel(props: { providerID?: string }) {
             key: item,
             value: { providerID: provider.id, modelID: model.id },
             title: modelName(provider.id, model.id),
-            description: provider.name,
+            // Hide provider name for mimo-auto to avoid redundancy
+            description: item.modelID === "mimo-auto" ? undefined : provider.name,
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
             footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -36,7 +36,6 @@ export function DialogModel(props: { providerID?: string }) {
   const connected = useConnected()
   const providers = createDialogProviderOptions()
   const t = useLanguage().t
-  const providerName = (p: { id: string; name: string }) => t("provider.name." + p.id) || p.name
   const modelName = (providerID: string, modelID: string) =>
     modelID === "mimo-auto" ? t("tui.model.mimo_auto.name") : Model.name(sync.data.provider, providerID, modelID)
 
@@ -65,7 +64,7 @@ export function DialogModel(props: { providerID?: string }) {
             key: item,
             value: { providerID: provider.id, modelID: model.id },
             title: modelName(provider.id, model.id),
-            description: providerName(provider),
+            description: provider.name,
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
             footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
@@ -90,7 +89,7 @@ export function DialogModel(props: { providerID?: string }) {
       sortBy(
         (provider) => provider.id !== "opencode",
         (provider) => PROVIDER_PRIORITY[provider.id] ?? 99,
-        (provider) => providerName(provider),
+        (provider) => provider.name,
       ),
       flatMap((provider) => {
         // The free mimo-auto model is surfaced as the top entry of the Xiaomi
@@ -105,7 +104,7 @@ export function DialogModel(props: { providerID?: string }) {
             value: { providerID: provider.id, modelID: model },
             title: info.name ?? model,
             description: undefined as string | undefined,
-            category: connected() ? providerName(provider) : undefined,
+            category: connected() ? provider.name : undefined,
             disabled: provider.id === "opencode" && model.includes("-nano"),
             footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
             onSelect() {
@@ -134,7 +133,7 @@ export function DialogModel(props: { providerID?: string }) {
                   value: { providerID: "mimo", modelID: "mimo-auto" },
                   title: modelName("mimo", "mimo-auto"),
                   description: undefined as string | undefined,
-                  category: connected() ? providerName(provider) : undefined,
+                  category: connected() ? provider.name : undefined,
                   disabled: false,
                   footer: undefined as "Free" | undefined,
                   onSelect() {
@@ -152,7 +151,7 @@ export function DialogModel(props: { providerID?: string }) {
             value: { providerID: provider.id, modelID: ADD_MODEL_SENTINEL },
             title: "+ Add model",
             description: undefined,
-            category: connected() ? providerName(provider) : undefined,
+            category: connected() ? provider.name : undefined,
             disabled: false,
             footer: undefined as "Free" | undefined,
             onSelect() {
@@ -191,7 +190,7 @@ export function DialogModel(props: { providerID?: string }) {
   const title = createMemo(() => {
     const value = provider()
     if (!value) return "Select model"
-    return providerName(value)
+    return value.name
   })
 
   function onSelect(providerID: string, modelID: string) {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -112,23 +112,41 @@ export function DialogModel(props: { providerID?: string }) {
             : []),
           // xiaomi provider models
           ...(xiaomiProvider
-            ? pipe(
-                xiaomiProvider.models,
-                entries(),
-                filter(([_, info]) => info.status !== "deprecated"),
-                map(([model, info]) => ({
-                  value: { providerID: xiaomiProvider.id, modelID: model },
-                  title: info.name ?? model,
-                  description: undefined as string | undefined,
-                  category: pinnedCategory,
-                  disabled: false,
-                  footer: undefined as "Free" | undefined,
-                  onSelect() {
-                    onSelect(xiaomiProvider.id, model)
-                  },
-                })),
-                filter((x) => !showSections || !inShortcuts(x.value.providerID, x.value.modelID)),
-              )
+            ? [
+                ...pipe(
+                  xiaomiProvider.models,
+                  entries(),
+                  filter(([_, info]) => info.status !== "deprecated"),
+                  map(([model, info]) => ({
+                    value: { providerID: xiaomiProvider.id, modelID: model },
+                    title: info.name ?? model,
+                    description: undefined as string | undefined,
+                    category: pinnedCategory,
+                    disabled: false,
+                    footer: undefined as "Free" | undefined,
+                    onSelect() {
+                      onSelect(xiaomiProvider.id, model)
+                    },
+                  })),
+                  filter((x) => !showSections || !inShortcuts(x.value.providerID, x.value.modelID)),
+                ),
+                // "+ Add model" for config-sourced providers
+                ...(xiaomiProvider.source === "config"
+                  ? [
+                      {
+                        value: { providerID: xiaomiProvider.id, modelID: ADD_MODEL_SENTINEL },
+                        title: "+ Add model",
+                        description: undefined,
+                        category: pinnedCategory,
+                        disabled: false,
+                        footer: undefined as "Free" | undefined,
+                        onSelect() {
+                          void runAddModelWizard({ dialog, sdk, sync, toast, providerID: xiaomiProvider.id })
+                        },
+                      },
+                    ]
+                  : []),
+              ]
             : []),
         ]
       : []

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -33,7 +33,7 @@ export function createDialogProviderOptions() {
         const connected = sync.data.provider_next.connected.includes(provider.id)
 
         return {
-          title: t("provider.name." + provider.id) || provider.name,
+          title: provider.name,
           value: provider.id,
           description: {
             anthropic: "(API key)",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -15,7 +15,6 @@ import * as Clipboard from "@tui/util/clipboard"
 import { useToast, type ToastContext } from "../ui/toast"
 import { isConsoleManagedProvider } from "@tui/util/provider-origin"
 import { isPopularProvider, PROVIDER_PRIORITY } from "@/util/provider-priority"
-import { useLanguage } from "@tui/context/language"
 
 export function createDialogProviderOptions() {
   const sync = useSync()
@@ -23,7 +22,6 @@ export function createDialogProviderOptions() {
   const sdk = useSDK()
   const toast = useToast()
   const { theme } = useTheme()
-  const t = useLanguage().t
   const options = createMemo(() => {
     const list = pipe(
       sync.data.provider_next.all,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1643,9 +1643,12 @@ export function Prompt(props: PromptProps) {
                           >
                             {local.model.parsed().model}
                           </text>
-                          <text fg={fadeColor(theme.textMuted, modelMetaAlpha())}>
-                            {currentProviderLabel()}
-                          </text>
+                          {/* Hide provider label for mimo-auto since model name already contains "MiMo" */}
+                          <Show when={local.model.current()?.providerID !== "mimo"}>
+                            <text fg={fadeColor(theme.textMuted, modelMetaAlpha())}>
+                              {currentProviderLabel()}
+                            </text>
+                          </Show>
                           <Show when={showVariant()}>
                             <text fg={fadeColor(theme.textMuted, variantMetaAlpha())}>·</text>
                             <text>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1644,7 +1644,7 @@ export function Prompt(props: PromptProps) {
                             {local.model.parsed().model}
                           </text>
                           {/* Hide provider label for mimo-auto since model name already contains "MiMo" */}
-                          <Show when={local.model.current()?.providerID !== "mimo"}>
+                          <Show when={!(local.model.current()?.providerID === "mimo" && local.model.current()?.modelID === "mimo-auto")}>
                             <text fg={fadeColor(theme.textMuted, modelMetaAlpha())}>
                               {currentProviderLabel()}
                             </text>

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -234,7 +234,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const provider = sync.data.provider.find((x) => x.id === value.providerID)
           const info = provider?.models[value.modelID]
           return {
-            provider: t("provider.name." + value.providerID) || provider?.name || value.providerID,
+            provider: provider?.name || value.providerID,
             model:
               value.modelID === "mimo-auto"
                 ? t("tui.model.mimo_auto.name")

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -18,9 +18,6 @@ export const dict: Record<string, string> = {
   "language.th": "ไทย",
   "language.tr": "Türkçe",
 
-  // Provider display names (override server-provided names per locale)
-  "provider.name.xiaomi": "Xiaomi",
-
   // Prompt placeholders
   "tui.prompt.placeholder.normal": "Type your message... (type / for commands)",
   "tui.prompt.placeholder.shell": 'Run a command... "{{example}}"',
@@ -264,7 +261,6 @@ export const dict: Record<string, string> = {
   "tui.consent.revoked": "Free-model agreement revoked — you'll be asked to agree again",
   "tui.dialog.select.placeholder": "Search",
   "tui.dialog.model.login_hint": "Tip: run /login to sign in before switching models",
-  "provider.name.mimo": "MiMo",
   "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, limited-time free)",
   "tui.dialog.token_plan.title": "Subscribe to a Token Plan or wait in queue",
   "tui.dialog.token_plan.line1": "In free mode, requests are currently queued. For stable, high-quality service,",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -327,7 +327,6 @@ export const dict = {
   "tui.consent.revoked": "Acuerdo de modelo gratuito revocado: se te pedirá aceptarlo de nuevo",
   "tui.dialog.select.placeholder": "Buscar",
   "tui.dialog.model.login_hint": "Consejo: ejecuta /login para iniciar sesión antes de cambiar de modelo",
-  "provider.name.mimo": "MiMo",
   "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, gratis por tiempo limitado)",
   "tui.dialog.token_plan.title": "Suscríbete a un Token Plan o espera en la cola",
   "tui.dialog.token_plan.line1":

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -316,7 +316,6 @@ export const dict = {
   "tui.consent.revoked": "Accord du modèle gratuit révoqué — vous devrez l'accepter à nouveau",
   "tui.dialog.select.placeholder": "Rechercher",
   "tui.dialog.model.login_hint": "Astuce : exécutez /login pour vous connecter avant de changer de modèle",
-  "provider.name.mimo": "MiMo",
   "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, gratuit pour une durée limitée)",
   "tui.dialog.token_plan.title": "Abonnez-vous à un Token Plan ou patientez dans la file",
   "tui.dialog.token_plan.line1":

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -22,9 +22,6 @@ export const dict = {
   "language.th": "ไทย",
   "language.tr": "Türkçe",
 
-  // Provider display names
-  "provider.name.xiaomi": "シャオミ",
-
   // Prompt placeholders
   "tui.prompt.placeholder.normal": '何でも聞いてください... "{{example}}"',
   "tui.prompt.placeholder.shell": 'コマンドを実行... "{{example}}"',
@@ -267,7 +264,6 @@ export const dict = {
   "tui.consent.revoked": "無料モデルの同意を取り消しました — 次回利用時に再度同意を求めます",
   "tui.dialog.select.placeholder": "検索",
   "tui.dialog.model.login_hint": "ヒント：モデルを切り替える前に /login でログインしてください",
-  "provider.name.mimo": "MiMo",
   "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 期間限定無料）",
   "tui.dialog.token_plan.title": "Token Plan を購読するか順番待ち",
   "tui.dialog.token_plan.line1":

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -22,9 +22,6 @@ export const dict = {
   "language.th": "ไทย",
   "language.tr": "Türkçe",
 
-  // Provider display names
-  "provider.name.xiaomi": "Сяоми",
-
   // Prompt placeholders
   "tui.prompt.placeholder.normal": 'Спросите что угодно... "{{example}}"',
   "tui.prompt.placeholder.shell": 'Выполните команду... "{{example}}"',
@@ -334,7 +331,6 @@ export const dict = {
   "tui.consent.revoked": "Согласие на бесплатную модель отозвано — потребуется принять снова",
   "tui.dialog.select.placeholder": "Поиск",
   "tui.dialog.model.login_hint": "Подсказка: выполните /login для входа перед сменой модели",
-  "provider.name.mimo": "MiMo",
   "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, временно бесплатно)",
   "tui.dialog.token_plan.title": "Оформите Token Plan или подождите в очереди",
   "tui.dialog.token_plan.line1":

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -22,9 +22,6 @@ export const dict = {
   "language.th": "ไทย",
   "language.tr": "Türkçe",
 
-  // Provider display names
-  "provider.name.xiaomi": "小米",
-
   // Prompt placeholders
   "tui.prompt.placeholder.normal": "输入消息...(输入/唤起命令)",
   "tui.prompt.placeholder.shell": '执行命令…… "{{example}}"',
@@ -253,7 +250,6 @@ export const dict = {
   "tui.consent.revoked": "已撤销免费模型协议 — 下次使用时将再次请求同意",
   "tui.dialog.select.placeholder": "搜索",
   "tui.dialog.model.login_hint": "提示：先 /login 登录再切换模型",
-  "provider.name.mimo": "MiMo",
   "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 限免中）",
   "tui.dialog.token_plan.title": "订阅token plan或排队等待",
   "tui.dialog.token_plan.line1": "免费模式下当前需要排队等待，如果想要稳定获取高质量服务，",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -22,9 +22,6 @@ export const dict = {
   "language.th": "ไทย",
   "language.tr": "Türkçe",
 
-  // Provider display names
-  "provider.name.xiaomi": "小米",
-
   // Prompt placeholders
   "tui.prompt.placeholder.normal": '問點什麼…… "{{example}}"',
   "tui.prompt.placeholder.shell": '執行指令…… "{{example}}"',
@@ -253,7 +250,6 @@ export const dict = {
   "tui.consent.revoked": "已撤銷免費模型協議 — 下次使用時將再次請求同意",
   "tui.dialog.select.placeholder": "搜尋",
   "tui.dialog.model.login_hint": "提示：先 /login 登入再切換模型",
-  "provider.name.mimo": "MiMo",
   "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 限免中）",
   "tui.dialog.token_plan.title": "訂閱token plan或排隊等待",
   "tui.dialog.token_plan.line1": "免費模式下目前需要排隊等待，若想穩定取得高品質服務，",


### PR DESCRIPTION
## Summary / 概述

- Remove `provider.name.xiaomi` and `provider.name.mimo` i18n translations — provider list is displayed in English, no need for localization
- Hide provider label in prompt for mimo-auto to avoid redundancy with model name
- Pin mimo-free and xiaomi provider at the top of model picker (after favorites/recent)
- Hide provider description for mimo-auto in favorites/recent sections
- Unify Ctrl+A with `/connect`: pressing Ctrl+A in the model dialog now opens `DialogMimoLogin` (same as `/connect`) instead of the bare `DialogProvider`, so users get the MiMo OAuth login and Claude Code import entries; button title fixed to "Connect provider"
- Scoped model picker (e.g. after connecting a provider) now shows only that provider's own models; the free mimo-auto (owned by the `mimo` provider) is no longer prepended into the xiaomi-scoped view — it remains pinned in the unscoped picker

---

- 移除 `provider.name.xiaomi` 和 `provider.name.mimo` 的 i18n 翻译 — Provider 列表统一显示英文，不需要本地化
- 在主界面隐藏 mimo-auto 的 provider 标签，避免与模型名重复显示
- 在模型选择器中置顶 mimo-free 和 xiaomi provider（在收藏/最近之后）
- 在收藏/最近部分隐藏 mimo-auto 的 provider 描述
- 统一 Ctrl+A 与 `/connect`：在模型对话框中按 Ctrl+A 现在打开 `DialogMimoLogin`（与 `/connect` 一致），不再是裸的 `DialogProvider`，用户可直接使用小米 OAuth 登录和 Claude Code 导入入口；按钮标题固定为 "Connect provider"
- Scoped 模型选择器（如连接某 provider 之后进入）现在只显示该 provider 自己的模型；免费的 mimo-auto（归属 `mimo` provider）不再被 prepend 进 xiaomi-scoped 视图 — 它仍在非 scoped 的选择器中置顶显示

## Motivation / 动机

PR #1241 introduced `provider.name.xiaomi` translations (小米/シャオミ/Сяоми) which are unnecessary — the provider list is displayed in English consistently, so these translations were never actually shown. The `provider.name.mimo` translation was used to shorten the display name, but this can be handled more cleanly with UI logic.

The mimo-free model name already contains "MiMo", so showing the provider label/description next to it is redundant.

Previously Ctrl+A and `/connect` led to two different dialogs (`DialogProvider` vs `DialogMimoLogin`) despite both meaning "connect a provider", which was confusing. They now share the same path.

The old code special-cased the xiaomi-scoped picker to prepend mimo-auto, which actually belongs to a *different* provider (`mimo`). Showing a cross-provider model inside a view scoped to "the provider you just connected" is itself confusing, so scoped views now consistently show only their own provider's models. A comment documents this so the prepend hack is not re-added as a perceived bug fix.

PR #1241 引入了 `provider.name.xiaomi` 翻译（小米/シャオミ/Сяоми），这是不必要的 — Provider 列表统一显示英文，这些翻译实际上不会被展示。`provider.name.mimo` 翻译用于缩短显示名称，但可以通过 UI 逻辑更优雅地处理。

mimo-auto 的模型名已经包含 "MiMo"，在旁边显示 provider 标签/描述是冗余的。

此前 Ctrl+A 和 `/connect` 虽然语义都是"连接 provider"，却分别打开两个不同的对话框（`DialogProvider` 与 `DialogMimoLogin`），容易让人困惑。现已统一走同一路径。

旧代码对 xiaomi-scoped 选择器做了特例处理，把 mimo-auto prepend 进去 — 而它实际归属于*另一个* provider（`mimo`）。在一个 scoped 到"你刚连接的 provider"的视图里展示跨 provider 的模型本身就令人困惑，因此 scoped 视图现在一致地只显示自己 provider 的模型。代码中加了注释说明，避免后人把这个 prepend hack 当成 bug 修复重新加回。