### PR TITLE
fix(provider): let xiaomi provider use its models.dev name "Xiaomi"

### DIFF
--- a/packages/opencode/src/plugin/mimo.ts
+++ b/packages/opencode/src/plugin/mimo.ts
@@ -86,10 +86,11 @@ export async function MimoAuthPlugin(_input: PluginInput): Promise<Hooks> {
   return {
     config: async (input) => {
       input.provider ??= {}
+      // Register xiaomi as a config provider so it shows up even before login.
+      // name/api are intentionally left to the models.dev database (name: "Xiaomi",
+      // api: https://api.xiaomimimo.com/v1) — hardcoding "MiMo" here collided with
+      // the free "mimo" provider's display name and confused users.
       input.provider.xiaomi ??= {}
-      const xiaomi = input.provider.xiaomi
-      xiaomi.name ??= "MiMo"
-      xiaomi.api ??= "https://api.xiaomimimo.com/v1"
       // Both "opencode" and "opencode-go" stay enabled. The opencode custom
       // loader strips the free/public tier (and hides paid models until the
       // user authenticates). "opencode-go" has no free models and no custom

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -53,10 +53,6 @@ async function defaultModel() {
   return run((provider) => provider.defaultModel())
 }
 
-function opencodeProviderPresent(providers: Awaited<ReturnType<typeof list>>): boolean {
-  return providers[ProviderID.make("opencode")] !== undefined
-}
-
 test("provider loaded from env variable", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -2612,41 +2608,3 @@ test("plugin config enabled and disabled providers are honored", async () => {
   })
 })
 
-test("opencode and opencode-go providers are disabled by MimoFreeAuthPlugin", async () => {
-  await using base = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "mimocode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          provider: {
-            opencode: {
-              options: {
-                apiKey: "test-key",
-              },
-            },
-          },
-        }),
-      )
-    },
-  })
-
-  const providers = await Instance.provide({
-    directory: base.path,
-    fn: async () => list(),
-  })
-
-  // MimoFreeAuthPlugin always pushes opencode/opencode-go into disabled_providers,
-  // so they should not appear even when the user supplies an apiKey or auth record.
-  // However, MimoFreeAuthPlugin is part of the private overlay (src/ext/) that only
-  // exists in the internal build. In the open-source build the plugin is absent and
-  // opencode/opencode-go remain loaded. Gate these assertions on mimo provider presence.
-  const mimo = providers[ProviderID.make("mimo")]
-  if (mimo) {
-    expect(opencodeProviderPresent(providers)).toBe(false)
-    expect(providers[ProviderID.make("opencode-go")]).toBeUndefined()
-    expect(mimo.models[ModelID.make("mimo-auto")]).toBeDefined()
-    expect(mimo.models[ModelID.make("mimo-auto")].limit.context).toBe(1_000_000)
-    expect(mimo.models[ModelID.make("mimo-auto")].limit.output).toBe(128_000)
-  }
-})


### PR DESCRIPTION
## Summary
- The `config()` hook in `plugin/mimo.ts` hardcoded the xiaomi provider's display name to "MiMo" and its api URL. That name collided with the free `mimo` provider (shown as "MiMo Auto (free)"), making the two indistinguishable in the model picker.
- Dropped the hardcoded `name`/`api` overrides — the models.dev database already provides `name: "Xiaomi"` and the identical api URL (verified across the network cache and the bundled models snapshot), so removal has no effect on the resolved base URL.
- Kept the `input.provider.xiaomi ??= {}` placeholder: it is the only path registering xiaomi as a config provider, so it must stay for the provider to appear before login.
- The intentional merge-display of `mimo` + `xiaomi` models in the picker is unaffected (the pinned category title now reads "Xiaomi").
- Removed the obsolete `opencode and opencode-go providers are disabled by MimoFreeAuthPlugin` test: no code path adds those providers to `disabled_providers`, and `plugin/mimo.ts` keeps them enabled.

## Test plan
- `bun typecheck` in `packages/opencode` passes; pre-push full-repo typecheck (12 packages) passes.
- `bun test test/provider/provider.test.ts`: 75 pass, 0 fail.