### PR TITLE
fix(worker): use named process handlers to enable cleanup on shutdown

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -26,17 +26,20 @@ await Log.init({
 
 Heap.start()
 
-process.on("unhandledRejection", (e) => {
+const onUnhandledRejection = (e: unknown) => {
   Log.Default.error("rejection", {
     e: e instanceof Error ? e.message : e,
   })
-})
+}
 
-process.on("uncaughtException", (e) => {
+const onUncaughtException = (e: Error) => {
   Log.Default.error("exception", {
     e: e instanceof Error ? e.message : e,
   })
-})
+}
+
+process.on("unhandledRejection", onUnhandledRejection)
+process.on("uncaughtException", onUncaughtException)
 
 // Subscribe to global events and forward them via RPC
 GlobalBus.on("event", (event) => {
@@ -89,6 +92,8 @@ export const rpc = {
   async shutdown() {
     Log.Default.info("worker shutting down")
 
+    process.off("unhandledRejection", onUnhandledRejection)
+    process.off("uncaughtException", onUncaughtException)
     await Instance.disposeAll()
     if (server) await server.stop(true)
   },


### PR DESCRIPTION
## Summary
Use named function references for `process.on("unhandledRejection")` and `process.on("uncaughtException")` so they can be properly cleaned up in `shutdown()`.

## Problem
Anonymous arrow functions were passed to `process.on()`. These can never be removed, so every worker lifecycle leaks the handlers.

## Fix
- Extract named constants `onUnhandledRejection` and `onUncaughtException`
- Add `process.off()` calls in `shutdown()` to clean them up

## Changes
- `packages/opencode/src/cli/cmd/tui/worker.ts`: extract named handlers + cleanup in shutdown

Ported pattern from OpenCode worker.ts (named handlers + process.off in shutdown).

## Checklist
- [x] Code follows project style guidelines
- [x] Backward compatible
- [x] Properly cleans up in shutdown