### PR TITLE
fix(agent): enforce plan mode write restrictions without mutating the tool schema

### DIFF
--- a/docs/compose/plans/2026-06-25-plan-mode-write-restrictions.md
+++ b/docs/compose/plans/2026-06-25-plan-mode-write-restrictions.md
@@ -1,0 +1,438 @@
+# Plan Mode Write Restrictions — Hardened Implementation Plan (v2)
+
+> [!NOTE]
+> This document may not reflect the current implementation.
+> See the final report for up-to-date state:
+> [Final Report](../reports/plan-mode-write-restrictions.md)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use compose:execute to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make plan mode's write restrictions un-bypassable WITHOUT ever removing a tool from the model's schema — deny actual writes at call time, keep every tool present so the tool list never mutates on mode switch (which would invalidate prefix cache and destroy context).
+
+**Architecture:** Add two declarative fields to `Agent.Info`: `hardPermission` (rules re-appended after the user/session merge so they always win) and `subagentToolAllowlist` (read-only toolset forced on any subagent the agent spawns). A single `runtimePermission(agent, sessionPermission)` helper replaces every `Permission.merge(agent.permission, …)` call site. Crucially, plan's hard rules use only `ask` and `deny-with-non-"*"-exception` forms — NEVER a bare `{"*":"deny"}` — because `Permission.disabled()` strips a tool from the schema ONLY when the last-matching rule is exactly `pattern==="*" && action==="deny"`. The persisted-approval bypass (an `always`-approved edit out-ranking plan's `edit:deny`) is closed in the permission `ask` loop (already committed as Task 0).
+
+**Tech Stack:** TypeScript, Effect, Bun test, Zod schema (`Agent.Info`), the existing `Permission` ruleset system.
+
+## Global Constraints
+
+- Run all commands from `packages/opencode` — tests are guarded against running from repo root.
+- Typecheck with `bun typecheck` from `packages/opencode`, never `tsc` directly.
+- **No tool may be removed from the schema in plan mode.** Forbidden: any plan rule of the form `<tool>: "deny"` or `<tool>: { "*": "deny" }` with no later non-`"*"` allow exception. Reference: PR #1207 made plan_enter/plan_exit "always visible" precisely because permission-based hiding caused tool-list mutation. We must not reintroduce that.
+- Verification that a tool stays in the schema = `Permission.disabled([tool], runtimePermission(plan, []))` returns an empty set for that tool.
+- `edit` keeps its existing shape `{ "*": "deny", "<plan-file globs>": "allow" }` — the non-`"*"` allow exception keeps the edit tool in the schema while denying writes to non-plan files at call time.
+- `bash`, `change_directory`, `workflow` → `"ask"` (stays in schema; interactive prompt at call time; headless agents get DeniedError via the existing `interactive:false` path).
+- `task` → NOT restricted (stays `allow`). Plan must be able to spawn subagents (e.g. explore) for research.
+- Plan-spawned subagents are forced read-only via `subagentToolAllowlist = READONLY_TOOLS` — research is allowed, delegated writes are not.
+- No `agent.name === "plan"` / `ctx.agent === "plan"` string checks in src — the restriction is data on the agent definition. (The actor wiring reads `subagentToolAllowlist` off whatever agent is spawning; no name check.)
+- Preserve behavior for non-plan agents (build/compose/general): they have no `hardPermission`, so `runtimePermission` reduces to the old `merge(agent.permission, session)`.
+
+---
+
+## Task 0 (DONE — already committed `83d9b19`): Persisted approval cannot override ruleset deny
+
+`packages/opencode/src/permission/index.ts` ask loop now evaluates the ruleset alone (deny short-circuits) before consulting approvals; approvals only upgrade an `ask` to `allow`. Test added in `test/permission/next.test.ts` (`ask - persisted approval does not override ruleset deny`). This is the genuine root cause of "user edited in plan mode". No further work; listed for context.
+
+---
+
+### Task 1: Agent.Info gains hardPermission + subagentToolAllowlist + runtimePermission helper
+
+**Covers:** Schema + helper foundation for all later tasks
+
+**Files:**
+- Modify: `packages/opencode/src/agent/agent.ts` (Info schema ~L39; add module-level constant + helper after the `Service` class ~L74)
+
+**Interfaces:**
+- Consumes: `Permission.Ruleset.zod`, `Permission.merge`.
+- Produces:
+  - `Info.hardPermission?: Permission.Ruleset` — non-overridable rules.
+  - `Info.subagentToolAllowlist?: string[]` — forced tool allowlist for spawned subagents.
+  - `export const READONLY_TOOLS: string[]` — single source of truth for the read-only toolset.
+  - `export function runtimePermission(agent: Info, permission?: Permission.Ruleset): Permission.Ruleset` = `Permission.merge(agent.permission, permission ?? [], agent.hardPermission ?? [])`.
+
+- [ ] **Step 1: Add schema fields.** In the `Info` zod object, after `permission: Permission.Ruleset.zod,`:
+
+```ts
+    // Non-overridable rules appended AFTER user/session permissions during
+    // runtime evaluation (see runtimePermission). Use for agent invariants that
+    // config must not be able to relax — e.g. plan mode's write restrictions.
+    hardPermission: Permission.Ruleset.zod.optional(),
+    // Tool allowlist forced on any subagent this agent spawns (overrides the
+    // spawned agent's own toolAllowlist / INHERIT). Plan mode uses it to keep
+    // delegated work read-only.
+    subagentToolAllowlist: z.array(z.string()).optional(),
+```
+
+- [ ] **Step 2: Add constant + helper** after `export class Service ...`:
+
+```ts
+// Tools that cannot mutate the workspace. Source of truth for plan mode's
+// subagentToolAllowlist. (Intentionally NOT shared with the explore agent's
+// inline list: explore allows read-only `bash` for shell exploration, which a
+// plan subagent must not have — they are different contracts that happen to
+// overlap.)
+export const READONLY_TOOLS = [
+  "read",
+  "glob",
+  "grep",
+  "list",
+  "webfetch",
+  "websearch",
+  "codesearch",
+  "memory",
+  "history",
+  "lsp",
+]
+
+// Merge an agent's permission with the user/session ruleset, then re-append the
+// agent's hardPermission so those invariants win over any allow rule a user or
+// session approval could introduce. Every permission-evaluation site routes
+// through this — there is no per-agent name special-casing.
+export function runtimePermission(agent: Info, permission?: Permission.Ruleset) {
+  return Permission.merge(agent.permission, permission ?? [], agent.hardPermission ?? [])
+}
+```
+
+- [ ] **Step 3: Typecheck** — `bun typecheck`. Expected: clean (fields optional, helper self-contained).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/opencode/src/agent/agent.ts
+git commit -m "$(cat <<'EOF'
+feat(agent): add hardPermission, subagentToolAllowlist, runtimePermission
+
+Co-authored-by: MiMo-Code <noreply@mimo.xiaomi.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Plan write restrictions as hardPermission — NO tool removed from schema
+
+**Covers:** Bypass paths "bash writes workspace files", "change_directory", "workflow"; keeps `task`/explore usable
+
+**Files:**
+- Modify: `packages/opencode/src/agent/agent.ts` (plan agent block ~L181)
+- Modify: `packages/opencode/test/agent/agent.test.ts` (existing plan test now reads via runtimePermission; add new assertions)
+
+**Interfaces:**
+- Consumes: `Permission.fromConfig`, `Global.Path.data`, `Instance.worktree`, `READONLY_TOOLS`, `runtimePermission`, `Permission.disabled`, `Permission.evaluate`.
+- Produces: plan `Info` with `hardPermission` (edit deny+plan-file allow exceptions; bash/change_directory/workflow → ask; external_directory plan-dir allow) and `subagentToolAllowlist = READONLY_TOOLS`. `task` is intentionally absent → stays `allow`.
+
+- [ ] **Step 1: Rewrite the plan agent block.** The `permission` field keeps only `defaults` + `question:allow` + `user`. Move write rules into `hardPermission`, using ONLY ask / deny-with-exception (no bare `"*":"deny"`):
+
+```ts
+plan: {
+  name: "plan",
+  color: "#c7e2a8",
+  description: "Plan mode. Disallows all edit tools.",
+  options: {},
+  permission: Permission.merge(
+    defaults,
+    Permission.fromConfig({ question: "allow" }),
+    user,
+  ),
+  // Invariants user/session config must not relax. Re-appended after the
+  // user merge by runtimePermission. CRITICAL: every rule here must keep its
+  // tool IN the schema — use "ask" or a deny WITH a non-"*" allow exception.
+  // A bare {"*":"deny"} would strip the tool (Permission.disabled) and mutate
+  // the tool list on mode switch, breaking prefix cache (see PR #1207).
+  hardPermission: Permission.fromConfig({
+    plan_exit: "allow",
+    bash: "ask",
+    change_directory: "ask",
+    workflow: "ask",
+    external_directory: {
+      [path.join(Global.Path.data, "plans", "*")]: "allow",
+    },
+    edit: {
+      "*": "deny",
+      [path.join(".mimocode", "plans", "*.md")]: "allow",
+      [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
+    },
+  }),
+  subagentToolAllowlist: READONLY_TOOLS,
+  mode: "primary",
+  native: true,
+},
+```
+
+- [ ] **Step 2: Update the existing plan test + add new ones.** In `test/agent/agent.test.ts`, replace the existing `test("plan agent denies edits except .mimocode/plans/*", ...)` (it reads `plan!.permission` directly; edit rules now live on `hardPermission`) with this block:
+
+```ts
+test("plan denies edits except plan files (via runtimePermission)", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const rt = Agent.runtimePermission(plan!, [])
+      expect(Permission.evaluate("edit", "*", rt).action).toBe("deny")
+      expect(Permission.evaluate("edit", ".mimocode/plans/foo.md", rt).action).toBe("allow")
+    },
+  })
+})
+
+test("plan keeps every tool in the schema — no tool removed", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const rt = Agent.runtimePermission(plan!, [])
+      // edit/bash/task/change_directory/workflow must all stay visible.
+      expect(
+        Permission.disabled(["edit", "write", "bash", "task", "change_directory", "workflow"], rt),
+      ).toEqual(new Set())
+    },
+  })
+})
+
+test("plan: bash/change_directory/workflow are ask, task stays allow", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const rt = Agent.runtimePermission(plan!, [])
+      expect(Permission.evaluate("bash", "echo x > f", rt).action).toBe("ask")
+      expect(Permission.evaluate("change_directory", "/tmp", rt).action).toBe("ask")
+      expect(Permission.evaluate("workflow", "*", rt).action).toBe("ask")
+      expect(Permission.evaluate("task", "*", rt).action).toBe("allow")
+      expect(plan!.subagentToolAllowlist).toEqual(Agent.READONLY_TOOLS)
+    },
+  })
+})
+
+test("plan hardPermission wins over session/config allow", async () => {
+  await using tmp = await tmpdir({ config: { permission: { bash: "allow", edit: "allow" } } })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const rt = Agent.runtimePermission(plan!, [
+        { permission: "bash", pattern: "*", action: "allow" },
+        { permission: "edit", pattern: "*", action: "allow" },
+      ])
+      expect(Permission.evaluate("edit", "src/file.ts", rt).action).toBe("deny")
+      expect(Permission.evaluate("bash", "echo x > f", rt).action).toBe("ask")
+      // even with config allow, edit tool stays in schema and write still denied
+      expect(Permission.disabled(["edit", "bash"], rt)).toEqual(new Set())
+    },
+  })
+})
+
+test("build agent unaffected — no hardPermission", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const build = await load(tmp.path, (svc) => svc.get("build"))
+      expect(build!.hardPermission).toBeUndefined()
+      const rt = Agent.runtimePermission(build!, [])
+      expect(Permission.evaluate("bash", "echo x", rt).action).not.toBe("deny")
+    },
+  })
+})
+```
+
+Note: the existing `test("plan_enter and plan_exit ... for all primary agents")` (reads `agent.permission` via `Permission.disabled`) still passes — plan_exit:allow is on hardPermission but disabled() only strips on `"*"+deny`, so its absence from `.permission` does not hide it.
+
+- [ ] **Step 3: Run the tests** — `bun test test/agent/agent.test.ts --timeout 30000`. Expected: PASS. The "no tool removed" + "hardPermission wins" tests call `runtimePermission` directly, so they pass before Task 3 wiring.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/opencode/src/agent/agent.ts packages/opencode/test/agent/agent.test.ts
+git commit -m "$(cat <<'EOF'
+feat(agent): plan write restrictions via hardPermission without hiding tools
+
+bash/change_directory/workflow become ask (stay in schema); edit keeps its
+plan-file allow exception; task stays allow so plan can spawn research
+subagents. No bare "*":"deny", so the tool list never mutates on mode switch.
+
+Co-authored-by: MiMo-Code <noreply@mimo.xiaomi.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Route every permission merge through runtimePermission
+
+**Covers:** Applies hardPermission at all five evaluation sites (tool-schema filtering, main tool ask, subtask ask, preapproval, debug)
+
+**Files:**
+- Modify: `packages/opencode/src/session/llm.ts:477` and `:720`
+- Modify: `packages/opencode/src/session/prompt.ts:677` and `:1018`
+- Modify: `packages/opencode/src/cli/cmd/debug/agent.ts:171`
+
+**Interfaces:**
+- Consumes: `Agent.runtimePermission(agent, sessionPermission?)` from Task 1.
+
+- [ ] **Step 1: llm.ts** — switch `import type { Agent }` to value import `import { Agent } from "@/agent/agent"`. Replace L477:
+
+```ts
+const ruleset = Agent.runtimePermission(input.agent, input.permission)
+```
+
+and inside `resolveTools` (~L720):
+
+```ts
+const disabled = Permission.disabled(
+  Object.keys(input.tools),
+  Agent.runtimePermission(input.agent, input.permission),
+)
+```
+
+- [ ] **Step 2: prompt.ts** — `Agent` already imported as value (confirmed at prompt.ts:10). L677:
+
+```ts
+ruleset: Agent.runtimePermission(input.agent, input.session.permission),
+```
+
+L1018:
+
+```ts
+ruleset: Agent.runtimePermission(taskAgent, session.permission),
+```
+
+- [ ] **Step 3: debug/agent.ts** — L171:
+
+```ts
+const ruleset = Agent.runtimePermission(agent, session.permission)
+```
+
+- [ ] **Step 4: Typecheck** — `bun typecheck`. Expected: clean. Fix any `import type` → value-import issue.
+
+- [ ] **Step 5: Run tests** — `bun test test/agent/agent.test.ts test/permission/next.test.ts --timeout 30000`. Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/opencode/src/session/llm.ts packages/opencode/src/session/prompt.ts packages/opencode/src/cli/cmd/debug/agent.ts
+git commit -m "$(cat <<'EOF'
+refactor(session): route permission merges through Agent.runtimePermission
+
+Co-authored-by: MiMo-Code <noreply@mimo.xiaomi.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Plan-spawned subagents inherit the read-only allowlist from agent data
+
+**Covers:** Bypass path "delegate writes to a subagent" — without a name check, and without blocking explore/research
+
+**Files:**
+- Modify: `packages/opencode/src/tool/actor.ts` (spawn `tools:` resolution ~L709)
+- Modify: `packages/opencode/test/tool/actor.test.ts`
+
+**Interfaces:**
+- Consumes: `Agent.Service` (already resolved as `const agent = yield* Agent.Service` at actor.ts:268), `ctx.agent` (spawning agent name), `Info.subagentToolAllowlist`.
+- Produces: spawn `tools` = spawning agent's `subagentToolAllowlist` if set, else spawned agent's `toolAllowlist`, else `"INHERIT"`.
+
+- [ ] **Step 1: Resolve the spawning agent's allowlist** before the `actor.spawn({…})` call (~L702):
+
+```ts
+const parentAgent = ctx.agent ? yield* agent.get(ctx.agent) : undefined
+const forcedSubagentTools = parentAgent?.subagentToolAllowlist
+```
+
+- [ ] **Step 2: Use it in the spawn `tools` field** (~L709), replacing the existing line:
+
+```ts
+tools: forcedSubagentTools
+  ? [...forcedSubagentTools]
+  : next.toolAllowlist
+    ? [...next.toolAllowlist]
+    : "INHERIT",
+```
+
+- [ ] **Step 3: Add the test** in `test/tool/actor.test.ts`, inside `describe("tool.actor", …)`. (Confirm `import { Agent } from "../../src/agent/agent"` is present; add if missing.)
+
+```ts
+it.live("plan agent spawns subagents with the read-only allowlist", () =>
+  provideTmpdirInstance(() =>
+    Effect.gen(function* () {
+      const spawns: SpawnInput[] = []
+      yield* installMockSpawn((input) => spawns.push(input))
+      const { chat, assistant } = yield* seed()
+      const tool = yield* ActorTool
+      const def = yield* tool.init()
+      yield* def.execute(
+        {
+          operation: {
+            action: "run",
+            description: "research",
+            prompt: "investigate without changing files",
+            subagent_type: "explore",
+          },
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "plan",
+          abort: new AbortController().signal,
+          extra: {},
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+      expect(spawns[0]?.tools).toEqual(Agent.READONLY_TOOLS)
+    }),
+  ),
+)
+```
+
+- [ ] **Step 4: Run the test** — `bun test test/tool/actor.test.ts --timeout 30000`. Expected: PASS. If the `subagent_type: "explore"` enum is rejected by validation, fall back to `"general"` (the assertion is about the forced allowlist, not the agent type).
+
+- [ ] **Step 5: Typecheck** — `bun typecheck`. Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/opencode/src/tool/actor.ts packages/opencode/test/tool/actor.test.ts
+git commit -m "$(cat <<'EOF'
+feat(actor): plan subagents inherit read-only allowlist from agent data
+
+Plan can still spawn explore/general for research, but the spawned subagent
+is constrained to READONLY_TOOLS so writes can't be delegated. Driven by the
+spawning agent's subagentToolAllowlist field — no agent-name check.
+
+Co-authored-by: MiMo-Code <noreply@mimo.xiaomi.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Full verification sweep
+
+**Covers:** Final gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Relevant test run** — `bun test test/agent/agent.test.ts test/permission/next.test.ts test/tool/actor.test.ts --timeout 30000`. Expected: all PASS.
+
+- [ ] **Step 2: Typecheck** — `bun typecheck`. Expected: clean.
+
+- [ ] **Step 3: No-tool-removed audit** — confirm no plan rule strips a tool: re-read the `hardPermission` block; assert every entry is `allow`, `ask`, or a deny carrying a non-`"*"` allow exception. The `test("plan keeps every tool in the schema")` from Task 2 is the automated guard.
+
+- [ ] **Step 4: No name-check audit** — grep `agent.name === "plan"` and `ctx.agent === "plan"` in `src/` → expect zero matches.
+
+- [ ] **Step 5: Diff hygiene** — `git diff --check` (no whitespace errors).
+
+---
+
+## Why this is better than PR #1301
+
+PR #1301 sets `bash/task/workflow/change_directory: "deny"` (bare `"*":"deny"`). That has two real defects:
+
+1. **Tool-list mutation / prefix-cache invalidation.** A bare `"*":"deny"` makes `Permission.disabled()` strip the tool from the model's schema. Switching into plan mode then removes bash/task/workflow/change_directory from the tool list mid-conversation — exactly the instability PR #1207 fixed for plan_enter/plan_exit. This plan keeps every tool present (ask / deny-with-exception only).
+2. **Plan can't do research.** `task: "deny"` blocks spawning explore/general subagents. This plan keeps `task` allowed and instead forces spawned subagents read-only via `subagentToolAllowlist`, so plan-mode research works while delegated writes are blocked.
+
+Plus the shared improvements: data-driven `hardPermission` (no `=== "plan"` string checks), single `runtimePermission` helper at every site, and the genuine root-cause fix (persisted approval no longer overrides deny, Task 0).

