### PR TITLE
fix(mcp): clean up subprocess listeners on OAuth browser open

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -822,17 +822,28 @@ export const layer = Layer.effect(
       yield* Effect.tryPromise(() => open(result.authorizationUrl)).pipe(
         Effect.flatMap((subprocess) =>
           Effect.callback<void, Error>((resume) => {
-            const timer = setTimeout(() => resume(Effect.void), 500)
-            subprocess.on("error", (err) => {
+            let timer: ReturnType<typeof setTimeout>
+            const cleanup = () => {
               clearTimeout(timer)
+              subprocess.off("error", onError)
+              subprocess.off("exit", onExit)
+            }
+            const onError = (err: Error) => {
+              cleanup()
               resume(Effect.fail(err))
-            })
-            subprocess.on("exit", (code) => {
+            }
+            const onExit = (code: number | null) => {
               if (code !== null && code !== 0) {
-                clearTimeout(timer)
+                cleanup()
                 resume(Effect.fail(new Error(`Browser open failed with exit code ${code}`)))
               }
-            })
+            }
+            timer = setTimeout(() => {
+              cleanup()
+              resume(Effect.void)
+            }, 500)
+            subprocess.on("error", onError)
+            subprocess.on("exit", onExit)
           }),
         ),
         Effect.catch(() => {


### PR DESCRIPTION
## Summary
Clean up `subprocess.on("error")` and `subprocess.on("exit")` listeners after they fire, and on the success path.

## Problem
When the 500ms timer fires (success path), `resume(Effect.void)` is called but the `error` and `exit` listeners on the subprocess are never removed. The closures captured by these listeners prevent GC of the subprocess object and surrounding scope.

## Fix
Extract a common `cleanup()` helper that:
1. Clears the timer
2. Removes both listeners via `subprocess.off()`
3. Then calls `resume()`

This ensures all three paths (timer, error, exit) properly clean up.

## Changes
- `packages/opencode/src/mcp/index.ts`: add cleanup helper for subprocess listeners

## Checklist
- [x] Code follows project style guidelines
- [x] All exit paths properly clean up