### PR TITLE
fix(session): honor toolChoice on max-mode's final step

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3221,7 +3221,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "break" as const
             }
 
-            const stepEffect = useMaxMode
+            const stepEffect = useMaxMode && !isLastStep
               ? MaxMode.runMaxStep({
                   // runMaxStep reuses the identical per-step args as handle.process,
                   // plus the orchestration handles it needs.

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -301,6 +301,25 @@ function providerCfg(url: string) {
   }
 }
 
+// Enables the "max" agent (only registered when experimental.maxMode is
+// configured) and caps it at a single step, so the very first step is also
+// the last one.
+function maxModeLastStepCfg(url: string) {
+  return {
+    ...providerCfg(url),
+    experimental: {
+      maxMode: {
+        candidates: 2,
+      },
+    },
+    agent: {
+      max: {
+        steps: 1,
+      },
+    },
+  }
+}
+
 const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string) {
   const session = yield* Session.Service
   const msg = yield* session.updateMessage({
@@ -1531,4 +1550,38 @@ it.live(
       { git: true, config: cfg },
     ),
   30_000,
+)
+
+// Max mode
+
+it.live("max mode's last step falls back to a single handle.process call", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Max mode last step",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* llm.text("final answer")
+
+      const result = yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "max",
+        model: ref,
+        parts: [{ type: "text", text: "hello" }],
+      })
+
+      expect(result.info.role).toBe("assistant")
+      expect(result.parts.some((part) => part.type === "text" && part.text === "final answer")).toBe(true)
+      // With steps: 1, the very first step is also the last one. If max mode
+      // still ran runMaxStep here, it would fan out to 2 candidates + 1 judge
+      // call (3 total) instead of the single handle.process call the step-cap
+      // wrap-up expects.
+      expect(yield* llm.calls).toBe(1)
+    }),
+    { git: true, config: maxModeLastStepCfg },
+  ),
+  15_000,
 )


### PR DESCRIPTION
## Summary
On the last step of a run, max-mode sessions can keep proposing and executing tool calls instead of being forced to wrap up with a text-only reply. This fixes the step-cap enforcement so it also applies when max-mode is active.

## Root Cause
In `packages/opencode/src/session/prompt.ts`, the main step loop computes `isLastStep = step >= maxSteps` and builds `processArgs` with `toolChoice: isLastStep ? "none" : ...` (around prompt.ts:3182) specifically so the final step forces a text-only wrap-up.

However, when max-mode is active (`useMaxMode`), the step is dispatched to `MaxMode.runMaxStep(...)` instead of `handle.process(processArgs)` (prompt.ts:3224-3235). `MaxStepInput.toolChoice` in `packages/opencode/src/session/max-mode.ts` (around max-mode.ts:61-66) is explicitly documented as "Accepted (so the same processArgs object can be spread in) but unused" — `runMaxStep` always runs its N parallel propose-only candidates and executes the winner's proposed tool calls via `handle.replay`, regardless of `toolChoice`. So on the last step, with max-mode on, the model can still propose and execute tool calls, silently bypassing the step-cap wrap-up.

## Changes
- `packages/opencode/src/session/prompt.ts`: gate the `stepEffect` ternary so `useMaxMode && !isLastStep` selects `MaxMode.runMaxStep`; the last step always falls back to `handle.process`, which does honor `toolChoice: "none"`.
- `packages/opencode/test/session/prompt-effect.test.ts`: add a regression test that pins the `max` agent to a single step (`agent: { max: { steps: 1 } }`) with max-mode enabled (`experimental: { maxMode: { candidates: 2 } }`), then asserts only a single LLM call happens on that step — proving `handle.process` ran instead of the 2-candidates+1-judge fan-out `runMaxStep` would otherwise trigger.

## Validation
- `bun typecheck`
- `bun test test/session/prompt-effect.test.ts -t "max mode's last step"`