### PR TITLE
fix(session): avoid structured output repetition false positives

### DIFF
--- a/packages/opencode/src/session/prompt/text-ngram-detection.ts
+++ b/packages/opencode/src/session/prompt/text-ngram-detection.ts
@@ -11,6 +11,41 @@ export function tokenizeForNgram(text: string): string[] {
     .filter(Boolean)
 }
 
+function isMarkdownListLine(line: string): boolean {
+  return /^\s*([-*+]|\d+[.)])\s+/.test(line)
+}
+
+function isMarkdownTableRow(line: string): boolean {
+  const trimmed = line.trim()
+  return /^\|.*\|$/.test(trimmed) && (trimmed.match(/\|/g)?.length ?? 0) >= 2
+}
+
+function isMarkdownTableSeparator(line: string): boolean {
+  return /^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(line.trim())
+}
+
+function structuredMarkdownLineIndexes(lines: readonly string[]): Set<number> {
+  const indexes = new Set<number>()
+  lines.forEach((line, index) => {
+    if (isMarkdownListLine(line)) indexes.add(index)
+    if (!isMarkdownTableSeparator(line)) return
+    for (let i = index; i >= 0 && isMarkdownTableRow(lines[i]); i--) indexes.add(i)
+    for (let i = index + 1; i < lines.length && isMarkdownTableRow(lines[i]); i++) indexes.add(i)
+  })
+  return indexes
+}
+
+function removeStructuredMarkdownBlocks(text: string): string {
+  const lines = text.split(/\r?\n/)
+  const indexes = structuredMarkdownLineIndexes(lines)
+  if (indexes.size < 3) return text
+  const counts = new Map<string, number>()
+  lines.forEach((line, index) => {
+    if (indexes.has(index)) counts.set(line.trim(), (counts.get(line.trim()) ?? 0) + 1)
+  })
+  return lines.filter((line, index) => !indexes.has(index) || (counts.get(line.trim()) ?? 0) >= 3).join("\n")
+}
+
 export function detectRepeatedNgram(tokens: readonly string[], n: number, threshold: number): boolean {
   if (tokens.length < n || threshold < 2) return false
   const counts = new Map<string, number>()
@@ -36,7 +71,7 @@ export class TextNgramMonitor {
   append(text: string): boolean {
     if (!text) return false
     this.buffer += text
-    const all = tokenizeForNgram(this.buffer)
+    const all = tokenizeForNgram(removeStructuredMarkdownBlocks(this.buffer))
     this.tokens = all.length > this.windowTokens ? all.slice(-this.windowTokens) : all
     if (all.length > this.windowTokens * 2) this.buffer = this.tokens.join(" ")
     return detectRepeatedNgram(this.tokens, this.n, this.threshold)

--- a/packages/opencode/test/session/text-ngram-detection.test.ts
+++ b/packages/opencode/test/session/text-ngram-detection.test.ts
@@ -59,4 +59,63 @@ describe("TextNgramMonitor", () => {
     expect(monitor.append(repeated)).toBe(false)
     expect(monitor.append(repeated)).toBe(true)
   })
+
+  test("ignores format-driven repetition in long markdown tables", () => {
+    const monitor = new TextNgramMonitor(6, 3, 500)
+    const table = [
+      "| Technology | Current | After Integration | Verdict |",
+      "| --- | --- | --- | --- |",
+      "| Search | Current after integration verdict needs review | Uses indexed retrieval | Stable |",
+      "| Storage | Current after integration verdict needs review | Uses durable cache | Stable |",
+      "| Billing | Current after integration verdict needs review | Uses invoice sync | Stable |",
+    ].join("\n")
+
+    expect(monitor.append(table)).toBe(false)
+  })
+
+  test("ignores format-driven repetition in long markdown lists", () => {
+    const monitor = new TextNgramMonitor(6, 3, 500)
+    const list = [
+      "  - Search: current after integration verdict needs review",
+      "  - Storage: current after integration verdict needs review",
+      "  - Billing: current after integration verdict needs review",
+    ].join("\n")
+
+    expect(monitor.append(list)).toBe(false)
+  })
+
+  test("does not treat pipe-bounded prose as a markdown table", () => {
+    const monitor = new TextNgramMonitor(6, 3, 500)
+    const repeated = "|x| the same failure keeps happening again now "
+
+    expect(monitor.append(`${repeated}${repeated}${repeated}`)).toBe(true)
+  })
+
+  test("does not ignore pipe rows without a table separator", () => {
+    const monitor = new TextNgramMonitor(6, 3, 500)
+    const row = "| Not a table | the same failure keeps happening again now |"
+
+    expect(monitor.append([row, row, row].join("\n"))).toBe(true)
+  })
+
+  test("still detects exact repeated structured rows", () => {
+    const monitor = new TextNgramMonitor(6, 3, 500)
+    const row = "| Repeat | the same failure keeps happening again now |"
+
+    expect(monitor.append([row, row, row].join("\n"))).toBe(true)
+  })
+
+  test("still detects repeated prose around structured output", () => {
+    const monitor = new TextNgramMonitor(6, 3, 500)
+    const table = [
+      "| Technology | Current | After Integration | Verdict |",
+      "| --- | --- | --- | --- |",
+      "| Search | Uses indexed retrieval | Stable |",
+      "| Storage | Uses durable cache | Stable |",
+      "| Billing | Uses invoice sync | Stable |",
+    ].join("\n")
+    const repeated = "the same failure keeps happening again now "
+
+    expect(monitor.append(`${table}\n${repeated}${repeated}${repeated}`)).toBe(true)
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #1441

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevents the text n-gram recovery guard from treating long structured markdown tables and lists as repeated prose.

The change recognizes real markdown table blocks by their separator row and handles indented list markers. It excludes distinct structured rows from the n-gram scan, while still keeping exact repeated structured rows so genuine loops continue to trigger recovery.

### How did you verify your code works?

- `bun test test/session/text-ngram-detection.test.ts test/session/text-loop-detection.test.ts test/session/text-loop-integration.test.ts --timeout 30000`
- `bun typecheck`
- `bunx oxlint packages/opencode/src/session/prompt/text-ngram-detection.ts packages/opencode/test/session/text-ngram-detection.test.ts`
- `git diff --check`

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
