### PR TITLE
fix(agent): plan-mode edit/write backstop (minimal alternative to #1324)

### DIFF
--- a/docs/compose/reports/plan-mode-edit-write-backstop.md
+++ b/docs/compose/reports/plan-mode-edit-write-backstop.md
@@ -60,10 +60,12 @@ Three focused changes:
 
 3. **Explicit plan prompt** (`src/session/prompt.ts`). Replaced the vague
    "no non-readonly tools / READ-ONLY actions only" reminder with explicit
-   guidance — recommended tools (`read`/`glob`/`grep`/`lsp` + read-only `bash` like
-   `git status`/`ls`/`cat`/running tests) and an explicit forbidden list (writes to
-   non-plan files are hard-blocked; no commits, package/config changes,
-   `change_directory`, or `workflow`). It also tells the model to take the
+   guidance — prefer the dedicated read-only tools (`read`/`grep`/`glob`/`lsp`),
+   and use read-only `bash` only for the gap they can't cover (`git status`/`log`/
+   `diff`, dependency listing, side-effect-free `test`/`lint`/`typecheck`) — plus
+   an explicit forbidden list (writes to non-plan files are hard-blocked; no
+   build/codegen/format/install, no commits, no `change_directory`, no
+   `workflow`). It also tells the model to take the
    read-only action itself rather than push avoidable confirmation prompts onto the
    user. This is the **model-adherence layer** that complements the permission
    backstop.

--- a/docs/compose/reports/plan-mode-edit-write-backstop.md
+++ b/docs/compose/reports/plan-mode-edit-write-backstop.md
@@ -1,10 +1,10 @@
 ---
 feature: plan-mode-edit-write-backstop
