### PR TITLE
fix(oauth-callback): clean up socket and server event listeners

### DIFF
--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -165,11 +165,16 @@ export async function ensureRunning(redirectUri?: string): Promise<void> {
 
   server = createServer(handleRequest)
   await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error) => {
+      server!.off("error", onError)
+      reject(err)
+    }
+    server!.on("error", onError)
     server!.listen(currentPort, () => {
+      server!.off("error", onError)
       log.info("oauth callback server started", { port: currentPort, path: currentPath })
       resolve()
     })
-    server!.on("error", reject)
   })
 }
 
@@ -204,13 +209,19 @@ export function cancelPending(mcpName: string): void {
 export async function isPortInUse(port: number = OAUTH_CALLBACK_PORT): Promise<boolean> {
   return new Promise((resolve) => {
     const socket = createConnection(port, "127.0.0.1")
-    socket.on("connect", () => {
+    const onConnect = () => {
+      socket.off("connect", onConnect)
+      socket.off("error", onError)
       socket.destroy()
       resolve(true)
-    })
-    socket.on("error", () => {
+    }
+    const onError = () => {
+      socket.off("connect", onConnect)
+      socket.off("error", onError)
       resolve(false)
-    })
+    }
+    socket.on("connect", onConnect)
+    socket.on("error", onError)
   })
 }
 


### PR DESCRIPTION
## Summary
Two listener leaks fixed in `oauth-callback.ts`.

## Leak 1: `isPortInUse()` socket listeners
`socket.on("connect")` and `socket.on("error")` were registered with anonymous lambdas that can never be removed. Extract named handlers and call `socket.off()` on both paths.

## Leak 2: `ensureRunning()` server error listener
`server!.on("error", reject)` registers the `reject` function as a listener but never removes it. Extract a named `onError` handler and call `server.off()` on both success and error paths.

## Changes
- `packages/opencode/src/mcp/oauth-callback.ts`

## Checklist
- [x] Both paths clean up on resolve and reject
- [x] Backward compatible