### PR TITLE
test: skip flaky cancel-truncation test

### DIFF
--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1322,7 +1322,8 @@ unix(
   30_000,
 )
 
-unix(
+// skip: flaky due to timing race — 150ms sleep insufficient on slow CI runners
+it.live.skip(
   "cancel finalizes interrupted bash tool output through normal truncation",
   () =>
     provideTmpdirServer(

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1322,7 +1322,7 @@ unix(
   30_000,
 )
 
-// skip: flaky due to timing race — 150ms sleep insufficient on slow CI runners
+// skip (was unix-only): flaky timing race — 150ms sleep insufficient on slow CI runners
 it.live.skip(
   "cancel finalizes interrupted bash tool output through normal truncation",
   () =>


### PR DESCRIPTION
## Summary

- Skip `cancel finalizes interrupted bash tool output through normal truncation` — it relies on a fixed 150ms sleep to let bash produce enough output for truncation before cancel, which is inherently racy on slow CI runners (times out locally too).