### PR TITLE
feat(agent): auto-allow read/write to system temp directories

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -19,6 +19,7 @@ import { Permission } from "@/permission"
 import { mergeDeep, pipe, sortBy, values } from "remeda"
 import { Global } from "@/global"
 import path from "path"
+import os from "os"
 import { Plugin } from "@/plugin"
 import { Skill } from "../skill"
 import { Effect, Context, Layer } from "effect"
@@ -55,6 +56,15 @@ export const Info = z
   })
 export type Info = z.infer<typeof Info>
 
+// Glob patterns for system temp directories that are auto-allowed for read/write
+// without prompting. Covers the literal /tmp, its macOS symlink target /private/tmp,
+// and the platform temp dir from os.tmpdir() (e.g. /var/folders/.../T on macOS,
+// %TEMP% on Windows). Permission matching uses the literal path, so all forms are
+// listed. Users can override with an explicit deny in their permission config.
+export function tmpDirAllowGlobs() {
+  return [...new Set(["/tmp", "/private/tmp", os.tmpdir()])].map((dir) => path.join(dir, "*"))
+}
+
 export interface Interface {
   readonly get: (agent: string) => Effect.Effect<Info>
   readonly list: () => Effect.Effect<Info[]>
@@ -86,7 +96,11 @@ export const layer = Layer.effect(
       Effect.fn("Agent.state")(function* (_ctx) {
         const cfg = yield* config.get()
         const skillDirs = yield* skill.dirs()
-        const whitelistedDirs = [Truncate.GLOB, ...skillDirs.map((dir) => path.join(dir, "*"))]
+        const whitelistedDirs = [
+          Truncate.GLOB,
+          ...skillDirs.map((dir) => path.join(dir, "*")),
+          ...tmpDirAllowGlobs(),
+        ]
 
         const defaults = Permission.fromConfig({
           "*": "allow",

--- a/packages/opencode/test/agent/tmpdir-allow.test.ts
+++ b/packages/opencode/test/agent/tmpdir-allow.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import os from "os"
+import path from "path"
+import { Permission } from "../../src/permission"
+import { tmpDirAllowGlobs } from "../../src/agent/agent"
+
+describe("Agent tmpDirAllowGlobs", () => {
+  test("includes /tmp, /private/tmp and os.tmpdir() globs", () => {
+    const globs = tmpDirAllowGlobs()
+    expect(globs).toContain("/tmp/*")
+    expect(globs).toContain("/private/tmp/*")
+    expect(globs).toContain(path.join(os.tmpdir(), "*"))
+  })
+
+  test("contains no duplicate globs", () => {
+    const globs = tmpDirAllowGlobs()
+    expect(new Set(globs).size).toBe(globs.length)
+  })
+
+  test("a temp file path resolves to allow via these globs", () => {
+    const ruleset = Permission.fromConfig({
+      external_directory: {
+        "*": "ask",
+        ...Object.fromEntries(tmpDirAllowGlobs().map((dir) => [dir, "allow"])),
+      },
+    })
+    expect(Permission.evaluate("external_directory", "/tmp/scratch.py", ruleset).action).toBe("allow")
+    expect(Permission.evaluate("external_directory", "/tmp/sub/nested.json", ruleset).action).toBe("allow")
+    expect(Permission.evaluate("external_directory", path.join(os.tmpdir(), "x.txt"), ruleset).action).toBe("allow")
+  })
+
+  test("user deny overrides the temp allow", () => {
+    const ruleset = Permission.merge(
+      Permission.fromConfig({
+        external_directory: {
+          "*": "ask",
+          ...Object.fromEntries(tmpDirAllowGlobs().map((dir) => [dir, "allow"])),
+        },
+      }),
+      Permission.fromConfig({ external_directory: { "/tmp/*": "deny" } }),
+    )
+    expect(Permission.evaluate("external_directory", "/tmp/scratch.py", ruleset).action).toBe("deny")
+  })
+
+  test("non-temp external path still asks", () => {
+    const ruleset = Permission.fromConfig({
+      external_directory: {
+        "*": "ask",
+        ...Object.fromEntries(tmpDirAllowGlobs().map((dir) => [dir, "allow"])),
+      },
+    })
+    expect(Permission.evaluate("external_directory", "/etc/passwd", ruleset).action).toBe("ask")
+  })
+})

--- a/packages/opencode/test/agent/tmpdir-allow.test.ts
+++ b/packages/opencode/test/agent/tmpdir-allow.test.ts
@@ -29,6 +29,21 @@ describe("Agent tmpDirAllowGlobs", () => {
     expect(Permission.evaluate("external_directory", path.join(os.tmpdir(), "x.txt"), ruleset).action).toBe("allow")
   })
 
+  // The external_directory ask sends the PARENT-DIR glob (path.dirname(target) + "/*"),
+  // not the raw file path (see tool/external-directory.ts). Assert against that shape so
+  // the nesting guarantee is exercised the way production actually evaluates it.
+  test("the parent-dir glob shape sent by external_directory resolves to allow", () => {
+    const ruleset = Permission.fromConfig({
+      external_directory: {
+        "*": "ask",
+        ...Object.fromEntries(tmpDirAllowGlobs().map((dir) => [dir, "allow"])),
+      },
+    })
+    expect(Permission.evaluate("external_directory", "/tmp/*", ruleset).action).toBe("allow")
+    expect(Permission.evaluate("external_directory", "/tmp/sub/*", ruleset).action).toBe("allow")
+    expect(Permission.evaluate("external_directory", "/private/tmp/x/*", ruleset).action).toBe("allow")
+  })
+
   test("user deny overrides the temp allow", () => {
     const ruleset = Permission.merge(
       Permission.fromConfig({


### PR DESCRIPTION
## Summary

Stop prompting for `external_directory` approval on every read/write under the system temp directory. The model frequently uses `/tmp` as scratch space, and each access previously required a manual confirmation, which was repetitive friction.

This adds `tmpDirAllowGlobs()` in `agent.ts` and injects its globs into the existing `whitelistedDirs` array (the canonical "always-allow a directory" mechanism that already covers the tool-output and skill dirs).

中文：让模型在系统临时目录下的读写不再每次都弹确认框。`/tmp` 常被当作临时空间使用，之前每次访问都要手动确认，非常麻烦。复用现有的 `whitelistedDirs` 机制即可。

## What changed

- New exported pure function `tmpDirAllowGlobs()` returns deduped globs for `/tmp/*`, `/private/tmp/*` and `<os.tmpdir()>/*`.
- These globs are spread into the default `external_directory` allow map via `whitelistedDirs`.
- This covers both reads (Read tool's `assertExternalDirectoryEffect` gate) and writes (Write/Edit's `assertWriteAllowed` gate). The `read` permission default is already `*: allow`.

中文：新增纯函数 `tmpDirAllowGlobs()`，返回去重后的 `/tmp/*`、`/private/tmp/*`、`<os.tmpdir()>/*`；并入默认的 `external_directory` 放行表。读和写两条路径都被覆盖。

## Why three path forms

Permission matching in `tool/external-directory.ts` uses the literal target path with no realpath resolution on non-Windows. On macOS, `/tmp` is a symlink to `/private/tmp`, and `os.tmpdir()` is `/var/folders/.../T` — not `/tmp`. All three forms are listed and deduped (on Linux they collapse to one).

中文：权限匹配用的是字面路径、不做 realpath 解析。macOS 上 `/tmp` 是指向 `/private/tmp` 的软链，且 `os.tmpdir()` 是 `/var/folders/.../T` 而非 `/tmp`，因此三种写法都要列出并去重（Linux 上会合并）。

## Default-on, user-overridable

Because `defaults` merge before the user ruleset in `Permission.merge(defaults, …, user)` and `evaluate` uses last-wins (`findLast`), a user config such as `external_directory: { "/tmp/*": "deny" }` still wins.

中文：默认开启，但用户可覆盖。默认规则在用户配置之前合并，`evaluate` 采用 last-wins，因此用户写 `deny` 仍然生效。

## Testing

`packages/opencode/test/agent/tmpdir-allow.test.ts` — 6 tests, verifying real `Permission.evaluate`/`merge` behavior: glob contents + dedup, file-path allow, the parent-dir glob shape that the ask actually sends, user-deny override, and that non-temp external paths still ask. All pass; typecheck clean.

中文：新增 6 个测试，针对真实的 `Permission.evaluate`/`merge` 行为验证。全部通过，typecheck 干净。

Co-authored-by: MiMo-Code <noreply@mimo.xiaomi.com>