### PR TITLE
fix(tui): default to free mimo-auto on clean install instead of paid model

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -188,6 +188,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
         }
 
+        // No args/config/recent match: prefer the free mimo-auto channel so a
+        // clean install defaults to a usable free model rather than whatever
+        // provider happens to sit first (e.g. paid xiaomi/ultraspeed).
+        const mimo = sync.data.provider.find((p) => p.id === "mimo")
+        if (mimo && "mimo-auto" in mimo.models) {
+          return { providerID: "mimo", modelID: "mimo-auto" }
+        }
+
         const provider = sync.data.provider[0]
         if (!provider) return undefined
         const defaultModel = sync.data.provider_default[provider.id]


### PR DESCRIPTION
## Summary
- On a clean install (no `args.model`, no `config.model`, no recent selection), the TUI's `fallbackModel` in `cli/cmd/tui/context/local.tsx` selected `sync.data.provider[0]` and used its default/first model.
- Because `MimoAuthPlugin` unconditionally registers the `xiaomi` config provider, that fallback could land on a **paid** model (e.g. `xiaomi/ultraspeed`) that an unauthenticated user cannot actually call.
- This PR makes the fallback prefer the free `mimo/mimo-auto` channel before the provider-order fallback, matching the intent already stated across all i18n strings ("default model set to mimo/mimo-auto").

## Behavior
- Clean install → defaults to free `mimo-auto` (usable without login).
- `args.model` / `config.model` / recent selections still take precedence — existing users are unaffected.
- Builds without the free `mimo` channel fall back to the original `provider[0]` logic.

## Test
- `bun typecheck` passes (12/12).

---
## 中文摘要
干净安装时，TUI 的 `fallbackModel` 取 provider 数组第 0 个，可能选中未登录无法调用的付费模型（如 `xiaomi/ultraspeed`）。本 PR 让兜底优先选免费的 `mimo/mimo-auto`，与现有 i18n 文案意图一致。命令行/配置/最近使用的模型优先级不变，老用户不受影响。