### PR TITLE
fix: allow worktree directories through InstanceMiddleware access check

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -1,10 +1,12 @@
 import { Effect, Layer, Redacted, Schema } from "effect"
+import nodePath from "path"
 import { HttpApiBuilder, HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi"
 import { HttpRouter, HttpServer, HttpServerRequest } from "effect/unstable/http"
 import { AppRuntime } from "@/effect/app-runtime"
 import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
 import { Observability } from "@/effect"
 import { Flag } from "@/flag/flag"
+import { Global } from "@/global"
 import { InstanceBootstrap } from "@/project/bootstrap"
 import { Instance } from "@/project/instance"
 import { lazy } from "@/util/lazy"
@@ -103,7 +105,8 @@ const instance = HttpRouter.middleware()(
 
         if (!Flag.MIMOCODE_SERVER_PASSWORD) {
           const cwd = Filesystem.resolve(process.cwd())
-          if (!Filesystem.contains(cwd, directory)) {
+          const worktreeRoot = Filesystem.resolve(nodePath.join(Global.Path.data, "worktree"))
+          if (!Filesystem.contains(cwd, directory) && !Filesystem.contains(worktreeRoot, directory)) {
             return yield* new DirectoryAccessDenied({
               message: "Access denied: directory must be within the server's working directory",
             })

--- a/packages/opencode/src/server/routes/instance/middleware.ts
+++ b/packages/opencode/src/server/routes/instance/middleware.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from "hono"
+import path from "path"
 import { Instance } from "@/project/instance"
 import { InstanceBootstrap } from "@/project/bootstrap"
 import { AppRuntime } from "@/effect/app-runtime"
@@ -6,6 +7,7 @@ import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { WorkspaceID } from "@/control-plane/schema"
 import { Flag } from "@/flag/flag"
+import { Global } from "@/global"
 import { Filesystem } from "@/util"
 
 export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler {
@@ -23,7 +25,8 @@ export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler
 
     if (!Flag.MIMOCODE_SERVER_PASSWORD) {
       const cwd = Filesystem.resolve(process.cwd())
-      if (!Filesystem.contains(cwd, directory)) {
+      const worktreeRoot = Filesystem.resolve(path.join(Global.Path.data, "worktree"))
+      if (!Filesystem.contains(cwd, directory) && !Filesystem.contains(worktreeRoot, directory)) {
         return c.json({ error: "Access denied: directory must be within the server's working directory" }, 403)
       }
     }


### PR DESCRIPTION
### Issue for this PR

Closes #1504 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Worktree 目录位于 Global.Path.data/worktree/ 下，不在服务器工作目录中。中间件
校验时只检查了 process.cwd()，导致 SDK client 通过 x-mimocode-directory header
携带 worktree 路径的请求被 403 拒绝。本 PR 在中间件校验中额外允许 worktree 根目
录下的路径。

### How did you verify your code works?
本地 typecheck 通过，worktree 创建流程中 DirectoryAccessDenied 错误不再触发。


```
# Run typecheck across all packages
$ source ~/.zshrc && bun turbo typecheck
Attention:
Turborepo now collects completely anonymous telemetry regarding usage.
This information is used to shape the Turborepo roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://turborepo.dev/docs/telemetry
• turbo 2.8.13
• Packages in scope: @mimo-ai/app, @mimo-ai/cli, @mimo-ai/console-app, @mimo-ai/console-core, @mimo-ai/console-function, @mimo-ai/console-mail, @mimo-ai/console-resource, @mimo-ai/desktop, @mimo-ai/enterprise, @mimo-ai/function, @mimo-ai/plugin, @mimo-ai/script, @mimo-ai/sdk, @mimo-ai/shared, @mimo-ai/slack, @mimo-ai/storybook, @mimo-ai/ui, @mimo-ai/web
• Running typecheck in 18 packages
• Remote caching disabled
@mimo-ai/cli:typecheck: cache miss, executing 9fb588ff96c13916
@mimo-ai/console-app:typecheck: cache miss, executing c058abbe45ff87ba
@mimo-ai/plugin:typecheck: cache miss, executing 84061f6412f725df
@mimo-ai/slack:typecheck: cache miss, executing 388e8e066c144874
@mimo-ai/ui:typecheck: cache miss, executing bf8bb27b42f5c46d
@mimo-ai/desktop:typecheck: cache miss, executing 1579b3706db71c46
@mimo-ai/enterprise:typecheck: cache miss, executing 1174f116618602a2
@mimo-ai/shared:typecheck: cache miss, executing ef9b598e9581f4a8
@mimo-ai/app:typecheck: cache miss, executing db2b750d9692495e
@mimo-ai/console-function:typecheck: cache miss, executing 60c1270dd2772144
@mimo-ai/desktop:typecheck: $ tsgo -b
@mimo-ai/cli:typecheck: $ tsgo --noEmit
@mimo-ai/plugin:typecheck: $ tsgo --noEmit
@mimo-ai/ui:typecheck: $ tsgo --noEmit
@mimo-ai/slack:typecheck: $ tsgo --noEmit
@mimo-ai/console-app:typecheck: $ tsgo --noEmit
@mimo-ai/console-function:typecheck: $ tsgo --noEmit
@mimo-ai/shared:typecheck: $ tsgo --noEmit
@mimo-ai/enterprise:typecheck: $ tsgo --noEmit
@mimo-ai/app:typecheck: $ tsgo -b
@mimo-ai/sdk:typecheck: cache miss, executing 7332b1edbb7aa1b4
@mimo-ai/sdk:typecheck: $ tsgo --noEmit
@mimo-ai/console-core:typecheck: cache miss, executing a28e8bafdd6bdc96
@mimo-ai/console-core:typecheck: $ tsgo --noEmit
 Tasks:    12 successful, 12 total
Cached:    0 cached, 12 total
  Time:    9.596s
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


