### PR TITLE
fix(tui): improve Task component rendering for async actor operations

### DIFF
--- a/docs/compose/plans/2025-07-01-fix-task-component-spawn-rendering.md
+++ b/docs/compose/plans/2025-07-01-fix-task-component-spawn-rendering.md
@@ -1,0 +1,162 @@
+# Fix Task Component Rendering for Spawned Actors
+
+> [!NOTE]
+> This document may not reflect the current implementation.
+> See the final report for up-to-date state:
+> [Final Report](../reports/task-spawn-rendering.md)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use compose:subagent (recommended) or compose:execute to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the `Task` TUI component so that spawned (background) actors are displayed with running/spinner state until the actor actually completes, rather than showing a misleading "completed" state with 0ms duration.
+
+**Architecture:** The `Task` component currently determines its visual state solely from `props.part.state.status` (the tool part's completion status). For `spawn` operations, this becomes "completed" immediately (spawn itself returned successfully), even though the spawned actor is still running. The fix adds a secondary check against the actor's actual runtime status from `sync.data.actor[sessionID]`. Additionally, `wait` tool calls (which have no `description`) should display context about what they're waiting for.
+
+**Tech Stack:** SolidJS (TUI rendering), TypeScript
+
+## Global Constraints
+
+- Run typecheck from `packages/opencode` via `bun typecheck`
+- Tests cannot run from repo root; run from `packages/opencode`
+- Avoid `any` types; rely on type inference where possible
+- Follow the existing code style (no destructuring, const-over-let, no else statements)
+
+---
+
+## Problem Summary
+
+When the LLM uses `actor spawn` + `actor wait` pattern:
+
+1. **spawn tool part** → status "completed" immediately (spawn returned actor_id)
+2. **Task component** sees `props.part.state.status === "completed"` → renders `└ N toolcalls · 0ms`
+3. The 0ms happens because `duration()` reads the subagent's last assistant message `time.completed`, which is still `undefined` (subagent still running)
+4. **wait tool part** → status "running", but `input().description` is `undefined` → renders as a bare spinner with no context
+
+The user sees: completed-looking tasks (clickable, with metadata) at top, mysterious spinners at bottom. The "completed" tasks are actually still running.
+
+### Root Cause Location
+
+`packages/opencode/src/cli/cmd/tui/routes/session/index.tsx:2721-2811` — the `Task` function.
+
+### Data Available for Fix
+
+- `sync.data.actor[sessionID]` contains `ActorEntry[]` with each actor's real-time `status` field (updated via `actor.status` events)
+- `props.metadata.actorId` identifies which actor this tool call is associated with
+- `props.metadata.sessionId` identifies the session
+
+---
+
+### Task 1: Make Task component check actual actor status for visual state
+
+**Files:**
+- Modify: `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx:2721-2811`
+
+**Interfaces:**
+- Consumes: `sync.data.actor[sessionID]: ActorEntry[]` from the sync store (already available via `useSync()`)
+- Produces: Corrected visual state — shows spinner/running UI when actor is still running, regardless of tool part status
+
+- [ ] **Step 1: Add actor status lookup to Task component**
+
+After line 2734 (`const targetBucket = ...`), add a memo that looks up the actual actor status:
+
+```ts
+const actorStatus = createMemo(() => {
+  const session = targetSession()
+  const actorId = targetBucket()
+  if (!session || actorId === "main") return undefined
+  const actors = sync.data.actor[session]
+  if (!actors) return undefined
+  return actors.find((a) => a.actor_id === actorId)?.status
+})
+```
+
+- [ ] **Step 2: Update `isRunning` memo to consider actor status**
+
+Replace the current `isRunning` (line 2757):
+
+```ts
+const isRunning = createMemo(() => props.part.state.status === "running")
+```
+
+With:
+
+```ts
+const isRunning = createMemo(() => {
+  if (props.part.state.status === "running") return true
+  if (props.part.state.status === "completed") {
+    const status = actorStatus()
+    return status === "running" || status === "pending"
+  }
+  return false
+})
+```
+
+- [ ] **Step 3: Update content memo to not show completed format when actor is still running**
+
+Replace the completed check in the content memo (line 2779):
+
+```ts
+if (props.part.state.status === "completed") {
+  content.push(`└ ${tools().length} toolcalls · ${Locale.duration(duration())}`)
+}
+```
+
+With:
+
+```ts
+if (props.part.state.status === "completed" && !isRunning()) {
+  content.push(`└ ${tools().length} toolcalls · ${Locale.duration(duration())}`)
+}
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `bun typecheck` from `packages/opencode`
+Expected: PASS with no new errors
+
+---
+
+### Task 2: Add context to `wait` tool call rendering
+
+**Files:**
+- Modify: `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx:2721-2811`
+
+**Interfaces:**
+- Consumes: `props.input` which for `wait` operations contains `{ operation: { action: "wait", actor_id: "..." } }`
+- Consumes: `sync.data.actor[sessionID]` to find the actor's description
+- Produces: Meaningful display text for wait operations instead of empty spinners
+
+- [ ] **Step 1: Update input parsing to handle wait/status/cancel operations**
+
+After the existing `input` memo, add a fallback description lookup:
+
+```ts
+const resolvedDescription = createMemo(() => {
+  if (input().description) return input().description
+  const raw = props.input as Partial<{ operation: { action: string; actor_id: string } }>
+  const op = raw?.operation
+  if (!op?.actor_id) return undefined
+  const session = targetSession() ?? props.part.sessionID
+  const actors = sync.data.actor[session]
+  if (!actors) return undefined
+  return actors.find((a) => a.actor_id === op.actor_id)?.description
+})
+```
+
+- [ ] **Step 2: Update content memo and InlineTool to use resolvedDescription**
+
+Replace `if (!input().description) return ""` with:
+```ts
+const desc = resolvedDescription()
+if (!desc) return ""
+```
+
+Update the content line and InlineTool's `complete` prop accordingly.
+
+- [ ] **Step 3: Update targetSession/targetBucket for wait operations**
+
+Add fallback logic to read `actor_id` from input when metadata isn't available.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `bun typecheck` from `packages/opencode`
+Expected: PASS with no new errors

--- a/docs/compose/reports/task-spawn-rendering.md
+++ b/docs/compose/reports/task-spawn-rendering.md
@@ -1,0 +1,82 @@
+---
+feature: task-spawn-rendering
+status: delivered
+specs: []
+plans:
+  - docs/compose/plans/2025-07-01-fix-task-component-spawn-rendering.md
+branch: fix/task-spawn-rendering
+commits: 7ea754e..781abf0
+---
+
+# Task Component Async Actor Rendering — Final Report
+
+## What Was Built
+
+The `Task` component in the TUI now correctly renders actor tool calls across all operation types (`run`, `spawn`, `wait`, `cancel`, `status`). Previously, spawned background actors immediately showed as "completed · 0ms" while still running, and `wait`/`cancel` operations rendered as bare spinners with no context. The fix checks the actor's actual runtime status from the sync store registry, displays appropriate state (spinner while running, completed format when done), and labels each operation type clearly.
+
+## Architecture
+
+All changes are in a single file: `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`, within the `Task` function (lines 2721–2848).
+
+**New memos added:**
+
+| Memo | Purpose |
+|------|---------|
+| `inputActorId` | Extracts `actor_id` from input for wait/cancel/status operations |
+| `inputAction` | Extracts `action` field (run/spawn/wait/cancel/status) |
+| `actorEntry` | Looks up the actor in `sync.data.actor[sessionID]` registry by ID |
+| `actorStatus` | Derives the actor's actual runtime status from the registry entry |
+| `resolvedDescription` | Falls back to actor registry description when input has none |
+
+**Modified memos:**
+
+| Memo | Change |
+|------|--------|
+| `targetSession` | Added fallback to `actorEntry().session_id` for ops without metadata |
+| `targetBucket` | Added fallback to `inputActorId()` for ops without metadata |
+| `isRunning` | Now returns `true` when tool part is "completed" but actor is still running/pending |
+| `content` | Renders action-specific headers and respects actual actor status |
+
+### Design Decisions
+
+- **Actor registry as source of truth** — Rather than trying to infer running state from message timing or tool part status alone, the component reads the actor's actual status from `sync.data.actor`. This is reliable because the sync store receives `actor.status` events in real-time.
+
+- **Unified Task component for all actor operations** — All actor tool calls (`run`, `spawn`, `wait`, `cancel`, `status`) render through the same `Task` component with differentiated labels, rather than splitting into separate components. This keeps navigation (click-to-view-subagent) working consistently.
+
+- **Labels per action type** — Each operation gets a distinct header format so the user can immediately understand what's happening without reading tool output.
+
+## Usage
+
+No configuration needed. The rendering is automatic based on the actor tool call's action:
+
+| Action | Running State | Completed State |
+|--------|--------------|-----------------|
+| `run` | `⠋ General Task — <desc>` + live activity | `│ General Task — <desc>` + `└ N toolcalls · Xs` |
+| `spawn` | `⠋ Background Explore Task — <desc>` + live activity | `│ Background Explore Task — <desc>` + `└ N toolcalls · Xs` |
+| `wait` | `⠋ Waiting for — <desc>` + live activity | `│ Waiting for — <desc>` + `└ N toolcalls · Xs` |
+| `cancel` | `⠋ Cancelling — <desc>` | `│ Cancelled — <desc>` + `└ N toolcalls · Xs` |
+
+When an actor is cancelled, non-cancel operations append `(cancelled)` to their header.
+
+## Verification
+
+- Typecheck: `bun typecheck` passes with zero errors
+- Manual testing: spawn + wait + cancel flow verified in live TUI session
+  - Background tasks correctly show spinner with live tool activity (not "0ms completed")
+  - Wait operations show "Waiting for — " with live activity from the actor
+  - Cancel shows "Cancelling" → "Cancelled" transition
+  - Normal synchronous `run` operations render unchanged
+
+## Journey Log
+
+> Brief notes on what informed the final design.
+
+- [lesson] Tool part "completed" status doesn't mean the actor finished — for `spawn`, the tool part completes immediately while the actor runs in background. Always cross-check `sync.data.actor` registry.
+- [pivot] Initially rendered `wait` as a minimal one-liner, then expanded to full info with live activity after user feedback — both spawn and wait benefit from showing the same real-time tool activity.
+- [lesson] "Cancelling" vs "Cancelled" distinction matters — the cancel tool part has a brief "running" phase before completing, so showing the transition gives correct feedback.
+
+## Source Materials
+
+| File | Role | Notes |
+|------|------|-------|
+| `docs/compose/plans/2025-07-01-fix-task-component-spawn-rendering.md` | Implementation plan | Covered Task 1 and Task 2 |

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2730,8 +2730,44 @@ function Task(props: ToolProps<typeof ActorTool>) {
     return (raw?.operation ?? raw) as Partial<{ description: string; subagent_type: string }>
   })
 
-  const targetSession = createMemo(() => props.metadata.sessionId as string | undefined)
-  const targetBucket = createMemo(() => (props.metadata.actorId as string | undefined) ?? "main")
+  const inputActorId = createMemo(() => {
+    const raw = props.input as Partial<{ operation: { actor_id: string; action: string } }>
+    return raw?.operation?.actor_id
+  })
+
+  const inputAction = createMemo(() => {
+    const raw = props.input as Partial<{ operation: { action: string } }>
+    return raw?.operation?.action
+  })
+
+  const actorEntry = createMemo(() => {
+    const actorId = (props.metadata.actorId as string | undefined) ?? inputActorId()
+    if (!actorId) return undefined
+    const actors = sync.data.actor[props.part.sessionID]
+    if (!actors) return undefined
+    return actors.find((a) => a.actor_id === actorId)
+  })
+
+  const targetSession = createMemo(() => {
+    const fromMeta = props.metadata.sessionId as string | undefined
+    if (fromMeta) return fromMeta
+    return actorEntry()?.session_id
+  })
+
+  const targetBucket = createMemo(() => {
+    const fromMeta = props.metadata.actorId as string | undefined
+    if (fromMeta) return fromMeta
+    return inputActorId() ?? "main"
+  })
+
+  const actorStatus = createMemo(() => {
+    return actorEntry()?.status
+  })
+
+  const resolvedDescription = createMemo(() => {
+    if (input().description) return input().description
+    return actorEntry()?.description
+  })
 
   createEffect(() => {
     const session = targetSession()
@@ -2754,7 +2790,14 @@ function Task(props: ToolProps<typeof ActorTool>) {
     tools().findLast((x) => (x.state.status === "running" || x.state.status === "completed") && x.state.title),
   )
 
-  const isRunning = createMemo(() => props.part.state.status === "running")
+  const isRunning = createMemo(() => {
+    if (props.part.state.status === "running") return true
+    if (props.part.state.status === "completed") {
+      const status = actorStatus()
+      return status === "running" || status === "pending"
+    }
+    return false
+  })
 
   const duration = createMemo(() => {
     const first = messages().find((x) => x.role === "user")?.time.created
@@ -2764,11 +2807,32 @@ function Task(props: ToolProps<typeof ActorTool>) {
   })
 
   const content = createMemo(() => {
-    if (!input().description) return ""
-    let content = [`${Locale.titlecase(input().subagent_type ?? "General")} Task — ${input().description}`]
+    const desc = resolvedDescription()
+    if (!desc) return ""
+
+    const action = inputAction()
+    const status = actorStatus()
+    const agent = Locale.titlecase(input().subagent_type ?? actorEntry()?.agent ?? "General")
+
+    let header: string
+    if (action === "cancel") {
+      const label = props.part.state.status === "running" ? "Cancelling" : "Cancelled"
+      header = `${label} — ${desc}`
+    } else if (action === "wait") {
+      header = `Waiting for — ${desc}`
+    } else if (action === "spawn") {
+      header = `Background ${agent} Task — ${desc}`
+    } else {
+      header = `${agent} Task — ${desc}`
+    }
+
+    if (status === "cancelled" && action !== "cancel") {
+      header += " (cancelled)"
+    }
+
+    let content = [header]
 
     if (isRunning() && tools().length > 0) {
-      // content[0] += ` · ${tools().length} toolcalls`
       if (current()) {
         const state = current()!.state
         const title = state.status === "running" || state.status === "completed" ? state.title : undefined
@@ -2776,7 +2840,7 @@ function Task(props: ToolProps<typeof ActorTool>) {
       } else content.push(`↳ ${tools().length} toolcalls`)
     }
 
-    if (props.part.state.status === "completed") {
+    if (props.part.state.status === "completed" && !isRunning()) {
       content.push(`└ ${tools().length} toolcalls · ${Locale.duration(duration())}`)
     }
 
@@ -2787,7 +2851,7 @@ function Task(props: ToolProps<typeof ActorTool>) {
     <InlineTool
       icon="│"
       spinner={isRunning()}
-      complete={input().description}
+      complete={resolvedDescription()}
       pending="Delegating..."
       part={props.part}
       onClick={() => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2819,7 +2819,7 @@ function Task(props: ToolProps<typeof ActorTool>) {
       const label = props.part.state.status === "running" ? "Cancelling" : "Cancelled"
       header = `${label} — ${desc}`
     } else if (action === "wait") {
-      const label = isRunning() ? "Waiting for" : "Waited for"
+      const label = props.part.state.status === "completed" ? "Waited for" : "Waiting for"
       header = `${label} — ${desc}`
     } else if (action === "spawn") {
       header = `Background ${agent} Task — ${desc}`

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2731,13 +2731,13 @@ function Task(props: ToolProps<typeof ActorTool>) {
   })
 
   const inputActorId = createMemo(() => {
-    const raw = props.input as Partial<{ operation: { actor_id: string; action: string } }>
-    return raw?.operation?.actor_id
+    const raw = props.input as Partial<{ operation: { actor_id: string }; actor_id: string }>
+    return raw?.operation?.actor_id ?? raw?.actor_id
   })
 
   const inputAction = createMemo(() => {
-    const raw = props.input as Partial<{ operation: { action: string } }>
-    return raw?.operation?.action
+    const raw = props.input as Partial<{ operation: { action: string }; action: string }>
+    return raw?.operation?.action ?? raw?.action
   })
 
   const actorEntry = createMemo(() => {
@@ -2819,7 +2819,8 @@ function Task(props: ToolProps<typeof ActorTool>) {
       const label = props.part.state.status === "running" ? "Cancelling" : "Cancelled"
       header = `${label} — ${desc}`
     } else if (action === "wait") {
-      header = `Waiting for — ${desc}`
+      const label = isRunning() ? "Waiting for" : "Waited for"
+      header = `${label} — ${desc}`
     } else if (action === "spawn") {
       header = `Background ${agent} Task — ${desc}`
     } else {


### PR DESCRIPTION
## Summary

- Fixed spawned (background) actors showing misleading "completed · 0ms" state while still running — now correctly displays spinner with live tool activity until the actor finishes
- Added contextual labels for different actor operations: `Background Explore Task`, `Waiting for`, `Cancelling`/`Cancelled`
- `wait`/`cancel` operations now resolve actor description from the registry instead of rendering as bare spinners

## Problem

When the LLM uses `actor spawn` + `actor wait` pattern:
1. Spawn tool part immediately becomes "completed" (spawn returns actor_id right away)
2. Task component only checked `props.part.state.status`, rendering the "completed" format with 0ms duration
3. `wait` tool parts had no `description` in their input, rendering as empty spinners

## Solution

The `Task` component now:
1. Looks up the actor's actual runtime status from `sync.data.actor` registry
2. Shows running state (spinner) when tool part is "completed" but actor is still running/pending
3. Resolves description from actor registry for operations without inline description (wait/cancel/status)
4. Displays clear labels per action type: `Background <Agent> Task`, `Waiting for`, `Cancelling`→`Cancelled`

## Result

<img width="1630" height="750" alt="img_v3_02136_32a064c7-53bf-46ad-a16c-64411316f2ag" src="https://github.com/user-attachments/assets/0cb356ff-9dc8-4ac5-b039-bd3904a6469d" />

<img width="1612" height="848" alt="img_v3_02136_6578b75c-82a1-43fa-b0e1-b15459083efg" src="https://github.com/user-attachments/assets/506ed6a0-ab73-45d1-b4d6-822c7838f343" />

