### PR TITLE
fix(tui): show scrollbar and increase height limit in dialog-select

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -153,7 +153,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   })
 
   const dimensions = useTerminalDimensions()
-  const height = createMemo(() => Math.min(rows(), Math.floor(dimensions().height / 2) - 6))
+  const height = createMemo(() => Math.min(rows(), Math.floor(dimensions().height * 0.7) - 4))
 
   const selected = createMemo(() => flat()[store.selected])
 
@@ -306,7 +306,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         <scrollbox
           paddingLeft={1}
           paddingRight={1}
-          scrollbarOptions={{ visible: false }}
+          scrollbarOptions={{ visible: true }}
           scrollAcceleration={scrollAcceleration()}
           ref={(r: ScrollBoxRenderable) => (scroll = r)}
           maxHeight={height()}


### PR DESCRIPTION
## What
- Enable scrollbar visibility in dialog-select scrollbox so users can see when content is scrollable
- Increase height limit from 50% to 70% of terminal height to show more options when AI generates long solutions

## Why
Fixes #1430 - When AI generates long solutions/plans, users couldn't scroll to view all options because:
1. The scrollbar was hidden (scrollbarOptions={{ visible: false }})
2. The height limit was too restrictive (50% of terminal height)

## How
1. Changed scrollbarOptions={{ visible: false }} to scrollbarOptions={{ visible: true }} to show the scrollbar
2. Changed height calculation from Math.floor(dimensions().height / 2) - 6 to Math.floor(dimensions().height * 0.7) - 4 to allow more vertical space

## Testing
- Verified the changes compile correctly
- The scrollbar is now visible when content overflows
- More options are displayed when the terminal is large enough

## Related Issues
Closes #1430

---
**此PR由mimocode全权生成**