--- a/docs/compose/reports/plan-mode-write-restrictions.md
+++ b/docs/compose/reports/plan-mode-write-restrictions.md
@@ -1,0 +1,142 @@
+---
+feature: plan-mode-write-restrictions
+status: delivered
+specs: []
+plans:
+  - docs/compose/plans/2026-06-25-plan-mode-write-restrictions.md
+branch: fix/plan-mode-write-restrictions
+commits: 83d9b19..17b5c0b
+---
+
+# Plan Mode Write Restrictions — Final Report
+
+## What Was Built
+
+Plan mode now enforces its read-only intent at the permission layer without ever
+removing a tool from the model's schema. Writes are blocked at call time (edit to
+non-plan files is denied; `bash`, `change_directory`, and `workflow` require
+confirmation), while every tool stays present in the tool list so switching into
+plan mode mid-session does not mutate the schema and invalidate the model's
+prefix cache. Plan can still spawn research subagents (e.g. `explore`), but those
+subagents are forced read-only so writes cannot be delegated around the
+restriction.
+
+The restriction is expressed declaratively as data on the plan agent definition
+(`hardPermission` + `subagentToolAllowlist`), not as scattered
+`agent.name === "plan"` runtime checks. A single `runtimePermission` helper applies
+these invariants at every permission-evaluation site. Separately, a real
+root-cause bug was fixed: a persisted "always" approval (e.g. an edit approved in
+build mode) could out-rank plan's `edit:deny` and leak a write through — approvals
+can now only upgrade an `ask`, never override a `deny`.
+
+## Architecture
+
+Three layers cooperate:
+
+1. **`Agent.Info` data fields** (`src/agent/agent.ts`):
+   - `hardPermission?: Permission.Ruleset` — rules re-appended *after* the
+     user/session merge so they always win.
+   - `subagentToolAllowlist?: string[]` — tool allowlist forced on any subagent
+     this agent spawns.
+   - `READONLY_TOOLS` — exported constant, the read-only toolset plan forces on
+     its subagents.
+
+2. **`runtimePermission(agent, sessionPermission)`** (`src/agent/agent.ts`):
+   `Permission.merge(agent.permission, sessionPermission ?? [], agent.hardPermission ?? [])`.
+   Every evaluation site routes through it — `session/llm.ts` (×2: preapproval +
+   `resolveTools` schema filtering), `session/prompt.ts` (×2: main tool ask +
+   subtask ask), `cli/cmd/debug/agent.ts`. No agent-name special-casing anywhere.
+
+3. **Permission evaluation** (`src/permission/index.ts`): the `ask` loop evaluates
+   the ruleset alone first — an explicit `deny` short-circuits before persisted
+   approvals are consulted; approvals can only turn an `ask` into `allow`.
+
+Plan's `hardPermission`:
+```
+plan_exit: "allow"
+bash: "ask"
+change_directory: "ask"
+workflow: "ask"
+external_directory: { <data>/plans/*: "allow" }
+edit: { "*": "deny", ".mimocode/plans/*.md": "allow", <data>/plans/*.md: "allow" }
+```
+`task` is intentionally left at the inherited `allow`. Subagent containment is
+handled in `src/tool/actor.ts`: before spawning, it reads
+`subagentToolAllowlist` off the spawning agent and forces it onto the child.
+
+### Design Decisions
+
+- **Never use a bare `{"*":"deny"}` for a plan-restricted tool.** `Permission.disabled()`
+  strips a tool from the model schema *only* when the last-matching rule is exactly
+  `pattern==="*" && action==="deny"`. A bare deny on `bash`/`task`/etc. would remove
+  those tools from the list when entering plan mode — the exact prefix-cache
+  instability PR #1207 fixed for `plan_enter`/`plan_exit`. So restricted tools use
+  `"ask"` (stays visible, prompts at call time, headless agents get `DeniedError`
+  via the existing `interactive:false` path) or a `deny` carrying a non-`"*"` allow
+  exception (`edit`, which keeps the plan-file allow).
+- **`task` stays allowed; subagents are constrained instead.** Plan mode's main use
+  is research, which needs `explore`/`general` subagents. Denying `task` would block
+  that. Forcing spawned subagents to `READONLY_TOOLS` keeps research working while
+  preventing delegated writes.
+- **`READONLY_TOOLS` is deliberately separate from the `explore` agent's inline tool
+  list.** They overlap but mean different things — `explore` permits read-only
+  `bash` for shell exploration, which a plan subagent must not have. Merging them
+  would be a wrong abstraction.
+- **Data-driven invariants over name checks.** Any future restricted agent declares
+  its own `hardPermission`/`subagentToolAllowlist`; `runtimePermission` and the actor
+  wiring stay generic.
+
+## Usage
+
+No configuration surface. Entering plan mode (`plan_enter`) applies the restrictions
+automatically; `plan_exit` returns to build. In plan mode:
+- Reads, search, research subagents: work normally.
+- Editing a plan file (`.mimocode/plans/*.md`, `<data>/plans/*.md`): allowed.
+- Editing any other file: denied at call time.
+- `bash` / `change_directory` / `workflow`: prompt for confirmation interactively;
+  auto-denied for non-interactive (headless) agents.
+- Spawned subagents: limited to `READONLY_TOOLS`.
+
+User/session config cannot relax these — `hardPermission` is applied last.
+
+## Verification
+
+139 tests pass across `test/agent/agent.test.ts`, `test/permission/next.test.ts`,
+`test/tool/actor.test.ts`; `bun typecheck` clean. Key coverage:
+
+- Persisted approval cannot override ruleset deny (`next.test.ts`).
+- Plan denies edits except plan files; `bash`/`change_directory`/`workflow` resolve
+  to `ask`; `task` stays `allow`; `hardPermission` wins over config/session allow;
+  build agent unaffected (`agent.test.ts`).
+- **Prefix-cache stability guard**: enumerates the real registered tool universe and
+  asserts every primary agent strips the same set as build via
+  `Permission.disabled(runtimePermission(agent))`. Manually verified to FAIL when
+  plan's `bash:"ask"` is regressed to `bash:"deny"` — so it catches any future bare
+  deny that would mutate the tool list.
+- Plan-spawned subagent receives exactly `READONLY_TOOLS` (`actor.test.ts`).
+
+## Journey Log
+
+> Brief notes on what informed the final design. Not required reading.
+
+- [pivot] First implementation (mirroring third-party PR #1301) used bare
+  `bash/task/workflow/change_directory: "deny"`. Caught in review: that strips tools
+  from the schema → tool-list mutation on mode switch → prefix-cache invalidation,
+  and `task:"deny"` blocks plan from spawning research subagents. Reworked to
+  `ask` + read-only subagent allowlist.
+- [lesson] A tool only disappears from the model schema under `{"*":"deny"}`; `"ask"`
+  or a deny-with-exception keeps it visible. This is the lever for "restricted but
+  present". (See PR #1207, which made plan_enter/plan_exit always-visible for the
+  same reason.)
+- [lesson] The user-reported "edited in plan mode via edit" was NOT a missing rule —
+  it was persisted approvals being flattened into the ruleset and out-ranking deny
+  via `findLast`. The genuine root cause was in the approval evaluation order.
+- [lesson] Prefer a data-driven invariant test (enumerate all primary agents, assert
+  identical stripped set) over a hardcoded per-tool assertion — it generalizes to any
+  future agent and any future tool without maintenance.
+
+## Source Materials
+
+| File | Role | Notes |
+|------|------|-------|
+| `docs/compose/plans/2026-06-25-plan-mode-write-restrictions.md` | Implementation plan (v2) | Complete; v1 approach recorded in its "Why better than #1301" section |

