### PR TITLE
fix(models): export setInterval handle so it can be cancelled

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -169,12 +169,12 @@ export async function refresh(force = false) {
   })
 }
 
+export let modelsRefreshTimer: ReturnType<typeof setInterval> | undefined
+
 if (!Flag.MIMOCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
   void refresh()
-  setInterval(
-    async () => {
-      await refresh()
-    },
-    60 * 1000 * 60,
-  ).unref()
+  modelsRefreshTimer = setInterval(() => {
+    void refresh()
+  }, 60 * 60 * 1000)
+  modelsRefreshTimer.unref()
 }


### PR DESCRIPTION
## Summary
Store the models refresh interval timer ID in an exported variable so it can be cleared if needed.

## Problem
`setInterval(...).unref()` was called without storing the handle. The timer ID was discarded, making it impossible to cancel the hourly refresh loop without killing the process. On module reload (HMR/development), a new interval is registered each time, accumulating timers.

## Fix
- Export `modelsRefreshTimer` variable
- Store the interval handle
- Clean up async wrapper (use `void refresh()` directly instead of `async () => { await refresh() }`)

## Changes
- `packages/opencode/src/provider/models.ts`

## Checklist
- [x] Timer can now be cleared externally
- [x] Backward compatible (optional export)