### PR TITLE
fix(test): settle fake checkpoint writer so main-slice test drains cleanly

### DIFF
--- a/packages/opencode/test/session/checkpoint-main-slice.test.ts
+++ b/packages/opencode/test/session/checkpoint-main-slice.test.ts
@@ -29,8 +29,9 @@ const ref = {
 
 // Capture the SpawnInput passed to actor.spawn so the test can inspect the
 // ForkContext (specifically watermarkMsgID) that tryStartCheckpointWriter
-// computed. The outcome never resolves — we only care about what was passed
-// in, not what the writer produces.
+// computed. The outcome resolves immediately so the checkpoint writer's
+// settlement watcher runs to completion (writers.delete) instead of leaving a
+// fiber suspended past scope close — the test asserts that drain at the end.
 interface PrefixRecord {
   id: string
   agentID?: string
@@ -49,6 +50,7 @@ const recordingActor = Layer.effect(
         Effect.gen(function* () {
           captures.input = input
           const outcome = yield* Deferred.make<AgentOutcome>()
+          yield* Deferred.succeed(outcome, { status: "success" })
           return {
             actorID: `${input.agentType}-1`,
             sessionID: input.sessionID,
@@ -253,6 +255,16 @@ describe("SessionCheckpoint.tryStartCheckpointWriter main-slice", () => {
         expect(seenIDs).not.toContain(subAsst.id)
         const seenAgents = new Set(capturedPrefixMsgs?.map((m) => m.agentID ?? "main"))
         expect(seenAgents).toEqual(new Set(["main"]))
+
+        const writerState = yield* Effect.gen(function* () {
+          for (let i = 0; i < 20; i++) {
+            const state = yield* svc.waitForWriter(info.id)
+            if (state === "no-writer") return state
+            yield* Effect.sleep("10 millis")
+          }
+          return yield* svc.waitForWriter(info.id)
+        })
+        expect(writerState).toBe("no-writer")
       }),
     ),
   )


### PR DESCRIPTION
## Summary

`checkpoint-main-slice` test: the recording actor's spawn outcome never resolved,
leaving `tryStartCheckpointWriter`'s settlement-watcher fiber suspended until scope
close force-interrupted it — a flaky source under `it.live`. Settle the outcome so
the watcher completes (`writers.delete`) and assert the writer drains to `no-writer`.

No production change — `actor/spawn.ts` is untouched; the test's spawn-ref finalizer
stays `= undefined`, consistent with the sibling checkpoint tests.

## Verification

- `bun typecheck` — exit 0
- `bun test test/session/checkpoint-main-slice.test.ts` — 1 pass / 13 assertions
