### PR TITLE
fix(tui): scroll to bottom when returning from subagent

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -93,6 +93,7 @@ import { DialogGoUpsell } from "../../component/dialog-go-upsell"
 import { DialogTokenPlan } from "../../component/dialog-token-plan"
 import { SessionRetry } from "@/session/retry"
 import { getRevertDiffFiles } from "../../util/revert-diff"
+import { conversationScrollKey } from "./scroll"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1082,8 +1083,9 @@ export function Session() {
     }
   })
 
-  // snap to bottom when session changes
-  createEffect(on(() => route.sessionID, toBottom))
+  // Snap to bottom when the rendered conversation changes. Subagent views share
+  // the same sessionID, so key by agentID as well as sessionID.
+  createEffect(on(() => conversationScrollKey({ sessionID: route.sessionID, agentID: currentAgentID() }), toBottom))
 
   return (
     <context.Provider

--- a/packages/opencode/src/cli/cmd/tui/routes/session/scroll.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/scroll.ts
@@ -1,0 +1,3 @@
+export function conversationScrollKey(input: { sessionID: string; agentID?: string }) {
+  return `${input.sessionID}:${input.agentID ?? "main"}`
+}

--- a/packages/opencode/test/cli/tui/session-scroll.test.ts
+++ b/packages/opencode/test/cli/tui/session-scroll.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test"
+import { conversationScrollKey } from "../../../src/cli/cmd/tui/routes/session/scroll"
+
+test("conversationScrollKey changes when switching between main and subagent views", () => {
+  expect(conversationScrollKey({ sessionID: "ses_1", agentID: "main" })).toBe("ses_1:main")
+  expect(conversationScrollKey({ sessionID: "ses_1", agentID: "agent_1" })).toBe("ses_1:agent_1")
+})
+
+test("conversationScrollKey defaults missing agentID to main", () => {
+  expect(conversationScrollKey({ sessionID: "ses_1" })).toBe("ses_1:main")
+})


### PR DESCRIPTION
## Summary

- key the TUI conversation scroll effect by both `sessionID` and active `agentID`
- make main/subagent switches within the same session call `toBottom()` when returning to the rendered conversation
- add a regression helper test for the scroll key behavior

Fixes #1433

## Verification

- RED: `bun test test/cli/tui/session-scroll.test.ts --timeout 30000` failed before the helper existed
- `cd packages/opencode && bun test test/cli/tui/session-scroll.test.ts test/cli/tui/route-agent-id.test.ts test/cli/tui/sync-bucket.test.ts --timeout 30000` (8 pass)
- `cd packages/opencode && bun typecheck`
- `bunx oxlint packages/opencode/src/cli/cmd/tui/routes/session/index.tsx packages/opencode/src/cli/cmd/tui/routes/session/scroll.ts packages/opencode/test/cli/tui/session-scroll.test.ts` (0 errors; existing warnings in `index.tsx`)
- `git diff --check`
- pre-push: `bun turbo typecheck` (12/12 successful)
