### PR TITLE
fix: handle EEXIST in mkdir for OneDrive-synced .git/info on Windows

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -44,7 +44,13 @@ async function setupProjectIdEnvironment(workingDir: string): Promise<void> {
 
   // Belt-and-suspenders: ensure .git/info/exclude lists .mimocode-project-id
   const excludeFile = nodePath.join(mainGit, "info", "exclude")
-  await nodeFs.mkdir(nodePath.dirname(excludeFile), { recursive: true })
+  await nodeFs
+    .mkdir(nodePath.dirname(excludeFile), { recursive: true })
+    .catch((e: any) => {
+      // Windows: EEXIST is thrown when the directory has the ReadOnly
+      // attribute (e.g. OneDrive-synced folders). nodejs#43994.
+      if (e?.code !== "EEXIST") throw e
+    })
   const existing = await nodeFs.readFile(excludeFile, "utf-8").catch(() => "")
   if (!existing.includes(".mimocode-project-id")) {
     await nodeFs.appendFile(excludeFile, "\n.mimocode-project-id\n")


### PR DESCRIPTION
On Windows, `mkdir` with `{recursive: true}` throws `EEXIST` when the target directory has the ReadOnly NTFS attribute (commonly set by OneDrive on synced folders). This is a known libuv/Node.js issue (nodejs#43994).

Catch and suppress `EEXIST` in `setupProjectIdEnvironment` so MiMo Code can start in OneDrive-synced Git repositories.

Closes: #721