### PR TITLE
fix: force UTF-8 for Windows shell subprocesses to fix CJK mojibake

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ sudo apt install xsel
 ```
 </details>
 
+<details>
+<summary><strong>Windows: garbled CJK (Chinese/Japanese/Korean) output in the shell</strong></summary>
+
+On Windows with a non-UTF-8 system locale (e.g. zh-CN, whose active code page is 936/GBK),
+command output containing CJK characters may appear garbled (mojibake). Recent versions
+force UTF-8 for spawned PowerShell/cmd subprocesses, but if you are on an older version, or
+still see garbled output from a tool we haven't special-cased (the UTF-8 forcing is applied
+per shell/tool, so some paths may be missed), enable Windows' system-wide UTF-8 support:
+
+**Settings → Time & language → Language & region → Administrative language settings →
+Change system locale → check "Beta: Use Unicode UTF-8 for worldwide language support" →
+reboot.**
+
+This switches the active code page (ACP) to UTF-8 (65001) for all programs, so subprocesses
+no longer inherit the legacy code page. Note it is a system-wide Beta toggle and may cause
+some older non-Unicode programs to display incorrectly, so treat it as a workaround.
+</details>
+
 ---
 
 ## Core Features

--- a/README.md
+++ b/README.md
@@ -54,10 +54,9 @@ sudo apt install xsel
 <summary><strong>Windows: garbled CJK (Chinese/Japanese/Korean) output in the shell</strong></summary>
 
 On Windows with a non-UTF-8 system locale (e.g. zh-CN, whose active code page is 936/GBK),
-command output containing CJK characters may appear garbled (mojibake). Recent versions of
-MiMoCode force UTF-8 for spawned PowerShell/cmd subprocesses. If you are running an older
-version of MiMoCode, or still encounter garbled output in cases this fix does not yet cover,
-enable Windows' system-wide UTF-8 support:
+command output containing CJK characters may appear garbled (mojibake). MiMoCode forces
+UTF-8 output for spawned PowerShell/cmd subprocesses. If you still encounter garbled output
+in cases this does not yet cover, enable Windows' system-wide UTF-8 support:
 
 **Settings → Time & language → Language & region → Administrative language settings →
 Change system locale → check "Beta: Use Unicode UTF-8 for worldwide language support" →

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ sudo apt install xsel
 <summary><strong>Windows: garbled CJK (Chinese/Japanese/Korean) output in the shell</strong></summary>
 
 On Windows with a non-UTF-8 system locale (e.g. zh-CN, whose active code page is 936/GBK),
-command output containing CJK characters may appear garbled (mojibake). Recent versions
-force UTF-8 for spawned PowerShell/cmd subprocesses, but if you are on an older version, or
-still see garbled output from a tool we haven't special-cased (the UTF-8 forcing is applied
-per shell/tool, so some paths may be missed), enable Windows' system-wide UTF-8 support:
+command output containing CJK characters may appear garbled (mojibake). Recent versions of
+MiMoCode force UTF-8 for spawned PowerShell/cmd subprocesses. If you are running an older
+version of MiMoCode, or still encounter garbled output in cases this fix does not yet cover,
+enable Windows' system-wide UTF-8 support:
 
 **Settings → Time & language → Language & region → Administrative language settings →
 Change system locale → check "Beta: Use Unicode UTF-8 for worldwide language support" →

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,9 +54,9 @@ sudo apt install xsel
 <summary><strong>Windows：shell 输出中文（CJK）乱码</strong></summary>
 
 在系统区域为非 UTF-8 的 Windows 上（如简体中文，活动代码页为 936/GBK），命令输出里的
-中日韩字符可能显示为乱码。较新版本已为 PowerShell/cmd 子进程强制 UTF-8，但如果你用的是
-旧版本，或仍有某个我们尚未特殊处理的工具出现乱码（UTF-8 强制是按 shell/工具逐个加的，
-可能有遗漏路径），可以开启 Windows 的系统级 UTF-8 支持：
+中日韩字符可能显示为乱码。较新版本的 MiMoCode 已为 PowerShell/cmd 子进程强制 UTF-8。
+如果你运行的是较旧版本的 MiMoCode，或在该修复尚未覆盖的场景下仍遇到乱码，可以开启
+Windows 的系统级 UTF-8 支持：
 
 **设置 → 时间和语言 → 语言和区域 → 管理语言设置 → 更改系统区域设置 →
 勾选「Beta 版: 使用 Unicode UTF-8 提供全球语言支持」→ 重启。**

--- a/README.zh.md
+++ b/README.zh.md
@@ -50,6 +50,21 @@ sudo apt install xsel
 ```
 </details>
 
