### PR TITLE
fix(acp): accept string initialize protocol version

### DIFF
--- a/packages/opencode/src/acp/protocol-version.ts
+++ b/packages/opencode/src/acp/protocol-version.ts
@@ -1,0 +1,38 @@
+import { PROTOCOL_VERSION, type ndJsonStream } from "@agentclientprotocol/sdk"
+
+type ACPStream = ReturnType<typeof ndJsonStream>
+type ACPMessage = ACPStream["readable"] extends ReadableStream<infer Message> ? Message : never
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function normalizeInitializeProtocolVersion<T>(message: T): T {
+  if (!isRecord(message)) return message
+  if (message.method !== "initialize") return message
+
+  const params = message.params
+  if (!isRecord(params)) return message
+  if (typeof params.protocolVersion !== "string") return message
+
+  return {
+    ...message,
+    params: {
+      ...params,
+      protocolVersion: PROTOCOL_VERSION,
+    },
+  } as T
+}
+
+export function normalizeAcpProtocolVersionStream(stream: ACPStream): ACPStream {
+  return {
+    readable: stream.readable.pipeThrough(
+      new TransformStream<ACPMessage, ACPMessage>({
+        transform(message, controller) {
+          controller.enqueue(normalizeInitializeProtocolVersion(message))
+        },
+      }),
+    ),
+    writable: stream.writable,
+  }
+}

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -3,6 +3,7 @@ import { bootstrap } from "../bootstrap"
 import { cmd } from "./cmd"
 import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk"
 import { ACP } from "@/acp/agent"
+import { normalizeAcpProtocolVersionStream } from "@/acp/protocol-version"
 import { Server } from "@/server/server"
 import { createOpencodeClient } from "@mimo-ai/sdk/v2"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
@@ -52,7 +53,7 @@ export const AcpCommand = cmd({
         },
       })
 
-      const stream = ndJsonStream(input, output)
+      const stream = normalizeAcpProtocolVersionStream(ndJsonStream(input, output))
       const agent = await ACP.init({ sdk })
 
       new AgentSideConnection((conn) => {

--- a/packages/opencode/test/acp/protocol-version.test.ts
+++ b/packages/opencode/test/acp/protocol-version.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test"
+import { PROTOCOL_VERSION, type ndJsonStream } from "@agentclientprotocol/sdk"
+import { normalizeAcpProtocolVersionStream, normalizeInitializeProtocolVersion } from "../../src/acp/protocol-version"
+
+type ACPStream = ReturnType<typeof ndJsonStream>
+type ACPMessage = ACPStream["readable"] extends ReadableStream<infer Message> ? Message : never
+
+function createStreamPair() {
+  const clientToAgent = new TransformStream<ACPMessage, ACPMessage>()
+  const agentToClient = new TransformStream<ACPMessage, ACPMessage>()
+
+  return [
+    {
+      readable: agentToClient.readable,
+      writable: clientToAgent.writable,
+    },
+    {
+      readable: clientToAgent.readable,
+      writable: agentToClient.writable,
+    },
+  ] as const
+}
+
+describe("acp protocol version compatibility", () => {
+  test("normalizes string initialize protocolVersion to the SDK protocol version", () => {
+    const message = normalizeInitializeProtocolVersion({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        clientCapabilities: {},
+        clientInfo: { name: "opencLaw", version: "2026.6.9" },
+      },
+    })
+
+    expect(message).toMatchObject({
+      params: {
+        protocolVersion: PROTOCOL_VERSION,
+      },
+    })
+  })
+
+  test("keeps numeric initialize protocolVersion unchanged", () => {
+    const message = normalizeInitializeProtocolVersion({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: 1,
+      },
+    })
+
+    expect(message).toMatchObject({
+      params: {
+        protocolVersion: 1,
+      },
+    })
+  })
+
+  test("normalizes initialize messages flowing into the ACP stream", async () => {
+    const [clientStream, agentStream] = createStreamPair()
+    const normalized = normalizeAcpProtocolVersionStream(agentStream)
+    const writer = clientStream.writable.getWriter()
+    const reader = normalized.readable.getReader()
+
+    await writer.write({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+      },
+    } as ACPMessage)
+
+    const message = await reader.read()
+    expect(message.value).toMatchObject({
+      params: {
+        protocolVersion: PROTOCOL_VERSION,
+      },
+    })
+
+    await writer.close()
+    reader.releaseLock()
+  })
+})


### PR DESCRIPTION
## Summary
- Normalize string ACP initialize `protocolVersion` values before SDK validation
- Preserve numeric protocol versions unchanged
- Add focused coverage for the normalize helper and ACP stream path

Fixes #1294

## Verification
- `bun test test/acp --timeout 30000`
- `bun typecheck`
- `git diff --check`