### PR TITLE
fix: remove SSRF check from MCP server connections

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -18,7 +18,6 @@ import { Installation } from "../installation"
 import { InstallationVersion } from "../installation/version"
 import { withTimeout } from "@/util/timeout"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
-import { assertSafeUrl } from "@/util/ssrf"
 import { McpOAuthProvider } from "./oauth-provider"
 import { McpOAuthCallback } from "./oauth-callback"
 import { McpAuth } from "./auth"
@@ -288,11 +287,6 @@ export const layer = Layer.effect(
       key: string,
       mcp: ConfigMCP.Info & { type: "remote" },
     ) {
-      yield* Effect.tryPromise({
-        try: () => assertSafeUrl(mcp.url),
-        catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
-      }).pipe(Effect.orDie)
-
       const oauthDisabled = mcp.oauth === false
       const oauthConfig = typeof mcp.oauth === "object" ? mcp.oauth : undefined
       let authProvider: McpOAuthProvider | undefined
@@ -750,11 +744,6 @@ export const layer = Layer.effect(
       if (!mcpConfig) throw new Error(`MCP server ${mcpName} not found or disabled`)
       if (mcpConfig.type !== "remote") throw new Error(`MCP server ${mcpName} is not a remote server`)
       if (mcpConfig.oauth === false) throw new Error(`MCP server ${mcpName} has OAuth explicitly disabled`)
-
-      yield* Effect.tryPromise({
-        try: () => assertSafeUrl(mcpConfig.url),
-        catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
-      }).pipe(Effect.orDie)
 
       // OAuth config is optional - if not provided, we'll use auto-discovery
       const oauthConfig = typeof mcpConfig.oauth === "object" ? mcpConfig.oauth : undefined


### PR DESCRIPTION
MCP server URLs are explicitly configured by the user, and internal deployments on private IPs (10.x, 172.x) are a normal pattern. SSRF protection should only apply to webfetch (AI-initiated requests to untrusted URLs), not to user-configured service endpoints.