### PR TITLE
fix(tui): update task glyph when status changes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/task-item.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/task-item.tsx
@@ -20,7 +20,7 @@ export function TaskItem(props: TaskItemProps) {
   const { theme } = useTheme()
   const kv = useKV()
   const running = () => props.status === "in_progress"
-  const glyph =
+  const glyph = () =>
     props.status === "done"
       ? "✓"
       : props.status === "blocked"
@@ -40,7 +40,7 @@ export function TaskItem(props: TaskItemProps) {
         when={running()}
         fallback={
           <text flexShrink={0} style={{ fg: fg() }}>
-            [{glyph}]{" "}
+            [{glyph()}]{" "}
           </text>
         }
       >

--- a/packages/opencode/test/cli/tui/task-item.test.tsx
+++ b/packages/opencode/test/cli/tui/task-item.test.tsx
@@ -1,0 +1,50 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { createSignal } from "solid-js"
+import fs from "fs/promises"
+import path from "path"
+import { TaskItem } from "../../../src/cli/cmd/tui/component/task-item"
+import { KVProvider } from "../../../src/cli/cmd/tui/context/kv"
+import { ThemeProvider } from "../../../src/cli/cmd/tui/context/theme"
+import { TuiConfigProvider } from "../../../src/cli/cmd/tui/context/tui-config"
+import { Global } from "../../../src/global"
+
+async function waitForText(app: { captureCharFrame: () => string; renderOnce: () => Promise<void> }, text: string) {
+  const start = Date.now()
+  while (!app.captureCharFrame().includes(text)) {
+    if (Date.now() - start > 2000) throw new Error(`timed out waiting for ${text}`)
+    await app.renderOnce()
+    await Bun.sleep(10)
+  }
+}
+
+test("TaskItem updates its glyph when status changes to done", async () => {
+  let setStatus!: (status: string) => void
+  await fs.mkdir(Global.Path.state, { recursive: true })
+  await Bun.write(path.join(Global.Path.state, "kv.json"), "{}")
+
+  const App = () => {
+    const [status, updateStatus] = createSignal("open")
+    setStatus = updateStatus
+    return (
+      <TuiConfigProvider config={{}}>
+        <KVProvider>
+          <ThemeProvider mode="dark" plain>
+            <TaskItem id="T1" status={status()} summary="Ship fix" depth={0} />
+          </ThemeProvider>
+        </KVProvider>
+      </TuiConfigProvider>
+    )
+  }
+
+  const app = await testRender(() => <App />, { width: 80, height: 10 })
+  try {
+    await waitForText(app, "[ ] T1 Ship fix")
+    setStatus("done")
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("[✓] T1 Ship fix")
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
## Summary
- make `TaskItem` compute its status glyph reactively so an existing row updates from `[ ]` to `[✓]` after `task.updated` marks it done
- add an OpenTUI regression test that renders a task, changes status from `open` to `done`, and verifies the glyph updates

Fixes #1281

## Tests
- `bun test test/cli/tui/task-item.test.tsx test/cli/tui/slot-replace.test.tsx test/cli/tui/use-event.test.tsx --timeout 30000`
- `bun typecheck`
- `git diff --check`