### PR TITLE
fix(tui): focus prompt on startup so Ctrl+P opens command palette

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -278,6 +278,12 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       setReady(true)
     })
 
+  createEffect(() => {
+    if (!ready()) return
+    if (dialog.stack.length > 0) return
+    queueMicrotask(() => promptRef.current?.focus())
+  })
+
   useKeyboard((evt) => {
     if (!Flag.MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
     const sel = renderer.getSelection()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1490,6 +1490,11 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
+                if (!autocomplete.visible && keybind.match("command_list", e)) {
+                  e.preventDefault()
+                  command.show()
+                  return
+                }
                 // Handle Ctrl+V for terminals that forward it to the app as a raw
                 // keypress (common on macOS/Linux). The textarea has no built-in
                 // paste action, so without this nothing gets inserted. Terminals
@@ -1616,6 +1621,7 @@ export function Prompt(props: PromptProps) {
                   // setTimeout is a workaround and needs to be addressed properly
                   if (!input || input.isDestroyed) return
                   input.cursorColor = theme.text
+                  if (props.visible !== false && dialog.stack.length === 0 && !input.focused) input.focus()
                 }, 0)
               }}
               onMouseDown={(r: MouseEvent) => r.target?.focus()}


### PR DESCRIPTION
## Summary
- focus the prompt textarea once TUI startup finishes
- handle `command_list` (Ctrl+P) in the prompt key handler when autocomplete is closed

Fixes #1334

## Test plan
- [x] `bun typecheck` in `packages/opencode`
- [x] launch `mimo`, press Ctrl+P immediately — command palette should open without pressing Ctrl+J first