### PR TITLE
feat(tui): vision-aware image paste with non-vision fallback

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1276,6 +1276,11 @@ export function Prompt(props: PromptProps) {
           }
         }
         if (mime.startsWith("image/") || mime === "application/pdf") {
+          if (mime.startsWith("image/") && !activeModelSupportsImage()) {
+            insertFileReference(filepath)
+            toast.show({ message: t("tui.paste.image.fallback_path"), variant: "info", duration: 3000 })
+            return
+          }
           const content = await Filesystem.readArrayBuffer(filepath)
             .then((buffer) => Buffer.from(buffer).toString("base64"))
             .catch(() => {})
@@ -1309,16 +1314,62 @@ export function Prompt(props: PromptProps) {
     }, 0)
   }
 
+  function activeModelSupportsImage() {
+    const current = local.model.current()
+    if (!current) return false
+    const provider = sync.data.provider.find((p) => p.id === current.providerID)
+    return provider?.models[current.modelID]?.capabilities?.input?.image ?? false
+  }
+
+  function insertFileReference(filepath: string) {
+    const filename = path.basename(filepath)
+    const currentOffset = input.visualCursor.offset
+    const extmarkStart = currentOffset
+    const virtualText = `@${filename}`
+    const extmarkEnd = extmarkStart + virtualText.length
+    input.insertText(virtualText + " ")
+    const extmarkId = input.extmarks.create({
+      start: extmarkStart,
+      end: extmarkEnd,
+      virtual: true,
+      styleId: fileStyleId,
+      typeId: promptPartTypeId,
+    })
+    setStore(
+      produce((draft) => {
+        const partIndex = draft.prompt.parts.length
+        draft.prompt.parts.push({
+          type: "file" as const,
+          mime: "text/plain",
+          filename,
+          url: `file://${filepath}`,
+          source: {
+            type: "file",
+            path: filepath,
+            text: { start: extmarkStart, end: extmarkEnd, value: virtualText },
+          },
+        })
+        draft.extmarkToPartIndex.set(extmarkId, partIndex)
+      }),
+    )
+  }
+
   async function pasteFromClipboard() {
     if (props.disabled) return
     const content = await Clipboard.read()
     if (!content) return
     if (content.mime.startsWith("image/")) {
-      await pasteAttachment({
-        filename: "clipboard",
-        mime: content.mime,
-        content: content.data,
-      })
+      if (activeModelSupportsImage()) {
+        await pasteAttachment({
+          filename: "clipboard",
+          mime: content.mime,
+          content: content.data,
+        })
+        return
+      }
+      const filepath = await Clipboard.spillImage(content)
+      insertFileReference(filepath)
+      toast.show({ message: t("tui.paste.image.fallback_path"), variant: "info", duration: 3000 })
       return
     }
     await pastePlainText(content.data.replace(/\r\n/g, "\n").replace(/\r/g, "\n"))

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -57,7 +57,7 @@ export const dict: Record<string, string> = {
   "tui.tips.redo": "Use {highlight}/redo{/highlight} to restore previously undone messages and file changes",
   "tui.tips.share": "Run {highlight}/share{/highlight} to create a public link to your conversation at opencode.ai",
   "tui.tips.drag_drop": "Drag and drop images or PDFs into the terminal to add them as context",
-  "tui.tips.paste_image": "Press {highlight}Ctrl+V{/highlight} to paste images from your clipboard into the prompt",
+  "tui.tips.paste_image": "Press {highlight}Ctrl+V{/highlight} to paste images from your clipboard (on macOS use Ctrl+V, not Cmd+V — the terminal intercepts Cmd+V)",
   "tui.tips.editor":
     "Press {highlight}Ctrl+X E{/highlight} or {highlight}/editor{/highlight} to compose messages in your external editor",
   "tui.tips.init": "Run {highlight}/init{/highlight} to auto-generate project rules based on your codebase",

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -22,6 +22,7 @@ export const dict: Record<string, string> = {
   "tui.prompt.placeholder.normal": "Type your message... (type / for commands)",
   "tui.prompt.placeholder.shell": 'Run a command... "{{example}}"',
   "tui.prompt.ghost": "{{prediction}}  (Tab to accept)",
+  "tui.paste.image.fallback_path": "Model has no vision support — inserted image path instead",
   "tui.home.placeholder.example.todo": "Fix a TODO in the codebase",
   "tui.home.placeholder.example.stack": "What is the tech stack of this project?",
   "tui.home.placeholder.example.tests": "Fix broken tests",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -66,7 +66,7 @@ export const dict = {
     "Ejecuta {highlight}/share{/highlight} para crear un enlace público a tu conversación en opencode.ai",
   "tui.tips.drag_drop": "Arrastra y suelta imágenes o PDF en el terminal para añadirlos como contexto",
   "tui.tips.paste_image":
-    "Pulsa {highlight}Ctrl+V{/highlight} para pegar imágenes desde el portapapeles en la entrada",
+    "Pulsa {highlight}Ctrl+V{/highlight} para pegar imágenes desde el portapapeles (en macOS usa Ctrl+V, no Cmd+V — la terminal intercepta Cmd+V)",
   "tui.tips.editor":
     "Pulsa {highlight}Ctrl+X E{/highlight} o {highlight}/editor{/highlight} para componer mensajes en tu editor externo",
   "tui.tips.init":

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -26,6 +26,7 @@ export const dict = {
   "tui.prompt.placeholder.normal": 'Pregunta lo que quieras... "{{example}}"',
   "tui.prompt.placeholder.shell": 'Ejecuta un comando... "{{example}}"',
   "tui.prompt.ghost": "{{prediction}}  (Tab para aceptar)",
+  "tui.paste.image.fallback_path": "El modelo no admite imágenes — se insertó la ruta de la imagen en su lugar",
   "tui.home.placeholder.example.todo": "Corregir un TODO en el código",
   "tui.home.placeholder.example.stack": "¿Cuál es el stack técnico del proyecto?",
   "tui.home.placeholder.example.tests": "Arreglar las pruebas fallidas",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -64,7 +64,7 @@ export const dict = {
     "Exécutez {highlight}/share{/highlight} pour créer un lien public vers votre conversation sur opencode.ai",
   "tui.tips.drag_drop": "Glissez-déposez des images ou PDF dans le terminal pour les ajouter au contexte",
   "tui.tips.paste_image":
-    "Appuyez sur {highlight}Ctrl+V{/highlight} pour coller des images du presse-papiers dans l'invite",
+    "Appuyez sur {highlight}Ctrl+V{/highlight} pour coller des images du presse-papiers (sur macOS, utilisez Ctrl+V et non Cmd+V — le terminal intercepte Cmd+V)",
   "tui.tips.editor":
     "Appuyez sur {highlight}Ctrl+X E{/highlight} ou {highlight}/editor{/highlight} pour rédiger des messages dans votre éditeur externe",
   "tui.tips.init":

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -26,6 +26,7 @@ export const dict = {
   "tui.prompt.placeholder.normal": 'Posez votre question... "{{example}}"',
   "tui.prompt.placeholder.shell": 'Exécuter une commande... "{{example}}"',
   "tui.prompt.ghost": "{{prediction}}  (Tab pour accepter)",
+  "tui.paste.image.fallback_path": "Le modèle ne prend pas en charge la vision — chemin de l'image inséré à la place",
   "tui.home.placeholder.example.todo": "Corriger un TODO dans le code",
   "tui.home.placeholder.example.stack": "Quelle est la stack technique de ce projet ?",
   "tui.home.placeholder.example.tests": "Réparer les tests cassés",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -60,7 +60,7 @@ export const dict = {
   "tui.tips.redo": "{highlight}/redo{/highlight} で取り消したメッセージとファイル変更を復元します",
   "tui.tips.share": "{highlight}/share{/highlight} を実行すると opencode.ai に会話の公開リンクを作成します",
   "tui.tips.drag_drop": "画像や PDF をターミナルにドラッグ＆ドロップしてコンテキストに追加できます",
-  "tui.tips.paste_image": "{highlight}Ctrl+V{/highlight} でクリップボードの画像をプロンプトに貼り付けます",
+  "tui.tips.paste_image": "{highlight}Ctrl+V{/highlight} でクリップボードの画像を貼り付けます（macOS では Cmd+V ではなく Ctrl+V を使用してください。Cmd+V は端末が横取りします）",
   "tui.tips.editor":
     "{highlight}Ctrl+X E{/highlight} または {highlight}/editor{/highlight} で外部エディタからメッセージを書けます",
   "tui.tips.init": "{highlight}/init{/highlight} を実行するとコードベースを基にプロジェクトのルールを自動生成します",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -26,6 +26,7 @@ export const dict = {
   "tui.prompt.placeholder.normal": '何でも聞いてください... "{{example}}"',
   "tui.prompt.placeholder.shell": 'コマンドを実行... "{{example}}"',
   "tui.prompt.ghost": "{{prediction}}  (Tab で確定)",
+  "tui.paste.image.fallback_path": "モデルは画像に対応していないため、代わりに画像パスを挿入しました",
   "tui.home.placeholder.example.todo": "コードベース内の TODO を修正",
   "tui.home.placeholder.example.stack": "このプロジェクトの技術スタックは？",
   "tui.home.placeholder.example.tests": "壊れたテストを修正",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -66,7 +66,7 @@ export const dict = {
     "Выполните {highlight}/share{/highlight}, чтобы получить публичную ссылку на диалог на opencode.ai",
   "tui.tips.drag_drop": "Перетащите изображения или PDF в терминал, чтобы добавить их в контекст",
   "tui.tips.paste_image":
-    "Нажмите {highlight}Ctrl+V{/highlight}, чтобы вставить изображение из буфера обмена в строку ввода",
+    "Нажмите {highlight}Ctrl+V{/highlight}, чтобы вставить изображение из буфера обмена (в macOS используйте Ctrl+V, а не Cmd+V — терминал перехватывает Cmd+V)",
   "tui.tips.editor":
     "Нажмите {highlight}Ctrl+X E{/highlight} или {highlight}/editor{/highlight}, чтобы редактировать сообщения во внешнем редакторе",
   "tui.tips.init":

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -26,6 +26,7 @@ export const dict = {
   "tui.prompt.placeholder.normal": 'Спросите что угодно... "{{example}}"',
   "tui.prompt.placeholder.shell": 'Выполните команду... "{{example}}"',
   "tui.prompt.ghost": "{{prediction}}  (Tab — принять)",
+  "tui.paste.image.fallback_path": "Модель не поддерживает изображения — вместо этого вставлен путь к изображению",
   "tui.home.placeholder.example.todo": "Исправь TODO в кодовой базе",
   "tui.home.placeholder.example.stack": "Какой технологический стек у этого проекта?",
   "tui.home.placeholder.example.tests": "Почини сломанные тесты",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -59,7 +59,7 @@ export const dict = {
   "tui.tips.redo": "使用 {highlight}/redo{/highlight} 恢复之前撤销的消息和文件改动",
   "tui.tips.share": "运行 {highlight}/share{/highlight} 在 opencode.ai 上为你的对话生成公开链接",
   "tui.tips.drag_drop": "把图片或 PDF 拖入终端可作为上下文添加",
-  "tui.tips.paste_image": "按 {highlight}Ctrl+V{/highlight} 把剪贴板中的图片粘贴到提示框",
+  "tui.tips.paste_image": "按 {highlight}Ctrl+V{/highlight} 把剪贴板中的图片粘贴到提示框（macOS 上请用 Ctrl+V，不要用 Cmd+V——Cmd+V 会被终端拦截）",
   "tui.tips.editor": "按 {highlight}Ctrl+X E{/highlight} 或 {highlight}/editor{/highlight} 在外部编辑器中编辑消息",
   "tui.tips.init": "运行 {highlight}/init{/highlight} 基于你的代码库自动生成项目规则",
   "tui.tips.models": "运行 {highlight}/models{/highlight} 或 {highlight}Ctrl+X M{/highlight} 切换模型",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -26,6 +26,7 @@ export const dict = {
   "tui.prompt.placeholder.normal": "输入消息...(输入/唤起命令)",
   "tui.prompt.placeholder.shell": '执行命令…… "{{example}}"',
   "tui.prompt.ghost": "{{prediction}}  (按 Tab 采纳)",
+  "tui.paste.image.fallback_path": "当前模型不支持图片，已改为插入图片路径",
   "tui.home.placeholder.example.todo": "修复代码库中的 TODO",
   "tui.home.placeholder.example.stack": "这个项目用了什么技术栈？",
   "tui.home.placeholder.example.tests": "修复失败的测试",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -59,7 +59,7 @@ export const dict = {
   "tui.tips.redo": "使用 {highlight}/redo{/highlight} 還原先前復原的訊息與檔案變更",
   "tui.tips.share": "執行 {highlight}/share{/highlight} 在 opencode.ai 上為你的對話產生公開連結",
   "tui.tips.drag_drop": "把圖片或 PDF 拖入終端機可作為上下文加入",
-  "tui.tips.paste_image": "按 {highlight}Ctrl+V{/highlight} 把剪貼簿中的圖片貼到輸入框",
+  "tui.tips.paste_image": "按 {highlight}Ctrl+V{/highlight} 把剪貼簿中的圖片貼到輸入框（macOS 上請用 Ctrl+V，不要用 Cmd+V——Cmd+V 會被終端攔截）",
   "tui.tips.editor": "按 {highlight}Ctrl+X E{/highlight} 或 {highlight}/editor{/highlight} 在外部編輯器中編輯訊息",
   "tui.tips.init": "執行 {highlight}/init{/highlight} 根據你的程式碼庫自動產生專案規則",
   "tui.tips.models": "執行 {highlight}/models{/highlight} 或 {highlight}Ctrl+X M{/highlight} 切換模型",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -26,6 +26,7 @@ export const dict = {
   "tui.prompt.placeholder.normal": '問點什麼…… "{{example}}"',
   "tui.prompt.placeholder.shell": '執行指令…… "{{example}}"',
   "tui.prompt.ghost": "{{prediction}}  (按 Tab 採納)",
+  "tui.paste.image.fallback_path": "目前模型不支援圖片，已改為插入圖片路徑",
   "tui.home.placeholder.example.todo": "修復程式碼庫中的 TODO",
   "tui.home.placeholder.example.stack": "這個專案用了什麼技術棧？",
   "tui.home.placeholder.example.tests": "修復失敗的測試",

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -43,6 +43,90 @@ export async function spillImage(content: { data: string; mime: string }): Promi
   return file
 }
 
+// Reads an image off the macOS clipboard as PNG, whatever representation the
+// source app put there (screenshots, PixPin, copied files, other tools).
+//
+// Enumerating specific pasteboard classes ("PNGf", TIFF) is fragile: it only
+// matches sources that happen to publish that exact type. Instead we ask AppKit
+// to decode ANY available image representation into an NSImage and re-encode it
+// to PNG — the same path native apps use — so format detection is the system's
+// job, not ours. `pngpaste` (if installed) is a faster shortcut for the common
+// case; the osascript path is a last resort when Swift tooling is unavailable.
+async function readDarwinClipboardImage(): Promise<Content | undefined> {
+  const dest = path.join(tmpdir(), `opencode-clipboard-${Date.now()}.png`)
+  try {
+    // Fast path: pngpaste (brew) reads any image representation as PNG.
+    const which = await getWhich()
+    if (which("pngpaste")) {
+      const out = await Process.run(["pngpaste", dest], { nothrow: true })
+      if (out.code === 0) {
+        const buf = await Filesystem.readBytes(dest).catch(() => Buffer.alloc(0))
+        if (buf.length > 0) return { data: buf.toString("base64"), mime: "image/png" }
+      }
+    }
+
+    // Primary path: let AppKit decode any image representation → PNG.
+    if (which("swift")) {
+      const script = path.join(tmpdir(), `opencode-clipboard-${Date.now()}.swift`)
+      const swift = [
+        "import AppKit",
+        "guard let image = NSImage(pasteboard: NSPasteboard.general) else { exit(1) }",
+        "guard let tiff = image.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff),",
+        "      let png = rep.representation(using: .png, properties: [:]) else { exit(1) }",
+        `try? png.write(to: URL(fileURLWithPath: "${dest}"))`,
+      ].join("\n")
+      try {
+        await Bun.write(script, swift)
+        const out = await Process.run(["swift", script], { nothrow: true })
+        if (out.code === 0) {
+          const buf = await Filesystem.readBytes(dest).catch(() => Buffer.alloc(0))
+          if (buf.length > 0) return { data: buf.toString("base64"), mime: "image/png" }
+        }
+      } finally {
+        await fs.rm(script, { force: true }).catch(() => {})
+      }
+    }
+
+    // Last resort: osascript PNGf, then TIFF via sips. Works without Swift CLT
+    // but only matches those two specific pasteboard classes.
+    const dumpClipboard = async (clazz: string, out: string) => {
+      await Process.run(
+        [
+          "osascript",
+          "-e",
+          `set imageData to the clipboard as ${clazz}`,
+          "-e",
+          `set fileRef to open for access POSIX file "${out}" with write permission`,
+          "-e",
+          "set eof fileRef to 0",
+          "-e",
+          "write imageData to fileRef",
+          "-e",
+          "close access fileRef",
+        ],
+        { nothrow: true },
+      )
+      return Filesystem.readBytes(out).catch(() => Buffer.alloc(0))
+    }
+    const png = await dumpClipboard('"PNGf"', dest)
+    if (png.length > 0) return { data: png.toString("base64"), mime: "image/png" }
+    const tifffile = dest.replace(/\.png$/, ".tiff")
+    try {
+      const tiff = await dumpClipboard("«class TIFF»", tifffile)
+      if (tiff.length > 0) {
+        await Process.run(["sips", "-s", "format", "png", tifffile, "--out", dest], { nothrow: true })
+        const converted = await Filesystem.readBytes(dest).catch(() => Buffer.alloc(0))
+        if (converted.length > 0) return { data: converted.toString("base64"), mime: "image/png" }
+      }
+    } finally {
+      await fs.rm(tifffile, { force: true }).catch(() => {})
+    }
+    return undefined
+  } finally {
+    await fs.rm(dest, { force: true }).catch(() => {})
+  }
+}
+
 // Checks clipboard for images first, then falls back to text.
 //
 // On Windows prompt/ can call this from multiple paste signals because
@@ -55,50 +139,8 @@ export async function read(): Promise<Content | undefined> {
   const os = platform()
 
   if (os === "darwin") {
-    // Dump a given clipboard class (e.g. "PNGf", «class TIFF») to a file via
-    // osascript. osascript runs with nothrow, so absence of that class leaves
-    // the file empty rather than throwing — callers must check the byte length.
-    const dumpClipboard = async (clazz: string, dest: string) => {
-      await Process.run(
-        [
-          "osascript",
-          "-e",
-          `set imageData to the clipboard as ${clazz}`,
-          "-e",
-          `set fileRef to open for access POSIX file "${dest}" with write permission`,
-          "-e",
-          "set eof fileRef to 0",
-          "-e",
-          "write imageData to fileRef",
-          "-e",
-          "close access fileRef",
-        ],
-        { nothrow: true },
-      )
-      return Filesystem.readBytes(dest).catch(() => Buffer.alloc(0))
-    }
-
-    const pngfile = path.join(tmpdir(), "opencode-clipboard.png")
-    const tifffile = path.join(tmpdir(), "opencode-clipboard.tiff")
-    try {
-      // Fast path: clipboard already carries a PNG representation.
-      const png = await dumpClipboard('"PNGf"', pngfile)
-      if (png.length > 0) return { data: png.toString("base64"), mime: "image/png" }
-
-      // Fallback: macOS screenshots land on the clipboard as TIFF with no PNG
-      // representation, so "PNGf" yields nothing. Read the TIFF and convert it
-      // to PNG with the built-in `sips`.
-      const tiff = await dumpClipboard("«class TIFF»", tifffile)
-      if (tiff.length > 0) {
-        await Process.run(["sips", "-s", "format", "png", tifffile, "--out", pngfile], { nothrow: true })
-        const converted = await Filesystem.readBytes(pngfile).catch(() => Buffer.alloc(0))
-        if (converted.length > 0) return { data: converted.toString("base64"), mime: "image/png" }
-      }
-    } catch {
-    } finally {
-      await fs.rm(pngfile, { force: true }).catch(() => {})
-      await fs.rm(tifffile, { force: true }).catch(() => {})
-    }
+    const image = await readDarwinClipboardImage()
+    if (image) return image
   }
 
   // Windows/WSL: probe clipboard for images via PowerShell.

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -55,15 +55,17 @@ export async function read(): Promise<Content | undefined> {
   const os = platform()
 
   if (os === "darwin") {
-    const tmpfile = path.join(tmpdir(), "opencode-clipboard.png")
-    try {
+    // Dump a given clipboard class (e.g. "PNGf", «class TIFF») to a file via
+    // osascript. osascript runs with nothrow, so absence of that class leaves
+    // the file empty rather than throwing — callers must check the byte length.
+    const dumpClipboard = async (clazz: string, dest: string) => {
       await Process.run(
         [
           "osascript",
           "-e",
-          'set imageData to the clipboard as "PNGf"',
+          `set imageData to the clipboard as ${clazz}`,
           "-e",
-          `set fileRef to open for access POSIX file "${tmpfile}" with write permission`,
+          `set fileRef to open for access POSIX file "${dest}" with write permission`,
           "-e",
           "set eof fileRef to 0",
           "-e",
@@ -73,11 +75,29 @@ export async function read(): Promise<Content | undefined> {
         ],
         { nothrow: true },
       )
-      const buffer = await Filesystem.readBytes(tmpfile)
-      return { data: buffer.toString("base64"), mime: "image/png" }
+      return Filesystem.readBytes(dest).catch(() => Buffer.alloc(0))
+    }
+
+    const pngfile = path.join(tmpdir(), "opencode-clipboard.png")
+    const tifffile = path.join(tmpdir(), "opencode-clipboard.tiff")
+    try {
+      // Fast path: clipboard already carries a PNG representation.
+      const png = await dumpClipboard('"PNGf"', pngfile)
+      if (png.length > 0) return { data: png.toString("base64"), mime: "image/png" }
+
+      // Fallback: macOS screenshots land on the clipboard as TIFF with no PNG
+      // representation, so "PNGf" yields nothing. Read the TIFF and convert it
+      // to PNG with the built-in `sips`.
+      const tiff = await dumpClipboard("«class TIFF»", tifffile)
+      if (tiff.length > 0) {
+        await Process.run(["sips", "-s", "format", "png", tifffile, "--out", pngfile], { nothrow: true })
+        const converted = await Filesystem.readBytes(pngfile).catch(() => Buffer.alloc(0))
+        if (converted.length > 0) return { data: converted.toString("base64"), mime: "image/png" }
+      }
     } catch {
     } finally {
-      await fs.rm(tmpfile, { force: true }).catch(() => {})
+      await fs.rm(pngfile, { force: true }).catch(() => {})
+      await fs.rm(tifffile, { force: true }).catch(() => {})
     }
   }
 

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -65,30 +65,30 @@ async function readDarwinClipboardImage(): Promise<Content | undefined> {
       }
     }
 
-    // Primary path: let AppKit decode any image representation → PNG.
-    if (which("swift")) {
-      const script = path.join(tmpdir(), `opencode-clipboard-${Date.now()}.swift`)
-      const swift = [
-        "import AppKit",
-        "guard let image = NSImage(pasteboard: NSPasteboard.general) else { exit(1) }",
-        "guard let tiff = image.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff),",
-        "      let png = rep.representation(using: .png, properties: [:]) else { exit(1) }",
-        `try? png.write(to: URL(fileURLWithPath: "${dest}"))`,
-      ].join("\n")
-      try {
-        await Bun.write(script, swift)
-        const out = await Process.run(["swift", script], { nothrow: true })
-        if (out.code === 0) {
-          const buf = await Filesystem.readBytes(dest).catch(() => Buffer.alloc(0))
-          if (buf.length > 0) return { data: buf.toString("base64"), mime: "image/png" }
-        }
-      } finally {
-        await fs.rm(script, { force: true }).catch(() => {})
-      }
+    // Primary path: let AppKit decode any image representation → PNG. Use JXA
+    // (osascript -l JavaScript) rather than `swift`, which recompiles on every
+    // invocation (multi-second cold stall) and needs Xcode CLT. JXA is
+    // interpreted, always available, and reaches the same AppKit APIs.
+    const jxa = [
+      "ObjC.import('AppKit');",
+      "const pb = $.NSPasteboard.generalPasteboard;",
+      "const img = $.NSImage.alloc.initWithPasteboard(pb);",
+      "if (!img) { $.exit(1); }",
+      "const tiff = img.TIFFRepresentation;",
+      "if (!tiff) { $.exit(1); }",
+      "const rep = $.NSBitmapImageRep.imageRepWithData(tiff);",
+      "const png = rep.representationUsingTypeProperties($.NSBitmapImageFileTypePNG, $());",
+      "if (!png) { $.exit(1); }",
+      `png.writeToFileAtomically($('${dest}'), true);`,
+    ].join("\n")
+    const jxaOut = await Process.run(["osascript", "-l", "JavaScript", "-e", jxa], { nothrow: true })
+    if (jxaOut.code === 0) {
+      const buf = await Filesystem.readBytes(dest).catch(() => Buffer.alloc(0))
+      if (buf.length > 0) return { data: buf.toString("base64"), mime: "image/png" }
     }
 
-    // Last resort: osascript PNGf, then TIFF via sips. Works without Swift CLT
-    // but only matches those two specific pasteboard classes.
+    // Last resort: osascript PNGf, then TIFF via sips. Works even on the rare
+    // system where JXA/AppKit is unavailable, but only matches those two classes.
     const dumpClipboard = async (clazz: string, out: string) => {
       await Process.run(
         [

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -36,6 +36,13 @@ export interface Content {
   mime: string
 }
 
+export async function spillImage(content: { data: string; mime: string }): Promise<string> {
+  const ext = content.mime === "image/png" ? "png" : content.mime === "image/jpeg" ? "jpg" : "bin"
+  const file = path.join(tmpdir(), `opencode-paste-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`)
+  await Bun.write(file, Buffer.from(content.data, "base64"))
+  return file
+}
+
 // Checks clipboard for images first, then falls back to text.
 //
 // On Windows prompt/ can call this from multiple paste signals because

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -140,6 +140,10 @@ const InfoSchema = Schema.Struct({
   small_model: Schema.optional(ConfigModelID).annotate({
     description: "Small model to use for tasks like title generation in the format of provider/model",
   }),
+  vision_model: Schema.optional(ConfigModelID).annotate({
+    description:
+      "Model to use for image/vision subagent tasks in the format of provider/model. If unset, a vision-capable model is chosen automatically (in-house models preferred, then cheapest).",
+  }),
   model_groups: Schema.optional(
     Schema.Record(
       Schema.String,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1694,10 +1694,16 @@ const layer: Layer.Layer<
 
     const getVisionModel = Effect.fn("Provider.getVisionModel")(function* () {
       const cfg = yield* config.get()
-      // Explicit vision_model literal wins.
+      // Explicit vision_model literal wins. getModel raises ModelNotFoundError as
+      // a defect, so a misconfigured vision_model must not propagate — catch it and
+      // fall back to the smart default. (This runs at SystemPrompt layer construction,
+      // so an uncaught defect would fail session startup, not just image reads.)
       if (cfg.vision_model) {
         const parsed = parseModel(cfg.vision_model)
-        return yield* getModel(parsed.providerID, parsed.modelID)
+        const explicit = yield* getModel(parsed.providerID, parsed.modelID).pipe(
+          Effect.catchDefect(() => Effect.succeed(undefined)),
+        )
+        if (explicit) return explicit
       }
       // Smart default: in-house preferred, then cheapest vision-capable model.
       const providers = yield* list()

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1239,6 +1239,11 @@ const layer: Layer.Layer<
               cachePromptTTL: model.cachePromptTTL ?? existingModel?.cachePromptTTL,
               variants: {},
             }
+            // mimo-auto is a free-tier routing alias absent from models.dev; it routes to a
+            // vision-capable model, so image input is supported.
+            if (providerID === "mimo" && modelID === "mimo-auto") {
+              parsedModel.capabilities.input.image = true
+            }
             const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
             parsedModel.variants = mapValues(
               pickBy(merged, (v) => !v.disabled),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -950,6 +950,7 @@ export interface Interface {
     query: string[],
   ) => Effect.Effect<{ providerID: ProviderID; modelID: string } | undefined>
   readonly getSmallModel: (providerID: ProviderID) => Effect.Effect<Model | undefined>
+  readonly getVisionModel: () => Effect.Effect<Model | undefined>
   readonly resolveModelRef: (ref: string, contextProviderID?: ProviderID) => Effect.Effect<Model>
   readonly defaultModel: () => Effect.Effect<{ providerID: ProviderID; modelID: ModelID }>
 }
@@ -963,6 +964,15 @@ interface State {
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Provider") {}
+
+export function sortVisionModels(models: Model[]): Model[] {
+  const inHouse = (m: Model) => m.providerID === "mimo" || m.providerID === "xiaomi"
+  return [...models].sort((a, b) => {
+    if (inHouse(a) !== inHouse(b)) return inHouse(a) ? -1 : 1
+    if (a.cost.input !== b.cost.input) return a.cost.input - b.cost.input
+    return `${a.providerID}/${a.id}`.localeCompare(`${b.providerID}/${b.id}`)
+  })
+}
 
 function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
   const result: Model["cost"] = {
@@ -1682,6 +1692,21 @@ const layer: Layer.Layer<
       return yield* resolveModelRef("lite", providerID)
     })
 
+    const getVisionModel = Effect.fn("Provider.getVisionModel")(function* () {
+      const cfg = yield* config.get()
+      // Explicit vision_model literal wins.
+      if (cfg.vision_model) {
+        const parsed = parseModel(cfg.vision_model)
+        return yield* getModel(parsed.providerID, parsed.modelID)
+      }
+      // Smart default: in-house preferred, then cheapest vision-capable model.
+      const providers = yield* list()
+      const vision = Object.values(providers)
+        .flatMap((info) => Object.values(info.models))
+        .filter((m) => m.capabilities.input.image === true)
+      return sortVisionModels(vision)[0]
+    })
+
     const defaultModel = Effect.fn("Provider.defaultModel")(function* () {
       const cfg = yield* config.get()
       if (cfg.model) return parseModel(cfg.model)
@@ -1721,7 +1746,7 @@ const layer: Layer.Layer<
       }
     })
 
-    return Service.of({ list, getProvider, getModel, getLanguage, closest, getSmallModel, defaultModel, resolveModelRef })
+    return Service.of({ list, getProvider, getModel, getLanguage, closest, getSmallModel, getVisionModel, defaultModel, resolveModelRef })
   }),
 )
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -17,23 +17,6 @@ function mimeToModality(mime: string): Modality | undefined {
   return undefined
 }
 
-// MiMo vision support isn't reflected in models.dev modality data, so the
-// generic capability check would strip images before they reach the model.
-// mimo-auto and mimo-v2.5 accept images; mimo-v2.5-pro is text-only.
-function supportsImageInput(model: Provider.Model): boolean {
-  if (model.providerID === "mimo" || model.providerID === "xiaomi") {
-    const id = model.id.toLowerCase()
-    if (id.includes("v2.5-pro")) return false
-    if (id === "mimo-auto" || id.includes("v2.5")) return true
-  }
-  // Claude and GPT models are all multimodal regardless of catalog data.
-  const id = model.id.toLowerCase()
-  const apiID = model.api.id.toLowerCase()
-  if (id.includes("claude") || apiID.includes("claude") || model.providerID === "anthropic") return true
-  if (id.includes("gpt") || apiID.includes("gpt")) return true
-  return model.capabilities.input.image
-}
-
 export const OUTPUT_TOKEN_MAX = Flag.MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
 const MIMO_OUTPUT_TOKEN_MAX = 128_000
 
@@ -388,7 +371,7 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
       const filename = part.type === "file" ? part.filename : undefined
       const modality = mimeToModality(mime)
       if (!modality) return part
-      const supported = modality === "image" ? supportsImageInput(model) : model.capabilities.input[modality]
+      const supported = model.capabilities.input[modality]
       if (supported) return part
 
       const name = filename ? `"${filename}"` : modality

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -15,6 +15,7 @@ import PROMPT_GLM from "./prompt/glm.txt"
 import PROMPT_MINIMAX from "./prompt/minimax.txt"
 import PROMPT_TRINITY from "./prompt/trinity.txt"
 import { Provider } from "@/provider"
+import { sortVisionModels } from "@/provider/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
@@ -51,19 +52,22 @@ export const layer = Layer.effect(
     const skill = yield* Skill.Service
 
     const provider = yield* Provider.Service
+    const preferred = yield* provider.getVisionModel().pipe(Effect.orElseSucceed(() => undefined))
     const visionModels = yield* provider
       .list()
       .pipe(
         Effect.map((providers) =>
-          Object.values(providers)
-            .flatMap((info) => Object.values(info.models))
-            .filter((m) => m.capabilities.input.image === true)
+          sortVisionModels(
+            Object.values(providers)
+              .flatMap((info) => Object.values(info.models))
+              .filter((m) => m.capabilities.input.image === true),
+          )
             .map((m) => `${m.providerID}/${m.id}`)
-            .sort((a, b) => a.localeCompare(b))
             .slice(0, 3),
         ),
       )
       .pipe(Effect.orElseSucceed(() => [] as string[]))
+    const preferredRef = preferred ? `${preferred.providerID}/${preferred.id}` : visionModels[0]
 
     return Service.of({
       environment(model, now) {
@@ -94,7 +98,7 @@ export const layer = Layer.effect(
               `You CANNOT see or interpret image content — this model has no vision support.`,
               `Never attempt to analyze an image's visual content yourself. If a task needs image understanding, dispatch a vision-capable subagent via the actor tool, passing the image file path so the subagent can Read it.`,
               visionModels.length
-                ? `Vision-capable models you can pass to --model: ${visionModels.join(", ")}. Run \`actor models --vision\` to see all of them. Example: actor run <type> "<desc>" "analyze the image at <path>" --model ${visionModels[0]}.`
+                ? `Vision-capable models you can pass to --model: ${visionModels.join(", ")}. Run \`actor models --vision\` to see all of them. Example: actor run <type> "<desc>" "analyze the image at <path>" --model ${preferredRef}.`
                 : `No vision-capable model is currently configured. Ask the user to configure a vision model, or use an OCR tool to extract text.`,
               `If instead you need a file's raw binary structure (not its visual content), use a shell tool such as \`hexdump -C <path>\`, NOT the read tool.`,
             ].join("\n"),

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -53,7 +53,7 @@ export const layer = Layer.effect(
     return Service.of({
       environment(model, now) {
         const project = Instance.project
-        return [
+        const base = [
           [
             `You are MiMo Code Agent, built by Xiaomi MiMo Team. You are an interactive agent that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.`,
             `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
@@ -72,6 +72,16 @@ export const layer = Layer.effect(
           ].join("\n"),
           `IMPORTANT: Your response must ALWAYS strictly follow the same major language as the user.`,
         ]
+        if (!model.capabilities.input.image)
+          base.push(
+            [
+              `<vision-capability>`,
+              `You CANNOT see or interpret image content — this model has no vision support.`,
+              `Never attempt to analyze an image's visual content yourself. If a task needs image understanding, dispatch a vision-capable subagent via the actor tool (actor run <type> "<desc>" "<prompt>" --model <a vision model>), passing the image file path so the subagent can Read it.`,
+              `If instead you need a file's raw binary structure (not its visual content), use a shell tool such as \`hexdump -C <path>\`, NOT the read tool.`,
+            ].join("\n"),
+          )
+        return base
       },
 
       skills: Effect.fn("SystemPrompt.skills")(function* (agent: Agent.Info) {

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -14,7 +14,7 @@ import PROMPT_DEEPSEEK from "./prompt/deepseek.txt"
 import PROMPT_GLM from "./prompt/glm.txt"
 import PROMPT_MINIMAX from "./prompt/minimax.txt"
 import PROMPT_TRINITY from "./prompt/trinity.txt"
-import type { Provider } from "@/provider"
+import { Provider } from "@/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
@@ -50,6 +50,21 @@ export const layer = Layer.effect(
   Effect.gen(function* () {
     const skill = yield* Skill.Service
 
+    const provider = yield* Provider.Service
+    const visionModels = yield* provider
+      .list()
+      .pipe(
+        Effect.map((providers) =>
+          Object.values(providers)
+            .flatMap((info) => Object.values(info.models))
+            .filter((m) => m.capabilities.input.image === true)
+            .map((m) => `${m.providerID}/${m.id}`)
+            .sort((a, b) => a.localeCompare(b))
+            .slice(0, 3),
+        ),
+      )
+      .pipe(Effect.orElseSucceed(() => [] as string[]))
+
     return Service.of({
       environment(model, now) {
         const project = Instance.project
@@ -77,7 +92,10 @@ export const layer = Layer.effect(
             [
               `<vision-capability>`,
               `You CANNOT see or interpret image content — this model has no vision support.`,
-              `Never attempt to analyze an image's visual content yourself. If a task needs image understanding, dispatch a vision-capable subagent via the actor tool (actor run <type> "<desc>" "<prompt>" --model <a vision model>), passing the image file path so the subagent can Read it.`,
+              `Never attempt to analyze an image's visual content yourself. If a task needs image understanding, dispatch a vision-capable subagent via the actor tool, passing the image file path so the subagent can Read it.`,
+              visionModels.length
+                ? `Vision-capable models you can pass to --model: ${visionModels.join(", ")}. Run \`actor models --vision\` to see all of them. Example: actor run <type> "<desc>" "analyze the image at <path>" --model ${visionModels[0]}.`
+                : `No vision-capable model is currently configured. Ask the user to configure a vision model, or use an OCR tool to extract text.`,
               `If instead you need a file's raw binary structure (not its visual content), use a shell tool such as \`hexdump -C <path>\`, NOT the read tool.`,
             ].join("\n"),
           )
@@ -101,6 +119,6 @@ export const layer = Layer.effect(
   }),
 )
 
-export const defaultLayer = layer.pipe(Layer.provide(Skill.defaultLayer))
+export const defaultLayer = layer.pipe(Layer.provide(Skill.defaultLayer), Layer.provide(Provider.defaultLayer))
 
 export * as SystemPrompt from "./system"

--- a/packages/opencode/src/tool/actor.shell.txt
+++ b/packages/opencode/src/tool/actor.shell.txt
@@ -34,6 +34,9 @@ appends them at request time per-agent).
     # --session: target session id (defaults to current); --type: 'text' (default) or 'actor_notification'
     # (--task is NOT valid here — it applies only to run/spawn for tying a subagent to a task_id)
 
+# list available models (optionally vision-only) to pick a --model value:
+    actor models [--vision] [--limit <n>]
+
 Examples:
     actor run explore "Find error recovery" "Scan src/parser.ts for catch blocks. Return file:line."
 
@@ -70,3 +73,4 @@ When to use what:
     run    — single delegation where the result drives your next step
     spawn  — fan-out for parallel work, OR fire-and-forget background tasks
     wait   — pick up a previously-spawned actor's result on demand
+    models — discover which models you can pass to --model (use --vision to find image-capable models for dispatching an image subagent)

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -9,6 +9,7 @@ import { SessionID, MessageID, PartID } from "../session/schema"
 import { MessageV2 } from "../session/message-v2"
 import { Agent } from "../agent/agent"
 import { Provider } from "../provider"
+import { sortVisionModels } from "../provider/provider"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "../config"
 import { ActorRegistry } from "@/actor/registry"
@@ -640,24 +641,20 @@ export const ActorTool = Tool.define(
 
         if (op.action === "models") {
           const providers = yield* provider.list()
-          const all = Object.values(providers).flatMap((info) =>
-            Object.values(info.models).map((m) => ({
-              ref: `${m.providerID}/${m.id}`,
-              name: m.name,
-              vision: m.capabilities.input.image === true,
-            })),
-          )
-          const filtered = op.vision ? all.filter((m) => m.vision) : all
-          const sorted = filtered.sort((a, b) => a.ref.localeCompare(b.ref))
+          const allModels = Object.values(providers).flatMap((info) => Object.values(info.models))
+          const filtered = op.vision ? allModels.filter((m) => m.capabilities.input.image === true) : allModels
+          const ordered = op.vision
+            ? sortVisionModels(filtered)
+            : [...filtered].sort((a, b) => `${a.providerID}/${a.id}`.localeCompare(`${b.providerID}/${b.id}`))
           const limit = op.limit ?? 50
-          const shown = sorted.slice(0, limit)
-          const lines = shown.map((m) => `${m.ref}${m.vision ? " (vision)" : ""}`)
+          const shown = ordered.slice(0, limit)
+          const lines = shown.map((m) => `${m.providerID}/${m.id}${m.capabilities.input.image ? " (vision)" : ""}`)
           const header = op.vision ? `Vision-capable models` : `Available models`
-          const more = sorted.length > shown.length ? `\n… and ${sorted.length - shown.length} more (raise --limit)` : ""
+          const more = ordered.length > shown.length ? `\n… and ${ordered.length - shown.length} more (raise --limit)` : ""
           const output = shown.length === 0
             ? (op.vision ? "No vision-capable models are configured. Configure a vision model or use an OCR tool." : "No models are configured.")
-            : `${header} (${shown.length} of ${sorted.length}):\n${lines.join("\n")}${more}\nPass any of these to actor --model.`
-          return { title: header, output, metadata: { count: shown.length, total: sorted.length, vision: !!op.vision } as Record<string, any> }
+            : `${header} (${shown.length} of ${ordered.length}):\n${lines.join("\n")}${more}\nPass any of these to actor --model.`
+          return { title: header, output, metadata: { count: shown.length, total: ordered.length, vision: !!op.vision } as Record<string, any> }
         }
 
         // op.action ==="run" or "spawn" — schema guarantees

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -31,7 +31,7 @@ const id = "actor"
 const MODEL_PARAM_DESCRIPTION =
   "(optional) Model for this subagent: a model group name (e.g. ultra/standard/lite) or a literal provider/model (e.g. mimo-v2.5-pro). Overrides the agent's configured model; defaults to the agent's model, else the parent's. If no model_groups are configured, the tier names resolve to the default model."
 
-const KNOWN_ACTOR_VERBS = ["run", "spawn", "status", "wait", "cancel", "send"]
+const KNOWN_ACTOR_VERBS = ["run", "spawn", "status", "wait", "cancel", "send", "models"]
 
 function levenshteinActor(a: string, b: string): number {
   const m = a.length, n = b.length
@@ -65,6 +65,7 @@ type ActorShellArgs =
   | { operation: { action: "wait"; actor_id: string; timeout_ms?: number } }
   | { operation: { action: "cancel"; actor_id: string } }
   | { operation: { action: "send"; to_actor_id: string; content: string; to_session_id?: string; type?: string } }
+  | { operation: { action: "models"; vision?: boolean; limit?: number } }
 
 function actorArityError(verb: string, expected: string, args: string[], line: number) {
   return Effect.fail({
@@ -183,6 +184,20 @@ const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefin
           content: rest[1],
           ...(flags.session ? { to_session_id: flags.session } : {}),
           ...(flags.type ? { type: flags.type } : {}),
+        },
+      } as ActorShellArgs
+    }
+    case "models": {
+      const vision = args.includes("--vision")
+      const withoutVision = args.filter((a) => a !== "--vision")
+      const { flags, rest } = yield* extractNamedFlags(withoutVision, ["limit"], line)
+      if (rest.length !== 0)
+        return yield* actorArityError("models", "[--vision] [--limit <n>]", rest, line)
+      return {
+        operation: {
+          action: "models" as const,
+          ...(vision ? { vision: true } : {}),
+          ...(flags.limit ? { limit: Number(flags.limit) } : {}),
         },
       } as ActorShellArgs
     }
@@ -444,6 +459,12 @@ export const ActorTool = Tool.define(
           ),
       })
 
+      const modelsSchema = z.strictObject({
+        action: z.literal("models"),
+        vision: z.boolean().optional().describe("(optional) If true, list only vision-capable models (models that accept image input)."),
+        limit: z.number().int().positive().optional().describe("(optional) Max number of models to return. Default 50."),
+      })
+
       const parameters = z.strictObject({
         // .meta({ type: "object" }) is REQUIRED — without it the emitted JSON
         // schema's `operation` node has only `anyOf`, no `type`, and some models
@@ -460,6 +481,7 @@ export const ActorTool = Tool.define(
             waitSchema,
             cancelSchema,
             sendSchema,
+            modelsSchema,
           ])
           .meta({ type: "object" }),
       })
@@ -614,6 +636,28 @@ export const ActorTool = Tool.define(
             output: JSON.stringify(snapshot),
             metadata: { actor_id: entry.actorID, status: "cancelled" } as Record<string, any>,
           }
+        }
+
+        if (op.action === "models") {
+          const providers = yield* provider.list()
+          const all = Object.values(providers).flatMap((info) =>
+            Object.values(info.models).map((m) => ({
+              ref: `${m.providerID}/${m.id}`,
+              name: m.name,
+              vision: m.capabilities.input.image === true,
+            })),
+          )
+          const filtered = op.vision ? all.filter((m) => m.vision) : all
+          const sorted = filtered.sort((a, b) => a.ref.localeCompare(b.ref))
+          const limit = op.limit ?? 50
+          const shown = sorted.slice(0, limit)
+          const lines = shown.map((m) => `${m.ref}${m.vision ? " (vision)" : ""}`)
+          const header = op.vision ? `Vision-capable models` : `Available models`
+          const more = sorted.length > shown.length ? `\n… and ${sorted.length - shown.length} more (raise --limit)` : ""
+          const output = shown.length === 0
+            ? (op.vision ? "No vision-capable models are configured. Configure a vision model or use an OCR tool." : "No models are configured.")
+            : `${header} (${shown.length} of ${sorted.length}):\n${lines.join("\n")}${more}\nPass any of these to actor --model.`
+          return { title: header, output, metadata: { count: shown.length, total: sorted.length, vision: !!op.vision } as Record<string, any> }
         }
 
         // op.action ==="run" or "spawn" — schema guarantees

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -29,7 +29,7 @@ export interface ActorPromptOps {
 const id = "actor"
 
 const MODEL_PARAM_DESCRIPTION =
-  "(optional) Model for this subagent: a model group name (e.g. ultra/standard/lite) or a literal provider/model (e.g. mimo-v2.5-pro). Overrides the agent's configured model; defaults to the agent's model, else the parent's. If no model_groups are configured, the tier names resolve to the default model."
+  "(optional) Model for this subagent: a model group name (e.g. ultra/standard/lite) or a literal provider/model (e.g. mimo-v2.5-pro). Overrides the agent's configured model; defaults to the agent's model, else the parent's. If no model_groups are configured, the tier names resolve to the default model. To discover valid provider/model values (e.g. a vision-capable model for image tasks), run `actor models` (or `actor models --vision`)."
 
 const KNOWN_ACTOR_VERBS = ["run", "spawn", "status", "wait", "cancel", "send", "models"]
 

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -198,7 +198,7 @@ const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefin
         operation: {
           action: "models" as const,
           ...(vision ? { vision: true } : {}),
-          ...(flags.limit ? { limit: Number(flags.limit) } : {}),
+          ...(Number.isInteger(Number(flags.limit)) && Number(flags.limit) > 0 ? { limit: Number(flags.limit) } : {}),
         },
       } as ActorShellArgs
     }

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -11,6 +11,7 @@ import { Instance } from "../project/instance"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { SessionCwd } from "./session-cwd"
 import { Instruction } from "../session/instruction"
+import { Provider } from "@/provider"
 import { isImageAttachment, isPdfAttachment, sniffAttachmentMime } from "@/util/media"
 
 const DEFAULT_READ_LIMIT = 2000
@@ -32,6 +33,7 @@ export const ReadTool = Tool.define(
     const fs = yield* AppFileSystem.Service
     const instruction = yield* Instruction.Service
     const lsp = yield* LSP.Service
+    const provider = yield* Provider.Service
     const scope = yield* Scope.Scope
 
     const miss = Effect.fn("ReadTool.miss")(function* (filepath: string) {
@@ -208,14 +210,55 @@ export const ReadTool = Tool.define(
       const sample = yield* readSample(filepath, Number(stat.size), SAMPLE_BYTES)
 
       const mime = sniffAttachmentMime(sample, AppFileSystem.mimeType(filepath))
-      if (isImageAttachment(mime) || isPdfAttachment(mime)) {
+      if (isImageAttachment(mime)) {
+        const modelRef = [...ctx.messages]
+          .reverse()
+          .map((m) => m.info)
+          .find((i): i is Extract<typeof i, { role: "user" }> => i.role === "user")?.model
+        const model = modelRef
+          ? yield* provider
+              .getModel(modelRef.providerID, modelRef.modelID)
+              .pipe(Effect.catch(() => Effect.succeed(undefined)))
+          : undefined
+        const supportsImage = model?.capabilities.input.image ?? false
+        if (!supportsImage) {
+          const warning = [
+            `Cannot read image "${path.basename(filepath)}" — the current model has no vision support, so its visual content is unavailable.`,
+            `If you need to understand the image visually, dispatch a vision-capable subagent: actor run <type> "<desc>" "analyze the image at ${filepath}" --model <a vision model>.`,
+            `If you instead need the file's raw binary structure, use a shell tool such as \`hexdump -C ${filepath}\` — do not use the read tool for that.`,
+          ].join("\n")
+          return {
+            title,
+            output: warning,
+            metadata: { preview: warning, truncated: false, loaded: [] as string[] },
+          }
+        }
         const bytes = yield* fs.readFile(filepath)
-        const msg = isPdfAttachment(mime) ? "PDF read successfully" : "Image read successfully"
         return {
           title,
-          output: msg,
+          output: "Image read successfully",
           metadata: {
-            preview: msg,
+            preview: "Image read successfully",
+            truncated: false,
+            loaded: loaded.map((item) => item.filepath),
+          },
+          attachments: [
+            {
+              type: "file" as const,
+              mime,
+              url: `data:${mime};base64,${Buffer.from(bytes).toString("base64")}`,
+            },
+          ],
+        }
+      }
+
+      if (isPdfAttachment(mime)) {
+        const bytes = yield* fs.readFile(filepath)
+        return {
+          title,
+          output: "PDF read successfully",
+          metadata: {
+            preview: "PDF read successfully",
             truncated: false,
             loaded: loaded.map((item) => item.filepath),
           },

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -222,22 +222,11 @@ export const ReadTool = Tool.define(
           : undefined
         const supportsImage = model?.capabilities.input.image ?? false
         if (!supportsImage) {
-          const visionModels = yield* provider
-            .list()
-            .pipe(
-              Effect.map((providers) =>
-                Object.values(providers)
-                  .flatMap((info) => Object.values(info.models))
-                  .filter((m) => m.capabilities.input.image === true)
-                  .map((m) => `${m.providerID}/${m.id}`)
-                  .sort((a, b) => a.localeCompare(b))
-                  .slice(0, 3),
-              ),
-            )
-            .pipe(Effect.orElseSucceed(() => [] as string[]))
-          const dispatch = visionModels.length
-            ? `dispatch a vision-capable subagent: actor run <type> "<desc>" "analyze the image at ${filepath}" --model ${visionModels[0]} (run \`actor models --vision\` for the full list)`
-            : `no vision-capable model is configured — ask the user to configure one or use an OCR tool`
+        const preferred = yield* provider.getVisionModel().pipe(Effect.orElseSucceed(() => undefined))
+        const preferredRef = preferred ? `${preferred.providerID}/${preferred.id}` : undefined
+        const dispatch = preferredRef
+          ? `dispatch a vision-capable subagent: actor run <type> "<desc>" "analyze the image at ${filepath}" --model ${preferredRef} (run \`actor models --vision\` for the full list)`
+          : `no vision-capable model is configured — ask the user to configure one or use an OCR tool`
           const warning = [
             `Cannot read image "${path.basename(filepath)}" — the current model has no vision support, so its visual content is unavailable.`,
             `If you need to understand the image visually, ${dispatch}.`,

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -218,7 +218,7 @@ export const ReadTool = Tool.define(
         const model = modelRef
           ? yield* provider
               .getModel(modelRef.providerID, modelRef.modelID)
-              .pipe(Effect.catch(() => Effect.succeed(undefined)))
+              .pipe(Effect.catchDefect(() => Effect.succeed(undefined)))
           : undefined
         const supportsImage = model?.capabilities.input.image ?? false
         if (!supportsImage) {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -211,15 +211,24 @@ export const ReadTool = Tool.define(
 
       const mime = sniffAttachmentMime(sample, AppFileSystem.mimeType(filepath))
       if (isImageAttachment(mime)) {
-        const modelRef = [...ctx.messages]
-          .reverse()
-          .map((m) => m.info)
-          .find((i): i is Extract<typeof i, { role: "user" }> => i.role === "user")?.model
-        const model = modelRef
-          ? yield* provider
-              .getModel(modelRef.providerID, modelRef.modelID)
-              .pipe(Effect.catchDefect(() => Effect.succeed(undefined)))
-          : undefined
+        // The active model is carried on ctx.extra.model (set on both the
+        // agent-call path and the @file resolution path, which passes messages: []).
+        // Fall back to resolving the last user message's model for any caller that
+        // doesn't populate extra. Mirrors tool/websearch/index.ts.
+        const extraModel = (ctx.extra as { model?: Provider.Model } | undefined)?.model
+        const messageModelRef = extraModel
+          ? undefined
+          : [...ctx.messages]
+              .reverse()
+              .map((m) => m.info)
+              .find((i): i is Extract<typeof i, { role: "user" }> => i.role === "user")?.model
+        const model =
+          extraModel ??
+          (messageModelRef
+            ? yield* provider
+                .getModel(messageModelRef.providerID, messageModelRef.modelID)
+                .pipe(Effect.catchDefect(() => Effect.succeed(undefined)))
+            : undefined)
         const supportsImage = model?.capabilities.input.image ?? false
         if (!supportsImage) {
         const preferred = yield* provider.getVisionModel().pipe(Effect.orElseSucceed(() => undefined))

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -222,9 +222,25 @@ export const ReadTool = Tool.define(
           : undefined
         const supportsImage = model?.capabilities.input.image ?? false
         if (!supportsImage) {
+          const visionModels = yield* provider
+            .list()
+            .pipe(
+              Effect.map((providers) =>
+                Object.values(providers)
+                  .flatMap((info) => Object.values(info.models))
+                  .filter((m) => m.capabilities.input.image === true)
+                  .map((m) => `${m.providerID}/${m.id}`)
+                  .sort((a, b) => a.localeCompare(b))
+                  .slice(0, 3),
+              ),
+            )
+            .pipe(Effect.orElseSucceed(() => [] as string[]))
+          const dispatch = visionModels.length
+            ? `dispatch a vision-capable subagent: actor run <type> "<desc>" "analyze the image at ${filepath}" --model ${visionModels[0]} (run \`actor models --vision\` for the full list)`
+            : `no vision-capable model is configured — ask the user to configure one or use an OCR tool`
           const warning = [
             `Cannot read image "${path.basename(filepath)}" — the current model has no vision support, so its visual content is unavailable.`,
-            `If you need to understand the image visually, dispatch a vision-capable subagent: actor run <type> "<desc>" "analyze the image at ${filepath}" --model <a vision model>.`,
+            `If you need to understand the image visually, ${dispatch}.`,
             `If you instead need the file's raw binary structure, use a shell tool such as \`hexdump -C ${filepath}\` — do not use the read tool for that.`,
           ].join("\n")
           return {

--- a/packages/opencode/test/cli/tui/clipboard-spill.test.ts
+++ b/packages/opencode/test/cli/tui/clipboard-spill.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test"
+import { spillImage } from "../../../src/cli/cmd/tui/util/clipboard"
+import fs from "fs/promises"
+
+test("spillImage writes base64 to a temp png and returns its path", async () => {
+  const onePxPng =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+  const p = await spillImage({ data: onePxPng, mime: "image/png" })
+  expect(p.endsWith(".png")).toBe(true)
+  const bytes = await fs.readFile(p)
+  expect(bytes.length).toBeGreaterThan(0)
+  await fs.rm(p, { force: true })
+})

--- a/packages/opencode/test/fake/provider.ts
+++ b/packages/opencode/test/fake/provider.ts
@@ -79,6 +79,9 @@ export namespace ProviderTest {
           getSmallModel: Effect.fn("TestProvider.getSmallModel")((providerID) =>
             Effect.succeed(providerID === row.id ? mdl : undefined),
           ),
+          getVisionModel: Effect.fn("TestProvider.getVisionModel")(() =>
+            Effect.succeed(mdl.capabilities.input.image ? mdl : undefined),
+          ),
           defaultModel: Effect.fn("TestProvider.defaultModel")(() =>
             Effect.succeed({ providerID: row.id, modelID: mdl.id }),
           ),

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1278,6 +1278,51 @@ test("getVisionModel returns undefined when no vision-capable model exists", asy
   })
 })
 
+// Regression: getModel raises ModelNotFoundError as a DEFECT. A misconfigured
+// vision_model must not propagate that defect (it runs at SystemPrompt layer
+// construction → would fail session startup). It should fall back to the smart
+// default instead of throwing.
+test("getVisionModel falls back to smart default when vision_model is misconfigured", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          vision_model: "vendor/does-not-exist",
+          provider: {
+            vendor: {
+              name: "Vendor",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "vision-cheap": {
+                  name: "Vision Cheap",
+                  tool_call: true,
+                  limit: { context: 8000, output: 2000 },
+                  cost: { input: 5, output: 10 },
+                  modalities: { input: ["text", "image"], output: ["text"] },
+                },
+              },
+              options: { apiKey: "test-key" },
+            },
+          },
+          enabled_providers: ["vendor"],
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      // Must not throw; falls back to the only vision-capable model.
+      const model = await getVisionModel()
+      expect(model).toBeDefined()
+      expect(String(model?.id)).toBe("vision-cheap")
+    },
+  })
+})
+
 test("provider.sort prioritizes preferred models", () => {
   const models = [
     { id: "random-model", name: "Random" },

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -49,6 +49,10 @@ async function getSmallModel(providerID: ProviderID) {
   return run((provider) => provider.getSmallModel(providerID))
 }
 
+async function getVisionModel() {
+  return run((provider) => provider.getVisionModel())
+}
+
 async function defaultModel() {
   return run((provider) => provider.defaultModel())
 }
@@ -1093,6 +1097,183 @@ test("getSmallModel respects config small_model override", async () => {
       expect(model).toBeDefined()
       expect(String(model?.providerID)).toBe("small")
       expect(String(model?.id)).toBe("small-big")
+    },
+  })
+})
+
+// getVisionModel: an explicit `vision_model` literal wins first; otherwise a
+// smart default picks a vision-capable model with in-house (mimo/xiaomi)
+// providers preferred, then cheapest by cost.input. Providers are fully
+// config-declared so tests don't depend on env-keyed models.dev autoload.
+const VISION_PROVIDER = {
+  mimo: {
+    name: "MiMo",
+    npm: "@ai-sdk/openai-compatible",
+    env: [],
+    models: {
+      "mimo-vision": {
+        name: "MiMo Vision",
+        tool_call: true,
+        limit: { context: 8000, output: 2000 },
+        cost: { input: 100, output: 200 },
+        modalities: { input: ["text", "image"], output: ["text"] },
+      },
+    },
+    options: { apiKey: "test-key" },
+  },
+  vendor: {
+    name: "Vendor",
+    npm: "@ai-sdk/openai-compatible",
+    env: [],
+    models: {
+      "vendor-cheap-vision": {
+        name: "Vendor Cheap Vision",
+        tool_call: true,
+        limit: { context: 8000, output: 2000 },
+        cost: { input: 1, output: 2 },
+        modalities: { input: ["text", "image"], output: ["text"] },
+      },
+      "vendor-text": {
+        name: "Vendor Text",
+        tool_call: true,
+        limit: { context: 8000, output: 2000 },
+        modalities: { input: ["text"], output: ["text"] },
+      },
+    },
+    options: { apiKey: "test-key" },
+  },
+}
+
+test("getVisionModel respects config vision_model override", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: VISION_PROVIDER,
+          vision_model: "vendor/vendor-cheap-vision",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = await getVisionModel()
+      expect(model).toBeDefined()
+      expect(String(model?.providerID)).toBe("vendor")
+      expect(String(model?.id)).toBe("vendor-cheap-vision")
+    },
+  })
+})
+
+test("getVisionModel prefers in-house model over cheaper non-in-house", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: VISION_PROVIDER,
+          enabled_providers: ["mimo", "vendor"],
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      // mimo-vision (cost 100, in-house) beats vendor-cheap-vision (cost 1);
+      // vendor-text is text-only and excluded entirely.
+      const model = await getVisionModel()
+      expect(model).toBeDefined()
+      expect(String(model?.providerID)).toBe("mimo")
+      expect(String(model?.id)).toBe("mimo-vision")
+    },
+  })
+})
+
+test("getVisionModel picks cheapest when no in-house vision model", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            vendor: {
+              name: "Vendor",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "vision-pricey": {
+                  name: "Vision Pricey",
+                  tool_call: true,
+                  limit: { context: 8000, output: 2000 },
+                  cost: { input: 50, output: 100 },
+                  modalities: { input: ["text", "image"], output: ["text"] },
+                },
+                "vision-cheap": {
+                  name: "Vision Cheap",
+                  tool_call: true,
+                  limit: { context: 8000, output: 2000 },
+                  cost: { input: 5, output: 10 },
+                  modalities: { input: ["text", "image"], output: ["text"] },
+                },
+              },
+              options: { apiKey: "test-key" },
+            },
+          },
+          enabled_providers: ["vendor"],
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = await getVisionModel()
+      expect(model).toBeDefined()
+      expect(String(model?.providerID)).toBe("vendor")
+      expect(String(model?.id)).toBe("vision-cheap")
+    },
+  })
+})
+
+test("getVisionModel returns undefined when no vision-capable model exists", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            vendor: {
+              name: "Vendor",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "text-only": {
+                  name: "Text Only",
+                  tool_call: true,
+                  limit: { context: 8000, output: 2000 },
+                  modalities: { input: ["text"], output: ["text"] },
+                },
+              },
+              options: { apiKey: "test-key" },
+            },
+          },
+          enabled_providers: ["vendor"],
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = await getVisionModel()
+      expect(model).toBeUndefined()
     },
   })
 })

--- a/packages/opencode/test/tool/actor-models.test.ts
+++ b/packages/opencode/test/tool/actor-models.test.ts
@@ -59,18 +59,46 @@ const textModel = ProviderTest.model({
 const visionRef = `${visionModel.providerID}/${visionModel.id}`
 const textRef = `${textModel.providerID}/${textModel.id}`
 
+// An in-house vision model whose ref sorts alphabetically AFTER acme/vision-1,
+// so plain alphabetic order would place it last — but vision preference must
+// float it to the top (in-house beats alphabetic).
+const inHouseVisionModel = ProviderTest.model({
+  id: ModelID.make("mimo-v2.5"),
+  providerID: ProviderID.make("xiaomi"),
+  name: "MiMo Vision",
+  capabilities: {
+    toolcall: true,
+    attachment: true,
+    reasoning: false,
+    temperature: true,
+    interleaved: false,
+    input: { text: true, image: true, audio: false, video: false, pdf: true },
+    output: { text: true, image: false, audio: false, video: false, pdf: false },
+  },
+})
+
+const inHouseVisionRef = `${inHouseVisionModel.providerID}/${inHouseVisionModel.id}`
+
 // A provider Info holding both models under a single provider.
 const providerInfo = ProviderTest.info(
   { id: ProviderID.make("acme"), models: { [visionModel.id]: visionModel, [textModel.id]: textModel } },
   visionModel,
 )
 
-// Provider layer whose list() returns the two-model provider. Only list() is
+// The in-house provider Info holding the xiaomi vision model.
+const inHouseInfo = ProviderTest.info(
+  { id: ProviderID.make("xiaomi"), models: { [inHouseVisionModel.id]: inHouseVisionModel } },
+  inHouseVisionModel,
+)
+
+// Provider layer whose list() returns both providers. Only list() is
 // exercised by the models branch; the other methods keep the fake defaults.
 const twoModelProvider = ProviderTest.fake({
   model: visionModel,
   info: providerInfo,
-  list: Effect.fn("TwoModelProvider.list")(() => Effect.succeed({ [providerInfo.id]: providerInfo })),
+  list: Effect.fn("TwoModelProvider.list")(() =>
+    Effect.succeed({ [providerInfo.id]: providerInfo, [inHouseInfo.id]: inHouseInfo }),
+  ),
 })
 
 const it = testEffect(
@@ -118,8 +146,8 @@ describe("actor tool — models action", () => {
         expect(result.output).toContain(visionRef)
         expect(result.output).toContain(textRef)
         expect(result.output).toContain(`${visionRef} (vision)`)
-        expect(result.metadata.count).toBe(2)
-        expect(result.metadata.total).toBe(2)
+        expect(result.metadata.count).toBe(3)
+        expect(result.metadata.total).toBe(3)
       }),
     ),
   )
@@ -135,9 +163,27 @@ describe("actor tool — models action", () => {
         const result = yield* def.execute({ operation: { action: "models", vision: true } }, ctxFor(chat.id))
 
         expect(result.output).toContain(visionRef)
+        expect(result.output).toContain(inHouseVisionRef)
         expect(result.output).not.toContain(textRef)
-        expect(result.metadata.count).toBe(1)
+        expect(result.metadata.count).toBe(2)
         expect(result.metadata.vision).toBe(true)
+      }),
+    ),
+  )
+
+  it.live(
+    "models --vision orders the in-house model first despite alphabetic order",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "chat" })
+        const def = yield* (yield* ActorTool).init()
+
+        const result = yield* def.execute({ operation: { action: "models", vision: true } }, ctxFor(chat.id))
+
+        // xiaomi/mimo-v2.5 sorts alphabetically AFTER acme/vision-1, but in-house
+        // preference must list it first.
+        expect(result.output.indexOf(inHouseVisionRef)).toBeLessThan(result.output.indexOf(visionRef))
       }),
     ),
   )
@@ -153,7 +199,7 @@ describe("actor tool — models action", () => {
         const result = yield* def.execute({ operation: { action: "models", limit: 1 } }, ctxFor(chat.id))
 
         expect(result.metadata.count).toBe(1)
-        expect(result.metadata.total).toBe(2)
+        expect(result.metadata.total).toBe(3)
         expect(result.output).toContain("more")
       }),
     ),

--- a/packages/opencode/test/tool/actor-models.test.ts
+++ b/packages/opencode/test/tool/actor-models.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config"
+import { Provider } from "../../src/provider"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionCheckpoint } from "../../src/session/checkpoint"
+import { MessageID, type SessionID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { ActorTool } from "../../src/tool/actor"
+import { ActorRegistry } from "../../src/actor/registry"
+import { TaskRegistry } from "../../src/task/registry"
+import { ActorWaiter } from "../../src/actor/waiter"
+import { Team } from "../../src/team"
+import { Truncate } from "../../src/tool"
+import { ToolRegistry } from "../../src/tool"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { ProviderTest } from "../fake/provider"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+// One vision-capable model + one text-only model, exposed through Provider.list().
+const visionModel = ProviderTest.model({
+  id: ModelID.make("vision-1"),
+  providerID: ProviderID.make("acme"),
+  name: "Vision One",
+  capabilities: {
+    toolcall: true,
+    attachment: true,
+    reasoning: false,
+    temperature: true,
+    interleaved: false,
+    input: { text: true, image: true, audio: false, video: false, pdf: true },
+    output: { text: true, image: false, audio: false, video: false, pdf: false },
+  },
+})
+
+const textModel = ProviderTest.model({
+  id: ModelID.make("text-1"),
+  providerID: ProviderID.make("acme"),
+  name: "Text One",
+  capabilities: {
+    toolcall: true,
+    attachment: false,
+    reasoning: false,
+    temperature: true,
+    interleaved: false,
+    input: { text: true, image: false, audio: false, video: false, pdf: false },
+    output: { text: true, image: false, audio: false, video: false, pdf: false },
+  },
+})
+
+const visionRef = `${visionModel.providerID}/${visionModel.id}`
+const textRef = `${textModel.providerID}/${textModel.id}`
+
+// A provider Info holding both models under a single provider.
+const providerInfo = ProviderTest.info(
+  { id: ProviderID.make("acme"), models: { [visionModel.id]: visionModel, [textModel.id]: textModel } },
+  visionModel,
+)
+
+// Provider layer whose list() returns the two-model provider. Only list() is
+// exercised by the models branch; the other methods keep the fake defaults.
+const twoModelProvider = ProviderTest.fake({
+  model: visionModel,
+  info: providerInfo,
+  list: Effect.fn("TwoModelProvider.list")(() => Effect.succeed({ [providerInfo.id]: providerInfo })),
+})
+
+const it = testEffect(
+  Layer.mergeAll(
+    Agent.defaultLayer,
+    Bus.layer,
+    Config.defaultLayer,
+    twoModelProvider.layer,
+    CrossSpawnSpawner.defaultLayer,
+    Session.defaultLayer,
+    Truncate.defaultLayer,
+    ToolRegistry.defaultLayer,
+    ActorRegistry.defaultLayer,
+    ActorWaiter.layer.pipe(Layer.provide(Bus.layer), Layer.provide(ActorRegistry.defaultLayer), Layer.provide(Session.defaultLayer)),
+    Team.defaultLayer,
+    SessionCheckpoint.defaultLayer,
+    TaskRegistry.defaultLayer,
+  ),
+)
+
+function ctxFor(sessionID: SessionID) {
+  return {
+    sessionID,
+    messageID: MessageID.ascending(),
+    agent: "build",
+    abort: new AbortController().signal,
+    extra: {},
+    messages: [],
+    metadata: () => Effect.void,
+    ask: () => Effect.void,
+  }
+}
+
+describe("actor tool — models action", () => {
+  it.live(
+    "models lists all configured models (both refs, vision tagged)",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "chat" })
+        const def = yield* (yield* ActorTool).init()
+
+        const result = yield* def.execute({ operation: { action: "models" } }, ctxFor(chat.id))
+
+        expect(result.output).toContain(visionRef)
+        expect(result.output).toContain(textRef)
+        expect(result.output).toContain(`${visionRef} (vision)`)
+        expect(result.metadata.count).toBe(2)
+        expect(result.metadata.total).toBe(2)
+      }),
+    ),
+  )
+
+  it.live(
+    "models --vision lists only the vision-capable model",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "chat" })
+        const def = yield* (yield* ActorTool).init()
+
+        const result = yield* def.execute({ operation: { action: "models", vision: true } }, ctxFor(chat.id))
+
+        expect(result.output).toContain(visionRef)
+        expect(result.output).not.toContain(textRef)
+        expect(result.metadata.count).toBe(1)
+        expect(result.metadata.vision).toBe(true)
+      }),
+    ),
+  )
+
+  it.live(
+    "models --limit 1 caps the list and mentions more",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "chat" })
+        const def = yield* (yield* ActorTool).init()
+
+        const result = yield* def.execute({ operation: { action: "models", limit: 1 } }, ctxFor(chat.id))
+
+        expect(result.metadata.count).toBe(1)
+        expect(result.metadata.total).toBe(2)
+        expect(result.output).toContain("more")
+      }),
+    ),
+  )
+})

--- a/packages/opencode/test/tool/read-vision-harness.test.ts
+++ b/packages/opencode/test/tool/read-vision-harness.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, afterEach } from "bun:test"
+import { Effect, Layer } from "effect"
+import path from "path"
+import { Agent } from "../../src/agent/agent"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { AppFileSystem } from "@mimo-ai/shared/filesystem"
+import { LSP } from "../../src/lsp"
+import { Instance } from "../../src/project/instance"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { Instruction } from "../../src/session/instruction"
+import { ReadTool } from "../../src/tool/read"
+import { Truncate } from "../../src/tool"
+import { Tool } from "../../src/tool"
+import { provideInstance, tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { ProviderTest } from "../fake/provider"
+
+// 1px PNG
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+)
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const nonVisionModel = ProviderTest.model({
+  capabilities: {
+    toolcall: true,
+    attachment: false,
+    reasoning: false,
+    temperature: true,
+    interleaved: false,
+    input: { text: true, image: false, audio: false, video: false, pdf: false },
+    output: { text: true, image: false, audio: false, video: false, pdf: false },
+  },
+})
+
+const visionModel = ProviderTest.model({
+  capabilities: {
+    toolcall: true,
+    attachment: true,
+    reasoning: false,
+    temperature: true,
+    interleaved: false,
+    input: { text: true, image: true, audio: false, video: false, pdf: true },
+    output: { text: true, image: false, audio: false, video: false, pdf: false },
+  },
+})
+
+const ctxFor = (model: typeof nonVisionModel): Tool.Context => ({
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [
+    {
+      info: {
+        id: MessageID.make(""),
+        sessionID: SessionID.make("ses_test"),
+        role: "user" as const,
+        time: { created: 0 },
+        agent: "build",
+        model: { providerID: model.providerID, modelID: model.id },
+      },
+      parts: [],
+    },
+  ],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+})
+
+const baseLayers = Layer.mergeAll(
+  Agent.defaultLayer,
+  AppFileSystem.defaultLayer,
+  CrossSpawnSpawner.defaultLayer,
+  Instruction.defaultLayer,
+  LSP.defaultLayer,
+  Truncate.defaultLayer,
+)
+
+const nonVision = testEffect(Layer.mergeAll(baseLayers, ProviderTest.fake({ model: nonVisionModel }).layer))
+const vision = testEffect(Layer.mergeAll(baseLayers, ProviderTest.fake({ model: visionModel }).layer))
+
+const put = Effect.fn("ReadVisionTest.put")(function* (p: string, content: Buffer) {
+  const fs = yield* AppFileSystem.Service
+  yield* fs.writeWithDirs(p, content)
+})
+
+const runRead = Effect.fn("ReadVisionTest.run")(function* (dir: string, file: string, ctx: Tool.Context) {
+  const tool = yield* (yield* ReadTool).init()
+  return yield* provideInstance(dir)(tool.execute({ file_path: file }, ctx))
+})
+
+describe("tool.read vision harness", () => {
+  nonVision.live("non-vision model reading an image returns a warning and no attachment", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const file = path.join(dir, "image.png")
+      yield* put(file, PNG)
+
+      const result = yield* runRead(dir, file, ctxFor(nonVisionModel))
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain("no vision support")
+    }),
+  )
+
+  vision.live("vision model reading an image returns an image attachment", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const file = path.join(dir, "image.png")
+      yield* put(file, PNG)
+
+      const result = yield* runRead(dir, file, ctxFor(visionModel))
+      expect(result.attachments?.[0].mime.startsWith("image/")).toBe(true)
+    }),
+  )
+})

