### PR TITLE
fix(opencode): prevent session rename from bumping time_updated

### DIFF
--- a/packages/opencode/src/storage/schema.sql.ts
+++ b/packages/opencode/src/storage/schema.sql.ts
@@ -6,5 +6,5 @@ export const Timestamps = {
     .$default(() => Date.now()),
   time_updated: integer()
     .notNull()
-    .$onUpdate(() => Date.now()),
+    .$default(() => Date.now())
 }


### PR DESCRIPTION
Renaming a session via Ctrl+R moves it to the "Today" group because Drizzle's `$onUpdate` on `time_updated` auto-sets the timestamp on any row update.

Fix: replace `$onUpdate` with `$default` so `time_updated` is only set on INSERT, not on every UPDATE. Places that actually need to bump the timestamp (`touch()`, `setPermission()`, etc.) already do it explicitly.

Fixes #1257
