### PR TITLE
fix(server): keep-alive heartbeat on POST /:sessionID/message stream

### DIFF
--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -1023,6 +1023,11 @@ export const SessionRoutes = lazy(() =>
               c,
               SessionPrompt.Service.use((svc) => svc.prompt({ ...body, sessionID })),
             )
+            // Safety invariant: no await/yield between this write and the
+            // clearInterval below (reached synchronously via finally) — else the
+            // interval could fire and append a stray space AFTER the JSON,
+            // breaking the "JSON is the whole body" contract. Leading spaces are
+            // JSON-insignificant; a trailing one would not be.
             void stream.write(JSON.stringify(msg))
           } finally {
             clearInterval(heartbeat)

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -34,6 +34,14 @@ import { RateLimitMiddleware } from "../../rate-limit"
 
 const log = Log.create({ service: "server" })
 
+// Cadence of the keep-alive whitespace written on the POST /:sessionID/message
+// stream while a turn is in flight. Matches the 10s SSE heartbeat in
+// event.ts/global.ts. Read per-request (not memoized) so it can be tuned at
+// runtime; smaller values are useful in tests.
+function promptHeartbeatIntervalMs() {
+  return Number(process.env["MIMOCODE_PROMPT_HEARTBEAT_INTERVAL_MS"]) || 10_000
+}
+
 function taskToTodo(t: Task) {
   const status =
     t.status === "in_progress"
@@ -995,6 +1003,20 @@ export const SessionRoutes = lazy(() =>
             return
           }
           signal.addEventListener("abort", onClientDisconnect, { once: true })
+          // Keep the response alive while the turn is in flight. A turn can sit
+          // silent for a long time — most notably while the `question` tool
+          // blocks on an un-timed Deferred waiting for a human reply (the Bun
+          // server itself never times out: adapter.bun.ts idleTimeout:0). A
+          // client with its own request timeout (e.g. the external `mimo run`
+          // driver's per-turn budget) would otherwise see a dead connection and
+          // abort with "error sending request for url". Periodic whitespace
+          // resets the client's idle timer; whitespace is JSON-insignificant,
+          // so the trailing JSON.stringify(msg) still parses as the whole body
+          // (clients JSON.parse the full body, which tolerates leading
+          // whitespace). Mirrors the 10s SSE heartbeat in event.ts/global.ts.
+          const heartbeat = setInterval(() => {
+            void stream.write(" ")
+          }, promptHeartbeatIntervalMs())
           try {
             const msg = await runRequest(
               "SessionRoutes.prompt",
@@ -1003,6 +1025,7 @@ export const SessionRoutes = lazy(() =>
             )
             void stream.write(JSON.stringify(msg))
           } finally {
+            clearInterval(heartbeat)
             signal.removeEventListener("abort", onClientDisconnect)
           }
         })

--- a/packages/opencode/test/server/session-prompt-heartbeat.test.ts
+++ b/packages/opencode/test/server/session-prompt-heartbeat.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, expect } from "bun:test"
+import { Effect } from "effect"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { Log } from "../../src/util"
+import { provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { makeLayer, ref, providerCfg } from "../workflow/lib"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const it = testEffect(makeLayer())
+
+// The turn blocks inside the `question` tool on an un-timed Deferred. With a
+// short heartbeat interval the route must emit keep-alive whitespace on the
+// open POST /:sessionID/message stream BEFORE the turn finishes — otherwise a
+// client with its own request timeout aborts mid-question with
+// "error sending request for url". After we reply, the trailing JSON must
+// still parse as the whole body despite the leading whitespace.
+it.live(
+  "writes keep-alive whitespace while the question tool blocks, then a parseable JSON tail",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ dir, llm }) {
+        const prev = process.env["MIMOCODE_PROMPT_HEARTBEAT_INTERVAL_MS"]
+        process.env["MIMOCODE_PROMPT_HEARTBEAT_INTERVAL_MS"] = "50"
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            if (prev === undefined) delete process.env["MIMOCODE_PROMPT_HEARTBEAT_INTERVAL_MS"]
+            else process.env["MIMOCODE_PROMPT_HEARTBEAT_INTERVAL_MS"] = prev
+          }),
+        )
+
+        // Model emits a single `question` tool call → the turn blocks in
+        // Question.ask waiting for a human reply, holding the stream open.
+        yield* llm.tool("question", {
+          questions: [{ question: "proceed?", header: "confirm", options: [{ label: "yes", description: "go" }] }],
+        })
+
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({
+          title: "heartbeat test",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        const app = Server.Default().app
+        const dirQuery = `?directory=${encodeURIComponent(dir)}`
+
+        const res = yield* Effect.promise(async () =>
+          app.request(`/session/${session.id}/message${dirQuery}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              model: { providerID: ref.providerID, modelID: ref.modelID },
+              parts: [{ type: "text", text: "hi" }],
+            }),
+          }),
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.body).not.toBeNull()
+        const reader = res.body!.getReader()
+        const decoder = new TextDecoder()
+
+        const readChunk = () =>
+          Effect.promise(() =>
+            Promise.race([
+              reader.read().then((r) => ({ timeout: false as const, ...r })),
+              new Promise<{ timeout: true }>((r) => setTimeout(() => r({ timeout: true as const }), 100)),
+            ]),
+          )
+
+        const listPending = () =>
+          Effect.promise(async () => {
+            const r = await app.request(`/question${dirQuery}`, { method: "GET" })
+            return (await r.json()) as Array<{ id: string }>
+          })
+
+        // Read until the pending question shows up over the same app instance
+        // and at least one heartbeat space has been written — proof bytes flow
+        // before the turn completes.
+        let buffer = ""
+        let sawHeartbeat = false
+        let pendingID: string | undefined
+        for (let i = 0; i < 300 && !(sawHeartbeat && pendingID); i++) {
+          if (!pendingID) {
+            const pending = yield* listPending()
+            if (pending.length > 0) pendingID = pending[0]!.id
+          }
+          const read = yield* readChunk()
+          if (!read.timeout && !read.done && read.value) buffer += decoder.decode(read.value, { stream: true })
+          if (buffer.length > 0 && /^\s+$/.test(buffer)) sawHeartbeat = true
+          yield* Effect.sleep("20 millis")
+        }
+
+        expect(sawHeartbeat).toBe(true)
+        expect(pendingID).toBeDefined()
+
+        // Reply over the same app instance so the turn finishes.
+        const replyRes = yield* Effect.promise(async () =>
+          app.request(`/question/${pendingID}/reply${dirQuery}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ answers: [["yes"]] }),
+          }),
+        )
+        expect(replyRes.status).toBe(200)
+
+        // Drain the rest of the stream.
+        let done = false
+        for (let i = 0; i < 2000 && !done; i++) {
+          const read = yield* readChunk()
+          if (read.timeout) continue
+          if (read.done) done = true
+          else buffer += decoder.decode(read.value, { stream: true })
+        }
+
+        // Leading whitespace + trailing JSON still parses as the whole body.
+        const parsed = JSON.parse(buffer)
+        expect(parsed).toBeDefined()
+        expect(parsed.info).toBeDefined()
+      }),
+      { git: true, config: providerCfg },
+    ),
+  30_000,
+)


