### PR TITLE
fix(tui): clear alternate screen buffer before spawning interactive commands

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1028,6 +1028,9 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     void (async () => {
       renderer.suspend()
       renderer.currentRenderBuffer.clear()
+      // Clear alternate screen buffer so child processes that enter alt screen
+      // (e.g. Go TUI tools like glab) don't see stale TUI content
+      process.stdout.write("\x1b[?1049h\x1b[2J\x1b[?1049l")
       let exitCode = 1
       let output = ""
       try {


### PR DESCRIPTION
## Problem

When an interactive bash command uses a TUI library that enters the alternate screen buffer (e.g. `glab auth login` which uses Go's bubbletea/survey), the child process sees **stale TUI content** left in the alt buffer from before `renderer.suspend()`. This causes the child's interactive UI to overlap with the old MiMoCode TUI rendering instead of appearing on a clean screen.

**问题概述**：使用了 alternate screen 的交互式子进程（如 `glab auth login`）会在 alt buffer 中看到 MiMoCode TUI 的残留内容，导致子进程界面与旧 TUI 画面重叠。

## Root Cause

The sequence was:
1. `renderer.suspend()` exits the alternate screen → switches to main screen
2. Main screen is cleared (`\x1b[2J\x1b[H`)
3. Child process spawned

But the **alternate screen buffer still holds the TUI's last rendered frame**. When the child process enters alternate screen (as Go TUI tools do), the terminal re-displays that stale content.

Simple commands like `for i in 1 2 3 4 5; do echo $i; done` work fine because they never enter alternate screen — they output to the (properly cleared) main screen.

**根因**：`renderer.suspend()` 退出 alt screen 后，alt buffer 中仍残留 TUI 内容。子进程若自行进入 alt screen，终端会重新显示该残留内容。不使用 alt screen 的简单命令不受影响。

## Fix

After `renderer.suspend()`, momentarily re-enter the alternate screen buffer, clear it, then exit back to main:

```ts
process.stdout.write("\x1b[?1049h\x1b[2J\x1b[?1049l")
```

This ensures the alt buffer is clean before any child process starts. The existing main screen clear (`\x1b[2J\x1b[H`) remains in place for commands that stay on main screen.

**修复方式**：suspend 后短暂进入 alt screen 并清空，确保子进程进入 alt screen 时看到的是干净缓冲区。

## Before

<img width="2616" height="740" alt="image" src="https://github.com/user-attachments/assets/65c99ff5-f4da-426c-b6aa-800ca871746c" />

## After

<img width="2634" height="684" alt="image" src="https://github.com/user-attachments/assets/887a703c-7f86-4882-a3e6-91ea2690d1c5" />

## Verification

Manually tested with `glab auth login` (a Go TUI tool that enters alternate screen). Before: TUI content visible behind glab's select menu. After: clean full-screen interactive session, TUI properly restored on exit.

**验证**：手动测试 `glab auth login`，修复前 TUI 内容与 glab 菜单重叠，修复后为干净的全屏交互界面。