### PR TITLE
fix(tui): reset mouse tracking on exit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -2,6 +2,12 @@ import { useRenderer } from "@opentui/solid"
 import { createSimpleContext } from "./helper"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 import { win32FlushInputBuffer } from "../win32"
+
+export const terminalExitCleanupSequence =
+  "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[0m\x1b[?25h\x1b]110\x07\x1b]111\x07\x1b]112\x07"
+
+export const terminalExitSignals = ["SIGHUP", "SIGINT", "SIGTERM"] as const
+
 type Exit = ((reason?: unknown) => Promise<void>) & {
   message: {
     set: (value?: string) => () => void
@@ -37,11 +43,11 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
           // Reset window title before destroying renderer
           renderer.setTerminalTitle("")
           renderer.destroy()
-          // SGR reset + show cursor + OSC 110/111/112 reset terminal fg/bg/cursor color.
+          // Disable mouse tracking + SGR reset + show cursor + OSC 110/111/112 reset terminal fg/bg/cursor color.
           // Without the OSC resets, whatever fg/bg the active mimocode theme pushed
           // via OSC 10/11/12 would persist in the terminal session, leaving the
           // shell prompt unreadable (e.g. white-on-white).
-          process.stdout.write("\x1b[0m\x1b[?25h\x1b]110\x07\x1b]111\x07\x1b]112\x07")
+          process.stdout.write(terminalExitCleanupSequence)
           win32FlushInputBuffer()
           if (reason) {
             const formatted = FormatError(reason) ?? FormatUnknownError(reason)
@@ -59,7 +65,9 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
         message: store,
       },
     )
-    process.on("SIGHUP", () => exit())
+    for (const signal of terminalExitSignals) {
+      process.on(signal, () => exit())
+    }
     return exit
   },
 })

--- a/packages/opencode/test/cli/cmd/tui/exit-cleanup.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/exit-cleanup.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { terminalExitCleanupSequence, terminalExitSignals } from "../../../../src/cli/cmd/tui/context/exit"
+
+describe("terminalExitCleanupSequence", () => {
+  test("disables mouse tracking when resetting the terminal", () => {
+    expect(terminalExitCleanupSequence).toContain("\x1b[?1000l")
+    expect(terminalExitCleanupSequence).toContain("\x1b[?1002l")
+    expect(terminalExitCleanupSequence).toContain("\x1b[?1003l")
+    expect(terminalExitCleanupSequence).toContain("\x1b[?1006l")
+    expect(terminalExitCleanupSequence).toContain("\x1b[0m")
+    expect(terminalExitCleanupSequence).toContain("\x1b[?25h")
+    expect(terminalExitCleanupSequence).toContain("\x1b]110\x07")
+    expect(terminalExitCleanupSequence).toContain("\x1b]111\x07")
+    expect(terminalExitCleanupSequence).toContain("\x1b]112\x07")
+  })
+
+  test("runs cleanup for external termination signals", () => {
+    expect(terminalExitSignals).toEqual(["SIGHUP", "SIGINT", "SIGTERM"])
+  })
+})


### PR DESCRIPTION
## Summary

- disable terminal mouse tracking modes during TUI exit cleanup
- route SIGHUP, SIGINT, and SIGTERM through the same cleanup path
- add focused coverage for the cleanup ANSI sequence and handled termination signals

Fixes #838.
Fixes #1458.
Fixes #498.

## Verification

- `bun test test/cli/cmd/tui/exit-cleanup.test.ts --timeout 30000`
- `bun typecheck` from `packages/opencode`
- `bunx oxlint packages/opencode/src/cli/cmd/tui/context/exit.tsx packages/opencode/test/cli/cmd/tui/exit-cleanup.test.ts` (0 errors, one pre-existing `unbound-method` warning in `exit.tsx`)
- `git diff --check`
- pre-push hook: `bun turbo typecheck` (12 successful, 12 total)