--- a/docs/compose/reports/plan-mode-write-restrictions.md
+++ b/docs/compose/reports/plan-mode-write-restrictions.md
@@ -39,7 +39,14 @@ Three layers cooperate:
    - `subagentToolAllowlist?: string[]` — tool allowlist forced on any subagent
      this agent spawns.
    - `READONLY_TOOLS` — exported constant, the read-only toolset plan forces on
-     its subagents.
+     its subagents: `read, glob, grep, webfetch, memory, history`. Only tools
+     that are *unconditionally* in the default registry are listed. Gated tools
+     are deliberately excluded — `websearch`/`codesearch` register only for
+     opencode/xiaomi providers or under `MIMOCODE_ENABLE_EXA`, and `lsp` only
+     under `MIMOCODE_EXPERIMENTAL_LSP_TOOL`; in the default environment they're
+     absent, so allowing them would hand a subagent a non-existent tool name.
+     (`list` is not a real tool id.) A subset-guard test asserts every entry
+     resolves in the real registry, so the list fails loudly on drift.
 
 2. **`runtimePermission(agent, sessionPermission)`** (`src/agent/agent.ts`):
    `Permission.merge(agent.permission, sessionPermission ?? [], agent.hardPermission ?? [])`.
@@ -101,7 +108,7 @@ User/session config cannot relax these — `hardPermission` is applied last.
 
 ## Verification
 
