### PR TITLE
fix(tui): hide stale retry status after model switch

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -45,6 +45,7 @@ import { DialogWorkspaceCreate, restoreWorkspaceSession } from "../dialog-worksp
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { DialogAgreement, FREE_AGREEMENT_KEY, FREE_MODEL_IDS } from "../dialog-agreement"
 import { useArgs } from "@tui/context/args"
+import { visiblePromptStatus } from "./status"
 
 export type PromptProps = {
   sessionID?: string
@@ -116,7 +117,9 @@ export function Prompt(props: PromptProps) {
   const sync = useSync()
   const dialog = useDialog()
   const toast = useToast()
-  const status = createMemo(() => sync.data.session_status?.[props.sessionID ?? ""] ?? { type: "idle" })
+  const status = createMemo(() =>
+    visiblePromptStatus(sync.data.session_status?.[props.sessionID ?? ""] ?? { type: "idle" }, local.model.current()),
+  )
   const history = usePromptHistory()
   const stash = usePromptStash()
   const command = useCommandDialog()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/status.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/status.ts
@@ -1,0 +1,18 @@
+import type { SessionStatus } from "@mimo-ai/sdk/v2"
+
+type ModelRef = {
+  providerID: string
+  modelID: string
+}
+
+type RetryStatus = Extract<SessionStatus, { type: "retry" }> & Partial<ModelRef>
+
+export function visiblePromptStatus(status: SessionStatus, model: ModelRef | undefined): SessionStatus {
+  if (status.type !== "retry") return status
+
+  const retry = status as RetryStatus
+  if (!retry.providerID || !retry.modelID || !model) return status
+  if (retry.providerID === model.providerID && retry.modelID === model.modelID) return status
+
+  return { type: "idle" }
+}

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -739,6 +739,8 @@ export const layer: Layer.Layer<
                         attempt: info.attempt,
                         message: info.message,
                         next: info.next,
+                        providerID: ctx.model.providerID,
+                        modelID: ctx.model.id,
                       })
                     : Effect.void,
               }),

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -15,6 +15,8 @@ export const Info = z
       attempt: z.number(),
       message: z.string(),
       next: z.number(),
+      providerID: z.string().optional(),
+      modelID: z.string().optional(),
     }),
     z.object({
       type: z.literal("busy"),

--- a/packages/opencode/test/cli/tui/prompt-status.test.ts
+++ b/packages/opencode/test/cli/tui/prompt-status.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { visiblePromptStatus } from "../../../src/cli/cmd/tui/component/prompt/status"
+
+test("hides retry status from a previously selected model", () => {
+  expect(
+    visiblePromptStatus(
+      {
+        type: "retry",
+        attempt: 1,
+        message: "quota exceeded",
+        next: Date.now() + 1000,
+        providerID: "glm",
+        modelID: "glm-4.5",
+      },
+      { providerID: "mimo", modelID: "mimo-auto" },
+    ),
+  ).toEqual({ type: "idle" })
+})
+
+test("keeps retry status for the current model", () => {
+  const status = {
+    type: "retry" as const,
+    attempt: 1,
+    message: "quota exceeded",
+    next: Date.now() + 1000,
+    providerID: "glm",
+    modelID: "glm-4.5",
+  }
+
+  expect(visiblePromptStatus(status, { providerID: "glm", modelID: "glm-4.5" })).toBe(status)
+})

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -121,6 +121,22 @@ describe("session.retry.delay", () => {
       },
     })
   })
+
+  test("retry status preserves the model that scheduled the retry", () => {
+    expect(
+      SessionStatus.Info.parse({
+        type: "retry",
+        attempt: 1,
+        message: "quota exceeded",
+        next: Date.now() + 1000,
+        providerID: "glm",
+        modelID: "glm-4.5",
+      }),
+    ).toMatchObject({
+      providerID: "glm",
+      modelID: "glm-4.5",
+    })
+  })
 })
 
 describe("session.retry.retryable", () => {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -743,6 +743,8 @@ export type SessionStatus =
       attempt: number
       message: string
       next: number
+      providerID?: string
+      modelID?: string
     }
   | {
       type: "busy"


### PR DESCRIPTION
## Summary

- Attach the provider/model that scheduled a retry status to `SessionStatus`.
- Hide retry banners in the prompt footer when they belong to a previously selected model.
- Keep legacy retry statuses without model metadata visible, preserving existing behavior for old state/events.
- Add regression coverage for retry status model metadata and prompt status filtering.

Fixes #1474.

## Verification

- RED before fix: `SessionStatus.Info.parse(...)` dropped `providerID/modelID`, and `test/cli/tui/prompt-status.test.ts` could not import the missing helper.
- `bun test test/session/retry.test.ts test/cli/tui/prompt-status.test.ts --timeout 30000` - 42 pass, 0 fail.
- `bun typecheck`
- `bunx oxlint packages/opencode/src/session/status.ts packages/opencode/src/session/processor.ts packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx packages/opencode/src/cli/cmd/tui/component/prompt/status.ts packages/opencode/test/session/retry.test.ts packages/opencode/test/cli/tui/prompt-status.test.ts` - 0 errors, existing warnings only.
- `git diff --check`
- Pre-push `bun turbo typecheck` - 12 successful, 12 total.
