### PR TITLE
fix(config): use MiMo schema for config writes

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -46,6 +46,8 @@ import { ConfigVariable } from "./variable"
 import { Npm } from "@/npm"
 
 const log = Log.create({ service: "config" })
+const CONFIG_SCHEMA_URL = "https://mimo.xiaomi.com/mimocode/config.json"
+const STALE_OPENCODE_SCHEMA_URL = "https://opencode.ai/config.json"
 
 // Custom merge function that concatenates array fields instead of replacing them
 function mergeConfigConcatArrays(target: Info, source: Info): Info {
@@ -560,9 +562,9 @@ export const layer = Layer.effect(
       if (!("path" in options)) return data
 
       yield* Effect.promise(() => resolveLoadedPlugins(data, options.path))
-      if (!data.$schema || data.$schema === "https://opencode.ai/config.json") {
-        data.$schema = "https://mimo.xiaomi.com/mimocode/config.json"
-        const edits = modify(text, ["$schema"], "https://mimo.xiaomi.com/mimocode/config.json", {
+      if (!data.$schema || data.$schema === STALE_OPENCODE_SCHEMA_URL) {
+        data.$schema = CONFIG_SCHEMA_URL
+        const edits = modify(text, ["$schema"], CONFIG_SCHEMA_URL, {
           formattingOptions: { insertSpaces: true, tabSize: 2 },
           isArrayInsertion: false,
         })
@@ -596,7 +598,7 @@ export const layer = Layer.effect(
             .then(async (mod) => {
               const { provider, model, ...rest } = mod.default
               if (provider && model) result.model = `${provider}/${model}`
-              result["$schema"] = "https://mimo.xiaomi.com/mimocode/config.json"
+              result["$schema"] = CONFIG_SCHEMA_URL
               result = mergeDeep(result, rest)
               await fsNode.writeFile(path.join(Global.Path.config, "config.json"), JSON.stringify(result, null, 2))
               await fsNode.unlink(legacy)
@@ -612,7 +614,7 @@ export const layer = Layer.effect(
         !existsSync(path.join(Global.Path.config, "mimocode.json")) &&
         !existsSync(globalConfigFile)
       ) {
-        const starter = '{\n  "$schema": "https://mimo.xiaomi.com/mimocode/config.json"\n}\n'
+        const starter = `{\n  "$schema": "${CONFIG_SCHEMA_URL}"\n}\n`
         yield* fs.writeFileString(globalConfigFile, starter).pipe(Effect.catch(() => Effect.void))
       }
 
@@ -757,7 +759,9 @@ export const layer = Layer.effect(
             }
             const wellknown = (yield* Effect.promise(() => response.json())) as { config?: Record<string, unknown> }
             const remoteConfig = wellknown.config ?? {}
-            if (!remoteConfig.$schema) remoteConfig.$schema = "https://mimo.xiaomi.com/mimocode/config.json"
+            if (!remoteConfig.$schema || remoteConfig.$schema === STALE_OPENCODE_SCHEMA_URL) {
+              remoteConfig.$schema = CONFIG_SCHEMA_URL
+            }
             const source = `${url}/.well-known/opencode`
             const next = yield* loadConfig(JSON.stringify(remoteConfig), {
               dir: path.dirname(source),
@@ -1000,7 +1004,10 @@ export const layer = Layer.effect(
       const file = path.join(dir, "config.json")
       const existing = yield* loadFile(file)
       yield* fs
-        .writeFileString(file, JSON.stringify(mergeDeep(writable(existing), writable(config)), null, 2))
+        .writeFileString(
+          file,
+          JSON.stringify({ ...mergeDeep(writable(existing), writable(config)), $schema: CONFIG_SCHEMA_URL }, null, 2),
+        )
         .pipe(Effect.orDie)
       yield* Effect.promise(() => Instance.dispose())
     })
@@ -1029,11 +1036,11 @@ export const layer = Layer.effect(
       let next: Info
       if (!file.endsWith(".jsonc")) {
         const existing = ConfigParse.schema(Info, ConfigParse.jsonc(before, file), file)
-        const merged = mergeDeep(writable(existing), writable(config))
+        const merged = { ...mergeDeep(writable(existing), writable(config)), $schema: CONFIG_SCHEMA_URL }
         yield* fs.writeFileString(file, JSON.stringify(merged, null, 2)).pipe(Effect.orDie)
         next = merged
       } else {
-        const updated = patchJsonc(before, writable(config))
+        const updated = patchJsonc(before, { ...writable(config), $schema: CONFIG_SCHEMA_URL })
         next = ConfigParse.schema(Info, ConfigParse.jsonc(updated, file), file)
         yield* fs.writeFileString(file, updated).pipe(Effect.orDie)
       }

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -61,6 +61,7 @@ const listDirs = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.directories()).pipe(Effect.scoped, Effect.provide(layer)))
 const ready = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.waitForDependencies()).pipe(Effect.scoped, Effect.provide(layer)))
+const MIMO_SCHEMA_URL = "https://mimo.xiaomi.com/mimocode/config.json"
 
 // Get managed config directory from environment (set in preload.ts)
 const managedConfigDir = process.env.MIMOCODE_TEST_MANAGED_CONFIG_DIR!
@@ -1051,10 +1052,96 @@ test("updates config and writes to file", async () => {
       const newConfig = { model: "updated/model" }
       await save(newConfig as any)
 
-      const writtenConfig = await Filesystem.readJson<{ model: string }>(path.join(tmp.path, "config.json"))
+      const writtenConfig = await Filesystem.readJson<{ $schema: string; model: string }>(
+        path.join(tmp.path, "config.json"),
+      )
+      expect(writtenConfig.$schema).toBe(MIMO_SCHEMA_URL)
       expect(writtenConfig.model).toBe("updated/model")
     },
   })
+})
+
+test("global config update writes MiMo schema", async () => {
+  await using tmp = await tmpdir()
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = tmp.path
+  await clear()
+  try {
+    const updated = await Effect.runPromise(
+      Config.Service.use((svc) => svc.updateGlobal({ model: "updated/model" })).pipe(
+        Effect.scoped,
+        Effect.provide(layer),
+      ),
+    )
+
+    const writtenConfig = await Filesystem.readJson<{ $schema: string; model: string }>(
+      path.join(tmp.path, "mimocode.jsonc"),
+    )
+    expect(updated.$schema).toBe(MIMO_SCHEMA_URL)
+    expect(writtenConfig.$schema).toBe(MIMO_SCHEMA_URL)
+    expect(writtenConfig.model).toBe("updated/model")
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear()
+  }
+})
+
+test("global JSONC config update replaces stale opencode schema", async () => {
+  await using tmp = await tmpdir()
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = tmp.path
+  await Filesystem.write(
+    path.join(tmp.path, "mimocode.jsonc"),
+    JSON.stringify({ $schema: "https://opencode.ai/config.json", model: "old/model" }, null, 2),
+  )
+  await clear()
+  try {
+    const updated = await Effect.runPromise(
+      Config.Service.use((svc) => svc.updateGlobal({ model: "updated/model" })).pipe(
+        Effect.scoped,
+        Effect.provide(layer),
+      ),
+    )
+
+    const writtenConfig = await Filesystem.readJson<{ $schema: string; model: string }>(
+      path.join(tmp.path, "mimocode.jsonc"),
+    )
+    expect(updated.$schema).toBe(MIMO_SCHEMA_URL)
+    expect(writtenConfig.$schema).toBe(MIMO_SCHEMA_URL)
+    expect(writtenConfig.model).toBe("updated/model")
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear()
+  }
+})
+
+test("legacy global config migration writes MiMo schema", async () => {
+  await using tmp = await tmpdir()
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = tmp.path
+  await Filesystem.write(
+    path.join(tmp.path, "config"),
+    `
+provider = "openai"
+model = "gpt-4"
+`,
+  )
+  await clear()
+  try {
+    const config = await Effect.runPromise(
+      Config.Service.use((svc) => svc.getGlobal()).pipe(Effect.scoped, Effect.provide(layer)),
+    )
+    const writtenConfig = await Filesystem.readJson<{ $schema: string; model: string }>(
+      path.join(tmp.path, "config.json"),
+    )
+    expect(config.$schema).toBe(MIMO_SCHEMA_URL)
+    expect(config.model).toBe("openai/gpt-4")
+    expect(writtenConfig.$schema).toBe(MIMO_SCHEMA_URL)
+    expect(writtenConfig.model).toBe("openai/gpt-4")
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear()
+  }
 })
 
 test("gets config directories", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #1369

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Config write paths still used the upstream opencode schema URL in a few places. This centralizes the MiMo schema URL and applies it when config files are created, updated, migrated from the legacy global config, or synthesized from remote well-known config.

The regression tests cover project config writes, global JSONC updates with a stale schema, and legacy global config migration.

### How did you verify your code works?

- `bun test test/config/config.test.ts --timeout 30000` from `packages/opencode`: 85 pass, 0 fail.
- `bun typecheck` from `packages/opencode`: passed.
- `bunx oxlint packages/opencode/src/config/config.ts packages/opencode/test/config/config.test.ts`: 0 errors; existing warnings only.
- `git diff --check`: passed.
- Pre-push hook ran `bun turbo typecheck`: 12/12 tasks successful.

### Screenshots / recordings

N/A, config-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR