### PR TITLE
fix(tui): prevent double session creation on home screen submit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -994,13 +994,12 @@ export function Prompt(props: PromptProps) {
     },
   ])
 
-  // While the free-model agreement dialog is open, ignore any further submit()
-  // calls. Enter triggers submit twice (the input_submit keybind plus the
-  // textarea's deferred onSubmit), and without this guard the deferred call can
-  // interleave with the post-accept re-submit and drop the user's message.
-  let agreementPending = false
+  // Enter triggers submit twice (the input_submit keybind plus the textarea's
+  // deferred onSubmit). This lock prevents the deferred call from re-entering
+  // while a dialog or async session-creation is in progress.
+  let submitLock = false
   async function submit() {
-    if (agreementPending) return false
+    if (submitLock) return false
     setGhost("")
     // IME: double-defer may fire before onContentChange flushes the last
     // composed character (e.g. Korean hangul) to the store, so read
@@ -1029,16 +1028,14 @@ export function Prompt(props: PromptProps) {
     // policy. Gate submission until the user accepts; the flag is stored in KV.
     const isFreeModel = FREE_MODEL_IDS.has(selectedModel.modelID)
     if (isFreeModel && !kv.get(FREE_AGREEMENT_KEY)) {
-      agreementPending = true
+      submitLock = true
       DialogAgreement.show(dialog, {
         onConfirm: () => {
           kv.set(FREE_AGREEMENT_KEY, true)
           void submit()
         },
-        // Fires on any dismissal (confirm, cancel, esc, click-outside). Reset
-        // the guard here so submission is unblocked once the dialog is gone.
         onClose: () => {
-          agreementPending = false
+          submitLock = false
         },
       })
       return false
@@ -1071,6 +1068,9 @@ export function Prompt(props: PromptProps) {
       ))
       return false
     }
+
+    submitLock = true
+    try {
 
     let sessionID = props.sessionID
     if (sessionID == null) {
@@ -1207,6 +1207,10 @@ export function Prompt(props: PromptProps) {
       }, 50)
     input.clear()
     return true
+
+    } finally {
+      submitLock = false
+    }
   }
   const exit = useExit()
 


### PR DESCRIPTION
## Summary

A single Enter keypress on the home screen calls `submit()` twice — once from the `input_submit` command keybind (immediate) and once from the textarea's deferred `onSubmit` (double `setTimeout`). When `props.sessionID` is null, both concurrent calls reach `await sdk.client.session.create()` before either clears the input store, resulting in two sessions: one with the user's actual message and one with an empty message that the model responds to.

This is most visible for first-time free-model users because the agreement dialog blocks the very first double-fire, but subsequent home-screen submissions have no guard.

**修复摘要：** 在 Home 页面按 Enter 时，`submit()` 被 keybind 和 textarea 的 `onSubmit` 分别触发（共两次）。两次并发调用都到达 `await session.create()` 导致创建两个 session。对首次使用免费模型的用户最明显。

## Fix

Consolidate the existing `agreementPending` flag and the missing async-section guard into a single `submitLock` variable. It prevents re-entrant `submit()` calls in both scenarios: while the free-model agreement dialog is open, and while the async session-creation is in flight.

```diff
- let agreementPending = false
+ let submitLock = false
  async function submit() {
-   if (agreementPending) return false
+   if (submitLock) return false
    // ...sync checks...

    // agreement dialog path
    if (isFreeModel && !kv.get(FREE_AGREEMENT_KEY)) {
-     agreementPending = true
+     submitLock = true
      DialogAgreement.show(dialog, {
        onConfirm: () => { kv.set(...); void submit() },
-       onClose: () => { agreementPending = false },
+       onClose: () => { submitLock = false },
      })
      return false
    }

    // async submission path
+   submitLock = true
    let sessionID = props.sessionID
    if (sessionID == null) {
      const res = await sdk.client.session.create(...)
      if (res.error) {
+       submitLock = false
        return true
      }
      sessionID = res.data.id
    }
    // ...send message, clear store...
    input.clear()
+   submitLock = false
    return true
  }
```

**修复方式：** 将原有的 `agreementPending`（仅保护弹窗期间）和缺失的异步区保护合并为单一 `submitLock` 变量。覆盖两种重入场景：协议弹窗展示中 + 异步 session 创建中。

## Root Cause

The code comment at `prompt/index.tsx:997-999` already documents the double-fire:

> "Enter triggers submit twice (the input_submit keybind plus the textarea's deferred onSubmit)"

The original `agreementPending` flag only protected during the free-model agreement dialog. For regular home-screen submissions (no dialog), both calls raced through with no guard.

**根因：** 代码注释已明确记录了双重触发。原有的 `agreementPending` 仅保护协议弹窗期间，普通 Home 页面提交时无重入保护。

## Testing

- `bun typecheck` passes (packages/opencode)
- Manual verification: single session created on home-screen submit
