### PR TITLE
fix(opencode): trim agent list payload

### DIFF
--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -31,6 +31,12 @@ import { SyncRoutes } from "./sync"
 import { InstanceMiddleware } from "./middleware"
 import { jsonRequest } from "./trace"
 
+export function agentListItem(agent: Agent.Info): Agent.Info {
+  const result = { ...agent }
+  delete result.prompt
+  return result
+}
+
 export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
   const app = new Hono()
 
@@ -226,7 +232,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
       async (c) =>
         jsonRequest("InstanceRoutes.agent.list", c, function* () {
           const svc = yield* Agent.Service
-          return yield* svc.list()
+          return (yield* svc.list()).map(agentListItem)
         }),
     )
     .get(

--- a/packages/opencode/test/server/agent-list-route.test.ts
+++ b/packages/opencode/test/server/agent-list-route.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { agentListItem } from "../../src/server/routes/instance"
+import { Permission } from "../../src/permission"
+import type { Agent } from "../../src/agent/agent"
+
+describe("agent list route", () => {
+  test("omits system prompts from list payloads", () => {
+    const agent: Agent.Info = {
+      name: "explore",
+      description: "Explore files",
+      mode: "subagent",
+      native: true,
+      prompt: "large system prompt",
+      permission: Permission.fromConfig({ "*": "allow" }),
+      options: {},
+    }
+
+    const result = agentListItem(agent)
+
+    expect(result.name).toBe("explore")
+    expect(result.mode).toBe("subagent")
+    expect(result.permission).toEqual(agent.permission)
+    expect("prompt" in result).toBe(false)
+    expect(agent.prompt).toBe("large system prompt")
+  })
+})


### PR DESCRIPTION
Fixes #1352

## What changed
- Strip `prompt` from `GET /agent` list responses before JSON serialization.
- Keep the internal `Agent.Service` output unchanged so runtime prompt construction and debug commands still have full agent prompts.
- Add a small regression test for the route projection.

## Verification
- `git diff --check` passes, with only the existing Windows LF/CRLF warning for touched files.
- Verified with git diff --check and added a focused regression test for the agent list projection to ensure stability.