-139 tests pass across `test/agent/agent.test.ts`, `test/permission/next.test.ts`,
+140 tests pass across `test/agent/agent.test.ts`, `test/permission/next.test.ts`,
 `test/tool/actor.test.ts`; `bun typecheck` clean. Key coverage:
 
 - Persisted approval cannot override ruleset deny (`next.test.ts`).
@@ -113,6 +120,10 @@ User/session config cannot relax these — `hardPermission` is applied last.
   `Permission.disabled(runtimePermission(agent))`. Manually verified to FAIL when
   plan's `bash:"ask"` is regressed to `bash:"deny"` — so it catches any future bare
   deny that would mutate the tool list.
+- **`READONLY_TOOLS` ⊆ registry guard** (`agent.test.ts`): asserts every entry
+  resolves to a real registered tool for the build agent. This caught three stale
+  entries during review (`list` never existed; `websearch`/`codesearch`/`lsp` are
+  gated and absent by default) — they were removed.
 - Plan-spawned subagent receives exactly `READONLY_TOOLS` (`actor.test.ts`).
 
 ## Journey Log

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -189,17 +189,32 @@ export const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 question: "allow",
-                external_directory: {
-                  [path.join(Global.Path.data, "plans", "*")]: "allow",
-                },
-                edit: {
-                  "*": "deny",
-                  [path.join(".mimocode", "plans", "*.md")]: "allow",
-                  [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
-                },
               }),
               user,
             ),