+<details>
+<summary><strong>Windows：shell 输出中文（CJK）乱码</strong></summary>
+
+在系统区域为非 UTF-8 的 Windows 上（如简体中文，活动代码页为 936/GBK），命令输出里的
+中日韩字符可能显示为乱码。较新版本已为 PowerShell/cmd 子进程强制 UTF-8，但如果你用的是
+旧版本，或仍有某个我们尚未特殊处理的工具出现乱码（UTF-8 强制是按 shell/工具逐个加的，
+可能有遗漏路径），可以开启 Windows 的系统级 UTF-8 支持：
+
+**设置 → 时间和语言 → 语言和区域 → 管理语言设置 → 更改系统区域设置 →
+勾选「Beta 版: 使用 Unicode UTF-8 提供全球语言支持」→ 重启。**
+
+这会把活动代码页（ACP）切换为 UTF-8（65001），所有程序都生效，子进程不再继承旧代码页。
+注意这是系统级 Beta 开关，可能导致部分老的非 Unicode 程序显示异常，建议作为临时方案。
+</details>
+
 ---
 
 ## 核心特性

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,9 +54,8 @@ sudo apt install xsel
 <summary><strong>Windows：shell 输出中文（CJK）乱码</strong></summary>
 
 在系统区域为非 UTF-8 的 Windows 上（如简体中文，活动代码页为 936/GBK），命令输出里的
-中日韩字符可能显示为乱码。较新版本的 MiMoCode 已为 PowerShell/cmd 子进程强制 UTF-8。
-如果你运行的是较旧版本的 MiMoCode，或在该修复尚未覆盖的场景下仍遇到乱码，可以开启
-Windows 的系统级 UTF-8 支持：
+中日韩字符可能显示为乱码。MiMoCode 已为 PowerShell/cmd 子进程强制开启 UTF-8 输出。
+如果在尚未覆盖的场景下仍遇到乱码，可以开启 Windows 的系统级 UTF-8 支持：
 
 **设置 → 时间和语言 → 语言和区域 → 管理语言设置 → 更改系统区域设置 →
 勾选「Beta 版: 使用 Unicode UTF-8 提供全球语言支持」→ 重启。**

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1256,9 +1256,21 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             `,
           ],
         },
-        cmd: { args: ["/c", input.command] },
-        powershell: { args: ["-NoProfile", "-Command", input.command] },
-        pwsh: { args: ["-NoProfile", "-Command", input.command] },
+        cmd: { args: ["/c", `chcp 65001 >nul & ${input.command}`] },
+        powershell: {
+          args: [
+            "-NoProfile",
+            "-Command",
+            `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);${input.command}`,
+          ],
+        },
+        pwsh: {
+          args: [
+            "-NoProfile",
+            "-Command",
+            `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);${input.command}`,
+          ],
+        },
         "": { args: ["-c", input.command] },
       }
 
@@ -1273,7 +1285,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const cmd = ChildProcess.make(sh, args, {
         cwd,
         extendEnv: true,
-        env: { ...shellEnv.env, TERM: "dumb" },
+        env: {
+          ...shellEnv.env,
+          ...(process.platform === "win32" ? { PYTHONIOENCODING: "utf-8" } : {}),
+          TERM: "dumb",
+        },
         stdin: "ignore",
         forceKillAfter: "3 seconds",
       })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1256,20 +1256,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             `,
           ],
         },
-        cmd: { args: ["/c", `chcp 65001 >nul & ${input.command}`] },
+        cmd: { args: ["/c", `${Shell.CMD_UTF8_PREFIX}${input.command}`] },
         powershell: {
-          args: [
-            "-NoProfile",
-            "-Command",
-            `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);${input.command}`,
-          ],
+          args: ["-NoProfile", "-Command", `${Shell.POWERSHELL_UTF8_PREFIX}${input.command}`],
         },
         pwsh: {
-          args: [
-            "-NoProfile",
-            "-Command",
-            `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);${input.command}`,
-          ],
+          args: ["-NoProfile", "-Command", `${Shell.POWERSHELL_UTF8_PREFIX}${input.command}`],
         },
         "": { args: ["-c", input.command] },
       }

--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -107,4 +107,18 @@ export const preferred = lazy(() => select(process.env.SHELL))
 
 export const acceptable = lazy(() => select(process.env.SHELL, { acceptable: true }))
 
