### PR TITLE
feat: add bash token efficient pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ experiment/last-outcome.json
 
 /mimoapi/
 /packages/opencode/src/ext
+
+# temp
+temp/

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -131,6 +131,21 @@ export const Flag = {
     copy === undefined ? process.platform === "win32" : truthy("MIMOCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"),
   MIMOCODE_ENABLE_EXA: truthy("MIMOCODE_ENABLE_EXA") || MIMOCODE_EXPERIMENTAL || truthy("MIMOCODE_EXPERIMENTAL_EXA"),
   MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: number("MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS"),
+  // Token-efficient post-cleanse: strip ANSI / fold \r progress bars / redact
+  // secrets / elide super-long lines from bash tool output before it is
+  // returned to the model. Only applies when the output fits inline — if the
+  // output spills to a truncation file, cleaning is skipped so the on-disk
+  // archive stays raw. Off by default. Set to 1/true to opt in.
+  MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY: truthy("MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY"),
+  // Tunables for the token-efficient post-cleanse pipeline (see
+  // src/tool/bash_token_efficient_pipeline.ts). Positive integers only;
+  // unset / non-positive values fall back to the documented defaults.
+  //   MAX_LINE_CHARS   threshold above which a single line is elided  (default 500)
+  //   LINE_HEAD_KEEP   chars kept from the head of an elided line     (default 160)
+  //   NEVER_WORSE_MARGIN  bytes the cleaned output must beat the raw  (default 0)
+  MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_MAX_LINE_CHARS: number("MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_MAX_LINE_CHARS") ?? 500,
+  MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_LINE_HEAD_KEEP: number("MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_LINE_HEAD_KEEP") ?? 160,
+  MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_NEVER_WORSE_MARGIN: number("MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_NEVER_WORSE_MARGIN") ?? 0,
   MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX: number("MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX"),
   MIMOCODE_EXPERIMENTAL_OXFMT: MIMOCODE_EXPERIMENTAL || truthy("MIMOCODE_EXPERIMENTAL_OXFMT"),
   MIMOCODE_EXPERIMENTAL_LSP_TY: truthy("MIMOCODE_EXPERIMENTAL_LSP_TY"),

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -22,6 +22,7 @@ import { Effect, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import * as BashInteractive from "./bash-interactive"
+import * as BashTokenEfficient from "./bash_token_efficient_pipeline"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
@@ -568,7 +569,24 @@ export const BashTool = Tool.define(
         file = yield* trunc.write(raw)
       }
 
-      let output = end.text
+      // Token-efficient post-cleanse: RTK-style ANSI strip / progress fold /
+      // secret redact / long-line elide. Only applied when no tool storage is
+      // involved — once the output spills to a truncation file, the on-disk
+      // archive stays raw and cleaning is skipped to keep the inline preview
+      // consistent with the archive.
+      const cleaned =
+        !file && Flag.MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY
+          ? BashTokenEfficient.clean(end.text, { command: input.command })
+          : null
+      if (cleaned && cleaned.bytesOut < cleaned.bytesIn) {
+        log.info("bash output cleaned", {
+          bytesIn: cleaned.bytesIn,
+          bytesOut: cleaned.bytesOut,
+          saved: cleaned.bytesIn - cleaned.bytesOut,
+        })
+      }
+
+      let output = cleaned?.text ?? end.text
       if (!output) output = "(no output)"
 
       if (cut && file) {

--- a/packages/opencode/src/tool/bash_token_efficient_pipeline.ts
+++ b/packages/opencode/src/tool/bash_token_efficient_pipeline.ts
@@ -1,0 +1,189 @@
+// Token-efficient post-cleanse pipeline for bash tool output.
+//
+// Architecture: a Pipeline composed from CleanPlugin instances via a factory.
+// Each plugin is a single pass over the text; `createPipeline` chains them and
+// wraps the chain with a never-worse guard (if the cleaned output isn't
+// strictly shorter than the original, the original is returned unchanged).
+//
+// Default plugin chain — order matters:
+//   progress  fold \r-redrawn lines, keep only the last frame
+//   ansi      strip ANSI CSI/OSC/DCS, backspace overstrike, control bytes
+//   redact    mask Bearer/JWT/PEM/AWS/GH/OpenAI/Anthropic/Slack/KEY=VALUE
+//   longline  collapse lines >MAX_LINE_CHARS to `<…N chars elided…>`
+//
+// progress must precede ansi (CR carries state across ANSI sequences). redact
+// must run before longline so a long secret isn't elided mid-pattern. New
+// filters drop in via:
+//
+//   createPipeline([...defaultPlugins(), myPlugin()]).run(text, { command })
+//
+// This is the extension point used by the heuristic shape plugins (gitdiff /
+// pytest / npm / make / tsc / stacktrace / kubectl / json / md / gostest).
+//
+// Opt-out: `# nofilter` / `# raw` in the command, or env MIMOCODE_BASH_RAW=1.
+//
+// Tunables (positive ints via env; defaults shown):
+//   MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_MAX_LINE_CHARS=500
+//   MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_LINE_HEAD_KEEP=160
+//   MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_NEVER_WORSE_MARGIN=0
+
+import { Flag } from "@/flag/flag"
+
+const MAX_LINE_CHARS = Flag.MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_MAX_LINE_CHARS
+const LINE_HEAD_KEEP = Flag.MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_LINE_HEAD_KEEP
+const NEVER_WORSE_MARGIN = Flag.MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_NEVER_WORSE_MARGIN
+
+const ANSI_CSI = /\x1b\[[0-?]*[ -/]*[@-~]/g
+const ANSI_OSC = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g
+const ANSI_DCS = /\x1b[PX^_][\s\S]*?\x1b\\/g
+const BACKSPACE = /[^\n]\x08/g
+const CTRL_BYTES = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g
+
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  // Bearer / Token <opaque>
+  [/\b(Bearer|Token)\s+[A-Za-z0-9._\-+/=]{16,}/gi, "$1 <redacted>"],
+  // JWT (three base64url segments separated by dots, >=10 chars each)
+  [/\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}/g, "<redacted-jwt>"],
+  // AWS access keys
+  [/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, "<redacted-aws-key>"],
+  // GitHub fine-grained / classic tokens
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, "<redacted-gh-token>"],
+  // OpenAI keys
+  [/\bsk-[A-Za-z0-9_\-]{20,}\b/g, "<redacted-openai-key>"],
+  // Anthropic keys
+  [/\bsk-ant-[A-Za-z0-9_\-]{20,}\b/g, "<redacted-anthropic-key>"],
+  // Slack tokens
+  [/\bxox[abprs]-[A-Za-z0-9\-]{10,}\b/g, "<redacted-slack-token>"],
+  // Generic api/secret/password/token assignments: KEY=VALUE / "key": "value"
+  [
+    /\b((?:api|access|refresh|secret|client|auth)[_-]?(?:key|token|secret|password))(\s*[:=]\s*)["']?[A-Za-z0-9._\-+/=]{12,}["']?/gi,
+    "$1$2<redacted>",
+  ],
+]
+
+// Replace embedded PEM blocks (possibly multi-line) with a single marker.
+const PEM_BLOCK = /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g
+
+const SKIP_MARKERS = ["# nofilter", "# raw"]
+
+export type CleanOptions = {
+  command?: string
+}
+
+export type CleanResult = {
+  text: string
+  bytesIn: number
+  bytesOut: number
+  degraded: boolean
+}
+
+export type CleanPlugin = {
+  name: string
+  apply: (text: string, ctx: CleanOptions) => string
+}
+
+export type CleanPipeline = {
+  plugins: ReadonlyArray<CleanPlugin>
+  run: (text: string, options?: CleanOptions) => CleanResult
+}
+
+function shouldSkip(command: string | undefined): boolean {
+  if (process.env["MIMOCODE_BASH_RAW"] === "1") return true
+  if (!command) return false
+  return SKIP_MARKERS.some((mark) => command.includes(mark))
+}
+
+// L1 — fold \r-redrawn lines. Per line, when carriage returns redraw the same
+// position, only the segment after the LAST `\r` survives — that's the final
+// rendered frame. No-op when the text contains no `\r`.
+export const progressPlugin = (): CleanPlugin => ({
+  name: "progress",
+  apply(text) {
+    if (!text.includes("\r")) return text
+    return text
+      .split("\n")
+      .map((line) => {
+        const stripped = line.endsWith("\r") ? line.slice(0, -1) : line
+        const idx = stripped.lastIndexOf("\r")
+        return idx === -1 ? stripped : stripped.slice(idx + 1)
+      })
+      .join("\n")
+  },
+})
+
+// L0 — strip ANSI escapes (CSI/OSC/DCS), backspace overstrike, control bytes.
+// The backspace `while` loop collapses `x\b` repeatedly: `ab\b\bcd` → `cd`.
+export const ansiPlugin = (): CleanPlugin => ({
+  name: "ansi",
+  apply(text) {
+    let out = text.replace(ANSI_CSI, "").replace(ANSI_OSC, "").replace(ANSI_DCS, "")
+    while (BACKSPACE.test(out)) out = out.replace(BACKSPACE, "")
+    return out.replace(CTRL_BYTES, "")
+  },
+})
+
+// L3 — re-mask common secret shapes. PEM block runs first (single cross-line
+// match), then the per-shape replacements fold in via reduce.
+export const redactPlugin = (): CleanPlugin => ({
+  name: "redact",
+  apply(text) {
+    return REDACT_PATTERNS.reduce(
+      (acc, [pattern, replacement]) => acc.replace(pattern, replacement),
+      text.replace(PEM_BLOCK, "<redacted-pem-block>"),
+    )
+  },
+})
+
+// L4 — long-line elide. Lines longer than MAX_LINE_CHARS keep their head and
+// get a `<elided N chars>` tail marker. Short-circuit when the whole text is
+// already shorter than the threshold.
+export const longLinePlugin = (): CleanPlugin => ({
+  name: "longline",
+  apply(text) {
+    if (text.length <= MAX_LINE_CHARS) return text
+    return text
+      .split("\n")
+      .map((line) => {
+        if (line.length <= MAX_LINE_CHARS) return line
+        return `${line.slice(0, LINE_HEAD_KEEP)}…<elided ${line.length - LINE_HEAD_KEEP} chars>`
+      })
+      .join("\n")
+  },
+})
+
+// Default plugin chain. Returns a fresh array each call so callers can safely
+// splice/extend without mutating shared state.
+export const defaultPlugins = (): CleanPlugin[] => [
+  progressPlugin(),
+  ansiPlugin(),
+  redactPlugin(),
+  longLinePlugin(),
+]
+
+// Pipeline factory. Composes the injected plugins into a runnable pipeline:
+// skip-check → fold plugins via reduce → never-worse guard. The guard runs at
+// the tail because individual plugins may temporarily inflate the text (e.g.
+// short secrets expanding to their `<redacted-*>` marker); only the chain as a
+// whole must shrink.
+export const createPipeline = (plugins: CleanPlugin[] = defaultPlugins()): CleanPipeline => ({
+  plugins,
+  run(text, options = {}) {
+    const bytesIn = Buffer.byteLength(text, "utf-8")
+    if (!text || shouldSkip(options.command)) {
+      return { text, bytesIn, bytesOut: bytesIn, degraded: false }
+    }
+    const out = plugins.reduce((acc, plugin) => plugin.apply(acc, options), text)
+    const bytesOut = Buffer.byteLength(out, "utf-8")
+    if (bytesOut + NEVER_WORSE_MARGIN >= bytesIn) {
+      return { text, bytesIn, bytesOut: bytesIn, degraded: true }
+    }
+    return { text: out, bytesIn, bytesOut, degraded: false }
+  },
+})
+
+const defaultPipeline = createPipeline()
+
+// Public entry point used by the bash tool. Backward-compatible signature.
+export function clean(text: string, options: CleanOptions = {}): CleanResult {
+  return defaultPipeline.run(text, options)
+}

--- a/packages/opencode/test/tool/bash_token_efficient_pipeline.test.ts
+++ b/packages/opencode/test/tool/bash_token_efficient_pipeline.test.ts
@@ -1,0 +1,329 @@
+import { describe, test, expect } from "bun:test"
+import {
+  clean,
+  createPipeline,
+  defaultPlugins,
+  progressPlugin,
+  ansiPlugin,
+  redactPlugin,
+  longLinePlugin,
+  type CleanPlugin,
+} from "../../src/tool/bash_token_efficient_pipeline"
+
+describe("progressPlugin", () => {
+  test("no \\r is a no-op", () => {
+    const text = "line 1\nline 2\nline 3"
+    expect(progressPlugin().apply(text, {})).toBe(text)
+  })
+
+  test("keeps only the last frame after \\r redraws", () => {
+    const text = "10%\r25%\r50%\r100%"
+    expect(progressPlugin().apply(text, {})).toBe("100%")
+  })
+
+  test("strips trailing \\r (CRLF tail)", () => {
+    const text = "hello\r"
+    expect(progressPlugin().apply(text, {})).toBe("hello")
+  })
+
+  test("folds each line independently", () => {
+    const text = "first\rFIRST\nsecond\rSECOND"
+    expect(progressPlugin().apply(text, {})).toBe("FIRST\nSECOND")
+  })
+
+  test("preserves lines without \\r in a mixed body", () => {
+    const text = "intact line\nold\rNEW\nanother intact"
+    expect(progressPlugin().apply(text, {})).toBe("intact line\nNEW\nanother intact")
+  })
+})
+
+describe("ansiPlugin", () => {
+  test("strips CSI color sequences", () => {
+    const text = "\x1b[31merror\x1b[0m message"
+    expect(ansiPlugin().apply(text, {})).toBe("error message")
+  })
+
+  test("strips OSC hyperlinks (BEL terminated)", () => {
+    const text = "before \x1b]8;;https://example.com\x07link\x1b]8;;\x07 after"
+    expect(ansiPlugin().apply(text, {})).toBe("before link after")
+  })
+
+  test("strips DCS sequences spanning multiple chars", () => {
+    const text = "before\x1bPpayload here\x1b\\after"
+    expect(ansiPlugin().apply(text, {})).toBe("beforeafter")
+  })
+
+  test("collapses backspace overstrike iteratively", () => {
+    expect(ansiPlugin().apply("ab\b\bcd", {})).toBe("cd")
+  })
+
+  test("removes other control bytes but preserves \\t \\n \\r", () => {
+    const text = "tab\there\x00\x07\nnext\rline"
+    expect(ansiPlugin().apply(text, {})).toBe("tab\there\nnext\rline")
+  })
+
+  test("clean text passes through unchanged", () => {
+    const text = "plain ascii output\nwith newlines"
+    expect(ansiPlugin().apply(text, {})).toBe(text)
+  })
+})
+
+describe("redactPlugin", () => {
+  test("masks Bearer tokens", () => {
+    const text = "Authorization: Bearer abcdefghijklmnop1234"
+    expect(redactPlugin().apply(text, {})).toBe("Authorization: Bearer <redacted>")
+  })
+
+  test("masks Token credentials", () => {
+    const text = "header: Token deadbeef1234567890abcd"
+    expect(redactPlugin().apply(text, {})).toBe("header: Token <redacted>")
+  })
+
+  test("masks JWT tokens", () => {
+    const text = "auth=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.dBjftJeZ4CVPmB92Sg done"
+    expect(redactPlugin().apply(text, {})).toBe("auth=<redacted-jwt> done")
+  })
+
+  test("masks AWS access keys (AKIA + ASIA)", () => {
+    const text = "key=AKIAIOSFODNN7EXAMPLE temp=ASIAIOSFODNN7EXAMPLE"
+    expect(redactPlugin().apply(text, {})).toBe("key=<redacted-aws-key> temp=<redacted-aws-key>")
+  })
+
+  test("masks GitHub tokens (all prefixes)", () => {
+    const text = "ghp_AAAAAAAAAAAAAAAAAAAAA gho_BBBBBBBBBBBBBBBBBBBBB ghs_CCCCCCCCCCCCCCCCCCCCC"
+    expect(redactPlugin().apply(text, {})).toBe(
+      "<redacted-gh-token> <redacted-gh-token> <redacted-gh-token>",
+    )
+  })
+
+  test("masks OpenAI keys", () => {
+    const text = "OPENAI_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz"
+    expect(redactPlugin().apply(text, {})).toContain("<redacted-openai-key>")
+  })
+
+  test("masks Slack tokens", () => {
+    const text = "SLACK=xoxb-1234567890-abcdefgh"
+    expect(redactPlugin().apply(text, {})).toBe("SLACK=<redacted-slack-token>")
+  })
+
+  test("masks PEM blocks across multiple lines", () => {
+    const text =
+      "header\n-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\nabcdef\n-----END RSA PRIVATE KEY-----\nfooter"
+    expect(redactPlugin().apply(text, {})).toBe("header\n<redacted-pem-block>\nfooter")
+  })
+
+  test("masks generic KEY=VALUE assignments (case insensitive)", () => {
+    const text = 'api_key="0123456789abcdef" SECRET_TOKEN=xyzxyzxyzxyz12'
+    const out = redactPlugin().apply(text, {})
+    expect(out).toContain("api_key=<redacted>")
+    expect(out).toContain("SECRET_TOKEN=<redacted>")
+  })
+
+  test("benign text passes through unchanged", () => {
+    const text = "Hello world\nNo secrets here\nJust regular output"
+    expect(redactPlugin().apply(text, {})).toBe(text)
+  })
+})
+
+describe("longLinePlugin", () => {
+  test("text under threshold passes through unchanged", () => {
+    const text = "short line\nanother short line"
+    expect(longLinePlugin().apply(text, {})).toBe(text)
+  })
+
+  test("elides a single long line preserving the head", () => {
+    const line = "a".repeat(600)
+    const out = longLinePlugin().apply(line, {})
+    expect(out.startsWith("a".repeat(160))).toBe(true)
+    expect(out).toContain("…<elided 440 chars>")
+  })
+
+  test("keeps short lines intact when mixed with one long line", () => {
+    const longLine = "x".repeat(600)
+    const text = `intro\n${longLine}\noutro`
+    const out = longLinePlugin().apply(text, {})
+    const lines = out.split("\n")
+    expect(lines[0]).toBe("intro")
+    expect(lines[2]).toBe("outro")
+    expect(lines[1]).toContain("…<elided 440 chars>")
+  })
+
+  test("threshold boundary: 500 chars stays, 501 chars elided", () => {
+    expect(longLinePlugin().apply("a".repeat(500), {})).toBe("a".repeat(500))
+    const out = longLinePlugin().apply("a".repeat(501), {})
+    expect(out).toContain("<elided 341 chars>")
+  })
+})
+
+describe("createPipeline", () => {
+  test("runs injected plugins in declaration order", () => {
+    const order: string[] = []
+    const tag = (name: string): CleanPlugin => ({
+      name,
+      apply(text) {
+        order.push(name)
+        return text
+      },
+    })
+    createPipeline([tag("first"), tag("second"), tag("third")]).run("hello", { command: "x" })
+    expect(order).toEqual(["first", "second", "third"])
+  })
+
+  test("never-worse guard returns original when chain doesn't shrink", () => {
+    const noop: CleanPlugin = { name: "noop", apply: (t) => t }
+    const result = createPipeline([noop]).run("unchanged content", { command: "x" })
+    expect(result.text).toBe("unchanged content")
+    expect(result.degraded).toBe(true)
+    expect(result.bytesOut).toBe(result.bytesIn)
+  })
+
+  test("never-worse guard reverts even when a plugin inflates output", () => {
+    const inflate: CleanPlugin = { name: "inflate", apply: (t) => t + "PADDING_PADDING" }
+    const result = createPipeline([inflate]).run("seed", { command: "x" })
+    expect(result.text).toBe("seed")
+    expect(result.degraded).toBe(true)
+  })
+
+  test("reports bytesIn / bytesOut when a plugin shrinks the text", () => {
+    const shrink: CleanPlugin = { name: "shrink", apply: (t) => t.replace(/X+/g, "") }
+    const result = createPipeline([shrink]).run("aaXXXXXXbb", { command: "x" })
+    expect(result.text).toBe("aabb")
+    expect(result.bytesIn).toBe(10)
+    expect(result.bytesOut).toBe(4)
+    expect(result.degraded).toBe(false)
+  })
+
+  test("empty input returns empty text without invoking plugins", () => {
+    let called = false
+    const spy: CleanPlugin = {
+      name: "spy",
+      apply(t) {
+        called = true
+        return t
+      },
+    }
+    const result = createPipeline([spy]).run("", { command: "x" })
+    expect(called).toBe(false)
+    expect(result.text).toBe("")
+    expect(result.bytesIn).toBe(0)
+    expect(result.bytesOut).toBe(0)
+    expect(result.degraded).toBe(false)
+  })
+
+  test("'# nofilter' marker bypasses the pipeline", () => {
+    const drop: CleanPlugin = { name: "drop", apply: () => "" }
+    const result = createPipeline([drop]).run("\x1b[31mraw\x1b[0m", {
+      command: "ls -la # nofilter",
+    })
+    expect(result.text).toBe("\x1b[31mraw\x1b[0m")
+    expect(result.degraded).toBe(false)
+  })
+
+  test("'# raw' marker bypasses the pipeline", () => {
+    const drop: CleanPlugin = { name: "drop", apply: () => "" }
+    const result = createPipeline([drop]).run("payload", { command: "ls # raw" })
+    expect(result.text).toBe("payload")
+  })
+
+  test("MIMOCODE_BASH_RAW=1 bypasses the pipeline", () => {
+    const prev = process.env.MIMOCODE_BASH_RAW
+    process.env.MIMOCODE_BASH_RAW = "1"
+    try {
+      const drop: CleanPlugin = { name: "drop", apply: () => "" }
+      const result = createPipeline([drop]).run("payload", { command: "ls" })
+      expect(result.text).toBe("payload")
+    } finally {
+      if (prev === undefined) delete process.env.MIMOCODE_BASH_RAW
+      else process.env.MIMOCODE_BASH_RAW = prev
+    }
+  })
+
+  test("plugins receive the command via ctx", () => {
+    const seen: Array<string | undefined> = []
+    const recorder: CleanPlugin = {
+      name: "rec",
+      apply(text, ctx) {
+        seen.push(ctx.command)
+        return text.slice(0, -1)
+      },
+    }
+    createPipeline([recorder]).run("hello", { command: "echo hi" })
+    expect(seen).toEqual(["echo hi"])
+  })
+
+  test("exposes its plugin list", () => {
+    const pipeline = createPipeline(defaultPlugins())
+    expect(pipeline.plugins.map((p) => p.name)).toEqual(["progress", "ansi", "redact", "longline"])
+  })
+
+  test("empty plugin list runs cleanly (degraded since nothing shrinks)", () => {
+    const result = createPipeline([]).run("hello world", { command: "x" })
+    expect(result.text).toBe("hello world")
+    expect(result.degraded).toBe(true)
+  })
+
+  test("missing options defaults to empty context", () => {
+    const result = createPipeline([{ name: "shrink", apply: (t) => t.replace("X", "") }]).run(
+      "aXb",
+    )
+    expect(result.text).toBe("ab")
+  })
+})
+
+describe("defaultPlugins", () => {
+  test("returns the canonical chain in correct order", () => {
+    expect(defaultPlugins().map((p) => p.name)).toEqual(["progress", "ansi", "redact", "longline"])
+  })
+
+  test("returns a fresh array each call (callers may splice safely)", () => {
+    const a = defaultPlugins()
+    const b = defaultPlugins()
+    expect(a).not.toBe(b)
+    a.push({ name: "extra", apply: (t) => t })
+    expect(defaultPlugins()).toHaveLength(4)
+  })
+})
+
+describe("clean (default pipeline)", () => {
+  test("end-to-end: ANSI + progress + secret + long line all cleaned", () => {
+    const longTail = "z".repeat(600)
+    const dirty =
+      "10%\r50%\r\x1b[32m100% done\x1b[0m\n" +
+      "Bearer abcdefghijklmnopqrstuv\n" +
+      `payload: ${longTail}`
+    const result = clean(dirty, { command: "build" })
+    expect(result.text).toContain("100% done")
+    expect(result.text).not.toContain("10%")
+    expect(result.text).not.toContain("\x1b[")
+    expect(result.text).toContain("Bearer <redacted>")
+    expect(result.text).toContain("…<elided")
+    expect(result.bytesOut).toBeLessThan(result.bytesIn)
+    expect(result.degraded).toBe(false)
+  })
+
+  test("clean output (no noise, no secrets) triggers never-worse and returns original", () => {
+    const text = "ok\nresult: 42\n"
+    const result = clean(text, { command: "echo ok" })
+    expect(result.text).toBe(text)
+    expect(result.degraded).toBe(true)
+    expect(result.bytesOut).toBe(result.bytesIn)
+  })
+
+  test("undefined command still runs cleaning", () => {
+    const dirty = "\x1b[31mred\x1b[0m text here"
+    const result = clean(dirty)
+    expect(result.text).toBe("red text here")
+  })
+
+  test("composition: user plugin can be appended after defaults", () => {
+    const stripBanner: CleanPlugin = {
+      name: "strip-banner",
+      apply: (t) => t.replace(/^=+ START =+\n/, ""),
+    }
+    const pipeline = createPipeline([...defaultPlugins(), stripBanner])
+    const input = "=== START ===\n" + "\x1b[31m" + "payload line\n".repeat(5) + "\x1b[0m"
+    const result = pipeline.run(input, { command: "x" })
+    expect(result.text.startsWith("=== START ===")).toBe(false)
+    expect(result.text).not.toContain("\x1b[")
+  })
+})


### PR DESCRIPTION
## Summary
- Add bash token efficient pipeline implementation for optimizing token usage in bash tool execution
- Add corresponding test coverage for the new pipeline

## Changes
- `packages/opencode/src/tool/bash_token_efficient_pipeline.ts` - New token efficient pipeline implementation
- `packages/opencode/test/tool/bash_token_efficient_pipeline.test.ts` - Test coverage for the pipeline
- `packages/opencode/src/tool/bash.ts` - Integration with existing bash tool
- `packages/opencode/src/flag/flag.ts` - Feature flag for the pipeline
- `.gitignore` - Updated ignore patterns

## Test plan
- [ ] Run existing bash tool tests to ensure no regressions
- [ ] Verify new pipeline tests pass
- [ ] Manual testing of bash tool with pipeline enabled/disabled