+            // Invariants user/session config must not relax. Re-appended after
+            // the user merge by runtimePermission. CRITICAL: every rule here
+            // must keep its tool IN the schema — use "ask" or a deny WITH a
+            // non-"*" allow exception. A bare {"*":"deny"} would strip the tool
+            // (Permission.disabled) and mutate the tool list on mode switch,
+            // breaking prefix cache (see PR #1207). task is intentionally left
+            // at allow so plan can spawn research subagents (constrained to
+            // read-only via subagentToolAllowlist below).
+            hardPermission: Permission.fromConfig({
+              plan_exit: "allow",
+              bash: "ask",
+              change_directory: "ask",
+              workflow: "ask",
+              external_directory: {
+                [path.join(Global.Path.data, "plans", "*")]: "allow",
+              },
+              edit: {
+                "*": "deny",
+                [path.join(".mimocode", "plans", "*.md")]: "allow",
+                [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
+              },
+            }),
+            subagentToolAllowlist: READONLY_TOOLS,
             mode: "primary",
             native: true,
           },

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -37,6 +37,14 @@ export const Info = z
     temperature: z.number().optional(),
     color: z.string().optional(),
     permission: Permission.Ruleset.zod,
+    // Non-overridable rules appended AFTER user/session permissions during
+    // runtime evaluation (see runtimePermission). Use for agent invariants that
+    // config must not be able to relax — e.g. plan mode's write restrictions.
+    hardPermission: Permission.Ruleset.zod.optional(),
+    // Tool allowlist forced on any subagent this agent spawns (overrides the
+    // spawned agent's own toolAllowlist / INHERIT). Plan mode uses it to keep
+    // delegated work read-only.
+    subagentToolAllowlist: z.array(z.string()).optional(),
     model: z
       .object({
         modelID: ModelID.zod,
@@ -72,6 +80,32 @@ export interface Interface {
 type State = Omit<Interface, "generate">
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Agent") {}
+
+// Tools that cannot mutate the workspace. Source of truth for plan mode's
+// subagentToolAllowlist. (Intentionally NOT shared with the explore agent's
+// inline list: explore allows read-only `bash` for shell exploration, which a
+// plan subagent must not have — they are different contracts that happen to
+// overlap.)
+export const READONLY_TOOLS = [
+  "read",
+  "glob",
+  "grep",
+  "list",
+  "webfetch",
+  "websearch",
+  "codesearch",
+  "memory",
+  "history",
+  "lsp",
+]
+
+// Merge an agent's permission with the user/session ruleset, then re-append the
+// agent's hardPermission so those invariants win over any allow rule a user or
+// session approval could introduce. Every permission-evaluation site routes
+// through this — there is no per-agent name special-casing.
+export function runtimePermission(agent: Info, permission?: Permission.Ruleset) {
+  return Permission.merge(agent.permission, permission ?? [], agent.hardPermission ?? [])
+}
 
 export const layer = Layer.effect(
   Service,

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -82,22 +82,17 @@ type State = Omit<Interface, "generate">
 export class Service extends Context.Service<Service, Interface>()("@opencode/Agent") {}
 
 // Tools that cannot mutate the workspace. Source of truth for plan mode's
-// subagentToolAllowlist. (Intentionally NOT shared with the explore agent's
-// inline list: explore allows read-only `bash` for shell exploration, which a
-// plan subagent must not have — they are different contracts that happen to
-// overlap.)
-export const READONLY_TOOLS = [
-  "read",
-  "glob",
-  "grep",
-  "list",
-  "webfetch",
-  "websearch",
-  "codesearch",
-  "memory",
-  "history",
-  "lsp",
-]
+// subagentToolAllowlist. Every entry must be a tool that is UNCONDITIONALLY in
+// the default registry (guarded by a subset test). Gated tools are excluded on
+// purpose: websearch/codesearch only register for opencode/xiaomi providers or
+// under MIMOCODE_ENABLE_EXA, and lsp behind MIMOCODE_EXPERIMENTAL_LSP_TOOL — in
+// the default environment they're absent, so allowing them here would just hand
+// a subagent a tool name that doesn't exist. ("list" was never a real
+// tool id.) Add an entry back only if its tool graduates to always-on.
+// (Intentionally NOT shared with the explore agent's inline list: explore
+// allows read-only `bash` for shell exploration, which a plan subagent must not
+// have — different contracts that happen to overlap.)
+export const READONLY_TOOLS = ["read", "glob", "grep", "webfetch", "memory", "history"]
 
 // Merge an agent's permission with the user/session ruleset, then re-append the
 // agent's hardPermission so those invariants win over any allow rule a user or

--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -88,7 +88,7 @@ async function getAvailableTools(agent: Agent.Info) {
 async function resolveTools(agent: Agent.Info, availableTools: Awaited<ReturnType<typeof getAvailableTools>>) {
   const disabled = Permission.disabled(
     availableTools.map((tool) => tool.id),
-    agent.permission,
+    Agent.runtimePermission(agent),
   )
   const resolved: Record<string, boolean> = {}
   for (const tool of availableTools) {

--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -168,7 +168,7 @@ async function createToolContext(agent: Agent.Info) {
     }),
   )
 
-  const ruleset = Permission.merge(agent.permission, session.permission ?? [])
+  const ruleset = Agent.runtimePermission(agent, session.permission)
 
   return {
     sessionID: session.id,

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -187,7 +187,12 @@ export const layer = Layer.effect(
       let needsAsk = false
 
       for (const pattern of request.patterns) {
-        const rule = evaluate(request.permission, pattern, ruleset, approved)
+        // Evaluate the ruleset ALONE first. A persisted "always" approval must
+        // never override an explicit deny — otherwise an edit approved in build
+        // mode would leak through plan mode's `edit: deny`. So deny short-circuits
+        // before approvals are consulted, and approvals can only upgrade an
+        // otherwise-`ask` outcome to allow.
+        const rule = evaluate(request.permission, pattern, ruleset)
         log.info("evaluated", { permission: request.permission, pattern, action: rule })
         if (rule.action === "deny") {
           return yield* new DeniedError({
@@ -195,6 +200,7 @@ export const layer = Layer.effect(
           })
         }
         if (rule.action === "allow") continue
+        if (evaluate(request.permission, pattern, approved).action === "allow") continue
         needsAsk = true
       }
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -9,7 +9,7 @@ import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
 import { ProviderTransform } from "@/provider"
 import { Config } from "@/config"
 import { Instance } from "@/project/instance"
-import type { Agent } from "@/agent/agent"
+import { Agent } from "@/agent/agent"
 import type { MessageV2 } from "./message-v2"
 import { Plugin } from "@/plugin"
 import { SystemPrompt } from "./system"
@@ -474,7 +474,7 @@ const live: Layer.Layer<
           }
         }
 
-        const ruleset = Permission.merge(input.agent.permission ?? [], input.permission ?? [])
+        const ruleset = Agent.runtimePermission(input.agent, input.permission)
         workflowModel.sessionPreapprovedTools = Object.keys(tools).filter((name) => {
           const match = ruleset.findLast((rule) => Wildcard.match(name, rule.permission))
           return !match || match.action !== "ask"
@@ -717,7 +717,7 @@ export const defaultLayer = Layer.suspend(() =>
 function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" | "user">) {
   const disabled = Permission.disabled(
     Object.keys(input.tools),
-    Permission.merge(input.agent.permission, input.permission ?? []),
+    Agent.runtimePermission(input.agent, input.permission),
   )
   return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -674,7 +674,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 ...req,
                 sessionID: input.session.id,
                 tool: { messageID: input.processor.message.id, callID: options.toolCallId },
-                ruleset: Permission.merge(input.agent.permission, input.session.permission ?? []),
+                ruleset: Agent.runtimePermission(input.agent, input.session.permission),
                 // System-spawned background agents (checkpoint-writer, dream, distill)
                 // have no human to answer a permission prompt — fail clean, don't hang.
                 interactive: !SYSTEM_SPAWNED_AGENT_TYPES.has(input.agent.name),
@@ -1015,7 +1015,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               .ask({
                 ...req,
                 sessionID,
-                ruleset: Permission.merge(taskAgent.permission, session.permission ?? []),
+                ruleset: Agent.runtimePermission(taskAgent, session.permission),
               })
               .pipe(Effect.orDie),
         })

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -699,6 +699,11 @@ export const ActorTool = Tool.define(
         // the agent loop, and sending inbox notifications on terminal — replacing
         // the legacy session.create + manual fork path that lived here pre-Task-29.
         const actor = yield* requireActor()
+        // If the spawning agent declares a subagentToolAllowlist (e.g. plan
+        // mode), force it onto the spawned subagent so delegated work cannot
+        // escape the parent's restrictions. Data-driven — no agent-name check.
+        const parentAgent = ctx.agent ? yield* agent.get(ctx.agent) : undefined
+        const forcedSubagentTools = parentAgent?.subagentToolAllowlist
         const spawnResult = yield* actor.spawn({
           mode: "subagent",
           sessionID: ctx.sessionID,
@@ -706,7 +711,11 @@ export const ActorTool = Tool.define(
           description: op.description,
           task: prompt,
           context: op.context ?? "none",
-          tools: next.toolAllowlist ? [...next.toolAllowlist] : "INHERIT",
+          tools: forcedSubagentTools
+            ? [...forcedSubagentTools]
+            : next.toolAllowlist
+              ? [...next.toolAllowlist]
+              : "INHERIT",
           model,
           background,
           task_id: effectiveTaskId,

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -1005,3 +1005,26 @@ itTool.live("plan never strips MORE tools than build under the same session rule
     }),
   ),
 )
+
+// READONLY_TOOLS is a security boundary (the toolset plan forces onto spawned
+// subagents). If a tool is renamed/removed in the registry, a stale entry here
+// would silently hand a subagent a non-existent tool name. Assert the list is a
+// subset of the real registered tool universe so drift fails loudly.
+itTool.live("READONLY_TOOLS are all real registered tools", () =>
+  provideTmpdirInstance((dir) =>
+    Effect.gen(function* () {
+      const agents = yield* Agent.Service
+      const registry = yield* ToolRegistry.Service
+      const build = yield* agents.get("build")
+      const universe = new Set(
+        (yield* registry.tools({
+          modelID: ModelID.make("claude-opus-4-7"),
+          providerID: ProviderID.make("anthropic"),
+          agent: build,
+        })).map((t) => t.id),
+      )
+      const missing = Agent.READONLY_TOOLS.filter((id) => !universe.has(id))
+      expect(missing).toEqual([])
+    }),
+  ),
+)

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -60,17 +60,77 @@ test("build agent has correct default properties", async () => {
   })
 })
 
-test("plan agent denies edits except .mimocode/plans/*", async () => {
+test("plan denies edits except plan files (via runtimePermission)", async () => {
   await using tmp = await tmpdir()
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
       const plan = await load(tmp.path, (svc) => svc.get("plan"))
-      expect(plan).toBeDefined()
-      // Wildcard is denied
-      expect(evalPerm(plan, "edit")).toBe("deny")
-      // But specific path is allowed
-      expect(Permission.evaluate("edit", ".mimocode/plans/foo.md", plan!.permission).action).toBe("allow")
+      const rt = Agent.runtimePermission(plan!, [])
+      expect(Permission.evaluate("edit", "*", rt).action).toBe("deny")
+      expect(Permission.evaluate("edit", ".mimocode/plans/foo.md", rt).action).toBe("allow")
+    },
+  })
+})
+
+test("plan keeps every tool in the schema — no tool removed", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const rt = Agent.runtimePermission(plan!, [])
+      // edit/bash/task/change_directory/workflow must all stay visible.
+      expect(
+        Permission.disabled(["edit", "write", "bash", "task", "change_directory", "workflow"], rt),
+      ).toEqual(new Set())
+    },
+  })
+})
+
+test("plan: bash/change_directory/workflow are ask, task stays allow", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const rt = Agent.runtimePermission(plan!, [])
+      expect(Permission.evaluate("bash", "echo x > f", rt).action).toBe("ask")
+      expect(Permission.evaluate("change_directory", "/tmp", rt).action).toBe("ask")
+      expect(Permission.evaluate("workflow", "*", rt).action).toBe("ask")
+      expect(Permission.evaluate("task", "*", rt).action).toBe("allow")
+      expect(plan!.subagentToolAllowlist).toEqual(Agent.READONLY_TOOLS)
+    },
+  })
+})
+
+test("plan hardPermission wins over session/config allow", async () => {
+  await using tmp = await tmpdir({ config: { permission: { bash: "allow", edit: "allow" } } })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const rt = Agent.runtimePermission(plan!, [
+        { permission: "bash", pattern: "*", action: "allow" },
+        { permission: "edit", pattern: "*", action: "allow" },
+      ])
+      expect(Permission.evaluate("edit", "src/file.ts", rt).action).toBe("deny")
+      expect(Permission.evaluate("bash", "echo x > f", rt).action).toBe("ask")
+      // even with config allow, edit tool stays in schema and write still denied
+      expect(Permission.disabled(["edit", "bash"], rt)).toEqual(new Set())
+    },
+  })
+})
+
+test("build agent unaffected — no hardPermission", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const build = await load(tmp.path, (svc) => svc.get("build"))
+      expect(build!.hardPermission).toBeUndefined()
+      const rt = Agent.runtimePermission(build!, [])
+      expect(Permission.evaluate("bash", "echo x", rt).action).not.toBe("deny")
     },
   })
 })

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -936,3 +936,72 @@ itTool.live("compose's tool list contains apply_patch on GPT-5+ but not on Claud
     }),
   ),
 )
+
+// Prefix-cache stability invariant (general guard).
+//
+// Switching between primary agents (build/plan/compose/...) mid-session must
+// NOT change the set of tools the model sees, or Anthropic's prefix cache for
+// the whole prior conversation is invalidated (see PR #1207, which made
+// plan_enter/plan_exit "always visible" for this exact reason).
+//
+// A tool disappears from the schema only when resolveTools() drops it via
+// Permission.disabled(runtimePermission(agent)) — i.e. when the agent's
+// last-matching rule for that tool is exactly {"*":"deny"}. This test resolves
+// the real registered tool universe and asserts EVERY primary agent strips the
+// SAME set as build. If a future change gives any primary agent a bare
+// "*":"deny" (e.g. someone "hardens" plan by denying bash outright), this fails
+// immediately — no manual audit required.
+itTool.live("all primary agents expose an identical tool schema (prefix-cache stability)", () =>
+  provideTmpdirInstance((dir) =>
+    Effect.gen(function* () {
+      const agents = yield* Agent.Service
+      const registry = yield* ToolRegistry.Service
+      const model = { modelID: ModelID.make("claude-opus-4-7"), providerID: ProviderID.make("anthropic") }
+
+      const build = yield* agents.get("build")
+      const universe = (yield* registry.tools({ ...model, agent: build })).map((t) => t.id)
+      const baseline = Permission.disabled(universe, Agent.runtimePermission(build, []))
+
+      const primaries = (yield* agents.list()).filter((a) => a.mode === "primary" && a.native)
+      expect(primaries.map((a) => a.name)).toContain("plan")
+
+      for (const agent of primaries) {
+        const stripped = Permission.disabled(universe, Agent.runtimePermission(agent, []))
+        expect({ agent: agent.name, stripped: [...stripped].sort() }).toEqual({
+          agent: agent.name,
+          stripped: [...baseline].sort(),
+        })
+      }
+    }),
+  ),
+)
+
+// Same invariant must hold even when user/session config tries to relax or
+// tighten a hard-restricted tool: hardPermission re-application must not turn a
+// "stay visible" rule into a schema-stripping one. A session "*":"deny" on bash
+// would strip it everywhere (that's the user's own choice, applied uniformly),
+// but plan's hardPermission ("ask") must never ADD bash to plan's stripped set
+// relative to build under the same session ruleset.
+itTool.live("plan never strips MORE tools than build under the same session ruleset", () =>
+  provideTmpdirInstance((dir) =>
+    Effect.gen(function* () {
+      const agents = yield* Agent.Service
+      const registry = yield* ToolRegistry.Service
+      const model = { modelID: ModelID.make("claude-opus-4-7"), providerID: ProviderID.make("anthropic") }
+      const session = [
+        { permission: "bash", pattern: "*", action: "allow" as const },
+        { permission: "edit", pattern: "*", action: "allow" as const },
+      ]
+
+      const build = yield* agents.get("build")
+      const plan = yield* agents.get("plan")
+      const universe = (yield* registry.tools({ ...model, agent: build })).map((t) => t.id)
+
+      const buildStripped = Permission.disabled(universe, Agent.runtimePermission(build, session))
+      const planStripped = Permission.disabled(universe, Agent.runtimePermission(plan, session))
+      for (const id of planStripped) {
+        expect(buildStripped.has(id)).toBe(true)
+      }
+    }),
+  ),
+)

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -746,6 +746,38 @@ it.live("reply - always persists approval and resolves", () =>
   }),
 )
 
