### PR TITLE
fix: scroll to bottom when returning from subagent

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1085,6 +1085,9 @@ export function Session() {
   // snap to bottom when session changes
   createEffect(on(() => route.sessionID, toBottom))
 
+  // snap to bottom when returning from subagent (agentID changes)
+  createEffect(on(() => route.data.type === "session" ? route.data.agentID : undefined, toBottom))
+
   return (
     <context.Provider
       value={{


### PR DESCRIPTION
Fixes #1433 - Scroll to bottom when returning from subagent