### PR TITLE
fix(actor): capture full context for spawned actors

### DIFF
--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -20,6 +20,7 @@ import { renderActorNotification } from "@/inbox/render"
 import { Plugin, HookEvent } from "@/plugin"
 import { parseReturnHeader, type ReturnStatus } from "./return-header"
 import { Log } from "@/util"
+import { prefixCaptureRef } from "@/session/prefix-capture-ref"
 
 const log = Log.create({ service: "actor.spawn" })
 
@@ -199,6 +200,51 @@ export const layer = Layer.effect(
     // (contextMode = "full"). Read by fork's runLoop (see prompt.ts) and
     // cleared on terminal status. Fiber tracking moved to SessionRunState.
     const forkContexts = new Map<string, ForkContext>()
+
+    const captureForkContext = Effect.fn("Actor.captureForkContext")(function* (
+      input: SpawnInput,
+      watermarkMsgID: MessageID | undefined,
+    ) {
+      if (input.context !== "full" || input.forkContext) return input.forkContext
+      if (!input.model || !watermarkMsgID) return undefined
+
+      const buildPrefix = prefixCaptureRef.current
+      if (!buildPrefix) {
+        log.warn("captureForkContext skipped: prefixCaptureRef not set", {
+          sessionID: input.sessionID,
+          agentType: input.agentType,
+        })
+        return undefined
+      }
+
+      const msgs = yield* session.messages({ sessionID: input.sessionID })
+      const watermarkIdx = msgs.findIndex((m) => m.info.id === watermarkMsgID)
+      if (watermarkIdx < 0) {
+        log.warn("captureForkContext skipped: watermark message not found", {
+          sessionID: input.sessionID,
+          agentType: input.agentType,
+          watermarkMsgID,
+        })
+        return undefined
+      }
+
+      const prefix = yield* buildPrefix({
+        sessionID: input.sessionID,
+        agentName: input.agentType,
+        providerID: input.model.providerID,
+        modelID: input.model.modelID,
+        msgs: msgs.slice(0, watermarkIdx + 1),
+      })
+
+      return {
+        system: prefix.system,
+        tools: prefix.tools,
+        inheritedMessages: prefix.inheritedMessages,
+        parentPermission: prefix.parentPermission,
+        watermarkMsgID,
+        model: input.model,
+      } satisfies ForkContext
+    })
 
     // Real agent loop: marks the actor running, then drives a SessionPrompt.prompt
     // turn. The user message persisted by SessionPrompt carries the actor's
@@ -612,8 +658,9 @@ export const layer = Layer.effect(
         lifecycle: input.lifecycle ?? "persistent",
         tools: input.tools,
       })
-      if (input.forkContext) {
-        forkContexts.set(child.id, input.forkContext) // peer's actorID === child.id
+      const forkContext = yield* captureForkContext(input, yield* session.lastMainMessageID(input.sessionID))
+      if (forkContext) {
+        forkContexts.set(child.id, forkContext) // peer's actorID === child.id
       }
       const { fiber, outcome } = yield* forkWork({
         sessionID: child.id,
@@ -657,8 +704,9 @@ export const layer = Layer.effect(
       // Synchronous + best-effort: a throwing callback must not fail the spawn.
       if (input.onActorID) yield* Effect.sync(() => input.onActorID!(actorID)).pipe(Effect.ignore)
 
-      if (input.forkContext) {
-        forkContexts.set(actorID, input.forkContext)
+      const forkContext = yield* captureForkContext(input, watermark)
+      if (forkContext) {
+        forkContexts.set(actorID, forkContext)
       }
 
       // Auto-inject return-format instruction for non-specialized subagents.

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -698,6 +698,60 @@ describe("mode × contextMode matrix", () => {
     ),
   )
 
+  it.live("subagent + full captures forkContext when caller does not provide one", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+
+        const parent = yield* session.create({
+          title: "matrix subagent+full auto capture",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        const mainMessageID = MessageID.ascending()
+        const mainMessage = {
+          id: mainMessageID,
+          sessionID: parent.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "build",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          tools: {},
+        } satisfies MessageV2.User
+        yield* session.updateMessage(mainMessage)
+        yield* session.updatePart({
+          id: PartID.ascending(),
+          sessionID: parent.id,
+          messageID: mainMessageID,
+          type: "text",
+          text: "parent context",
+        })
+
+        yield* llm.hang
+
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "explore",
+          task: "read the inherited context",
+          context: "full",
+          tools: ["read"],
+          background: true,
+          model: ref,
+        })
+
+        const ctx = yield* actor.getForkContext(result.actorID)
+        expect(ctx).toBeDefined()
+        expect(ctx?.watermarkMsgID).toBe(mainMessageID)
+        expect(ctx?.inheritedMessages.length).toBeGreaterThan(0)
+
+        yield* actor.cancel(result.sessionID, result.actorID, "forced")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
   it.live("subagent + none: no forkContext stored", () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {


### PR DESCRIPTION
## Summary

- capture a fork context inside `Actor.spawn` when a spawned actor uses `context="full"` and the caller did not provide one
- reuse the existing `prefixCaptureRef` path so the child actor gets the inherited parent main-message slice up to the spawn watermark
- add regression coverage for the normal actor-tool path: `context="full"` without an explicit `forkContext`

Fixes #1481.

## Verification

- `bun test test/actor/spawn.test.ts --timeout 30000`
- `bun test test/actor/spawn.test.ts test/session/fork-prefix-invariant.test.ts --timeout 30000`
- `bun typecheck` from `packages/opencode`
- `bunx oxlint packages/opencode/src/actor/spawn.ts packages/opencode/test/actor/spawn.test.ts` (0 errors, existing warnings only)
- `git diff --check`
- pre-push hook: `bun turbo typecheck` (12 successful, 12 total)