--- a/packages/opencode/test/tool/read-vision-harness.test.ts
+++ b/packages/opencode/test/tool/read-vision-harness.test.ts
@@ -138,6 +138,7 @@ const nonVision = testEffect(
       model: nonVisionModel,
       info: bothModelsInfo,
       list: Effect.fn("NonVisionHarness.list")(() => Effect.succeed({ [bothModelsInfo.id]: bothModelsInfo })),
+      getVisionModel: Effect.fn("NonVisionHarness.getVisionModel")(() => Effect.succeed(visionModel)),
     }).layer,
   ),
 )

--- a/packages/opencode/test/tool/read-vision-harness.test.ts
+++ b/packages/opencode/test/tool/read-vision-harness.test.ts
@@ -7,6 +7,7 @@ import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { LSP } from "../../src/lsp"
 import { Instance } from "../../src/project/instance"
 import { SessionID, MessageID } from "../../src/session/schema"
+import { ModelID } from "../../src/provider/schema"
 import { Instruction } from "../../src/session/instruction"
 import { ReadTool } from "../../src/tool/read"
 import { Truncate } from "../../src/tool"
@@ -72,6 +73,43 @@ const ctxFor = (model: typeof nonVisionModel): Tool.Context => ({
   ask: () => Effect.void,
 })
 
