### PR TITLE
fix(session): rescue malformed JSON in tool call args (LaTeX/literal newlines)

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -581,6 +581,11 @@ const live: Layer.Layer<
               input: repaired.input,
             }
           }
+          const rescued = ToolCompat.rescueMalformedJson(failed.toolCall.input)
+          if (rescued !== undefined) {
+            l.info("rescued malformed tool call JSON", { tool: failed.toolCall.toolName })
+            return { ...failed.toolCall, input: rescued }
+          }
           return {
             ...failed.toolCall,
             input: JSON.stringify({

--- a/packages/opencode/src/util/tool-compat.ts
+++ b/packages/opencode/src/util/tool-compat.ts
@@ -125,6 +125,59 @@ export type RepairedToolCall = {
   input: string
 }
 
+/** Escape literal control chars and lone backslashes inside JSON string values so the payload can be re-parsed. */
+export function rescueMalformedJson(raw: string): string | undefined {
+  if (!raw || raw.trim() === "") return undefined
+  try {
+    JSON.parse(raw)
+    return undefined
+  } catch {
+    // fall through to rescue
+  }
+
+  const VALID_ESCAPE = '"\\/bfnrtu'
+  let out = ""
+  let inStr = false
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i]
+    if (inStr) {
+      if (ch === "\\") {
+        const next = i + 1 < raw.length ? raw[i + 1] : ""
+        if (VALID_ESCAPE.includes(next)) {
+          out += ch + next
+          i++
+        } else {
+          out += "\\\\"
+        }
+        continue
+      }
+      if (ch === '"') {
+        inStr = false
+        out += ch
+        continue
+      }
+      const code = ch.charCodeAt(0)
+      if (code < 0x20) {
+        if (ch === "\n") out += "\\n"
+        else if (ch === "\r") out += "\\r"
+        else if (ch === "\t") out += "\\t"
+        else out += "\\u" + code.toString(16).padStart(4, "0")
+        continue
+      }
+    } else if (ch === '"') {
+      inStr = true
+    }
+    out += ch
+  }
+
+  try {
+    JSON.parse(out)
+    return out
+  } catch {
+    return undefined
+  }
+}
+
 /** Repair tool name and/or argument keys so AI SDK validation can succeed. */
 export async function repairToolCall(input: RepairToolCallInput): Promise<RepairedToolCall | undefined> {
   const resolvedName = resolveName(input.toolName, input.toolNames)

--- a/packages/opencode/test/util/tool-compat.test.ts
+++ b/packages/opencode/test/util/tool-compat.test.ts
@@ -4,6 +4,7 @@ import {
   canonical,
   normalizeInput,
   repairToolCall,
+  rescueMalformedJson,
   resolveName,
 } from "../../src/util/tool-compat"
 
@@ -184,6 +185,62 @@ describe("util.tool-compat", () => {
       })
 
       expect(repaired).toBeUndefined()
+    })
+  })
+
+  describe("rescueMalformedJson", () => {
+    test("returns undefined for empty input", () => {
+      expect(rescueMalformedJson("")).toBeUndefined()
+      expect(rescueMalformedJson("   ")).toBeUndefined()
+    })
+
+    test("returns undefined for already-valid JSON", () => {
+      expect(rescueMalformedJson('{"key":"value"}')).toBeUndefined()
+      expect(rescueMalformedJson('{"a":1,"b":true}')).toBeUndefined()
+    })
+
+    test("escapes literal newlines inside string values", () => {
+      const raw = '{"new_string":"line1\nline2"}'
+      const result = rescueMalformedJson(raw)
+      expect(result).toBeDefined()
+      const parsed = JSON.parse(result!)
+      expect(parsed.new_string).toBe("line1\nline2")
+    })
+
+    test("escapes literal carriage returns inside string values", () => {
+      const raw = '{"content":"a\r\nb"}'
+      const result = rescueMalformedJson(raw)
+      expect(result).toBeDefined()
+      const parsed = JSON.parse(result!)
+      expect(parsed.content).toContain("a")
+      expect(parsed.content).toContain("b")
+    })
+
+    test("doubles lone backslashes from LaTeX sequences", () => {
+      // \s is not a valid JSON escape char, so \sum triggers a rescue
+      const raw = '{"content":"\\sum_{i=0}^{n}"}'
+      const result = rescueMalformedJson(raw)
+      expect(result).toBeDefined()
+      const parsed = JSON.parse(result!)
+      expect(parsed.content).toContain("sum")
+    })
+
+    test("preserves valid JSON escape sequences untouched", () => {
+      // \\n in source is an already-valid escaped backslash+n — no rescue needed
+      expect(rescueMalformedJson('{"msg":"hello\\nworld"}')).toBeUndefined()
+    })
+
+    test("handles multi-line LaTeX content across several lines", () => {
+      const raw = `{"new_string":"The formula is \\frac{1}{2}\nwhere n is an integer."}`
+      const result = rescueMalformedJson(raw)
+      expect(result).toBeDefined()
+      const parsed = JSON.parse(result!)
+      expect(parsed.new_string).toContain("formula")
+      expect(parsed.new_string).toContain("integer")
+    })
+
+    test("returns undefined for truly unrecoverable JSON", () => {
+      expect(rescueMalformedJson('{"key": unquoted}')).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
### Issue for this PR
Closes #1357

### Type of change
- [x] Bug fix

### What does this PR do?
When a model emits tool call arguments containing literal newlines (e.g. multi-line LaTeX math spanning several lines) or unescaped backslash sequences (`\frac`, `\sum`), `JSON.parse` throws `SyntaxError: Unterminated string`. The `experimental_repairToolCall` handler in `llm.ts` couldn't recover from parse failures — it fell straight through to the `invalid` tool with a generic error the model can't act on.

This PR adds `rescueMalformedJson` to `util/tool-compat.ts`. It scans the raw JSON character-by-character and:
- escapes literal control characters (newlines, carriage returns, tabs) that appeared inside string values
- doubles lone backslashes that aren't valid JSON escape sequences

`experimental_repairToolCall` now tries this rescue before falling back to `invalid`, so the repaired tool call is retried instead of producing a dead-end error.

### How did you verify your code works?
Added unit tests for `rescueMalformedJson` in `test/util/tool-compat.test.ts` covering: empty input, already-valid JSON, literal newlines, carriage returns, lone backslashes, and truly unrecoverable JSON.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR