### PR TITLE
fix(actor): scope forkContext by session to prevent cross-session collisions

### DIFF
--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -176,7 +176,7 @@ export interface SpawnResult {
 export interface Interface {
   readonly spawn: (input: SpawnInput) => Effect.Effect<SpawnResult>
   readonly cancel: (sessionID: SessionID, actorID: string, mode: "graceful" | "forced") => Effect.Effect<void>
-  readonly getForkContext: (actorID: string) => Effect.Effect<ForkContext | undefined>
+  readonly getForkContext: (sessionID: SessionID, actorID: string) => Effect.Effect<ForkContext | undefined>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Actor") {}
@@ -198,7 +198,14 @@ export const layer = Layer.effect(
     // ForkContext snapshot per actor, captured at spawn for fork agents
     // (contextMode = "full"). Read by fork's runLoop (see prompt.ts) and
     // cleared on terminal status. Fiber tracking moved to SessionRunState.
+    //
+    // Keyed by (sessionID, actorID) rather than actorID alone: actorID is only
+    // unique within a (sessionID, agentType) scope (see
+    // ActorRegistry.allocateActorID), so two concurrent sessions spawning the
+    // same agentType can allocate the same actorID. A bare actorID key would
+    // let one session's forkContext clobber or be deleted by another's.
     const forkContexts = new Map<string, ForkContext>()
+    const forkContextKey = (sessionID: SessionID, actorID: string) => `${sessionID}:${actorID}`
 
     // Real agent loop: marks the actor running, then drives a SessionPrompt.prompt
     // turn. The user message persisted by SessionPrompt carries the actor's
@@ -574,7 +581,7 @@ export const layer = Layer.effect(
                   lastFinalText = newTurn.finalText
                 }
 
-                yield* Effect.sync(() => forkContexts.delete(input.actorID))
+                yield* Effect.sync(() => forkContexts.delete(forkContextKey(input.sessionID, input.actorID)))
               }),
             onFailure: (cause) =>
               Effect.gen(function* () {
@@ -585,7 +592,7 @@ export const layer = Layer.effect(
                   outcome,
                   cancelled ? { status: "cancelled" as const } : { status: "failure" as const, error },
                 )
-                yield* Effect.sync(() => forkContexts.delete(input.actorID))
+                yield* Effect.sync(() => forkContexts.delete(forkContextKey(input.sessionID, input.actorID)))
               }),
           }),
         )