+// ctx whose last user message references a modelID the fake provider does not know,
+// so getModel raises a defect (Effect.die) and the read must degrade to non-vision.
+const ctxUnknownModel: Tool.Context = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [
+    {
+      info: {
+        id: MessageID.make(""),
+        sessionID: SessionID.make("ses_test"),
+        role: "user" as const,
+        time: { created: 0 },
+        agent: "build",
+        model: { providerID: visionModel.providerID, modelID: ModelID.make("nonexistent-model") },
+      },
+      parts: [],
+    },
+  ],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+// ctx with no user message carrying a model, so modelRef is undefined.
+const ctxNoModel: Tool.Context = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
 const baseLayers = Layer.mergeAll(
   Agent.defaultLayer,
   AppFileSystem.defaultLayer,
@@ -115,6 +153,30 @@ describe("tool.read vision harness", () => {
 
       const result = yield* runRead(dir, file, ctxFor(visionModel))
       expect(result.attachments?.[0].mime.startsWith("image/")).toBe(true)
+    }),
+  )
+
+  vision.live("unresolvable model on last user message degrades to non-vision instead of crashing", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const file = path.join(dir, "image.png")
+      yield* put(file, PNG)
+
+      const result = yield* runRead(dir, file, ctxUnknownModel)
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain("no vision support")
+    }),
+  )
+
+  vision.live("no user model on messages treats the model as non-vision", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const file = path.join(dir, "image.png")
+      yield* put(file, PNG)
+
+      const result = yield* runRead(dir, file, ctxNoModel)
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain("no vision support")
     }),
   )
 })

