### PR TITLE
fix: use MiMo schema URL for generated configs

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -46,6 +46,7 @@ import { ConfigVariable } from "./variable"
 import { Npm } from "@/npm"
 
 const log = Log.create({ service: "config" })
+const CONFIG_SCHEMA_URL = "https://mimo.xiaomi.com/mimocode/config.json"
 
 // Custom merge function that concatenates array fields instead of replacing them
 function mergeConfigConcatArrays(target: Info, source: Info): Info {
@@ -557,8 +558,8 @@ export const layer = Layer.effect(
 
       yield* Effect.promise(() => resolveLoadedPlugins(data, options.path))
       if (!data.$schema) {
-        data.$schema = "https://opencode.ai/config.json"
-        const updated = text.replace(/^\s*\{/, '{\n  "$schema": "https://opencode.ai/config.json",')
+        data.$schema = CONFIG_SCHEMA_URL
+        const updated = text.replace(/^\s*\{/, `{\n  "$schema": "${CONFIG_SCHEMA_URL}",`)
         yield* fs.writeFileString(options.path, updated).pipe(Effect.catch(() => Effect.void))
       }
       return data
@@ -586,7 +587,7 @@ export const layer = Layer.effect(
             .then(async (mod) => {
               const { provider, model, ...rest } = mod.default
               if (provider && model) result.model = `${provider}/${model}`
-              result["$schema"] = "https://opencode.ai/config.json"
+              result["$schema"] = CONFIG_SCHEMA_URL
               result = mergeDeep(result, rest)
               await fsNode.writeFile(path.join(Global.Path.config, "config.json"), JSON.stringify(result, null, 2))
               await fsNode.unlink(legacy)
@@ -736,7 +737,7 @@ export const layer = Layer.effect(
             }
             const wellknown = (yield* Effect.promise(() => response.json())) as { config?: Record<string, unknown> }
             const remoteConfig = wellknown.config ?? {}
-            if (!remoteConfig.$schema) remoteConfig.$schema = "https://opencode.ai/config.json"
+            if (!remoteConfig.$schema) remoteConfig.$schema = CONFIG_SCHEMA_URL
             const source = `${url}/.well-known/opencode`
             const next = yield* loadConfig(JSON.stringify(remoteConfig), {
               dir: path.dirname(source),

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -452,6 +452,38 @@ test("preserves env variables when adding $schema to config", async () => {
   }
 })
 
+test("adds MiMo schema URL to config without $schema", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, "mimocode.jsonc"),
+        JSON.stringify({
+          provider: {
+            custom: {
+              name: "Custom",
+              models: {
+                "custom-model": {
+                  name: "Custom Model",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await load()
+      const content = await Filesystem.readText(path.join(tmp.path, "mimocode.jsonc"))
+
+      expect(content).toContain('"$schema": "https://mimo.xiaomi.com/mimocode/config.json"')
+      expect(content).not.toContain("https://opencode.ai/config.json")
+    },
+  })
+})
+
 test("resolves env templates in account config with account token", async () => {
   const originalControlToken = process.env["MIMOCODE_CONSOLE_TOKEN"]
 


### PR DESCRIPTION
## Summary
- use the MiMo config schema URL when auto-adding `$schema` to config files
- reuse the same schema URL for legacy config migration and well-known config defaults
- add a regression test for `mimocode.jsonc` files created without `$schema`

Fixes #1369

## Tests
- `bun typecheck` from `packages/opencode`
- `bun test test/config/config.test.ts --timeout 30000` from `packages/opencode`
- pre-push hook: `bun turbo typecheck`