+// On non-UTF-8 Windows locales (e.g. zh-CN ACP 936/GBK) shell subprocesses emit
+// output in the legacy code page, which we decode as UTF-8 → mojibake. These
+// prefixes force UTF-8 output before the user command runs.
+
+// PowerShell/pwsh: set both the output pipe encoding and the console encoding.
+// UTF8Encoding($false) is BOM-less to avoid leading garbage bytes.
+export const POWERSHELL_UTF8_PREFIX =
+  "$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);"
+
+// cmd.exe: switch the code page to 65001. `&` (not `&&`) so the user command's
+// exit code is preserved and a chcp failure doesn't block it; redirect both
+// stdout and stderr so chcp output never pollutes the result.
+export const CMD_UTF8_PREFIX = "chcp 65001 >nul 2>nul & "
+
 export * as Shell from "./shell"

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -308,7 +308,11 @@ const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) 
 
 function cmd(shell: string, name: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && PS.has(name)) {
-    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+    // On non-UTF-8 Windows locales (e.g. zh-CN ACP 936/GBK) PowerShell emits
+    // output in the legacy code page, which we then decode as UTF-8 and get
+    // mojibake. Force UTF-8 for both the output pipe and the console.
+    const prefixed = `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);${command}`
+    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", prefixed], {
       cwd,
       env,
       stdin: "ignore",
@@ -316,7 +320,11 @@ function cmd(shell: string, name: string, command: string, cwd: string, env: Nod
     })
   }
 
-  return ChildProcess.make(command, [], {
+  // cmd.exe inherits the legacy code page too; switch it to UTF-8 (65001).
+  const finalCommand =
+    process.platform === "win32" && name === "cmd" ? `chcp 65001 >nul & ${command}` : command
+
+  return ChildProcess.make(finalCommand, [], {
     shell,
     cwd,
     env,
@@ -429,6 +437,10 @@ export const BashTool = Tool.define(
       )
       return {
         ...process.env,
+        // Python ignores the console code page when stdout is a pipe and falls
+        // back to the ANSI code page (GBK on zh-CN), producing mojibake. Force
+        // UTF-8 for child Python processes on Windows.
+        ...(process.platform === "win32" ? { PYTHONIOENCODING: "utf-8" } : {}),
         ...extra.env,
       }
     })

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -308,10 +308,7 @@ const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) 
 
 function cmd(shell: string, name: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && PS.has(name)) {
-    // On non-UTF-8 Windows locales (e.g. zh-CN ACP 936/GBK) PowerShell emits
-    // output in the legacy code page, which we then decode as UTF-8 and get
-    // mojibake. Force UTF-8 for both the output pipe and the console.
-    const prefixed = `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);${command}`
+    const prefixed = `${Shell.POWERSHELL_UTF8_PREFIX}${command}`
     return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", prefixed], {
       cwd,
       env,
@@ -320,9 +317,8 @@ function cmd(shell: string, name: string, command: string, cwd: string, env: Nod
     })
   }
 
-  // cmd.exe inherits the legacy code page too; switch it to UTF-8 (65001).
   const finalCommand =
