### PR TITLE
fix: task status glyph not updating in TUI until reload

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/task-item.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/task-item.tsx
@@ -20,7 +20,7 @@ export function TaskItem(props: TaskItemProps) {
   const { theme } = useTheme()
   const kv = useKV()
   const running = () => props.status === "in_progress"
-  const glyph =
+  const glyph = () =>
     props.status === "done"
       ? "✓"
       : props.status === "blocked"
@@ -40,7 +40,7 @@ export function TaskItem(props: TaskItemProps) {
         when={running()}
         fallback={
           <text flexShrink={0} style={{ fg: fg() }}>
-            [{glyph}]{" "}
+            [{glyph()}]{" "}
           </text>
         }
       >


### PR DESCRIPTION
### Issue for this PR

Closes #926

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

TaskItem 组件里的状态标记 `glyph` 是个普通常量,只在组件创建时按当时的
`props.status` 计算一次。之后 `props.status` 变成 done 时它不会重算,所以任务
完成后方框一直显示 [ ] 而不是 [✓],看起来像没完成(退出重进会话才正确)。

改成响应式访问器(函数),和旁边已有的 `running` / `fg` 写法一致,这样
`props.status` 变化时 `[{glyph()}]` 会重新渲染成 [✓]。只改了一个文件一处。

### How did you verify your code works?

本地 bun dev 启动 TUI,让 agent 用 task 工具创建任务并标记 done。
修复前:任务完成后右侧面板仍显示 [ ],需退出重进才显示 [✓]。
修复后:标记 done 的瞬间右侧面板实时变为 [✓]。
bun typecheck 通过。

### Screenshots / recordings

修复前:
<img width="1662" height="586" alt="image" src="https://github.com/user-attachments/assets/8ebc5e8e-e1c6-4bbf-90ef-acf80344ddb6" />

修复后:
<img width="1654" height="584" alt="22d26f2a300f452946177d32c81a6b89" src="https://github.com/user-attachments/assets/6b5c8451-7fd0-48bd-9b36-2461c1c8652b" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR