### PR TITLE
fix: correct \ URL to mimo.xiaomi.com in config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -557,8 +557,8 @@ export const layer = Layer.effect(
 
       yield* Effect.promise(() => resolveLoadedPlugins(data, options.path))
       if (!data.$schema) {
-        data.$schema = "https://opencode.ai/config.json"
-        const updated = text.replace(/^\s*\{/, '{\n  "$schema": "https://opencode.ai/config.json",')
+        data.$schema = "https://mimo.xiaomi.com/mimocode/config.json"
+        const updated = text.replace(/^\s*\{/, '{\n  "$schema": "https://mimo.xiaomi.com/mimocode/config.json",')
         yield* fs.writeFileString(options.path, updated).pipe(Effect.catch(() => Effect.void))
       }
       return data
@@ -586,7 +586,7 @@ export const layer = Layer.effect(
             .then(async (mod) => {
               const { provider, model, ...rest } = mod.default
               if (provider && model) result.model = `${provider}/${model}`
-              result["$schema"] = "https://opencode.ai/config.json"
+              result["$schema"] = "https://mimo.xiaomi.com/mimocode/config.json"
               result = mergeDeep(result, rest)
               await fsNode.writeFile(path.join(Global.Path.config, "config.json"), JSON.stringify(result, null, 2))
               await fsNode.unlink(legacy)
@@ -736,7 +736,7 @@ export const layer = Layer.effect(
             }
             const wellknown = (yield* Effect.promise(() => response.json())) as { config?: Record<string, unknown> }
             const remoteConfig = wellknown.config ?? {}
-            if (!remoteConfig.$schema) remoteConfig.$schema = "https://opencode.ai/config.json"
+            if (!remoteConfig.$schema) remoteConfig.$schema = "https://mimo.xiaomi.com/mimocode/config.json"
             const source = `${url}/.well-known/opencode`
             const next = yield* loadConfig(JSON.stringify(remoteConfig), {
               dir: path.dirname(source),


### PR DESCRIPTION
## Summary

The \\\ field in generated config files was pointing to \https://opencode.ai/config.json\ which is incorrect for MiMo Code. This caused custom provider configurations created via \/connect\ to not work properly.

Update all occurrences to use the correct URL: \https://mimo.xiaomi.com/mimocode/config.json\

## Changes

- \packages/opencode/src/config/config.ts\: Fixed 4 instances of incorrect schema URL

## Test Plan

1. Run \/connect\ command and create a custom provider
2. Check generated \mimocode.jsonc\ file
3. Verify \\\ points to \https://mimo.xiaomi.com/mimocode/config.json\
4. Verify custom provider configuration works correctly

Fixes #1369