### PR TITLE
feat(workflow/compose): autonomous compose pipeline — auto-parallel, amend, phase I/O chaining

### DIFF
--- a/packages/opencode/src/actor/registry.ts
+++ b/packages/opencode/src/actor/registry.ts
@@ -308,7 +308,12 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
       if (actorID === "main") return false
       const actor = yield* get(sessionID, actorID)
       if (!actor) return false
-      return SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent)
+      // System-spawned by agent type (checkpoint-writer/dream/distill) OR any
+      // background actor: both have no human attached to answer a permission
+      // prompt. Workflow subagents (e.g. compose) spawn with background:true and
+      // agentType "general", so the type check alone misses them — include
+      // background so their permission asks fail clean instead of hanging.
+      return SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent) || actor.background
     })
 
     const allocateActorID = Effect.fn("ActorRegistry.allocateActorID")(function* (

--- a/packages/opencode/src/actor/registry.ts
+++ b/packages/opencode/src/actor/registry.ts
@@ -308,12 +308,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
       if (actorID === "main") return false
       const actor = yield* get(sessionID, actorID)
       if (!actor) return false
-      // System-spawned by agent type (checkpoint-writer/dream/distill) OR any
-      // background actor: both have no human attached to answer a permission
-      // prompt. Workflow subagents (e.g. compose) spawn with background:true and
-      // agentType "general", so the type check alone misses them — include
-      // background so their permission asks fail clean instead of hanging.
-      return SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent) || actor.background
+      return SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent)
     })
 
     const allocateActorID = Effect.fn("ActorRegistry.allocateActorID")(function* (

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -651,13 +651,17 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const whitelist = yield* whitelistFor()
       // Whether a permission ask must be non-interactive (fail clean, never hang):
       // true for system-spawned actors (checkpoint-writer/dream/distill) AND any
-      // background actor such as compose workflow subagents (spawned as
-      // "general" + background:true).  isSystemSpawned only checks agent type;
-      // we also test the background flag so workflow subagents that aren't
-      // checkpoint-writer/dream/distill don't hang on permission prompts.
-      const askNonInteractive = input.agentID
-        ? (yield* actorRegistry.isSystemSpawned(input.session.id, input.agentID)) ||
-          (yield* Effect.map(actorRegistry.get(input.session.id, input.agentID), (a) => a?.background === true))
+      // background actor such as compose workflow subagents (spawned as "general"
+      // + background:true). Scoped to THIS permission decision on purpose — not
+      // folded into the shared isSystemSpawned, which also gates memory
+      // instructions and checkpoint self-triggering for user background actors.
+      // Fall back to the agent-name check if the actor row is missing (race /
+      // unregistered) so a system actor can't slip through as interactive.
+      const askActor = input.agentID
+        ? yield* actorRegistry.get(input.session.id, input.agentID)
+        : undefined
+      const askNonInteractive = askActor
+        ? SYSTEM_SPAWNED_AGENT_TYPES.has(askActor.agent) || askActor.background
         : SYSTEM_SPAWNED_AGENT_TYPES.has(input.agent.name)
       const rejectionFor = (toolID: string) => ({
         title: "Tool not permitted",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -649,6 +649,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         return new Set(actor.tools)
       })
       const whitelist = yield* whitelistFor()
+      // Whether a permission ask must be non-interactive (fail clean, never hang):
+      // true for system-spawned background actors — checkpoint-writer/dream/distill
+      // AND any background actor such as compose workflow subagents (spawned as
+      // "general" + background:true). Computed once per tool execution.
+      const askNonInteractive = input.agentID
+        ? yield* actorRegistry.isSystemSpawned(input.session.id, input.agentID)
+        : SYSTEM_SPAWNED_AGENT_TYPES.has(input.agent.name)
       const rejectionFor = (toolID: string) => ({
         title: "Tool not permitted",
         output: `The "${toolID}" tool is not in this actor's whitelist. Allowed tools: ${
@@ -690,8 +697,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 tool: { messageID: input.processor.message.id, callID: options.toolCallId },
                 ruleset: Agent.runtimePermission(input.agent, input.session.permission),
                 // System-spawned background agents (checkpoint-writer, dream, distill)
-                // have no human to answer a permission prompt — fail clean, don't hang.
-                interactive: !SYSTEM_SPAWNED_AGENT_TYPES.has(input.agent.name),
+                // AND any background actor (e.g. compose workflow subagents) have no
+                // human to answer a permission prompt — fail clean, don't hang.
+                interactive: !askNonInteractive,
               },
               options.abortSignal,
             )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -650,11 +650,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
       const whitelist = yield* whitelistFor()
       // Whether a permission ask must be non-interactive (fail clean, never hang):
-      // true for system-spawned background actors — checkpoint-writer/dream/distill
-      // AND any background actor such as compose workflow subagents (spawned as
-      // "general" + background:true). Computed once per tool execution.
+      // true for system-spawned actors (checkpoint-writer/dream/distill) AND any
+      // background actor such as compose workflow subagents (spawned as
+      // "general" + background:true).  isSystemSpawned only checks agent type;
+      // we also test the background flag so workflow subagents that aren't
+      // checkpoint-writer/dream/distill don't hang on permission prompts.
       const askNonInteractive = input.agentID
-        ? yield* actorRegistry.isSystemSpawned(input.session.id, input.agentID)
+        ? (yield* actorRegistry.isSystemSpawned(input.session.id, input.agentID)) ||
+          (yield* Effect.map(actorRegistry.get(input.session.id, input.agentID), (a) => a?.background === true))
         : SYSTEM_SPAWNED_AGENT_TYPES.has(input.agent.name)
       const rejectionFor = (toolID: string) => ({
         title: "Tool not permitted",

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -3,11 +3,24 @@ import DESCRIPTION from "./workflow.txt"
 import z from "zod"
 import { Effect, Fiber } from "effect"
 import { Config } from "../config"
+import { ConfigCompose } from "../config"
+import { InstanceState } from "@/effect"
 import { workflowRef } from "@/workflow/runtime-ref"
 import { BuiltinWorkflow } from "@/workflow/builtin"
 import type { SessionID } from "../session/schema"
 
 const id = "workflow"
+
+// Mirror compose.js arg normalization: a bare task string OR a JSON string both
+// collapse to an object. Used so host-side docs-dir injection can merge into args
+// regardless of how the caller serialized them.
+function parseComposeArgString(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw)
+    if (typeof parsed === "object" && parsed !== null) return parsed as Record<string, unknown>
+  } catch {}
+  return { task: raw }
+}
 
 const runSchema = z.strictObject({
   operation: z.literal("run"),
@@ -111,6 +124,25 @@ export const WorkflowTool = Tool.define<typeof parameters, Metadata, Config.Serv
       return Effect.succeed(runtime)
     }
 
+    // Thread the operator-configured compose docs dir into the `compose` built-in's
+    // args, mirroring the `<compose_docs_dir>` block prompt.ts injects for the
+    // interactive compose agent. The compose guest reads `args._composeDocsDir` and
+    // tells its plan/report subagents where to write specs/plans/reports. We
+    // normalize args the same way compose.js does (object | JSON-string | bare task
+    // string) so the injection survives the AI-SDK string-serialization boundary.
+    const enrichComposeArgs = (raw: unknown) =>
+      Effect.gen(function* () {
+        const ctx = yield* InstanceState.context
+        const docs = ConfigCompose.resolveDocsDir(ctx.worktree, (yield* config.get()).compose)
+        const base =
+          typeof raw === "object" && raw !== null
+            ? (raw as Record<string, unknown>)
+            : typeof raw === "string"
+              ? parseComposeArgString(raw)
+              : {}
+        return { ...base, _composeDocsDir: docs }
+      })
+
     const run = Effect.fn("WorkflowTool.execute")(function* (
       input: z.infer<typeof parameters>,
       ctx: Tool.Context<Metadata>,
@@ -145,7 +177,7 @@ export const WorkflowTool = Tool.define<typeof parameters, Metadata, Config.Serv
           script,
           sessionID: ctx.sessionID as SessionID,
           parentActorID: ctx.agent ?? "main",
-          args: input.args,
+          args: input.name === "compose" ? yield* enrichComposeArgs(input.args) : input.args,
           workspace: input.workspace,
           maxConcurrentAgents: cfg.workflow?.maxConcurrentAgents,
           scriptDeadlineMs: cfg.workflow?.scriptDeadlineMs,

--- a/packages/opencode/src/workflow/builtin.ts
+++ b/packages/opencode/src/workflow/builtin.ts
@@ -11,6 +11,8 @@ export * as BuiltinWorkflow from "./builtin"
 // compiled standalone binary.
 // @ts-expect-error TS1192: import-attribute text loader, resolved by Bun not tsgo
 import DEEP_RESEARCH_SCRIPT from "./builtin/deep-research.js" with { type: "text" }
+// @ts-expect-error TS1192: import-attribute text loader, resolved by Bun not tsgo
+import COMPOSE_SCRIPT from "./builtin/compose.js" with { type: "text" }
 import { parseMeta } from "./meta"
 
 export type Entry = {
@@ -26,7 +28,10 @@ export type Entry = {
 // `file` is carried so a malformed meta names the offending script — this throw
 // runs at module init, so a broken built-in fails the whole app boot; the path
 // tells the user which one.
-const SCRIPTS: { file: string; script: string }[] = [{ file: "deep-research.js", script: DEEP_RESEARCH_SCRIPT }]
+const SCRIPTS: { file: string; script: string }[] = [
+  { file: "deep-research.js", script: DEEP_RESEARCH_SCRIPT },
+  { file: "compose.js", script: COMPOSE_SCRIPT },
+]
 
 // Null-prototype so the registry is a self-evidently closed set: a lookup like
 // get("constructor")/get("toString") returns undefined, not an inherited

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -1,19 +1,43 @@
 export const meta = {
   name: "compose",
-  description: "Autonomous compose pipeline — classifies a task and runs plan→tdd→verify→review→merge with bounded retry, all in never-ask mode.",
-  whenToUse: "Use to drive a feature, bugfix, refactor, or review-feedback task through the full compose flow without user prompting. Pass args.task = the user's request. Optionally pass args.type to skip classification.",
+  description:
+    "Autonomous compose pipeline — brainstorms context, designs (spec/plan), implements via parallel per-task worktrees with TDD, verifies, reviews, reports, and merges. Bounded retry, never-ask mode.",
+  whenToUse:
+    "Use to drive a feature, bugfix, refactor, or review-feedback task through the full compose flow without user prompting. Pass args.task = the user's request. Optionally args.type to skip classification, args.feature_name for the report filename, args.skip_brainstorm / args.skip_report to drop those phases, args.maxConcurrent to bound per-batch parallelism.",
   phases: [
+    { title: "Brainstorm", detail: "Context recon (never-ask): conventions, recent changes, relevant files" },
     { title: "Classify", detail: "Decide task type (feature/bugfix/refactor/feedback)" },
-    { title: "Design", detail: "Apply compose:plan, compose:debug, or compose:feedback by type" },
-    { title: "Implement", detail: "compose:tdd loop, retry on verify failure (≤3)" },
+    { title: "Design", detail: "Apply compose:plan, compose:debug, or compose:feedback; emit task list with deps" },
+    { title: "Implement", detail: "Topo-sorted batches, each task in its own worktree (compose:tdd), then integrate" },
     { title: "Verify", detail: "Run project verify commands; structured pass/fail" },
     { title: "Review", detail: "compose:review for critical/important/minor issues" },
+    { title: "Report", detail: "compose:report per-iteration + final consolidated report" },
     { title: "Merge", detail: "compose:merge to commit (and optionally push/PR)" },
   ],
 }
 
 const MAX_TDD_ATTEMPTS = 3
 const MAX_REVIEW_FIX_ATTEMPTS = 2
+const DEFAULT_MAX_CONCURRENT = 8
+
+const BRAINSTORM_SHAPE = {
+  type: "object",
+  required: ["context"],
+  properties: {
+    context: {
+      type: "object",
+      required: ["projectType", "conventions", "recentChanges", "relevantFiles"],
+      properties: {
+        projectType: { type: "string" },
+        conventions: { type: "array", items: { type: "string" } },
+        recentChanges: { type: "array", items: { type: "string" } },
+        relevantFiles: { type: "array", items: { type: "string" } },
+      },
+    },
+    assumptions: { type: "array", items: { type: "string" } },
+    notes: { type: "string" },
+  },
+}
 
 const CLASSIFY_SHAPE = {
   type: "object",
@@ -40,10 +64,27 @@ const DESIGN_SHAPE = {
           description: { type: "string" },
           acceptance: { type: "string" },
           files: { type: "array", items: { type: "string" } },
+          dependsOn: { type: "array", items: { type: "string" } },
         },
       },
     },
     notes: { type: "string" },
+  },
+}
+
+const INTEGRATE_SHAPE = {
+  type: "object",
+  required: ["merged", "conflicts", "skipped_pristine"],
+  properties: {
+    merged: {
+      type: "array",
+      items: { type: "object", properties: { taskId: { type: "string" }, branch: { type: "string" }, sha: { type: "string" } } },
+    },
+    conflicts: {
+      type: "array",
+      items: { type: "object", properties: { taskId: { type: "string" }, branch: { type: "string" }, error: { type: "string" } } },
+    },
+    skipped_pristine: { type: "array", items: { type: "string" } },
   },
 }
 
@@ -78,6 +119,30 @@ const REVIEW_SHAPE = {
   },
 }
 
+const ITERATION_REPORT_SHAPE = {
+  type: "object",
+  required: ["iteration", "what_changed"],
+  properties: {
+    iteration: { type: "number" },
+    what_changed: { type: "string" },
+    files_added: { type: "array", items: { type: "string" } },
+    files_modified: { type: "array", items: { type: "string" } },
+    tests_passed: { type: "number" },
+    tests_failed: { type: "number" },
+    notes: { type: "string" },
+  },
+}
+
+const FINAL_REPORT_SHAPE = {
+  type: "object",
+  required: ["path"],
+  properties: {
+    path: { type: "string" },
+    sha: { type: "string" },
+    summary: { type: "string" },
+  },
+}
+
 const MERGE_SHAPE = {
   type: "object",
   required: ["committed", "action"],
@@ -89,9 +154,8 @@ const MERGE_SHAPE = {
   },
 }
 
-// Placeholder body — replaced in subsequent tasks.
-// Accept args as either an object {task,type?} OR a JSON string OR a bare task string,
-// because the AI-SDK tool boundary often serializes nested args as strings.
+// Accept args as either an object {task,type?,...} OR a JSON string OR a bare task
+// string, because the AI-SDK tool boundary often serializes nested args as strings.
 let _argsObj
 if (typeof args === "object" && args !== null) {
   _argsObj = args
@@ -108,7 +172,66 @@ if (!TASK) {
 
 const VALID_TYPES = ["feature", "bugfix", "refactor", "feedback"]
 const argType = typeof _argsObj.type === "string" ? _argsObj.type : ""
+const SKIP_BRAINSTORM = _argsObj.skip_brainstorm === true
+const SKIP_REPORT = _argsObj.skip_report === true
+const MAX_CONCURRENT =
+  typeof _argsObj.maxConcurrent === "number" && _argsObj.maxConcurrent > 0 ? _argsObj.maxConcurrent : DEFAULT_MAX_CONCURRENT
 
+// Docs dir injected by the host (workflow.ts) from ConfigCompose.resolveDocsDir,
+// mirroring the <compose_docs_dir> block prompt.ts gives the interactive compose
+// agent. Default keeps the workflow self-sufficient if the host didn't inject.
+const DOCS_DIR = typeof _argsObj._composeDocsDir === "string" && _argsObj._composeDocsDir ? _argsObj._composeDocsDir : "docs/compose"
+const SPECS_DIR = DOCS_DIR + "/specs"
+const PLANS_DIR = DOCS_DIR + "/plans"
+const REPORTS_DIR = DOCS_DIR + "/reports"
+const docsBlock =
+  "<compose_docs_dir>\n" +
+  "Save compose skill outputs: specs in `" + SPECS_DIR + "`, plans in `" + PLANS_DIR + "`, reports in `" + REPORTS_DIR + "`.\n" +
+  "</compose_docs_dir>"
+
+// Slug for the per-run report filename. feature_name overrides; else slugify task.
+const FEATURE_NAME =
+  (typeof _argsObj.feature_name === "string" && _argsObj.feature_name ? _argsObj.feature_name : TASK)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60) || "compose-run"
+const REPORT_PATH = REPORTS_DIR + "/" + FEATURE_NAME + ".md"
+
+// ---------------------------------------------------------------------------
+// Phase 0 — Brainstorm (autonomous-mode contract: context recon only, never-ask)
+// ---------------------------------------------------------------------------
+phase("Brainstorm")
+const SYNTHETIC_CONTEXT = { projectType: "unknown", conventions: [], recentChanges: [], relevantFiles: [] }
+let brainstorm
+if (SKIP_BRAINSTORM) {
+  brainstorm = { context: SYNTHETIC_CONTEXT, assumptions: [] }
+} else {
+  brainstorm = await agent(
+    "Apply the `compose:brainstorm` skill in AUTONOMOUS mode — no user is available. Use the `skill` tool to load it first.\n\n" +
+    "Per the skill's autonomous override: do STEP 1 ONLY (context recon). Do NOT present a design, ask questions, write a spec, or wait for approval.\n\n" +
+    "## Task\n" + TASK + "\n\n" +
+    "## What to gather\n" +
+    "- Read AGENTS.md / CLAUDE.md / README.md if present\n" +
+    "- Skim recent commits (`git log --oneline -20`)\n" +
+    "- Map top-level directory layout\n" +
+    "- Identify files clearly relevant to the task\n" +
+    "- Note any reasonable assumptions you are making (so Design sees them)\n\n" +
+    "Return structured output only.",
+    { label: "brainstorm", phase: "Brainstorm", schema: BRAINSTORM_SHAPE, model: "lite" }
+  )
+  if (!brainstorm || !brainstorm.context) brainstorm = { context: SYNTHETIC_CONTEXT, assumptions: [] }
+}
+const contextDigest =
+  "Project: " + brainstorm.context.projectType + "\n" +
+  "Conventions:\n" + (brainstorm.context.conventions || []).map((c) => "- " + c).join("\n") + "\n" +
+  "Recent changes:\n" + (brainstorm.context.recentChanges || []).map((c) => "- " + c).join("\n") + "\n" +
+  "Relevant files:\n" + (brainstorm.context.relevantFiles || []).map((f) => "- " + f).join("\n") +
+  ((brainstorm.assumptions && brainstorm.assumptions.length) ? "\nAssumptions:\n" + brainstorm.assumptions.map((a) => "- " + a).join("\n") : "")
+
+// ---------------------------------------------------------------------------
+// Phase 1 — Classify
+// ---------------------------------------------------------------------------
 phase("Classify")
 let classification = null
 let type
@@ -137,23 +260,86 @@ const SKILL_BY_TYPE = {
   feedback: "compose:feedback",
 }
 
+// ---------------------------------------------------------------------------
+// Phase 2 — Design (spec/plan, context-grounded, dependency-aware)
+// ---------------------------------------------------------------------------
 phase("Design")
 const designSkill = SKILL_BY_TYPE[type] || "compose:plan"
 const design = await agent(
   "Apply the `" + designSkill + "` skill to the task below. Use the `skill` tool to load the skill before working.\n\n" +
+  docsBlock + "\n\n" +
   "## Task\n" + TASK + "\n\n" +
+  "## Project context (from brainstorm)\n" + contextDigest + "\n\n" +
   "## What to produce\n" +
-  "A task list of bite-sized work items, each with id, description, and acceptance criteria. " +
-  "Optionally list the files each task touches.\n\n" +
+  "Write the spec/plan to the docs dirs above per the skill, then return a task list of bite-sized work items, " +
+  "each with id, description, and acceptance criteria. Optionally list the files each task touches.\n" +
+  "Mark independent tasks with empty `dependsOn`. Mark a task that needs another committed first with that task's id in `dependsOn`. " +
+  "No cycles in dependsOn.\n\n" +
   "Return structured output only.",
   { label: "design:" + type, phase: "Design", schema: DESIGN_SHAPE }
 )
 if (!design) {
-  return { error: "design-failed", type, classification }
+  return { error: "design-failed", type, classification, brainstorm }
 }
 log("Designed " + design.tasks.length + " task(s) using " + designSkill)
 
+// Topo-sort (Kahn) over design.tasks by dependsOn → ordered batches.
+const topoSort = (tasks) => {
+  const byId = Object.create(null)
+  for (const t of tasks) byId[t.id] = t
+  const indeg = Object.create(null)
+  const deps = Object.create(null)
+  for (const t of tasks) {
+    deps[t.id] = (t.dependsOn || []).filter((d) => byId[d])
+    indeg[t.id] = deps[t.id].length
+  }
+  const batches = []
+  let remaining = tasks.map((t) => t.id)
+  while (remaining.length) {
+    const ready = remaining.filter((id) => indeg[id] === 0)
+    if (!ready.length) return { error: "design-cycle", cycleNodes: remaining }
+    batches.push(ready)
+    const readySet = Object.create(null)
+    for (const id of ready) readySet[id] = true
+    remaining = remaining.filter((id) => !readySet[id])
+    for (const id of remaining) {
+      indeg[id] = deps[id].filter((d) => !readySet[d] && remaining.indexOf(d) >= 0).length
+    }
+  }
+  return { batches }
+}
+const topo = topoSort(design.tasks)
+if (topo.error) {
+  return { error: "design-cycle", cycleNodes: topo.cycleNodes, type, classification, brainstorm, design }
+}
+const batches = topo.batches
+const taskById = Object.create(null)
+for (const t of design.tasks) taskById[t.id] = t
+
 const TASKS_DIGEST = design.tasks.map((t, i) => (i + 1) + ". " + t.id + ": " + t.description + " — " + t.acceptance).join("\n")
+
+// ---------------------------------------------------------------------------
+// Helpers: implement (per-task, worktree), integrate, verify, debug, report
+// ---------------------------------------------------------------------------
+const runImplementTask = (task, failuresOrEmpty) => agent(
+  "Apply the `compose:tdd` skill. Use the `skill` tool to load it before working.\n\n" +
+  "## Overall task\n" + TASK + "\n\n" +
+  "## Your work item (" + task.id + ")\n" + task.description + "\nAcceptance: " + task.acceptance +
+  (task.files && task.files.length ? "\nFiles: " + task.files.join(", ") : "") + "\n\n" +
+  (failuresOrEmpty ? "## Verify failures from previous attempt — focus on these\n" + failuresOrEmpty + "\n\n" : "") +
+  "Write the failing test first, then the minimal code to pass, then refactor. Commit your work inside this worktree.",
+  { label: "implement:" + task.id, phase: "Implement", isolation: "worktree" }
+)
+
+const runIntegrate = (kept) => agent(
+  "Integrate the per-task worktrees below into the main workspace.\n\n" +
+  "## Worktrees to merge\n" + JSON.stringify(kept) + "\n\n" +
+  "For each `_worktree`, fetch its branch into the main workspace and merge (or fast-forward) it onto current HEAD. " +
+  "Resolve trivial conflicts (whitespace, import order, formatting) automatically. Surface real conflicts unmodified. " +
+  "Then `git worktree remove` each integrated worktree.\n\n" +
+  "Return structured output only.",
+  { label: "integrate", phase: "Implement", schema: INTEGRATE_SHAPE }
+)
 
 const runVerify = () => agent(
   "Run the project's verification commands and report the outcome.\n\n" +
@@ -165,42 +351,112 @@ const runVerify = () => agent(
   { label: "verify", phase: "Verify", schema: VERIFY_SHAPE }
 )
 
-const runImplement = (failuresOrEmpty) => agent(
-  "Apply the `compose:tdd` skill. Use the `skill` tool to load it before working.\n\n" +
-  "## Task\n" + TASK + "\n\n" +
-  "## Plan\n" + TASKS_DIGEST + "\n\n" +
-  (failuresOrEmpty ? "## Verify failures from previous attempt — focus on these\n" + failuresOrEmpty + "\n\n" : "") +
-  "Implement the plan. Write the failing test first, then the minimal code to pass, then refactor. " +
-  "Commit each task as you complete it.",
-  { label: "implement", phase: "Implement" }
-)
-
 const runDebug = (failures) => agent(
   "Apply the `compose:debug` skill. Use the `skill` tool to load it before working.\n\n" +
-  "## Verify failures\n" + failures + "\n\n" +
+  "## Verify failures / integrate conflicts\n" + failures + "\n\n" +
   "Identify the root cause and fix it. Do not paper over symptoms.",
   { label: "debug", phase: "Implement" }
 )
 
+const runIterationReport = (iteration, verifyResult) => {
+  if (SKIP_REPORT) return Promise.resolve(null)
+  return agent(
+    "Apply the `compose:report` skill in per-iteration mode. Use the `skill` tool to load it first.\n\n" +
+    docsBlock + "\n\n" +
+    "## Report file (overwrite-in-place, accumulate Journey Log)\n" + REPORT_PATH + "\n\n" +
+    "## Iteration\n" + iteration + "\n\n" +
+    "## Overall task\n" + TASK + "\n\n" +
+    "## Verify result\n" + JSON.stringify(verifyResult) + "\n\n" +
+    "Read the existing report if present, update sections, append a Journey Log entry for this iteration, and overwrite the file. " +
+    "Keep it brief.\n\n" +
+    "Return structured output only.",
+    { label: "iteration-report:" + iteration, phase: "Report", schema: ITERATION_REPORT_SHAPE }
+  )
+}
+
+// Dispatch a batch of tasks in parallel, each isolated in its own worktree, then
+// integrate the kept worktrees. Returns { perTaskResults, integrate }.
+const runBatch = async (batchIds, failuresOrEmpty) => {
+  const tasks = batchIds.map((id) => taskById[id])
+  const limit = Math.min(MAX_CONCURRENT, tasks.length)
+  // Soft per-batch cap: chunk so no more than `limit` run at once.
+  const perTaskResults = []
+  const kept = []
+  for (let i = 0; i < tasks.length; i += limit) {
+    const chunk = tasks.slice(i, i + limit)
+    const results = await parallel(chunk.map((t) => () => runImplementTask(t, failuresOrEmpty)))
+    for (let j = 0; j < chunk.length; j++) {
+      const t = chunk[j]
+      const r = results[j]
+      const wt = r && typeof r === "object" ? r._worktree : null
+      if (wt && wt.changed) {
+        kept.push({ taskId: t.id, _worktree: wt })
+        perTaskResults.push({ taskId: t.id, status: "ok", branch: wt.branch })
+      } else if (r === null) {
+        perTaskResults.push({ taskId: t.id, status: "failed" })
+      } else {
+        perTaskResults.push({ taskId: t.id, status: "pristine" })
+      }
+    }
+  }
+  const integrate = kept.length
+    ? await runIntegrate(kept)
+    : { merged: [], conflicts: [], skipped_pristine: perTaskResults.filter((r) => r.status !== "ok").map((r) => r.taskId) }
+  return { perTaskResults, integrate: integrate || { merged: [], conflicts: [], skipped_pristine: [] } }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 — Implement (TDD outer loop, ≤3 attempts)
+// ---------------------------------------------------------------------------
 phase("Implement")
 const verifyHistory = []
+const implementHistory = []
 let verify = null
 let tddAttempts = 0
 for (let attempt = 0; attempt < MAX_TDD_ATTEMPTS; attempt++) {
   tddAttempts = attempt + 1
-  await runImplement(attempt === 0 ? "" : (verify && verify.failures ? verify.failures : ""))
+  const failures = attempt === 0 ? "" : (verify && verify.failures ? verify.failures : "")
+  let attemptConflicts = []
+  const perTaskResults = []
+  const integrateHistory = []
+  for (const batchIds of batches) {
+    const batchOut = await runBatch(batchIds, failures)
+    for (const r of batchOut.perTaskResults) perTaskResults.push(r)
+    integrateHistory.push(batchOut.integrate)
+    if (batchOut.integrate.conflicts && batchOut.integrate.conflicts.length) {
+      attemptConflicts = attemptConflicts.concat(batchOut.integrate.conflicts)
+    }
+  }
+
+  phase("Verify")
   verify = await runVerify()
   if (verify) verifyHistory.push(verify)
-  if (verify && verify.allPassed) {
+  const conflictText = attemptConflicts.length ? "\nIntegrate conflicts: " + JSON.stringify(attemptConflicts) : ""
+  const passed = verify && verify.allPassed && attemptConflicts.length === 0
+
+  implementHistory.push({
+    attempt: tddAttempts,
+    perTaskResults,
+    integrate: { batches: integrateHistory },
+    verify: verify || null,
+  })
+
+  if (passed) {
     log("Verify passed on attempt " + tddAttempts)
+    phase("Report")
+    await runIterationReport(tddAttempts, verify)
     break
   }
   if (attempt + 1 === MAX_TDD_ATTEMPTS) {
-    return { error: "verify-exhausted", type, classification, design, verifyHistory, attempts: MAX_TDD_ATTEMPTS }
+    return { error: "verify-exhausted", type, classification, brainstorm, design, batches, verifyHistory, implementHistory, attempts: MAX_TDD_ATTEMPTS }
   }
-  await runDebug(verify ? (verify.failures || "verify returned no detail") : "verify agent failed (null)")
+  phase("Implement")
+  await runDebug((verify ? (verify.failures || "verify returned no detail") : "verify agent failed (null)") + conflictText)
 }
 
+// ---------------------------------------------------------------------------
+// Phase 4 — Review  +  Phase 5 — Fix loop (≤2 attempts)
+// ---------------------------------------------------------------------------
 const runReview = () => agent(
   "Apply the `compose:review` skill. Use the `skill` tool to load it before working.\n\n" +
   "## Task context\n" + TASK + "\n\n" +
@@ -211,27 +467,57 @@ const runReview = () => agent(
   { label: "review", phase: "Review", schema: REVIEW_SHAPE }
 )
 
-const runFix = (criticalList) => agent(
-  "Address the CRITICAL review findings below. Apply the `compose:tdd` skill to fix them with tests where possible.\n\n" +
-  "## Critical findings\n" + criticalList.map((c, i) => (i + 1) + ". " + c).join("\n") + "\n\n" +
-  "Fix each, then commit.",
-  { label: "fix", phase: "Review" }
+const runFixTask = (finding, i) => agent(
+  "Address the CRITICAL review finding below. Apply the `compose:tdd` skill to fix it with tests where possible. " +
+  "Use the `skill` tool to load it first.\n\n" +
+  "## Critical finding (" + (i + 1) + ")\n" + finding + "\n\n" +
+  "Fix it and commit inside this worktree.",
+  { label: "fix:" + i, phase: "Fix", isolation: "worktree" }
 )
 
 phase("Review")
 let review = await runReview()
 if (!review) review = { critical: [], important: [], minor: [], readyToMerge: true }
 let reviewFixAttempts = 0
+const fixHistory = []
 
 if (review.critical && review.critical.length > 0) {
   phase("Fix")
   for (let attempt = 0; attempt < MAX_REVIEW_FIX_ATTEMPTS; attempt++) {
     reviewFixAttempts = attempt + 1
-    await runFix(review.critical)
+    const limit = Math.min(MAX_CONCURRENT, review.critical.length)
+    const perTaskResults = []
+    const kept = []
+    const criticals = review.critical
+    for (let i = 0; i < criticals.length; i += limit) {
+      const chunk = criticals.slice(i, i + limit)
+      const results = await parallel(chunk.map((finding, k) => () => runFixTask(finding, i + k)))
+      for (let j = 0; j < chunk.length; j++) {
+        const r = results[j]
+        const wt = r && typeof r === "object" ? r._worktree : null
+        if (wt && wt.changed) {
+          kept.push({ taskId: "fix-" + (i + j), _worktree: wt })
+          perTaskResults.push({ taskId: "fix-" + (i + j), status: "ok", branch: wt.branch })
+        } else {
+          perTaskResults.push({ taskId: "fix-" + (i + j), status: r === null ? "failed" : "pristine" })
+        }
+      }
+    }
+    const integrate = kept.length ? (await runIntegrate(kept)) || { merged: [], conflicts: [], skipped_pristine: [] } : { merged: [], conflicts: [], skipped_pristine: [] }
+
+    phase("Verify")
     const reverify = await runVerify()
     if (reverify) verifyHistory.push(reverify)
+
+    phase("Review")
     review = await runReview()
     if (!review) review = { critical: [], important: [], minor: [], readyToMerge: false }
+
+    fixHistory.push({ attempt: reviewFixAttempts, perTaskResults, integrate, verify: reverify || null, review })
+
+    phase("Report")
+    await runIterationReport(MAX_TDD_ATTEMPTS + reviewFixAttempts, reverify)
+
     if (!review.critical || review.critical.length === 0) {
       log("Critical issues cleared on fix attempt " + reviewFixAttempts)
       break
@@ -240,12 +526,37 @@ if (review.critical && review.critical.length > 0) {
   if (review.critical && review.critical.length > 0) {
     return {
       readyToMerge: false,
-      type, classification, design, verifyHistory, review,
+      type, classification, brainstorm, design, batches, verifyHistory, implementHistory, fixHistory, review,
       attempts: { tdd: tddAttempts, reviewFix: reviewFixAttempts },
     }
   }
 }
 
+// ---------------------------------------------------------------------------
+// Phase 6 — Final Report (consolidate, committed before merge)
+// ---------------------------------------------------------------------------
+let finalReport = null
+if (!SKIP_REPORT) {
+  phase("Report")
+  finalReport = await agent(
+    "Apply the `compose:report` skill in FINAL consolidation mode. Use the `skill` tool to load it first.\n\n" +
+    docsBlock + "\n\n" +
+    "## Report file (read the in-progress per-iteration file, overwrite with canonical final state)\n" + REPORT_PATH + "\n\n" +
+    "## Overall task\n" + TASK + "\n\n" +
+    "## Run history\n" +
+    "verifyHistory: " + JSON.stringify(verifyHistory) + "\n" +
+    "implementHistory: " + JSON.stringify(implementHistory) + "\n" +
+    "reviewFixAttempts: " + reviewFixAttempts + "\n\n" +
+    "Produce the final-state report (What Was Built / Architecture / Design Decisions / Usage / Verification / Journey Log / Source Materials). " +
+    "Distill the Journey Log to at most 5 entries. Commit the report file.\n\n" +
+    "Return structured output only.",
+    { label: "final-report", phase: "Report", schema: FINAL_REPORT_SHAPE }
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Phase 7 — Merge
+// ---------------------------------------------------------------------------
 phase("Merge")
 const merge = await agent(
   "Apply the `compose:merge` skill. Use the `skill` tool to load it before working.\n\n" +
@@ -261,23 +572,29 @@ const merge = await agent(
 if (!merge || !merge.committed) {
   return {
     error: "merge-failed",
-    type, classification, design, verifyHistory, review,
+    type, classification, brainstorm, design, batches, verifyHistory, implementHistory, review, finalReport,
     merge: merge || { committed: false, action: "none" },
     attempts: { tdd: tddAttempts, reviewFix: reviewFixAttempts },
   }
 }
 
 return {
+  brainstorm,
   type,
   classification,
   design,
+  batches,
+  implementHistory,
   verifyHistory,
   review,
+  fixHistory: fixHistory.length ? fixHistory : undefined,
   reviewFixes: reviewFixAttempts,
+  finalReport,
   merge,
   stats: {
-    agents: verifyHistory.length + tddAttempts + reviewFixAttempts + 3, // classify + design + review + merge + impl/debug
-    phases: 6,
+    agents: verifyHistory.length + tddAttempts + reviewFixAttempts + 4, // brainstorm + classify + design + review + merge
+    phases: 8,
+    parallelBatches: batches.length,
     durationMs: 0, // QuickJS guest has no Date; host can compute from journal if needed
   },
 }

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -235,5 +235,38 @@ if (review.critical && review.critical.length > 0) {
   }
 }
 
-// Placeholder return — replaced in next task.
-return { type, classification, design, verifyHistory, review, todo: "merge" }
+phase("Merge")
+const merge = await agent(
+  "Apply the `compose:merge` skill. Use the `skill` tool to load it before working.\n\n" +
+  "## Task\n" + TASK + "\n\n" +
+  "Commit the changes. If the branch tracks a remote and a PR is appropriate, push and open one.\n" +
+  "Pick the smallest action that satisfies the goal:\n" +
+  "- `commit`: just record locally\n" +
+  "- `commit+push`: also push to the existing remote branch\n" +
+  "- `commit+pr`: push and open a PR\n\n" +
+  "Return structured output only.",
+  { label: "merge", phase: "Merge", schema: MERGE_SHAPE }
+)
+if (!merge || !merge.committed) {
+  return {
+    error: "merge-failed",
+    type, classification, design, verifyHistory, review,
+    merge: merge || { committed: false, action: "none" },
+    attempts: { tdd: tddAttempts, reviewFix: reviewFixAttempts },
+  }
+}
+
+return {
+  type,
+  classification,
+  design,
+  verifyHistory,
+  review,
+  reviewFixes: reviewFixAttempts,
+  merge,
+  stats: {
+    agents: verifyHistory.length + tddAttempts + reviewFixAttempts + 3, // classify + design + review + merge + impl/debug
+    phases: 6,
+    durationMs: 0, // QuickJS guest has no Date; host can compute from journal if needed
+  },
+}

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -119,5 +119,28 @@ if (VALID_TYPES.indexOf(argType) >= 0) {
   log("Classified as " + type + (classification ? " (" + classification.confidence + ")" : " (default)"))
 }
 
+const SKILL_BY_TYPE = {
+  feature: "compose:plan",
+  refactor: "compose:plan",
+  bugfix: "compose:debug",
+  feedback: "compose:feedback",
+}
+
+phase("Design")
+const designSkill = SKILL_BY_TYPE[type] || "compose:plan"
+const design = await agent(
+  "Apply the `" + designSkill + "` skill to the task below. Use the `skill` tool to load the skill before working.\n\n" +
+  "## Task\n" + TASK + "\n\n" +
+  "## What to produce\n" +
+  "A task list of bite-sized work items, each with id, description, and acceptance criteria. " +
+  "Optionally list the files each task touches.\n\n" +
+  "Return structured output only.",
+  { label: "design:" + type, phase: "Design", schema: DESIGN_SHAPE }
+)
+if (!design) {
+  return { error: "design-failed", type, classification }
+}
+log("Designed " + design.tasks.length + " task(s) using " + designSkill)
+
 // Placeholder return — replaced in subsequent tasks.
-return { type, classification, todo: "design+impl+review+merge" }
+return { type, classification, design, todo: "impl+review+merge" }

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -349,7 +349,7 @@ const design = await agent(
   "(empty for independent tasks; a prerequisite task id otherwise; no cycles).",
   { label: "design-extract:" + type, phase: "Design", schema: DESIGN_SHAPE }
 )
-if (!design) {
+if (!design || !Array.isArray(design.tasks) || design.tasks.length === 0) {
   return { error: "design-failed", type, brainstorm, docs: { specWritten, planWritten } }
 }
 // Normalize task ids: the extract agent sometimes returns tasks with a missing or

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -12,5 +12,82 @@ export const meta = {
   ],
 }
 
+const MAX_TDD_ATTEMPTS = 3
+const MAX_REVIEW_FIX_ATTEMPTS = 2
+
+const CLASSIFY_SHAPE = {
+  type: "object",
+  required: ["type", "confidence", "reasoning"],
+  properties: {
+    type: { enum: ["feature", "bugfix", "refactor", "feedback"] },
+    confidence: { enum: ["high", "medium", "low"] },
+    reasoning: { type: "string" },
+  },
+}
+
+const DESIGN_SHAPE = {
+  type: "object",
+  required: ["tasks"],
+  properties: {
+    tasks: {
+      type: "array",
+      minItems: 1,
+      items: {
+        type: "object",
+        required: ["id", "description", "acceptance"],
+        properties: {
+          id: { type: "string" },
+          description: { type: "string" },
+          acceptance: { type: "string" },
+          files: { type: "array", items: { type: "string" } },
+        },
+      },
+    },
+    notes: { type: "string" },
+  },
+}
+
+const VERIFY_SHAPE = {
+  type: "object",
+  required: ["typecheck", "tests", "build", "allPassed"],
+  properties: {
+    typecheck: { enum: ["ok", "fail", "skipped"] },
+    tests: {
+      type: "object",
+      required: ["passed", "failed"],
+      properties: {
+        passed: { type: "number" },
+        failed: { type: "number" },
+        output: { type: "string" },
+      },
+    },
+    build: { enum: ["ok", "fail", "skipped"] },
+    allPassed: { type: "boolean" },
+    failures: { type: "string" },
+  },
+}
+
+const REVIEW_SHAPE = {
+  type: "object",
+  required: ["critical", "important", "minor", "readyToMerge"],
+  properties: {
+    critical: { type: "array", items: { type: "string" } },
+    important: { type: "array", items: { type: "string" } },
+    minor: { type: "array", items: { type: "string" } },
+    readyToMerge: { type: "boolean" },
+  },
+}
+
+const MERGE_SHAPE = {
+  type: "object",
+  required: ["committed", "action"],
+  properties: {
+    committed: { type: "boolean" },
+    sha: { type: "string" },
+    prUrl: { type: "string" },
+    action: { enum: ["commit", "commit+push", "commit+pr", "none"] },
+  },
+}
+
 // Placeholder body — replaced in subsequent tasks.
 return { ok: true, todo: "implement phases" }

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -3,11 +3,11 @@ export const meta = {
   description:
     "Autonomous compose pipeline — brainstorms context, designs (spec/plan), implements via parallel per-task worktrees with TDD, verifies, reviews, reports, and merges. Bounded retry, never-ask mode.",
   whenToUse:
-    "Use to drive a feature, bugfix, refactor, or review-feedback task through the full compose flow without user prompting. Pass args.task = the user's request. Optionally args.type to set the task type (feature/bugfix/refactor/feedback; otherwise inferred), args.feature_name for the report filename, args.skip_brainstorm / args.skip_report to drop those phases, args.maxConcurrent to bound per-batch parallelism.",
+    "Use to drive a feature, bugfix, refactor, or review-feedback task through the full compose flow without user prompting. Pass args.task = the user's request. Optionally args.type to set the task type (feature/bugfix/refactor/feedback; otherwise inferred), args.feature_name for the report filename, args.skip_brainstorm / args.skip_report to drop those phases, args.maxConcurrent to bound per-batch parallelism. Independent tasks auto-run in parallel, each in its own worktree, then merge back; pass args.isolate_worktrees=false to force all-sequential or =true to force isolation.",
   phases: [
     { title: "Brainstorm", detail: "Context recon (never-ask): conventions, recent changes, relevant files" },
     { title: "Design", detail: "Apply compose:plan, compose:debug, or compose:feedback; emit task list with deps" },
-    { title: "Implement", detail: "Topo-sorted batches (compose:tdd), then integrate" },
+    { title: "Implement", detail: "Topo-sorted batches; independent tasks parallelize in per-task worktrees, then integrate" },
     { title: "Verify", detail: "Run project verify commands; structured pass/fail" },
     { title: "Review", detail: "compose:review for critical/important/minor issues" },
     { title: "Report", detail: "compose:report per-iteration + final consolidated report" },
@@ -139,11 +139,17 @@ const VALID_TYPES = ["feature", "bugfix", "refactor", "feedback"]
 const argType = typeof _argsObj.type === "string" ? _argsObj.type : ""
 const SKIP_BRAINSTORM = _argsObj.skip_brainstorm === true
 const SKIP_REPORT = _argsObj.skip_report === true
-// Per-task worktree isolation is OPT-IN. Default OFF: implement/fix agents run in
-// the main workspace so their writes materialize directly (and verify sees them).
-// The worktree-isolation runtime path can leave tasks "pristine" (writes not landing
-// in the worktree) in some environments; opt in only when that path is known-good.
-const ISOLATE = _argsObj.isolate_worktrees === true
+// Per-batch worktree isolation. Independent tasks that would run concurrently MUST
+// be isolated (parallel writes to one workspace conflict) — the runtime creates a
+// worktree per task, the agent works in it, and an integrate agent merges it back.
+// Decision is per batch: auto-isolate a batch iff it runs >1 task; a single-task
+// batch stays sequential in the main workspace. args.isolate_worktrees forces it:
+// true = always isolate, false = never. (Runtime worktree path verified by
+// test/workflow/runtime-worktree.test.ts; not opt-in-off anymore.)
+const ISOLATE_OVERRIDE =
+  _argsObj.isolate_worktrees === true ? true : _argsObj.isolate_worktrees === false ? false : undefined
+const isolateBatch = (batchIds) =>
+  ISOLATE_OVERRIDE === true ? true : ISOLATE_OVERRIDE === false ? false : batchIds.length > 1
 const MAX_CONCURRENT =
   typeof _argsObj.maxConcurrent === "number" && _argsObj.maxConcurrent > 0 ? _argsObj.maxConcurrent : DEFAULT_MAX_CONCURRENT
 
@@ -346,7 +352,7 @@ const TASKS_DIGEST = design.tasks.map((t, i) => (i + 1) + ". " + t.id + ": " + t
 // ---------------------------------------------------------------------------
 // Helpers: implement (per-task, worktree), integrate, verify, debug, report
 // ---------------------------------------------------------------------------
-const runImplementTask = (task, failuresOrEmpty) => agent(
+const runImplementTask = (task, failuresOrEmpty, isolate) => agent(
   "Apply the `compose:tdd` skill. Use the `skill` tool to load it before working.\n\n" +
   "## Overall task\n" + TASK + "\n\n" +
   "## Your work item (" + task.id + ")\n" + task.description + "\nAcceptance: " + task.acceptance +
@@ -354,8 +360,8 @@ const runImplementTask = (task, failuresOrEmpty) => agent(
   (failuresOrEmpty ? "## Verify failures from previous attempt — focus on these\n" + failuresOrEmpty + "\n\n" : "") +
   "Write the failing test first (use the `write` tool), then the minimal code to pass, then refactor. " +
   "Actually create the source and test files on disk with the `write` tool — do not just describe them. " +
-  (ISOLATE ? "Commit your work inside this worktree." : "Commit your work in the workspace."),
-  ISOLATE
+  (isolate ? "Commit your work inside this worktree." : "Commit your work in the workspace."),
+  isolate
     ? { label: "implement:" + task.id, phase: "Implement", isolation: "worktree" }
     : { label: "implement:" + task.id, phase: "Implement" }
 )
@@ -415,15 +421,15 @@ const runBatch = async (batchIds, failuresOrEmpty) => {
   const tasks = batchIds.map((id) => taskById[id])
   const perTaskResults = []
   const kept = []
-  // Concurrency model (aligned with the compose skill): only run implement tasks
-  // CONCURRENTLY when each task is isolated in its own worktree. In the default
-  // (non-isolated) mode all tasks write to the SAME workspace, so the original
-  // compose:subagent skill forbids parallel implementation (file conflicts) — run
-  // them one at a time. parallel() here is gated on ISOLATE for exactly that reason.
+  // Per-batch isolation: a batch with >1 independent task auto-isolates (worktree
+  // per task) so they can run CONCURRENTLY without clobbering the shared workspace;
+  // a single-task batch stays sequential in the main workspace. args.isolate_worktrees
+  // forces either way. parallel() is gated on ISOLATE for exactly this reason.
+  const ISOLATE = isolateBatch(batchIds)
   const limit = ISOLATE ? Math.min(MAX_CONCURRENT, tasks.length) : 1
   for (let i = 0; i < tasks.length; i += limit) {
     const chunk = tasks.slice(i, i + limit)
-    const results = await parallel(chunk.map((t) => () => runImplementTask(t, failuresOrEmpty)))
+    const results = await parallel(chunk.map((t) => () => runImplementTask(t, failuresOrEmpty, ISOLATE)))
     for (let j = 0; j < chunk.length; j++) {
       const t = chunk[j]
       const r = results[j]
@@ -514,12 +520,12 @@ const runReview = () => agent(
   { label: "review", phase: "Review", schema: REVIEW_SHAPE }
 )
 
-const runFixTask = (finding, i) => agent(
+const runFixTask = (finding, i, isolate) => agent(
   "Address the CRITICAL review finding below. Apply the `compose:tdd` skill to fix it with tests where possible. " +
   "Use the `skill` tool to load it first.\n\n" +
   "## Critical finding (" + (i + 1) + ")\n" + finding + "\n\n" +
-  "Fix it with the `write`/`edit` tools and commit " + (ISOLATE ? "inside this worktree." : "in the workspace."),
-  ISOLATE ? { label: "fix:" + i, phase: "Fix", isolation: "worktree" } : { label: "fix:" + i, phase: "Fix" }
+  "Fix it with the `write`/`edit` tools and commit " + (isolate ? "inside this worktree." : "in the workspace."),
+  isolate ? { label: "fix:" + i, phase: "Fix", isolation: "worktree" } : { label: "fix:" + i, phase: "Fix" }
 )
 
 phase("Review")
@@ -532,15 +538,16 @@ if (review.critical && review.critical.length > 0) {
   phase("Fix")
   for (let attempt = 0; attempt < MAX_REVIEW_FIX_ATTEMPTS; attempt++) {
     reviewFixAttempts = attempt + 1
-    // Same concurrency rule as implement: parallel only when worktree-isolated;
-    // otherwise fixes share the workspace → run sequentially to avoid conflicts.
+    // Same per-batch rule as implement: isolate (worktree per fix) when >1 critical
+    // fix would run concurrently, or when forced; otherwise sequential in main workspace.
+    const ISOLATE = isolateBatch(review.critical.map((_, i) => "fix-" + i))
     const limit = ISOLATE ? Math.min(MAX_CONCURRENT, review.critical.length) : 1
     const perTaskResults = []
     const kept = []
     const criticals = review.critical
     for (let i = 0; i < criticals.length; i += limit) {
       const chunk = criticals.slice(i, i + limit)
-      const results = await parallel(chunk.map((finding, k) => () => runFixTask(finding, i + k)))
+      const results = await parallel(chunk.map((finding, k) => () => runFixTask(finding, i + k, ISOLATE)))
       for (let j = 0; j < chunk.length; j++) {
         const r = results[j]
         if (ISOLATE) {

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -171,12 +171,15 @@ const docsBlock =
   "</compose_docs_dir>"
 
 // Slug for the per-run report filename. feature_name overrides; else slugify task.
+// Strip trailing dashes AFTER the length cap too, so a 60-char cut that lands on a
+// separator doesn't leave an ugly trailing "-" in the filename.
 const FEATURE_NAME =
-  (typeof _argsObj.feature_name === "string" && _argsObj.feature_name ? _argsObj.feature_name : TASK)
+  ((typeof _argsObj.feature_name === "string" && _argsObj.feature_name ? _argsObj.feature_name : TASK)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
-    .slice(0, 60) || "compose-run"
+    .slice(0, 60)
+    .replace(/-+$/, "")) || "compose-run"
 const REPORT_PATH = REPORTS_DIR + "/" + FEATURE_NAME + ".md"
 
 // ---------------------------------------------------------------------------
@@ -269,21 +272,35 @@ const runDesignWrite = (sharpen) => agent(
 await runDesignWrite(false)
 // Gate: the agent owns the writes; the workflow only verifies they happened and
 // re-dispatches the agent once if not. The workflow itself never writes the files.
-if (!(await exists(SPEC_PATH)) || !(await exists(PLAN_PATH))) {
+// Robustness: the agent may write under a slightly different leaf name than our
+// computed slug (model-chosen filename, trailing-dash drift, etc.). So treat the
+// gate as "did ANY .md land in the specs and plans dirs", not an exact-path match —
+// this avoids a redundant, expensive re-dispatch when the files are actually there.
+const docsPresent = async () => {
+  const specs = await glob(SPECS_DIR + "/*.md")
+  const plans = await glob(PLANS_DIR + "/*.md")
+  return specs.length > 0 && plans.length > 0
+}
+if (!(await docsPresent())) {
   await runDesignWrite(true)
 }
-const specWritten = await exists(SPEC_PATH)
-const planWritten = await exists(PLAN_PATH)
+const specWritten = (await glob(SPECS_DIR + "/*.md")).length > 0
+const planWritten = (await glob(PLANS_DIR + "/*.md")).length > 0
 
 // Step 2 — structured extraction: a separate agent reads the plan the previous
 // agent wrote and returns the machine-usable task list. Schema lives here, where
-// JSON-only is exactly what we want — no file work expected in this call.
+// JSON-only is exactly what we want — no file work expected in this call. The
+// prompt FORCES a direct StructuredOutput tool call: the model otherwise tends to
+// answer with prose/markdown/XML, which fails schema validation and triggers a
+// slow retry loop (each round-trip is a full model call).
 const design = await agent(
-  "Read the implementation plan at `" + PLAN_PATH + "` (use the `read` tool) and extract its task list.\n\n" +
-  (planWritten ? "" : "## The plan file is missing — derive the task list from the task below instead.\n## Task\n" + TASK + "\n\n") +
-  "Return a task list of bite-sized work items, each with id, description, acceptance, optional files, and `dependsOn` " +
-  "(empty for independent tasks; a prerequisite task id otherwise; no cycles).\n\n" +
-  "Return structured output only.",
+  "Read the implementation plan markdown in `" + PLANS_DIR + "` (use the `read` tool; if multiple files, read the most recent) and extract its task list.\n\n" +
+  (planWritten ? "" : "## No plan file found — derive the task list from the task below instead.\n## Task\n" + TASK + "\n\n") +
+  "## Output contract (STRICT)\n" +
+  "Call the `StructuredOutput` tool EXACTLY ONCE with a JSON object matching the schema. " +
+  "Do NOT reply with prose, markdown, XML, or a code block — those do not count and will be rejected. " +
+  "The JSON has a `tasks` array; each task: id, description, acceptance, optional files[], and dependsOn[] " +
+  "(empty for independent tasks; a prerequisite task id otherwise; no cycles).",
   { label: "design-extract:" + type, phase: "Design", schema: DESIGN_SHAPE }
 )
 if (!design) {

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -34,6 +34,11 @@ const BRAINSTORM_SHAPE = {
       },
     },
     assumptions: { type: "array", items: { type: "string" } },
+    selfQA: { type: "array", items: { type: "object", properties: { question: { type: "string" }, answer: { type: "string" } } } },
+    approaches: { type: "array", items: { type: "object", properties: { name: { type: "string" }, tradeoffs: { type: "string" } } } },
+    chosenApproach: { type: "string" },
+    chosenRationale: { type: "string" },
+    openQuestions: { type: "array", items: { type: "string" } },
     amends: { type: "string" },
     existingDocs: { type: "array", items: { type: "string" } },
     notes: { type: "string" },
@@ -206,18 +211,23 @@ if (SKIP_BRAINSTORM) {
   brainstorm = { context: SYNTHETIC_CONTEXT, assumptions: [] }
 } else {
   brainstorm = await agent(
-    "Apply the `compose:brainstorm` skill in AUTONOMOUS mode — no user is available. Use the `skill` tool to load it first.\n\n" +
-    "Per the skill's autonomous override: do STEP 1 ONLY (context recon). Do NOT present a design, ask questions, write a spec, or wait for approval.\n\n" +
+    "Apply the `compose:brainstorm` skill in AUTONOMOUS mode — no user is available to answer. Use the `skill` tool to load it first.\n\n" +
+    "## Autonomous brainstorming — self-conduct the dialogue (do NOT stop at context recon)\n" +
+    "'No user' means you ask and answer the questions YOURSELF; it does NOT mean skip the thinking. Run the real brainstorm:\n" +
+    "1. Explore project context (files, docs, recent commits, layout) and note assumptions.\n" +
+    "2. Pose the clarifying questions you WOULD ask a user, and answer each from the context/your best judgment (record as selfQA).\n" +
+    "3. Propose 2-3 distinct approaches with trade-offs (record as approaches).\n" +
+    "4. Pick ONE and justify it (chosenApproach + chosenRationale). Note any unresolved openQuestions.\n" +
+    "Do NOT present a design to a user, do NOT wait for approval, do NOT write a spec here — that is Design's job. " +
+    "This reasoning is the KEY input Design consumes, so capture it fully in the structured output.\n\n" +
     "## Task\n" + TASK + "\n\n" +
     existingDocsBlock +
-    "## What to gather\n" +
+    "## Context to gather\n" +
     "- Read AGENTS.md / CLAUDE.md / README.md if present\n" +
     "- Skim recent commits (`git log --oneline -20`)\n" +
-    "- Map top-level directory layout\n" +
-    "- Identify files clearly relevant to the task\n" +
-    "- Note any reasonable assumptions you are making (so Design sees them)\n\n" +
+    "- Map top-level directory layout; identify files relevant to the task\n\n" +
     "Return structured output only.",
-    { label: "brainstorm", phase: "Brainstorm", schema: BRAINSTORM_SHAPE, model: "lite" }
+    { label: "brainstorm", phase: "Brainstorm", schema: BRAINSTORM_SHAPE }
   )
   if (!brainstorm || !brainstorm.context) brainstorm = { context: SYNTHETIC_CONTEXT, assumptions: [] }
 }
@@ -228,6 +238,10 @@ const contextDigest =
   "Recent changes:\n" + _arr(brainstorm.context.recentChanges).map((c) => "- " + c).join("\n") + "\n" +
   "Relevant files:\n" + _arr(brainstorm.context.relevantFiles).map((f) => "- " + f).join("\n") +
   (_arr(brainstorm.assumptions).length ? "\nAssumptions:\n" + _arr(brainstorm.assumptions).map((a) => "- " + a).join("\n") : "") +
+  (_arr(brainstorm.selfQA).length ? "\nSelf-Q&A (brainstorm reasoning):\n" + _arr(brainstorm.selfQA).map((q) => "- Q: " + (q && q.question) + "\n  A: " + (q && q.answer)).join("\n") : "") +
+  (_arr(brainstorm.approaches).length ? "\nApproaches considered:\n" + _arr(brainstorm.approaches).map((a) => "- " + (a && a.name) + " — " + (a && a.tradeoffs)).join("\n") : "") +
+  ((brainstorm.chosenApproach && typeof brainstorm.chosenApproach === "string") ? "\nChosen approach: " + brainstorm.chosenApproach + (brainstorm.chosenRationale ? " (because: " + brainstorm.chosenRationale + ")" : "") : "") +
+  (_arr(brainstorm.openQuestions).length ? "\nOpen questions:\n" + _arr(brainstorm.openQuestions).map((q) => "- " + q).join("\n") : "") +
   ((brainstorm.amends && typeof brainstorm.amends === "string") ? "\nAmends existing feature: " + brainstorm.amends : "")
 
 // ---------------------------------------------------------------------------
@@ -387,7 +401,14 @@ const batches = topo.batches
 const taskById = Object.create(null)
 for (const t of design.tasks) taskById[t.id] = t
 
-const TASKS_DIGEST = design.tasks.map((t, i) => (i + 1) + ". " + t.id + ": " + t.description + " — " + t.acceptance).join("\n")
+// Intent carried from brainstorm/design into each implementer so it builds toward
+// the CHOSEN approach, not its own re-derivation. Plan path lets it read the spec.
+const intentBlock =
+  ((brainstorm.chosenApproach && typeof brainstorm.chosenApproach === "string")
+    ? "## Intent (from design — build toward THIS approach)\n" + brainstorm.chosenApproach +
+      (brainstorm.chosenRationale ? "\nRationale: " + brainstorm.chosenRationale : "") + "\n" +
+      "Spec/plan for the whole feature: `" + SPEC_PATH + "` / `" + PLAN_PATH + "` (read if you need fuller context).\n\n"
+    : "")
 
 // ---------------------------------------------------------------------------
 // Helpers: implement (per-task, worktree), integrate, verify, debug, report
@@ -395,6 +416,7 @@ const TASKS_DIGEST = design.tasks.map((t, i) => (i + 1) + ". " + t.id + ": " + t
 const runImplementTask = (task, failuresOrEmpty, isolate) => agent(
   "Apply the `compose:tdd` skill. Use the `skill` tool to load it before working.\n\n" +
   "## Overall task\n" + TASK + "\n\n" +
+  intentBlock +
   "## Your work item (" + task.id + ")\n" + task.description + "\nAcceptance: " + task.acceptance +
   (task.files && task.files.length ? "\nFiles: " + task.files.join(", ") : "") + "\n\n" +
   (failuresOrEmpty ? "## Verify failures from previous attempt — focus on these\n" + failuresOrEmpty + "\n\n" : "") +
@@ -550,12 +572,22 @@ for (let attempt = 0; attempt < MAX_TDD_ATTEMPTS; attempt++) {
 // ---------------------------------------------------------------------------
 // Phase 4 — Review  +  Phase 5 — Fix loop (≤2 attempts)
 // ---------------------------------------------------------------------------
+const IMPLEMENTED_DIGEST = design.tasks.map((t) => "- " + t.id + ": " + t.description + " (acceptance: " + t.acceptance + ")").join("\n")
 const runReview = () => agent(
-  "Apply the `compose:review` skill. Use the `skill` tool to load it before working.\n\n" +
-  "## Task context\n" + TASK + "\n\n" +
+  "Apply the `compose:review` skill. Use the `skill` tool to load it FIRST, then follow it.\n\n" +
+  "Review the implemented change in TWO STAGES, spec-compliance BEFORE code-quality (this mirrors compose:subagent's two-stage gate):\n" +
+  "### Stage 1 — Spec compliance (evidence-gated)\n" +
+  "Run `git diff` (e.g. `git diff HEAD~<n>..HEAD`, or against the run's base) to see EXACTLY what changed, and read the changed files. " +
+  "For each acceptance criterion below, confirm with evidence from the diff/tests that it is met. Anything unmet or unverifiable is a CRITICAL finding. " +
+  "Do this from the diff + spec ALONE first — do not assume the implementer's claims are correct.\n" +
+  "### Stage 2 — Code quality\n" +
+  "Only once spec compliance holds, review the diff for quality: correctness bugs, missing error handling at real boundaries, tests that don't test, dead code, simplification.\n\n" +
+  "## Overall task\n" + TASK + "\n\n" +
+  intentBlock +
+  "## What was implemented (acceptance criteria to verify)\n" + IMPLEMENTED_DIGEST + "\n\n" +
   "## What to produce\n" +
-  "Triage findings into critical (must fix before merge), important (should fix), and minor (nits). " +
-  "Set readyToMerge=true only if critical is empty.\n\n" +
+  "Triage findings into critical (must fix before merge — includes ANY unmet spec/acceptance), important (should fix), and minor (nits). " +
+  "Set readyToMerge=true ONLY if critical is empty AND every acceptance criterion is met with evidence.\n\n" +
   "Return structured output only.",
   { label: "review", phase: "Review", schema: REVIEW_SHAPE }
 )
@@ -648,7 +680,8 @@ if (!SKIP_REPORT) {
     "## Run history\n" +
     "verifyHistory: " + JSON.stringify(verifyHistory) + "\n" +
     "implementHistory: " + JSON.stringify(implementHistory) + "\n" +
-    "reviewFixAttempts: " + reviewFixAttempts + "\n\n" +
+    "reviewFixAttempts: " + reviewFixAttempts + "\n" +
+    "review: " + JSON.stringify(review) + "\n\n" +
     "Produce the final-state report (What Was Built / Architecture / Design Decisions / Usage / Verification / Journey Log / Source Materials). " +
     "Distill the Journey Log to at most 5 entries. Write the file with the `write` tool, then commit it. " +
     "Writing the file is the deliverable — do not just describe it.",
@@ -672,6 +705,12 @@ phase("Merge")
 const merge = await agent(
   "Apply the `compose:merge` skill. Use the `skill` tool to load it before working.\n\n" +
   "## Task\n" + TASK + "\n\n" +
+  "## What was built (use this for the commit/PR message)\n" + IMPLEMENTED_DIGEST + "\n\n" +
+  ((review && (_arr(review.important).length || _arr(review.minor).length))
+    ? "## Review outcome (critical cleared; note any deferred items)\n" +
+      (_arr(review.important).length ? "Important (should follow up):\n" + _arr(review.important).map((x) => "- " + x).join("\n") + "\n" : "") +
+      (_arr(review.minor).length ? "Minor (nits):\n" + _arr(review.minor).map((x) => "- " + x).join("\n") + "\n" : "") + "\n"
+    : "") +
   "Commit the changes. If the branch tracks a remote and a PR is appropriate, push and open one.\n" +
   "Pick the smallest action that satisfies the goal:\n" +
   "- `commit`: just record locally\n" +

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -3,12 +3,11 @@ export const meta = {
   description:
     "Autonomous compose pipeline — brainstorms context, designs (spec/plan), implements via parallel per-task worktrees with TDD, verifies, reviews, reports, and merges. Bounded retry, never-ask mode.",
   whenToUse:
-    "Use to drive a feature, bugfix, refactor, or review-feedback task through the full compose flow without user prompting. Pass args.task = the user's request. Optionally args.type to skip classification, args.feature_name for the report filename, args.skip_brainstorm / args.skip_report to drop those phases, args.maxConcurrent to bound per-batch parallelism.",
+    "Use to drive a feature, bugfix, refactor, or review-feedback task through the full compose flow without user prompting. Pass args.task = the user's request. Optionally args.type to set the task type (feature/bugfix/refactor/feedback; otherwise inferred), args.feature_name for the report filename, args.skip_brainstorm / args.skip_report to drop those phases, args.maxConcurrent to bound per-batch parallelism.",
   phases: [
     { title: "Brainstorm", detail: "Context recon (never-ask): conventions, recent changes, relevant files" },
-    { title: "Classify", detail: "Decide task type (feature/bugfix/refactor/feedback)" },
     { title: "Design", detail: "Apply compose:plan, compose:debug, or compose:feedback; emit task list with deps" },
-    { title: "Implement", detail: "Topo-sorted batches, each task in its own worktree (compose:tdd), then integrate" },
+    { title: "Implement", detail: "Topo-sorted batches (compose:tdd), then integrate" },
     { title: "Verify", detail: "Run project verify commands; structured pass/fail" },
     { title: "Review", detail: "compose:review for critical/important/minor issues" },
     { title: "Report", detail: "compose:report per-iteration + final consolidated report" },
@@ -36,16 +35,6 @@ const BRAINSTORM_SHAPE = {
     },
     assumptions: { type: "array", items: { type: "string" } },
     notes: { type: "string" },
-  },
-}
-
-const CLASSIFY_SHAPE = {
-  type: "object",
-  required: ["type", "confidence", "reasoning"],
-  properties: {
-    type: { enum: ["feature", "bugfix", "refactor", "feedback"] },
-    confidence: { enum: ["high", "medium", "low"] },
-    reasoning: { type: "string" },
   },
 }
 
@@ -214,27 +203,24 @@ const contextDigest =
   ((brainstorm.assumptions && brainstorm.assumptions.length) ? "\nAssumptions:\n" + brainstorm.assumptions.map((a) => "- " + a).join("\n") : "")
 
 // ---------------------------------------------------------------------------
-// Phase 1 — Classify
+// Type resolution (no separate Classify phase)
 // ---------------------------------------------------------------------------
-phase("Classify")
+// First-principles: picking the design skill is a low-risk, reversible routing
+// decision the later Design/Implement phases can self-correct — it does NOT
+// warrant its own LLM phase (the original compose flow has no classifier; it goes
+// brainstorm → compose:plan). So: honor an explicit args.type; otherwise default
+// to "feature" (→ compose:plan) and let a cheap keyword heuristic divert obvious
+// bugfix / PR-feedback tasks. The design agent re-judges with full context anyway.
 let classification = null
 let type
 if (VALID_TYPES.indexOf(argType) >= 0) {
   type = argType
 } else {
-  classification = await agent(
-    "Classify the task below into exactly one of: feature, bugfix, refactor, feedback.\n\n" +
-    "## Task\n" + TASK + "\n\n" +
-    "## Definitions\n" +
-    "- feature: net-new capability or user-visible behavior\n" +
-    "- bugfix: existing behavior is broken; root-cause + fix\n" +
-    "- refactor: restructure without behavior change\n" +
-    "- feedback: address PR review or user-reported issues against an existing change\n\n" +
-    "Return structured output only.",
-    { label: "classify", phase: "Classify", schema: CLASSIFY_SHAPE, model: "lite" }
-  )
-  type = classification && classification.type ? classification.type : "feature"
-  log("Classified as " + type + (classification ? " (" + classification.confidence + ")" : " (default)"))
+  const t = TASK.toLowerCase()
+  if (/\b(pr|review)\b.*\b(feedback|comment|address)\b|address .*\bfeedback\b/.test(t)) type = "feedback"
+  else if (/\b(bug|broken|regression|crash|fails?|incorrect|wrong|error)\b/.test(t)) type = "bugfix"
+  else type = "feature"
+  log("Resolved type=" + type + " (heuristic; no classify phase)")
 }
 
 const SKILL_BY_TYPE = {
@@ -305,6 +291,20 @@ const design = await agent(
 )
 if (!design) {
   return { error: "design-failed", type, classification, brainstorm, docs: { specWritten, planWritten } }
+}
+// Normalize task ids: the extract agent sometimes returns tasks with a missing or
+// blank `id` (schema validation can let an empty string through), which then shows
+// up as "implement:undefined" in labels and breaks dependsOn wiring. Backfill any
+// missing/duplicate id with a synthetic Tn so labels, topo-sort, and deps are stable.
+{
+  const seen = Object.create(null)
+  let n = 0
+  for (const t of design.tasks) {
+    n++
+    const raw = typeof t.id === "string" ? t.id.trim() : ""
+    t.id = raw && !seen[raw] ? raw : "T" + n
+    seen[t.id] = true
+  }
 }
 log("Designed " + design.tasks.length + " task(s) using " + designSkill + " (spec=" + specWritten + " plan=" + planWritten + ")")
 

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -190,5 +190,50 @@ for (let attempt = 0; attempt < MAX_TDD_ATTEMPTS; attempt++) {
   await runDebug(verify ? (verify.failures || "verify returned no detail") : "verify agent failed (null)")
 }
 
-// Placeholder return — replaced in subsequent tasks.
-return { type, classification, design, verifyHistory, todo: "review+merge" }
+const runReview = () => agent(
+  "Apply the `compose:review` skill. Use the `skill` tool to load it before working.\n\n" +
+  "## Task context\n" + TASK + "\n\n" +
+  "## What to produce\n" +
+  "Triage findings into critical (must fix before merge), important (should fix), and minor (nits). " +
+  "Set readyToMerge=true only if critical is empty.\n\n" +
+  "Return structured output only.",
+  { label: "review", phase: "Review", schema: REVIEW_SHAPE }
+)
+
+const runFix = (criticalList) => agent(
+  "Address the CRITICAL review findings below. Apply the `compose:tdd` skill to fix them with tests where possible.\n\n" +
+  "## Critical findings\n" + criticalList.map((c, i) => (i + 1) + ". " + c).join("\n") + "\n\n" +
+  "Fix each, then commit.",
+  { label: "fix", phase: "Review" }
+)
+
+phase("Review")
+let review = await runReview()
+if (!review) review = { critical: [], important: [], minor: [], readyToMerge: true }
+let reviewFixAttempts = 0
+
+if (review.critical && review.critical.length > 0) {
+  phase("Fix")
+  for (let attempt = 0; attempt < MAX_REVIEW_FIX_ATTEMPTS; attempt++) {
+    reviewFixAttempts = attempt + 1
+    await runFix(review.critical)
+    const reverify = await runVerify()
+    if (reverify) verifyHistory.push(reverify)
+    review = await runReview()
+    if (!review) review = { critical: [], important: [], minor: [], readyToMerge: false }
+    if (!review.critical || review.critical.length === 0) {
+      log("Critical issues cleared on fix attempt " + reviewFixAttempts)
+      break
+    }
+  }
+  if (review.critical && review.critical.length > 0) {
+    return {
+      readyToMerge: false,
+      type, classification, design, verifyHistory, review,
+      attempts: { tdd: tddAttempts, reviewFix: reviewFixAttempts },
+    }
+  }
+}
+
+// Placeholder return — replaced in next task.
+return { type, classification, design, verifyHistory, review, todo: "merge" }

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -142,5 +142,53 @@ if (!design) {
 }
 log("Designed " + design.tasks.length + " task(s) using " + designSkill)
 
+const TASKS_DIGEST = design.tasks.map((t, i) => (i + 1) + ". " + t.id + ": " + t.description + " — " + t.acceptance).join("\n")
+
+const runVerify = () => agent(
+  "Run the project's verification commands and report the outcome.\n\n" +
+  "## Steps\n" +
+  "1. Inspect AGENTS.md / CLAUDE.md / package.json for the project's verify commands (typecheck, test, build).\n" +
+  "2. Run them via the Bash tool, in the right directory (e.g. `packages/<x>/` not the repo root if AGENTS.md says so).\n" +
+  "3. Capture passed/failed test counts. Summarize failures concisely if any.\n\n" +
+  "Return structured output only.",
+  { label: "verify", phase: "Verify", schema: VERIFY_SHAPE }
+)
+
+const runImplement = (failuresOrEmpty) => agent(
+  "Apply the `compose:tdd` skill. Use the `skill` tool to load it before working.\n\n" +
+  "## Task\n" + TASK + "\n\n" +
+  "## Plan\n" + TASKS_DIGEST + "\n\n" +
+  (failuresOrEmpty ? "## Verify failures from previous attempt — focus on these\n" + failuresOrEmpty + "\n\n" : "") +
+  "Implement the plan. Write the failing test first, then the minimal code to pass, then refactor. " +
+  "Commit each task as you complete it.",
+  { label: "implement", phase: "Implement" }
+)
+
+const runDebug = (failures) => agent(
+  "Apply the `compose:debug` skill. Use the `skill` tool to load it before working.\n\n" +
+  "## Verify failures\n" + failures + "\n\n" +
+  "Identify the root cause and fix it. Do not paper over symptoms.",
+  { label: "debug", phase: "Implement" }
+)
+
+phase("Implement")
+const verifyHistory = []
+let verify = null
+let tddAttempts = 0
+for (let attempt = 0; attempt < MAX_TDD_ATTEMPTS; attempt++) {
+  tddAttempts = attempt + 1
+  await runImplement(attempt === 0 ? "" : (verify && verify.failures ? verify.failures : ""))
+  verify = await runVerify()
+  if (verify) verifyHistory.push(verify)
+  if (verify && verify.allPassed) {
+    log("Verify passed on attempt " + tddAttempts)
+    break
+  }
+  if (attempt + 1 === MAX_TDD_ATTEMPTS) {
+    return { error: "verify-exhausted", type, classification, design, verifyHistory, attempts: MAX_TDD_ATTEMPTS }
+  }
+  await runDebug(verify ? (verify.failures || "verify returned no detail") : "verify agent failed (null)")
+}
+
 // Placeholder return — replaced in subsequent tasks.
-return { type, classification, design, todo: "impl+review+merge" }
+return { type, classification, design, verifyHistory, todo: "review+merge" }

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -239,7 +239,6 @@ const contextDigest =
 // brainstorm → compose:plan). So: honor an explicit args.type; otherwise default
 // to "feature" (→ compose:plan) and let a cheap keyword heuristic divert obvious
 // bugfix / PR-feedback tasks. The design agent re-judges with full context anyway.
-let classification = null
 let type
 if (VALID_TYPES.indexOf(argType) >= 0) {
   type = argType
@@ -337,7 +336,7 @@ const design = await agent(
   { label: "design-extract:" + type, phase: "Design", schema: DESIGN_SHAPE }
 )
 if (!design) {
-  return { error: "design-failed", type, classification, brainstorm, docs: { specWritten, planWritten } }
+  return { error: "design-failed", type, brainstorm, docs: { specWritten, planWritten } }
 }
 // Normalize task ids: the extract agent sometimes returns tasks with a missing or
 // blank `id` (schema validation can let an empty string through), which then shows
@@ -382,7 +381,7 @@ const topoSort = (tasks) => {
 }
 const topo = topoSort(design.tasks)
 if (topo.error) {
-  return { error: "design-cycle", cycleNodes: topo.cycleNodes, type, classification, brainstorm, design }
+  return { error: "design-cycle", cycleNodes: topo.cycleNodes, type, brainstorm, design }
 }
 const batches = topo.batches
 const taskById = Object.create(null)
@@ -542,7 +541,7 @@ for (let attempt = 0; attempt < MAX_TDD_ATTEMPTS; attempt++) {
     break
   }
   if (attempt + 1 === MAX_TDD_ATTEMPTS) {
-    return { error: "verify-exhausted", type, classification, brainstorm, design, batches, verifyHistory, implementHistory, attempts: MAX_TDD_ATTEMPTS }
+    return { error: "verify-exhausted", type, brainstorm, design, batches, verifyHistory, implementHistory, attempts: MAX_TDD_ATTEMPTS }
   }
   phase("Implement")
   await runDebug((verify ? (verify.failures || "verify returned no detail") : "verify agent failed (null)") + conflictText)
@@ -627,7 +626,7 @@ if (review.critical && review.critical.length > 0) {
   if (review.critical && review.critical.length > 0) {
     return {
       readyToMerge: false,
-      type, classification, brainstorm, design, batches, verifyHistory, implementHistory, fixHistory, review,
+      type, brainstorm, design, batches, verifyHistory, implementHistory, fixHistory, review,
       attempts: { tdd: tddAttempts, reviewFix: reviewFixAttempts },
     }
   }
@@ -684,7 +683,7 @@ const merge = await agent(
 if (!merge || !merge.committed) {
   return {
     error: "merge-failed",
-    type, classification, brainstorm, design, batches, verifyHistory, implementHistory, review, finalReport,
+    type, brainstorm, design, batches, verifyHistory, implementHistory, review, finalReport,
     merge: merge || { committed: false, action: "none" },
     attempts: { tdd: tddAttempts, reviewFix: reviewFixAttempts },
   }
@@ -693,7 +692,6 @@ if (!merge || !merge.committed) {
 return {
   brainstorm,
   type,
-  classification,
   design,
   batches,
   implementHistory,

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -90,4 +90,34 @@ const MERGE_SHAPE = {
 }
 
 // Placeholder body — replaced in subsequent tasks.
-return { ok: true, todo: "implement phases" }
+const TASK = (typeof args === "object" && args && typeof args.task === "string") ? args.task : ""
+if (!TASK) {
+  return { error: "no-task", message: "Pass args.task = '<request>'." }
+}
+
+const VALID_TYPES = ["feature", "bugfix", "refactor", "feedback"]
+const argType = (typeof args === "object" && args && typeof args.type === "string") ? args.type : ""
+
+phase("Classify")
+let classification = null
+let type
+if (VALID_TYPES.indexOf(argType) >= 0) {
+  type = argType
+} else {
+  classification = await agent(
+    "Classify the task below into exactly one of: feature, bugfix, refactor, feedback.\n\n" +
+    "## Task\n" + TASK + "\n\n" +
+    "## Definitions\n" +
+    "- feature: net-new capability or user-visible behavior\n" +
+    "- bugfix: existing behavior is broken; root-cause + fix\n" +
+    "- refactor: restructure without behavior change\n" +
+    "- feedback: address PR review or user-reported issues against an existing change\n\n" +
+    "Return structured output only.",
+    { label: "classify", phase: "Classify", schema: CLASSIFY_SHAPE, model: "lite" }
+  )
+  type = classification && classification.type ? classification.type : "feature"
+  log("Classified as " + type + (classification ? " (" + classification.confidence + ")" : " (default)"))
+}
+
+// Placeholder return — replaced in subsequent tasks.
+return { type, classification, todo: "design+impl+review+merge" }

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -90,13 +90,24 @@ const MERGE_SHAPE = {
 }
 
 // Placeholder body — replaced in subsequent tasks.
-const TASK = (typeof args === "object" && args && typeof args.task === "string") ? args.task : ""
+// Accept args as either an object {task,type?} OR a JSON string OR a bare task string,
+// because the AI-SDK tool boundary often serializes nested args as strings.
+let _argsObj
+if (typeof args === "object" && args !== null) {
+  _argsObj = args
+} else if (typeof args === "string") {
+  try { _argsObj = JSON.parse(args) } catch (_) { _argsObj = { task: args } }
+  if (typeof _argsObj !== "object" || _argsObj === null) _argsObj = { task: args }
+} else {
+  _argsObj = {}
+}
+const TASK = typeof _argsObj.task === "string" ? _argsObj.task : ""
 if (!TASK) {
   return { error: "no-task", message: "Pass args.task = '<request>'." }
 }
 
 const VALID_TYPES = ["feature", "bugfix", "refactor", "feedback"]
-const argType = (typeof args === "object" && args && typeof args.type === "string") ? args.type : ""
+const argType = typeof _argsObj.type === "string" ? _argsObj.type : ""
 
 phase("Classify")
 let classification = null

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -119,30 +119,6 @@ const REVIEW_SHAPE = {
   },
 }
 
-const ITERATION_REPORT_SHAPE = {
-  type: "object",
-  required: ["iteration", "what_changed"],
-  properties: {
-    iteration: { type: "number" },
-    what_changed: { type: "string" },
-    files_added: { type: "array", items: { type: "string" } },
-    files_modified: { type: "array", items: { type: "string" } },
-    tests_passed: { type: "number" },
-    tests_failed: { type: "number" },
-    notes: { type: "string" },
-  },
-}
-
-const FINAL_REPORT_SHAPE = {
-  type: "object",
-  required: ["path"],
-  properties: {
-    path: { type: "string" },
-    sha: { type: "string" },
-    summary: { type: "string" },
-  },
-}
-
 const MERGE_SHAPE = {
   type: "object",
   required: ["committed", "action"],
@@ -174,6 +150,11 @@ const VALID_TYPES = ["feature", "bugfix", "refactor", "feedback"]
 const argType = typeof _argsObj.type === "string" ? _argsObj.type : ""
 const SKIP_BRAINSTORM = _argsObj.skip_brainstorm === true
 const SKIP_REPORT = _argsObj.skip_report === true
+// Per-task worktree isolation is OPT-IN. Default OFF: implement/fix agents run in
+// the main workspace so their writes materialize directly (and verify sees them).
+// The worktree-isolation runtime path can leave tasks "pristine" (writes not landing
+// in the worktree) in some environments; opt in only when that path is known-good.
+const ISOLATE = _argsObj.isolate_worktrees === true
 const MAX_CONCURRENT =
   typeof _argsObj.maxConcurrent === "number" && _argsObj.maxConcurrent > 0 ? _argsObj.maxConcurrent : DEFAULT_MAX_CONCURRENT
 
@@ -265,23 +246,50 @@ const SKILL_BY_TYPE = {
 // ---------------------------------------------------------------------------
 phase("Design")
 const designSkill = SKILL_BY_TYPE[type] || "compose:plan"
-const design = await agent(
-  "Apply the `" + designSkill + "` skill to the task below. Use the `skill` tool to load the skill before working.\n\n" +
+const SPEC_PATH = SPECS_DIR + "/" + FEATURE_NAME + ".md"
+const PLAN_PATH = PLANS_DIR + "/" + FEATURE_NAME + ".md"
+
+// Step 1 — the AGENT writes the spec + plan files. The workflow does NOT write
+// them; it only gates on existence and re-dispatches the agent if it skipped the
+// write. No `schema` here so the agent is free to use its write/skill tools and
+// isn't biased into emitting JSON instead of doing the work.
+const runDesignWrite = (sharpen) => agent(
+  "Apply the `" + designSkill + "` skill to the task below. Use the `skill` tool to load the skill FIRST, then follow it.\n\n" +
   docsBlock + "\n\n" +
   "## Task\n" + TASK + "\n\n" +
   "## Project context (from brainstorm)\n" + contextDigest + "\n\n" +
-  "## What to produce\n" +
-  "Write the spec/plan to the docs dirs above per the skill, then return a task list of bite-sized work items, " +
-  "each with id, description, and acceptance criteria. Optionally list the files each task touches.\n" +
-  "Mark independent tasks with empty `dependsOn`. Mark a task that needs another committed first with that task's id in `dependsOn`. " +
-  "No cycles in dependsOn.\n\n" +
+  "## Your deliverable (REQUIRED — this is the whole job)\n" +
+  "Use the `write` tool to create BOTH of these files on disk:\n" +
+  "1. Spec: `" + SPEC_PATH + "`\n" +
+  "2. Plan: `" + PLAN_PATH + "` — a bite-sized task list per the skill, each task with id, description, acceptance, optional files, and `dependsOn` (empty for independent tasks; a prerequisite task id otherwise; no cycles).\n\n" +
+  (sharpen ? "## You did NOT write the required files last time. Write them NOW with the write tool before finishing.\n\n" : "") +
+  "Do the writes with the `write` tool. Do not just describe them.",
+  { label: "design:" + type, phase: "Design" }
+)
+await runDesignWrite(false)
+// Gate: the agent owns the writes; the workflow only verifies they happened and
+// re-dispatches the agent once if not. The workflow itself never writes the files.
+if (!(await exists(SPEC_PATH)) || !(await exists(PLAN_PATH))) {
+  await runDesignWrite(true)
+}
+const specWritten = await exists(SPEC_PATH)
+const planWritten = await exists(PLAN_PATH)
+
+// Step 2 — structured extraction: a separate agent reads the plan the previous
+// agent wrote and returns the machine-usable task list. Schema lives here, where
+// JSON-only is exactly what we want — no file work expected in this call.
+const design = await agent(
+  "Read the implementation plan at `" + PLAN_PATH + "` (use the `read` tool) and extract its task list.\n\n" +
+  (planWritten ? "" : "## The plan file is missing — derive the task list from the task below instead.\n## Task\n" + TASK + "\n\n") +
+  "Return a task list of bite-sized work items, each with id, description, acceptance, optional files, and `dependsOn` " +
+  "(empty for independent tasks; a prerequisite task id otherwise; no cycles).\n\n" +
   "Return structured output only.",
-  { label: "design:" + type, phase: "Design", schema: DESIGN_SHAPE }
+  { label: "design-extract:" + type, phase: "Design", schema: DESIGN_SHAPE }
 )
 if (!design) {
-  return { error: "design-failed", type, classification, brainstorm }
+  return { error: "design-failed", type, classification, brainstorm, docs: { specWritten, planWritten } }
 }
-log("Designed " + design.tasks.length + " task(s) using " + designSkill)
+log("Designed " + design.tasks.length + " task(s) using " + designSkill + " (spec=" + specWritten + " plan=" + planWritten + ")")
 
 // Topo-sort (Kahn) over design.tasks by dependsOn → ordered batches.
 const topoSort = (tasks) => {
@@ -327,8 +335,12 @@ const runImplementTask = (task, failuresOrEmpty) => agent(
   "## Your work item (" + task.id + ")\n" + task.description + "\nAcceptance: " + task.acceptance +
   (task.files && task.files.length ? "\nFiles: " + task.files.join(", ") : "") + "\n\n" +
   (failuresOrEmpty ? "## Verify failures from previous attempt — focus on these\n" + failuresOrEmpty + "\n\n" : "") +
-  "Write the failing test first, then the minimal code to pass, then refactor. Commit your work inside this worktree.",
-  { label: "implement:" + task.id, phase: "Implement", isolation: "worktree" }
+  "Write the failing test first (use the `write` tool), then the minimal code to pass, then refactor. " +
+  "Actually create the source and test files on disk with the `write` tool — do not just describe them. " +
+  (ISOLATE ? "Commit your work inside this worktree." : "Commit your work in the workspace."),
+  ISOLATE
+    ? { label: "implement:" + task.id, phase: "Implement", isolation: "worktree" }
+    : { label: "implement:" + task.id, phase: "Implement" }
 )
 
 const runIntegrate = (kept) => agent(
@@ -344,9 +356,10 @@ const runIntegrate = (kept) => agent(
 const runVerify = () => agent(
   "Run the project's verification commands and report the outcome.\n\n" +
   "## Steps\n" +
-  "1. Inspect AGENTS.md / CLAUDE.md / package.json for the project's verify commands (typecheck, test, build).\n" +
-  "2. Run them via the Bash tool, in the right directory (e.g. `packages/<x>/` not the repo root if AGENTS.md says so).\n" +
-  "3. Capture passed/failed test counts. Summarize failures concisely if any.\n\n" +
+  "1. First run `pwd` and `ls` to confirm your working directory and that the project's source/test files are actually present here. The implemented code lives in THIS workspace — verify from the workspace root (or the package subdir AGENTS.md specifies), never from a stale or temp cwd.\n" +
+  "2. Inspect AGENTS.md / CLAUDE.md / package.json for the project's verify commands (typecheck, test, build).\n" +
+  "3. Run them via the Bash tool from the correct directory. If a command reports 'file not found' or 0 tests, you are in the wrong directory — `cd` to where the files are and re-run before reporting.\n" +
+  "4. Capture passed/failed test counts. Summarize failures concisely if any.\n\n" +
   "Return structured output only.",
   { label: "verify", phase: "Verify", schema: VERIFY_SHAPE }
 )
@@ -358,20 +371,23 @@ const runDebug = (failures) => agent(
   { label: "debug", phase: "Implement" }
 )
 
-const runIterationReport = (iteration, verifyResult) => {
-  if (SKIP_REPORT) return Promise.resolve(null)
-  return agent(
+const runIterationReport = async (iteration, verifyResult) => {
+  if (SKIP_REPORT) return null
+  // The agent writes the markdown report file. No schema — a schema would bias the
+  // agent into emitting JSON instead of doing the write. The workflow only verifies
+  // the file exists afterward.
+  await agent(
     "Apply the `compose:report` skill in per-iteration mode. Use the `skill` tool to load it first.\n\n" +
     docsBlock + "\n\n" +
-    "## Report file (overwrite-in-place, accumulate Journey Log)\n" + REPORT_PATH + "\n\n" +
+    "## Report file you MUST write (overwrite-in-place, accumulate Journey Log)\n" + REPORT_PATH + "\n\n" +
     "## Iteration\n" + iteration + "\n\n" +
     "## Overall task\n" + TASK + "\n\n" +
     "## Verify result\n" + JSON.stringify(verifyResult) + "\n\n" +
-    "Read the existing report if present, update sections, append a Journey Log entry for this iteration, and overwrite the file. " +
-    "Keep it brief.\n\n" +
-    "Return structured output only.",
-    { label: "iteration-report:" + iteration, phase: "Report", schema: ITERATION_REPORT_SHAPE }
+    "Read the existing report if present (use `read`), update sections, append a Journey Log entry for this iteration, " +
+    "and write the file with the `write` tool. Keep it brief. Writing the file is the deliverable — do not just describe it.",
+    { label: "iteration-report:" + iteration, phase: "Report" }
   )
+  return { iteration, written: await exists(REPORT_PATH) }
 }
 
 // Dispatch a batch of tasks in parallel, each isolated in its own worktree, then
@@ -388,17 +404,25 @@ const runBatch = async (batchIds, failuresOrEmpty) => {
     for (let j = 0; j < chunk.length; j++) {
       const t = chunk[j]
       const r = results[j]
-      const wt = r && typeof r === "object" ? r._worktree : null
-      if (wt && wt.changed) {
-        kept.push({ taskId: t.id, _worktree: wt })
-        perTaskResults.push({ taskId: t.id, status: "ok", branch: wt.branch })
-      } else if (r === null) {
-        perTaskResults.push({ taskId: t.id, status: "failed" })
+      if (ISOLATE) {
+        const wt = r && typeof r === "object" ? r._worktree : null
+        if (wt && wt.changed) {
+          kept.push({ taskId: t.id, _worktree: wt })
+          perTaskResults.push({ taskId: t.id, status: "ok", branch: wt.branch })
+        } else if (r === null) {
+          perTaskResults.push({ taskId: t.id, status: "failed" })
+        } else {
+          perTaskResults.push({ taskId: t.id, status: "pristine" })
+        }
       } else {
-        perTaskResults.push({ taskId: t.id, status: "pristine" })
+        // Non-isolated: the agent wrote directly into the main workspace. A non-null
+        // result means it ran; failure surfaces as null. No worktree to integrate.
+        perTaskResults.push({ taskId: t.id, status: r === null ? "failed" : "ok" })
       }
     }
   }
+  // Integrate only when isolated worktrees were kept. In non-isolated mode the work
+  // already lives in the main workspace, so there is nothing to merge.
   const integrate = kept.length
     ? await runIntegrate(kept)
     : { merged: [], conflicts: [], skipped_pristine: perTaskResults.filter((r) => r.status !== "ok").map((r) => r.taskId) }
@@ -471,8 +495,8 @@ const runFixTask = (finding, i) => agent(
   "Address the CRITICAL review finding below. Apply the `compose:tdd` skill to fix it with tests where possible. " +
   "Use the `skill` tool to load it first.\n\n" +
   "## Critical finding (" + (i + 1) + ")\n" + finding + "\n\n" +
-  "Fix it and commit inside this worktree.",
-  { label: "fix:" + i, phase: "Fix", isolation: "worktree" }
+  "Fix it with the `write`/`edit` tools and commit " + (ISOLATE ? "inside this worktree." : "in the workspace."),
+  ISOLATE ? { label: "fix:" + i, phase: "Fix", isolation: "worktree" } : { label: "fix:" + i, phase: "Fix" }
 )
 
 phase("Review")
@@ -494,12 +518,16 @@ if (review.critical && review.critical.length > 0) {
       const results = await parallel(chunk.map((finding, k) => () => runFixTask(finding, i + k)))
       for (let j = 0; j < chunk.length; j++) {
         const r = results[j]
-        const wt = r && typeof r === "object" ? r._worktree : null
-        if (wt && wt.changed) {
-          kept.push({ taskId: "fix-" + (i + j), _worktree: wt })
-          perTaskResults.push({ taskId: "fix-" + (i + j), status: "ok", branch: wt.branch })
+        if (ISOLATE) {
+          const wt = r && typeof r === "object" ? r._worktree : null
+          if (wt && wt.changed) {
+            kept.push({ taskId: "fix-" + (i + j), _worktree: wt })
+            perTaskResults.push({ taskId: "fix-" + (i + j), status: "ok", branch: wt.branch })
+          } else {
+            perTaskResults.push({ taskId: "fix-" + (i + j), status: r === null ? "failed" : "pristine" })
+          }
         } else {
-          perTaskResults.push({ taskId: "fix-" + (i + j), status: r === null ? "failed" : "pristine" })
+          perTaskResults.push({ taskId: "fix-" + (i + j), status: r === null ? "failed" : "ok" })
         }
       }
     }
@@ -538,20 +566,31 @@ if (review.critical && review.critical.length > 0) {
 let finalReport = null
 if (!SKIP_REPORT) {
   phase("Report")
-  finalReport = await agent(
+  // The agent writes the consolidated final report file; the workflow only gates
+  // on existence. No schema — writing the markdown is the deliverable.
+  await agent(
     "Apply the `compose:report` skill in FINAL consolidation mode. Use the `skill` tool to load it first.\n\n" +
     docsBlock + "\n\n" +
-    "## Report file (read the in-progress per-iteration file, overwrite with canonical final state)\n" + REPORT_PATH + "\n\n" +
+    "## Report file you MUST write (read the in-progress per-iteration file, overwrite with canonical final state)\n" + REPORT_PATH + "\n\n" +
     "## Overall task\n" + TASK + "\n\n" +
     "## Run history\n" +
     "verifyHistory: " + JSON.stringify(verifyHistory) + "\n" +
     "implementHistory: " + JSON.stringify(implementHistory) + "\n" +
     "reviewFixAttempts: " + reviewFixAttempts + "\n\n" +
     "Produce the final-state report (What Was Built / Architecture / Design Decisions / Usage / Verification / Journey Log / Source Materials). " +
-    "Distill the Journey Log to at most 5 entries. Commit the report file.\n\n" +
-    "Return structured output only.",
-    { label: "final-report", phase: "Report", schema: FINAL_REPORT_SHAPE }
+    "Distill the Journey Log to at most 5 entries. Write the file with the `write` tool, then commit it. " +
+    "Writing the file is the deliverable — do not just describe it.",
+    { label: "final-report", phase: "Report" }
   )
+  // Re-dispatch once if the agent skipped the write.
+  if (!(await exists(REPORT_PATH))) {
+    await agent(
+      "The final report file `" + REPORT_PATH + "` does not exist yet. Apply `compose:report` and WRITE it now with the `write` tool " +
+      "(What Was Built / Architecture / Design Decisions / Usage / Verification / Journey Log / Source Materials) for the task: " + TASK,
+      { label: "final-report-retry", phase: "Report" }
+    )
+  }
+  finalReport = { path: REPORT_PATH, written: await exists(REPORT_PATH) }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -34,6 +34,8 @@ const BRAINSTORM_SHAPE = {
       },
     },
     assumptions: { type: "array", items: { type: "string" } },
+    amends: { type: "string" },
+    existingDocs: { type: "array", items: { type: "string" } },
     notes: { type: "string" },
   },
 }
@@ -182,6 +184,22 @@ const REPORT_PATH = REPORTS_DIR + "/" + FEATURE_NAME + ".md"
 // ---------------------------------------------------------------------------
 phase("Brainstorm")
 const SYNTHETIC_CONTEXT = { projectType: "unknown", conventions: [], recentChanges: [], relevantFiles: [] }
+// Surface any prior compose artifacts so brainstorm can detect an AMENDMENT (a
+// change to an existing feature) vs new work — enabling incremental re-runs that
+// reuse the existing spec/plan instead of regenerating everything. The workflow
+// only lists the files; the agent reads + judges.
+const existingDocs = [
+  ...(await glob(SPECS_DIR + "/*.md")),
+  ...(await glob(PLANS_DIR + "/*.md")),
+  ...(await glob(REPORTS_DIR + "/*.md")),
+]
+const existingDocsBlock = existingDocs.length
+  ? "\n## Existing compose artifacts (this project has prior compose work)\n" +
+    existingDocs.map((p) => "- " + p).join("\n") + "\n" +
+    "If the task below is a CHANGE/ADDITION to a feature documented above, READ the relevant spec/plan (use the `read` tool) " +
+    "and treat this as an AMENDMENT: set `amends` to that feature's name and list the docs you used in `existingDocs`. " +
+    "If the task is unrelated/new, leave `amends` empty.\n"
+  : ""
 let brainstorm
 if (SKIP_BRAINSTORM) {
   brainstorm = { context: SYNTHETIC_CONTEXT, assumptions: [] }
@@ -190,6 +208,7 @@ if (SKIP_BRAINSTORM) {
     "Apply the `compose:brainstorm` skill in AUTONOMOUS mode — no user is available. Use the `skill` tool to load it first.\n\n" +
     "Per the skill's autonomous override: do STEP 1 ONLY (context recon). Do NOT present a design, ask questions, write a spec, or wait for approval.\n\n" +
     "## Task\n" + TASK + "\n\n" +
+    existingDocsBlock +
     "## What to gather\n" +
     "- Read AGENTS.md / CLAUDE.md / README.md if present\n" +
     "- Skim recent commits (`git log --oneline -20`)\n" +
@@ -206,7 +225,8 @@ const contextDigest =
   "Conventions:\n" + (brainstorm.context.conventions || []).map((c) => "- " + c).join("\n") + "\n" +
   "Recent changes:\n" + (brainstorm.context.recentChanges || []).map((c) => "- " + c).join("\n") + "\n" +
   "Relevant files:\n" + (brainstorm.context.relevantFiles || []).map((f) => "- " + f).join("\n") +
-  ((brainstorm.assumptions && brainstorm.assumptions.length) ? "\nAssumptions:\n" + brainstorm.assumptions.map((a) => "- " + a).join("\n") : "")
+  ((brainstorm.assumptions && brainstorm.assumptions.length) ? "\nAssumptions:\n" + brainstorm.assumptions.map((a) => "- " + a).join("\n") : "") +
+  ((brainstorm.amends && typeof brainstorm.amends === "string") ? "\nAmends existing feature: " + brainstorm.amends : "")
 
 // ---------------------------------------------------------------------------
 // Type resolution (no separate Classify phase)
@@ -243,22 +263,32 @@ phase("Design")
 const designSkill = SKILL_BY_TYPE[type] || "compose:plan"
 const SPEC_PATH = SPECS_DIR + "/" + FEATURE_NAME + ".md"
 const PLAN_PATH = PLANS_DIR + "/" + FEATURE_NAME + ".md"
+// Amendment: brainstorm flagged this as a change to an existing feature. Design
+// edits the existing spec/plan in place and re-runs only the affected tasks,
+// instead of regenerating everything.
+const AMENDS = brainstorm && typeof brainstorm.amends === "string" ? brainstorm.amends.trim() : ""
 
-// Step 1 — the AGENT writes the spec + plan files. The workflow does NOT write
-// them; it only gates on existence and re-dispatches the agent if it skipped the
-// write. No `schema` here so the agent is free to use its write/skill tools and
-// isn't biased into emitting JSON instead of doing the work.
+// Step 1 — the AGENT writes (or amends) the spec + plan files. The workflow does
+// NOT write them; it only gates on existence and re-dispatches if skipped. No
+// `schema` here so the agent is free to use its write/skill tools.
 const runDesignWrite = (sharpen) => agent(
   "Apply the `" + designSkill + "` skill to the task below. Use the `skill` tool to load the skill FIRST, then follow it.\n\n" +
   docsBlock + "\n\n" +
   "## Task\n" + TASK + "\n\n" +
   "## Project context (from brainstorm)\n" + contextDigest + "\n\n" +
-  "## Your deliverable (REQUIRED — this is the whole job)\n" +
-  "Use the `write` tool to create BOTH of these files on disk:\n" +
-  "1. Spec: `" + SPEC_PATH + "`\n" +
-  "2. Plan: `" + PLAN_PATH + "` — a bite-sized task list per the skill, each task with id, description, acceptance, optional files, and `dependsOn` (empty for independent tasks; a prerequisite task id otherwise; no cycles).\n\n" +
-  (sharpen ? "## You did NOT write the required files last time. Write them NOW with the write tool before finishing.\n\n" : "") +
-  "Do the writes with the `write` tool. Do not just describe them.",
+  (AMENDS
+    ? "## This is an AMENDMENT to an existing feature: " + AMENDS + "\n" +
+      "Use `glob`/`read` to find that feature's existing spec under `" + SPECS_DIR + "` and plan under `" + PLANS_DIR + "`. " +
+      "EDIT them IN PLACE (write back to the SAME file paths) to reflect ONLY the change in the task above — do NOT rewrite from scratch. " +
+      "In the plan, the task list must then contain ONLY the tasks that need to be (re-)implemented for this change, PLUS any tasks that " +
+      "depend on them. Tasks unaffected by the change MUST be omitted from the actionable list — they are reused as-is.\n\n" +
+      "Write the updated files with the `write` tool. Do not just describe them.\n"
+    : "## Your deliverable (REQUIRED — this is the whole job)\n" +
+      "Use the `write` tool to create BOTH of these files on disk:\n" +
+      "1. Spec: `" + SPEC_PATH + "`\n" +
+      "2. Plan: `" + PLAN_PATH + "` — a bite-sized task list per the skill, each task with id, description, acceptance, optional files, and `dependsOn` (empty for independent tasks; a prerequisite task id otherwise; no cycles).\n\n" +
+      (sharpen ? "## You did NOT write the required files last time. Write them NOW with the write tool before finishing.\n\n" : "") +
+      "Do the writes with the `write` tool. Do not just describe them."),
   { label: "design:" + type, phase: "Design" }
 )
 await runDesignWrite(false)
@@ -288,6 +318,7 @@ const planWritten = (await glob(PLANS_DIR + "/*.md")).length > 0
 const design = await agent(
   "Read the implementation plan markdown in `" + PLANS_DIR + "` (use the `read` tool; if multiple files, read the most recent) and extract its task list.\n\n" +
   (planWritten ? "" : "## No plan file found — derive the task list from the task below instead.\n## Task\n" + TASK + "\n\n") +
+  (AMENDS ? "## Amendment\nThis run amends the existing feature \"" + AMENDS + "\". Return ONLY the tasks that need to be (re-)implemented for the current change (plus their dependents). OMIT tasks that are unaffected — they are reused as-is.\n\n" : "") +
   "## Output contract (STRICT)\n" +
   "Call the `StructuredOutput` tool EXACTLY ONCE with a JSON object matching the schema. " +
   "Do NOT reply with prose, markdown, XML, or a code block — those do not count and will be rejected. " +

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -371,13 +371,15 @@ const runIntegrate = (kept) => agent(
 )
 
 const runVerify = () => agent(
-  "Run the project's verification commands and report the outcome.\n\n" +
-  "## Steps\n" +
+  "Apply the `compose:verify` skill. Use the `skill` tool to load it FIRST, then follow its discipline " +
+  "(the Iron Law: no completion claim without fresh verification evidence — run the real commands, read the full output, " +
+  "never trust 'should pass' or an agent's self-report).\n\n" +
+  "## Run the project's verification commands and report the outcome\n" +
   "1. First run `pwd` and `ls` to confirm your working directory and that the project's source/test files are actually present here. The implemented code lives in THIS workspace — verify from the workspace root (or the package subdir AGENTS.md specifies), never from a stale or temp cwd.\n" +
   "2. Inspect AGENTS.md / CLAUDE.md / package.json for the project's verify commands (typecheck, test, build).\n" +
   "3. Run them via the Bash tool from the correct directory. If a command reports 'file not found' or 0 tests, you are in the wrong directory — `cd` to where the files are and re-run before reporting.\n" +
-  "4. Capture passed/failed test counts. Summarize failures concisely if any.\n\n" +
-  "Return structured output only.",
+  "4. Capture passed/failed test counts from the ACTUAL command output. Summarize failures concisely if any.\n\n" +
+  "Return structured output only — and it must reflect the real command output, not an assumption.",
   { label: "verify", phase: "Verify", schema: VERIFY_SHAPE }
 )
 
@@ -411,10 +413,14 @@ const runIterationReport = async (iteration, verifyResult) => {
 // integrate the kept worktrees. Returns { perTaskResults, integrate }.
 const runBatch = async (batchIds, failuresOrEmpty) => {
   const tasks = batchIds.map((id) => taskById[id])
-  const limit = Math.min(MAX_CONCURRENT, tasks.length)
-  // Soft per-batch cap: chunk so no more than `limit` run at once.
   const perTaskResults = []
   const kept = []
+  // Concurrency model (aligned with the compose skill): only run implement tasks
+  // CONCURRENTLY when each task is isolated in its own worktree. In the default
+  // (non-isolated) mode all tasks write to the SAME workspace, so the original
+  // compose:subagent skill forbids parallel implementation (file conflicts) — run
+  // them one at a time. parallel() here is gated on ISOLATE for exactly that reason.
+  const limit = ISOLATE ? Math.min(MAX_CONCURRENT, tasks.length) : 1
   for (let i = 0; i < tasks.length; i += limit) {
     const chunk = tasks.slice(i, i + limit)
     const results = await parallel(chunk.map((t) => () => runImplementTask(t, failuresOrEmpty)))
@@ -526,7 +532,9 @@ if (review.critical && review.critical.length > 0) {
   phase("Fix")
   for (let attempt = 0; attempt < MAX_REVIEW_FIX_ATTEMPTS; attempt++) {
     reviewFixAttempts = attempt + 1
-    const limit = Math.min(MAX_CONCURRENT, review.critical.length)
+    // Same concurrency rule as implement: parallel only when worktree-isolated;
+    // otherwise fixes share the workspace → run sequentially to avoid conflicts.
+    const limit = ISOLATE ? Math.min(MAX_CONCURRENT, review.critical.length) : 1
     const perTaskResults = []
     const kept = []
     const criticals = review.critical
@@ -648,8 +656,8 @@ return {
   finalReport,
   merge,
   stats: {
-    agents: verifyHistory.length + tddAttempts + reviewFixAttempts + 4, // brainstorm + classify + design + review + merge
-    phases: 8,
+    agents: verifyHistory.length + tddAttempts + reviewFixAttempts + 4, // brainstorm + design-write + design-extract + review + merge (approx)
+    phases: 7,
     parallelBatches: batches.length,
     durationMs: 0, // QuickJS guest has no Date; host can compute from journal if needed
   },

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -188,10 +188,11 @@ const SYNTHETIC_CONTEXT = { projectType: "unknown", conventions: [], recentChang
 // change to an existing feature) vs new work — enabling incremental re-runs that
 // reuse the existing spec/plan instead of regenerating everything. The workflow
 // only lists the files; the agent reads + judges.
+const _globArr = async (pat) => { const r = await glob(pat); return Array.isArray(r) ? r : [] }
 const existingDocs = [
-  ...(await glob(SPECS_DIR + "/*.md")),
-  ...(await glob(PLANS_DIR + "/*.md")),
-  ...(await glob(REPORTS_DIR + "/*.md")),
+  ...(await _globArr(SPECS_DIR + "/*.md")),
+  ...(await _globArr(PLANS_DIR + "/*.md")),
+  ...(await _globArr(REPORTS_DIR + "/*.md")),
 ]
 const existingDocsBlock = existingDocs.length
   ? "\n## Existing compose artifacts (this project has prior compose work)\n" +
@@ -220,12 +221,13 @@ if (SKIP_BRAINSTORM) {
   )
   if (!brainstorm || !brainstorm.context) brainstorm = { context: SYNTHETIC_CONTEXT, assumptions: [] }
 }
+const _arr = (v) => (Array.isArray(v) ? v : [])
 const contextDigest =
   "Project: " + brainstorm.context.projectType + "\n" +
-  "Conventions:\n" + (brainstorm.context.conventions || []).map((c) => "- " + c).join("\n") + "\n" +
-  "Recent changes:\n" + (brainstorm.context.recentChanges || []).map((c) => "- " + c).join("\n") + "\n" +
-  "Relevant files:\n" + (brainstorm.context.relevantFiles || []).map((f) => "- " + f).join("\n") +
-  ((brainstorm.assumptions && brainstorm.assumptions.length) ? "\nAssumptions:\n" + brainstorm.assumptions.map((a) => "- " + a).join("\n") : "") +
+  "Conventions:\n" + _arr(brainstorm.context.conventions).map((c) => "- " + c).join("\n") + "\n" +
+  "Recent changes:\n" + _arr(brainstorm.context.recentChanges).map((c) => "- " + c).join("\n") + "\n" +
+  "Relevant files:\n" + _arr(brainstorm.context.relevantFiles).map((f) => "- " + f).join("\n") +
+  (_arr(brainstorm.assumptions).length ? "\nAssumptions:\n" + _arr(brainstorm.assumptions).map((a) => "- " + a).join("\n") : "") +
   ((brainstorm.amends && typeof brainstorm.amends === "string") ? "\nAmends existing feature: " + brainstorm.amends : "")
 
 // ---------------------------------------------------------------------------
@@ -282,6 +284,14 @@ const runDesignWrite = (sharpen) => agent(
       "EDIT them IN PLACE (write back to the SAME file paths) to reflect ONLY the change in the task above — do NOT rewrite from scratch. " +
       "In the plan, the task list must then contain ONLY the tasks that need to be (re-)implemented for this change, PLUS any tasks that " +
       "depend on them. Tasks unaffected by the change MUST be omitted from the actionable list — they are reused as-is.\n\n" +
+      "## Scope the work to the actual change (CRITICAL)\n" +
+      "First assess the MAGNITUDE of this change: small (one spot / a few lines), medium (a few related tasks), " +
+      "or large (a foundational refactor touching many modules). Make the plan's actionable task list MATCH that magnitude:\n" +
+      "- Small change → ONE task (or zero, if the code already satisfies it). Do NOT split one small change into multiple tasks.\n" +
+      "- Medium → only the genuinely distinct tasks the change requires, plus their dependents.\n" +
+      "- Large refactor → re-decompose into as many independent tasks as the work truly needs.\n" +
+      "NEVER emit two near-identical or duplicate tasks for the same change. One distinct unit of work = exactly one task. " +
+      "The number of tasks must reflect the real scope — it is not fixed.\n\n" +
       "Write the updated files with the `write` tool. Do not just describe them.\n"
     : "## Your deliverable (REQUIRED — this is the whole job)\n" +
       "Use the `write` tool to create BOTH of these files on disk:\n" +
@@ -318,7 +328,7 @@ const planWritten = (await glob(PLANS_DIR + "/*.md")).length > 0
 const design = await agent(
   "Read the implementation plan markdown in `" + PLANS_DIR + "` (use the `read` tool; if multiple files, read the most recent) and extract its task list.\n\n" +
   (planWritten ? "" : "## No plan file found — derive the task list from the task below instead.\n## Task\n" + TASK + "\n\n") +
-  (AMENDS ? "## Amendment\nThis run amends the existing feature \"" + AMENDS + "\". Return ONLY the tasks that need to be (re-)implemented for the current change (plus their dependents). OMIT tasks that are unaffected — they are reused as-is.\n\n" : "") +
+  (AMENDS ? "## Amendment\nThis run amends the existing feature \"" + AMENDS + "\". Return the SMALLEST set of tasks that covers the actual change (plus their dependents). One distinct unit of work = exactly one task — do NOT return duplicate or near-identical tasks, and do NOT split a single small change across multiple tasks. OMIT every task unaffected by this change — they are reused as-is.\n\n" : "") +
   "## Output contract (STRICT)\n" +
   "Call the `StructuredOutput` tool EXACTLY ONCE with a JSON object matching the schema. " +
   "Do NOT reply with prose, markdown, XML, or a code block — those do not count and will be rejected. " +

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -248,7 +248,7 @@ if (VALID_TYPES.indexOf(argType) >= 0) {
   if (/\b(pr|review)\b.*\b(feedback|comment|address)\b|address .*\bfeedback\b/.test(t)) type = "feedback"
   else if (/\b(bug|broken|regression|crash|fails?|incorrect|wrong|error)\b/.test(t)) type = "bugfix"
   else type = "feature"
-  log("Resolved type=" + type + " (heuristic; no classify phase)")
+  log("Task type: " + type)
 }
 
 const SKILL_BY_TYPE = {

--- a/packages/opencode/src/workflow/builtin/compose.js
+++ b/packages/opencode/src/workflow/builtin/compose.js
@@ -1,0 +1,16 @@
+export const meta = {
+  name: "compose",
+  description: "Autonomous compose pipeline — classifies a task and runs plan→tdd→verify→review→merge with bounded retry, all in never-ask mode.",
+  whenToUse: "Use to drive a feature, bugfix, refactor, or review-feedback task through the full compose flow without user prompting. Pass args.task = the user's request. Optionally pass args.type to skip classification.",
+  phases: [
+    { title: "Classify", detail: "Decide task type (feature/bugfix/refactor/feedback)" },
+    { title: "Design", detail: "Apply compose:plan, compose:debug, or compose:feedback by type" },
+    { title: "Implement", detail: "compose:tdd loop, retry on verify failure (≤3)" },
+    { title: "Verify", detail: "Run project verify commands; structured pass/fail" },
+    { title: "Review", detail: "compose:review for critical/important/minor issues" },
+    { title: "Merge", detail: "compose:merge to commit (and optionally push/PR)" },
+  ],
+}
+
+// Placeholder body — replaced in subsequent tasks.
+return { ok: true, todo: "implement phases" }

--- a/packages/opencode/test/workflow/builtin.test.ts
+++ b/packages/opencode/test/workflow/builtin.test.ts
@@ -19,4 +19,18 @@ describe("BuiltinWorkflow registry", () => {
   test("get returns undefined for an unknown name", () => {
     expect(BuiltinWorkflow.get("nope")).toBeUndefined()
   })
+
+  test("lists compose with parsed meta", () => {
+    const list = BuiltinWorkflow.list()
+    const c = list.find((w) => w.name === "compose")
+    expect(c).toBeDefined()
+    expect(c!.description).toContain("compose")
+    expect(c!.phases?.length).toBeGreaterThanOrEqual(6)
+  })
+
+  test("get('compose') returns the script body starting with export const meta", () => {
+    const c = BuiltinWorkflow.get("compose")
+    expect(c).toBeDefined()
+    expect(c!.script.startsWith("export const meta")).toBe(true)
+  })
 })

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -17,18 +17,41 @@ describe("compose script structure", () => {
 
   test("declares schemas for every phase", () => {
     const script = composeScript()
+    expect(script).toContain("BRAINSTORM_SHAPE")
     expect(script).toContain("CLASSIFY_SHAPE")
     expect(script).toContain("DESIGN_SHAPE")
+    expect(script).toContain("INTEGRATE_SHAPE")
     expect(script).toContain("VERIFY_SHAPE")
     expect(script).toContain("REVIEW_SHAPE")
+    expect(script).toContain("ITERATION_REPORT_SHAPE")
+    expect(script).toContain("FINAL_REPORT_SHAPE")
     expect(script).toContain("MERGE_SHAPE")
   })
 })
 
-const runCompose = async (args: unknown, agentImpl: (prompt: string, opts?: any) => unknown) => {
+// Default agent stub that drives a clean happy path. Implement/fix agents return a
+// `_worktree` (changed) so the integrate path is exercised. Override per-test.
+const happyAgent = (prompt: string, opts?: any) => {
+  const o = opts as any
+  if (o?.schema?.properties?.context) return { context: { projectType: "Bun TS", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+  if (o?.schema?.properties?.type) return { type: "feature", confidence: "high", reasoning: "r" }
+  if (o?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+  if (o?.schema?.properties?.merged) return { merged: [{ taskId: "t1", branch: "b", sha: "s" }], conflicts: [], skipped_pristine: [] }
+  if (o?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
+  if (o?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
+  if (o?.schema?.properties?.iteration) return { iteration: 1, what_changed: "x" }
+  if (o?.schema?.properties?.path) return { path: "docs/compose/reports/x.md", sha: "rsha" }
+  if (o?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
+  if (o?.label && String(o.label).startsWith("implement")) return { _worktree: { branch: "wt-" + o.label, directory: "/tmp/" + o.label, changed: true } }
+  if (o?.label && String(o.label).startsWith("fix")) return { _worktree: { branch: "wt-" + o.label, directory: "/tmp/" + o.label, changed: true } }
+  return "ok"
+}
+
+const runCompose = async (args: unknown, agentImpl: (prompt: string, opts?: any) => unknown = happyAgent) => {
   const parsed = parseMeta(composeScript())
   if (!parsed.ok) throw new Error(parsed.error)
   const calls: { prompt: string; opts?: any }[] = []
+  const phases: string[] = []
   const hooks = {
     agent: async (prompt: unknown, opts?: unknown) => {
       const p = String(prompt)
@@ -36,7 +59,7 @@ const runCompose = async (args: unknown, agentImpl: (prompt: string, opts?: any)
       calls.push({ prompt: p, opts: o })
       return agentImpl(p, o)
     },
-    phase: () => undefined,
+    phase: (title: unknown) => { phases.push(String(title)) },
     log: () => undefined,
     workflow: async () => null,
     readFile: async () => null,
@@ -44,35 +67,62 @@ const runCompose = async (args: unknown, agentImpl: (prompt: string, opts?: any)
     exists: async () => false,
     glob: async () => [],
   }
-  // The sandbox exposes args via globalThis.args; inject by prepending a global.
   const body = `globalThis.args = ${JSON.stringify(args)};\n` + parsed.body
   const result = await evalScript(body, hooks)
-  return { result, calls }
+  return { result, calls, phases }
 }
+
+describe("compose phase 0: Brainstorm", () => {
+  test("runs brainstorm context recon by default", async () => {
+    const { calls } = await runCompose({ task: "add dark mode", type: "feature" })
+    const bs = calls.find((c) => c.opts?.schema?.properties?.context)
+    expect(bs).toBeDefined()
+    expect(bs!.opts.label).toBe("brainstorm")
+    expect(bs!.prompt).toContain("compose:brainstorm")
+    expect(bs!.prompt).toContain("AUTONOMOUS")
+  })
+
+  test("skips brainstorm agent when args.skip_brainstorm", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature", skip_brainstorm: true })
+    expect(calls.find((c) => c.opts?.schema?.properties?.context)).toBeUndefined()
+  })
+})
+
+describe("compose docs dir injection", () => {
+  test("design + report prompts carry the configured docs dir", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature", _composeDocsDir: "custom/docs" })
+    const design = calls.find((c) => c.opts?.schema?.properties?.tasks)
+    expect(design!.prompt).toContain("custom/docs/specs")
+    expect(design!.prompt).toContain("custom/docs/plans")
+    const report = calls.find((c) => c.opts?.schema?.properties?.path)
+    expect(report!.prompt).toContain("custom/docs/reports")
+  })
+
+  test("defaults to docs/compose when host did not inject", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature" })
+    const design = calls.find((c) => c.opts?.schema?.properties?.tasks)
+    expect(design!.prompt).toContain("docs/compose/specs")
+  })
+})
 
 describe("compose phase 1: Classify", () => {
   test("calls classifier when args.type absent", async () => {
-    const { calls } = await runCompose(
-      { task: "fix the foo regression" },
-      (prompt, opts) => {
-        if (opts?.schema?.properties?.type) {
-          return { type: "bugfix", confidence: "high", reasoning: "regression keyword" }
-        }
-        return null
-      },
-    )
+    const { calls } = await runCompose({ task: "fix the foo regression" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+      if (opts?.schema?.properties?.type) return { type: "bugfix", confidence: "high", reasoning: "regression keyword" }
+      return null
+    })
     const classifyCall = calls.find((c) => c.opts?.schema?.properties?.type)
     expect(classifyCall).toBeDefined()
     expect(classifyCall!.prompt).toContain("fix the foo regression")
   })
 
   test("skips classifier when args.type provided", async () => {
-    const { calls } = await runCompose(
-      { task: "implement bar", type: "feature" },
-      () => null,
-    )
-    const classifyCall = calls.find((c) => c.opts?.schema?.properties?.type)
-    expect(classifyCall).toBeUndefined()
+    const { calls } = await runCompose({ task: "implement bar", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+      return null
+    })
+    expect(calls.find((c) => c.opts?.schema?.properties?.type)).toBeUndefined()
   })
 })
 
@@ -83,26 +133,87 @@ describe("compose phase 2: Design", () => {
     ["bugfix", "compose:debug"],
     ["feedback", "compose:feedback"],
   ])("type=%s routes to %s", async (type, skill) => {
-    const { calls } = await runCompose(
-      { task: "x", type },
-      (prompt, opts) => {
-        if (opts?.schema?.properties?.tasks) {
-          return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-        }
-        return null
-      },
-    )
+    const { calls } = await runCompose({ task: "x", type }, (prompt, opts) => {
+      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+      if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+      return null
+    })
     const designCall = calls.find((c) => c.opts?.schema?.properties?.tasks)
     expect(designCall).toBeDefined()
     expect(designCall!.prompt).toContain(skill)
   })
 
   test("design returning null surfaces design-failed", async () => {
-    const { result } = await runCompose(
-      { task: "x", type: "feature" },
-      () => null,
-    )
+    const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+      return null
+    })
     expect(result).toMatchObject({ error: "design-failed" })
+  })
+})
+
+describe("compose phase 3: parallelism, dependencies, worktrees", () => {
+  test("independent tasks land in one batch dispatched in parallel with worktree isolation", async () => {
+    let maxConcurrent = 0
+    let active = 0
+    const { result, calls } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+      if (opts?.schema?.properties?.tasks) return { tasks: [
+        { id: "T1", description: "d", acceptance: "a", dependsOn: [] },
+        { id: "T2", description: "d", acceptance: "a", dependsOn: [] },
+        { id: "T3", description: "d", acceptance: "a", dependsOn: [] },
+        { id: "T4", description: "d", acceptance: "a", dependsOn: [] },
+      ] }
+      if (opts?.schema?.properties?.merged) return { merged: [], conflicts: [], skipped_pristine: [] }
+      if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
+      if (opts?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
+      if (opts?.schema?.properties?.iteration) return { iteration: 1, what_changed: "x" }
+      if (opts?.schema?.properties?.path) return { path: "p", sha: "s" }
+      if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
+      if (opts?.label && String(opts.label).startsWith("implement")) {
+        active++; maxConcurrent = Math.max(maxConcurrent, active); active--
+        return { _worktree: { branch: "b", directory: "/tmp/d", changed: true } }
+      }
+      return "ok"
+    })
+    expect((result as any).batches).toEqual([["T1", "T2", "T3", "T4"]])
+    const implCalls = calls.filter((c) => c.opts?.label && String(c.opts.label).startsWith("implement:"))
+    expect(implCalls).toHaveLength(4)
+    for (const c of implCalls) expect(c.opts.isolation).toBe("worktree")
+  })
+
+  test("dependency chain produces sequential batches in order", async () => {
+    const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+      if (opts?.schema?.properties?.tasks) return { tasks: [
+        { id: "T1", description: "d", acceptance: "a", dependsOn: [] },
+        { id: "T2", description: "d", acceptance: "a", dependsOn: ["T1"] },
+        { id: "T3", description: "d", acceptance: "a", dependsOn: ["T2"] },
+      ] }
+      return happyAgent(prompt, opts)
+    })
+    expect((result as any).batches).toEqual([["T1"], ["T2"], ["T3"]])
+  })
+
+  test("dependency cycle returns design-cycle", async () => {
+    const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+      if (opts?.schema?.properties?.tasks) return { tasks: [
+        { id: "T1", description: "d", acceptance: "a", dependsOn: ["T2"] },
+        { id: "T2", description: "d", acceptance: "a", dependsOn: ["T1"] },
+      ] }
+      return happyAgent(prompt, opts)
+    })
+    expect(result).toMatchObject({ error: "design-cycle" })
+    expect((result as any).cycleNodes).toEqual(expect.arrayContaining(["T1", "T2"]))
+  })
+
+  test("integrate agent dispatched with kept worktrees", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature" })
+    const integrate = calls.find((c) => c.opts?.label === "integrate")
+    expect(integrate).toBeDefined()
+    expect(integrate!.opts.schema.properties.merged).toBeDefined()
+    expect(integrate!.prompt).toContain("_worktree")
   })
 })
 
@@ -111,21 +222,12 @@ describe("compose phase 3: TDD loop", () => {
     let implCalls = 0
     let verifyCalls = 0
     let debugCalls = 0
-    const { result } = await runCompose(
-      { task: "x", type: "feature" },
-      (prompt, opts) => {
-        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-        if (opts?.schema?.properties?.allPassed) {
-          verifyCalls++
-          return { typecheck: "ok", tests: { passed: 5, failed: 0 }, build: "ok", allPassed: true }
-        }
-        if (opts?.label === "implement") implCalls++
-        if (opts?.label?.startsWith("debug")) debugCalls++
-        if (opts?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
-        if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
-        return "ok"
-      },
-    )
+    const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.label && String(opts.label).startsWith("implement")) { implCalls++; return { _worktree: { branch: "b", directory: "/d", changed: true } } }
+      if (opts?.schema?.properties?.allPassed) { verifyCalls++; return { typecheck: "ok", tests: { passed: 5, failed: 0 }, build: "ok", allPassed: true } }
+      if (opts?.label === "debug") debugCalls++
+      return happyAgent(prompt, opts)
+    })
     expect(implCalls).toBe(1)
     expect(verifyCalls).toBe(1)
     expect(debugCalls).toBe(0)
@@ -134,46 +236,39 @@ describe("compose phase 3: TDD loop", () => {
 
   test("verify fails 3 times → returns verify-exhausted with history", async () => {
     let verifyCalls = 0
-    const { result } = await runCompose(
-      { task: "x", type: "feature" },
-      (prompt, opts) => {
-        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-        if (opts?.schema?.properties?.allPassed) {
-          verifyCalls++
-          return { typecheck: "fail", tests: { passed: 0, failed: 1 }, build: "skipped", allPassed: false, failures: "tc#" + verifyCalls }
-        }
-        return "ok"
-      },
-    )
+    const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.allPassed) { verifyCalls++; return { typecheck: "fail", tests: { passed: 0, failed: 1 }, build: "skipped", allPassed: false, failures: "tc#" + verifyCalls } }
+      return happyAgent(prompt, opts)
+    })
     expect(verifyCalls).toBe(3)
     expect(result).toMatchObject({ error: "verify-exhausted", attempts: 3 })
     expect((result as any).verifyHistory).toHaveLength(3)
   })
 
-  test("verify fails twice then passes → loop runs 3 impls + 3 verifies + 2 debugs", async () => {
+  test("verify fails twice then passes → 3 verifies + 2 debugs", async () => {
     let verifyCalls = 0
-    let implCalls = 0
     let debugCalls = 0
-    await runCompose(
-      { task: "x", type: "feature" },
-      (prompt, opts) => {
-        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-        if (opts?.schema?.properties?.allPassed) {
-          verifyCalls++
-          return verifyCalls >= 3
-            ? { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
-            : { typecheck: "fail", tests: { passed: 0, failed: 1 }, build: "skipped", allPassed: false, failures: "x" }
-        }
-        if (opts?.label === "implement") implCalls++
-        if (opts?.label?.startsWith("debug")) debugCalls++
-        if (opts?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
-        if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
-        return "ok"
-      },
-    )
-    expect(implCalls).toBe(3)
+    await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.allPassed) {
+        verifyCalls++
+        return verifyCalls >= 3
+          ? { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
+          : { typecheck: "fail", tests: { passed: 0, failed: 1 }, build: "skipped", allPassed: false, failures: "x" }
+      }
+      if (opts?.label === "debug") debugCalls++
+      return happyAgent(prompt, opts)
+    })
     expect(verifyCalls).toBe(3)
     expect(debugCalls).toBe(2)
+  })
+
+  test("one successful iteration writes one iteration-report", async () => {
+    let reportCalls = 0
+    await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.iteration) { reportCalls++; return { iteration: 1, what_changed: "x" } }
+      return happyAgent(prompt, opts)
+    })
+    expect(reportCalls).toBe(1)
   })
 })
 
@@ -181,20 +276,11 @@ describe("compose phases 4-5: Review + Fix loop", () => {
   test("review with no critical → no fix loop, proceeds to merge", async () => {
     let fixCalls = 0
     let reviewCalls = 0
-    const { result } = await runCompose(
-      { task: "x", type: "feature" },
-      (prompt, opts) => {
-        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-        if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
-        if (opts?.schema?.properties?.readyToMerge) {
-          reviewCalls++
-          return { critical: [], important: ["nit"], minor: [], readyToMerge: true }
-        }
-        if (opts?.label === "fix") fixCalls++
-        if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
-        return "ok"
-      },
-    )
+    const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.readyToMerge) { reviewCalls++; return { critical: [], important: ["nit"], minor: [], readyToMerge: true } }
+      if (opts?.label && String(opts.label).startsWith("fix")) fixCalls++
+      return happyAgent(prompt, opts)
+    })
     expect(reviewCalls).toBe(1)
     expect(fixCalls).toBe(0)
     expect(result).not.toMatchObject({ readyToMerge: false })
@@ -202,108 +288,81 @@ describe("compose phases 4-5: Review + Fix loop", () => {
 
   test("review critical, fix succeeds on iteration 1 → exits loop, merges", async () => {
     let reviewCalls = 0
-    const { result } = await runCompose(
-      { task: "x", type: "feature" },
-      (prompt, opts) => {
-        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-        if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
-        if (opts?.schema?.properties?.readyToMerge) {
-          reviewCalls++
-          return reviewCalls === 1
-            ? { critical: ["bug X"], important: [], minor: [], readyToMerge: false }
-            : { critical: [], important: [], minor: [], readyToMerge: true }
-        }
-        if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
-        return "ok"
-      },
-    )
+    const { result, calls } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.readyToMerge) {
+        reviewCalls++
+        return reviewCalls === 1
+          ? { critical: ["bug X"], important: [], minor: [], readyToMerge: false }
+          : { critical: [], important: [], minor: [], readyToMerge: true }
+      }
+      return happyAgent(prompt, opts)
+    })
     expect(reviewCalls).toBe(2)
+    const fixCall = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("fix:"))
+    expect(fixCall!.opts.isolation).toBe("worktree")
     expect(result).not.toMatchObject({ readyToMerge: false })
   })
 
   test("review critical persists through 2 fix iterations → readyToMerge:false", async () => {
     let reviewCalls = 0
-    const { result } = await runCompose(
-      { task: "x", type: "feature" },
-      (prompt, opts) => {
-        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-        if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
-        if (opts?.schema?.properties?.readyToMerge) {
-          reviewCalls++
-          return { critical: ["unfixable"], important: [], minor: [], readyToMerge: false }
-        }
-        return "ok"
-      },
-    )
-    expect(reviewCalls).toBe(3) // initial + 2 fix-loop reviews
+    const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.readyToMerge) { reviewCalls++; return { critical: ["unfixable"], important: [], minor: [], readyToMerge: false } }
+      return happyAgent(prompt, opts)
+    })
+    expect(reviewCalls).toBe(3)
     expect(result).toMatchObject({ readyToMerge: false })
     expect((result as any).review.critical).toContain("unfixable")
   })
 })
 
-describe("compose phase 6: Merge + final shape", () => {
+describe("compose phase 6: Final report", () => {
+  test("final-report agent runs before merge", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature" })
+    const finalIdx = calls.findIndex((c) => c.opts?.label === "final-report")
+    const mergeIdx = calls.findIndex((c) => c.opts?.label === "merge")
+    expect(finalIdx).toBeGreaterThanOrEqual(0)
+    expect(mergeIdx).toBeGreaterThan(finalIdx)
+  })
+
+  test("skip_report short-circuits iteration + final report writes", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature", skip_report: true })
+    expect(calls.find((c) => c.opts?.schema?.properties?.iteration)).toBeUndefined()
+    expect(calls.find((c) => c.opts?.schema?.properties?.path)).toBeUndefined()
+  })
+})
+
+describe("compose phase 7: Merge + final shape", () => {
   test("happy path returns full shape per [S4]", async () => {
-    const { result } = await runCompose(
-      { task: "x", type: "feature" },
-      (prompt, opts) => {
-        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-        if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
-        if (opts?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
-        if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc1234", action: "commit", prUrl: undefined }
-        return "ok"
-      },
-    )
+    const { result } = await runCompose({ task: "x", type: "feature" })
     expect(result).toMatchObject({
       type: "feature",
       design: { tasks: expect.any(Array) },
       review: { readyToMerge: true },
-      merge: { committed: true, sha: "abc1234", action: "commit" },
+      merge: { committed: true, sha: "abc", action: "commit" },
     })
+    expect((result as any).brainstorm).toBeDefined()
+    expect((result as any).batches).toBeDefined()
     expect((result as any).verifyHistory).toBeDefined()
-    expect((result as any).stats).toMatchObject({ agents: expect.any(Number), durationMs: expect.any(Number) })
+    expect((result as any).stats).toMatchObject({ agents: expect.any(Number), parallelBatches: expect.any(Number) })
   })
 
   test("merge failure returns merge-failed", async () => {
-    const { result } = await runCompose(
-      { task: "x", type: "feature" },
-      (prompt, opts) => {
-        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-        if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
-        if (opts?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
-        if (opts?.schema?.properties?.committed) return { committed: false, action: "none" }
-        return "ok"
-      },
-    )
+    const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.committed) return { committed: false, action: "none" }
+      return happyAgent(prompt, opts)
+    })
     expect(result).toMatchObject({ error: "merge-failed", merge: { committed: false } })
   })
 })
 
 describe("compose E2E smoke", () => {
-  test("happy path runs 5 phases in order (Fix conditional on review-critical)", async () => {
-    const phases: string[] = []
-    const parsed = parseMeta(composeScript())
-    if (!parsed.ok) throw new Error(parsed.error)
-    const argsValue = { task: "ship a feature", type: "feature" }
-    const hooks = {
-      agent: async (prompt: unknown, opts: unknown) => {
-        const o = opts as any
-        if (o?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-        if (o?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
-        if (o?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
-        if (o?.schema?.properties?.committed) return { committed: true, sha: "deadbeef", action: "commit" }
-        return "ok"
-      },
-      phase: (title: unknown) => { phases.push(String(title)) },
-      log: () => undefined,
-      workflow: async () => null,
-      readFile: async () => null,
-      writeFile: async () => undefined,
-      exists: async () => false,
-      glob: async () => [],
-    }
-    const body = `globalThis.args = ${JSON.stringify(argsValue)};\n` + parsed.body
-    const result = await evalScript(body, hooks)
-    expect(phases).toEqual(["Classify", "Design", "Implement", "Review", "Merge"]) // Fix only runs on review failure
+  test("happy path runs phases in order (Brainstorm→Classify→Design→Implement→Verify→Report→Review→Merge)", async () => {
+    const { result, phases } = await runCompose({ task: "ship a feature", type: "feature" })
+    // First occurrence of each phase, in order. The iteration report (Report) fires
+    // inside the TDD loop on a successful verify, before Phase 4 Review (spec [S3] 3f).
+    const firstSeen: string[] = []
+    for (const p of phases) if (firstSeen.indexOf(p) < 0) firstSeen.push(p)
+    expect(firstSeen).toEqual(["Brainstorm", "Classify", "Design", "Implement", "Verify", "Report", "Review", "Merge"])
     expect((result as any).merge?.committed).toBe(true)
   })
 })

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -240,3 +240,40 @@ describe("compose phases 4-5: Review + Fix loop", () => {
     expect((result as any).review.critical).toContain("unfixable")
   })
 })
+
+describe("compose phase 6: Merge + final shape", () => {
+  test("happy path returns full shape per [S4]", async () => {
+    const { result } = await runCompose(
+      { task: "x", type: "feature" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+        if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
+        if (opts?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
+        if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc1234", action: "commit", prUrl: undefined }
+        return "ok"
+      },
+    )
+    expect(result).toMatchObject({
+      type: "feature",
+      design: { tasks: expect.any(Array) },
+      review: { readyToMerge: true },
+      merge: { committed: true, sha: "abc1234", action: "commit" },
+    })
+    expect((result as any).verifyHistory).toBeDefined()
+    expect((result as any).stats).toMatchObject({ agents: expect.any(Number), durationMs: expect.any(Number) })
+  })
+
+  test("merge failure returns merge-failed", async () => {
+    const { result } = await runCompose(
+      { task: "x", type: "feature" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+        if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
+        if (opts?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
+        if (opts?.schema?.properties?.committed) return { committed: false, action: "none" }
+        return "ok"
+      },
+    )
+    expect(result).toMatchObject({ error: "merge-failed", merge: { committed: false } })
+  })
+})

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -220,6 +220,15 @@ describe("compose phase 2: Design", () => {
     expect(result).toMatchObject({ error: "design-failed" })
   })
 
+  test("extract returning a truthy object without a tasks array surfaces design-failed (no crash)", async () => {
+    const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+      if (opts?.schema?.properties?.tasks) return { notes: "oops, no tasks field" } // truthy but malformed
+      return "ok"
+    })
+    expect(result).toMatchObject({ error: "design-failed" })
+  })
+
   test("tasks with missing/blank ids get backfilled (no implement:undefined label)", async () => {
     const { calls, result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
       if (opts?.schema?.properties?.tasks) return { tasks: [

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -238,8 +238,8 @@ describe("compose phase 2: Design", () => {
 })
 
 describe("compose phase 3: parallelism, dependencies, worktrees", () => {
-  test("independent tasks land in one batch dispatched in parallel; worktree isolation opt-in", async () => {
-    const { result, calls } = await runCompose({ task: "x", type: "feature", isolate_worktrees: true }, (prompt, opts) => {
+  test("multiple independent tasks AUTO-isolate (worktree per task), no flag needed", async () => {
+    const { result, calls } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
       if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
       if (opts?.schema?.properties?.tasks) return { tasks: [
         { id: "T1", description: "d", acceptance: "a", dependsOn: [] },
@@ -257,26 +257,29 @@ describe("compose phase 3: parallelism, dependencies, worktrees", () => {
     expect((result as any).batches).toEqual([["T1", "T2", "T3", "T4"]])
     const implCalls = calls.filter((c) => c.opts?.label && String(c.opts.label).startsWith("implement:"))
     expect(implCalls).toHaveLength(4)
-    for (const c of implCalls) expect(c.opts.isolation).toBe("worktree")
+    for (const c of implCalls) expect(c.opts.isolation).toBe("worktree") // auto, no flag
+    expect(calls.find((c) => c.opts?.label === "integrate")).toBeDefined()
   })
 
-  test("default mode (no isolate_worktrees) runs implement WITHOUT worktree isolation and skips integrate", async () => {
-    const { result, calls } = await runCompose({ task: "x", type: "feature" })
+  test("a single-task batch stays sequential, no isolation, no integrate (auto)", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "T1", description: "d", acceptance: "a", dependsOn: [] }] }
+      return happyAgent(prompt, opts)
+    })
     const implCalls = calls.filter((c) => c.opts?.label && String(c.opts.label).startsWith("implement:"))
-    expect(implCalls.length).toBeGreaterThan(0)
-    for (const c of implCalls) expect(c.opts.isolation).toBeUndefined() // runs in main workspace
-    expect(calls.find((c) => c.opts?.label === "integrate")).toBeUndefined() // nothing to integrate
-    expect(result).not.toMatchObject({ error: expect.anything() })
+    expect(implCalls).toHaveLength(1)
+    expect(implCalls[0].opts.isolation).toBeUndefined()
+    expect(calls.find((c) => c.opts?.label === "integrate")).toBeUndefined()
   })
 
-  test("default mode runs implement tasks SEQUENTIALLY (no same-workspace parallel conflicts)", async () => {
+  test("args.isolate_worktrees:false forces all-sequential, no isolation even for a multi-task batch", async () => {
     let active = 0
     let maxConcurrent = 0
     const agentImpl = async (prompt: string, opts?: any) => {
       if (opts?.label && String(opts.label).startsWith("implement:")) {
         active++
         maxConcurrent = Math.max(maxConcurrent, active)
-        await new Promise((r) => setTimeout(r, 5)) // hold the slot so overlap is observable
+        await new Promise((r) => setTimeout(r, 5))
         active--
         return "ok"
       }
@@ -288,11 +291,13 @@ describe("compose phase 3: parallelism, dependencies, worktrees", () => {
       ] }
       return happyAgent(prompt, opts)
     }
-    await runCompose({ task: "x", type: "feature" }, agentImpl)
-    expect(maxConcurrent).toBe(1) // sequential in default (same-workspace) mode
+    const { calls } = await runCompose({ task: "x", type: "feature", isolate_worktrees: false }, agentImpl)
+    const implCalls = calls.filter((c) => c.opts?.label && String(c.opts.label).startsWith("implement:"))
+    for (const c of implCalls) expect(c.opts.isolation).toBeUndefined()
+    expect(maxConcurrent).toBe(1) // forced sequential
   })
 
-  test("isolated mode runs independent implement tasks CONCURRENTLY", async () => {
+  test("auto-isolated independent tasks run CONCURRENTLY (worktree per task)", async () => {
     let active = 0
     let maxConcurrent = 0
     const agentImpl = async (prompt: string, opts?: any) => {
@@ -311,8 +316,8 @@ describe("compose phase 3: parallelism, dependencies, worktrees", () => {
       ] }
       return happyAgent(prompt, opts)
     }
-    await runCompose({ task: "x", type: "feature", isolate_worktrees: true }, agentImpl)
-    expect(maxConcurrent).toBeGreaterThan(1) // parallel when each task has its own worktree
+    await runCompose({ task: "x", type: "feature" }, agentImpl) // no flag — auto
+    expect(maxConcurrent).toBeGreaterThan(1)
   })
 
   test("dependency chain produces sequential batches in order", async () => {

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -609,3 +609,51 @@ describe("compose brainstorm robustness", () => {
     expect((result as any).type).toBe("feature")
   })
 })
+
+describe("compose phase I/O chaining", () => {
+  test("brainstorm prompt self-conducts Socratic Q&A + approaches (autonomous)", () => {
+    const s = composeScript()
+    expect(s).toContain("self-conduct the dialogue")
+    expect(s).toContain("selfQA")
+    expect(s).toContain("approaches")
+    expect(s).toContain("chosenApproach")
+  })
+
+  test("brainstorm is NOT downgraded to lite model anymore", () => {
+    const s = composeScript()
+    // the brainstorm agent opts must not pin model:"lite"
+    expect(s).not.toMatch(/label: "brainstorm"[^}]*model: "lite"/)
+  })
+
+  test("implement carries Intent (chosen approach) and TASKS_DIGEST is gone", () => {
+    const s = composeScript()
+    expect(s).toContain("Intent (from design")
+    expect(s).not.toContain("TASKS_DIGEST")
+  })
+
+  test("review is two-stage: spec-compliance before code-quality, with git diff", () => {
+    const s = composeScript()
+    expect(s).toContain("TWO STAGES")
+    expect(s).toMatch(/Stage 1 — Spec compliance/i)
+    expect(s).toMatch(/Stage 2 — Code quality/i)
+    expect(s).toContain("git diff")
+  })
+
+  test("merge prompt receives what-was-built + review outcome", () => {
+    const s = composeScript()
+    expect(s).toContain("What was built")
+    expect(s).toContain("Review outcome")
+  })
+
+  test("brainstorm self-Q&A reasoning flows into the design prompt at runtime", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.context)
+        return { context: { projectType: "p", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [],
+                 approaches: [{ name: "A1", tradeoffs: "fast" }], chosenApproach: "A1", chosenRationale: "simplest" }
+      return happyAgent(prompt, opts)
+    })
+    const designWrite = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))!
+    expect(designWrite.prompt).toContain("Chosen approach: A1")
+    expect(designWrite.prompt).toContain("simplest")
+  })
+})

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -30,12 +30,15 @@ describe("compose script structure", () => {
     const script = composeScript()
     // The design-write and report agents must NOT use a schema (a schema biases the
     // agent into emitting JSON instead of writing the file). They are dispatched by
-    // label and gated by exists().
+    // label and gated by glob (specs/plans) / exists (report).
     expect(script).toContain('label: "design:"')
     expect(script).toContain('label: "design-extract:"')
-    expect(script).toContain("exists(SPEC_PATH)")
-    expect(script).toContain("exists(PLAN_PATH)")
+    expect(script).toContain("glob(SPECS_DIR")
+    expect(script).toContain("glob(PLANS_DIR")
     expect(script).toContain("exists(REPORT_PATH)")
+    // The extract agent must force a direct StructuredOutput tool call (avoids the
+    // prose→retry loop that stalled the Design phase).
+    expect(script).toContain("StructuredOutput")
   })
 })
 
@@ -60,7 +63,7 @@ const happyAgent = (prompt: string, opts?: any) => {
 const runCompose = async (
   args: unknown,
   agentImpl: (prompt: string, opts?: any) => unknown = happyAgent,
-  opts?: { exists?: (p: string) => boolean },
+  opts?: { exists?: (p: string) => boolean; globEmpty?: boolean },
 ) => {
   const parsed = parseMeta(composeScript())
   if (!parsed.ok) throw new Error(parsed.error)
@@ -68,6 +71,10 @@ const runCompose = async (
   const phases: string[] = []
   const written: string[] = []
   const existsImpl = opts?.exists ?? (() => true)
+  // The design gate globs SPECS_DIR/PLANS_DIR for *.md. By default simulate the
+  // agent having written a doc (one match), so the gate passes. globEmpty:true
+  // simulates the agent never writing → the gate re-dispatches.
+  const globImpl = (pattern: string) => (opts?.globEmpty ? [] : [pattern.replace("*.md", "x.md")])
   const hooks = {
     agent: async (prompt: unknown, opts?: unknown) => {
       const p = String(prompt)
@@ -81,7 +88,7 @@ const runCompose = async (
     readFile: async () => null,
     writeFile: async (p: unknown) => { written.push(String(p)) },
     exists: async (p: unknown) => existsImpl(String(p)),
-    glob: async () => [],
+    glob: async (p: unknown) => globImpl(String(p)),
   }
   const body = `globalThis.args = ${JSON.stringify(args)};\n` + parsed.body
   const result = await evalScript(body, hooks)
@@ -141,7 +148,7 @@ describe("compose docs are written by the AGENT, gated by the workflow", () => {
         if (opts?.label && String(opts.label).startsWith("design:")) designWrites++
         return happyAgent(prompt, opts)
       },
-      { exists: () => false }, // simulate: files never appear
+      { globEmpty: true, exists: () => false }, // simulate: docs never appear
     )
     expect(designWrites).toBe(2) // initial + one re-dispatch
     expect(written).toHaveLength(0) // the WORKFLOW never writes files — only agents do

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -75,3 +75,33 @@ describe("compose phase 1: Classify", () => {
     expect(classifyCall).toBeUndefined()
   })
 })
+
+describe("compose phase 2: Design", () => {
+  test.each([
+    ["feature", "compose:plan"],
+    ["refactor", "compose:plan"],
+    ["bugfix", "compose:debug"],
+    ["feedback", "compose:feedback"],
+  ])("type=%s routes to %s", async (type, skill) => {
+    const { calls } = await runCompose(
+      { task: "x", type },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.tasks) {
+          return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+        }
+        return null
+      },
+    )
+    const designCall = calls.find((c) => c.opts?.schema?.properties?.tasks)
+    expect(designCall).toBeDefined()
+    expect(designCall!.prompt).toContain(skill)
+  })
+
+  test("design returning null surfaces design-failed", async () => {
+    const { result } = await runCompose(
+      { task: "x", type: "feature" },
+      () => null,
+    )
+    expect(result).toMatchObject({ error: "design-failed" })
+  })
+})

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { BuiltinWorkflow } from "../../src/workflow/builtin"
+import { parseMeta } from "../../src/workflow/meta"
+import { evalScript } from "../../src/workflow/sandbox"
+
+const composeScript = () => {
+  const c = BuiltinWorkflow.get("compose")
+  expect(c).toBeDefined()
+  return c!.script
+}
+
+describe("compose script structure", () => {
+  test("body parses cleanly", () => {
+    const parsed = parseMeta(composeScript())
+    expect(parsed.ok).toBe(true)
+  })
+
+  test("declares schemas for every phase", () => {
+    const script = composeScript()
+    expect(script).toContain("CLASSIFY_SHAPE")
+    expect(script).toContain("DESIGN_SHAPE")
+    expect(script).toContain("VERIFY_SHAPE")
+    expect(script).toContain("REVIEW_SHAPE")
+    expect(script).toContain("MERGE_SHAPE")
+  })
+})

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { BuiltinWorkflow } from "../../src/workflow/builtin"
-import { parseMeta } from "../../src/workflow/meta"
+import { parseMeta, parseMeta as pm } from "../../src/workflow/meta"
 import { evalScript } from "../../src/workflow/sandbox"
 
 const composeScript = () => {
@@ -275,5 +275,35 @@ describe("compose phase 6: Merge + final shape", () => {
       },
     )
     expect(result).toMatchObject({ error: "merge-failed", merge: { committed: false } })
+  })
+})
+
+describe("compose E2E smoke", () => {
+  test("full happy path runs all 6 phases in order", async () => {
+    const phases: string[] = []
+    const parsed = pm(composeScript())
+    if (!parsed.ok) throw new Error(parsed.error)
+    const argsValue = { task: "ship a feature", type: "feature" }
+    const hooks = {
+      agent: async (prompt: unknown, opts: unknown) => {
+        const o = opts as any
+        if (o?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+        if (o?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
+        if (o?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
+        if (o?.schema?.properties?.committed) return { committed: true, sha: "deadbeef", action: "commit" }
+        return "ok"
+      },
+      phase: (title: unknown) => { phases.push(String(title)) },
+      log: () => undefined,
+      workflow: async () => null,
+      readFile: async () => null,
+      writeFile: async () => undefined,
+      exists: async () => false,
+      glob: async () => [],
+    }
+    const body = `globalThis.args = ${JSON.stringify(argsValue)};\n` + parsed.body
+    const result = await evalScript(body, hooks)
+    expect(phases).toEqual(["Classify", "Design", "Implement", "Review", "Merge"]) // Fix only runs on review failure
+    expect((result as any).merge?.committed).toBe(true)
   })
 })

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -18,12 +18,17 @@ describe("compose script structure", () => {
   test("declares schemas for every structured phase", () => {
     const script = composeScript()
     expect(script).toContain("BRAINSTORM_SHAPE")
-    expect(script).toContain("CLASSIFY_SHAPE")
     expect(script).toContain("DESIGN_SHAPE")
     expect(script).toContain("INTEGRATE_SHAPE")
     expect(script).toContain("VERIFY_SHAPE")
     expect(script).toContain("REVIEW_SHAPE")
     expect(script).toContain("MERGE_SHAPE")
+  })
+
+  test("has no separate Classify phase (type resolved inline)", () => {
+    const script = composeScript()
+    expect(script).not.toContain('phase("Classify")')
+    expect(script).not.toContain("CLASSIFY_SHAPE")
   })
 
   test("design and report phases write files via agent (no output schema)", () => {
@@ -155,24 +160,29 @@ describe("compose docs are written by the AGENT, gated by the workflow", () => {
   })
 })
 
-describe("compose phase 1: Classify", () => {
-  test("calls classifier when args.type absent", async () => {
-    const { calls } = await runCompose({ task: "fix the foo regression" }, (prompt, opts) => {
-      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
-      if (opts?.schema?.properties?.type) return { type: "bugfix", confidence: "high", reasoning: "regression keyword" }
-      return null
-    })
-    const classifyCall = calls.find((c) => c.opts?.schema?.properties?.type)
-    expect(classifyCall).toBeDefined()
-    expect(classifyCall!.prompt).toContain("fix the foo regression")
+describe("compose type resolution (no Classify phase)", () => {
+  test("no classifier agent is ever dispatched", async () => {
+    const { calls } = await runCompose({ task: "fix the foo regression" })
+    // There must be no classify agent (no agent with a {type,confidence,reasoning} schema).
+    expect(calls.find((c) => c.opts?.schema?.properties?.type && c.opts?.schema?.properties?.confidence)).toBeUndefined()
   })
 
-  test("skips classifier when args.type provided", async () => {
-    const { calls } = await runCompose({ task: "implement bar", type: "feature" }, (prompt, opts) => {
-      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
-      return null
-    })
-    expect(calls.find((c) => c.opts?.schema?.properties?.type)).toBeUndefined()
+  test("heuristic routes a bug task to compose:debug without an LLM classify call", async () => {
+    const { calls } = await runCompose({ task: "fix the foo regression that crashes on startup" })
+    const designWrite = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))
+    expect(designWrite!.prompt).toContain("compose:debug")
+  })
+
+  test("explicit args.type is honored", async () => {
+    const { calls } = await runCompose({ task: "implement bar", type: "feedback" })
+    const designWrite = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))
+    expect(designWrite!.prompt).toContain("compose:feedback")
+  })
+
+  test("default (no keyword, no args.type) routes to compose:plan", async () => {
+    const { calls } = await runCompose({ task: "implement a brand new widget gallery" })
+    const designWrite = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))
+    expect(designWrite!.prompt).toContain("compose:plan")
   })
 })
 
@@ -200,6 +210,23 @@ describe("compose phase 2: Design", () => {
       return "ok"
     })
     expect(result).toMatchObject({ error: "design-failed" })
+  })
+
+  test("tasks with missing/blank ids get backfilled (no implement:undefined label)", async () => {
+    const { calls, result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.tasks) return { tasks: [
+        { description: "first", acceptance: "a" },        // no id
+        { id: "", description: "second", acceptance: "a" }, // blank id
+        { id: "T2", description: "third", acceptance: "a" }, // real id
+      ] }
+      return happyAgent(prompt, opts)
+    })
+    // No implement label may contain "undefined".
+    const implLabels = calls.filter((c) => c.opts?.label && String(c.opts.label).startsWith("implement:")).map((c) => String(c.opts.label))
+    expect(implLabels.length).toBeGreaterThan(0)
+    for (const l of implLabels) expect(l).not.toContain("undefined")
+    // Every designed task ends up with a non-empty id.
+    for (const t of (result as any).design.tasks) expect(typeof t.id === "string" && t.id.length > 0).toBe(true)
   })
 })
 
@@ -412,13 +439,13 @@ describe("compose phase 7: Merge + final shape", () => {
 })
 
 describe("compose E2E smoke", () => {
-  test("happy path runs phases in order (Brainstorm→Classify→Design→Implement→Verify→Report→Review→Merge)", async () => {
+  test("happy path runs phases in order (Brainstorm→Design→Implement→Verify→Report→Review→Merge)", async () => {
     const { result, phases } = await runCompose({ task: "ship a feature", type: "feature" })
     // First occurrence of each phase, in order. The iteration report (Report) fires
     // inside the TDD loop on a successful verify, before Phase 4 Review (spec [S3] 3f).
     const firstSeen: string[] = []
     for (const p of phases) if (firstSeen.indexOf(p) < 0) firstSeen.push(p)
-    expect(firstSeen).toEqual(["Brainstorm", "Classify", "Design", "Implement", "Verify", "Report", "Review", "Merge"])
+    expect(firstSeen).toEqual(["Brainstorm", "Design", "Implement", "Verify", "Report", "Review", "Merge"])
     expect((result as any).merge?.committed).toBe(true)
   })
 })

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -15,7 +15,7 @@ describe("compose script structure", () => {
     expect(parsed.ok).toBe(true)
   })
 
-  test("declares schemas for every phase", () => {
+  test("declares schemas for every structured phase", () => {
     const script = composeScript()
     expect(script).toContain("BRAINSTORM_SHAPE")
     expect(script).toContain("CLASSIFY_SHAPE")
@@ -23,14 +23,26 @@ describe("compose script structure", () => {
     expect(script).toContain("INTEGRATE_SHAPE")
     expect(script).toContain("VERIFY_SHAPE")
     expect(script).toContain("REVIEW_SHAPE")
-    expect(script).toContain("ITERATION_REPORT_SHAPE")
-    expect(script).toContain("FINAL_REPORT_SHAPE")
     expect(script).toContain("MERGE_SHAPE")
+  })
+
+  test("design and report phases write files via agent (no output schema)", () => {
+    const script = composeScript()
+    // The design-write and report agents must NOT use a schema (a schema biases the
+    // agent into emitting JSON instead of writing the file). They are dispatched by
+    // label and gated by exists().
+    expect(script).toContain('label: "design:"')
+    expect(script).toContain('label: "design-extract:"')
+    expect(script).toContain("exists(SPEC_PATH)")
+    expect(script).toContain("exists(PLAN_PATH)")
+    expect(script).toContain("exists(REPORT_PATH)")
   })
 })
 
 // Default agent stub that drives a clean happy path. Implement/fix agents return a
-// `_worktree` (changed) so the integrate path is exercised. Override per-test.
+// `_worktree` (changed) so the integrate path is exercised. Design-write and report
+// agents have no schema (they write files); the harness's exists() returns true to
+// simulate the agent having written them. Override per-test.
 const happyAgent = (prompt: string, opts?: any) => {
   const o = opts as any
   if (o?.schema?.properties?.context) return { context: { projectType: "Bun TS", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
@@ -39,19 +51,23 @@ const happyAgent = (prompt: string, opts?: any) => {
   if (o?.schema?.properties?.merged) return { merged: [{ taskId: "t1", branch: "b", sha: "s" }], conflicts: [], skipped_pristine: [] }
   if (o?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
   if (o?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
-  if (o?.schema?.properties?.iteration) return { iteration: 1, what_changed: "x" }
-  if (o?.schema?.properties?.path) return { path: "docs/compose/reports/x.md", sha: "rsha" }
   if (o?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
   if (o?.label && String(o.label).startsWith("implement")) return { _worktree: { branch: "wt-" + o.label, directory: "/tmp/" + o.label, changed: true } }
   if (o?.label && String(o.label).startsWith("fix")) return { _worktree: { branch: "wt-" + o.label, directory: "/tmp/" + o.label, changed: true } }
   return "ok"
 }
 
-const runCompose = async (args: unknown, agentImpl: (prompt: string, opts?: any) => unknown = happyAgent) => {
+const runCompose = async (
+  args: unknown,
+  agentImpl: (prompt: string, opts?: any) => unknown = happyAgent,
+  opts?: { exists?: (p: string) => boolean },
+) => {
   const parsed = parseMeta(composeScript())
   if (!parsed.ok) throw new Error(parsed.error)
   const calls: { prompt: string; opts?: any }[] = []
   const phases: string[] = []
+  const written: string[] = []
+  const existsImpl = opts?.exists ?? (() => true)
   const hooks = {
     agent: async (prompt: unknown, opts?: unknown) => {
       const p = String(prompt)
@@ -63,13 +79,13 @@ const runCompose = async (args: unknown, agentImpl: (prompt: string, opts?: any)
     log: () => undefined,
     workflow: async () => null,
     readFile: async () => null,
-    writeFile: async () => undefined,
-    exists: async () => false,
+    writeFile: async (p: unknown) => { written.push(String(p)) },
+    exists: async (p: unknown) => existsImpl(String(p)),
     glob: async () => [],
   }
   const body = `globalThis.args = ${JSON.stringify(args)};\n` + parsed.body
   const result = await evalScript(body, hooks)
-  return { result, calls, phases }
+  return { result, calls, phases, written }
 }
 
 describe("compose phase 0: Brainstorm", () => {
@@ -89,19 +105,46 @@ describe("compose phase 0: Brainstorm", () => {
 })
 
 describe("compose docs dir injection", () => {
-  test("design + report prompts carry the configured docs dir", async () => {
+  test("design-write + report prompts carry the configured docs dir", async () => {
     const { calls } = await runCompose({ task: "x", type: "feature", _composeDocsDir: "custom/docs" })
-    const design = calls.find((c) => c.opts?.schema?.properties?.tasks)
-    expect(design!.prompt).toContain("custom/docs/specs")
-    expect(design!.prompt).toContain("custom/docs/plans")
-    const report = calls.find((c) => c.opts?.schema?.properties?.path)
+    const designWrite = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))
+    expect(designWrite!.prompt).toContain("custom/docs/specs")
+    expect(designWrite!.prompt).toContain("custom/docs/plans")
+    const report = calls.find((c) => c.opts?.label === "final-report")
     expect(report!.prompt).toContain("custom/docs/reports")
   })
 
   test("defaults to docs/compose when host did not inject", async () => {
     const { calls } = await runCompose({ task: "x", type: "feature" })
-    const design = calls.find((c) => c.opts?.schema?.properties?.tasks)
-    expect(design!.prompt).toContain("docs/compose/specs")
+    const designWrite = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))
+    expect(designWrite!.prompt).toContain("docs/compose/specs")
+  })
+})
+
+describe("compose docs are written by the AGENT, gated by the workflow", () => {
+  test("design dispatches a write agent (no schema) then a structured extract agent", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature" })
+    const write = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))
+    const extract = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design-extract:"))
+    expect(write).toBeDefined()
+    expect(write!.opts.schema).toBeUndefined() // agent must be free to use write tool
+    expect(write!.prompt).toContain("write")
+    expect(extract).toBeDefined()
+    expect(extract!.opts.schema?.properties?.tasks).toBeDefined() // extraction is structured
+  })
+
+  test("when agent skips the write, workflow re-dispatches the design agent (does not write files itself)", async () => {
+    let designWrites = 0
+    const { written } = await runCompose(
+      { task: "x", type: "feature" },
+      (prompt, opts) => {
+        if (opts?.label && String(opts.label).startsWith("design:")) designWrites++
+        return happyAgent(prompt, opts)
+      },
+      { exists: () => false }, // simulate: files never appear
+    )
+    expect(designWrites).toBe(2) // initial + one re-dispatch
+    expect(written).toHaveLength(0) // the WORKFLOW never writes files — only agents do
   })
 })
 
@@ -132,31 +175,30 @@ describe("compose phase 2: Design", () => {
     ["refactor", "compose:plan"],
     ["bugfix", "compose:debug"],
     ["feedback", "compose:feedback"],
-  ])("type=%s routes to %s", async (type, skill) => {
+  ])("type=%s routes the design-write agent to %s", async (type, skill) => {
     const { calls } = await runCompose({ task: "x", type }, (prompt, opts) => {
       if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
       if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
-      return null
+      return "ok"
     })
-    const designCall = calls.find((c) => c.opts?.schema?.properties?.tasks)
-    expect(designCall).toBeDefined()
-    expect(designCall!.prompt).toContain(skill)
+    const designWrite = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))
+    expect(designWrite).toBeDefined()
+    expect(designWrite!.prompt).toContain(skill)
   })
 
-  test("design returning null surfaces design-failed", async () => {
+  test("extract returning null surfaces design-failed", async () => {
     const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
       if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
-      return null
+      if (opts?.schema?.properties?.tasks) return null // extraction fails
+      return "ok"
     })
     expect(result).toMatchObject({ error: "design-failed" })
   })
 })
 
 describe("compose phase 3: parallelism, dependencies, worktrees", () => {
-  test("independent tasks land in one batch dispatched in parallel with worktree isolation", async () => {
-    let maxConcurrent = 0
-    let active = 0
-    const { result, calls } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+  test("independent tasks land in one batch dispatched in parallel; worktree isolation opt-in", async () => {
+    const { result, calls } = await runCompose({ task: "x", type: "feature", isolate_worktrees: true }, (prompt, opts) => {
       if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
       if (opts?.schema?.properties?.tasks) return { tasks: [
         { id: "T1", description: "d", acceptance: "a", dependsOn: [] },
@@ -167,19 +209,23 @@ describe("compose phase 3: parallelism, dependencies, worktrees", () => {
       if (opts?.schema?.properties?.merged) return { merged: [], conflicts: [], skipped_pristine: [] }
       if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
       if (opts?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
-      if (opts?.schema?.properties?.iteration) return { iteration: 1, what_changed: "x" }
-      if (opts?.schema?.properties?.path) return { path: "p", sha: "s" }
       if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
-      if (opts?.label && String(opts.label).startsWith("implement")) {
-        active++; maxConcurrent = Math.max(maxConcurrent, active); active--
-        return { _worktree: { branch: "b", directory: "/tmp/d", changed: true } }
-      }
+      if (opts?.label && String(opts.label).startsWith("implement")) return { _worktree: { branch: "b", directory: "/tmp/d", changed: true } }
       return "ok"
     })
     expect((result as any).batches).toEqual([["T1", "T2", "T3", "T4"]])
     const implCalls = calls.filter((c) => c.opts?.label && String(c.opts.label).startsWith("implement:"))
     expect(implCalls).toHaveLength(4)
     for (const c of implCalls) expect(c.opts.isolation).toBe("worktree")
+  })
+
+  test("default mode (no isolate_worktrees) runs implement WITHOUT worktree isolation and skips integrate", async () => {
+    const { result, calls } = await runCompose({ task: "x", type: "feature" })
+    const implCalls = calls.filter((c) => c.opts?.label && String(c.opts.label).startsWith("implement:"))
+    expect(implCalls.length).toBeGreaterThan(0)
+    for (const c of implCalls) expect(c.opts.isolation).toBeUndefined() // runs in main workspace
+    expect(calls.find((c) => c.opts?.label === "integrate")).toBeUndefined() // nothing to integrate
+    expect(result).not.toMatchObject({ error: expect.anything() })
   })
 
   test("dependency chain produces sequential batches in order", async () => {
@@ -208,8 +254,8 @@ describe("compose phase 3: parallelism, dependencies, worktrees", () => {
     expect((result as any).cycleNodes).toEqual(expect.arrayContaining(["T1", "T2"]))
   })
 
-  test("integrate agent dispatched with kept worktrees", async () => {
-    const { calls } = await runCompose({ task: "x", type: "feature" })
+  test("integrate agent dispatched with kept worktrees when isolated", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature", isolate_worktrees: true })
     const integrate = calls.find((c) => c.opts?.label === "integrate")
     expect(integrate).toBeDefined()
     expect(integrate!.opts.schema.properties.merged).toBeDefined()
@@ -262,13 +308,16 @@ describe("compose phase 3: TDD loop", () => {
     expect(debugCalls).toBe(2)
   })
 
-  test("one successful iteration writes one iteration-report", async () => {
+  test("one successful iteration writes one iteration-report (agent dispatched by label, no schema)", async () => {
     let reportCalls = 0
-    await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
-      if (opts?.schema?.properties?.iteration) { reportCalls++; return { iteration: 1, what_changed: "x" } }
+    const { calls } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.label && String(opts.label).startsWith("iteration-report:")) reportCalls++
       return happyAgent(prompt, opts)
     })
     expect(reportCalls).toBe(1)
+    const ir = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("iteration-report:"))
+    expect(ir!.opts.schema).toBeUndefined() // report agent writes a file, not JSON
+    expect(ir!.prompt).toContain("write")
   })
 })
 
@@ -288,7 +337,7 @@ describe("compose phases 4-5: Review + Fix loop", () => {
 
   test("review critical, fix succeeds on iteration 1 → exits loop, merges", async () => {
     let reviewCalls = 0
-    const { result, calls } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+    const { result, calls } = await runCompose({ task: "x", type: "feature", isolate_worktrees: true }, (prompt, opts) => {
       if (opts?.schema?.properties?.readyToMerge) {
         reviewCalls++
         return reviewCalls === 1
@@ -326,8 +375,8 @@ describe("compose phase 6: Final report", () => {
 
   test("skip_report short-circuits iteration + final report writes", async () => {
     const { calls } = await runCompose({ task: "x", type: "feature", skip_report: true })
-    expect(calls.find((c) => c.opts?.schema?.properties?.iteration)).toBeUndefined()
-    expect(calls.find((c) => c.opts?.schema?.properties?.path)).toBeUndefined()
+    expect(calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("iteration-report:"))).toBeUndefined()
+    expect(calls.find((c) => c.opts?.label === "final-report")).toBeUndefined()
   })
 })
 

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -105,3 +105,74 @@ describe("compose phase 2: Design", () => {
     expect(result).toMatchObject({ error: "design-failed" })
   })
 })
+
+describe("compose phase 3: TDD loop", () => {
+  test("verify passes first try → no debug, no retry", async () => {
+    let implCalls = 0
+    let verifyCalls = 0
+    let debugCalls = 0
+    const { result } = await runCompose(
+      { task: "x", type: "feature" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+        if (opts?.schema?.properties?.allPassed) {
+          verifyCalls++
+          return { typecheck: "ok", tests: { passed: 5, failed: 0 }, build: "ok", allPassed: true }
+        }
+        if (opts?.label === "implement") implCalls++
+        if (opts?.label?.startsWith("debug")) debugCalls++
+        if (opts?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
+        if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
+        return "ok"
+      },
+    )
+    expect(implCalls).toBe(1)
+    expect(verifyCalls).toBe(1)
+    expect(debugCalls).toBe(0)
+    expect(result).not.toMatchObject({ error: "verify-exhausted" })
+  })
+
+  test("verify fails 3 times → returns verify-exhausted with history", async () => {
+    let verifyCalls = 0
+    const { result } = await runCompose(
+      { task: "x", type: "feature" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+        if (opts?.schema?.properties?.allPassed) {
+          verifyCalls++
+          return { typecheck: "fail", tests: { passed: 0, failed: 1 }, build: "skipped", allPassed: false, failures: "tc#" + verifyCalls }
+        }
+        return "ok"
+      },
+    )
+    expect(verifyCalls).toBe(3)
+    expect(result).toMatchObject({ error: "verify-exhausted", attempts: 3 })
+    expect((result as any).verifyHistory).toHaveLength(3)
+  })
+
+  test("verify fails twice then passes → loop runs 3 impls + 3 verifies + 2 debugs", async () => {
+    let verifyCalls = 0
+    let implCalls = 0
+    let debugCalls = 0
+    await runCompose(
+      { task: "x", type: "feature" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+        if (opts?.schema?.properties?.allPassed) {
+          verifyCalls++
+          return verifyCalls >= 3
+            ? { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
+            : { typecheck: "fail", tests: { passed: 0, failed: 1 }, build: "skipped", allPassed: false, failures: "x" }
+        }
+        if (opts?.label === "implement") implCalls++
+        if (opts?.label?.startsWith("debug")) debugCalls++
+        if (opts?.schema?.properties?.readyToMerge) return { critical: [], important: [], minor: [], readyToMerge: true }
+        if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
+        return "ok"
+      },
+    )
+    expect(implCalls).toBe(3)
+    expect(verifyCalls).toBe(3)
+    expect(debugCalls).toBe(2)
+  })
+})

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -24,3 +24,54 @@ describe("compose script structure", () => {
     expect(script).toContain("MERGE_SHAPE")
   })
 })
+
+const runCompose = async (args: unknown, agentImpl: (prompt: string, opts?: any) => unknown) => {
+  const parsed = parseMeta(composeScript())
+  if (!parsed.ok) throw new Error(parsed.error)
+  const calls: { prompt: string; opts?: any }[] = []
+  const hooks = {
+    agent: async (prompt: unknown, opts?: unknown) => {
+      const p = String(prompt)
+      const o = opts as any
+      calls.push({ prompt: p, opts: o })
+      return agentImpl(p, o)
+    },
+    phase: () => undefined,
+    log: () => undefined,
+    workflow: async () => null,
+    readFile: async () => null,
+    writeFile: async () => undefined,
+    exists: async () => false,
+    glob: async () => [],
+  }
+  // The sandbox exposes args via globalThis.args; inject by prepending a global.
+  const body = `globalThis.args = ${JSON.stringify(args)};\n` + parsed.body
+  const result = await evalScript(body, hooks)
+  return { result, calls }
+}
+
+describe("compose phase 1: Classify", () => {
+  test("calls classifier when args.type absent", async () => {
+    const { calls } = await runCompose(
+      { task: "fix the foo regression" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.type) {
+          return { type: "bugfix", confidence: "high", reasoning: "regression keyword" }
+        }
+        return null
+      },
+    )
+    const classifyCall = calls.find((c) => c.opts?.schema?.properties?.type)
+    expect(classifyCall).toBeDefined()
+    expect(classifyCall!.prompt).toContain("fix the foo regression")
+  })
+
+  test("skips classifier when args.type provided", async () => {
+    const { calls } = await runCompose(
+      { task: "implement bar", type: "feature" },
+      () => null,
+    )
+    const classifyCall = calls.find((c) => c.opts?.schema?.properties?.type)
+    expect(classifyCall).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -176,3 +176,67 @@ describe("compose phase 3: TDD loop", () => {
     expect(debugCalls).toBe(2)
   })
 })
+
+describe("compose phases 4-5: Review + Fix loop", () => {
+  test("review with no critical → no fix loop, proceeds to merge", async () => {
+    let fixCalls = 0
+    let reviewCalls = 0
+    const { result } = await runCompose(
+      { task: "x", type: "feature" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+        if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
+        if (opts?.schema?.properties?.readyToMerge) {
+          reviewCalls++
+          return { critical: [], important: ["nit"], minor: [], readyToMerge: true }
+        }
+        if (opts?.label === "fix") fixCalls++
+        if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
+        return "ok"
+      },
+    )
+    expect(reviewCalls).toBe(1)
+    expect(fixCalls).toBe(0)
+    expect(result).not.toMatchObject({ readyToMerge: false })
+  })
+
+  test("review critical, fix succeeds on iteration 1 → exits loop, merges", async () => {
+    let reviewCalls = 0
+    const { result } = await runCompose(
+      { task: "x", type: "feature" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+        if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
+        if (opts?.schema?.properties?.readyToMerge) {
+          reviewCalls++
+          return reviewCalls === 1
+            ? { critical: ["bug X"], important: [], minor: [], readyToMerge: false }
+            : { critical: [], important: [], minor: [], readyToMerge: true }
+        }
+        if (opts?.schema?.properties?.committed) return { committed: true, sha: "abc", action: "commit" }
+        return "ok"
+      },
+    )
+    expect(reviewCalls).toBe(2)
+    expect(result).not.toMatchObject({ readyToMerge: false })
+  })
+
+  test("review critical persists through 2 fix iterations → readyToMerge:false", async () => {
+    let reviewCalls = 0
+    const { result } = await runCompose(
+      { task: "x", type: "feature" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "t1", description: "d", acceptance: "a" }] }
+        if (opts?.schema?.properties?.allPassed) return { typecheck: "ok", tests: { passed: 1, failed: 0 }, build: "ok", allPassed: true }
+        if (opts?.schema?.properties?.readyToMerge) {
+          reviewCalls++
+          return { critical: ["unfixable"], important: [], minor: [], readyToMerge: false }
+        }
+        return "ok"
+      },
+    )
+    expect(reviewCalls).toBe(3) // initial + 2 fix-loop reviews
+    expect(result).toMatchObject({ readyToMerge: false })
+    expect((result as any).review.critical).toContain("unfixable")
+  })
+})

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -75,7 +75,7 @@ const happyAgent = (prompt: string, opts?: any) => {
 const runCompose = async (
   args: unknown,
   agentImpl: (prompt: string, opts?: any) => unknown = happyAgent,
-  opts?: { exists?: (p: string) => boolean; globEmpty?: boolean },
+  opts?: { exists?: (p: string) => boolean; globEmpty?: boolean; glob?: (pattern: string) => string[] },
 ) => {
   const parsed = parseMeta(composeScript())
   if (!parsed.ok) throw new Error(parsed.error)
@@ -85,8 +85,9 @@ const runCompose = async (
   const existsImpl = opts?.exists ?? (() => true)
   // The design gate globs SPECS_DIR/PLANS_DIR for *.md. By default simulate the
   // agent having written a doc (one match), so the gate passes. globEmpty:true
-  // simulates the agent never writing → the gate re-dispatches.
-  const globImpl = (pattern: string) => (opts?.globEmpty ? [] : [pattern.replace("*.md", "x.md")])
+  // simulates the agent never writing → the gate re-dispatches. A custom glob
+  // override simulates pre-existing docs (for amend tests).
+  const globImpl = opts?.glob ?? ((pattern: string) => (opts?.globEmpty ? [] : [pattern.replace("*.md", "x.md")]))
   const hooks = {
     agent: async (prompt: unknown, opts?: unknown) => {
       const p = String(prompt)
@@ -505,5 +506,61 @@ describe("compose E2E smoke", () => {
     for (const p of phases) if (firstSeen.indexOf(p) < 0) firstSeen.push(p)
     expect(firstSeen).toEqual(["Brainstorm", "Design", "Implement", "Verify", "Report", "Review", "Merge"])
     expect((result as any).merge?.committed).toBe(true)
+  })
+})
+
+describe("compose incremental amend", () => {
+  const withExistingDocs = (p: string) =>
+    p.includes("/specs") ? ["docs/compose/specs/strutil.md"] : p.includes("/plans") ? ["docs/compose/plans/strutil.md"] : []
+
+  test("brainstorm is given the list of existing compose docs", async () => {
+    const { calls } = await runCompose(
+      { task: "change the truncate ellipsis to a unicode … in the strutil lib" },
+      happyAgent,
+      { glob: withExistingDocs },
+    )
+    const bs = calls.find((c) => c.opts?.label === "brainstorm")
+    expect(bs!.prompt).toContain("strutil.md")
+    expect(bs!.prompt.toLowerCase()).toContain("existing")
+  })
+
+  test("when brainstorm flags an amendment, design-write is told to amend the existing plan", async () => {
+    const { calls } = await runCompose(
+      { task: "change truncate ellipsis to unicode …" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.context)
+          return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [], amends: "strutil", existingDocs: ["docs/compose/plans/strutil.md"] }
+        return happyAgent(prompt, opts)
+      },
+      { glob: withExistingDocs },
+    )
+    const write = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))
+    expect(write!.prompt).toContain("AMENDMENT")
+    expect(write!.prompt).toContain("strutil")
+  })
+
+  test("amend: design-extract returning only the changed task drives a single implement", async () => {
+    const { calls } = await runCompose(
+      { task: "change truncate ellipsis" },
+      (prompt, opts) => {
+        if (opts?.schema?.properties?.context)
+          return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [], amends: "strutil" }
+        if (opts?.schema?.properties?.tasks) return { tasks: [{ id: "T-truncate", description: "update ellipsis", acceptance: "uses …", dependsOn: [] }] }
+        return happyAgent(prompt, opts)
+      },
+      { glob: withExistingDocs },
+    )
+    const impl = calls.filter((c) => c.opts?.label && String(c.opts.label).startsWith("implement:"))
+    expect(impl).toHaveLength(1)
+    // amend reuses existing docs → no redundant second design-write
+    const writes = calls.filter((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))
+    expect(writes).toHaveLength(1)
+  })
+
+  test("non-amend (empty amends) keeps the normal create-spec/plan prompt", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature" })
+    const write = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))
+    expect(write!.prompt).not.toContain("AMENDMENT")
+    expect(write!.prompt).toContain("create BOTH of these files")
   })
 })

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -31,6 +31,13 @@ describe("compose script structure", () => {
     expect(script).not.toContain("CLASSIFY_SHAPE")
   })
 
+  test("each phase applies its compose skill (verify included)", () => {
+    const script = composeScript()
+    for (const skill of ["compose:brainstorm", "compose:debug", "compose:feedback", "compose:plan", "compose:tdd", "compose:review", "compose:report", "compose:merge", "compose:verify"]) {
+      expect(script).toContain(skill)
+    }
+  })
+
   test("design and report phases write files via agent (no output schema)", () => {
     const script = composeScript()
     // The design-write and report agents must NOT use a schema (a schema biases the
@@ -260,6 +267,52 @@ describe("compose phase 3: parallelism, dependencies, worktrees", () => {
     for (const c of implCalls) expect(c.opts.isolation).toBeUndefined() // runs in main workspace
     expect(calls.find((c) => c.opts?.label === "integrate")).toBeUndefined() // nothing to integrate
     expect(result).not.toMatchObject({ error: expect.anything() })
+  })
+
+  test("default mode runs implement tasks SEQUENTIALLY (no same-workspace parallel conflicts)", async () => {
+    let active = 0
+    let maxConcurrent = 0
+    const agentImpl = async (prompt: string, opts?: any) => {
+      if (opts?.label && String(opts.label).startsWith("implement:")) {
+        active++
+        maxConcurrent = Math.max(maxConcurrent, active)
+        await new Promise((r) => setTimeout(r, 5)) // hold the slot so overlap is observable
+        active--
+        return "ok"
+      }
+      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+      if (opts?.schema?.properties?.tasks) return { tasks: [
+        { id: "T1", description: "d", acceptance: "a", dependsOn: [] },
+        { id: "T2", description: "d", acceptance: "a", dependsOn: [] },
+        { id: "T3", description: "d", acceptance: "a", dependsOn: [] },
+      ] }
+      return happyAgent(prompt, opts)
+    }
+    await runCompose({ task: "x", type: "feature" }, agentImpl)
+    expect(maxConcurrent).toBe(1) // sequential in default (same-workspace) mode
+  })
+
+  test("isolated mode runs independent implement tasks CONCURRENTLY", async () => {
+    let active = 0
+    let maxConcurrent = 0
+    const agentImpl = async (prompt: string, opts?: any) => {
+      if (opts?.label && String(opts.label).startsWith("implement:")) {
+        active++
+        maxConcurrent = Math.max(maxConcurrent, active)
+        await new Promise((r) => setTimeout(r, 5))
+        active--
+        return { _worktree: { branch: "b", directory: "/tmp/d", changed: true } }
+      }
+      if (opts?.schema?.properties?.context) return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [] }
+      if (opts?.schema?.properties?.tasks) return { tasks: [
+        { id: "T1", description: "d", acceptance: "a", dependsOn: [] },
+        { id: "T2", description: "d", acceptance: "a", dependsOn: [] },
+        { id: "T3", description: "d", acceptance: "a", dependsOn: [] },
+      ] }
+      return happyAgent(prompt, opts)
+    }
+    await runCompose({ task: "x", type: "feature", isolate_worktrees: true }, agentImpl)
+    expect(maxConcurrent).toBeGreaterThan(1) // parallel when each task has its own worktree
   })
 
   test("dependency chain produces sequential batches in order", async () => {

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -564,3 +564,48 @@ describe("compose incremental amend", () => {
     expect(write!.prompt).toContain("create BOTH of these files")
   })
 })
+
+describe("compose amend scope-aware fan-out", () => {
+  const existing = (p: string) =>
+    p.includes("/plans") ? ["docs/compose/plans/strutil.md"] : p.includes("/specs") ? ["docs/compose/specs/strutil.md"] : []
+  const amendAgent = (prompt: string, opts?: any) => {
+    if (opts?.schema?.properties?.context)
+      return { context: { projectType: "x", conventions: [], recentChanges: [], relevantFiles: [] }, assumptions: [], amends: "strutil" }
+    return happyAgent(prompt, opts)
+  }
+
+  test("amend design-write prompt instructs scope assessment + forbids duplicate tasks", async () => {
+    const { calls } = await runCompose({ task: "change truncate ellipsis to unicode …" }, amendAgent, { glob: existing })
+    const write = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))!
+    expect(write.prompt.toLowerCase()).toContain("scope")
+    expect(write.prompt.toLowerCase()).toContain("magnitude")
+    expect(write.prompt).toMatch(/NEVER emit two near-identical or duplicate tasks/i)
+  })
+
+  test("amend extract prompt forbids duplicate/near-identical tasks and sizes to the change", async () => {
+    const { calls } = await runCompose({ task: "change truncate ellipsis" }, amendAgent, { glob: existing })
+    const extract = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design-extract:"))!
+    expect(extract.prompt).toMatch(/SMALLEST set of tasks/i)
+    expect(extract.prompt).toMatch(/do NOT return duplicate or near-identical tasks/i)
+  })
+
+  test("non-amend design-write has no scope-assessment block", async () => {
+    const { calls } = await runCompose({ task: "x", type: "feature" })
+    const write = calls.find((c) => c.opts?.label && String(c.opts.label).startsWith("design:"))!
+    expect(write.prompt).not.toContain("assess the MAGNITUDE")
+  })
+})
+
+describe("compose brainstorm robustness", () => {
+  test("non-array brainstorm fields (string conventions etc.) do not crash the script", async () => {
+    const { result } = await runCompose({ task: "x", type: "feature" }, (prompt, opts) => {
+      if (opts?.schema?.properties?.context)
+        // Malformed: fields that should be arrays come back as strings/undefined.
+        return { context: { projectType: "p", conventions: "a, b", recentChanges: undefined, relevantFiles: "x.js" }, assumptions: "none" }
+      return happyAgent(prompt, opts)
+    })
+    // Must reach a normal terminal shape, not throw / reject the script.
+    expect(result).toBeDefined()
+    expect((result as any).type).toBe("feature")
+  })
+})

--- a/packages/opencode/test/workflow/compose.test.ts
+++ b/packages/opencode/test/workflow/compose.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { BuiltinWorkflow } from "../../src/workflow/builtin"
-import { parseMeta, parseMeta as pm } from "../../src/workflow/meta"
+import { parseMeta } from "../../src/workflow/meta"
 import { evalScript } from "../../src/workflow/sandbox"
 
 const composeScript = () => {
@@ -279,9 +279,9 @@ describe("compose phase 6: Merge + final shape", () => {
 })
 
 describe("compose E2E smoke", () => {
-  test("full happy path runs all 6 phases in order", async () => {
+  test("happy path runs 5 phases in order (Fix conditional on review-critical)", async () => {
     const phases: string[] = []
-    const parsed = pm(composeScript())
+    const parsed = parseMeta(composeScript())
     if (!parsed.ok) throw new Error(parsed.error)
     const argsValue = { task: "ship a feature", type: "feature" }
     const hooks = {


### PR DESCRIPTION
## Summary
- Builds out the `compose` built-in workflow into a full autonomous pipeline: Brainstorm → Design → Implement (TDD) → Verify → Review → Merge, honoring the `compose:*` skills and the configured docs dir.
- **Auto-parallelism + per-task worktrees:** independent topo-batch tasks auto-isolate into worktrees, run concurrently, and integrate back; single/coupled batches stay sequential.
- **Incremental amend, scope-aware:** re-running on an existing feature reuses its docs and sizes the task fan-out to the actual change (small change → one task, not duplicate clones) instead of a fixed count.
- **Phase I/O chaining (skill-faithful):** each phase's output now feeds the next instead of being dropped at the structured-output boundary —
  - brainstorm self-conducts the Socratic loop (self-Q&A, 2-3 approaches, chosen approach + rationale) and carries it forward;
  - implement receives that chosen approach (Intent block);
  - review is **two-stage** — Stage 1 spec-compliance via `git diff` against the acceptance criteria (evidence-gated), then Stage 2 code-quality;
  - merge/report receive what-was-built + the review outcome.
- **Permission fix:** background actors (compose subagents spawn as `general` + `background:true`) are treated as non-interactive so their permission asks fail clean instead of hanging headless.

## Verification
- Unit tests: full `test/workflow/compose.test.ts` + `builtin.test.ts` suites pass; `bun typecheck` clean.
- Live E2E (mimo-v2.5-pro, LRU cache with a real backing-store design choice): the full pipeline ran to completion — brainstorm emitted the chosen approach (DLL+Map) with rationale, the implementer built toward it, review ran the two stages, 14/14 tests passed, and the work was committed.

## Notes
- Design/plan/report docs are intentionally kept out of this public branch (moved to the internal repo); branch history was rewritten to exclude them.