### PR TITLE
docs(compose): remind subagents to cd into worktree when one is used

### DIFF
--- a/packages/opencode/src/skill/compose/.bundle/review/code-reviewer.md
+++ b/packages/opencode/src/skill/compose/.bundle/review/code-reviewer.md
@@ -22,6 +22,10 @@ tool's own description. Use a title like "Review code changes" with this prompt:
 
     ## Git Range to Review
 
+    [If the work was done in an isolated worktree, add a line here: "Run all
+    commands from `<worktree path>` — `cd` there first." Omit this if there's no
+    separate worktree; the current checkout is correct by default.]
+
     **Base:** {BASE_SHA}
     **Head:** {HEAD_SHA}
 
@@ -129,6 +133,9 @@ tool's own description. Use a title like "Review code changes" with this prompt:
 - `{PLAN_OR_REQUIREMENTS}` — what it should do (plan file path, task text, or requirements)
 - `{BASE_SHA}` — starting commit
 - `{HEAD_SHA}` — ending commit
+
+If the work was done in an isolated worktree, also add a `cd <worktree path>`
+instruction to the Git Range section; otherwise the current checkout is correct.
 
 **Reviewer returns:** Strengths, Issues (Critical / Important / Minor), Recommendations, Assessment
 

--- a/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
@@ -52,6 +52,14 @@ This is how each task's spec-compliance review works. It replaces a single
 prose review with intent-grounded implementation and a two-phase, evidence-gated
 verdict.
 
