### PR TITLE
test(plugin): fix MimoAuthPlugin config tests after xiaomi name removal

### DIFF
--- a/packages/opencode/test/plugin/mimo.test.ts
+++ b/packages/opencode/test/plugin/mimo.test.ts
@@ -41,22 +41,24 @@ const fakeInput = {
 
 describe("MimoAuthPlugin", () => {
   describe("config hook", () => {
-    test("registers mimo provider with correct name", async () => {
+    test("registers xiaomi provider placeholder", async () => {
       const hooks = await MimoAuthPlugin(fakeInput)
       const cfg: any = {}
       await hooks.config!(cfg)
-      expect(cfg.provider.xiaomi.name).toBe("MiMo")
-      expect(cfg.provider.xiaomi.api).toBeTruthy()
+      // The plugin only registers the provider so it shows up before login.
+      // name/api are left to the models.dev database (name: "Xiaomi").
+      expect(cfg.provider.xiaomi).toBeDefined()
+      expect(cfg.provider.xiaomi.name).toBeUndefined()
+      expect(cfg.provider.xiaomi.api).toBeUndefined()
     })
 
     test("registers all expected models", async () => {
       const hooks = await MimoAuthPlugin(fakeInput)
       const cfg: any = {}
       await hooks.config!(cfg)
-      // The plugin only sets name and api; models are not registered by the plugin
-      // (they come from the provider registry). Verify the provider is created.
+      // Models are not registered by the plugin (they come from the provider
+      // registry). Verify the provider placeholder is created.
       expect(cfg.provider.xiaomi).toBeDefined()
-      expect(cfg.provider.xiaomi.name).toBe("MiMo")
     })
 
     test("does not overwrite existing config", async () => {


### PR DESCRIPTION
## Summary
- Follow-up to #1366, which dropped the hardcoded `xiaomi.name = "MiMo"` and api overrides from `MimoAuthPlugin`'s config hook.
- `test/plugin/mimo.test.ts` still asserted the old `name === "MiMo"` / truthy api, so the `test` job went red on `main` after #1366 merged.
- Updated the two affected cases to reflect the new behavior: the hook only registers the `xiaomi` provider placeholder and leaves `name`/`api` to the models.dev database (`name: "Xiaomi"`).
- The "does not overwrite existing config" case still holds and is left unchanged.

## Test plan
- `bun test test/plugin/mimo.test.ts`: 18 pass, 0 fail.
- `bun typecheck` passes.