### PR TITLE
fix: restore previous spawnRef binding on finalizer cleanup

### DIFF
--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -716,10 +716,16 @@ export const layer = Layer.effect(
     const impl = Service.of({ spawn, cancel, getForkContext })
     // Late-bind the impl so SessionCheckpoint.tryStartCheckpointWriter can resolve it
     // without forming a layer cycle. See spawn-ref.ts for rationale.
+    // Save the previous binding so the finalizer can restore it: when the same
+    // process initialises Actor.layer more than once (memo'd ManagedRuntimes,
+    // overlapping test runtimes, etc.) the inner scope's dispose must hand
+    // control back to the outer scope's impl instead of wiping the ref to
+    // `undefined` and breaking every subsequent tryStartCheckpointWriter call.
+    const prevSpawnRef = spawnRef.current
     spawnRef.current = impl
     yield* Effect.addFinalizer(() =>
       Effect.sync(() => {
-        if (spawnRef.current === impl) spawnRef.current = undefined
+        if (spawnRef.current === impl) spawnRef.current = prevSpawnRef
       }),
     )
     return impl

--- a/packages/opencode/test/session/checkpoint-child-session.test.ts
+++ b/packages/opencode/test/session/checkpoint-child-session.test.ts
@@ -51,6 +51,7 @@ const pendingOutcomes: Array<Deferred.Deferred<AgentOutcome>> = []
 const recordingActor = Layer.effect(
   Actor.Service,
   Effect.gen(function* () {
+    const prevSpawnRef = spawnRef.current
     let counter = 0
     const impl = Actor.Service.of({
       spawn: (input) =>
@@ -80,7 +81,7 @@ const recordingActor = Layer.effect(
     spawnRef.current = impl
     yield* Effect.addFinalizer(() =>
       Effect.sync(() => {
-        if (spawnRef.current === impl) spawnRef.current = undefined
+        if (spawnRef.current === impl) spawnRef.current = prevSpawnRef
       }),
     )
     return impl

--- a/packages/opencode/test/session/checkpoint-drain.test.ts
+++ b/packages/opencode/test/session/checkpoint-drain.test.ts
@@ -34,6 +34,7 @@ const ref = {
 const hangingActor = Layer.effect(
   Actor.Service,
   Effect.gen(function* () {
+    const prevSpawnRef = spawnRef.current
     let counter = 0
     const impl = Actor.Service.of({
       spawn: (input) =>
@@ -52,7 +53,7 @@ const hangingActor = Layer.effect(
     spawnRef.current = impl
     yield* Effect.addFinalizer(() =>
       Effect.sync(() => {
-        if (spawnRef.current === impl) spawnRef.current = undefined
+        if (spawnRef.current === impl) spawnRef.current = prevSpawnRef
       }),
     )
     return impl

--- a/packages/opencode/test/session/checkpoint-fork-mode.test.ts
+++ b/packages/opencode/test/session/checkpoint-fork-mode.test.ts
@@ -42,6 +42,7 @@ const captureLog: { calls: Array<{ sessionID: string; agentName: string; msgsLen
 const recordingActor = Layer.effect(
   Actor.Service,
   Effect.gen(function* () {
+    const prevSpawnRef = spawnRef.current
     let counter = 0
     const impl = Actor.Service.of({
       spawn: (input) =>
@@ -63,7 +64,7 @@ const recordingActor = Layer.effect(
     spawnRef.current = impl
     yield* Effect.addFinalizer(() =>
       Effect.sync(() => {
-        if (spawnRef.current === impl) spawnRef.current = undefined
+        if (spawnRef.current === impl) spawnRef.current = prevSpawnRef
       }),
     )
     return impl

--- a/packages/opencode/test/session/checkpoint-main-slice.test.ts
+++ b/packages/opencode/test/session/checkpoint-main-slice.test.ts
@@ -44,6 +44,8 @@ const captures: Captures = { input: undefined, prefixMsgs: undefined }
 const recordingActor = Layer.effect(
   Actor.Service,
   Effect.gen(function* () {
+    const prevSpawnRef = spawnRef.current
+    const prevPrefixCaptureRef = prefixCaptureRef.current
     const impl = Actor.Service.of({
       spawn: (input) =>
         Effect.gen(function* () {
@@ -80,8 +82,8 @@ const recordingActor = Layer.effect(
 
     yield* Effect.addFinalizer(() =>
       Effect.sync(() => {
-        if (spawnRef.current === impl) spawnRef.current = undefined
-        if (prefixCaptureRef.current === capture) prefixCaptureRef.current = undefined
+        if (spawnRef.current === impl) spawnRef.current = prevSpawnRef
+        if (prefixCaptureRef.current === capture) prefixCaptureRef.current = prevPrefixCaptureRef
       }),
     )
     return impl

--- a/packages/opencode/test/tool/actor.test.ts
+++ b/packages/opencode/test/tool/actor.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect } from "bun:test"
+import { afterEach, beforeAll, describe, expect } from "bun:test"
 import { Deferred, Effect, Layer } from "effect"
 import z from "zod"
 import { schema as transformSchema } from "../../src/provider/transform"
@@ -26,8 +26,13 @@ import { ToolRegistry } from "../../src/tool"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
+let prevSpawnRef: typeof spawnRef.current
+beforeAll(() => {
+  prevSpawnRef = spawnRef.current
+})
+
 afterEach(async () => {
-  spawnRef.current = undefined
+  spawnRef.current = prevSpawnRef
   await Instance.disposeAll()
 })
 


### PR DESCRIPTION
## Summary
- Fix `spawnRef` finalizer to restore the previous binding instead of wiping to `undefined`
- Prevents breaking `tryStartCheckpointWriter` when `Actor.layer` is initialized more than once in the same process (memo'd ManagedRuntimes, overlapping test runtimes)
- Apply the same fix to all test files that mock `Actor.layer`

## Changes
- `src/actor/spawn.ts`: Save `prevSpawnRef` before overwriting and restore it in the finalizer
- `test/session/checkpoint-*.test.ts`: Apply matching fix to test actor mocks
- `test/tool/actor.test.ts`: Save/restore `spawnRef` in `beforeAll`/`afterEach` instead of setting to `undefined`