@@ -613,7 +620,7 @@ export const layer = Layer.effect(
         tools: input.tools,
       })
       if (input.forkContext) {
-        forkContexts.set(child.id, input.forkContext) // peer's actorID === child.id
+        forkContexts.set(forkContextKey(child.id, child.id), input.forkContext) // peer's actorID === child.id === sessionID
       }
       const { fiber, outcome } = yield* forkWork({
         sessionID: child.id,
@@ -658,7 +665,7 @@ export const layer = Layer.effect(
       if (input.onActorID) yield* Effect.sync(() => input.onActorID!(actorID)).pipe(Effect.ignore)
 
       if (input.forkContext) {
-        forkContexts.set(actorID, input.forkContext)
+        forkContexts.set(forkContextKey(input.sessionID, actorID), input.forkContext)
       }
 
       // Auto-inject return-format instruction for non-specialized subagents.
@@ -706,11 +713,11 @@ export const layer = Layer.effect(
         yield* actorReg
           .updateStatus(sessionID, actorID, { status: "idle", lastOutcome: "cancelled" })
           .pipe(Effect.ignore)
-        yield* Effect.sync(() => forkContexts.delete(actorID))
+        yield* Effect.sync(() => forkContexts.delete(forkContextKey(sessionID, actorID)))
       })
 
-    const getForkContext = Effect.fn("Actor.getForkContext")(function* (actorID: string) {
-      return forkContexts.get(actorID)
+    const getForkContext = Effect.fn("Actor.getForkContext")(function* (sessionID: SessionID, actorID: string) {
+      return forkContexts.get(forkContextKey(sessionID, actorID))
     })
 
     const impl = Service.of({ spawn, cancel, getForkContext })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2927,7 +2927,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // If forkCtx is missing (race / cleanup bug / spawn skipped), fail the
             // actor so the next prune turn can spawn a fresh fork.
             if (isForkAgent) {
-              const forkCtxEffect = spawnRef.current?.getForkContext(lastUser.agentID!)
+              const forkCtxEffect = spawnRef.current?.getForkContext(sessionID, lastUser.agentID!)
               const forkCtx = forkCtxEffect ? yield* forkCtxEffect : undefined
               if (!forkCtx) {
                 yield* slog.warn("fork agent runLoop: missing forkContext, failing actor", {

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -637,7 +637,7 @@ describe("Actor forkContext lifecycle", () => {
         })
 
         // Before cancel: forkContext must be present.
-        const before = yield* actor.getForkContext(result.actorID)
+        const before = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(before).toBeDefined()
         expect(before?.system).toEqual(["test-system"])
 
@@ -645,8 +645,92 @@ describe("Actor forkContext lifecycle", () => {
         yield* actor.cancel(result.sessionID, result.actorID, "forced")
 
         // After cancel: forkContext must be gone.
-        const after = yield* actor.getForkContext(result.actorID)
+        const after = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(after).toBeUndefined()
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  it.live("forkContext does not leak across sessions that allocate the same actorID", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+
+        // Two independent sessions. allocateActorID scopes its incrementing
+        // suffix by (sessionID, agentType), so the first "explore" subagent
+        // spawned in each session below is expected to collide on the same
+        // actorID (e.g. "explore-1") even though the sessions are unrelated.
+        const sessionA = yield* session.create({
+          title: "forkCtx cross-session A",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const sessionB = yield* session.create({
+          title: "forkCtx cross-session B",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        // Hang the LLM so both fibers stay alive while we verify state.
+        yield* llm.hang
+
+        const forkCtxA = {
+          system: ["session-a"],
+          tools: {},
+          inheritedMessages: [],
+          parentPermission: [],
+          watermarkMsgID: MessageID.ascending(),
+          model: ref,
+        }
+        const forkCtxB = {
+          system: ["session-b"],
+          tools: {},
+          inheritedMessages: [],
+          parentPermission: [],
+          watermarkMsgID: MessageID.ascending(),
+          model: ref,
+        }
+
+        const resultA = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: sessionA.id,
+          agentType: "explore",
+          task: "noop",
+          context: "none",
+          tools: [],
+          background: true,
+          model: ref,
+          forkContext: forkCtxA,
+        })
+        const resultB = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: sessionB.id,
+          agentType: "explore",
+          task: "noop",
+          context: "none",
+          tools: [],
+          background: true,
+          model: ref,
+          forkContext: forkCtxB,
+        })
+
+        // Confirms the collision precondition: both sessions allocated the
+        // same locally-scoped actorID.
+        expect(resultA.actorID).toBe(resultB.actorID)
+
+        // Each session must read back its own forkContext, not the other's.
+        const ctxA = yield* actor.getForkContext(sessionA.id, resultA.actorID)
+        const ctxB = yield* actor.getForkContext(sessionB.id, resultB.actorID)
+        expect(ctxA?.system).toEqual(["session-a"])
+        expect(ctxB?.system).toEqual(["session-b"])
+
+        yield* actor.cancel(sessionA.id, resultA.actorID, "forced")
+
+        // Cancelling session A's actor must not clear session B's forkContext.
+        const ctxBAfterCancelA = yield* actor.getForkContext(sessionB.id, resultB.actorID)
+        expect(ctxBAfterCancelA?.system).toEqual(["session-b"])
+
+        yield* actor.cancel(sessionB.id, resultB.actorID, "forced")
       }),
       { git: true, config: providerCfg },
     ),
@@ -688,7 +772,7 @@ describe("mode × contextMode matrix", () => {
           forkContext: fakeForkCtx,
         })
 
-        const ctx = yield* actor.getForkContext(result.actorID)
+        const ctx = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(ctx).toBeDefined()
         expect(ctx?.system).toEqual(["test-system"])
 
@@ -723,7 +807,7 @@ describe("mode × contextMode matrix", () => {
           // no forkContext
         })
 
-        const ctx = yield* actor.getForkContext(result.actorID)
+        const ctx = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(ctx).toBeUndefined()
 
         yield* actor.cancel(result.sessionID, result.actorID, "forced")
@@ -759,7 +843,7 @@ describe("mode × contextMode matrix", () => {
 
         // For peer, result.actorID === child.id (the new session id)
         expect(result.actorID).not.toBe(parent.id)
-        const ctx = yield* actor.getForkContext(result.actorID)
+        const ctx = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(ctx).toBeDefined()
         expect(ctx?.system).toEqual(["test-system"])
 
@@ -794,7 +878,7 @@ describe("mode × contextMode matrix", () => {
           // no forkContext
         })
 
-        const ctx = yield* actor.getForkContext(result.actorID)
+        const ctx = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(ctx).toBeUndefined()
 
         yield* actor.cancel(result.sessionID, result.actorID, "forced")

--- a/packages/opencode/test/inbox/fork-agent-compat.test.ts
+++ b/packages/opencode/test/inbox/fork-agent-compat.test.ts
@@ -312,7 +312,7 @@ describe("Fork-agent inbox compat (Plan 4 / Task 5)", () => {
         const forkActorID = result.actorID
 
         // Tier 2 — structural: capture forkContext BEFORE inbox send.
-        const forkCtxBefore = yield* actor.getForkContext(forkActorID)
+        const forkCtxBefore = yield* actor.getForkContext(result.sessionID, forkActorID)
         expect(forkCtxBefore).toBeDefined()
         expect(forkCtxBefore?.system).toEqual(["inherited-system-prompt"])
         expect(forkCtxBefore?.inheritedMessages).toHaveLength(2)
@@ -353,7 +353,7 @@ describe("Fork-agent inbox compat (Plan 4 / Task 5)", () => {
 
         // Tier 2 — structural: forkContext must still have the exact same
         // inheritedMessages snapshot. Drain must not touch forkContexts.
-        const forkCtxAfter = yield* actor.getForkContext(forkActorID)
+        const forkCtxAfter = yield* actor.getForkContext(result.sessionID, forkActorID)
         expect(forkCtxAfter).toBeDefined()
         expect(forkCtxAfter?.inheritedMessages).toStrictEqual(forkCtxBefore?.inheritedMessages)
         expect(forkCtxAfter?.system).toEqual(["inherited-system-prompt"])

--- a/packages/opencode/test/session/classify-integration.test.ts
+++ b/packages/opencode/test/session/classify-integration.test.ts
@@ -368,7 +368,8 @@ describe("classifier routing — integration", () => {
                 model: { providerID: ProviderID.make("alibaba"), modelID: ModelID.make("qwen-plus") },
               }
               spawnRef.current = {
-                getForkContext: (id: string) => Effect.succeed(id === forkActorID ? forkCtx : undefined),
+                getForkContext: (sessionID: string, actorID: string) =>
+                  Effect.succeed(actorID === forkActorID ? forkCtx : undefined),
                 spawn: () => Effect.die("spawn not used in fork-gate test"),
                 cancel: () => Effect.die("cancel not used in fork-gate test"),
               } as unknown as NonNullable<typeof spawnRef.current>
@@ -443,7 +444,8 @@ describe("classifier routing — integration", () => {
                 model: { providerID: ProviderID.make("alibaba"), modelID: ModelID.make("qwen-plus") },
               }
               spawnRef.current = {
-                getForkContext: (id: string) => Effect.succeed(id === forkActorID ? forkCtx : undefined),
+                getForkContext: (sessionID: string, actorID: string) =>
+                  Effect.succeed(actorID === forkActorID ? forkCtx : undefined),
                 spawn: () => Effect.die("spawn not used in fork content-filter test"),
                 cancel: () => Effect.die("cancel not used in fork content-filter test"),
               } as unknown as NonNullable<typeof spawnRef.current>


### PR DESCRIPTION
## Summary
`Actor`'s `forkContexts` map is keyed by `actorID` alone, but `actorID` is not globally unique across sessions — this lets one session's frozen fork context overwrite or be deleted by another's. This PR scopes the map key to `(sessionID, actorID)`.

## Root Cause
`packages/opencode/src/actor/spawn.ts:201` declares:
```ts
const forkContexts = new Map<string, ForkContext>()
```
keyed only by `actorID`, and `getForkContext` (interface at `spawn.ts:179`, implementation at `spawn.ts:712-713`) looks it up the same way.

`actorID` for subagents comes from `allocateActorID(sessionID, agentType)` in `packages/opencode/src/actor/registry.ts:314-336`. That function queries existing actor rows filtered by `session_id = sessionID AND agent = agentType` (`registry.ts:318-326`) and returns `${agentType}-${max + 1}` — i.e. the incrementing suffix is scoped per `(sessionID, agentType)`, not global. The first `explore` subagent spawned in *any* session gets `actorID = "explore-1"`.

Because `forkContexts` is a single process-wide `Map` keyed by `actorID` alone, two unrelated, concurrent sessions that each spawn their first `explore` subagent both get `actorID = "explore-1"` and collide on the same map entry:
- `spawn.ts:661` (`forkContexts.set(actorID, input.forkContext)` in the subagent path) — whichever session spawns second overwrites the first session's frozen `ForkContext` (system prompt + inherited messages + tools).
- `spawn.ts:577` / `spawn.ts:588` (cleanup on success/failure) and `spawn.ts:709` (`cancel`) all call `forkContexts.delete(actorID)` — cancelling or completing one session's actor deletes the *other* session's still-in-use context.

The consumer at `packages/opencode/src/session/prompt.ts:2930` (`spawnRef.current?.getForkContext(...)`) then reads whichever context happens to still be in the map, so a fork agent in one session can silently pick up (or lose) another unrelated session's frozen context snapshot.

## Changes
- `packages/opencode/src/actor/spawn.ts`: added a `forkContextKey(sessionID, actorID)` helper and routed every `forkContexts.set/get/delete` call through it; changed `getForkContext`'s signature (interface + implementation) to `(sessionID, actorID)`, matching the existing `cancel(sessionID, actorID, mode)` pattern.
- `packages/opencode/src/session/prompt.ts`: updated the sole call site to pass `sessionID` (already in scope) alongside the actor id.
- `packages/opencode/test/actor/spawn.test.ts`: updated existing `getForkContext` calls to the new two-arg signature; added a regression test that spawns same-`agentType` subagents in two different sessions, asserts they allocate the same `actorID` (the collision precondition), and asserts each session reads back only its own `forkContext` (including after cancelling one of them).
- `packages/opencode/test/inbox/fork-agent-compat.test.ts`: updated `getForkContext` calls to the new two-arg signature.
- `packages/opencode/test/session/classify-integration.test.ts`: updated the `spawnRef.current` mock's `getForkContext` stub to accept `(sessionID, actorID)` and match on `actorID` (it previously matched on the sole positional argument, which would silently receive `sessionID` under the new signature).

## Validation
- `bun typecheck`
- `bun test test/actor/spawn.test.ts test/inbox/fork-agent-compat.test.ts test/session/classify-integration.test.ts`