### PR TITLE
docs: add MiMo Ecosystem section linking awesome-mimo-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,16 @@ MiMoCode is built as a fork of [OpenCode](https://github.com/anomalyco/opencode)
 
 ---
 
+## MiMo Ecosystem
+
+Want to use Xiaomi MiMo models in other agents and coding assistants too?
+
+👉 **[awesome-mimo-agent](https://github.com/XiaomiMiMo/awesome-mimo-agent)** — a curated list of guides for integrating MiMo models into popular AI agent and coding-assistant tools (Cursor, Cline, Zed, and more).
+
+If you've integrated MiMo into a tool, contributions are welcome — open an issue or PR there to add your guide.
+
+---
+
 ## Community
 
 Scan the QR code to join the community group chat:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ some older non-Unicode programs to display incorrectly, so treat it as a workaro
 
 ---
 
+## MiMo Ecosystem
+
+Beyond MiMoCode, Xiaomi MiMo models also work in other agents and coding tools like Cursor, Cline, and Zed.
+
+**[awesome-mimo-agent](https://github.com/XiaomiMiMo/awesome-mimo-agent)** collects setup guides for using MiMo in those tools — worth a look if you want to try MiMo elsewhere. Contributions welcome: open a PR to add your own setup.
+
+---
+
 ## Core Features
 
 ### Multiple Agents
@@ -253,16 +261,6 @@ bun turbo typecheck      # Type check
 ## Relationship to OpenCode
 
 MiMoCode is built as a fork of [OpenCode](https://github.com/anomalyco/opencode). It keeps all core OpenCode capabilities (multiple providers, TUI, LSP, MCP, plugins) and adds persistent memory, intelligent context management, subagent orchestration, goal-driven autonomous loops, compose workflows, and self-improvement via dream/distill.
-
----
-
-## MiMo Ecosystem
-
-Want to use Xiaomi MiMo models in other agents and coding assistants too?
-
-👉 **[awesome-mimo-agent](https://github.com/XiaomiMiMo/awesome-mimo-agent)** — a curated list of guides for integrating MiMo models into popular AI agent and coding-assistant tools (Cursor, Cline, Zed, and more).
-
-If you've integrated MiMo into a tool, contributions are welcome — open an issue or PR there to add your guide.
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -248,6 +248,16 @@ MiMoCode 基于 [OpenCode](https://github.com/anomalyco/opencode) fork 构建，
 
 ---
 
+## MiMo 生态
+
+想在其他 Agent 和编程助手里也用上小米 MiMo 模型？
+
+👉 **[awesome-mimo-agent](https://github.com/XiaomiMiMo/awesome-mimo-agent)** —— 一个精选清单，收录了把 MiMo 模型接入各类主流 AI Agent 与编程助手（Cursor、Cline、Zed 等）的接入指南。
+
+如果你已经把 MiMo 接入了某个工具，欢迎去那里提 issue 或 PR 补充你的接入指南。
+
+---
+
 ## 社区
 
 扫描二维码加入社区群聊：

--- a/README.zh.md
+++ b/README.zh.md
@@ -250,11 +250,9 @@ MiMoCode 基于 [OpenCode](https://github.com/anomalyco/opencode) fork 构建，
 
 ## MiMo 生态
 
-想在其他 Agent 和编程助手里也用上小米 MiMo 模型？
+除了 MiMoCode，小米 MiMo 模型也能在 Cursor、Cline、Zed 等各种 Agent 和编程工具里使用。
 
-👉 **[awesome-mimo-agent](https://github.com/XiaomiMiMo/awesome-mimo-agent)** —— 一个精选清单，收录了把 MiMo 模型接入各类主流 AI Agent 与编程助手（Cursor、Cline、Zed 等）的接入指南。
-
-如果你已经把 MiMo 接入了某个工具，欢迎去那里提 issue 或 PR 补充你的接入指南。
+**[awesome-mimo-agent](https://github.com/XiaomiMiMo/awesome-mimo-agent)** 收集了这些工具接入 MiMo 模型的配置教程，想换个工具试试 MiMo 的话可以去看看。也欢迎把你自己的接入方式提 PR 分享出来。
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -66,6 +66,14 @@ sudo apt install xsel
 
 ---
 
+## MiMo 生态
+
+除了 MiMoCode，小米 MiMo 模型也能在 Cursor、Cline、Zed 等各种 Agent 和编程工具里使用。
+
+**[awesome-mimo-agent](https://github.com/XiaomiMiMo/awesome-mimo-agent)** 收集了这些工具接入 MiMo 模型的配置教程，想换个工具试试 MiMo 的话可以去看看。也欢迎把你自己的接入方式提 PR 分享出来。
+
+---
+
 ## 核心特性
 
 ### 多智能体
@@ -245,14 +253,6 @@ bun turbo typecheck      # 类型检查
 ## 与 OpenCode 的关系
 
 MiMoCode 基于 [OpenCode](https://github.com/anomalyco/opencode) fork 构建，保留其全部核心能力（多 Provider、TUI、LSP、MCP、插件），并在此基础上构建了持久化记忆、智能上下文管理、子智能体编排、目标驱动的自主循环、Compose 工作流，以及通过 dream/distill 实现的自我进化。
-
----
-
-## MiMo 生态
-
-除了 MiMoCode，小米 MiMo 模型也能在 Cursor、Cline、Zed 等各种 Agent 和编程工具里使用。
-
-**[awesome-mimo-agent](https://github.com/XiaomiMiMo/awesome-mimo-agent)** 收集了这些工具接入 MiMo 模型的配置教程，想换个工具试试 MiMo 的话可以去看看。也欢迎把你自己的接入方式提 PR 分享出来。
 
 ---
 


### PR DESCRIPTION
Add a 'MiMo Ecosystem' section to README.md and README.zh.md that links to [awesome-mimo-agent](https://github.com/XiaomiMiMo/awesome-mimo-agent) — the curated list of guides for integrating MiMo models into other agent/coding tools — and invites contributions.

Placed between 'Relationship to OpenCode' and 'Community'.