### PR TITLE
docs: simplify npm README to reduce sync overhead

### DIFF
--- a/README_npm.md
+++ b/README_npm.md
@@ -33,109 +33,21 @@ The first launch guides you through configuration automatically. Supported optio
 - **Import from Claude Code** — migrate existing authentication in one step
 - **Custom Provider** — add any OpenAI-compatible API in the TUI
 
-<details>
-<summary><strong>WSL: clipboard issues</strong></summary>
-
-If you encounter garbled text when copying on WSL, install `xsel`:
-```bash
-sudo apt install xsel
-```
-</details>
-
 ---
 
 ## Core Features
 
-### Multiple Agents
+- **Multiple Agents** — build (default), plan (read-only analysis), compose (specs-driven orchestration); press `Tab` to switch
+- **Persistent Memory** — cross-session project knowledge, checkpoints, and task progress powered by SQLite FTS5
+- **Intelligent Context Management** — automatic checkpoints, context reconstruction, and budgeted injection to stay within model limits
+- **Task Tracking** — tree-shaped task system integrated with the checkpoint system
+- **Subagent System** — parallel subagents with lifecycle tracking, cancellation, and background execution
+- **Goal / Stop Condition** — judge model prevents premature stops during autonomous work
+- **Compose Mode** — structured workflow for specs-driven development with built-in skills
+- **Voice Input** — real-time streaming voice input powered by TenVAD and MiMo ASR
+- **Dream & Distill** — extract knowledge into memory (`/dream`) and discover reusable workflows (`/distill`)
 
-| Agent | Description |
-|--------|------|
-| **build** | Default. Full tool permissions for development |
-| **plan** | Read-only analysis mode for code exploration and solution design |
-| **compose** | Orchestration mode for specs-driven development and skill-driven workflows |
-
-Press `Tab` to switch between primary agents. Subagents are created by the system as needed.
-
-### Persistent Memory
-
-Cross-session memory powered by SQLite FTS5 full-text search:
-
-- **Project memory** (`MEMORY.md`) — persistent project knowledge, rules, and architecture decisions
-- **Session checkpoint** (`checkpoint.md`) — structured state snapshots maintained automatically by the checkpoint-writer subagent
-- **Scratch notes** (`notes.md`) — temporary note area for agents
-- **Task progress** (`tasks/<id>/progress.md`) — per-task logs
-
-Memory is injected automatically when a session resumes, so the agent does not need to relearn project context.
-
-### Intelligent Context Management
-
-- **Automatic checkpoints** — decides when to save session state based on the model context window
-- **Context reconstruction** — when context approaches the limit, rebuilds it from the latest checkpoint, project memory, task progress, and retained recent messages so the agent can continue the current task
-- **Budgeted injection** — uses a token budget to control how much checkpoint, memory, and notes content enters context, with importance ranking
-
-### Task Tracking
-
-A tree-shaped task system (`T1`, `T1.1`, `T1.2`, …) that integrates automatically with the checkpoint system, so task progress is preserved when sessions resume.
-
-### Subagent System
-
-The primary agent can create subagents on demand. Subagents share the current session context and can work in parallel, with lifecycle tracking, cancellation, and background execution.
-
-### Goal / Stop Condition
-
-The `/goal` command sets a stopping condition for a session. When the agent tries to stop, an independent judge model evaluates the conversation to decide whether the condition is truly satisfied — preventing premature "optimistic stops" during autonomous work.
-
-### Compose Mode
-
-Compose mode provides a structured workflow for specs-driven development. It includes built-in skills for planning, execution, code review, TDD, debugging, verification, and merging — orchestrating the full lifecycle from spec to shipped code.
-
-### Voice Input
-
-Real-time streaming voice input powered by TenVAD and MiMo ASR. Activate with `/voice`, then speak — audio is segmented by pauses and transcribed incrementally into the input. Available for MiMo logged-in users. Requires `sox` (`brew install sox` on macOS, other platforms similar).
-
-<details>
-<summary><strong>WSLg audio setup</strong></summary>
-
-```bash
-sudo apt install -y sox pulseaudio libasound2-plugins
-export PULSE_SERVER=unix:/mnt/wslg/PulseServer
-```
-</details>
-
-<details>
-<summary><strong>SSH remote audio (Mac → remote host)</strong></summary>
-
-```bash
-# Mac (local)
-brew install pulseaudio
-pulseaudio --load="module-native-protocol-tcp auth-ip-acl=127.0.0.1" --exit-idle-time=-1 --daemonize
-# Add to ~/.ssh/config: RemoteForward 4713 127.0.0.1:4713
-
-# Remote host
-apt install -y pulseaudio pulseaudio-utils sox
-export PULSE_SERVER=tcp:127.0.0.1:4713
-# Verify: pactl info
-```
-</details>
-
-### Dream & Distill
-
-- **`/dream`** — scans recent session traces, extracts persistent knowledge into project memory, and removes outdated entries
-- **`/distill`** — discovers repeated manual workflows in recent work and packages high-confidence candidates into reusable skills, subagents, or commands
-
----
-
-## Configuration
-
-MiMoCode is configured via `.mimocode/mimocode.json` in the project directory (or `~/.config/mimocode/mimocode.json` globally). Key options include:
-
-- Provider and model selection
-- Agent permissions and custom agents
-- Checkpoint and memory behavior
-- MCP server connections
-- Keybindings and theme
-
-Max Mode (parallel best-of-N reasoning with judge selection) can be enabled via `experimental.maxMode` in the config.
+For detailed documentation, configuration options, and troubleshooting, see the [GitHub repository](https://github.com/XiaomiMiMo/MiMo-Code).
 
 ---
 


### PR DESCRIPTION
## Motivation

The npm README (`README_npm.md`) was duplicating most of the detailed content from the main GitHub README — feature sections, configuration details, troubleshooting guides, etc. This creates an ongoing maintenance burden: every time we update docs (which happens frequently), we need to remember to update both files or they drift apart.

Since npm users naturally navigate to GitHub for full documentation, the npm page only needs to serve as a concise overview that answers "what is this?" and "how do I install it?", then points them to the repo.

npm 的 README 之前几乎复制了 GitHub 主 README 的大部分内容（功能详情、配置说明、排障指南等）。这导致每次更新文档都需要同步两处，容易遗漏导致内容不一致。npm 用户如果需要详细信息自然会去 GitHub 看，所以 npm 页面只需要简洁地告诉用户"这是什么"和"怎么安装"即可。

## Changes

- Replaced expanded Core Features sections (Multiple Agents table, Persistent Memory details, Voice Input with WSLg/SSH setup, etc.) with a single bullet-point list — one line per feature
- Removed Configuration section details (pointing to GitHub instead)
- Removed WSL clipboard troubleshooting from Quick Start
- Added a line linking to the GitHub repository for full docs

将展开的 Core Features 各子章节（Agent 表格、Memory 详情、Voice 的 WSLg/SSH 配置等）替换为简洁的 bullet list，每个功能一行描述。移除了 Configuration 详细说明和 WSL 剪贴板排障内容，改为引导用户去 GitHub 查看完整文档。

## Result

- npm README: 148 lines → ~55 lines
- Future doc updates only need to touch the main README; npm README rarely needs changes
- Users still get a clear feature overview on npm, with easy path to full docs

npm README 从 148 行精简到约 55 行。今后更新文档只需改主 README，npm README 基本不需要频繁变动。用户在 npm 页面仍能快速了解功能概览，详情一键跳转 GitHub。