### PR TITLE
fix(opencode): handle spaces in package names in sanitize()

### DIFF
--- a/packages/opencode/src/npm/index.ts
+++ b/packages/opencode/src/npm/index.ts
@@ -39,7 +39,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Npm") {}
 
-const illegal = process.platform === "win32" ? new Set(["<", ">", ":", '"', "|", "?", "*"]) : undefined
+const illegal = process.platform === "win32" ? new Set(["<", ">", ":", '"', "|", "?", "*", " "]) : undefined
 
 export function sanitize(pkg: string) {
   if (!illegal) return pkg


### PR DESCRIPTION
## Summary
- Fix `sanitize()` function to handle spaces in package names on Windows

## Problem
When installing a plugin with a package name containing spaces, the `sanitize()` function in `packages/opencode/src/npm/index.ts` failed to replace space characters, creating malformed cache directory paths like:
```
C:\Users\user\.cache\mimocode\packages\npm install ecc-universal\node_modules\npm install ecc-universal
```

## Solution
Added space to the illegal characters set so spaces are replaced with underscores.

## Testing
- Verified the fix by checking the illegal characters set now includes space
- The change is minimal (one character addition) and follows existing pattern

Fixes #1368