--- a/packages/opencode/test/tool/read-vision-harness.test.ts
+++ b/packages/opencode/test/tool/read-vision-harness.test.ts
@@ -122,6 +122,21 @@ const ctxNoModel: Tool.Context = {
   ask: () => Effect.void,
 }
 
+// The @file path: messages is empty and the active model is supplied via
+// extra.model (see session/prompt.ts execRead). ctx.messages alone would
+// resolve undefined → wrongly report "no vision support" for a vision model.
+const ctxExtraModel = (model: typeof visionModel): Tool.Context => ({
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  extra: { model },
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+})
+
 const baseLayers = Layer.mergeAll(
   Agent.defaultLayer,
   AppFileSystem.defaultLayer,
@@ -199,6 +214,32 @@ describe("tool.read vision harness", () => {
       yield* put(file, PNG)
 
       const result = yield* runRead(dir, file, ctxNoModel)
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain("no vision support")
+    }),
+  )
+
+  // Regression: the @file path passes messages: [] and the model via extra.model.
+  // Resolving from ctx.messages alone wrongly reported "no vision support" for a
+  // vision model referencing an image (e.g. autocomplete @image.png).
+  vision.live("vision model supplied via extra.model returns the image attachment", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const file = path.join(dir, "image.png")
+      yield* put(file, PNG)
+
+      const result = yield* runRead(dir, file, ctxExtraModel(visionModel))
+      expect(result.attachments?.[0].mime.startsWith("image/")).toBe(true)
+    }),
+  )
+
+  vision.live("non-vision model supplied via extra.model returns the warning", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const file = path.join(dir, "image.png")
+      yield* put(file, PNG)
+
+      const result = yield* runRead(dir, file, ctxExtraModel(nonVisionModel))
       expect(result.attachments).toBeUndefined()
       expect(result.output).toContain("no vision support")
     }),