### PR DESCRIPTION
## Summary

The `POST /:sessionID/message` stream wrote nothing until the whole turn finished. When a turn blocks for a long time — most notably while the `question` tool waits on an un-timed `Deferred` for a human reply — the response stayed completely silent.

The Bun server never times out (`adapter.bun.ts` `idleTimeout: 0`), but an **external client with its own per-turn request timeout** (e.g. the `mimo run` driver) sees a dead connection and aborts with `I/O error: error sending request for url ...`. This reproduced reliably whenever the user took a while to answer a `question` prompt.

## Fix

Write JSON-insignificant whitespace every 10s while the turn is in flight, resetting the client's idle timer. This mirrors the existing SSE heartbeat in `event.ts` / `global.ts` ("Send heartbeat every 10s to prevent stalled proxy streams").

- The trailing `JSON.stringify(msg)` still parses as the whole body: clients `JSON.parse` the full body and leading whitespace is JSON-insignificant.
- Interval is read per-request via `MIMOCODE_PROMPT_HEARTBEAT_INTERVAL_MS` (default 10s) for runtime tuning and tests.

> Note: this keeps the connection alive while the server waits for human input. A genuinely long-running turn that exceeds the external driver's hard per-turn budget still needs that budget raised on the driver side (outside this repo).

## Test

New `test/server/session-prompt-heartbeat.test.ts` drives a `question` tool call so the turn blocks, asserts keep-alive whitespace flows on the open stream **before** the turn completes, then replies and verifies the trailing JSON still parses as the whole body. Verified TDD red/green (without the heartbeat the turn hangs and the test fails).

## Verification

- `bun typecheck` — clean
- `bun test test/server/` — 52/52 pass (incl. new test)