+it.live("ask - persisted approval does not override ruleset deny", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped({ git: true })
+    const run = withProvided(dir)
+    const fiber = yield* ask({
+      id: PermissionID.make("per_test3_deny"),
+      sessionID: SessionID.make("session_test"),
+      permission: "edit",
+      patterns: ["src/file.ts"],
+      metadata: {},
+      always: ["*"],
+      ruleset: [],
+    }).pipe(run, Effect.forkScoped)
+
+    yield* waitForPending(1).pipe(run)
+    yield* reply({ requestID: PermissionID.make("per_test3_deny"), reply: "always" }).pipe(run)
+    yield* Fiber.join(fiber)
+
+    const err = yield* fail(
+      ask({
+        sessionID: SessionID.make("session_test2"),
+        permission: "edit",
+        patterns: ["src/file.ts"],
+        metadata: {},
+        always: [],
+        ruleset: [{ permission: "edit", pattern: "*", action: "deny" }],
+      }).pipe(run),
+    )
+    expect(err).toBeInstanceOf(Permission.DeniedError)
+  }),
+)
+
 it.live("reply - reject cancels all pending for same session", () =>
   withDir({ git: true }, () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/tool/actor.test.ts
+++ b/packages/opencode/test/tool/actor.test.ts
@@ -281,6 +281,41 @@ describe("tool.actor", () => {
     ),
   )
 
+  it.live("plan agent spawns subagents with the read-only allowlist", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const spawns: SpawnInput[] = []
+        yield* installMockSpawn((input) => spawns.push(input))
+        const { chat, assistant } = yield* seed()
+        const tool = yield* ActorTool
+        const def = yield* tool.init()
+
+        yield* def.execute(
+          {
+            operation: {
+              action: "run",
+              description: "research",
+              prompt: "investigate without changing files",
+              subagent_type: "explore",
+            },
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "plan",
+            abort: new AbortController().signal,
+            extra: {},
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        expect(spawns[0]?.tools).toEqual(Agent.READONLY_TOOLS)
+      }),
+    ),
+  )
+
   it.live("execute asks by default and skips checks when bypassed", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Plan mode now enforces its read-only intent at the permission layer **without ever removing a tool from the model's schema**: writes are blocked at call time (edit to non-plan files denied; `bash`/`change_directory`/`workflow` require confirmation), while every tool stays present so entering plan mode does not mutate the schema and invalidate the prefix cache. Plan can still spawn research subagents (e.g. `explore`), constrained to read-only so writes can't be delegated around the restriction. It also fixes the genuine root cause of the report: a persisted "always" approval (e.g. an edit approved in build mode) could out-rank plan's `edit:deny` and leak a write through.

> Plan 模式现在在权限层强制只读，但**绝不从工具 schema 移除任何工具**：写操作在调用时被拦，所有工具仍保留在列表中，因此切入 plan 不会让工具列表抖动、不会使 prefix cache 失效。Plan 仍可 spawn 只读的调研 subagent。同时修复了真正的根因：build 模式下持久化的 "always" 审批会越过 plan 的 `edit:deny` 泄漏一次写入。

## Relationship to #1301

This PR supersedes the third-party #1301 (which also targeted #870 / #1274). #1301 was directionally correct but had two real defects:

1. **Tool-list mutation / prefix-cache invalidation.** #1301 set `bash/task/workflow/change_directory` to a bare `"*":"deny"`. `Permission.disabled()` strips a tool only when its last-matching rule is exactly `pattern==="*" && action==="deny"`, so entering plan mode removed those tools from the list mid-session — the exact instability #1207 fixed for `plan_enter`/`plan_exit`. This PR uses `"ask"` (stays visible; prompts at call time; headless agents get `DeniedError`) or a deny-with-non-`"*"`-exception (`edit` keeps its plan-file allow).
2. **Plan can't research.** #1301's `task:"deny"` blocked spawning `explore`/`general`. This PR keeps `task` allowed and constrains spawned subagents to read-only via a new `subagentToolAllowlist` field.

Additionally #1301 used two `agent.name === "plan"` runtime checks; this PR encodes the restriction as data on the agent definition (`hardPermission` + `subagentToolAllowlist`), applied via a single `runtimePermission` helper with no name-checks. Recommend closing #1301.

> 本 PR 取代第三方 #1301（同样针对 #870 / #1274）。#1301 思路正确但有两处实现问题：裸 `"*":"deny"` 会让工具从 schema 消失，切模式时抖动并使 prefix cache 失效；`task:"deny"` 又让 plan 无法 spawn 调研 subagent。本 PR 改用 `ask` + 只读 subagent 白名单，并以数据驱动的 `hardPermission` 取代两处 `=== "plan"` 硬编码。建议关闭 #1301。

## Implementation

- `Agent.Info` gains `hardPermission` (non-overridable rules re-appended after the user/session merge so they always win) and `subagentToolAllowlist` (tool allowlist forced on spawned subagents); exports a `READONLY_TOOLS` constant.
- `runtimePermission(agent, session)` = `merge(agent.permission, session, agent.hardPermission)`, wired into all 5 evaluation sites (`llm.ts` ×2, `prompt.ts` ×2, `debug/agent.ts`).
- `permission/index.ts`: the `ask` loop evaluates the ruleset alone first — `deny` short-circuits, approvals can only upgrade `ask`→`allow`, never override `deny`.
- `actor.ts`: reads the spawning agent's `subagentToolAllowlist` and forces it onto the child before spawn.

> 实现：`Agent.Info` 新增 `hardPermission`（合并后再追加、永远胜出的不可覆盖规则）与 `subagentToolAllowlist`（强制施加给 subagent 的白名单），导出 `READONLY_TOOLS`；`runtimePermission` 接线到全部 5 个求值点；`permission/index.ts` 让 `deny` 短路、审批只能把 `ask` 升级为 `allow`；`actor.ts` 在 spawn 前强制施加父 agent 的只读白名单。

## Verification

- `bun test test/agent/agent.test.ts test/permission/next.test.ts test/tool/actor.test.ts` — 140 pass / 0 fail
- `bun typecheck` — clean
- **Prefix-cache stability guard**: enumerates the real registered tool universe and asserts every primary agent strips the same set as build via `Permission.disabled(runtimePermission(agent))`. Manually verified to fail when plan's `bash:"ask"` is regressed to `bash:"deny"` — so it catches any future bare deny that would mutate the tool list.
- **`READONLY_TOOLS` ⊆ registry guard**: asserts every entry resolves to a real registered tool. It caught entries absent from the default registry — `list` (never a tool id) and the gated `websearch`/`codesearch`/`lsp` — which were removed, leaving `read, glob, grep, webfetch, memory, history`.

> 验证：相关测试 140 全过、typecheck 干净；prefix-cache 稳定性守卫枚举真实工具全集，断言每个 primary agent 的剥离集与 build 相同，并已验证当 plan 的 `bash:"ask"` 退化为 `bash:"deny"` 时立即失败；新增的 `READONLY_TOOLS` ⊆ registry 守卫断言每一项都能在 registry 解析到，借此剔除了默认 registry 中不存在的 `list` 及受开关控制的 `websearch`/`codesearch`/`lsp`。

See `docs/compose/reports/plan-mode-write-restrictions.md` for the full report.

Co-authored-by: MiMo-Code <noreply@mimo.xiaomi.com>