--- a/packages/opencode/test/tool/read-vision-harness.test.ts
+++ b/packages/opencode/test/tool/read-vision-harness.test.ts
@@ -7,7 +7,7 @@ import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { LSP } from "../../src/lsp"
 import { Instance } from "../../src/project/instance"
 import { SessionID, MessageID } from "../../src/session/schema"
-import { ModelID } from "../../src/provider/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Instruction } from "../../src/session/instruction"
 import { ReadTool } from "../../src/tool/read"
 import { Truncate } from "../../src/tool"
@@ -27,6 +27,8 @@ afterEach(async () => {
 })
 
 const nonVisionModel = ProviderTest.model({
+  id: ModelID.make("text-1"),
+  providerID: ProviderID.make("acme"),
   capabilities: {
     toolcall: true,
     attachment: false,
@@ -39,6 +41,8 @@ const nonVisionModel = ProviderTest.model({
 })
 
 const visionModel = ProviderTest.model({
+  id: ModelID.make("vision-1"),
+  providerID: ProviderID.make("acme"),
   capabilities: {
     toolcall: true,
     attachment: true,
@@ -49,6 +53,14 @@ const visionModel = ProviderTest.model({
     output: { text: true, image: false, audio: false, video: false, pdf: false },
   },
 })
+
+const visionRef = `${visionModel.providerID}/${visionModel.id}`
+
+// A provider Info holding both models so provider.list() yields a real vision ref.
+const bothModelsInfo = ProviderTest.info(
+  { id: ProviderID.make("acme"), models: { [visionModel.id]: visionModel, [nonVisionModel.id]: nonVisionModel } },
+  visionModel,
+)
 
 const ctxFor = (model: typeof nonVisionModel): Tool.Context => ({
   sessionID: SessionID.make("ses_test"),
@@ -119,7 +131,16 @@ const baseLayers = Layer.mergeAll(
   Truncate.defaultLayer,
 )
 
-const nonVision = testEffect(Layer.mergeAll(baseLayers, ProviderTest.fake({ model: nonVisionModel }).layer))
+const nonVision = testEffect(
+  Layer.mergeAll(
+    baseLayers,
+    ProviderTest.fake({
+      model: nonVisionModel,
+      info: bothModelsInfo,
+      list: Effect.fn("NonVisionHarness.list")(() => Effect.succeed({ [bothModelsInfo.id]: bothModelsInfo })),
+    }).layer,
+  ),
+)
 const vision = testEffect(Layer.mergeAll(baseLayers, ProviderTest.fake({ model: visionModel }).layer))
 
 const put = Effect.fn("ReadVisionTest.put")(function* (p: string, content: Buffer) {
@@ -142,6 +163,8 @@ describe("tool.read vision harness", () => {
       const result = yield* runRead(dir, file, ctxFor(nonVisionModel))
       expect(result.attachments).toBeUndefined()
       expect(result.output).toContain("no vision support")
+      expect(result.output).toContain(visionRef)
+      expect(result.output).toContain("actor models --vision")
     }),
   )
 

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -15,6 +15,7 @@ import { Tool } from "../../src/tool"
 import { Filesystem } from "../../src/util"
 import { provideInstance, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
+import { ProviderTest } from "../fake/provider"
 
 const FIXTURES_DIR = path.join(import.meta.dir, "fixtures")
 
@@ -22,13 +23,38 @@ afterEach(async () => {
   await Instance.disposeAll()
 })
 
+const visionModel = ProviderTest.model({
+  capabilities: {
+    toolcall: true,
+    attachment: true,
+    reasoning: false,
+    temperature: true,
+    interleaved: false,
+    input: { text: true, image: true, audio: false, video: false, pdf: true },
+    output: { text: true, image: false, audio: false, video: false, pdf: false },
+  },
+})
+const visionProvider = ProviderTest.fake({ model: visionModel })
+
 const ctx = {
   sessionID: SessionID.make("ses_test"),
   messageID: MessageID.make(""),
   callID: "",
   agent: "build",
   abort: AbortSignal.any([]),
-  messages: [],
+  messages: [
+    {
+      info: {
+        id: MessageID.make(""),
+        sessionID: SessionID.make("ses_test"),
+        role: "user" as const,
+        time: { created: 0 },
+        agent: "build",
+        model: { providerID: visionModel.providerID, modelID: visionModel.id },
+      },
+      parts: [],
+    },
+  ],
   metadata: () => Effect.void,
   ask: () => Effect.void,
 }
@@ -41,6 +67,7 @@ const it = testEffect(
     Instruction.defaultLayer,
     LSP.defaultLayer,
     Truncate.defaultLayer,
+    visionProvider.layer,
   ),
 )
 


### PR DESCRIPTION
## Summary

Makes TUI image paste vision-aware, guarantees **non-vision models never receive image bytes** (which cause hallucination), and gives the agent a discoverable, cost-aware way to pick a vision model when it needs to dispatch an image subagent.

### Vision-aware paste + fallback
- **Unify vision capability:** removed the redundant hardcoded `supportsImageInput` special-casing in `transform.ts`; `capabilities.input.image` is the single source of truth (models.dev already marks mimo-v2.5 / mimo-v2-omni image-capable). Kept one explicit `mimo-auto` override.
- **TUI paste routing:** vision model → existing base64 attach; non-vision model → spill clipboard image to a temp file and insert an `@file` reference (matching autocomplete's file-part shape) with a toast. Same fallback for pasting an image-file path. PDF/SVG unchanged. New `Clipboard.spillImage`. i18n across 7 locales.
- **Build-time notice:** `system.ts` injects a `<vision-capability>` block ONLY for non-vision models.
- **Read tool harness:** a non-vision model reading an image gets a warning (no base64); vision/PDF reads unchanged. `Effect.catchDefect` so an unresolvable model degrades to non-vision rather than crashing.

### Model discovery (so `--model` is usable)
- **`actor models` verb:** read-only subcommand listing available models, optionally `--vision`-filtered, count-capped.
- **`--model` description** points at `actor models` for valid values.
- **Non-vision hints name real vision models** + point to `actor models --vision`, in both the system prompt and the Read-tool warning.

### Cost-aware vision model selection
- **`vision_model` config knob** (analogous to `small_model`) lets the user pin which model handles image/vision subagent tasks.
- **`getVisionModel()` resolver:** explicit `vision_model` wins; otherwise a smart default over vision-capable models — **in-house (mimo/xiaomi) preferred, then cheapest by input cost, then name**. Fixes the prior behavior where an expensive model was recommended purely because its name sorted first alphabetically.
- **`actor models --vision` and the non-vision hints** use this same ordering / resolved model, so the recommended `--model` example is the sensible default, not an arbitrary one.
- Also cherry-picks a related fix: a non-empty `provider.models` config now acts as an implicit whitelist.

## Test Plan

- [x] `bun typecheck` clean (pre-push turbo, all tasks pass)
- [x] `bun test` on the touched suites → all pass (provider / actor-models / read-vision-harness / read / clipboard-spill)
- [x] Non-vision model + paste image → temp file + `@file` reference + toast; vision model → base64 attach unchanged
- [x] Non-vision model + `read` image → warning naming the resolved vision model + `actor models --vision`; vision model → attachment
- [x] Unresolvable/missing model → degrades to non-vision (no crash)
- [x] `actor models` lists all; `actor models --vision` filters + orders in-house-first/cheapest; `--limit` caps
- [x] `getVisionModel`: explicit `vision_model` wins; in-house beats cheaper foreign; cheapest when no in-house; undefined when none
- [x] Main model IS vision → no `<vision-capability>` injection

Plans under `docs/compose/plans/`: tui-paste-image-vision-fallback, actor-models-discovery, vision-model-selection.