-status: delivered (draft PR)
+status: delivered (PR #1330)
 specs: []
 plans: []
 branch: fix/plan-mode-edit-write-backstop
-commits: 9c8f950..ee9c003
+commits: 9c8f950..HEAD
 related: docs/compose/reports/plan-mode-write-restrictions.md (PR #1324, kept as draft for comparison)
 ---
 
@@ -148,7 +148,6 @@ permission layer.
 - **MCP write tools** are outside all of this — MCP calls don't route through the
   `edit` permission key. Pre-existing, orthogonal, theoretical write vector in
   plan mode. Track separately.
-- Both this branch and PR #1324 are left as **draft PRs** for human experts to
-  compare the "minimal backstop" vs "active gate" approaches.
-</content>
-</invoke>
+- This branch is **PR #1330** (ready for review); PR #1324 (the "active gate"
+  approach) is kept as a **draft** for human experts to compare the "minimal
+  backstop" vs "active gate" approaches.

--- a/docs/compose/reports/plan-mode-edit-write-backstop.md
+++ b/docs/compose/reports/plan-mode-edit-write-backstop.md
@@ -1,0 +1,150 @@
+---
+feature: plan-mode-edit-write-backstop
+status: delivered (draft PR)
+specs: []
+plans: []
+branch: fix/plan-mode-edit-write-backstop
+commits: 9c8f950..ee9c003
+related: docs/compose/reports/plan-mode-write-restrictions.md (PR #1324, kept as draft for comparison)
+---
+
+# Plan Mode edit/write Backstop — Final Report
+
+> No plan doc was written for this branch; it was implemented directly as a
+> deliberately-simplified alternative to PR #1324. This report is the
+> authoritative record of the final state and the scope decisions.
+
+## Context & Why This Exists
+
+A first attempt (branch `fix/plan-mode-write-restrictions`, PR #1324) hardened
+plan mode by routing `bash`/`change_directory`/`workflow` to `"ask"` and forcing
+plan-spawned subagents to a read-only allowlist, on top of the edit/write block.
+In review it was sound, but a design discussion concluded it overreached:
+
+- **opencode/mimocode favors trusting the model and minimizing user prompts.**
+  The permission layer is a **backstop**, not an active gate.
+- Gating `bash` via `"ask"` causes **repeated confirmation prompts** for plainly
+  read-only shell use (`git status`, `ls`, `cat`, running tests), because the
+  codebase has **no read-only-bash classifier** — every non-`cd` command under an
+  `"ask"` ruleset prompts. (Claude Code, by contrast, ships a built-in read-only
+  command allowlist and runs those silently; mirroring that is a separate, larger
+  effort.)
+- The model also wasn't told *which* tools were gated — only a vague "read-only
+  only" — so it would try `bash`, hit the prompt, and offload the decision to the
+  user.
+
+PR #1324 was therefore set to **draft** (kept for human experts to compare), and
+this branch implements the minimal backstop.
+
+## What Was Built
+
+Three focused changes:
+
+1. **Root-cause permission fix** (`src/permission/index.ts`). The `ask` loop used
+   to evaluate the agent ruleset and persisted approvals together in one
+   `findLast`, so an `"always"`-approved action (e.g. an edit approved in build
+   mode) could out-rank an explicit ruleset `deny` and leak a write through. Now
+   the ruleset is evaluated **alone first** — a `deny` short-circuits — and
+   approvals are consulted only to upgrade an otherwise-`"ask"` to `"allow"`. This
+   is the genuine root cause of "edited a file while in plan mode".
+
+2. **edit/write backstop** (`src/agent/agent.ts`). New `Agent.hardPermission`
+   field (rules re-appended *after* the user/session merge so they always win) and
+   a `runtimePermission(agent, sessionPermission)` helper. Plan's `edit` deny +
+   plan-file allow exception moves out of `permission` (where `user` config was
+   merged last and could override it) into `hardPermission`. A user/session
+   `permission: { edit: "allow" }` can no longer relax it. `runtimePermission` is
+   wired into all five evaluation sites: `session/llm.ts` x2 (preapproval +
+   `resolveTools` schema filtering), `session/prompt.ts` x2 (main tool ask + subtask
+   ask), `cli/cmd/debug/agent.ts` x2 (tool-disabled view + ask callback).
+
+3. **Explicit plan prompt** (`src/session/prompt.ts`). Replaced the vague
+   "no non-readonly tools / READ-ONLY actions only" reminder with explicit
+   guidance — recommended tools (`read`/`glob`/`grep`/`lsp` + read-only `bash` like
+   `git status`/`ls`/`cat`/running tests) and an explicit forbidden list (writes to
+   non-plan files are hard-blocked; no commits, package/config changes,
+   `change_directory`, or `workflow`). It also tells the model to take the
+   read-only action itself rather than push avoidable confirmation prompts onto the
+   user. This is the **model-adherence layer** that complements the permission
+   backstop.
+
+## Architecture
+
+`runtimePermission(agent, session)` = `Permission.merge(agent.permission,
+session ?? [], agent.hardPermission ?? [])`. Because `hardPermission` is appended
+last, it wins over any allow a user/session/approval could introduce. The
+mechanism is data-driven — no `agent.name === "plan"` checks were added (the
+pre-existing plan-mode prompt gate and `tool/plan.ts` check are unrelated to the
+permission mechanism).
+
+Plan's `hardPermission`:
+```
+edit: { "*": "deny", ".mimocode/plans/*.md": "allow", <data>/plans/*.md: "allow" }
+```
+The `"*":"deny"` carries a non-`"*"` allow exception, so `Permission.disabled()`
+does **not** strip the edit tool from the schema — entering plan mode does not
+mutate the tool list (the prefix-cache concern from PR #1207). All write tools
+(`write`/`edit`/`multiedit`/`apply_patch`/`notebook_edit`) funnel through
+`ctx.ask({ permission: "edit" })`, so this single rule governs every file write.
+
+### Scope decisions (vs PR #1324)
+
+- **Only edit/write is enforced at the permission layer.** `bash`,
+  `change_directory`, `workflow` are NOT in `deny`/`ask` — left to the model's
+  discipline + the explicit prompt. This is the "backstop, not gate" stance.
+- **No `subagentToolAllowlist` / `READONLY_TOOLS` / actor wiring.** Without bash
+  gating there's no write vector to delegate around, so forcing subagents
+  read-only is unnecessary complexity. Dropped.
+- **Kept** the data-driven `hardPermission` mechanism, the single
+  `runtimePermission` helper at every site, and the persisted-approval root-cause
+  fix — these are correct regardless of scope.
+
+## Usage
+
+No configuration surface. Entering plan mode applies the edit/write backstop
+automatically. In plan mode: reads/search/research subagents and read-only bash
+work normally; editing the plan file is allowed; editing any other file is denied
+at call time and **cannot** be relaxed by user/session config. Side-effecting
+bash/commits/etc. are discouraged by the prompt but not hard-blocked by the
+permission layer.
+
+## Verification
+
+- `bun test test/permission test/agent` — **164 pass / 0 fail**.
+- `bun typecheck` — clean.
+- New tests:
+  - Persisted `"always"` approval cannot override a ruleset `deny` (`next.test.ts`).
+  - Plan denies edits except plan files via `runtimePermission` (`agent.test.ts`).
+  - Plan edit deny is a backstop: user config `edit:"allow"` + session allow both
+    lose to `hardPermission` (`agent.test.ts`).
+  - Plan keeps the edit tool in the schema — not stripped (`agent.test.ts`).
+  - Plan does NOT restrict bash/change_directory/workflow (`agent.test.ts`).
+  - Build agent unaffected — no `hardPermission` (`agent.test.ts`).
+- Name-check audit: the permission mechanism adds no `=== "plan"` checks.
+- `git diff --check` — clean.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/permission/index.ts` | ask loop: evaluate ruleset alone before approvals |
+| `src/agent/agent.ts` | `hardPermission` field + `runtimePermission`; plan edit-only backstop |
+| `src/session/llm.ts` | 2 sites -> `runtimePermission` (type->value import) |
+| `src/session/prompt.ts` | 2 sites -> `runtimePermission`; explicit plan reminder |
+| `src/cli/cmd/debug/agent.ts` | 2 sites -> `runtimePermission` |
+| `test/permission/next.test.ts` | persisted-approval-vs-deny test |
+| `test/agent/agent.test.ts` | backstop + scope tests |
+
+## Open / Follow-up
+
+- **Read-only bash classifier** (mirror Claude Code's built-in read-only command
+  allowlist, run silently in plan mode): the richer way to let plan run
+  `git status`/`ls`/tests without prompting. Out of scope here; worth a separate
+  issue if plan-mode shell use becomes friction.
+- **MCP write tools** are outside all of this — MCP calls don't route through the
+  `edit` permission key. Pre-existing, orthogonal, theoretical write vector in
+  plan mode. Track separately.
+- Both this branch and PR #1324 are left as **draft PRs** for human experts to
+  compare the "minimal backstop" vs "active gate" approaches.
+</content>
+</invoke>

--- a/docs/compose/reports/plan-mode-edit-write-backstop.md
+++ b/docs/compose/reports/plan-mode-edit-write-backstop.md
@@ -61,11 +61,13 @@ Three focused changes:
 3. **Explicit plan prompt** (`src/session/prompt.ts`). Replaced the vague
    "no non-readonly tools / READ-ONLY actions only" reminder with explicit
    guidance — prefer the dedicated read-only tools (`read`/`grep`/`glob`/`lsp`),
-   and use read-only `bash` only for the gap they can't cover (`git status`/`log`/
-   `diff`, dependency listing, side-effect-free `test`/`lint`/`typecheck`) — plus
-   an explicit forbidden list (writes to non-plan files are hard-blocked; no
-   build/codegen/format/install, no commits, no `change_directory`, no
-   `workflow`). It also tells the model to take the
+   and use `bash` only for the gap they can't cover and only when certain it is a
+   pure read (`git status`/`log`/`diff`). The forbidden list is explicit and
+   strict: writes to non-plan files are hard-blocked; `test`/`lint`/`typecheck`/
+   `build` are forbidden by default (lint may be `--fix`, test may write
+   snapshots/db, build writes artifacts) UNLESS the model has verified the exact
+   invocation has no side effects; no commits, no install, no `change_directory`,
+   no `workflow`. It also tells the model to take the
    read-only action itself rather than push avoidable confirmation prompts onto the
    user. This is the **model-adherence layer** that complements the permission
    backstop.

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -37,6 +37,10 @@ export const Info = z
     temperature: z.number().optional(),
     color: z.string().optional(),
     permission: Permission.Ruleset.zod,
+    // Non-overridable rules appended AFTER the user/session permissions during
+    // runtime evaluation (see runtimePermission). Use for agent invariants that
+    // config must not be able to relax — e.g. plan mode's edit/write block.
+    hardPermission: Permission.Ruleset.zod.optional(),
     model: z
       .object({
         modelID: ModelID.zod,
@@ -72,6 +76,14 @@ export interface Interface {
 type State = Omit<Interface, "generate">
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Agent") {}
+
+// Merge an agent's permission with the user/session ruleset, then re-append the
+// agent's hardPermission so those invariants win over any allow rule a user or
+// session approval could introduce. Every permission-evaluation site routes
+// through this — there is no per-agent name special-casing.
+export function runtimePermission(agent: Info, permission?: Permission.Ruleset) {
+  return Permission.merge(agent.permission, permission ?? [], agent.hardPermission ?? [])
+}
 
 export const layer = Layer.effect(
   Service,
@@ -158,14 +170,28 @@ export const layer = Layer.effect(
                 external_directory: {
                   [path.join(Global.Path.data, "plans", "*")]: "allow",
                 },
-                edit: {
-                  "*": "deny",
-                  [path.join(".mimocode", "plans", "*.md")]: "allow",
-                  [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
-                },
               }),
               user,
             ),
+            // Plan mode's one hard invariant: writes to non-plan files are
+            // blocked and user/session config must NOT be able to relax it.
+            // Re-appended after the user merge by runtimePermission so it always
+            // wins. (Every write tool — write/edit/multiedit/apply_patch/
+            // notebook_edit — funnels through ctx.ask({ permission: "edit" }),
+            // so this single rule governs all file writes.) Deliberately scoped
+            // to edit only: bash/change_directory/workflow are left to the
+            // model's own read-only discipline + plan prompt, matching the
+            // project's "trust the model, permission layer is a backstop"
+            // stance. The "*":"deny" carries a non-"*" allow exception, so the
+            // edit tool stays in the schema (no tool-list mutation on mode
+            // switch, see PR #1207).
+            hardPermission: Permission.fromConfig({
+              edit: {
+                "*": "deny",
+                [path.join(".mimocode", "plans", "*.md")]: "allow",
+                [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
+              },
+            }),
             mode: "primary",
             native: true,
           },

--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -88,7 +88,7 @@ async function getAvailableTools(agent: Agent.Info) {
 async function resolveTools(agent: Agent.Info, availableTools: Awaited<ReturnType<typeof getAvailableTools>>) {
   const disabled = Permission.disabled(
     availableTools.map((tool) => tool.id),
-    agent.permission,
+    Agent.runtimePermission(agent),
   )
   const resolved: Record<string, boolean> = {}
   for (const tool of availableTools) {
@@ -168,7 +168,7 @@ async function createToolContext(agent: Agent.Info) {
     }),
   )
 
-  const ruleset = Permission.merge(agent.permission, session.permission ?? [])
+  const ruleset = Agent.runtimePermission(agent, session.permission)
 
   return {
     sessionID: session.id,

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -187,14 +187,18 @@ export const layer = Layer.effect(
       let needsAsk = false
 
       for (const pattern of request.patterns) {
-        const rule = evaluate(request.permission, pattern, ruleset, approved)
-        log.info("evaluated", { permission: request.permission, pattern, action: rule })
-        if (rule.action === "deny") {
+        // Evaluate the ruleset ALONE first. An explicit deny here must win
+        // outright — a persisted approval (e.g. an edit approved "always" in
+        // build mode) must NOT be able to out-rank it. Only once the ruleset
+        // itself does not deny do we let approvals upgrade an "ask" to "allow".
+        const ruleAction = evaluate(request.permission, pattern, ruleset).action
+        if (ruleAction === "deny") {
           return yield* new DeniedError({
             ruleset: ruleset.filter((rule) => Wildcard.match(request.permission, rule.permission)),
           })
         }
-        if (rule.action === "allow") continue
+        if (ruleAction === "allow") continue
+        if (evaluate(request.permission, pattern, approved).action === "allow") continue
         needsAsk = true
       }
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -9,7 +9,7 @@ import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
 import { ProviderTransform } from "@/provider"
 import { Config } from "@/config"
 import { Instance } from "@/project/instance"
-import type { Agent } from "@/agent/agent"
+import { Agent } from "@/agent/agent"
 import type { MessageV2 } from "./message-v2"
 import { Plugin } from "@/plugin"
 import { SystemPrompt } from "./system"
@@ -474,7 +474,7 @@ const live: Layer.Layer<
           }
         }
 
-        const ruleset = Permission.merge(input.agent.permission ?? [], input.permission ?? [])
+        const ruleset = Agent.runtimePermission(input.agent, input.permission)
         workflowModel.sessionPreapprovedTools = Object.keys(tools).filter((name) => {
           const match = ruleset.findLast((rule) => Wildcard.match(name, rule.permission))
           return !match || match.action !== "ask"
@@ -717,7 +717,7 @@ export const defaultLayer = Layer.suspend(() =>
 function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" | "user">) {
   const disabled = Permission.disabled(
     Object.keys(input.tools),
-    Permission.merge(input.agent.permission, input.permission ?? []),
+    Agent.runtimePermission(input.agent, input.permission),
   )
   return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -538,11 +538,12 @@ Plan mode is active. The user wants you to research and design, NOT to execute y
 ## What you SHOULD do (recommended)
 - Prefer the dedicated read-only tools for everything they cover — \`read\` (view files), \`grep\` (search contents), \`glob\` (find files), and the \`lsp\` tools (definitions, references, diagnostics). These are the right way to explore the code.
 - Spawn \`explore\`/\`general\` subagents for parallel research.
-- Only when those tools genuinely can't get what you need, use read-only \`bash\` for the gap — e.g. \`git status\`, \`git log\`, \`git diff\`, listing dependencies, or running tests/lint/typecheck to observe current behavior. Stick to commands with no side effects: do NOT build, codegen, format/fix, install, or run anything that writes files or changes state. And do NOT reach for \`bash\` to do what \`read\`/\`grep\`/\`glob\` already do.
+- Only when those tools genuinely can't get what you need, you MAY use \`bash\` for the gap — but ONLY for commands you are certain are a pure read with NO side effects (e.g. \`git status\`/\`log\`/\`diff\`, listing dependencies). Do NOT reach for \`bash\` to do what \`read\`/\`grep\`/\`glob\` already do.
 
 ## What you MUST NOT do
 - Do NOT edit or create any file other than the plan file below. Writes to non-plan files are blocked outright and will fail — do not attempt them and do not ask the user to approve them.
-- Do NOT run side-effecting \`bash\`: no commits, no \`git push\`, no installing/removing packages, no writing/moving/deleting files, no changing configs, no \`change_directory\`, no \`workflow\`.
+- Do NOT run \`test\`, \`lint\`, \`typecheck\`, \`build\`, or similar project commands. These are NOT safe by default: \`lint\` is often configured with \`--fix\`, \`test\` may write snapshots or touch a database, \`build\` writes artifacts, and scripts behind them can do anything. The ONLY exception is if you have explicitly verified — by reading the exact command/config — that this specific invocation has no side effects (no \`--fix\`/\`--write\`, no file/state/db mutation). If you cannot verify that, treat it as forbidden and note it in the plan instead.
+- Do NOT run any other side-effecting \`bash\`: no commits, no \`git push\`, no installing/removing packages, no writing/moving/deleting files, no changing configs, no \`change_directory\`, no \`workflow\`.
 - If you find yourself wanting to mutate something to make progress, that's a signal to write it into the plan instead and continue researching read-only.
 
 Use good judgment: take the read-only action yourself rather than pushing avoidable confirmation prompts onto the user. Only the plan file is writable.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -674,7 +674,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 ...req,
                 sessionID: input.session.id,
                 tool: { messageID: input.processor.message.id, callID: options.toolCallId },
-                ruleset: Permission.merge(input.agent.permission, input.session.permission ?? []),
+                ruleset: Agent.runtimePermission(input.agent, input.session.permission),
                 // System-spawned background agents (checkpoint-writer, dream, distill)
                 // have no human to answer a permission prompt — fail clean, don't hang.
                 interactive: !SYSTEM_SPAWNED_AGENT_TYPES.has(input.agent.name),
@@ -1015,7 +1015,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               .ask({
                 ...req,
                 sessionID,
-                ruleset: Permission.merge(taskAgent.permission, session.permission ?? []),
+                ruleset: Agent.runtimePermission(taskAgent, session.permission),
               })
               .pipe(Effect.orDie),
         })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -533,7 +533,19 @@ export const layer = Layer.effect(
         sessionID: userMessage.info.sessionID,
         type: "text",
         text: `<system-reminder>
-Plan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits (with the exception of the plan file mentioned below), run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received.
+Plan mode is active. The user wants you to research and design, NOT to execute yet. This supersedes any other instructions you have received.
+
+## What you SHOULD do (recommended)
+- Read and understand the codebase freely: \`read\`, \`glob\`, \`grep\`, and the \`lsp\` tools.
+- Spawn \`explore\`/\`general\` subagents for parallel research.
+- Use read-only \`bash\` to gather information you can't get from the tools above — e.g. \`git status\`, \`git log\`, \`git diff\`, \`ls\`, \`cat\`, \`rg\`, listing dependencies, or running tests/builds to observe current behavior. Prefer the dedicated read tools when they suffice; reach for \`bash\` when you genuinely need shell output.
+
+## What you MUST NOT do
+- Do NOT edit or create any file other than the plan file below. Writes to non-plan files are blocked outright and will fail — do not attempt them and do not ask the user to approve them.
+- Do NOT run side-effecting \`bash\`: no commits, no \`git push\`, no installing/removing packages, no writing/moving/deleting files, no changing configs, no \`change_directory\`, no \`workflow\`.
+- If you find yourself wanting to mutate something to make progress, that's a signal to write it into the plan instead and continue researching read-only.
+
+Use good judgment: take the read-only action yourself rather than pushing avoidable confirmation prompts onto the user. Only the plan file is writable.
 
 ## Plan File Info:
 ${exists ? `A plan file already exists at ${plan}. You can read it and make incremental edits using the edit tool.` : `No plan file exists yet. You should create your plan at ${plan} using the write tool.`}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -538,7 +538,7 @@ Plan mode is active. The user wants you to research and design, NOT to execute y
 ## What you SHOULD do (recommended)
 - Prefer the dedicated read-only tools for everything they cover — \`read\` (view files), \`grep\` (search contents), \`glob\` (find files), and the \`lsp\` tools (definitions, references, diagnostics). These are the right way to explore the code.
 - Spawn \`explore\`/\`general\` subagents for parallel research.
-- Only when those tools genuinely can't get what you need, use read-only \`bash\` for the gap — e.g. \`git status\`, \`git log\`, \`git diff\`, listing dependencies, or running tests/builds to observe current behavior. Do NOT reach for \`bash\` to do what \`read\`/\`grep\`/\`glob\` already do.
+- Only when those tools genuinely can't get what you need, use read-only \`bash\` for the gap — e.g. \`git status\`, \`git log\`, \`git diff\`, listing dependencies, or running tests/lint/typecheck to observe current behavior. Stick to commands with no side effects: do NOT build, codegen, format/fix, install, or run anything that writes files or changes state. And do NOT reach for \`bash\` to do what \`read\`/\`grep\`/\`glob\` already do.
 
 ## What you MUST NOT do
 - Do NOT edit or create any file other than the plan file below. Writes to non-plan files are blocked outright and will fail — do not attempt them and do not ask the user to approve them.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -536,9 +536,9 @@ export const layer = Layer.effect(
 Plan mode is active. The user wants you to research and design, NOT to execute yet. This supersedes any other instructions you have received.
 
 ## What you SHOULD do (recommended)
-- Read and understand the codebase freely: \`read\`, \`glob\`, \`grep\`, and the \`lsp\` tools.
+- Prefer the dedicated read-only tools for everything they cover — \`read\` (view files), \`grep\` (search contents), \`glob\` (find files), and the \`lsp\` tools (definitions, references, diagnostics). These are the right way to explore the code.
 - Spawn \`explore\`/\`general\` subagents for parallel research.
-- Use read-only \`bash\` to gather information you can't get from the tools above — e.g. \`git status\`, \`git log\`, \`git diff\`, \`ls\`, \`cat\`, \`rg\`, listing dependencies, or running tests/builds to observe current behavior. Prefer the dedicated read tools when they suffice; reach for \`bash\` when you genuinely need shell output.
+- Only when those tools genuinely can't get what you need, use read-only \`bash\` for the gap — e.g. \`git status\`, \`git log\`, \`git diff\`, listing dependencies, or running tests/builds to observe current behavior. Do NOT reach for \`bash\` to do what \`read\`/\`grep\`/\`glob\` already do.
 
 ## What you MUST NOT do
 - Do NOT edit or create any file other than the plan file below. Writes to non-plan files are blocked outright and will fail — do not attempt them and do not ask the user to approve them.

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -60,17 +60,74 @@ test("build agent has correct default properties", async () => {
   })
 })
 
-test("plan agent denies edits except .mimocode/plans/*", async () => {
+test("plan denies edits except plan files (via runtimePermission)", async () => {
   await using tmp = await tmpdir()
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
       const plan = await load(tmp.path, (svc) => svc.get("plan"))
       expect(plan).toBeDefined()
-      // Wildcard is denied
-      expect(evalPerm(plan, "edit")).toBe("deny")
-      // But specific path is allowed
-      expect(Permission.evaluate("edit", ".mimocode/plans/foo.md", plan!.permission).action).toBe("allow")
+      const rt = Agent.runtimePermission(plan!, [])
+      expect(Permission.evaluate("edit", "*", rt).action).toBe("deny")
+      expect(Permission.evaluate("edit", ".mimocode/plans/foo.md", rt).action).toBe("allow")
+    },
+  })
+})
+
+test("plan edit deny is a backstop: user/session config cannot relax it", async () => {
+  await using tmp = await tmpdir({ config: { permission: { edit: "allow" } } })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const rt = Agent.runtimePermission(plan!, [{ permission: "edit", pattern: "*", action: "allow" }])
+      // config allow + session allow both lose to hardPermission's deny.
+      expect(Permission.evaluate("edit", "src/file.ts", rt).action).toBe("deny")
+      // plan files still writable.
+      expect(Permission.evaluate("edit", ".mimocode/plans/foo.md", rt).action).toBe("allow")
+    },
+  })
+})
+
+test("plan keeps the edit tool in the schema — not stripped", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const rt = Agent.runtimePermission(plan!, [])
+      // edit carries a non-"*" allow exception, so it is NOT disabled — no
+      // tool-list mutation on mode switch (PR #1207).
+      expect(Permission.disabled(["edit", "write", "bash"], rt)).toEqual(new Set())
+    },
+  })
+})
+
+test("plan does not restrict bash/change_directory/workflow", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const rt = Agent.runtimePermission(plan!, [])
+      // These are left to the model's discipline; the permission layer is a
+      // backstop for writes only.
+      expect(Permission.evaluate("bash", "ls", rt).action).not.toBe("deny")
+      expect(Permission.evaluate("change_directory", "/tmp", rt).action).not.toBe("deny")
+      expect(Permission.evaluate("workflow", "*", rt).action).not.toBe("deny")
+    },
+  })
+})
+
+test("build agent unaffected — no hardPermission", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const build = await load(tmp.path, (svc) => svc.get("build"))
+      expect(build!.hardPermission).toBeUndefined()
+      const rt = Agent.runtimePermission(build!, [])
+      expect(Permission.evaluate("edit", "src/file.ts", rt).action).not.toBe("deny")
     },
   })
 })

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -746,6 +746,42 @@ it.live("reply - always persists approval and resolves", () =>
   }),
 )
 
+it.live("ask - persisted approval does not override ruleset deny", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped({ git: true })
+    const run = withProvided(dir)
+
+    // Session 1: approve edit "*" "always" — persists into the approved ruleset.
+    const fiber = yield* ask({
+      id: PermissionID.make("per_deny_test"),
+      sessionID: SessionID.make("session_approve"),
+      permission: "edit",
+      patterns: ["src/file.ts"],
+      metadata: {},
+      always: ["*"],
+      ruleset: [],
+    }).pipe(run, Effect.forkScoped)
+
+    yield* waitForPending(1).pipe(run)
+    yield* reply({ requestID: PermissionID.make("per_deny_test"), reply: "always" }).pipe(run)
+    yield* Fiber.join(fiber)
+
+    // Session 2: a ruleset that DENIES edit must win outright — the persisted
+    // "always" approval from session 1 must not upgrade it to allow.
+    const err = yield* fail(
+      ask({
+        sessionID: SessionID.make("session_deny"),
+        permission: "edit",
+        patterns: ["src/file.ts"],
+        metadata: {},
+        always: [],
+        ruleset: [{ permission: "edit", pattern: "*", action: "deny" }],
+      }).pipe(run),
+    )
+    expect(err).toBeInstanceOf(Permission.DeniedError)
+  }),
+)
+
 it.live("reply - reject cancels all pending for same session", () =>
   withDir({ git: true }, () =>
     Effect.gen(function* () {


### PR DESCRIPTION
> A deliberately-minimal alternative to #1324 — the two PRs offer "minimal backstop" vs "active gate" approaches to plan-mode safety for comparison. #1324 is kept as a draft.

## Summary

Plan mode's read-only intent is enforced at the permission layer as a **backstop for writes only** — a user/session config can no longer relax plan's `edit`/`write` deny — while `bash`/`change_directory`/`workflow` are left to the model's own discipline (reinforced by a clearer plan prompt). This reflects opencode/mimocode's stance: trust the model, minimize user prompts, the permission layer is a backstop, not an active gate.

> Plan 模式的只读意图在权限层只作为**写操作的兜底**：用户/会话配置无法再绕过 plan 的 `edit`/`write` 拦截；而 `bash`/`change_directory`/`workflow` 交给模型自觉（由更明确的 plan 提示词强化）。这符合 opencode/mimocode 的取向：信任模型、少打断用户，权限层是兜底而非主动管控。

## Relationship to #1324

#1324 additionally routed `bash`/`change_directory`/`workflow` to `"ask"` and forced plan-spawned subagents read-only. That is sound but overreaches for this codebase: there is no read-only-bash classifier, so every non-`cd` command under `"ask"` prompts — `git status`/`ls`/`cat`/running tests would repeatedly interrupt the user. This PR drops that gating and the subagent allowlist, keeping only:

1. **Root-cause fix** — a persisted `"always"` approval could out-rank a ruleset `deny`; the ask loop now evaluates the ruleset alone first (deny short-circuits), approvals only upgrade an `"ask"`.
2. **edit/write backstop** — new data-driven `Agent.hardPermission` (re-appended after the user merge so it always wins) + a single `runtimePermission` helper wired into all 5 evaluation sites. Plan's edit deny moves there. No `=== "plan"` checks in the mechanism. The `edit` rule keeps a non-`"*"` allow exception so the tool is never stripped from the schema (no tool-list mutation on mode switch, #1207).
3. **Explicit plan prompt** — replaces vague "READ-ONLY actions only" with explicit guidance: prefer the dedicated read-only tools (`read`/`grep`/`glob`/`lsp`), and use `bash` only for the gap they can't cover and only when certain it's a pure read (`git status`/`log`/`diff`). The forbidden list is strict — `test`/`lint`/`typecheck`/`build` are forbidden **by default** (lint may be `--fix`, test may write snapshots/db, build writes artifacts, scripts can do anything) unless the model has verified the exact invocation has no side effects; plus no commits/install/`change_directory`/`workflow`. Tells the model to act read-only itself rather than push avoidable prompts onto the user.

> 相比 #1324：本 PR 去掉对 bash/change_directory/workflow 的 `ask` 拦截与 subagent 只读白名单（因为缺只读 bash 分类器，`ask` 会让 git status/ls 等反复打断用户），只保留：持久化审批不越过 deny 的根因修复、数据驱动的 edit/write 兜底（`hardPermission` + `runtimePermission`，无 `=="plan"` 硬编码，edit 工具不从 schema 移除）、以及更明确且更严格的 plan 提示词（优先用 read/grep/glob/lsp；bash 仅限确定纯读；test/lint/typecheck/build 默认禁止，除非已验证本次调用无 `--fix` 等副作用）。

## Verification

- `bun test test/permission test/agent` — **164 pass / 0 fail**
- `bun typecheck` — clean
- New tests cover: persisted-approval-vs-deny, edit backstop unrelaxable by config/session, edit tool not stripped from the schema, bash/change_directory/workflow NOT restricted, and the build *agent* unaffected (no `hardPermission`).

See `docs/compose/reports/plan-mode-edit-write-backstop.md` for the full report.

## Scope note: two `agent.permission` sites intentionally NOT migrated

Reviewers may notice two permission-evaluation sites still read `agent.permission` directly rather than `runtimePermission`. These are **not misses** — neither affects the plan backstop:

- `session/processor.ts:434` (the `doom_loop` ask): plan's `hardPermission` only contains an `edit` rule, so routing the `doom_loop` evaluation through `runtimePermission` would not change its outcome. (It does omit the `session.permission` merge that sibling ask sites include — a pre-existing consistency gap, not a write vector.)
- `actor/spawn.ts:319` (`canWrite` nudge-gate): deliberately agent-static (see the comment at lines 307–317) — it uses `agentInfo.permission` only, by design, and resolves `true` for plan regardless. It gates a post-stop "write the journal" nudge, not an actual write.

Both could be migrated later purely for consistency; they are out of scope here because they don't impact the edit/write backstop.

Co-authored-by: MiMo-Code <noreply@mimo.xiaomi.com>