+**Working directory (only if isolated).** Subagents run with fresh context and start
+in the repo root. If `compose:worktree` set up an isolated worktree, the work does NOT
+live there — tell every subagent to `cd` into the worktree first (fill the
+implementer's `Work from:` line, and add the `cd` note the reviewer prompts describe).
+Otherwise there's nothing to do: the current checkout is correct and you can leave
+those lines out. When a worktree IS in use and you forget, a reviewer's `git diff` and
+tests run against the wrong checkout and the verdict is meaningless.
+
 **1. Create and bind a task before dispatching.** Before the implementer runs, create
 a work-item with the `task` tool (`task create "<plan task summary>"`) and capture its
 TID. Dispatch the implementer bound to that task by passing `--task <TID>` on the actor
@@ -65,7 +73,9 @@ implementer prompt's `## Intent (from spec)` block (see `./implementer-prompt.md
 The implementer never reads the spec itself — you hand it exactly the sections its
 task covers, with the scope boundary intact.
 
-**3. Run the spec reviewer in two phases** (see `./spec-reviewer-prompt.md`):
+**3. Run the spec reviewer in two phases** (see `./spec-reviewer-prompt.md`).
+If an isolated worktree is in use, add the `cd <worktree>` instruction to each
+dispatch (see the working-directory note above):
 - **Phase 1:** dispatch with the covered spec section text + `git diff` ONLY. Do NOT
   include the implementer's report — its claims anchor the reviewer toward confirming
   what was reported and away from spotting silent omissions. Phase 1 returns a

--- a/packages/opencode/src/skill/compose/.bundle/subagent/code-quality-reviewer-prompt.md
+++ b/packages/opencode/src/skill/compose/.bundle/subagent/code-quality-reviewer-prompt.md
@@ -15,6 +15,8 @@ tool's own description. Build the prompt from
 - BASE_SHA: [commit before task]
 - HEAD_SHA: [current commit]
 
+If the work was done in an isolated worktree, also tell the reviewer to `cd` there before running git/tests (see `code-reviewer.md`'s Git Range note). Skip this if there's no separate worktree.
+
 **In addition to standard code quality concerns, the reviewer should check:**
 - Does each file have one clear responsibility with a well-defined interface?
 - Are units decomposed so they can be understood and tested independently?

--- a/packages/opencode/src/skill/compose/.bundle/subagent/implementer-prompt.md
+++ b/packages/opencode/src/skill/compose/.bundle/subagent/implementer-prompt.md
@@ -49,7 +49,9 @@ it this prompt:
     5. Self-review (see below)
     6. Report back
 
-    Work from: [directory]
+    [If an isolated worktree was set up for this task, add: "Work from: <worktree
+    path> — `cd` here before running any git, test, or build command." Omit this line
+    entirely if there's no separate worktree; the current checkout is correct.]
 
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.

--- a/packages/opencode/src/skill/compose/.bundle/subagent/spec-reviewer-prompt.md
+++ b/packages/opencode/src/skill/compose/.bundle/subagent/spec-reviewer-prompt.md
@@ -32,6 +32,10 @@ ask for one.
 
 ## Git range to review
 
+[If the work was done in an isolated worktree, add a line here: "Run all commands
+from `<worktree path>` — `cd` there first." Omit this if there's no separate
+worktree; the current checkout is correct by default.]
+
 **Base:** {BASE_SHA}
 **Head:** {HEAD_SHA}
 
@@ -105,7 +109,9 @@ phase-1 re-review after the implementer acts, not here.
 - [Sn · "<claim>"] downgraded: <report's justification> — was: <prior status>
 ~~~
 
-**Placeholders:** `{BASE_SHA}`, `{HEAD_SHA}` — commit range for this task.
+**Placeholders:** `{BASE_SHA}`, `{HEAD_SHA}` — commit range for this task. If an
+isolated worktree was used, also add a `cd <worktree path>` instruction (see the
+note in the Git range section); otherwise the current checkout is correct.
 
 **Reviewer returns:** structured Status + per-claim verdicts. The controller gates on
 this (see `compose:subagent`): the task is not complete while any in-scope claim is


### PR DESCRIPTION
## Summary

The subagent-driven development prompts dispatch implementer and reviewer subagents with **fresh context** that starts in the repo root. When `compose:worktree` has set up an isolated worktree, the reviewers' `git diff` and test commands would run against the wrong checkout — producing a meaningless verdict — because nothing tells the subagent where the work actually lives.

This PR adds an **optional** working-directory instruction across the relevant prompt templates: the controller adds a `cd <worktree>` line only when an isolated worktree is actually in use, and omits it otherwise (the current checkout is correct by default).

> **中文：** subagent 驱动开发的各个 prompt 在派发 implementer / reviewer 子代理时，子代理是**全新上下文**，默认从仓库根目录开始。当 `compose:worktree` 创建了隔离 worktree 时，reviewer 的 `git diff` 和测试命令会跑在错误的 checkout 上，导致评审结论毫无意义——因为没有任何地方告诉子代理实际代码在哪。本 PR 在相关 prompt 模板里加入**可选的**工作目录说明：只有当确实使用了隔离 worktree 时，控制方才追加一行 `cd <worktree>`；否则省略（默认当前 checkout 即正确）。

## Changes

- `subagent/SKILL.md` — added a "Working directory (only if isolated)" note and a conditional `cd` reminder in step 3 of the review gate.
- `subagent/implementer-prompt.md` — `Work from:` line is now conditional on a worktree existing.
- `subagent/spec-reviewer-prompt.md` — optional `cd <worktree>` note in the Git range section + placeholders.
- `subagent/code-quality-reviewer-prompt.md` — optional `cd` reminder in the fill-in list.
- `review/code-reviewer.md` — optional `cd <worktree>` note in the Git Range section + placeholders.

> **中文：** 改动涉及 5 个文件:`subagent/SKILL.md` 新增「工作目录(仅隔离时)」说明及评审环节第 3 步的条件式 `cd` 提醒;`implementer-prompt.md` 的 `Work from:` 行改为「存在 worktree 时才填」;`spec-reviewer-prompt.md` 与 `code-reviewer.md` 在 Git range/diff 区块及占位符处加入可选的 `cd <worktree>` 说明;`code-quality-reviewer-prompt.md` 在填充清单里加入可选 `cd` 提醒。

## Why optional

Most compose runs do not use a separate worktree (the user may decline, or already be on a feature branch in place). Making `WORKTREE_DIR` a mandatory placeholder in every dispatch would clutter the prompts for the common case. The instruction is therefore added only when a worktree truly exists.

> **中文：** 大多数 compose 流程并不使用独立 worktree(用户可能拒绝,或已直接在某个特性分支上工作)。若把 `WORKTREE_DIR` 设成每次派发都必填的占位符,会在常见场景下让 prompt 变得冗余。因此该说明仅在真正存在 worktree 时才追加。

## Verification

Docs-only change to compose skill templates. No code or tests affected; verified by reviewing the diff for consistency across all five files.

> **中文：** 仅修改 compose skill 模板文档,不涉及代码或测试。已通过检查 5 个文件 diff 的一致性完成验证。