-    process.platform === "win32" && name === "cmd" ? `chcp 65001 >nul & ${command}` : command
+    process.platform === "win32" && name === "cmd" ? `${Shell.CMD_UTF8_PREFIX}${command}` : command
 
   return ChildProcess.make(finalCommand, [], {
     shell,


### PR DESCRIPTION
## Summary

Fixes CJK mojibake (garbled Chinese/Japanese/Korean text) in shell command output on Windows with non-UTF-8 locales (e.g. zh-CN, where the active code page is 936/GBK). Spawned PowerShell/cmd subprocesses emit output in the legacy code page, which we decode as UTF-8 → garbled characters.

> 中文：修复 Windows 非 UTF-8 区域（如简体中文，活动代码页 936/GBK）下 shell 命令输出的 CJK 乱码。子进程（PowerShell/cmd）按旧代码页输出，我们按 UTF-8 解码，于是出现乱码。

## Background

Based on upstream **anomalyco/opencode#31658** ("set default UTF-8 encoding for spawned subprocess on Windows"), which prepends an encoding statement to the command and adds `PYTHONIOENCODING`.

We investigated two earlier upstream attempts first and rejected them:
- **#14766** (`SetConsoleCP(CP_UTF8)` via FFI) — targets TUI keyboard *input*, not command *output*; verified ineffective for our mojibake case on the test machine.
- **#23635** (`[Console]::OutputEncoding` only) — partial; doesn't cover cmd or piped Python output.

> 中文：本 PR 参考上游 #31658（为 Windows 子进程设置默认 UTF-8 编码）。我们先排查并否决了另外两个上游方案：#14766（用 FFI 调 `SetConsoleCP`，改的是 TUI 键盘*输入*而非命令*输出*，实测对乱码无效）；#23635（只设 `[Console]::OutputEncoding`，不覆盖 cmd 和管道里的 Python 输出）。

## What we changed (beyond upstream #31658)

Upstream only patched the single subprocess spawn path. **Our codebase has two independent shell execution paths**, and we fixed both:

1. **bash tool** (`src/tool/bash.ts`) — used by the model/LLM tool calls.
2. **TUI shell mode** (`src/session/prompt.ts` `shellImpl`) — the interactive path when the user presses \`tab\` to switch into shell mode and types commands directly. This path is completely separate from the bash tool and was missed by a naive single-location port; it has its own \`invocations\` table for picking shell args.

In both paths, on Windows:
- **PowerShell / pwsh**: prepend \`\$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(\$false);\` (sets both the pipe output encoding and the console encoding).
- **cmd**: prepend \`chcp 65001 >nul & \`.
- **env**: inject \`PYTHONIOENCODING=utf-8\` so piped Python output is UTF-8 (Python ignores the console code page when stdout is a pipe and falls back to ANSI/GBK).

> 中文：上游只改了单一的子进程路径，而我们代码库里有**两条独立的 shell 执行路径**，两条都改了：(1) bash 工具 `src/tool/bash.ts`（模型工具调用走这条）；(2) TUI shell 模式 `src/session/prompt.ts` 的 `shellImpl`（用户按 `tab` 切到 shell 模式直接敲命令，这条完全独立，单点移植容易漏掉，它有自己的 `invocations` 表）。两条路径在 Windows 上都做了：PowerShell/pwsh 命令前加 `$OutputEncoding = [Console]::OutputEncoding = ...UTF8...`（同时设管道输出和控制台编码）；cmd 前加 `chcp 65001 >nul &`；环境变量注入 `PYTHONIOENCODING=utf-8`（管道输出时 Python 会忽略代码页、回退到 ANSI/GBK）。

## Recommended workaround before this lands

Until this fix is merged and released, the most reliable workaround is to enable Windows' system-wide UTF-8 support, which sets the active code page (ACP) to 65001 for all programs:

**Settings → Time & language → Language & region → Administrative language settings (Change system locale) → check "Beta: Use Unicode UTF-8 for worldwide language support" → reboot.**

This makes the ACP UTF-8 globally, so subprocesses no longer inherit GBK and the mojibake disappears without any build change. Note it is a system-wide Beta toggle and may affect other legacy (non-Unicode) apps, so treat it as a workaround rather than a permanent requirement.

This PR also adds a "Windows: garbled CJK output" note documenting this workaround to both the English and Chinese README.

> 中文：在本修复合入并发版之前，现阶段最推荐的临时方案是开启 Windows 的系统级 UTF-8 支持（把活动代码页 ACP 设为 65001）：**设置 → 时间和语言 → 语言和区域 → 管理语言设置 / 更改系统区域设置 → 勾选「Beta 版: 使用 Unicode UTF-8 提供全球语言支持」→ 重启**。这样全局 ACP 变为 UTF-8，子进程不再继承 GBK，无需改任何代码即可消除乱码。注意这是系统级 Beta 开关，可能影响其它老的非 Unicode 程序，建议作为临时方案而非长期依赖。本 PR 也在中英文 README 中新增了「Windows：shell 输出中文（CJK）乱码」一节，记录该临时方案。

## Verification

Built a \`windows-x64\` binary and tested on Windows 11 + Windows Terminal (zh-CN, code page 936):
- Model-invoked \`ls\` of a directory containing files with Chinese names now renders correctly, previously garbled.
- TUI shell-mode \`ls\` fixed by the second change in \`prompt.ts\`.

> 中文：在 Windows 11 + Windows Terminal（简体中文，代码页 936）上用 windows-x64 二进制实测：模型调用 `ls` 列含中文名文件的目录已正常显示（此前为乱码）；TUI shell 模式的 `ls` 由 `prompt.ts` 的第二处改动修复。

**Before**

<img width="2559" height="1516" alt="img_v3_02133_36dabe28-87c4-4230-9215-81fc987691ag" src="https://github.com/user-attachments/assets/d115e3ff-fcee-4726-a52a-62fb31df3a9b" />

**After**

<img width="2559" height="1516" alt="img_v3_02133_0149dbd5-a984-47f6-81cd-346aedae829g" src="https://github.com/user-attachments/assets/bf6aff8c-9929-4809-b285-b6bf6a515488" />

