### PR TITLE
fix(tui): fix paste & autocomplete corruption with CJK (Chinese) input

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete-detect.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete-detect.ts
@@ -1,0 +1,34 @@
+import { stringIndexToWidth, widthToStringIndex } from "./offset"
+
+export type TriggerKind = "@" | "$" | "/"
+
+// Decide whether an autocomplete popup should open for the current input.
+//
+// `value` is the editor plainText (UTF-16) and `cursorWidth` is the editor's
+// display-width cursor offset (CJK = 2 columns). We convert the cursor to a
+// UTF-16 index before doing any string work, then report the trigger position
+// back in width coordinates so it matches the editor's extmark/cursor space.
+export function detectTrigger(value: string, cursorWidth: number): { kind: TriggerKind; index: number } | undefined {
+  if (cursorWidth === 0) return undefined
+
+  const cursorIndex = widthToStringIndex(value, cursorWidth)
+
+  // "/" command only when it is the very first character and nothing before the cursor is whitespace.
+  if (value.startsWith("/") && !value.slice(0, cursorIndex).match(/\s/)) {
+    return { kind: "/", index: 0 }
+  }
+
+  // Nearest "@" (files) or "$" (agents) before the cursor with no whitespace in between.
+  const text = value.slice(0, cursorIndex)
+  const idx = Math.max(text.lastIndexOf("@"), text.lastIndexOf("$"))
+  if (idx === -1) return undefined
+
+  const kind: TriggerKind = idx === text.lastIndexOf("$") ? "$" : "@"
+  const before = idx === 0 ? undefined : value[idx - 1]
+  const between = text.slice(idx)
+  if ((before === undefined || /\s/.test(before)) && !between.match(/\s/)) {
+    return { kind, index: stringIndexToWidth(value, idx) }
+  }
+
+  return undefined
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -17,6 +17,8 @@ import { useTerminalDimensions } from "@opentui/solid"
 import { Locale } from "@/util"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
+import { detectTrigger } from "./autocomplete-detect"
+import { widthToStringIndex } from "./offset"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -158,7 +160,7 @@ export function Autocomplete(props: {
     const input = props.input()
     const currentCursorOffset = input.cursorOffset
 
-    const charAfterCursor = props.value.at(currentCursorOffset)
+    const charAfterCursor = props.value.at(widthToStringIndex(props.value, currentCursorOffset))
     const needsSpace = charAfterCursor !== " "
     const append = prefix + text + (needsSpace ? " " : "")
 
@@ -531,32 +533,12 @@ export function Autocomplete(props: {
           return
         }
 
-        // Check if autocomplete should reopen (e.g., after backspace deleted a space)
-        const offset = props.input().cursorOffset
-        if (offset === 0) return
-
-        // Check for "/" at position 0 - reopen slash commands
-        if (value.startsWith("/") && !value.slice(0, offset).match(/\s/)) {
-          show("/")
-          setStore("index", 0)
-          return
-        }
-
-        // Check for "@" (files) or "$" (agents) trigger - find the nearest one before
-        // the cursor with no whitespace between it and the cursor.
-        const text = value.slice(0, offset)
-        const atIdx = text.lastIndexOf("@")
-        const dollarIdx = text.lastIndexOf("$")
-        const idx = Math.max(atIdx, dollarIdx)
-        if (idx === -1) return
-
-        const trigger = idx === dollarIdx ? "$" : "@"
-        const between = text.slice(idx)
-        const before = idx === 0 ? undefined : value[idx - 1]
-        if ((before === undefined || /\s/.test(before)) && !between.match(/\s/)) {
-          show(trigger)
-          setStore("index", idx)
-        }
+        // Check if autocomplete should reopen (e.g., after backspace deleted a space).
+        // detectTrigger works in width coordinates so CJK before/after the trigger stays correct.
+        const trigger = detectTrigger(value, props.input().cursorOffset)
+        if (!trigger) return
+        show(trigger.kind)
+        setStore("index", trigger.index)
       },
       onKeyDown(e: KeyEvent) {
         if (store.visible) {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -18,7 +18,7 @@ import { Locale } from "@/util"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
 import { detectTrigger } from "./autocomplete-detect"
-import { widthToStringIndex } from "./offset"
+import { charAfterCursor } from "./offset"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -160,8 +160,7 @@ export function Autocomplete(props: {
     const input = props.input()
     const currentCursorOffset = input.cursorOffset
 
-    const charAfterCursor = props.value.at(widthToStringIndex(props.value, currentCursorOffset))
-    const needsSpace = charAfterCursor !== " "
+    const needsSpace = charAfterCursor(props.value, currentCursorOffset) !== " "
     const append = prefix + text + (needsSpace ? " " : "")
 
     input.cursorOffset = store.index

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -16,7 +16,7 @@ import { MessageID, PartID } from "@/session/schema"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
 import { usePromptHistory, type PromptInfo } from "./history"
-import { assign } from "./part"
+import { assign, expandPlaceholders } from "./part"
 import { usePromptStash } from "./stash"
 import { DialogStash } from "../dialog-stash"
 import { type AutocompleteRef, Autocomplete } from "./autocomplete"
@@ -1091,23 +1091,20 @@ export function Prompt(props: PromptProps) {
     }
 
     const messageID = MessageID.ascending()
-    let inputText = store.prompt.input
 
-    // Expand pasted text inline before submitting
-    const allExtmarks = input.extmarks.getAllForTypeId(promptPartTypeId)
-    const sortedExtmarks = allExtmarks.sort((a: { start: number }, b: { start: number }) => b.start - a.start)
-
-    for (const extmark of sortedExtmarks) {
-      const partIndex = store.extmarkToPartIndex.get(extmark.id)
-      if (partIndex !== undefined) {
+    // Expand pasted text inline before submitting. Extmark offsets are
+    // display-width based while plainText is UTF-16, so expandPlaceholders
+    // bridges the two coordinate systems (otherwise CJK content desyncs them).
+    const marks = input.extmarks
+      .getAllForTypeId(promptPartTypeId)
+      .flatMap((extmark: { id: number; start: number; end: number }) => {
+        const partIndex = store.extmarkToPartIndex.get(extmark.id)
+        if (partIndex === undefined) return []
         const part = store.prompt.parts[partIndex]
-        if (part?.type === "text" && part.text) {
-          const before = inputText.slice(0, extmark.start)
-          const after = inputText.slice(extmark.end)
-          inputText = before + part.text + after
-        }
-      }
-    }
+        if (part?.type !== "text" || !part.text) return []
+        return [{ start: extmark.start, end: extmark.end, text: part.text }]
+      })
+    const inputText = expandPlaceholders(store.prompt.input, marks)
 
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/offset.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/offset.ts
@@ -1,0 +1,19 @@
+// The editor (@opentui/core) tracks cursor/extmark positions as display-WIDTH
+// offsets: a wide CJK character counts as 2 columns. The plainText we slice in
+// JS is a UTF-16 string where that same character is 1 unit. These helpers
+// translate between the two coordinate systems so the two never get mixed.
+
+export function widthToStringIndex(text: string, widthOffset: number): number {
+  let width = 0
+  let index = 0
+  for (const ch of text) {
+    if (width >= widthOffset) break
+    width += Bun.stringWidth(ch)
+    index += ch.length
+  }
+  return index
+}
+
+export function stringIndexToWidth(text: string, stringIndex: number): number {
+  return Bun.stringWidth(text.slice(0, stringIndex))
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/offset.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/offset.ts
@@ -6,19 +6,36 @@
 // the editor ever emits; an offset landing inside a wide char rounds up to the
 // next boundary.
 
+// The editor advances its offset by 1 for a newline and 2 for a tab, but
+// Bun.stringWidth returns 0 for both, so we special-case them to stay aligned
+// with the editor. (Pasted "\r" never reaches here — paste input is normalized
+// to "\n" and the editor itself maps "\r" to "\n".)
+function charWidth(ch: string): number {
+  if (ch === "\n") return 1
+  if (ch === "\t") return 2
+  return Bun.stringWidth(ch)
+}
+
 export function widthToStringIndex(text: string, widthOffset: number): number {
   let width = 0
   let index = 0
   for (const ch of text) {
     if (width >= widthOffset) break
-    width += Bun.stringWidth(ch)
+    width += charWidth(ch)
     index += ch.length
   }
   return index
 }
 
 export function stringIndexToWidth(text: string, stringIndex: number): number {
-  return Bun.stringWidth(text.slice(0, stringIndex))
+  let width = 0
+  let index = 0
+  for (const ch of text) {
+    if (index >= stringIndex) break
+    width += charWidth(ch)
+    index += ch.length
+  }
+  return width
 }
 
 // The character immediately after a width-based cursor offset, or undefined at

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/offset.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/offset.ts
@@ -2,6 +2,9 @@
 // offsets: a wide CJK character counts as 2 columns. The plainText we slice in
 // JS is a UTF-16 string where that same character is 1 unit. These helpers
 // translate between the two coordinate systems so the two never get mixed.
+// Inputs are assumed to sit on character (code-point) boundaries, which is all
+// the editor ever emits; an offset landing inside a wide char rounds up to the
+// next boundary.
 
 export function widthToStringIndex(text: string, widthOffset: number): number {
   let width = 0
@@ -16,4 +19,10 @@ export function widthToStringIndex(text: string, widthOffset: number): number {
 
 export function stringIndexToWidth(text: string, stringIndex: number): number {
   return Bun.stringWidth(text.slice(0, stringIndex))
+}
+
+// The character immediately after a width-based cursor offset, or undefined at
+// end of input. Used to decide whether an inserted mention needs a trailing space.
+export function charAfterCursor(text: string, cursorWidth: number): string | undefined {
+  return text.at(widthToStringIndex(text, cursorWidth))
 }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/part.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/part.ts
@@ -1,5 +1,6 @@
 import { PartID } from "@/session/schema"
 import type { PromptInfo } from "./history"
+import { widthToStringIndex } from "./offset"
 
 type Item = PromptInfo["parts"][number]
 
@@ -16,19 +17,8 @@ export function assign(part: Item): Item & { id: PartID } {
 }
 
 // Editor extmark offsets are display-WIDTH based (a wide CJK char counts as 2),
-// while plainText is a JS UTF-16 string (a CJK char is 1 unit). Convert a
-// width offset into the matching UTF-16 string index so .slice lines up.
-function widthToStringIndex(text: string, widthOffset: number): number {
-  let width = 0
-  let index = 0
-  for (const ch of text) {
-    if (width >= widthOffset) break
-    width += Bun.stringWidth(ch)
-    index += ch.length
-  }
-  return index
-}
-
+// while plainText is a JS UTF-16 string (a CJK char is 1 unit). widthToStringIndex
+// converts a width offset into the matching UTF-16 string index so .slice lines up.
 // Replace each placeholder span (given in width-based offsets) in the editor
 // plainText with its real pasted content. Marks are applied right-to-left so
 // earlier offsets stay valid as the string is rewritten.

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/part.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/part.ts
@@ -14,3 +14,33 @@ export function assign(part: Item): Item & { id: PartID } {
     id: PartID.ascending(),
   }
 }
+
+// Editor extmark offsets are display-WIDTH based (a wide CJK char counts as 2),
+// while plainText is a JS UTF-16 string (a CJK char is 1 unit). Convert a
+// width offset into the matching UTF-16 string index so .slice lines up.
+function widthToStringIndex(text: string, widthOffset: number): number {
+  let width = 0
+  let index = 0
+  for (const ch of text) {
+    if (width >= widthOffset) break
+    width += Bun.stringWidth(ch)
+    index += ch.length
+  }
+  return index
+}
+
+// Replace each placeholder span (given in width-based offsets) in the editor
+// plainText with its real pasted content. Marks are applied right-to-left so
+// earlier offsets stay valid as the string is rewritten.
+export function expandPlaceholders(
+  plainText: string,
+  marks: { start: number; end: number; text: string }[],
+): string {
+  return [...marks]
+    .sort((a, b) => b.start - a.start)
+    .reduce((text, mark) => {
+      const start = widthToStringIndex(text, mark.start)
+      const end = widthToStringIndex(text, mark.end)
+      return text.slice(0, start) + mark.text + text.slice(end)
+    }, plainText)
+}

--- a/packages/opencode/test/cli/cmd/tui/autocomplete-detect.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/autocomplete-detect.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import { detectTrigger } from "../../../../src/cli/cmd/tui/component/prompt/autocomplete-detect"
+
+// cursorWidth is the editor's display-width cursor offset (CJK = 2 columns).
+// detectTrigger inspects the plainText and returns the trigger kind plus the
+// trigger's position expressed in the SAME width coordinate (matching store.index),
+// or undefined when nothing should open.
+describe("detectTrigger", () => {
+  test("returns undefined at start of input", () => {
+    expect(detectTrigger("", 0)).toBeUndefined()
+    expect(detectTrigger("@foo", 0)).toBeUndefined()
+  })
+
+  test("detects a leading slash command", () => {
+    expect(detectTrigger("/hel", 4)).toEqual({ kind: "/", index: 0 })
+  })
+
+  test("detects @ trigger in pure ascii", () => {
+    // "hi @fo" cursor at end (width 6)
+    expect(detectTrigger("hi @fo", 6)).toEqual({ kind: "@", index: 3 })
+  })
+
+  test("detects $ trigger in pure ascii", () => {
+    expect(detectTrigger("run $ag", 7)).toEqual({ kind: "$", index: 4 })
+  })
+
+  test("returns width-based index when CJK precedes the trigger", () => {
+    // "你好 @fo" — 你好 width 4, space width 1, so @ sits at width index 5 (string index 3)
+    // cursor at end: width = 5 + 3 = 8
+    expect(detectTrigger("你好 @fo", 8)).toEqual({ kind: "@", index: 5 })
+  })
+
+  test("does not over-read past the cursor when CJK follows the trigger", () => {
+    // "你好 @x尾巴", cursor right after "@x": 你好(4)+space(1)+@x(2) = width 7 (string index 5).
+    // There is no whitespace between @ and the cursor, so it must still trigger,
+    // and must NOT be fooled by the trailing "尾巴" after the cursor.
+    expect(detectTrigger("你好 @x尾巴", 7)).toEqual({ kind: "@", index: 5 })
+  })
+
+  test("does not trigger when whitespace sits between trigger and cursor", () => {
+    // "你 @ x" — @ is preceded by a space (valid start) but a space sits between @ and the cursor.
+    // 你(2)+space(1)+@(1)+space(1)+x(1) = width 6
+    expect(detectTrigger("你 @ x", 6)).toBeUndefined()
+  })
+
+  test("does not trigger when char before @ is non-whitespace", () => {
+    // "a@fo" — '@' is glued to 'a', not a fresh mention
+    expect(detectTrigger("a@fo", 4)).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/cli/cmd/tui/autocomplete-detect.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/autocomplete-detect.test.ts
@@ -30,6 +30,11 @@ describe("detectTrigger", () => {
     expect(detectTrigger("你好 @fo", 8)).toEqual({ kind: "@", index: 5 })
   })
 
+  test("returns width-based index for a $ trigger preceded by CJK", () => {
+    // "你好 $ag" — same geometry as the @ case but for the agent trigger.
+    expect(detectTrigger("你好 $ag", 8)).toEqual({ kind: "$", index: 5 })
+  })
+
   test("does not over-read past the cursor when CJK follows the trigger", () => {
     // "你好 @x尾巴", cursor right after "@x": 你好(4)+space(1)+@x(2) = width 7 (string index 5).
     // There is no whitespace between @ and the cursor, so it must still trigger,

--- a/packages/opencode/test/cli/cmd/tui/offset.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/offset.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test"
-import { stringIndexToWidth, widthToStringIndex } from "../../../../src/cli/cmd/tui/component/prompt/offset"
+import {
+  charAfterCursor,
+  stringIndexToWidth,
+  widthToStringIndex,
+} from "../../../../src/cli/cmd/tui/component/prompt/offset"
 
 // The editor uses display-width offsets (a wide CJK char counts as 2 columns)
 // while plainText is a JS UTF-16 string (a CJK char is 1 unit). These helpers
@@ -24,5 +28,37 @@ describe("offset conversion", () => {
       const width = stringIndexToWidth(text, i)
       expect(widthToStringIndex(text, width)).toBe(i)
     }
+  })
+
+  test("round-trips across supplementary-plane (emoji) code-point boundaries", () => {
+    // 😀 is one code point but 2 UTF-16 units and display width 2. The converters
+    // are only contracted to agree on real code-point boundaries (the editor never
+    // emits an offset that splits a surrogate pair), so iterate by code point.
+    const text = "a😀好b"
+    let index = 0
+    for (const ch of text) {
+      const width = stringIndexToWidth(text, index)
+      expect(widthToStringIndex(text, width)).toBe(index)
+      index += ch.length
+    }
+  })
+})
+
+describe("charAfterCursor", () => {
+  test("reads the char right after the cursor in pure ascii", () => {
+    // "ab cd", cursor (width 2) sits before the space
+    expect(charAfterCursor("ab cd", 2)).toBe(" ")
+  })
+
+  test("reads the correct char when CJK precedes the cursor", () => {
+    // "你好 x" — cursor after 你好 (width 4) must land on the space, not be shifted
+    // by the width/UTF-16 mismatch.
+    expect(charAfterCursor("你好 x", 4)).toBe(" ")
+    // cursor after "你好 " (width 5) lands on "x"
+    expect(charAfterCursor("你好 x", 5)).toBe("x")
+  })
+
+  test("returns undefined at end of input", () => {
+    expect(charAfterCursor("你好", 4)).toBeUndefined()
   })
 })

--- a/packages/opencode/test/cli/cmd/tui/offset.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/offset.test.ts
@@ -30,6 +30,43 @@ describe("offset conversion", () => {
     }
   })
 
+  test("counts a newline as width 1 (matching the editor, not Bun.stringWidth)", () => {
+    // The editor advances its width offset by 1 per "\n", but Bun.stringWidth("\n")
+    // is 0. The converters must follow the editor, otherwise every newline before an
+    // offset desyncs the two coordinate systems by one.
+    // "你好\n[" — 你好=4, \n=1, so "[" sits at width 5 / string index 3
+    expect(stringIndexToWidth("你好\n[", 3)).toBe(5)
+    expect(widthToStringIndex("你好\n[", 5)).toBe(3)
+  })
+
+  test("round-trips across newlines and CJK together", () => {
+    const text = "你好\n世界\nA"
+    let index = 0
+    for (const ch of text) {
+      const width = stringIndexToWidth(text, index)
+      expect(widthToStringIndex(text, width)).toBe(index)
+      index += ch.length
+    }
+  })
+
+  test("counts a tab as width 2 (matching the editor, not Bun.stringWidth)", () => {
+    // The editor advances its width offset by 2 per "\t", but Bun.stringWidth("\t")
+    // is 0. Pasted code often contains tabs, so the converters must follow the editor.
+    // "ab\tc" — ab=2, \t=2, so "c" sits at width 4 / string index 3
+    expect(stringIndexToWidth("ab\tc", 3)).toBe(4)
+    expect(widthToStringIndex("ab\tc", 4)).toBe(3)
+  })
+
+  test("round-trips across tabs, newlines and CJK together", () => {
+    const text = "你好\t世界\nA\tB"
+    let index = 0
+    for (const ch of text) {
+      const width = stringIndexToWidth(text, index)
+      expect(widthToStringIndex(text, width)).toBe(index)
+      index += ch.length
+    }
+  })
+
   test("round-trips across supplementary-plane (emoji) code-point boundaries", () => {
     // 😀 is one code point but 2 UTF-16 units and display width 2. The converters
     // are only contracted to agree on real code-point boundaries (the editor never

--- a/packages/opencode/test/cli/cmd/tui/offset.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/offset.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { stringIndexToWidth, widthToStringIndex } from "../../../../src/cli/cmd/tui/component/prompt/offset"
+
+// The editor uses display-width offsets (a wide CJK char counts as 2 columns)
+// while plainText is a JS UTF-16 string (a CJK char is 1 unit). These helpers
+// translate between the two coordinate systems.
+describe("offset conversion", () => {
+  test("widthToStringIndex maps a width offset to a UTF-16 index", () => {
+    // "你好" is width 4 but 2 UTF-16 units
+    expect(widthToStringIndex("你好world", 4)).toBe(2)
+    expect(widthToStringIndex("你好world", 6)).toBe(4) // 你好wo
+    expect(widthToStringIndex("hello", 3)).toBe(3) // ascii: width == index
+  })
+
+  test("stringIndexToWidth maps a UTF-16 index to a width offset", () => {
+    expect(stringIndexToWidth("你好world", 2)).toBe(4) // 你好 -> width 4
+    expect(stringIndexToWidth("你好world", 4)).toBe(6) // 你好wo
+    expect(stringIndexToWidth("hello", 3)).toBe(3)
+  })
+
+  test("the two conversions round-trip on character boundaries", () => {
+    const text = "前缀@x后缀"
+    for (let i = 0; i <= text.length; i++) {
+      const width = stringIndexToWidth(text, i)
+      expect(widthToStringIndex(text, width)).toBe(i)
+    }
+  })
+})

--- a/packages/opencode/test/cli/cmd/tui/prompt-part.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-part.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { PromptInfo } from "../../../../src/cli/cmd/tui/component/prompt/history"
-import { assign, strip } from "../../../../src/cli/cmd/tui/component/prompt/part"
+import { assign, expandPlaceholders, strip } from "../../../../src/cli/cmd/tui/component/prompt/part"
 
 describe("prompt part", () => {
   test("strip removes persisted ids from reused file parts", () => {
@@ -43,5 +43,45 @@ describe("prompt part", () => {
       filename: "tiny.png",
       url: "data:image/png;base64,abc",
     })
+  })
+})
+
+describe("expandPlaceholders", () => {
+  // Editor extmark offsets are display-WIDTH based (CJK = 2 columns), while the
+  // plain text is a JS UTF-16 string (CJK = 1 unit). expandPlaceholders must
+  // bridge the two coordinate systems.
+
+  test("expands a single ascii placeholder", () => {
+    const result = expandPlaceholders("[Pasted ~3 lines] ", [
+      { start: 0, end: "[Pasted ~3 lines]".length, text: "line1\nline2\nline3" },
+    ])
+    expect(result).toBe("line1\nline2\nline3 ")
+  })
+
+  test("does not leave residue or swallow content when preceded by CJK", () => {
+    // User typed "你好" (width 4, but string index 2) then pasted.
+    // plainText shown in editor: "你好[Pasted ~3 lines] "
+    // extmark.start is width-based = 4, extmark.end = 4 + 17 = 21
+    const result = expandPlaceholders("你好[Pasted ~3 lines] ", [
+      { start: 4, end: 4 + "[Pasted ~3 lines]".length, text: "line1\nline2\nline3" },
+    ])
+    expect(result).toBe("你好line1\nline2\nline3 ")
+  })
+
+  test("handles multiple placeholders interleaved with CJK", () => {
+    const v1 = "[Pasted ~3 lines]"
+    const v2 = "[Pasted ~2 lines]"
+    // plainText: "你好" + v1 + " " + "世界" + v2 + " " + "末"
+    // widths: 你好=4 -> v1 start 4, end 4+17=21; after v1+space width=18 => 22; 世界=4 => 26; v2 start 26 end 43
+    const plain = `你好${v1} 世界${v2} 末`
+    const result = expandPlaceholders(plain, [
+      { start: 4, end: 4 + v1.length, text: "AAA" },
+      { start: 26, end: 26 + v2.length, text: "BBB" },
+    ])
+    expect(result).toBe("你好AAA 世界BBB 末")
+  })
+
+  test("returns input unchanged when there are no placeholders", () => {
+    expect(expandPlaceholders("你好世界", [])).toBe("你好世界")
   })
 })

--- a/packages/opencode/test/cli/cmd/tui/prompt-part.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-part.test.ts
@@ -81,6 +81,16 @@ describe("expandPlaceholders", () => {
     expect(result).toBe("你好AAA 世界BBB 末")
   })
 
+  test("expands a placeholder that sits on its own line after CJK", () => {
+    const v = "[Pasted ~3 lines]"
+    // User typed CJK on line 1, pasted on line 2, typed CJK on line 3:
+    //   "你好\n" + v + " " + "\n世界"
+    // Editor offsets count "\n" as width 1: 你好=4, \n=5, so the placeholder starts at width 5.
+    const plain = `你好\n${v} \n世界`
+    const result = expandPlaceholders(plain, [{ start: 5, end: 5 + v.length, text: "CONTENT" }])
+    expect(result).toBe("你好\nCONTENT \n世界")
+  })
+
   test("returns input unchanged when there are no placeholders", () => {
     expect(expandPlaceholders("你好世界", [])).toBe("你好世界")
   })


### PR DESCRIPTION
## Summary

Fixes input-corruption bugs in the TUI prompt that share one root cause: mixing the editor's **display-width** offsets with **UTF-16** string indices. The editor (`@opentui/core`) tracks cursor/extmark offsets in display-width units (a wide CJK char = 2 columns, a newline = 1, a tab = 2), while the `plainText` we slice in JS is UTF-16 (a CJK char = 1 unit). Mixing them drifts positions to the right whenever a wide char, newline, or tab precedes the offset.

修复 TUI prompt 输入框的输入错乱，根因相同：**显示宽度坐标** 与 **UTF-16 字符串坐标** 混用。编辑器（`@opentui/core`）的光标 / extmark 偏移量按显示宽度计（一个中文字符 = 2 列，换行 = 1，Tab = 2），而我们在 JS 里 `slice` 的 `plainText` 是 UTF-16 字符串（同一个字符 = 1 个单位）。两者混用，只要偏移量前出现宽字符、换行或 Tab，定位就会右偏。

## Symptoms

- **Paste**: pasting multi-line content collapses to a `[Pasted ~N lines]` placeholder that expands on submit. With CJK text before it, the placeholder prefix was left as residue and trailing content was swallowed. A placeholder sitting on its own line after CJK (e.g. `A\n[Pasted]\nB`) expanded to `A\n[CONTENT\nB` — a stray `[` left behind — because each preceding newline/tab was mis-counted.
- **Autocomplete**: the `@` (files) / `$` (agents) / `/` (commands) trigger detection misaligned when CJK preceded the trigger — wrong filter term, misplaced mention placeholder, and wrong trailing-space decision.

- **粘贴**：粘贴多行内容会折叠成 `[Pasted ~N lines]` 占位符，提交时展开。若粘贴位置前有中文，展开时占位符前缀残留、且吞掉尾部内容。当占位符独占一行且前面有中文（如 `A\n[Pasted]\nB`）时，会展开成 `A\n[CONTENT\nB`——残留一个 `[`，原因是前面的换行 / Tab 被错误计数。
- **自动补全**：`@文件` / `$agent` / `/命令` 的触发检测在前面有中文时错位——过滤词错误、提及占位符错位、尾部空格判断出错。

## Root cause detail

The display-width offset is not simply `Bun.stringWidth(text)`: the editor counts a **newline as width 1** and a **tab as width 2**, but `Bun.stringWidth` returns **0** for both. The converters therefore special-case `"\n"` (1) and `"\t"` (2) so they track the editor exactly (verified char-by-char against `@opentui/core`). Pasted `"\r"` never reaches the converters — paste input is normalized to `"\n"` and the editor itself maps `"\r"` to `"\n"`.

显示宽度偏移并不等于 `Bun.stringWidth(text)`：编辑器把**换行计为宽度 1**、**Tab 计为宽度 2**，而 `Bun.stringWidth` 对两者都返回 **0**。因此换算器对 `"\n"`（1）和 `"\t"`（2）做特判，与编辑器逐字符对齐（已与 `@opentui/core` 逐字符核对）。粘贴的 `"\r"` 不会到达换算器——粘贴入口已归一化为 `"\n"`，且编辑器自身也把 `"\r"` 映射为 `"\n"`。

## Changes

- New `offset.ts` with the shared coordinate converters `widthToStringIndex` / `stringIndexToWidth` / `charAfterCursor`, reused by both fixes; an internal `charWidth` handles the newline/tab special cases.
- `expandPlaceholders()` in `part.ts`, used by `submit()` to expand placeholders in the correct coordinate system.
- Pure `detectTrigger()` in `autocomplete-detect.ts`, wired into `onInput`; and a coordinate fix for `insertPart`'s cursor-char lookup.

- 新增 `offset.ts`，提供两条修复共用的坐标换算函数 `widthToStringIndex` / `stringIndexToWidth` / `charAfterCursor`；内部 `charWidth` 处理换行 / Tab 的特判。
- `part.ts` 新增 `expandPlaceholders()`，`submit()` 改用它在正确坐标系下展开占位符。
- 新增 `autocomplete-detect.ts` 的纯函数 `detectTrigger()`，`onInput` 改用它；并修正 `insertPart` 取光标后字符的坐标。

## Tests

Followed TDD throughout — a failing test reproduced each bug first, then the fix made it pass.

- `offset.test.ts`: both-direction conversion, round-trip (CJK, supplementary-plane emoji, newlines, tabs), and `charAfterCursor`.
- `autocomplete-detect.test.ts`: every `detectTrigger` branch (leading `/`, `@`/`$` ASCII, CJK before/after the trigger, whitespace in between, non-whitespace before).
- `prompt-part.test.ts`: `expandPlaceholders` (single, CJK-preceded, multiple, and a placeholder on its own line after CJK).

`bun test test/cli/cmd/tui/` → **27 passed**; `bun typecheck` clean.

全程 TDD —— 先写失败测试复现每个 bug，再修复使其通过。

- `offset.test.ts`：双向换算、round-trip（中文、emoji 补充平面、换行、Tab）、`charAfterCursor`。
- `autocomplete-detect.test.ts`：`detectTrigger` 的每个分支（行首 `/`、`@`/`$` ASCII、中文在触发符前 / 后、中间有空白、前置非空白）。
- `prompt-part.test.ts`：`expandPlaceholders`（单个、中文前置、多占位符、占位符在中文后独占一行）。

`bun test test/cli/cmd/tui/` → **27 通过**；`bun typecheck` 干净。

## Regression risk

Low. The dominant ASCII single-line path is unchanged — the converters are identity for pure-ASCII input without newlines/tabs, and `detectTrigger` maps 1:1 to the original `onInput` logic. Verified line-by-line by an independent code review with no regressions found.

风险低。ASCII 单行主路径行为不变——换算器对不含换行 / Tab 的纯 ASCII 输入是恒等映射，`detectTrigger` 与原 `onInput` 逻辑 1:1 对应。经独立 code review 逐行核对，未发现回归。