### PR TITLE
fix: guard plan mode writes

### DIFF
--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -16,6 +16,28 @@ type Options = {
   kind?: Kind
 }
 
+function normalizeFilePath(target: string) {
+  return process.platform === "win32" ? AppFileSystem.normalizePath(target) : path.resolve(target)
+}
+
+function isDirectMarkdownChild(target: string, dir: string) {
+  const relative = path.relative(normalizeFilePath(dir), normalizeFilePath(target))
+  return (
+    relative !== "" &&
+    !relative.startsWith("..") &&
+    !path.isAbsolute(relative) &&
+    path.dirname(relative) === "." &&
+    path.extname(relative) === ".md"
+  )
+}
+
+function isPlanWriteTarget(target: string) {
+  return (
+    isDirectMarkdownChild(target, path.join(Instance.worktree, ".mimocode", "plans")) ||
+    isDirectMarkdownChild(target, path.join(Global.Path.data, "plans"))
+  )
+}
+
 export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirectory")(function* (
   ctx: Tool.Context,
   target?: string,
@@ -78,6 +100,10 @@ export const assertWriteAllowed = Effect.fn("Tool.assertWriteAllowed")(function*
   target?: string,
   options?: Options,
 ) {
+  if (ctx.agent === "plan" && target && !isPlanWriteTarget(target)) {
+    throw new Error("Plan mode can only write plan files. Switch to build mode before modifying project files.")
+  }
+
   yield* assertExternalDirectoryEffect(ctx, target, options)
   if (!target) return
 

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -3,7 +3,7 @@ import path from "path"
 import { Effect } from "effect"
 import type { Tool } from "../../src/tool"
 import { Instance } from "../../src/project/instance"
-import { assertExternalDirectory } from "../../src/tool/external-directory"
+import { assertExternalDirectory, assertWriteAllowed } from "../../src/tool/external-directory"
 import { Filesystem } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
 import type { Permission } from "../../src/permission"
@@ -118,15 +118,7 @@ describe("tool.assertExternalDirectory", () => {
   test("does NOT ask for paths under the memory root (defers to memory-path-guard)", async () => {
     const { requests, ctx } = makeCtx()
 
-    const memTarget = path.join(
-      Global.Path.data,
-      "memory",
-      "sessions",
-      "ses_test",
-      "tasks",
-      "T3",
-      "progress.md",
-    )
+    const memTarget = path.join(Global.Path.data, "memory", "sessions", "ses_test", "tasks", "T3", "progress.md")
 
     await Instance.provide({
       directory: "/tmp/project", // memTarget is OUTSIDE the project dir on purpose
@@ -204,4 +196,59 @@ describe("tool.assertExternalDirectory", () => {
       expect(req!.always).toEqual([expected])
     })
   }
+})
+
+describe("tool.assertWriteAllowed", () => {
+  test("rejects project file writes from plan mode before asking permissions", async () => {
+    const { requests, ctx } = makeCtx()
+
+    await using tmp = await tmpdir({ git: true })
+    const target = path.join(tmp.path, "src", "index.ts")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const error = await Effect.runPromise(assertWriteAllowed({ ...ctx, agent: "plan" }, target)).then(
+          () => undefined,
+          (cause) => cause,
+        )
+
+        expect(String(error)).toContain("Plan mode can only write plan files")
+      },
+    })
+
+    expect(requests.length).toBe(0)
+  })
+
+  test("allows plan mode to write its session plan file", async () => {
+    const { requests, ctx } = makeCtx()
+
+    await using tmp = await tmpdir({ git: true })
+    const target = path.join(tmp.path, ".mimocode", "plans", "next.md")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Effect.runPromise(assertWriteAllowed({ ...ctx, agent: "plan" }, target))
+      },
+    })
+
+    expect(requests.length).toBe(0)
+  })
+
+  test("does not restrict build mode writes", async () => {
+    const { requests, ctx } = makeCtx()
+
+    await using tmp = await tmpdir({ git: true })
+    const target = path.join(tmp.path, "src", "index.ts")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Effect.runPromise(assertWriteAllowed(ctx, target))
+      },
+    })
+
+    expect(requests.length).toBe(0)
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #1274

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a direct write guard in the shared file mutation gate so the plan agent can only write plan markdown files. This keeps the existing plan-file exception while preventing normal project files from being changed if a tool path reaches the write gate with a permissive ask handler.

### How did you verify your code works?

- `bun test test/tool/external-directory.test.ts`
- `bun test test/tool/write.test.ts test/tool/edit.test.ts test/tool/apply_patch.test.ts test/tool/memory-path-guard.test.ts`
- `bun typecheck`
- `bunx oxlint packages/opencode/src/tool/external-directory.ts packages/opencode/test/tool/external-directory.test.ts`
- `bunx prettier --check packages/opencode/src/tool/external-directory.ts packages/opencode/test/tool/external-directory.test.ts`
- `git diff --check`
- pre-push: `bun turbo typecheck` (12/12 tasks)

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR