### PR TITLE
refactor: default edit tool to exact string matching with closest-match error hints

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -111,6 +111,13 @@ export const Flag = {
   MIMOCODE_SERVER_USERNAME: process.env["MIMOCODE_SERVER_USERNAME"],
   MIMOCODE_ENABLE_QUESTION_TOOL: truthy("MIMOCODE_ENABLE_QUESTION_TOOL"),
 
+  // Defaults to false. The edit tool does pure exact-string matching with
+  // explicit error signals. Set MIMOCODE_ENABLE_FUZZY_EDIT=true to opt into the
+  // legacy multi-stage fuzzy fallback chain (line-trimmed / block-anchor /
+  // whitespace-normalized / indentation-flexible / etc.) when old_string fails
+  // to match exactly.
+  MIMOCODE_ENABLE_FUZZY_EDIT: truthy("MIMOCODE_ENABLE_FUZZY_EDIT"),
+
   // Experimental
   MIMOCODE_EXPERIMENTAL,
   MIMOCODE_EXPERIMENTAL_FILEWATCHER: Config.boolean("MIMOCODE_EXPERIMENTAL_FILEWATCHER").pipe(

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -20,6 +20,7 @@ import { Snapshot } from "@/snapshot"
 import { assertWriteAllowed, askEditUnlessMemory } from "./external-directory"
 import { assertFileRead } from "./read-state"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
+import { Flag } from "@/flag/flag"
 
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
@@ -191,6 +192,42 @@ export const EditTool = Tool.define(
     }
   }),
 )
+
+export function trimDiff(diff: string): string {
+  const lines = diff.split("\n")
+  const contentLines = lines.filter(
+    (line) =>
+      (line.startsWith("+") || line.startsWith("-") || line.startsWith(" ")) &&
+      !line.startsWith("---") &&
+      !line.startsWith("+++"),
+  )
+
+  if (contentLines.length === 0) return diff
+
+  let min = Infinity
+  for (const line of contentLines) {
+    const content = line.slice(1)
+    if (content.trim().length > 0) {
+      const match = content.match(/^(\s*)/)
+      if (match) min = Math.min(min, match[1].length)
+    }
+  }
+  if (min === Infinity || min === 0) return diff
+  const trimmedLines = lines.map((line) => {
+    if (
+      (line.startsWith("+") || line.startsWith("-") || line.startsWith(" ")) &&
+      !line.startsWith("---") &&
+      !line.startsWith("+++")
+    ) {
+      const prefix = line[0]
+      const content = line.slice(1)
+      return prefix + content.slice(min)
+    }
+    return line
+  })
+
+  return trimmedLines.join("\n")
+}
 
 export type Replacer = (content: string, find: string) => Generator<string, void, unknown>
 
@@ -617,47 +654,31 @@ export const ContextAwareReplacer: Replacer = function* (content, find) {
   }
 }
 
-export function trimDiff(diff: string): string {
-  const lines = diff.split("\n")
-  const contentLines = lines.filter(
-    (line) =>
-      (line.startsWith("+") || line.startsWith("-") || line.startsWith(" ")) &&
-      !line.startsWith("---") &&
-      !line.startsWith("+++"),
-  )
-
-  if (contentLines.length === 0) return diff
-
-  let min = Infinity
-  for (const line of contentLines) {
-    const content = line.slice(1)
-    if (content.trim().length > 0) {
-      const match = content.match(/^(\s*)/)
-      if (match) min = Math.min(min, match[1].length)
-    }
-  }
-  if (min === Infinity || min === 0) return diff
-  const trimmedLines = lines.map((line) => {
-    if (
-      (line.startsWith("+") || line.startsWith("-") || line.startsWith(" ")) &&
-      !line.startsWith("---") &&
-      !line.startsWith("+++")
-    ) {
-      const prefix = line[0]
-      const content = line.slice(1)
-      return prefix + content.slice(min)
-    }
-    return line
-  })
-
-  return trimmedLines.join("\n")
-}
-
 export function replace(content: string, oldString: string, newString: string, replaceAll = false): string {
   if (oldString === newString) {
     throw new Error("No changes to apply: old_string and new_string are identical.")
   }
 
+  // Default: pure exact match with explicit, actionable errors. Set
+  // MIMOCODE_ENABLE_FUZZY_EDIT=true to opt into the legacy fuzzy fallback chain.
+  if (!Flag.MIMOCODE_ENABLE_FUZZY_EDIT) {
+    const firstIndex = content.indexOf(oldString)
+    if (firstIndex === -1) {
+      throw new Error(buildNotFoundError(content, oldString))
+    }
+    if (replaceAll) {
+      return content.replaceAll(oldString, newString)
+    }
+    const matches = content.split(oldString).length - 1
+    if (matches > 1) {
+      throw new Error(
+        `Found ${matches} matches of the string to replace, but replace_all is false. To replace all occurrences, set replace_all to true. To replace only one occurrence, provide more surrounding context to make the match unique.\nString: ${oldString}`,
+      )
+    }
+    return content.substring(0, firstIndex) + newString + content.substring(firstIndex + oldString.length)
+  }
+
+  // Fuzzy fallback chain (opt-in via MIMOCODE_ENABLE_FUZZY_EDIT)
   let notFound = true
 
   for (const replacer of [
@@ -685,9 +706,47 @@ export function replace(content: string, oldString: string, newString: string, r
   }
 
   if (notFound) {
-    throw new Error(
-      "Could not find old_string in the file. It must match exactly, including whitespace, indentation, and line endings.",
-    )
+    throw new Error(buildNotFoundError(content, oldString))
   }
-  throw new Error("Found multiple matches for old_string. Provide more surrounding context to make the match unique.")
+  throw new Error(
+    `Found multiple matches of the string to replace, but replace_all is false. To replace all occurrences, set replace_all to true. To replace only one occurrence, provide more surrounding context to make the match unique.\nString: ${oldString}`,
+  )
+}
+
+// Cap on the closest-match hint to keep error messages bounded. Long enough to
+// show a meaningful surrounding block; short enough to not flood the tool result.
+const CLOSEST_MATCH_HINT_MAX_CHARS = 2000
+
+function buildNotFoundError(content: string, oldString: string): string {
+  const base = `String to replace not found in file. It must match exactly, including whitespace, indentation, and line endings.\nString: ${oldString}`
+  const hint = findClosestMatch(content, oldString)
+  if (!hint) return base
+  const truncated =
+    hint.length > CLOSEST_MATCH_HINT_MAX_CHARS
+      ? hint.slice(0, CLOSEST_MATCH_HINT_MAX_CHARS) + "\n... (truncated)"
+      : hint
+  return `${base}\n\nClosest match found in file (note the exact whitespace / indentation / line endings — resubmit old_string copying this verbatim):\n${truncated}`
+}
+
+// Try the fuzzy Replacers in order of specificity and return the first block
+// from the file that "looks like" oldString. Used only to enrich error messages
+// — never to silently apply an edit. SimpleReplacer/MultiOccurrenceReplacer are
+// skipped because they yield oldString itself, which is useless as a hint.
+function findClosestMatch(content: string, oldString: string): string | undefined {
+  for (const replacer of [
+    LineTrimmedReplacer,
+    BlockAnchorReplacer,
+    IndentationFlexibleReplacer,
+    WhitespaceNormalizedReplacer,
+    TrimmedBoundaryReplacer,
+    EscapeNormalizedReplacer,
+    ContextAwareReplacer,
+  ]) {
+    for (const match of replacer(content, oldString)) {
+      if (match && match !== oldString && content.includes(match)) {
+        return match
+      }
+    }
+  }
+  return undefined
 }


### PR DESCRIPTION
## Summary

- Default the edit tool to pure exact-string matching instead of the multi-stage fuzzy fallback chain
- Add `MIMOCODE_ENABLE_FUZZY_EDIT` flag to opt into the legacy fuzzy behavior
- Improve error messages with closest-match hints from the file to help callers resubmit with correct whitespace/indentation

## Motivation

Exact matching is more predictable and avoids silent mismatches. The fuzzy chain is preserved behind a flag for users who prefer the legacy behavior. When an exact match fails, the new error message includes the closest matching block from the file as a hint, making it easier to correct `old_string` without trial-and-error.