### PR TITLE
fix: replace ngram frequency detection with consecutive-block repeat detection

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -69,10 +69,10 @@ export const Flag = {
   MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT: number("MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT") ?? 2,
   MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT: number("MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT") ?? 2,
 
-  // Sliding-window n-gram repetition detection for streamed reasoning + text.
-  // An n-gram of size N appearing REPEAT_THRESHOLD times within the last
-  // WINDOW_TOKENS tokens triggers recovery (remind → replan → terminate).
-  MIMOCODE_TEXT_NGRAM_N: number("MIMOCODE_TEXT_NGRAM_N") ?? 6,
+  // Consecutive-block repetition detection for streamed reasoning + text.
+  // A block of at least N tokens repeating REPEAT_THRESHOLD times consecutively
+  // within the last WINDOW_TOKENS tokens triggers recovery (remind → replan → terminate).
+  MIMOCODE_TEXT_NGRAM_N: number("MIMOCODE_TEXT_NGRAM_N") ?? 20,
   MIMOCODE_TEXT_REPEAT_THRESHOLD: number("MIMOCODE_TEXT_REPEAT_THRESHOLD") ?? 3,
   MIMOCODE_TEXT_WINDOW_TOKENS: number("MIMOCODE_TEXT_WINDOW_TOKENS") ?? 500,
 

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -72,8 +72,8 @@ export const Flag = {
   // Consecutive-block repetition detection for streamed reasoning + text.
   // A block of at least N tokens repeating REPEAT_THRESHOLD times consecutively
   // within the last WINDOW_TOKENS tokens triggers recovery (remind → replan → terminate).
-  MIMOCODE_TEXT_NGRAM_N: number("MIMOCODE_TEXT_NGRAM_N") ?? 20,
-  MIMOCODE_TEXT_REPEAT_THRESHOLD: number("MIMOCODE_TEXT_REPEAT_THRESHOLD") ?? 3,
+  MIMOCODE_TEXT_NGRAM_N: number("MIMOCODE_TEXT_NGRAM_N") ?? 4,
+  MIMOCODE_TEXT_REPEAT_THRESHOLD: number("MIMOCODE_TEXT_REPEAT_THRESHOLD") ?? 20,
   MIMOCODE_TEXT_WINDOW_TOKENS: number("MIMOCODE_TEXT_WINDOW_TOKENS") ?? 500,
 
   // Caps applied to image attachments before a prompt is sent. Both default to

--- a/packages/opencode/src/session/prompt/text-ngram-detection.ts
+++ b/packages/opencode/src/session/prompt/text-ngram-detection.ts
@@ -23,6 +23,33 @@ export function detectRepeatedNgram(tokens: readonly string[], n: number, thresh
   return false
 }
 
+export function detectConsecutiveRepeat(
+  tokens: readonly string[],
+  minBlockSize: number,
+  threshold: number,
+  minDistinct: number = 3,
+): boolean {
+  if (threshold < 2 || tokens.length < minBlockSize * threshold) return false
+  const maxPeriod = Math.floor(tokens.length / threshold)
+  for (let p = minBlockSize; p <= maxPeriod; p++) {
+    let run = 0
+    for (let i = 0; i <= tokens.length - p - 1; i++) {
+      if (tokens[i] === tokens[i + p]) {
+        run++
+        if (run >= p * (threshold - 1)) {
+          const blockStart = i - run + 1
+          const distinct = new Set(tokens.slice(blockStart, blockStart + p)).size
+          if (distinct >= minDistinct) return true
+          run = 0
+        }
+      } else {
+        run = 0
+      }
+    }
+  }
+  return false
+}
+
 export class TextNgramMonitor {
   private buffer = ""
   private tokens: string[] = []
@@ -31,6 +58,7 @@ export class TextNgramMonitor {
     private readonly n: number,
     private readonly threshold: number,
     private readonly windowTokens: number,
+    private readonly minDistinct: number = 3,
   ) {}
 
   append(text: string): boolean {
@@ -39,7 +67,7 @@ export class TextNgramMonitor {
     const all = tokenizeForNgram(this.buffer)
     this.tokens = all.length > this.windowTokens ? all.slice(-this.windowTokens) : all
     if (all.length > this.windowTokens * 2) this.buffer = this.tokens.join(" ")
-    return detectRepeatedNgram(this.tokens, this.n, this.threshold)
+    return detectConsecutiveRepeat(this.tokens, this.n, this.threshold, this.minDistinct)
   }
 
   reset() {

--- a/packages/opencode/src/session/prompt/text-ngram-detection.ts
+++ b/packages/opencode/src/session/prompt/text-ngram-detection.ts
@@ -6,7 +6,7 @@ export function tokenizeForNgram(text: string): string[] {
   return text
     .toLowerCase()
     .replace(/\s+/g, " ")
-    .replace(/([　-〿㐀-䶿一-鿿豈-﫿＀-￯])/g, " $1 ")
+    .replace(/([　-ヿ㐀-䶿一-鿿豈-﫿＀-￯])/g, " $1 ")
     .trim()
     .split(" ")
     .filter(Boolean)

--- a/packages/opencode/src/session/prompt/text-ngram-detection.ts
+++ b/packages/opencode/src/session/prompt/text-ngram-detection.ts
@@ -6,6 +6,7 @@ export function tokenizeForNgram(text: string): string[] {
   return text
     .toLowerCase()
     .replace(/\s+/g, " ")
+    .replace(/([　-〿㐀-䶿一-鿿豈-﫿＀-￯])/g, " $1 ")
     .trim()
     .split(" ")
     .filter(Boolean)

--- a/packages/opencode/test/session/text-ngram-detection.test.ts
+++ b/packages/opencode/test/session/text-ngram-detection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   TextNgramMonitor,
+  detectConsecutiveRepeat,
   detectRepeatedNgram,
   tokenizeForNgram,
 } from "../../src/session/prompt/text-ngram-detection"
@@ -11,7 +12,7 @@ describe("tokenizeForNgram", () => {
   })
 })
 
-describe("detectRepeatedNgram", () => {
+describe("detectRepeatedNgram (legacy)", () => {
   test("returns false when window is too small", () => {
     expect(detectRepeatedNgram(["a", "b", "c"], 6, 3)).toBe(false)
   })
@@ -29,18 +30,107 @@ describe("detectRepeatedNgram", () => {
   })
 })
 
+describe("detectConsecutiveRepeat", () => {
+  test("returns false when tokens are too few", () => {
+    expect(detectConsecutiveRepeat(["a", "b", "c"], 20, 3)).toBe(false)
+  })
+
+  test("detects 20-token block repeated 3 times consecutively", () => {
+    const block = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty".split(" ")
+    const tokens = [...block, ...block, ...block]
+    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(true)
+  })
+
+  test("detects longer block repeated consecutively", () => {
+    const block = "the model is stuck in a loop and keeps repeating itself over and over again without making any progress on the task".split(" ")
+    const tokens = [...block, ...block, ...block]
+    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(true)
+  })
+
+  test("returns false when same block appears only twice", () => {
+    const block = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty".split(" ")
+    const tokens = [...block, ...block]
+    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+  })
+
+  test("returns false for markdown table with repeated column values", () => {
+    const table = `| field1 | string | required | - |
+| field2 | string | required | - |
+| field3 | string | required | - |
+| field4 | string | required | - |
+| field5 | string | required | - |
+| field6 | string | required | - |
+| field7 | string | required | - |
+| field8 | string | required | - |`
+    const tokens = tokenizeForNgram(table)
+    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+  })
+
+  test("returns false for Yes/No feature comparison table", () => {
+    const table = `| feature1 | Yes | No | Yes |
+| feature2 | Yes | No | Yes |
+| feature3 | Yes | No | Yes |
+| feature4 | Yes | No | Yes |
+| feature5 | Yes | No | Yes |
+| feature6 | Yes | No | Yes |
+| feature7 | Yes | No | Yes |
+| feature8 | Yes | No | Yes |`
+    const tokens = tokenizeForNgram(table)
+    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+  })
+
+  test("returns false for API docs table with repeated descriptions", () => {
+    const table = `| userId | string | The unique identifier for the user |
+| teamId | string | The unique identifier for the team |
+| orgId | string | The unique identifier for the org |
+| roleId | string | The unique identifier for the role |
+| groupId | string | The unique identifier for the group |
+| tokenId | string | The unique identifier for the token |
+| sessionId | string | The unique identifier for the session |
+| accountId | string | The unique identifier for the account |`
+    const tokens = tokenizeForNgram(table)
+    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+  })
+
+  test("returns false for low-distinct repetition (single token repeated)", () => {
+    // e.g. "1 1 1 1 1 ..." — only 1 distinct token
+    const tokens = Array(60).fill("1")
+    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+  })
+
+  test("returns false for low-distinct repetition (two tokens alternating)", () => {
+    // e.g. "| --- | --- | --- ..." — only 2 distinct tokens
+    const tokens: string[] = []
+    for (let i = 0; i < 30; i++) tokens.push("|", "---")
+    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+  })
+
+  test("detects real loop: same sentence repeated back-to-back", () => {
+    const sentence = "let me try a different approach to fix this issue in the codebase right now and see what happens with the new changes "
+    const tokens = tokenizeForNgram(sentence + sentence + sentence)
+    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(true)
+  })
+
+  test("returns false for non-consecutive repetition with varying content between", () => {
+    const tokens = tokenizeForNgram(
+      "I am the wind that blows through the valley at dawn, I am the flower that blooms in the garden of spring, I am the moon that shines over the mountains at night, I am the sun that rises above the endless horizon",
+    )
+    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+  })
+})
+
 describe("TextNgramMonitor", () => {
   test("detects repetition across incremental appends", () => {
-    const monitor = new TextNgramMonitor(6, 3, 500)
-    const chunk = "one two three four five six "
+    const monitor = new TextNgramMonitor(20, 3, 500)
+    const chunk = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty "
     expect(monitor.append(chunk)).toBe(false)
     expect(monitor.append(chunk)).toBe(false)
     expect(monitor.append(chunk)).toBe(true)
   })
 
   test("reset clears prior repetition state", () => {
-    const monitor = new TextNgramMonitor(6, 3, 500)
-    const chunk = "one two three four five six "
+    const monitor = new TextNgramMonitor(20, 3, 500)
+    const chunk = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty "
     monitor.append(chunk)
     monitor.append(chunk)
     monitor.append(chunk)
@@ -48,15 +138,27 @@ describe("TextNgramMonitor", () => {
     expect(monitor.append(chunk)).toBe(false)
   })
 
-  test("respects sliding window token limit", () => {
-    const monitor = new TextNgramMonitor(3, 3, 10)
-    const filler = Array.from({ length: 10 }, (_, i) => `f${i}`).join(" ") + " "
-    const repeated = "alpha beta gamma "
-    expect(monitor.append(filler + repeated + repeated + repeated)).toBe(true)
-    monitor.reset()
-    monitor.append(filler)
-    expect(monitor.append(repeated)).toBe(false)
-    expect(monitor.append(repeated)).toBe(false)
-    expect(monitor.append(repeated)).toBe(true)
+  test("does not trigger on markdown tables", () => {
+    const monitor = new TextNgramMonitor(20, 3, 500)
+    const table = `| name | string | required | The name of the user |
+| email | string | required | The email of the user |
+| phone | string | required | The phone of the user |
+| address | string | required | The address of the user |
+| city | string | required | The city of the user |
+| country | string | required | The country of the user |
+| zipcode | string | required | The zipcode of the user |
+| state | string | required | The state of the user |`
+    expect(monitor.append(table)).toBe(false)
+  })
+
+  test("does not trigger on single-token repetition", () => {
+    const monitor = new TextNgramMonitor(20, 3, 500)
+    expect(monitor.append(Array(100).fill("1").join(" "))).toBe(false)
+  })
+
+  test("triggers on real model loop", () => {
+    const monitor = new TextNgramMonitor(20, 3, 500)
+    const stuck = "I will help you fix this bug in the codebase by checking the implementation and running all the tests to verify correctness "
+    expect(monitor.append(stuck + stuck + stuck)).toBe(true)
   })
 })

--- a/packages/opencode/test/session/text-ngram-detection.test.ts
+++ b/packages/opencode/test/session/text-ngram-detection.test.ts
@@ -10,6 +10,14 @@ describe("tokenizeForNgram", () => {
   test("normalizes whitespace and case", () => {
     expect(tokenizeForNgram("  Hello   WORLD  ")).toEqual(["hello", "world"])
   })
+
+  test("splits CJK characters individually", () => {
+    expect(tokenizeForNgram("你好世界")).toEqual(["你", "好", "世", "界"])
+  })
+
+  test("handles mixed CJK and English", () => {
+    expect(tokenizeForNgram("hello 你好 world")).toEqual(["hello", "你", "好", "world"])
+  })
 })
 
 describe("detectRepeatedNgram (legacy)", () => {
@@ -32,25 +40,21 @@ describe("detectRepeatedNgram (legacy)", () => {
 
 describe("detectConsecutiveRepeat", () => {
   test("returns false when tokens are too few", () => {
-    expect(detectConsecutiveRepeat(["a", "b", "c"], 20, 3)).toBe(false)
+    expect(detectConsecutiveRepeat(["a", "b", "c"], 4, 20)).toBe(false)
   })
 
-  test("detects 20-token block repeated 3 times consecutively", () => {
-    const block = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty".split(" ")
-    const tokens = [...block, ...block, ...block]
-    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(true)
+  test("detects block repeated 20 times consecutively", () => {
+    const block = ["one", "two", "three", "four", "five", "six"]
+    const tokens: string[] = []
+    for (let i = 0; i < 20; i++) tokens.push(...block)
+    expect(detectConsecutiveRepeat(tokens, 4, 20)).toBe(true)
   })
 
-  test("detects longer block repeated consecutively", () => {
-    const block = "the model is stuck in a loop and keeps repeating itself over and over again without making any progress on the task".split(" ")
-    const tokens = [...block, ...block, ...block]
-    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(true)
-  })
-
-  test("returns false when same block appears only twice", () => {
-    const block = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty".split(" ")
-    const tokens = [...block, ...block]
-    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+  test("returns false when same block appears only 19 times", () => {
+    const block = ["one", "two", "three", "four", "five", "six"]
+    const tokens: string[] = []
+    for (let i = 0; i < 19; i++) tokens.push(...block)
+    expect(detectConsecutiveRepeat(tokens, 4, 20)).toBe(false)
   })
 
   test("returns false for markdown table with repeated column values", () => {
@@ -63,7 +67,7 @@ describe("detectConsecutiveRepeat", () => {
 | field7 | string | required | - |
 | field8 | string | required | - |`
     const tokens = tokenizeForNgram(table)
-    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+    expect(detectConsecutiveRepeat(tokens, 4, 20)).toBe(false)
   })
 
   test("returns false for Yes/No feature comparison table", () => {
@@ -76,70 +80,67 @@ describe("detectConsecutiveRepeat", () => {
 | feature7 | Yes | No | Yes |
 | feature8 | Yes | No | Yes |`
     const tokens = tokenizeForNgram(table)
-    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
-  })
-
-  test("returns false for API docs table with repeated descriptions", () => {
-    const table = `| userId | string | The unique identifier for the user |
-| teamId | string | The unique identifier for the team |
-| orgId | string | The unique identifier for the org |
-| roleId | string | The unique identifier for the role |
-| groupId | string | The unique identifier for the group |
-| tokenId | string | The unique identifier for the token |
-| sessionId | string | The unique identifier for the session |
-| accountId | string | The unique identifier for the account |`
-    const tokens = tokenizeForNgram(table)
-    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+    expect(detectConsecutiveRepeat(tokens, 4, 20)).toBe(false)
   })
 
   test("returns false for low-distinct repetition (single token repeated)", () => {
-    // e.g. "1 1 1 1 1 ..." — only 1 distinct token
-    const tokens = Array(60).fill("1")
-    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+    const tokens = Array(200).fill("1")
+    expect(detectConsecutiveRepeat(tokens, 4, 20)).toBe(false)
   })
 
   test("returns false for low-distinct repetition (two tokens alternating)", () => {
-    // e.g. "| --- | --- | --- ..." — only 2 distinct tokens
     const tokens: string[] = []
-    for (let i = 0; i < 30; i++) tokens.push("|", "---")
-    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+    for (let i = 0; i < 100; i++) tokens.push("|", "---")
+    expect(detectConsecutiveRepeat(tokens, 4, 20)).toBe(false)
   })
 
-  test("detects real loop: same sentence repeated back-to-back", () => {
-    const sentence = "let me try a different approach to fix this issue in the codebase right now and see what happens with the new changes "
-    const tokens = tokenizeForNgram(sentence + sentence + sentence)
-    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(true)
+  test("detects CJK repetition: same phrase repeated 20 times", () => {
+    // "你好我的用户" repeated 20 times
+    const text = "你好我的用户".repeat(20)
+    const tokens = tokenizeForNgram(text)
+    expect(detectConsecutiveRepeat(tokens, 4, 20)).toBe(true)
+  })
+
+  test("does not trigger CJK with only 10 repetitions", () => {
+    const text = "你好我的用户".repeat(10)
+    const tokens = tokenizeForNgram(text)
+    expect(detectConsecutiveRepeat(tokens, 4, 20)).toBe(false)
+  })
+
+  test("detects real English loop repeated 20 times", () => {
+    const sentence = "let me try again "
+    const tokens = tokenizeForNgram(sentence.repeat(20))
+    expect(detectConsecutiveRepeat(tokens, 4, 20)).toBe(true)
   })
 
   test("returns false for non-consecutive repetition with varying content between", () => {
     const tokens = tokenizeForNgram(
       "I am the wind that blows through the valley at dawn, I am the flower that blooms in the garden of spring, I am the moon that shines over the mountains at night, I am the sun that rises above the endless horizon",
     )
-    expect(detectConsecutiveRepeat(tokens, 20, 3)).toBe(false)
+    expect(detectConsecutiveRepeat(tokens, 4, 20)).toBe(false)
   })
 })
 
 describe("TextNgramMonitor", () => {
   test("detects repetition across incremental appends", () => {
-    const monitor = new TextNgramMonitor(20, 3, 500)
-    const chunk = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty "
-    expect(monitor.append(chunk)).toBe(false)
-    expect(monitor.append(chunk)).toBe(false)
+    const monitor = new TextNgramMonitor(4, 20, 500)
+    const chunk = "one two three four five six "
+    for (let i = 0; i < 19; i++) {
+      expect(monitor.append(chunk)).toBe(false)
+    }
     expect(monitor.append(chunk)).toBe(true)
   })
 
   test("reset clears prior repetition state", () => {
-    const monitor = new TextNgramMonitor(20, 3, 500)
-    const chunk = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty "
-    monitor.append(chunk)
-    monitor.append(chunk)
-    monitor.append(chunk)
+    const monitor = new TextNgramMonitor(4, 20, 500)
+    const chunk = "one two three four five six "
+    for (let i = 0; i < 20; i++) monitor.append(chunk)
     monitor.reset()
     expect(monitor.append(chunk)).toBe(false)
   })
 
   test("does not trigger on markdown tables", () => {
-    const monitor = new TextNgramMonitor(20, 3, 500)
+    const monitor = new TextNgramMonitor(4, 20, 500)
     const table = `| name | string | required | The name of the user |
 | email | string | required | The email of the user |
 | phone | string | required | The phone of the user |
@@ -152,13 +153,17 @@ describe("TextNgramMonitor", () => {
   })
 
   test("does not trigger on single-token repetition", () => {
-    const monitor = new TextNgramMonitor(20, 3, 500)
-    expect(monitor.append(Array(100).fill("1").join(" "))).toBe(false)
+    const monitor = new TextNgramMonitor(4, 20, 500)
+    expect(monitor.append(Array(200).fill("1").join(" "))).toBe(false)
   })
 
-  test("triggers on real model loop", () => {
-    const monitor = new TextNgramMonitor(20, 3, 500)
-    const stuck = "I will help you fix this bug in the codebase by checking the implementation and running all the tests to verify correctness "
-    expect(monitor.append(stuck + stuck + stuck)).toBe(true)
+  test("detects CJK model loop", () => {
+    const monitor = new TextNgramMonitor(4, 20, 500)
+    expect(monitor.append("你好我的用户".repeat(20))).toBe(true)
+  })
+
+  test("detects English model loop", () => {
+    const monitor = new TextNgramMonitor(4, 20, 500)
+    expect(monitor.append("I will fix this bug ".repeat(20))).toBe(true)
   })
 })


### PR DESCRIPTION
## Problem

The existing sliding-window n-gram frequency detector triggers false positives on structured content:
- Markdown tables: `|` tokens inflate n-gram matches, causing 3-row tables with repeated column values (e.g. `string`, `required`) to trigger
- CJK text: space-based tokenizer treats entire Chinese sentences as a single token, making repetition undetectable

## Solution

Replace the n-gram frequency counter with consecutive-block repeat detection:
- **Algorithm change**: instead of counting how many times a token sequence appears *anywhere* in the window, detect whether a block repeats *contiguously* (back-to-back). Real model loops are always contiguous; structural repetition is interleaved with varying content.
- **CJK tokenization**: split CJK characters individually so Chinese/Japanese repetition is detected
- **distinctN filter**: require ≥3 distinct tokens in the repeating block to filter out low-diversity patterns (numbers, table separators)
- **Threshold = 20**: require 20 consecutive repetitions before triggering (conservative to avoid false positives)

## Parameters

| Flag | Old | New |
|------|-----|-----|
| MIMOCODE_TEXT_NGRAM_N (minBlockSize) | 6 | 4 |
| MIMOCODE_TEXT_REPEAT_THRESHOLD | 3 | 20 |
| minDistinct | - | 3 (new) |