### PR TITLE
fix(session): strip leaked model end tokens

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -28,6 +28,17 @@ import { createTextNgramMonitor, type TextNgramMonitor } from "./prompt/text-ngr
 const DOOM_LOOP_THRESHOLD = 3
 const log = Log.create({ service: "session.processor" })
 
+const LEAKED_MODEL_END_TOKENS = ["<eos>", "<end_of_turn>"] as const
+
+function stripLeakedModelEndTokens(text: string) {
+  let result = text
+  for (const token of LEAKED_MODEL_END_TOKENS) {
+    while (result.startsWith(token)) result = result.slice(token.length)
+    while (result.endsWith(token)) result = result.slice(0, -token.length)
+  }
+  return result
+}
+
 export type Result = "overflow" | "stop" | "continue" | "text-repeat"
 
 export type Event = LLM.Event
@@ -565,15 +576,17 @@ export const layer: Layer.Layer<
           case "text-delta":
             if (!ctx.firstTokenAt) ctx.firstTokenAt = Date.now()
             if (!ctx.currentText) return
-            ctx.currentText.text += value.text
-            checkTextNgram(value.text)
+            const text = stripLeakedModelEndTokens(value.text)
+            if (!text) return
+            ctx.currentText.text += text
+            checkTextNgram(text)
             if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
             yield* session.updatePartDelta({
               sessionID: ctx.currentText.sessionID,
               messageID: ctx.currentText.messageID,
               partID: ctx.currentText.id,
               field: "text",
-              delta: value.text,
+              delta: text,
             })
             return
 
@@ -595,6 +608,17 @@ export const layer: Layer.Layer<
               ctx.currentText.time = { start: ctx.currentText.time?.start ?? end, end }
             }
             if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
+            if (!ctx.currentText.text) {
+              const partID = ctx.currentText.id
+              yield* session.removePart({
+                sessionID: ctx.currentText.sessionID,
+                messageID: ctx.currentText.messageID,
+                partID,
+              })
+              ctx.stepPartIds = ctx.stepPartIds.filter((id) => id !== partID)
+              ctx.currentText = undefined
+              return
+            }
             yield* session.updatePart(ctx.currentText)
             ctx.currentText = undefined
             return

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -231,6 +231,143 @@ it.live("session.processor effect tests capture llm input cleanly", () =>
   ),
 )
 
+it.live("session.processor strips leaked model end tokens from streamed text", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { content: "<eos>" } }],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { content: "patched" } }],
+              },
+            ],
+            tail: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: {}, finish_reason: "stop" }],
+              },
+            ],
+          }),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "hi")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "hi" }],
+          tools: {},
+        })
+
+        const text = MessageV2.parts(msg.id).find((part): part is MessageV2.TextPart => part.type === "text")
+
+        expect(value).toBe("continue")
+        expect(text?.text).toBe("patched")
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor drops text parts that only contain leaked model end tokens", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { content: "<end_of_turn>" } }],
+              },
+            ],
+            tail: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: {}, finish_reason: "stop" }],
+              },
+            ],
+          }),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "hi")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "hi" }],
+          tools: {},
+        })
+
+        const textParts = MessageV2.parts(msg.id).filter((part): part is MessageV2.TextPart => part.type === "text")
+
+        expect(value).toBe("continue")
+        expect(textParts).toHaveLength(0)
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests preserve text start time", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>


### PR DESCRIPTION
## Summary

- Strip leaked Gemma/OpenAI-compatible end tokens (`<eos>`, `<end_of_turn>`) from streamed assistant text before it is accumulated and persisted.
- Drop assistant text parts that become empty after stripping, so special-token-only content is not replayed in later turns.
- Add fake SSE regression coverage for both mixed text (`<eos>` then useful content) and special-token-only text.

Fixes #578.

## Verification

- RED before fix: `bun test test/session/processor-effect.test.ts --timeout 30000` failed with expected `"patched"`, received `"<eos>patched"`.
- `bun test test/session/processor-effect.test.ts --timeout 30000` - 13 pass, 1 skip, 0 fail.
- `bun typecheck`
- `bunx oxlint packages/opencode/src/session/processor.ts packages/opencode/test/session/processor-effect.test.ts` - 0 errors, existing warnings only.
- `git diff --check`
- Pre-push `bun turbo typecheck` - 12 successful, 12 total.
