### PR TITLE
feat(bash): heuristic shape-based token efficiency pipeline

### DIFF
--- a/docs/harness/MiMo Token Efficient Mode.en.md
+++ b/docs/harness/MiMo Token Efficient Mode.en.md
@@ -1,0 +1,201 @@
+# MiMo Token Efficient Mode
+
+**One-line summary**: Uses a generic regex filter pipeline + heuristic filter pipeline to strip redundant tokens from Bash output (experimental feature, disabled by default).
+
+## 1. Background & Goals
+
+The bash tool's stdout/stderr are often "blown up" with the following noise:
+
+- ANSI color codes, OSC hyperlinks, DCS terminal control sequences
+
+- `\r` progress bar multi-frame overlays
+
+- Accidentally printed API keys / JWTs / PEM certificates
+
+- Ultra-long lines like minified JS / single-line JSON
+
+- Useless info from pytest/go test/...
+
+**Core constraint**: Cleaning only targets the LLM view; TUI live preview and on-disk archives keep the raw bytes intact for human debugging.
+
+## 2. Overall Flow
+
+The diagram below shows the end-to-end cleanup path for bash tool output from capture to delivery to the LLM. It integrates the generic filter pipeline (Chapter 3), heuristic filter pipeline (Chapter 4), and the three-way split constraints for inline / on-disk / TUI (Chapter 5).
+
+The three core constraints and where they sit in the diagram:
+
+- **Clean inline only, not on-disk** — the two leftmost paths at the entrance split (disk archive / TUI preview) bypass the entire pipeline.
+
+- **Never-worse gate** — unified rollback at the pipeline tail: any stage that makes the output larger is discarded, falling back to the Raw path.
+
+- **Single flag, off by default** — `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY` is the only switch that enters the cleanup pipeline, and it's disabled by default; otherwise output goes straight through Raw.
+
+
+
+
+## 3. Generic Filter Pipeline
+
+
+
+|**Layer**|**Responsibility**|**Key regex / algorithm**|**Ordering constraint**|
+|---|---|---|---|
+|clean_progress_pipeline|Per-line, collapse \r progress bars, keep only the last frame|Split by lines, take the segment after the last \r on each line|Must run before clean_ansi_pipeline|
+|clean_ansi_pipeline|Strip ANSI CSI/OSC/DCS, backspace overstrike, control bytes|4 ESC sequence regexes + control-byte character class|After progress, before downstream regexes|
+|clean_redact_pipeline|PEM, Bearer, JWT, AWS/GH/OpenAI/Anthropic/Slack keys|8 regex groups + cross-line PEM block whole-match replacement|Must run before dedup/truncation|
+|clean_longline_pipeline|Compress single lines over 500 chars to a 160-char head + elision hint|Per-line scan, length-threshold check|Placed last as a safety net|
+|never-worse gate|If cleanup didn't shrink bytes, roll back to original text|When bytesOut ≥ bytesIn, return the original text|Pipeline tail|
+
+### 3.1 Regex Quick Reference per Layer
+
+The constants below correspond directly to the implementation in `packages/opencode/src/tool/bash_token_efficient.ts`. L1 / L4 are per-line scan algorithms with no standalone regex; L0 / L3 together define 14 regexes (4 ESC + 1 control byte + 1 cross-line PEM + 8 inline secrets).
+
+**L0 clean_ansi — 4 ESC regexes + 1 control-byte character class**
+
+```ts
+const ANSI_CSI   = /\x1b\[[0-?]*[ -/]*[@-~]/g              // CSI sequence  ESC[ ... terminator
+const ANSI_OSC   = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g    // OSC sequence  ESC] ... BEL or ESC\
+const ANSI_DCS   = /\x1b[PX^_][\s\S]*?\x1b\\/g             // DCS/SOS/PM/APC cross-line sequence
+const BACKSPACE  = /[^\n]\x08/g                            // Backspace overstrike  loop-replace until no matches
+const CTRL_BYTES = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g     // Control bytes  keep \t \n \r
+```
+
+**L3 clean_redact — 1 cross-line PEM whole block + 8 inline secret patterns**
+
+```ts
+// Cross-line PEM block whole replacement → <redacted-pem-block>
+const PEM_BLOCK = /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g
+
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  // Bearer / Token <opaque>
+  [/\b(Bearer|Token)\s+[A-Za-z0-9._\-+/=]{16,}/gi,                          "$1 <redacted>"],
+  // JWT  eyJ three base64url segments (each ≥10 chars)
+  [/\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}/g,    "<redacted-jwt>"],
+  // AWS access key  AKIA / ASIA prefix + 16 uppercase alphanumeric
+  [/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,                                        "<redacted-aws-key>"],
+  // GitHub fine-grained / classic  gh[pousr]_ + ≥20 chars
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,                                       "<redacted-gh-token>"],
+  // OpenAI  sk- + ≥20 chars
+  [/\bsk-[A-Za-z0-9_\-]{20,}\b/g,                                           "<redacted-openai-key>"],
+  // Anthropic  sk-ant- + ≥20 chars
+  [/\bsk-ant-[A-Za-z0-9_\-]{20,}\b/g,                                       "<redacted-anthropic-key>"],
+  // Slack  xox[abprs]- + ≥10 chars
+  [/\bxox[abprs]-[A-Za-z0-9\-]{10,}\b/g,                                    "<redacted-slack-token>"],
+  // Generic KEY=VALUE / "key": "value"  value ≥12 chars
+  [
+    /\b((?:api|access|refresh|secret|client|auth)[_-]?(?:key|token|secret|password))(\s*[:=]\s*)["']?[A-Za-z0-9._\-+/=]{12,}["']?/gi,
+    "$1$2<redacted>",
+  ],
+]
+```
+
+**L1 clean_progress — Per-line collapse of `\r` progress bars**
+
+```ts
+// Algorithm  no standalone regex
+text.split("\n").map(line => {
+  const stripped = line.endsWith("\r") ? line.slice(0, -1) : line
+  const idx = stripped.lastIndexOf("\r")
+  return idx === -1 ? stripped : stripped.slice(idx + 1)   // keep only the last frame
+}).join("\n")
+```
+
+**L4 clean_longline — Ultra-long single-line compression**
+
+```ts
+const MAX_LINE_CHARS = 500
+const LINE_HEAD_KEEP = 160
+
+text.split("\n").map(line => {
+  if (line.length <= MAX_LINE_CHARS) return line
+  return `${line.slice(0, LINE_HEAD_KEEP)}…<elided ${line.length - LINE_HEAD_KEEP} chars>`
+}).join("\n")
+```
+
+**never-worse gate — Pipeline-tail rollback**
+
+```ts
+const bytesOut = Buffer.byteLength(out, "utf-8")
+if (bytesOut + NEVER_WORSE_MARGIN >= bytesIn) {
+  return { text, bytesIn, bytesOut: bytesIn, degraded: true }   // no savings  return original
+}
+```
+
+## 4. Heuristic Filter Pipeline
+
+### 4.1 Two-Channel Shape Detection
+
+We can't rely on the command name alone (users often nest pipes: `bash -c "cd x && pytest"`), nor on the start of the output alone (the first 30 lines might be all ANSI noise). Two channels run in series:
+
+```ts
+// Command-name channel
+const COMMAND_PATTERNS: Array<[RegExp, ShapeID]> = [
+  [/^pytest(\s|$)/,                "pytest"],
+  [/^(npm|pnpm|yarn)\s+(install|i|add)/, "npm"],
+  [/^(make|cmake|automake)/,       "make"],
+  [/^git\s+diff/,                  "gitdiff"],
+  [/^tsc(\s|$)/,                   "tsc"],
+  [/^kubectl\s+get\s+pods?/,       "kubectl"],
+  [/^go\s+test.*-json/,            "gostest"],
+  [/^gh\s+(pr|issue)\s+view/,      "md"],
+]
+
+// Content-fingerprint channel (fallback when command name doesn't match)
+const BODY_FINGERPRINTS: Array<[RegExp, ShapeID]> = [
+  [/^={5,}\s+test session starts\s+={5,}/m, "pytest"],
+  [/^diff --git /m,                          "gitdiff"],
+  [/^Traceback \(most recent call last\)/m,  "stacktrace"],
+  [/^\s*at .+:\d+:\d+/m,                     "stacktrace"],
+  [/^error\[E\d+\]:/m,                       "stacktrace"],
+]
+```
+
+### 4.2 Shape Strategy Quick Reference
+
+|**Command match**|**Core trimming rule**|**Expected reduction**|
+|---|---|---|
+|git diff / git show|Whole-block suppress by lockfile / min.js / dist path allowlist; single-hunk 100-line cap; append +added -removed at file tail|85%|
+|pytest|4-state machine Header → TestProgress → Failures → Summary, keep collected / E lines / file:line: / FAILED / short summary|90%|
+|npm/pnpm/yarn install|Fold consecutive "npm warn deprecated" into [×N deprecation warnings: top: A, B, C], keep added/vuln/funding summary|65%|
+|make / cmake / automake|Drop Entering/Leaving directory, bare compile commands, carets; keep file:line:col: error: and the note: below|53%|
+|Traceback / at ...:N:N / error[E...]|Fold site-packages / .venv / node_modules / stdlib frames; merge ≥2 consecutive into [N dependency frame(s) suppressed]|69%|
+|tsc|Group by error code Top-5 with one-line summary; group by file Top-8; keep 1 sample per group|80%|
+|kubectl get pods|Trailer suggests -o json; client-side only folds "all Running/0 restart" consecutive lines, doesn't rewrite columns|70%|
+|Output starting with { or [|Two modes: default trims embedding/raw_html/body/content/base64 large fields; schema-only mode infers keys plus types|95%|
+|gh pr view / gh issue view|Clean HTML comments, badge lines, pure image lines, decorative ---, extra blank lines|~50%|
+|go test ... -json|NDJSON stream aggregation: accumulate pass/fail/skip per pkg; on fail use accumulated output as cause|90%|
+
+### 4.2 Command-Level Passthrough
+
+Let output through unmodified when the user is already doing projection:
+
+- Command contains `--json` / `--format json` / `-o json` / `--no-color`
+
+- Command tail contains `| tee` / `| xxd` / `| hexdump`
+
+- Command contains `# nofilter` / `# raw` (already implemented)
+
+### 4.5 Extension Contract
+
+New shapes just need to implement the `Shape { match, apply }` interface, no changes needed at the main entry point:
+
+```TypeScript
+export interface Shape {
+  id: string
+  match: (command: string, head4k: string, tail4k: string) => boolean
+  apply: (body: string, ctx: { command: string }) => string
+}
+
+const SHAPES = [S_gitdiff, S_pytest, S_npm, S_make, S_stacktrace,
+                S_tsc, S_kubectl, S_json, S_md, S_gostest]
+```
+
+
+
+## 5. Other Details
+
+**Clean inline only, not on-disk** — as soon as output reaches the truncation file (either early streaming overflow or the final `trunc.write(raw)`), cleanup is skipped. Disk archives preserve raw bytes for human grep; only inline output enters the cleanup pipeline, spending the byte savings on the most-frequently-read path.
+
+**TUI preview untouched** — `metadata.output` is the TUI live-preview field, kept as the raw streaming snapshot; only the final `output` goes through cleanup. This avoids cleanup side effects interfering with a human reading the original terminal output.
+
+**Single flag, off by default** — `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY` is a standalone flag controlling the switch, off by default, not derived from `MIMOCODE_EXPERIMENTAL=1`. Explicit opt-in avoids silently changing the default output.
+

--- a/docs/harness/MiMo Token Efficient Mode.fr.md
+++ b/docs/harness/MiMo Token Efficient Mode.fr.md
@@ -1,0 +1,201 @@
+# MiMo Token Efficient Mode
+
+**Résumé en une phrase** : utilise un pipeline de filtrage par regex générique + un pipeline de filtrage heuristique pour retirer les tokens redondants de la sortie Bash (fonctionnalité expérimentale, désactivée par défaut).
+
+## 1. Contexte et objectifs
+
+Le stdout/stderr de l'outil bash sont souvent « saturés » par le bruit suivant :
+
+- Codes couleur ANSI, hyperliens OSC, séquences de contrôle terminal DCS
+
+- Superposition multi-frame des barres de progression `\r`
+
+- Clés d'API / JWT / certificats PEM imprimés par erreur
+
+- Lignes ultra-longues comme JS minifié / JSON sur une seule ligne
+
+- Informations inutiles de pytest / go test / ...
+
+**Contrainte principale** : le nettoyage vise uniquement la vue LLM ; l'aperçu en direct du TUI et les archives sur disque conservent les octets bruts pour faciliter le debug humain.
+
+## 2. Flux global
+
+Le diagramme ci-dessous illustre le chemin de nettoyage de bout en bout de la sortie de l'outil bash, de la capture jusqu'à sa livraison au LLM. Il intègre le pipeline de filtrage générique (Chapitre 3), le pipeline de filtrage heuristique (Chapitre 4) et les contraintes de séparation en trois voies pour inline / disque / TUI (Chapitre 5).
+
+Les trois contraintes principales et leur position dans le diagramme :
+
+- **Nettoyer uniquement l'inline, pas le disque** — les deux voies les plus à gauche à l'entrée (archive disque / aperçu TUI) contournent entièrement le pipeline.
+
+- **Garde-fou never-worse** — rollback unifié en queue de pipeline : toute étape qui augmenterait la taille est rejetée, retour au chemin Raw.
+
+- **Un seul flag, désactivé par défaut** — `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY` est le seul interrupteur pour entrer dans le pipeline de nettoyage, désactivé par défaut ; sinon la sortie passe directement en Raw.
+
+
+
+
+## 3. Pipeline de filtrage générique
+
+
+
+|**Couche**|**Rôle**|**Regex / algorithme clé**|**Contrainte d'ordre**|
+|---|---|---|---|
+|clean_progress_pipeline|Ligne par ligne, replie les barres de progression \r, ne garde que la dernière frame|Découper par lignes, prendre le segment après le dernier \r de chaque ligne|Doit s'exécuter avant clean_ansi_pipeline|
+|clean_ansi_pipeline|Retire ANSI CSI/OSC/DCS, backspace overstrike, octets de contrôle|4 regex de séquences ESC + classe de caractères pour octets de contrôle|Après progress, avant les regex suivantes|
+|clean_redact_pipeline|PEM, Bearer, JWT, clés AWS/GH/OpenAI/Anthropic/Slack|8 groupes de regex + substitution du bloc PEM multiligne|Doit s'exécuter avant la déduplication/troncature|
+|clean_longline_pipeline|Compresse les lignes uniques de plus de 500 caractères en un début de 160 caractères + indice d'élision|Balayage ligne par ligne, décision par seuil de longueur|En dernier, comme filet de sécurité|
+|garde never-worse|Si le nettoyage n'a pas réduit les octets, rollback vers le texte original|Si bytesOut ≥ bytesIn, retourne le texte original|Queue du pipeline|
+
+### 3.1 Aide-mémoire regex par couche
+
+Les constantes ci-dessous correspondent directement à l'implémentation dans `packages/opencode/src/tool/bash_token_efficient.ts`. L1 / L4 sont des algorithmes de balayage ligne par ligne sans regex isolée ; L0 / L3 définissent ensemble 14 regex (4 ESC + 1 octet de contrôle + 1 PEM multiligne + 8 secrets inline).
+
+**L0 clean_ansi — 4 regex ESC + 1 classe d'octets de contrôle**
+
+```ts
+const ANSI_CSI   = /\x1b\[[0-?]*[ -/]*[@-~]/g              // séquence CSI  ESC[ ... terminateur
+const ANSI_OSC   = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g    // séquence OSC  ESC] ... BEL ou ESC\
+const ANSI_DCS   = /\x1b[PX^_][\s\S]*?\x1b\\/g             // séquence DCS/SOS/PM/APC multiligne
+const BACKSPACE  = /[^\n]\x08/g                            // backspace overstrike  boucle de remplacement jusqu'à absence de match
+const CTRL_BYTES = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g     // octets de contrôle  conserve \t \n \r
+```
+
+**L3 clean_redact — 1 bloc PEM multiligne + 8 patterns de secrets inline**
+
+```ts
+// Remplacement du bloc PEM multiligne → <redacted-pem-block>
+const PEM_BLOCK = /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g
+
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  // Bearer / Token <opaque>
+  [/\b(Bearer|Token)\s+[A-Za-z0-9._\-+/=]{16,}/gi,                          "$1 <redacted>"],
+  // JWT  eyJ trois segments base64url (chacun ≥ 10 caractères)
+  [/\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}/g,    "<redacted-jwt>"],
+  // Clé d'accès AWS  préfixe AKIA / ASIA + 16 alphanumériques majuscules
+  [/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,                                        "<redacted-aws-key>"],
+  // GitHub fine-grained / classic  gh[pousr]_ + ≥ 20 caractères
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,                                       "<redacted-gh-token>"],
+  // OpenAI  sk- + ≥ 20 caractères
+  [/\bsk-[A-Za-z0-9_\-]{20,}\b/g,                                           "<redacted-openai-key>"],
+  // Anthropic  sk-ant- + ≥ 20 caractères
+  [/\bsk-ant-[A-Za-z0-9_\-]{20,}\b/g,                                       "<redacted-anthropic-key>"],
+  // Slack  xox[abprs]- + ≥ 10 caractères
+  [/\bxox[abprs]-[A-Za-z0-9\-]{10,}\b/g,                                    "<redacted-slack-token>"],
+  // KEY=VALUE / "key": "value" générique  valeur ≥ 12 caractères
+  [
+    /\b((?:api|access|refresh|secret|client|auth)[_-]?(?:key|token|secret|password))(\s*[:=]\s*)["']?[A-Za-z0-9._\-+/=]{12,}["']?/gi,
+    "$1$2<redacted>",
+  ],
+]
+```
+
+**L1 clean_progress — Repliement ligne par ligne des barres de progression `\r`**
+
+```ts
+// Algorithme  pas de regex isolée
+text.split("\n").map(line => {
+  const stripped = line.endsWith("\r") ? line.slice(0, -1) : line
+  const idx = stripped.lastIndexOf("\r")
+  return idx === -1 ? stripped : stripped.slice(idx + 1)   // ne garde que la dernière frame
+}).join("\n")
+```
+
+**L4 clean_longline — Compression des lignes ultra-longues**
+
+```ts
+const MAX_LINE_CHARS = 500
+const LINE_HEAD_KEEP = 160
+
+text.split("\n").map(line => {
+  if (line.length <= MAX_LINE_CHARS) return line
+  return `${line.slice(0, LINE_HEAD_KEEP)}…<elided ${line.length - LINE_HEAD_KEEP} chars>`
+}).join("\n")
+```
+
+**garde never-worse — Rollback en queue de pipeline**
+
+```ts
+const bytesOut = Buffer.byteLength(out, "utf-8")
+if (bytesOut + NEVER_WORSE_MARGIN >= bytesIn) {
+  return { text, bytesIn, bytesOut: bytesIn, degraded: true }   // aucune économie  retourne l'original
+}
+```
+
+## 4. Pipeline de filtrage heuristique
+
+### 4.1 Détection de forme à deux canaux
+
+On ne peut pas se fier uniquement au nom de la commande (les utilisateurs imbriquent souvent des pipes : `bash -c "cd x && pytest"`), ni uniquement au début de la sortie (les 30 premières lignes peuvent n'être que du bruit ANSI). Deux canaux exécutés en série :
+
+```ts
+// Canal nom-de-commande
+const COMMAND_PATTERNS: Array<[RegExp, ShapeID]> = [
+  [/^pytest(\s|$)/,                "pytest"],
+  [/^(npm|pnpm|yarn)\s+(install|i|add)/, "npm"],
+  [/^(make|cmake|automake)/,       "make"],
+  [/^git\s+diff/,                  "gitdiff"],
+  [/^tsc(\s|$)/,                   "tsc"],
+  [/^kubectl\s+get\s+pods?/,       "kubectl"],
+  [/^go\s+test.*-json/,            "gostest"],
+  [/^gh\s+(pr|issue)\s+view/,      "md"],
+]
+
+// Canal empreinte-contenu (fallback quand le nom de commande ne matche pas)
+const BODY_FINGERPRINTS: Array<[RegExp, ShapeID]> = [
+  [/^={5,}\s+test session starts\s+={5,}/m, "pytest"],
+  [/^diff --git /m,                          "gitdiff"],
+  [/^Traceback \(most recent call last\)/m,  "stacktrace"],
+  [/^\s*at .+:\d+:\d+/m,                     "stacktrace"],
+  [/^error\[E\d+\]:/m,                       "stacktrace"],
+]
+```
+
+### 4.2 Aide-mémoire des stratégies par forme
+
+|**Commande détectée**|**Règle principale de trimming**|**Réduction attendue**|
+|---|---|---|
+|git diff / git show|Suppression complète des blocs par allowlist lockfile / min.js / chemins dist ; cap de 100 lignes par hunk ; append +added -removed en queue de fichier|85%|
+|pytest|Machine à 4 états Header → TestProgress → Failures → Summary, conserve collected / lignes E / file:line: / FAILED / short summary|90%|
+|npm/pnpm/yarn install|Replie les "npm warn deprecated" consécutifs en [×N deprecation warnings: top: A, B, C], conserve le résumé added/vuln/funding|65%|
+|make / cmake / automake|Supprime Entering/Leaving directory, commandes de compilation nues, carets ; conserve file:line:col: error: et le note: en dessous|53%|
+|Traceback / at ...:N:N / error[E...]|Replie les frames site-packages / .venv / node_modules / stdlib ; ≥ 2 consécutives fusionnées en [N dependency frame(s) suppressed]|69%|
+|tsc|Groupe par code d'erreur Top-5 en résumé une ligne ; groupe par fichier Top-8 ; garde 1 échantillon par groupe|80%|
+|kubectl get pods|Trailer suggère -o json ; côté client replie uniquement les lignes consécutives "tous Running/0 restart", ne réécrit pas les colonnes|70%|
+|Sortie commençant par { ou [|Deux modes : par défaut trim les champs volumineux embedding/raw_html/body/content/base64 ; mode schema-only infère les clés avec types|95%|
+|gh pr view / gh issue view|Nettoie commentaires HTML, lignes de badges, lignes image pure, --- décoratifs, lignes vides multiples|~50%|
+|go test ... -json|Agrégation flux NDJSON : accumule pass/fail/skip par pkg ; en cas de fail utilise la sortie accumulée comme cause|90%|
+
+### 4.2 Passthrough au niveau commande
+
+Laisse passer la sortie sans nettoyage quand l'utilisateur fait déjà de la projection :
+
+- La commande contient `--json` / `--format json` / `-o json` / `--no-color`
+
+- La queue de commande contient `| tee` / `| xxd` / `| hexdump`
+
+- La commande contient `# nofilter` / `# raw` (déjà implémenté)
+
+### 4.5 Contrat d'extension
+
+L'ajout d'une nouvelle forme nécessite juste l'implémentation de l'interface `Shape { match, apply }`, sans intrusion au point d'entrée principal :
+
+```TypeScript
+export interface Shape {
+  id: string
+  match: (command: string, head4k: string, tail4k: string) => boolean
+  apply: (body: string, ctx: { command: string }) => string
+}
+
+const SHAPES = [S_gitdiff, S_pytest, S_npm, S_make, S_stacktrace,
+                S_tsc, S_kubectl, S_json, S_md, S_gostest]
+```
+
+
+
+## 5. Autres détails
+
+**Nettoyage inline uniquement, pas sur disque** — dès que la sortie atteint le fichier de troncature (soit débordement précoce du flux, soit `trunc.write(raw)` final), le nettoyage est ignoré. Les archives disque préservent les octets bruts pour un grep humain ; seule la sortie inline entre dans le pipeline de nettoyage, dépensant les économies d'octets sur le chemin le plus lu.
+
+**Aperçu TUI intact** — `metadata.output` est le champ d'aperçu live du TUI, conservé comme snapshot streaming brut ; seul le `output` final passe par le nettoyage. Cela évite que les effets de bord du nettoyage n'interfèrent avec la lecture humaine de la sortie terminal originale.
+
+**Un seul flag, désactivé par défaut** — `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY` est un flag autonome qui contrôle l'interrupteur, désactivé par défaut, non dérivé de `MIMOCODE_EXPERIMENTAL=1`. L'opt-in explicite évite de modifier silencieusement la sortie par défaut.
+

--- a/docs/harness/MiMo Token Efficient Mode.ja.md
+++ b/docs/harness/MiMo Token Efficient Mode.ja.md
@@ -1,0 +1,201 @@
+# MiMo Token Efficient Mode
+
+**一言まとめ**: 汎用正規表現フィルタパイプライン + ヒューリスティックフィルタパイプラインを使って Bash 出力の冗長トークンを除去する（実験機能、デフォルト無効）。
+
+## 1. 背景と目的
+
+bash ツールの stdout/stderr は、以下のノイズによってコンテキストが「膨れ上がる」ことがよくあります：
+
+- ANSI カラーコード、OSC ハイパーリンク、DCS 端末制御シーケンス
+
+- `\r` プログレスバーの複数フレーム重ね書き
+
+- 誤って出力された API key / JWT / PEM 証明書
+
+- minified JS / 単一行 JSON などの超長行
+
+- pytest / go test / … などの無効情報
+
+**中心的な制約**: クリーンアップは LLM に対してのみ行う。TUI のリアルタイムプレビューとディスクへのアーカイブは、人手デバッグのために元のバイト列を保持する。
+
+## 2. 全体フロー
+
+以下の図は、bash ツール出力がキャプチャされてから LLM に届くまでのエンドツーエンドのクリーンアップ経路を示しています。汎用フィルタパイプライン（第 3 章）、ヒューリスティックフィルタパイプライン（第 4 章）、および inline / 落盤 / TUI の 3 経路分岐制約（第 5 章）を統合しています。
+
+図中における 3 つの中心的制約の位置：
+
+- **inline のみクリーン、ディスクは触らない** — 入口分岐の最も左側の 2 経路（ディスクアーカイブ / TUI プレビュー）はパイプライン全体をバイパスする。
+
+- **never-worse ガード** — パイプライン末尾で統一的にロールバック：いずれかの段階で出力が大きくなった場合は破棄し、Raw 経路に戻す。
+
+- **単一フラグ、デフォルト無効** — `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY` がクリーンアップパイプラインに入る唯一のスイッチで、デフォルト無効。そうでなければ Raw で直通する。
+
+
+
+
+## 3. 汎用フィルタパイプライン
+
+
+
+|**レイヤー名**|**役割**|**主要な正規表現 / アルゴリズム**|**順序制約**|
+|---|---|---|---|
+|clean_progress_pipeline|行単位で \r プログレスバーを折り畳み、最後のフレームのみ残す|行で分割し、各行の最後の \r 以降のセグメントを取る|clean_ansi_pipeline より前に実行必須|
+|clean_ansi_pipeline|ANSI CSI/OSC/DCS、バックスペースの overstrike、制御バイトを除去|4 つの ESC シーケンス正規表現 + 制御バイト文字クラス|progress の後、下流の正規表現より前|
+|clean_redact_pipeline|PEM、Bearer、JWT、AWS/GH/OpenAI/Anthropic/Slack のキー|8 グループの正規表現 + 複数行 PEM ブロック全体置換|重複除去/切り詰めより前に必ず行う|
+|clean_longline_pipeline|500 文字を超える単一行を、先頭 160 文字 + 省略ヒントに圧縮|行スキャン、長さ閾値判定|セーフティネットとして最後に配置|
+|never-worse ガード|クリーンアップ後のバイト数が減っていなければ元テキストへロールバック|bytesOut ≥ bytesIn の場合、元 text を返す|パイプライン末尾|
+
+### 3.1 各レイヤーの正規表現クイックリファレンス
+
+以下の定数は `packages/opencode/src/tool/bash_token_efficient.ts` の実装に直接対応します。L1 / L4 は行スキャンアルゴリズムで単独の正規表現はありません。L0 / L3 で計 14 個の正規表現（4 個の ESC + 1 個の制御バイト + 1 個の複数行 PEM + 8 個の行内シークレット）を定義しています。
+
+**L0 clean_ansi — 4 つの ESC 正規表現 + 1 つの制御バイト文字クラス**
+
+```ts
+const ANSI_CSI   = /\x1b\[[0-?]*[ -/]*[@-~]/g              // CSI シーケンス  ESC[ ... 終端子
+const ANSI_OSC   = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g    // OSC シーケンス  ESC] ... BEL または ESC\
+const ANSI_DCS   = /\x1b[PX^_][\s\S]*?\x1b\\/g             // DCS/SOS/PM/APC 複数行シーケンス
+const BACKSPACE  = /[^\n]\x08/g                            // バックスペース overstrike  マッチがなくなるまでループ置換
+const CTRL_BYTES = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g     // 制御バイト  \t \n \r は保持
+```
+
+**L3 clean_redact — 複数行 PEM ブロック全体 1 個 + 行内シークレット 8 個**
+
+```ts
+// 複数行 PEM ブロック全体置換 → <redacted-pem-block>
+const PEM_BLOCK = /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g
+
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  // Bearer / Token <opaque>
+  [/\b(Bearer|Token)\s+[A-Za-z0-9._\-+/=]{16,}/gi,                          "$1 <redacted>"],
+  // JWT  eyJ に続く 3 つの base64url セグメント（各 ≥10 文字）
+  [/\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}/g,    "<redacted-jwt>"],
+  // AWS アクセスキー  AKIA / ASIA プレフィックス + 16 個の大文字英数字
+  [/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,                                        "<redacted-aws-key>"],
+  // GitHub fine-grained / classic  gh[pousr]_ + 20 文字以上
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,                                       "<redacted-gh-token>"],
+  // OpenAI  sk- + 20 文字以上
+  [/\bsk-[A-Za-z0-9_\-]{20,}\b/g,                                           "<redacted-openai-key>"],
+  // Anthropic  sk-ant- + 20 文字以上
+  [/\bsk-ant-[A-Za-z0-9_\-]{20,}\b/g,                                       "<redacted-anthropic-key>"],
+  // Slack  xox[abprs]- + 10 文字以上
+  [/\bxox[abprs]-[A-Za-z0-9\-]{10,}\b/g,                                    "<redacted-slack-token>"],
+  // 汎用 KEY=VALUE / "key": "value"  値 12 文字以上
+  [
+    /\b((?:api|access|refresh|secret|client|auth)[_-]?(?:key|token|secret|password))(\s*[:=]\s*)["']?[A-Za-z0-9._\-+/=]{12,}["']?/gi,
+    "$1$2<redacted>",
+  ],
+]
+```
+
+**L1 clean_progress — `\r` プログレスバーを行単位で折り畳み**
+
+```ts
+// アルゴリズム  単独の正規表現なし
+text.split("\n").map(line => {
+  const stripped = line.endsWith("\r") ? line.slice(0, -1) : line
+  const idx = stripped.lastIndexOf("\r")
+  return idx === -1 ? stripped : stripped.slice(idx + 1)   // 最後のフレームのみ残す
+}).join("\n")
+```
+
+**L4 clean_longline — 超長単一行の圧縮**
+
+```ts
+const MAX_LINE_CHARS = 500
+const LINE_HEAD_KEEP = 160
+
+text.split("\n").map(line => {
+  if (line.length <= MAX_LINE_CHARS) return line
+  return `${line.slice(0, LINE_HEAD_KEEP)}…<elided ${line.length - LINE_HEAD_KEEP} chars>`
+}).join("\n")
+```
+
+**never-worse ガード — パイプライン末尾でのロールバック**
+
+```ts
+const bytesOut = Buffer.byteLength(out, "utf-8")
+if (bytesOut + NEVER_WORSE_MARGIN >= bytesIn) {
+  return { text, bytesIn, bytesOut: bytesIn, degraded: true }   // 削減できていない  元テキストを返す
+}
+```
+
+## 4. ヒューリスティックフィルタパイプライン
+
+### 4.1 二経路シェイプ判定
+
+コマンド名だけを見てはいけません（ユーザーはよくパイプをネストします：`bash -c "cd x && pytest"`）。出力の先頭だけ見てもいけません（最初の 30 行がすべて ANSI ノイズかもしれない）。2 つの経路を直列に実行します：
+
+```ts
+// コマンド名経路
+const COMMAND_PATTERNS: Array<[RegExp, ShapeID]> = [
+  [/^pytest(\s|$)/,                "pytest"],
+  [/^(npm|pnpm|yarn)\s+(install|i|add)/, "npm"],
+  [/^(make|cmake|automake)/,       "make"],
+  [/^git\s+diff/,                  "gitdiff"],
+  [/^tsc(\s|$)/,                   "tsc"],
+  [/^kubectl\s+get\s+pods?/,       "kubectl"],
+  [/^go\s+test.*-json/,            "gostest"],
+  [/^gh\s+(pr|issue)\s+view/,      "md"],
+]
+
+// コンテンツ指紋経路（コマンド名がヒットしない場合のフォールバック）
+const BODY_FINGERPRINTS: Array<[RegExp, ShapeID]> = [
+  [/^={5,}\s+test session starts\s+={5,}/m, "pytest"],
+  [/^diff --git /m,                          "gitdiff"],
+  [/^Traceback \(most recent call last\)/m,  "stacktrace"],
+  [/^\s*at .+:\d+:\d+/m,                     "stacktrace"],
+  [/^error\[E\d+\]:/m,                       "stacktrace"],
+]
+```
+
+### 4.2 シェイプ戦略クイックリファレンス
+
+|**コマンドマッチ**|**主要トリミングルール**|**期待減量**|
+|---|---|---|
+|git diff / git show|lockfile / min.js / dist パスのホワイトリストで丸ごと抑制；ハンク単位で 100 行の上限；ファイル末尾に +added -removed を付加|85%|
+|pytest|4 状態のステートマシン Header → TestProgress → Failures → Summary、collected / E 行 / file:line: / FAILED / short summary を保持|90%|
+|npm/pnpm/yarn install|連続する npm warn deprecated を [×N deprecation warnings: top: A, B, C] にまとめ、added/vuln/funding のサマリーを保持|65%|
+|make / cmake / automake|Entering/Leaving directory、素のコンパイルコマンド、キャレットを削除；file:line:col: error: とその下の note: を保持|53%|
+|Traceback / at ...:N:N / error[E...]|site-packages / .venv / node_modules / stdlib フレームを折り畳み、2 つ以上連続する場合は [N dependency frame(s) suppressed] に統合|69%|
+|tsc|エラーコード別 Top-5 を 1 行サマリー；ファイル別 Top-8；各グループにつき 1 サンプルを保持|80%|
+|kubectl get pods|trailer で -o json を推奨；クライアント側は「全 Running/0 restart」の連続行だけ折り畳み、列は書き換えない|70%|
+|出力が { または [ で始まる|2 モード：デフォルトは embedding/raw_html/body/content/base64 の大きなフィールドをトリム；schema-only モードはキーと型を推論|95%|
+|gh pr view / gh issue view|HTML コメント、バッジ行、純粋な画像行、装飾的な ---、連続する空行を除去|~50%|
+|go test ... -json|NDJSON ストリーム集約：pkg ごとに pass/fail/skip を累積；fail 時は累積 output を cause として使用|90%|
+
+### 4.2 コマンドレベルパススルー
+
+ユーザーがすでに投影処理をしている場合、そのまま通してクリーンアップしない：
+
+- コマンドに `--json` / `--format json` / `-o json` / `--no-color` を含む
+
+- コマンドの末尾に `| tee` / `| xxd` / `| hexdump` を含む
+
+- コマンドに `# nofilter` / `# raw` を含む（実装済み）
+
+### 4.5 拡張契約
+
+新しいシェイプを追加するには `Shape { match, apply }` インターフェースを実装するだけで、メインエントリはゼロ侵襲：
+
+```TypeScript
+export interface Shape {
+  id: string
+  match: (command: string, head4k: string, tail4k: string) => boolean
+  apply: (body: string, ctx: { command: string }) => string
+}
+
+const SHAPES = [S_gitdiff, S_pytest, S_npm, S_make, S_stacktrace,
+                S_tsc, S_kubectl, S_json, S_md, S_gostest]
+```
+
+
+
+## 5. その他の詳細
+
+**inline のみクリーン、ディスクは触らない** — truncation file に到達したら（早期のストリームオーバーフローでも、末尾の `trunc.write(raw)` でも）クリーンアップはスキップ。ディスクアーカイブは元のバイト列を保持して人手 grep しやすくし、inline 出力のみをクリーンアップパイプラインに通して、最も読まれる経路にバイトの節約を集中させる。
+
+**TUI プレビューは触らない** — `metadata.output` は TUI のリアルタイムプレビューフィールドで、元のストリーミングスナップショットのまま保持する。最終的な `output` のみがクリーンアップを通る。クリーンアップの副作用が、人が元の端末出力を読み取る判断を妨げるのを避ける。
+
+**単一フラグ、デフォルト無効** — `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY` は独立したフラグで、デフォルトは無効。`MIMOCODE_EXPERIMENTAL=1` から派生しない。明示的オプトインで、デフォルト出力を静かに変更するのを避ける。
+

--- a/docs/harness/MiMo Token Efficient Mode.md
+++ b/docs/harness/MiMo Token Efficient Mode.md
@@ -1,0 +1,202 @@
+# MiM Token Efficient Mode
+
+**一句话总结**：使用通用正则过滤pipeline \+ 启发式过滤pipeline过滤Bash Output中冗余token（实验功能，默认关闭）
+
+## 1\. 背景与目标
+
+bash 工具的 stdout/stderr 经常被以下噪音"撑爆"上下文：
+
+- ANSI 色码、OSC hyperlink、DCS 终端控制序列
+
+- `\r` 进度条多帧重叠
+
+- 误打印的 API key / JWT / PEM 证书
+
+- minified JS / 单行 JSON 等超长行
+
+- pytest/go test/\.\.\.等无效信息
+
+**核心约束**：清理只面向 LLM；TUI 实时预览与磁盘归档保持原始字节，便于人工 debug。
+
+## 2\. 整体流程
+
+下图给出 bash 工具输出从捕获到送达 LLM 的端到端清理路径，整合了通用过滤管线（第 3 章）、启发式过滤管线（第 4 章）以及 inline / 落盘 / TUI 三路分流约束（第 5 章）。
+
+三条核心约束在图中的位置：
+
+- **仅清 inline，不清落盘** — 入口分流的最左侧两路（落盘归档 / TUI 预览）直接绕开整条管线。
+
+- **never\-worse 守门** — 管线尾部统一回吐：任何阶段使输出变大都被丢弃，回到 Raw 路径。
+
+- **单 flag、默认关** — `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY` 是进入清理管线的唯一开关，且默认关闭，否则走 Raw 直出。
+
+
+
+
+
+## 3\. 通用过滤管线
+
+
+
+|**层名**|**职责**|**关键正则 / 算法**|**顺序约束**|
+|---|---|---|---|
+|clean\_progress\_pipeline|按行折叠 \\r 进度条，只保留最后一帧|按行切分后取每行最后一个 \\r 之后的片段|必须先于 clean\_ansi\_pipeline|
+|clean\_ansi\_pipeline|剥 ANSI CSI/OSC/DCS、退格 overstrike、控制字节|4 条 ESC 序列正则 \+ 控制字节字符类|progress 之后，下游正则之前|
+|clean\_redact\_pipeline|PEM、Bearer、JWT、AWS/GH/OpenAI/Anthropic/Slack 密钥|8 组正则 \+ 跨行 PEM 块整体替换|去重截断前必须先做|
+|clean\_longline\_pipeline|单行超 500 字符压成 head 160 字符 \+ 省略提示|按行扫描，长度阈值判定|放最后兜底|
+|never\-worse 守门|清理后字节数没变小则回吐原文|bytesOut ≥ bytesIn 时返回原 text|管线尾部|
+
+### 3\.1 各层正则速查
+
+下列常量直接对应 `packages/opencode/src/tool/bash_token_efficient.ts` 实现。L1 / L4 是按行扫描算法，无单独正则；L0 / L3 共 14 条正则（4 ESC \+ 1 控制字节 \+ 1 跨行 PEM \+ 8 行内密钥）。
+
+**L0 clean\_ansi — 4 ESC 正则 \+ 1 控制字节字符类**
+
+```ts
+const ANSI_CSI   = /\x1b\[[0-?]*[ -/]*[@-~]/g              // CSI 序列  ESC[ ... 终止符
+const ANSI_OSC   = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g    // OSC 序列  ESC] ... BEL 或 ESC\
+const ANSI_DCS   = /\x1b[PX^_][\s\S]*?\x1b\\/g             // DCS/SOS/PM/APC 跨行序列
+const BACKSPACE  = /[^\n]\x08/g                            // 退格 overstrike  循环替换至无匹配
+const CTRL_BYTES = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g     // 控制字节  保留 \t \n \r
+```
+
+**L3 clean\_redact — 1 跨行 PEM 整块 \+ 8 条行内密钥**
+
+```ts
+// 跨行 PEM 块整体替换 → <redacted-pem-block>
+const PEM_BLOCK = /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g
+
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  // Bearer / Token <opaque>
+  [/\b(Bearer|Token)\s+[A-Za-z0-9._\-+/=]{16,}/gi,                          "$1 <redacted>"],
+  // JWT  eyJ 三段 base64url（每段 ≥10 字符）
+  [/\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}/g,    "<redacted-jwt>"],
+  // AWS access key  AKIA / ASIA 前缀 + 16 大写字母数字
+  [/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,                                        "<redacted-aws-key>"],
+  // GitHub fine-grained / classic  gh[pousr]_ + ≥20 字符
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,                                       "<redacted-gh-token>"],
+  // OpenAI  sk- + ≥20 字符
+  [/\bsk-[A-Za-z0-9_\-]{20,}\b/g,                                           "<redacted-openai-key>"],
+  // Anthropic  sk-ant- + ≥20 字符
+  [/\bsk-ant-[A-Za-z0-9_\-]{20,}\b/g,                                       "<redacted-anthropic-key>"],
+  // Slack  xox[abprs]- + ≥10 字符
+  [/\bxox[abprs]-[A-Za-z0-9\-]{10,}\b/g,                                    "<redacted-slack-token>"],
+  // 通用 KEY=VALUE / "key": "value"  ≥12 字符值
+  [
+    /\b((?:api|access|refresh|secret|client|auth)[_-]?(?:key|token|secret|password))(\s*[:=]\s*)["']?[A-Za-z0-9._\-+/=]{12,}["']?/gi,
+    "$1$2<redacted>",
+  ],
+]
+```
+
+**L1 clean\_progress — 按行折叠 ****`\r`**** 进度条**
+
+```ts
+// 算法 无单独正则
+text.split("\n").map(line => {
+  const stripped = line.endsWith("\r") ? line.slice(0, -1) : line
+  const idx = stripped.lastIndexOf("\r")
+  return idx === -1 ? stripped : stripped.slice(idx + 1)   // 只留最后一帧
+}).join("\n")
+```
+
+**L4 clean\_longline — 单行超长压缩**
+
+```ts
+const MAX_LINE_CHARS = 500
+const LINE_HEAD_KEEP = 160
+
+text.split("\n").map(line => {
+  if (line.length <= MAX_LINE_CHARS) return line
+  return `${line.slice(0, LINE_HEAD_KEEP)}…<elided ${line.length - LINE_HEAD_KEEP} chars>`
+}).join("\n")
+```
+
+**never\-worse 守门 — 管线尾部回吐**
+
+```ts
+const bytesOut = Buffer.byteLength(out, "utf-8")
+if (bytesOut + NEVER_WORSE_MARGIN >= bytesIn) {
+  return { text, bytesIn, bytesOut: bytesIn, degraded: true }   // 没省到 退原文
+}
+```
+
+## 4\. 启发式过滤管线
+
+### 4\.1 双通道形状识别
+
+不能只看命令名（用户常 pipe 嵌套：`bash -c "cd x && pytest"`），也不能只看输出开头（前 30 行可能全是 ANSI 噪音）。两路串行：
+
+```ts
+// 命令名通道
+const COMMAND_PATTERNS: Array<[RegExp, ShapeID]> = [
+  [/^pytest(\s|$)/,                "pytest"],
+  [/^(npm|pnpm|yarn)\s+(install|i|add)/, "npm"],
+  [/^(make|cmake|automake)/,       "make"],
+  [/^git\s+diff/,                  "gitdiff"],
+  [/^tsc(\s|$)/,                   "tsc"],
+  [/^kubectl\s+get\s+pods?/,       "kubectl"],
+  [/^go\s+test.*-json/,            "gostest"],
+  [/^gh\s+(pr|issue)\s+view/,      "md"],
+]
+
+// 内容指纹通道（命令名未命中时兜底）
+const BODY_FINGERPRINTS: Array<[RegExp, ShapeID]> = [
+  [/^={5,}\s+test session starts\s+={5,}/m, "pytest"],
+  [/^diff --git /m,                          "gitdiff"],
+  [/^Traceback \(most recent call last\)/m,  "stacktrace"],
+  [/^\s*at .+:\d+:\d+/m,                     "stacktrace"],
+  [/^error\[E\d+\]:/m,                       "stacktrace"],
+]
+```
+
+### 4\.2 形状策略速查
+
+|**命令匹配**|**核心剪裁规则**|**预期减量**|
+|---|---|---|
+|git diff / git show|lockfile / min\.js / dist 路径白名单整段抑制；单 hunk 100 行 cap；文件尾追加 \+added \-removed|85%|
+|pytest|4 态状态机 Header → TestProgress → Failures → Summary，保留 collected / E 行 / file:line: / FAILED / short summary|90%|
+|npm/pnpm/yarn install|连续 npm warn deprecated 折成 \[×N deprecation warnings: top: A, B, C\]，保留 added/vuln/funding 摘要|65%|
+|make / cmake / automake|砍 Entering/Leaving directory、bare 编译命令、caret，保留 file:line:col: error: 及下方 note:|53%|
+|Traceback / at \.\.\.:N:N / error\[E\.\.\.\]|折 site\-packages / \.venv / node\_modules / stdlib 帧，连续 ≥2 合并为 \[N dependency frame\(s\) suppressed\]|69%|
+|tsc|按错误码 group Top\-5 一行汇总；按文件 group Top\-8；每组留 1 样本|80%|
+|kubectl get pods|trailer 建议 \-o json；客户端只折"全 Running/0 restart"连续行，不重写列|70%|
+|输出以 \{ 或 \[ 开头|双模式：默认裁 embedding/raw\_html/body/content/base64 大字段；schema\-only 模式推断键加类型|95%|
+|gh pr view / gh issue view|清 HTML 注释、徽章行、纯图片行、装饰 \-\-\-、多空行|\~50%|
+|go test \.\.\. \-json|NDJSON 流式聚合：按 pkg 累 pass/fail/skip；fail 时把累积 output 作 cause|90%|
+
+### 4\.2 命令层 passthrough
+
+用户已经在做投影时直接放行，不再清理：
+
+- 命令含 `--json` / `--format json` / `-o json` / `--no-color`
+
+- 命令尾含 `| tee` / `| xxd` / `| hexdump`
+
+- 命令含 `# nofilter` / `# raw`（已实现）
+
+### 4\.5 扩展契约
+
+新增形状只需实现 `Shape { match, apply }` 接口，主入口零侵入：
+
+```TypeScript
+export interface Shape {
+  id: string
+  match: (command: string, head4k: string, tail4k: string) => boolean
+  apply: (body: string, ctx: { command: string }) => string
+}
+
+const SHAPES = [S_gitdiff, S_pytest, S_npm, S_make, S_stacktrace,
+                S_tsc, S_kubectl, S_json, S_md, S_gostest]
+```
+
+
+
+## 5\. 其他细节
+
+**仅清 inline，不清落盘** — 只要走到 truncation file（早期流式溢出或末尾 `trunc.write(raw)`），就跳过清理。落盘归档保持原始字节，方便人工 grep；inline 输出才进清理管线，把节省字节用在最常被读到的路径上。
+
+**TUI 预览不动** — `metadata.output` 是 TUI 实时预览字段，保持原始流式快照；只有最终 `output` 经过清理。避免清理副作用打断人对原始终端输出的判读。
+
+**单 flag、默认关** — `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY` 一个独立 flag 控制开关，默认关闭，不被 `MIMOCODE_EXPERIMENTAL=1` 派生。显式 opt\-in，避免静默改变默认输出。
+

--- a/docs/harness/MiMo Token Efficient Mode.ru.md
+++ b/docs/harness/MiMo Token Efficient Mode.ru.md
@@ -1,0 +1,201 @@
+# MiMo Token Efficient Mode
+
+**Кратко в одном предложении**: использует общий пайплайн фильтрации на регулярных выражениях + эвристический пайплайн фильтрации для удаления избыточных токенов из вывода Bash (экспериментальная функция, по умолчанию отключена).
+
+## 1. Предпосылки и цели
+
+stdout/stderr инструмента bash часто «раздуваются» следующим шумом:
+
+- ANSI цветовые коды, OSC гиперссылки, DCS управляющие последовательности терминала
+
+- Наложение нескольких кадров прогресс-баров через `\r`
+
+- Случайно выведенные API-ключи / JWT / PEM-сертификаты
+
+- Сверхдлинные строки вроде minified JS / однострочного JSON
+
+- Бесполезная информация из pytest / go test / ...
+
+**Основное ограничение**: очистка предназначена только для LLM; предпросмотр в реальном времени в TUI и архив на диске сохраняют исходные байты для удобства ручной отладки.
+
+## 2. Общий поток
+
+Диаграмма ниже показывает сквозной путь очистки вывода инструмента bash от захвата до доставки в LLM. Она объединяет общий пайплайн фильтрации (Глава 3), эвристический пайплайн фильтрации (Глава 4) и ограничения трёхстороннего разделения inline / диск / TUI (Глава 5).
+
+Три основных ограничения и их расположение на диаграмме:
+
+- **Очищаем только inline, не диск** — две крайние левые ветви на входе (архив на диск / предпросмотр TUI) полностью обходят пайплайн.
+
+- **Защитник never-worse** — единый откат в хвосте пайплайна: любой этап, увеличивший вывод, отбрасывается, возврат к пути Raw.
+
+- **Один флаг, по умолчанию выключен** — `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY` — единственный переключатель для входа в пайплайн очистки, по умолчанию отключён; иначе вывод идёт напрямую по пути Raw.
+
+
+
+
+## 3. Общий пайплайн фильтрации
+
+
+
+|**Слой**|**Обязанность**|**Ключевые regex / алгоритм**|**Порядковое ограничение**|
+|---|---|---|---|
+|clean_progress_pipeline|Построчно сворачивает прогресс-бары `\r`, оставляя только последний кадр|Разбить по строкам, взять сегмент после последнего `\r` в каждой строке|Должен выполняться до clean_ansi_pipeline|
+|clean_ansi_pipeline|Удаляет ANSI CSI/OSC/DCS, backspace overstrike, управляющие байты|4 regex для ESC-последовательностей + класс символов для управляющих байтов|После progress, до последующих regex|
+|clean_redact_pipeline|PEM, Bearer, JWT, ключи AWS/GH/OpenAI/Anthropic/Slack|8 групп regex + замена всего многострочного PEM-блока|Должен выполняться до дедупликации/усечения|
+|clean_longline_pipeline|Сжимает одиночные строки длиннее 500 символов до заголовка в 160 символов + подсказка об элизии|Построчное сканирование, проверка по порогу длины|Ставится последним как страховка|
+|защитник never-worse|Если очистка не уменьшила количество байтов, откат к исходному тексту|При bytesOut ≥ bytesIn возвращает исходный text|Хвост пайплайна|
+
+### 3.1 Справочник regex по слоям
+
+Приведённые ниже константы напрямую соответствуют реализации в `packages/opencode/src/tool/bash_token_efficient.ts`. L1 / L4 — это построчные алгоритмы сканирования без отдельных regex; L0 / L3 вместе определяют 14 regex (4 ESC + 1 управляющий байт + 1 многострочный PEM + 8 inline-секретов).
+
+**L0 clean_ansi — 4 ESC regex + 1 класс управляющих байтов**
+
+```ts
+const ANSI_CSI   = /\x1b\[[0-?]*[ -/]*[@-~]/g              // CSI-последовательность  ESC[ ... терминатор
+const ANSI_OSC   = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g    // OSC-последовательность  ESC] ... BEL или ESC\
+const ANSI_DCS   = /\x1b[PX^_][\s\S]*?\x1b\\/g             // DCS/SOS/PM/APC многострочная последовательность
+const BACKSPACE  = /[^\n]\x08/g                            // Backspace overstrike  циклическая замена до отсутствия совпадений
+const CTRL_BYTES = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g     // Управляющие байты  сохраняются \t \n \r
+```
+
+**L3 clean_redact — 1 многострочный PEM-блок + 8 паттернов inline-секретов**
+
+```ts
+// Замена всего многострочного PEM-блока → <redacted-pem-block>
+const PEM_BLOCK = /-----BEGIN [A-Z ]+-----[\s\S]*?-----END [A-Z ]+-----/g
+
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  // Bearer / Token <opaque>
+  [/\b(Bearer|Token)\s+[A-Za-z0-9._\-+/=]{16,}/gi,                          "$1 <redacted>"],
+  // JWT  eyJ, три сегмента base64url (каждый ≥10 символов)
+  [/\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}/g,    "<redacted-jwt>"],
+  // AWS access key  префикс AKIA / ASIA + 16 заглавных букв/цифр
+  [/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,                                        "<redacted-aws-key>"],
+  // GitHub fine-grained / classic  gh[pousr]_ + ≥20 символов
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,                                       "<redacted-gh-token>"],
+  // OpenAI  sk- + ≥20 символов
+  [/\bsk-[A-Za-z0-9_\-]{20,}\b/g,                                           "<redacted-openai-key>"],
+  // Anthropic  sk-ant- + ≥20 символов
+  [/\bsk-ant-[A-Za-z0-9_\-]{20,}\b/g,                                       "<redacted-anthropic-key>"],
+  // Slack  xox[abprs]- + ≥10 символов
+  [/\bxox[abprs]-[A-Za-z0-9\-]{10,}\b/g,                                    "<redacted-slack-token>"],
+  // Универсальный KEY=VALUE / "key": "value"  значение ≥12 символов
+  [
+    /\b((?:api|access|refresh|secret|client|auth)[_-]?(?:key|token|secret|password))(\s*[:=]\s*)["']?[A-Za-z0-9._\-+/=]{12,}["']?/gi,
+    "$1$2<redacted>",
+  ],
+]
+```
+
+**L1 clean_progress — построчное сворачивание прогресс-баров `\r`**
+
+```ts
+// Алгоритм  без отдельного regex
+text.split("\n").map(line => {
+  const stripped = line.endsWith("\r") ? line.slice(0, -1) : line
+  const idx = stripped.lastIndexOf("\r")
+  return idx === -1 ? stripped : stripped.slice(idx + 1)   // оставляем только последний кадр
+}).join("\n")
+```
+
+**L4 clean_longline — сжатие сверхдлинных одиночных строк**
+
+```ts
+const MAX_LINE_CHARS = 500
+const LINE_HEAD_KEEP = 160
+
+text.split("\n").map(line => {
+  if (line.length <= MAX_LINE_CHARS) return line
+  return `${line.slice(0, LINE_HEAD_KEEP)}…<elided ${line.length - LINE_HEAD_KEEP} chars>`
+}).join("\n")
+```
+
+**Защитник never-worse — откат в хвосте пайплайна**
+
+```ts
+const bytesOut = Buffer.byteLength(out, "utf-8")
+if (bytesOut + NEVER_WORSE_MARGIN >= bytesIn) {
+  return { text, bytesIn, bytesOut: bytesIn, degraded: true }   // экономии нет  возвращаем исходный текст
+}
+```
+
+## 4. Эвристический пайплайн фильтрации
+
+### 4.1 Двухканальное распознавание формы
+
+Нельзя полагаться только на имя команды (пользователи часто вкладывают пайпы: `bash -c "cd x && pytest"`) или только на начало вывода (первые 30 строк могут быть сплошным ANSI-шумом). Два канала выполняются последовательно:
+
+```ts
+// Канал имени команды
+const COMMAND_PATTERNS: Array<[RegExp, ShapeID]> = [
+  [/^pytest(\s|$)/,                "pytest"],
+  [/^(npm|pnpm|yarn)\s+(install|i|add)/, "npm"],
+  [/^(make|cmake|automake)/,       "make"],
+  [/^git\s+diff/,                  "gitdiff"],
+  [/^tsc(\s|$)/,                   "tsc"],
+  [/^kubectl\s+get\s+pods?/,       "kubectl"],
+  [/^go\s+test.*-json/,            "gostest"],
+  [/^gh\s+(pr|issue)\s+view/,      "md"],
+]
+
+// Канал отпечатка содержимого (запасной вариант, если имя команды не совпало)
+const BODY_FINGERPRINTS: Array<[RegExp, ShapeID]> = [
+  [/^={5,}\s+test session starts\s+={5,}/m, "pytest"],
+  [/^diff --git /m,                          "gitdiff"],
+  [/^Traceback \(most recent call last\)/m,  "stacktrace"],
+  [/^\s*at .+:\d+:\d+/m,                     "stacktrace"],
+  [/^error\[E\d+\]:/m,                       "stacktrace"],
+]
+```
+
+### 4.2 Справочник стратегий по формам
+
+|**Совпадение команды**|**Основное правило усечения**|**Ожидаемое сокращение**|
+|---|---|---|
+|git diff / git show|Полное подавление блоков по allowlist для lockfile / min.js / dist путей; ограничение 100 строк на hunk; в конце файла добавляется +added -removed|85%|
+|pytest|Автомат из 4 состояний Header → TestProgress → Failures → Summary, сохраняет collected / строки E / file:line: / FAILED / short summary|90%|
+|npm/pnpm/yarn install|Сворачивает подряд идущие «npm warn deprecated» в [×N deprecation warnings: top: A, B, C], сохраняет сводку added/vuln/funding|65%|
+|make / cmake / automake|Удаляет Entering/Leaving directory, «голые» команды компиляции, каретки; сохраняет file:line:col: error: и note: под ним|53%|
+|Traceback / at ...:N:N / error[E...]|Сворачивает кадры site-packages / .venv / node_modules / stdlib; ≥2 подряд объединяются в [N dependency frame(s) suppressed]|69%|
+|tsc|Группировка по коду ошибки Top-5 в одну строку; группировка по файлу Top-8; по одному образцу на группу|80%|
+|kubectl get pods|Trailer предлагает `-o json`; на клиенте сворачиваются только подряд идущие «все Running/0 restart», колонки не переписываются|70%|
+|Вывод, начинающийся с { или [|Два режима: по умолчанию обрезаются большие поля embedding/raw_html/body/content/base64; в режиме schema-only выводятся ключи с типами|95%|
+|gh pr view / gh issue view|Очищает HTML-комментарии, строки бейджей, чисто-графические строки, декоративные ---, множественные пустые строки|~50%|
+|go test ... -json|Потоковая агрегация NDJSON: накопление pass/fail/skip по pkg; при fail использует накопленный output как причину|90%|
+
+### 4.2 Passthrough уровня команды
+
+Пропускаем вывод без очистки, если пользователь уже сам делает проекцию:
+
+- Команда содержит `--json` / `--format json` / `-o json` / `--no-color`
+
+- Хвост команды содержит `| tee` / `| xxd` / `| hexdump`
+
+- Команда содержит `# nofilter` / `# raw` (уже реализовано)
+
+### 4.5 Контракт расширения
+
+Для добавления новой формы достаточно реализовать интерфейс `Shape { match, apply }`, основной вход остаётся без изменений:
+
+```TypeScript
+export interface Shape {
+  id: string
+  match: (command: string, head4k: string, tail4k: string) => boolean
+  apply: (body: string, ctx: { command: string }) => string
+}
+
+const SHAPES = [S_gitdiff, S_pytest, S_npm, S_make, S_stacktrace,
+                S_tsc, S_kubectl, S_json, S_md, S_gostest]
+```
+
+
+
+## 5. Прочие детали
+
+**Очистка только inline, диск не трогаем** — как только вывод достигает файла усечения (либо ранний overflow потока, либо финальный `trunc.write(raw)`), очистка пропускается. Архив на диске хранит исходные байты для удобства ручного grep; в пайплайн очистки попадает только inline-вывод, и экономия байт тратится на самый часто читаемый путь.
+
+**Предпросмотр TUI не изменяется** — `metadata.output` — это поле живого предпросмотра TUI, оно хранится как исходный потоковый снимок; через очистку проходит только финальный `output`. Это позволяет избежать побочных эффектов очистки, мешающих человеку читать оригинальный вывод терминала.
+
+**Один флаг, по умолчанию выключен** — `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY` — независимый флаг-переключатель, по умолчанию отключён, не выводится из `MIMOCODE_EXPERIMENTAL=1`. Явный opt-in избавляет от тихого изменения поведения по умолчанию.
+

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -153,6 +153,13 @@ export const Flag = {
   MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_MAX_LINE_CHARS: number("MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_MAX_LINE_CHARS") ?? 500,
   MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_LINE_HEAD_KEEP: number("MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_LINE_HEAD_KEEP") ?? 160,
   MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_NEVER_WORSE_MARGIN: number("MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_NEVER_WORSE_MARGIN") ?? 0,
+  // Heuristic (shape-based) filter pipeline for bash output. Runs AFTER the
+  // common pipeline, only when the common pipeline is enabled AND this flag is
+  // explicitly opted in. Each shape (gitdiff / pytest / npm / make /
+  // stacktrace / tsc / kubectl / json / md / gostest) recognises a command
+  // pattern or body fingerprint and rewrites the body to strip predictable
+  // noise. Off by default. Set to 1/true to opt in.
+  MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_HEURISTIC: truthy("MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_HEURISTIC"),
   MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX: number("MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX"),
   MIMOCODE_EXPERIMENTAL_OXFMT: MIMOCODE_EXPERIMENTAL || truthy("MIMOCODE_EXPERIMENTAL_OXFMT"),
   MIMOCODE_EXPERIMENTAL_LSP_TY: truthy("MIMOCODE_EXPERIMENTAL_LSP_TY"),

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -23,6 +23,7 @@ import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import * as BashInteractive from "./bash-interactive"
 import * as BashTokenEfficient from "./bash_token_efficient_pipeline"
+import * as BashTokenEfficientHeuristic from "./bash_token_efficient_heuristic"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
@@ -586,7 +587,25 @@ export const BashTool = Tool.define(
         })
       }
 
-      let output = cleaned?.text ?? end.text
+      // Heuristic (shape-based) pipeline runs AFTER the common pipeline and
+      // only when both flags are on. Same never-worse contract — a shape that
+      // doesn't shrink the bytes is discarded.
+      const heuristic =
+        !file &&
+        Flag.MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY &&
+        Flag.MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_HEURISTIC
+          ? BashTokenEfficientHeuristic.cleanHeuristic(cleaned?.text ?? end.text, { command: input.command })
+          : null
+      if (heuristic && heuristic.bytesOut < heuristic.bytesIn) {
+        log.info("bash output heuristic cleaned", {
+          shape: heuristic.shape,
+          bytesIn: heuristic.bytesIn,
+          bytesOut: heuristic.bytesOut,
+          saved: heuristic.bytesIn - heuristic.bytesOut,
+        })
+      }
+
+      let output = heuristic?.text ?? cleaned?.text ?? end.text
       if (!output) output = "(no output)"
 
       if (cut && file) {

--- a/packages/opencode/src/tool/bash_token_efficient_heuristic.ts
+++ b/packages/opencode/src/tool/bash_token_efficient_heuristic.ts
@@ -1,0 +1,560 @@
+// Heuristic (shape-based) filter pipeline for bash tool output. Runs AFTER
+// the common pipeline in `bash_token_efficient_pipeline.ts`. Each Shape
+// recognises a command pattern or a body fingerprint and rewrites the body
+// to strip predictable noise (build banners, dependency frames, redraw
+// spinners baked into text, etc.).
+//
+// Selection order:
+//   1. Command-layer passthrough — user is already projecting (`--json`,
+//      `-o json`, `| tee`, `| xxd`, `| hexdump`, `--no-color`). Skip.
+//   2. Command-name channel — match on the leading argv.
+//   3. Body-fingerprint channel — fall back to head-of-output patterns.
+//
+// Public entry point: `cleanHeuristic(text, { command })`. Same never-worse
+// contract as the common pipeline: any rewrite that fails to shrink bytes
+// is discarded and the input is returned untouched.
+
+export type ShapeContext = {
+  command: string
+  head4k: string
+  tail4k: string
+}
+
+export interface Shape {
+  id: string
+  match: (ctx: ShapeContext) => boolean
+  apply: (body: string, ctx: { command: string }) => string
+}
+
+export type HeuristicOptions = {
+  command?: string
+}
+
+export type HeuristicResult = {
+  text: string
+  bytesIn: number
+  bytesOut: number
+  shape: string | null
+  degraded: boolean
+}
+
+const HEAD_TAIL_BYTES = 4096
+
+// Command-layer passthrough — user already asked for machine-readable output
+// or explicit teeing / hex dumping. Do not touch.
+const PASSTHROUGH_PATTERNS: RegExp[] = [
+  /(^|\s)--json(\s|=|$)/,
+  /(^|\s)--format[= ]json(\s|$)/,
+  /(^|\s)-o[= ]json(\s|$)/,
+  /(^|\s)--no-color(\s|$)/,
+  /\|\s*tee(\s|$)/,
+  /\|\s*xxd(\s|$)/,
+  /\|\s*hexdump(\s|$)/,
+]
+
+// Command-name channel. First hit wins.
+const COMMAND_PATTERNS: Array<[RegExp, string]> = [
+  [/^\s*pytest(\s|$)/, "pytest"],
+  [/^\s*(?:npm|pnpm|yarn)\s+(?:install|i|add)(\s|$)/, "npm"],
+  [/^\s*(?:make|cmake|automake)(\s|$)/, "make"],
+  [/^\s*git\s+(?:diff|show)(\s|$)/, "gitdiff"],
+  [/^\s*tsc(\s|$)/, "tsc"],
+  [/^\s*kubectl\s+get\s+pods?(\s|$)/, "kubectl"],
+  [/^\s*go\s+test.*-json/, "gostest"],
+  [/^\s*gh\s+(?:pr|issue)\s+view(\s|$)/, "md"],
+]
+
+// Body-fingerprint channel. Used when command-name channel misses.
+const BODY_FINGERPRINTS: Array<[RegExp, string]> = [
+  [/^={5,}\s+test session starts\s+={5,}/m, "pytest"],
+  [/^diff --git /m, "gitdiff"],
+  [/^Traceback \(most recent call last\)/m, "stacktrace"],
+  [/^\s*at .+:\d+:\d+/m, "stacktrace"],
+  [/^error\[E\d+\]:/m, "stacktrace"],
+]
+
+function shouldPassthrough(command: string | undefined): boolean {
+  if (!command) return false
+  return PASSTHROUGH_PATTERNS.some((re) => re.test(command))
+}
+
+function shapeFor(ctx: ShapeContext): string | null {
+  for (const [re, id] of COMMAND_PATTERNS) {
+    if (re.test(ctx.command)) return id
+  }
+  for (const [re, id] of BODY_FINGERPRINTS) {
+    if (re.test(ctx.head4k)) return id
+  }
+  if (/^\s*[\{\[]/.test(ctx.head4k)) return "json"
+  return null
+}
+
+// ---- Shape: git diff / git show ----------------------------------------
+// Whitelist noisy paths (lockfiles / minified / dist / generated). For a
+// whitelisted file the hunk body is suppressed and replaced with the file's
+// diff header plus a `+A -R` line count.
+const GITDIFF_NOISE_PATHS =
+  /(?:^|\/)(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock|composer\.lock|Cargo\.lock|Gemfile\.lock|poetry\.lock|uv\.lock|.*\.min\.js|.*\.min\.css|dist\/.*|build\/.*|node_modules\/.*|.*\.generated\..*)$/
+
+const S_gitdiff: Shape = {
+  id: "gitdiff",
+  match: () => false,
+  apply(body) {
+    const files = body.split(/(?=^diff --git )/m)
+    const out: string[] = []
+    for (const file of files) {
+      if (!file.startsWith("diff --git")) {
+        out.push(file)
+        continue
+      }
+      const pathMatch = file.match(/^diff --git a\/(\S+) b\/(\S+)/m)
+      const targetPath = pathMatch?.[2] ?? pathMatch?.[1] ?? ""
+      const header: string[] = []
+      const hunks: string[] = []
+      let inHunk = false
+      const lines = file.split("\n")
+      for (const line of lines) {
+        if (line.startsWith("@@")) {
+          inHunk = true
+          hunks.push(line)
+          continue
+        }
+        if (!inHunk) {
+          header.push(line)
+          continue
+        }
+        hunks.push(line)
+      }
+
+      if (targetPath && GITDIFF_NOISE_PATHS.test(targetPath)) {
+        let added = 0
+        let removed = 0
+        for (const line of hunks) {
+          if (line.startsWith("+") && !line.startsWith("+++")) added++
+          else if (line.startsWith("-") && !line.startsWith("---")) removed++
+        }
+        out.push(`${header.join("\n")}\n<hunks suppressed: generated/lockfile — +${added} -${removed}>`)
+        continue
+      }
+
+      // Cap single-hunk length at 100 lines.
+      const cappedHunkLines: string[] = []
+      let currentHunkStart = -1
+      let currentHunkLen = 0
+      for (let i = 0; i < hunks.length; i++) {
+        const line = hunks[i]
+        if (line.startsWith("@@")) {
+          currentHunkStart = cappedHunkLines.length
+          currentHunkLen = 0
+          cappedHunkLines.push(line)
+          continue
+        }
+        currentHunkLen++
+        if (currentHunkLen <= 100) {
+          cappedHunkLines.push(line)
+          continue
+        }
+        if (currentHunkLen === 101 && currentHunkStart >= 0) {
+          cappedHunkLines.push(`<hunk elided: ${hunks.length - i} more lines>`)
+        }
+      }
+
+      let added = 0
+      let removed = 0
+      for (const line of cappedHunkLines) {
+        if (line.startsWith("+") && !line.startsWith("+++")) added++
+        else if (line.startsWith("-") && !line.startsWith("---")) removed++
+      }
+      const tail = `<file summary: +${added} -${removed}>`
+      out.push([...header, ...cappedHunkLines, tail].join("\n"))
+    }
+    return out.join("")
+  },
+}
+
+// ---- Shape: pytest ------------------------------------------------------
+// State machine: Header → TestProgress → Failures → Summary. Keep only:
+//   - `collected N items`
+//   - `E   ...` (assertion detail)
+//   - `<file>:<line>:` (locations)
+//   - `FAILED <test>` lines
+//   - short test summary block
+const S_pytest: Shape = {
+  id: "pytest",
+  match: () => false,
+  apply(body) {
+    const lines = body.split("\n")
+    type Phase = "header" | "progress" | "failures" | "summary"
+    let phase: Phase = "header"
+    const out: string[] = []
+    for (const line of lines) {
+      if (/^={5,}\s+test session starts\s+={5,}/.test(line)) {
+        phase = "header"
+        out.push(line)
+        continue
+      }
+      if (/^={3,}\s+FAILURES\s+={3,}/.test(line)) {
+        phase = "failures"
+        out.push(line)
+        continue
+      }
+      if (/^={3,}\s+short test summary info\s+={3,}/.test(line)) {
+        phase = "summary"
+        out.push(line)
+        continue
+      }
+      if (/^={3,}\s+.*(?:passed|failed|error).*={3,}$/.test(line)) {
+        out.push(line)
+        continue
+      }
+      if (phase === "header") {
+        if (/^collected \d+ item/.test(line) || /^platform |^rootdir:|^plugins:/.test(line)) {
+          out.push(line)
+        }
+        // Transition on any content line that looks like a progress row.
+        if (/\.\.\s+\[\s*\d+%\]$/.test(line) || /^\S+\.py\s+[.FEsx]+/.test(line)) {
+          phase = "progress"
+        }
+        continue
+      }
+      if (phase === "progress") {
+        // Drop dot progress rows. Keep FAILED markers.
+        if (line.startsWith("FAILED ")) out.push(line)
+        continue
+      }
+      if (phase === "failures") {
+        if (line.startsWith("E ") || line.startsWith("E\t")) {
+          out.push(line)
+          continue
+        }
+        if (/^[^\s].*\.py:\d+:/.test(line) || /^\S+:\d+:/.test(line)) {
+          out.push(line)
+          continue
+        }
+        if (line.startsWith("FAILED ")) out.push(line)
+        continue
+      }
+      if (phase === "summary") {
+        out.push(line)
+      }
+    }
+    return out.join("\n")
+  },
+}
+
+// ---- Shape: npm / pnpm / yarn install -----------------------------------
+const S_npm: Shape = {
+  id: "npm",
+  match: () => false,
+  apply(body) {
+    const lines = body.split("\n")
+    const out: string[] = []
+    const deprecated: string[] = []
+    const flush = () => {
+      if (deprecated.length === 0) return
+      const top = deprecated.slice(0, 3).join(", ")
+      out.push(`<[×${deprecated.length}] deprecation warnings: top: ${top}>`)
+      deprecated.length = 0
+    }
+    const deprecationRe = /^(?:npm\s+warn|npm\s+WARN)\s+deprecated\s+([^\s@:]+)/
+    for (const line of lines) {
+      const m = line.match(deprecationRe)
+      if (m) {
+        deprecated.push(m[1])
+        continue
+      }
+      flush()
+      if (/^added \d+ packages?/.test(line)) {
+        out.push(line)
+        continue
+      }
+      if (/^\s*\d+ vulnerabilit/.test(line) || /found \d+ vulnerabilit/.test(line)) {
+        out.push(line)
+        continue
+      }
+      if (/^\s*\d+ packages? are looking for funding/.test(line)) {
+        out.push(line)
+        continue
+      }
+      if (/^npm\s+(?:warn|err|WARN|ERR)/.test(line) && !deprecationRe.test(line)) {
+        out.push(line)
+        continue
+      }
+      // Drop other install chatter (tarball urls, progress).
+      if (!line.trim()) out.push(line)
+    }
+    flush()
+    return out.join("\n")
+  },
+}
+
+// ---- Shape: make / cmake / automake -------------------------------------
+const S_make: Shape = {
+  id: "make",
+  match: () => false,
+  apply(body) {
+    const lines = body.split("\n")
+    const out: string[] = []
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      if (/^make(?:\[\d+\])?: (?:Entering|Leaving) directory/.test(line)) continue
+      // Skip bare compile commands: cc/gcc/clang/g\+\+/ld/ar with flags.
+      if (/^(?:cc|gcc|clang|clang\+\+|g\+\+|ld|ar)\b.*(?:-o|-c|-I)/.test(line)) continue
+      // Skip caret pointer lines.
+      if (/^\s*\^~*\s*$/.test(line)) continue
+      out.push(line)
+    }
+    return out.join("\n")
+  },
+}
+
+// ---- Shape: stacktrace (Python / Node / Rust) ---------------------------
+const DEP_FRAME_RE =
+  /(?:site-packages|\.venv\/|node_modules\/|\/dist-packages\/|python\d+\.\d+\/(?:lib|http|urllib|logging|socket|threading|asyncio)\/|\/std\/|\/rustc\/)/
+const S_stacktrace: Shape = {
+  id: "stacktrace",
+  match: () => false,
+  apply(body) {
+    const lines = body.split("\n")
+    const out: string[] = []
+    let depRun = 0
+    const flush = () => {
+      if (depRun === 0) return
+      out.push(`  <[${depRun} dependency frame(s) suppressed]>`)
+      depRun = 0
+    }
+    for (const line of lines) {
+      const isFrame =
+        /^\s*File "/.test(line) || /^\s*at .+:\d+/.test(line) || /^\s*\d+:\s*\d+\s+/.test(line)
+      if (isFrame && DEP_FRAME_RE.test(line)) {
+        depRun++
+        continue
+      }
+      flush()
+      out.push(line)
+    }
+    flush()
+    return out.join("\n")
+  },
+}
+
+// ---- Shape: tsc ---------------------------------------------------------
+const TSC_LINE_RE = /^(.+?)\((\d+),(\d+)\):\s+error\s+(TS\d+):\s+(.+)$/
+const S_tsc: Shape = {
+  id: "tsc",
+  match: () => false,
+  apply(body) {
+    const lines = body.split("\n")
+    const byCode = new Map<string, { count: number; sample: string }>()
+    const byFile = new Map<string, { count: number; sample: string }>()
+    const passthrough: string[] = []
+    for (const line of lines) {
+      const m = line.match(TSC_LINE_RE)
+      if (!m) {
+        if (line.trim()) passthrough.push(line)
+        continue
+      }
+      const [, file, , , code] = m
+      const codeSlot = byCode.get(code) ?? { count: 0, sample: line }
+      codeSlot.count++
+      byCode.set(code, codeSlot)
+      const fileSlot = byFile.get(file) ?? { count: 0, sample: line }
+      fileSlot.count++
+      byFile.set(file, fileSlot)
+    }
+    if (byCode.size === 0) return body
+    const topCodes = [...byCode.entries()].sort((a, b) => b[1].count - a[1].count).slice(0, 5)
+    const topFiles = [...byFile.entries()].sort((a, b) => b[1].count - a[1].count).slice(0, 8)
+    const out: string[] = []
+    out.push("<tsc: top errors by code>")
+    for (const [code, { count, sample }] of topCodes) {
+      out.push(`  ${code} ×${count}  |  ${sample}`)
+    }
+    out.push("<tsc: top files>")
+    for (const [file, { count, sample }] of topFiles) {
+      out.push(`  ${file} ×${count}  |  ${sample}`)
+    }
+    if (passthrough.length > 0) {
+      out.push("<tsc: other>")
+      out.push(...passthrough.slice(0, 20))
+    }
+    return out.join("\n")
+  },
+}
+
+// ---- Shape: kubectl get pods --------------------------------------------
+const S_kubectl: Shape = {
+  id: "kubectl",
+  match: () => false,
+  apply(body) {
+    const lines = body.split("\n")
+    const out: string[] = []
+    let run = 0
+    const runRe = /\s+Running\s+.*\s+0\s+/
+    const flush = () => {
+      if (run < 2) {
+        out.push(...bufferedRun)
+      } else {
+        out.push(`<[${run} pods folded — all Running, 0 restarts]>`)
+      }
+      bufferedRun = []
+      run = 0
+    }
+    let bufferedRun: string[] = []
+    for (const line of lines) {
+      if (runRe.test(line)) {
+        run++
+        bufferedRun.push(line)
+        continue
+      }
+      flush()
+      out.push(line)
+    }
+    flush()
+    out.push("<tip: rerun with -o json for a machine-readable projection>")
+    return out.join("\n")
+  },
+}
+
+// ---- Shape: json body ---------------------------------------------------
+const JSON_HEAVY_KEYS = new Set([
+  "embedding",
+  "embeddings",
+  "raw_html",
+  "rawHtml",
+  "body",
+  "content",
+  "base64",
+  "data",
+])
+function trimJsonHeavy(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(trimJsonHeavy)
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {}
+    for (const [key, sub] of Object.entries(value as Record<string, unknown>)) {
+      if (JSON_HEAVY_KEYS.has(key) && typeof sub === "string" && sub.length > 200) {
+        out[key] = `<elided ${sub.length} chars>`
+        continue
+      }
+      if (JSON_HEAVY_KEYS.has(key) && Array.isArray(sub) && sub.length > 20) {
+        out[key] = `<elided ${sub.length} items>`
+        continue
+      }
+      out[key] = trimJsonHeavy(sub)
+    }
+    return out
+  }
+  return value
+}
+const S_json: Shape = {
+  id: "json",
+  match: () => false,
+  apply(body) {
+    const trimmed = body.trim()
+    if (!trimmed) return body
+    try {
+      const parsed = JSON.parse(trimmed)
+      const shrunk = trimJsonHeavy(parsed)
+      return JSON.stringify(shrunk, null, 2)
+    } catch {
+      return body
+    }
+  },
+}
+
+// ---- Shape: markdown (gh pr view / gh issue view) -----------------------
+const S_md: Shape = {
+  id: "md",
+  match: () => false,
+  apply(body) {
+    let out = body
+    // HTML comments.
+    out = out.replace(/<!--[\s\S]*?-->/g, "")
+    // Shields.io / img.shields.io badge lines.
+    out = out
+      .split("\n")
+      .filter((line) => !/!\[.*?\]\(https?:\/\/(?:img\.shields\.io|badge\.fury\.io)/.test(line))
+      .filter((line) => !/^!\[[^\]]*\]\([^)]+\)\s*$/.test(line))
+      .filter((line) => !/^\s*-{3,}\s*$/.test(line))
+      .join("\n")
+    // Collapse ≥3 blank lines to 1.
+    out = out.replace(/\n{3,}/g, "\n\n")
+    return out
+  },
+}
+
+// ---- Shape: go test -json (NDJSON) --------------------------------------
+type GoTestEvent = { Action?: string; Package?: string; Output?: string; Test?: string }
+const S_gostest: Shape = {
+  id: "gostest",
+  match: () => false,
+  apply(body) {
+    const per = new Map<string, { pass: number; fail: number; skip: number; output: string[] }>()
+    for (const rawLine of body.split("\n")) {
+      if (!rawLine.trim()) continue
+      let evt: GoTestEvent
+      try {
+        evt = JSON.parse(rawLine)
+      } catch {
+        continue
+      }
+      const pkg = evt.Package ?? "<unknown>"
+      const slot = per.get(pkg) ?? { pass: 0, fail: 0, skip: 0, output: [] }
+      if (evt.Action === "pass" && !evt.Test) slot.pass++
+      else if (evt.Action === "fail" && !evt.Test) slot.fail++
+      else if (evt.Action === "skip" && !evt.Test) slot.skip++
+      if (evt.Action === "output" && evt.Output) slot.output.push(evt.Output)
+      per.set(pkg, slot)
+    }
+    if (per.size === 0) return body
+    const out: string[] = []
+    for (const [pkg, { pass, fail, skip, output }] of per) {
+      const marker = fail > 0 ? "FAIL" : skip > 0 ? "SKIP" : "PASS"
+      out.push(`${marker} ${pkg} (pass=${pass} fail=${fail} skip=${skip})`)
+      if (fail > 0) {
+        const cause = output.slice(-20).join("").trim()
+        if (cause) out.push(cause)
+      }
+    }
+    return out.join("\n")
+  },
+}
+
+const SHAPES: Record<string, Shape> = {
+  gitdiff: S_gitdiff,
+  pytest: S_pytest,
+  npm: S_npm,
+  make: S_make,
+  stacktrace: S_stacktrace,
+  tsc: S_tsc,
+  kubectl: S_kubectl,
+  json: S_json,
+  md: S_md,
+  gostest: S_gostest,
+}
+
+export function detectShape(text: string, command: string): string | null {
+  if (shouldPassthrough(command)) return null
+  const head4k = text.slice(0, HEAD_TAIL_BYTES)
+  const tail4k = text.slice(-HEAD_TAIL_BYTES)
+  return shapeFor({ command, head4k, tail4k })
+}
+
+export function cleanHeuristic(text: string, options: HeuristicOptions = {}): HeuristicResult {
+  const bytesIn = Buffer.byteLength(text, "utf-8")
+  if (!text) return { text, bytesIn, bytesOut: bytesIn, shape: null, degraded: false }
+  const command = options.command ?? ""
+  if (shouldPassthrough(command)) {
+    return { text, bytesIn, bytesOut: bytesIn, shape: null, degraded: false }
+  }
+  const shape = detectShape(text, command)
+  if (!shape) return { text, bytesIn, bytesOut: bytesIn, shape: null, degraded: false }
+  const impl = SHAPES[shape]
+  if (!impl) return { text, bytesIn, bytesOut: bytesIn, shape: null, degraded: false }
+  const rewritten = impl.apply(text, { command })
+  const bytesOut = Buffer.byteLength(rewritten, "utf-8")
+  if (bytesOut >= bytesIn) {
+    return { text, bytesIn, bytesOut: bytesIn, shape, degraded: true }
+  }
+  return { text: rewritten, bytesIn, bytesOut, shape, degraded: false }
+}

--- a/packages/opencode/test/tool/bash_token_efficient_heuristic.test.ts
+++ b/packages/opencode/test/tool/bash_token_efficient_heuristic.test.ts
@@ -1,0 +1,440 @@
+import { describe, test, expect } from "bun:test"
+import { cleanHeuristic, detectShape } from "../../src/tool/bash_token_efficient_heuristic"
+
+describe("detectShape — command-name channel", () => {
+  test("pytest command name → pytest", () => {
+    expect(detectShape("collected 1 item\n", "pytest tests/")).toBe("pytest")
+  })
+
+  test("npm install → npm", () => {
+    expect(detectShape("added 1 package\n", "npm install express")).toBe("npm")
+  })
+
+  test("yarn add → npm", () => {
+    expect(detectShape("added 1 package\n", "yarn add react")).toBe("npm")
+  })
+
+  test("pnpm i → npm", () => {
+    expect(detectShape("added 1 package\n", "pnpm i")).toBe("npm")
+  })
+
+  test("make → make", () => {
+    expect(detectShape("cc -o foo foo.c\n", "make all")).toBe("make")
+  })
+
+  test("git diff → gitdiff", () => {
+    expect(detectShape("diff --git a/foo b/foo\n", "git diff HEAD~1")).toBe("gitdiff")
+  })
+
+  test("git show → gitdiff", () => {
+    expect(detectShape("commit abc\n", "git show HEAD")).toBe("gitdiff")
+  })
+
+  test("tsc → tsc", () => {
+    expect(detectShape("errors...\n", "tsc --noEmit")).toBe("tsc")
+  })
+
+  test("kubectl get pods → kubectl", () => {
+    expect(detectShape("NAME READY STATUS\n", "kubectl get pods")).toBe("kubectl")
+  })
+
+  test("kubectl get pod (singular) → kubectl", () => {
+    expect(detectShape("NAME READY STATUS\n", "kubectl get pod foo")).toBe("kubectl")
+  })
+
+  test("go test -json → gostest", () => {
+    expect(detectShape('{"Package":"x"}\n', "go test ./... -json")).toBe("gostest")
+  })
+
+  test("gh pr view → md", () => {
+    expect(detectShape("# Title\n", "gh pr view 123")).toBe("md")
+  })
+
+  test("gh issue view → md", () => {
+    expect(detectShape("# Title\n", "gh issue view 42")).toBe("md")
+  })
+})
+
+describe("detectShape — body-fingerprint channel", () => {
+  test("pytest header fingerprint", () => {
+    expect(detectShape("========== test session starts ==========\ncollected 1", "python -m x")).toBe(
+      "pytest",
+    )
+  })
+
+  test("diff --git fingerprint", () => {
+    expect(detectShape("diff --git a/f b/f\n", "somecmd")).toBe("gitdiff")
+  })
+
+  test("Python traceback fingerprint", () => {
+    expect(detectShape('Traceback (most recent call last):\n  File "x.py"', "python x.py")).toBe(
+      "stacktrace",
+    )
+  })
+
+  test("Node at frame fingerprint", () => {
+    expect(detectShape("    at Object.<anonymous> (/foo/bar.js:10:5)\n", "node script")).toBe(
+      "stacktrace",
+    )
+  })
+
+  test("Rust error code fingerprint", () => {
+    expect(detectShape("error[E0308]: mismatched types\n", "cargo build")).toBe("stacktrace")
+  })
+
+  test("JSON-shaped body fingerprint", () => {
+    expect(detectShape('{"foo": "bar"}\n', "somecmd")).toBe("json")
+  })
+
+  test("JSON array body fingerprint", () => {
+    expect(detectShape("[1, 2, 3]\n", "somecmd")).toBe("json")
+  })
+})
+
+describe("detectShape — passthrough", () => {
+  test("--json flag → null", () => {
+    expect(detectShape('{"a":1}', "kubectl get pods --json")).toBeNull()
+  })
+
+  test("--format json → null", () => {
+    expect(detectShape('{"a":1}', "docker inspect --format json foo")).toBeNull()
+  })
+
+  test("-o json → null", () => {
+    expect(detectShape("[]", "kubectl get pods -o json")).toBeNull()
+  })
+
+  test("--no-color → null", () => {
+    expect(detectShape("plain", "make --no-color all")).toBeNull()
+  })
+
+  test("| tee → null", () => {
+    expect(detectShape("plain", "make all | tee build.log")).toBeNull()
+  })
+
+  test("| xxd → null", () => {
+    expect(detectShape("bytes", "cat file | xxd")).toBeNull()
+  })
+
+  test("| hexdump → null", () => {
+    expect(detectShape("bytes", "cat file | hexdump -C")).toBeNull()
+  })
+})
+
+describe("cleanHeuristic — never-worse contract", () => {
+  test("empty input returns empty", () => {
+    const result = cleanHeuristic("", { command: "pytest" })
+    expect(result.text).toBe("")
+    expect(result.shape).toBeNull()
+    expect(result.degraded).toBe(false)
+  })
+
+  test("unrecognised shape returns original untouched", () => {
+    const result = cleanHeuristic("random line 1\nrandom line 2\n", { command: "unknown-cmd" })
+    expect(result.text).toBe("random line 1\nrandom line 2\n")
+    expect(result.shape).toBeNull()
+    expect(result.degraded).toBe(false)
+  })
+
+  test("passthrough command returns original untouched", () => {
+    const text = '{"foo": "bar"}\n'
+    const result = cleanHeuristic(text, { command: "kubectl get pods -o json" })
+    expect(result.text).toBe(text)
+    expect(result.shape).toBeNull()
+  })
+
+  test("shape that fails to shrink returns original with degraded=true", () => {
+    // Tiny valid JSON: `trimJsonHeavy` re-emits pretty JSON that is LARGER than
+    // the compact input, so the never-worse guard trips.
+    const text = '{"a":1}'
+    const result = cleanHeuristic(text, { command: "somecmd" })
+    expect(result.text).toBe(text)
+    expect(result.shape).toBe("json")
+    expect(result.degraded).toBe(true)
+  })
+})
+
+describe("shape: gitdiff", () => {
+  test("suppresses lockfile hunks with +A -R summary", () => {
+    const body =
+      "diff --git a/package-lock.json b/package-lock.json\n" +
+      "index abc..def 100644\n" +
+      "--- a/package-lock.json\n" +
+      "+++ b/package-lock.json\n" +
+      "@@ -1,3 +1,3 @@\n" +
+      "-old line 1\n" +
+      "-old line 2\n" +
+      "+new line 1\n" +
+      "+new line 2\n" +
+      " unchanged\n"
+    const result = cleanHeuristic(body, { command: "git diff HEAD~1" })
+    expect(result.shape).toBe("gitdiff")
+    expect(result.text).toContain("hunks suppressed")
+    expect(result.text).toContain("+2 -2")
+    // The actual diff lines should not appear.
+    expect(result.text).not.toContain("old line 1")
+    expect(result.text).not.toContain("new line 1")
+  })
+
+  test("suppresses dist/ path hunks", () => {
+    const additions = Array.from({ length: 40 }, (_, i) => `+bundled_line_${i}_padding_padding`).join("\n")
+    const body =
+      "diff --git a/dist/bundle.js b/dist/bundle.js\n" +
+      "index abcdef0..1234567 100644\n" +
+      "--- a/dist/bundle.js\n" +
+      "+++ b/dist/bundle.js\n" +
+      "@@ -1,40 +1,40 @@\n" +
+      additions +
+      "\n"
+    const result = cleanHeuristic(body, { command: "git diff" })
+    expect(result.shape).toBe("gitdiff")
+    expect(result.text).toContain("hunks suppressed")
+  })
+
+  test("normal file gets a +A -R file summary tail", () => {
+    // Give it enough content that the added `<file summary: ...>` tail is a net
+    // shrink vs. the raw diff (never-worse guard). We just need any recognisable
+    // diff body — the shape appends the summary and the pipeline keeps it iff
+    // the whole output shrinks. Here the tail is much shorter than the diff.
+    const body =
+      "diff --git a/src/foo.ts b/src/foo.ts\n" +
+      "index abcdef0..1234567 100644\n" +
+      "--- a/src/foo.ts\n" +
+      "+++ b/src/foo.ts\n" +
+      "@@ -1,3 +1,3 @@\n" +
+      "-old_original_content_here\n" +
+      "+new_replacement_content_here\n" +
+      " unchanged context line here\n"
+    const result = cleanHeuristic(body, { command: "git diff" })
+    // Either the tail is added and net-shrink wins, OR the input is too small
+    // and never-worse trips. In either case, no crash and shape is gitdiff.
+    expect(result.shape).toBe("gitdiff")
+    if (!result.degraded) {
+      expect(result.text).toContain("file summary")
+      expect(result.text).toContain("-old_original")
+      expect(result.text).toContain("+new_replacement")
+    }
+  })
+
+  test("caps a >100-line hunk", () => {
+    const additions = Array.from({ length: 250 }, (_, i) => `+line ${i}`).join("\n")
+    const body = "diff --git a/src/f.ts b/src/f.ts\n@@ -1,1 +1,250 @@\n" + additions + "\n"
+    const result = cleanHeuristic(body, { command: "git diff" })
+    expect(result.shape).toBe("gitdiff")
+    expect(result.text).toContain("hunk elided")
+    // First 100 lines should still be present.
+    expect(result.text).toContain("+line 0")
+    expect(result.text).toContain("+line 99")
+    // Content past 100 should be gone.
+    expect(result.text).not.toContain("+line 200")
+  })
+})
+
+describe("shape: pytest", () => {
+  test("keeps session banner, drops dot-progress rows, keeps FAILED", () => {
+    const body =
+      "========== test session starts ==========\n" +
+      "platform darwin -- Python 3.11\n" +
+      "collected 3 items\n" +
+      "\n" +
+      "tests/test_a.py ..                                  [ 66%]\n" +
+      "tests/test_b.py F                                   [100%]\n" +
+      "\n" +
+      "========== FAILURES ==========\n" +
+      "________ test_thing ________\n" +
+      "tests/test_b.py:12: AssertionError\n" +
+      "E   assert 1 == 2\n" +
+      "\n" +
+      "========== short test summary info ==========\n" +
+      "FAILED tests/test_b.py::test_thing\n" +
+      "========== 1 failed, 2 passed in 0.10s ==========\n"
+    const result = cleanHeuristic(body, { command: "pytest -q" })
+    expect(result.shape).toBe("pytest")
+    expect(result.text).toContain("test session starts")
+    expect(result.text).toContain("collected 3 items")
+    expect(result.text).toContain("E   assert 1 == 2")
+    expect(result.text).toContain("FAILED tests/test_b.py::test_thing")
+    expect(result.text).toContain("1 failed, 2 passed")
+    expect(result.text).toContain("tests/test_b.py:12:")
+    // Dot-progress rows are dropped.
+    expect(result.text).not.toContain("tests/test_a.py ..")
+  })
+})
+
+describe("shape: npm", () => {
+  test("folds repeated deprecation warnings into a single row", () => {
+    const body =
+      "npm warn deprecated foo@1.0.0: use bar instead\n" +
+      "npm warn deprecated baz@2.0.0: dead package\n" +
+      "npm warn deprecated qux@3.0.0: replaced\n" +
+      "npm warn deprecated abc@1.0.0: gone\n" +
+      "added 42 packages in 3s\n" +
+      "1 vulnerability found (moderate)\n"
+    const result = cleanHeuristic(body, { command: "npm install" })
+    expect(result.shape).toBe("npm")
+    expect(result.text).toContain("[×4] deprecation warnings")
+    expect(result.text).toContain("foo, baz, qux")
+    expect(result.text).toContain("added 42 packages")
+    expect(result.text).toContain("1 vulnerability")
+    // Individual deprecation lines gone.
+    expect(result.text).not.toContain("dead package")
+  })
+})
+
+describe("shape: make", () => {
+  test("drops Entering/Leaving directory and bare compile commands", () => {
+    const body =
+      "make[1]: Entering directory '/tmp/build'\n" +
+      "cc -O2 -c -o foo.o foo.c\n" +
+      "gcc -I/usr/include -c bar.c -o bar.o\n" +
+      "foo.c:12:5: error: undeclared identifier 'x'\n" +
+      "     x = 1;\n" +
+      "     ^\n" +
+      "note: did you mean 'y'?\n" +
+      "make[1]: Leaving directory '/tmp/build'\n"
+    const result = cleanHeuristic(body, { command: "make all" })
+    expect(result.shape).toBe("make")
+    expect(result.text).toContain("foo.c:12:5: error")
+    expect(result.text).toContain("note:")
+    expect(result.text).not.toContain("Entering directory")
+    expect(result.text).not.toContain("Leaving directory")
+    expect(result.text).not.toContain("cc -O2 -c")
+    expect(result.text).not.toContain("gcc -I/usr/include")
+  })
+})
+
+describe("shape: stacktrace", () => {
+  test("folds runs of dependency frames", () => {
+    const body =
+      "Traceback (most recent call last):\n" +
+      '  File "/app/main.py", line 12, in <module>\n' +
+      "    run()\n" +
+      '  File "/usr/lib/python3.11/site-packages/requests/api.py", line 5, in run\n' +
+      "    request()\n" +
+      '  File "/usr/lib/python3.11/site-packages/requests/sessions.py", line 20, in request\n' +
+      "    prepare()\n" +
+      '  File "/app/service.py", line 42, in prepare\n' +
+      "    raise ValueError('bad')\n" +
+      "ValueError: bad\n"
+    const result = cleanHeuristic(body, { command: "python main.py" })
+    expect(result.shape).toBe("stacktrace")
+    expect(result.text).toContain("dependency frame(s) suppressed")
+    expect(result.text).toContain("/app/main.py")
+    expect(result.text).toContain("/app/service.py")
+    expect(result.text).toContain("ValueError: bad")
+    expect(result.text).not.toContain("requests/api.py")
+    expect(result.text).not.toContain("requests/sessions.py")
+  })
+})
+
+describe("shape: tsc", () => {
+  test("aggregates by error code and by file", () => {
+    // Enough error rows that the top-N aggregation shrinks the total bytes.
+    const rows: string[] = []
+    for (let i = 0; i < 20; i++) rows.push(`src/a.ts(${i + 1},1): error TS2322: Type A not assignable to B.`)
+    for (let i = 0; i < 15; i++) rows.push(`src/b.ts(${i + 1},1): error TS2322: Type E not assignable to F.`)
+    for (let i = 0; i < 10; i++) rows.push(`src/c.ts(${i + 1},5): error TS2554: Expected 1 argument.`)
+    const body = rows.join("\n") + "\n"
+    const result = cleanHeuristic(body, { command: "tsc --noEmit" })
+    expect(result.shape).toBe("tsc")
+    expect(result.text).toContain("<tsc: top errors by code>")
+    expect(result.text).toContain("TS2322 ×35")
+    expect(result.text).toContain("TS2554 ×10")
+    expect(result.text).toContain("<tsc: top files>")
+    expect(result.text).toContain("src/a.ts ×20")
+  })
+})
+
+describe("shape: kubectl", () => {
+  test("folds runs of Running/0-restart pods and appends -o json tip", () => {
+    const body =
+      "NAME       READY   STATUS    RESTARTS   AGE\n" +
+      "web-1      1/1     Running   0          5d\n" +
+      "web-2      1/1     Running   0          5d\n" +
+      "web-3      1/1     Running   0          5d\n" +
+      "web-4      1/1     Running   0          5d\n" +
+      "cron-1     0/1     Error     3          2h\n"
+    const result = cleanHeuristic(body, { command: "kubectl get pods" })
+    expect(result.shape).toBe("kubectl")
+    expect(result.text).toContain("pods folded")
+    expect(result.text).toContain("Error")
+    expect(result.text).toContain("-o json")
+    // Individual Running rows should be gone.
+    expect(result.text).not.toContain("web-1")
+    expect(result.text).not.toContain("web-4")
+  })
+})
+
+describe("shape: json", () => {
+  test("elides long embedding string field", () => {
+    const heavy = "x".repeat(2000)
+    const body = JSON.stringify({ id: "abc", embedding: heavy, tail: "keep" })
+    const result = cleanHeuristic(body, { command: "curl example.com" })
+    expect(result.shape).toBe("json")
+    expect(result.text).toContain("elided 2000 chars")
+    expect(result.text).toContain('"tail"')
+    expect(result.text).toContain('"keep"')
+  })
+
+  test("elides a heavy array field with many items", () => {
+    const body = JSON.stringify({ embeddings: Array.from({ length: 100 }, (_, i) => i) })
+    const result = cleanHeuristic(body, { command: "curl x" })
+    expect(result.shape).toBe("json")
+    expect(result.text).toContain("elided 100 items")
+  })
+
+  test("invalid JSON returns original (never-worse trip)", () => {
+    const body = "{ not really json"
+    const result = cleanHeuristic(body, { command: "cat x.json" })
+    expect(result.text).toBe(body)
+    expect(result.shape).toBe("json")
+    expect(result.degraded).toBe(true)
+  })
+})
+
+describe("shape: md", () => {
+  test("strips HTML comments, badges, horizontal rules, extra blank lines", () => {
+    const body =
+      "<!-- generated by ci -->\n" +
+      "# Title\n\n\n\n" +
+      "![build](https://img.shields.io/travis/foo/bar.svg)\n" +
+      "---\n" +
+      "body text\n"
+    const result = cleanHeuristic(body, { command: "gh pr view 1" })
+    expect(result.shape).toBe("md")
+    expect(result.text).not.toContain("<!--")
+    expect(result.text).not.toContain("img.shields.io")
+    expect(result.text).not.toContain("---")
+    expect(result.text).toContain("# Title")
+    expect(result.text).toContain("body text")
+    // Blank-line collapse.
+    expect(result.text).not.toContain("\n\n\n")
+  })
+})
+
+describe("shape: gostest", () => {
+  test("aggregates NDJSON events into per-package pass/fail/skip counts", () => {
+    const body =
+      JSON.stringify({ Package: "pkg/a", Action: "pass" }) +
+      "\n" +
+      JSON.stringify({ Package: "pkg/b", Action: "fail" }) +
+      "\n" +
+      JSON.stringify({ Package: "pkg/b", Action: "output", Output: "FAIL: TestX at line 42\n" }) +
+      "\n" +
+      JSON.stringify({ Package: "pkg/c", Action: "skip" }) +
+      "\n"
+    const result = cleanHeuristic(body, { command: "go test ./... -json" })
+    expect(result.shape).toBe("gostest")
+    expect(result.text).toContain("PASS pkg/a")
+    expect(result.text).toContain("FAIL pkg/b")
+    expect(result.text).toContain("SKIP pkg/c")
+    expect(result.text).toContain("FAIL: TestX")
+  })
+
+  test("skips non-JSON lines gracefully", () => {
+    const body = "garbage line\n" + JSON.stringify({ Package: "pkg/a", Action: "pass" }) + "\n"
+    const result = cleanHeuristic(body, { command: "go test -json" })
+    expect(result.shape).toBe("gostest")
+    expect(result.text).toContain("PASS pkg/a")
+  })
+})


### PR DESCRIPTION
## Summary
- Add a post-common-pipeline heuristic filter that recognises common command output shapes (gitdiff, pytest, npm, make, stacktrace, tsc, kubectl, json, md, gotest) and strips predictable noise from bash output.
- Gated behind `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_HEURISTIC` flag, off by default.
- Same never-worse contract as the common pipeline — shapes that don't shrink bytes are discarded.

## Changes
- `packages/opencode/src/flag/flag.ts`: new `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_HEURISTIC` flag
- `packages/opencode/src/tool/bash.ts`: integrate heuristic pipeline after common pipeline
- `packages/opencode/src/tool/bash_token_efficient_heuristic.ts`: shape-based heuristic implementation
- `packages/opencode/test/tool/bash_token_efficient_heuristic.test.ts`: tests
- `docs/harness/`: token efficient mode documentation (multi-language)