### PR TITLE
fix(effect): order instance disposal so Bus shuts down after other services

### DIFF
--- a/packages/opencode/src/bus/index.ts
+++ b/packages/opencode/src/bus/index.ts
@@ -66,6 +66,7 @@ export const layer = Layer.effect(
 
         return { wildcard, typed }
       }),
+      { phase: "late" },
     )
 
     function getOrCreate<D extends BusEvent.Definition>(state: State, def: D) {

--- a/packages/opencode/src/effect/instance-registry.ts
+++ b/packages/opencode/src/effect/instance-registry.ts
@@ -1,12 +1,28 @@
-const disposers = new Set<(directory: string) => Promise<void>>()
+interface Disposer {
+  fn: (directory: string) => Promise<void>
+  phase: "normal" | "late"
+}
 
-export function registerDisposer(disposer: (directory: string) => Promise<void>) {
-  disposers.add(disposer)
+const disposers = new Set<Disposer>()
+
+export function registerDisposer(
+  fn: (directory: string) => Promise<void>,
+  opts?: { phase?: "normal" | "late" },
+) {
+  const entry: Disposer = { fn, phase: opts?.phase ?? "normal" }
+  disposers.add(entry)
   return () => {
-    disposers.delete(disposer)
+    disposers.delete(entry)
   }
 }
 
 export async function disposeInstance(directory: string) {
-  await Promise.allSettled([...disposers].map((disposer) => disposer(directory)))
+  const normal: Disposer[] = []
+  const late: Disposer[] = []
+  for (const d of disposers) {
+    if (d.phase === "late") late.push(d)
+    else normal.push(d)
+  }
+  await Promise.allSettled(normal.map((d) => d.fn(directory)))
+  await Promise.allSettled(late.map((d) => d.fn(directory)))
 }

--- a/packages/opencode/src/effect/instance-state.ts
+++ b/packages/opencode/src/effect/instance-state.ts
@@ -37,6 +37,7 @@ export const directory = Effect.map(context, (ctx) => ctx.directory)
 
 export const make = <A, E = never, R = never>(
   init: (ctx: InstanceContext) => Effect.Effect<A, E, R | Scope.Scope>,
+  opts?: { phase?: "normal" | "late" },
 ): Effect.Effect<InstanceState<A, E, Exclude<R, Scope.Scope>>, never, R | Scope.Scope> =>
   Effect.gen(function* () {
     const cache = yield* ScopedCache.make<string, A, E, R>({
@@ -47,8 +48,9 @@ export const make = <A, E = never, R = never>(
         }),
     })
 
-    const off = registerDisposer((directory) =>
-      Effect.runPromise(ScopedCache.invalidate(cache, directory).pipe(Effect.provide(EffectLogger.layer))),
+    const off = registerDisposer(
+      (directory) => Effect.runPromise(ScopedCache.invalidate(cache, directory).pipe(Effect.provide(EffectLogger.layer))),
+      { phase: opts?.phase },
     )
     yield* Effect.addFinalizer(() => Effect.sync(off))
 


### PR DESCRIPTION
## Summary

`disposeInstance()` runs all `InstanceState` disposers concurrently via `Promise.allSettled`. This causes a race condition where the Bus PubSub can shut down **before** `SessionRunState` publishes the terminal `session.idle` event during runner cancellation. Any active subscriber (e.g. the `/event` SSE stream) misses the event entirely, leaving the session appearing permanently busy to consumers.

## Root Cause

```
disposeInstance() → Promise.allSettled([...disposers])
    ├── Bus disposer:           publish InstanceDisposed → PubSub.shutdown()
    └── SessionRunState disposer: runner.cancel → onIdle → bus.publish(session.idle)
                                                              ↑ PubSub already shut down
```

No ordering guarantee between disposers means the Bus can complete teardown before SessionRunState finishes publishing its terminal events.

## Fix

Introduce a two-phase disposal model:

1. `registerDisposer(fn, { phase?: "normal" | "late" })` — disposers can declare their phase (default: `"normal"`)
2. `disposeInstance()` runs all `"normal"` disposers first (awaits completion), then runs `"late"` disposers
3. Bus registers its `InstanceState` with `{ phase: "late" }`

This ensures all services (SessionRunState, etc.) complete teardown and publish final events **before** the Bus PubSub channels are shut down.

## Changes

- `src/effect/instance-registry.ts` — two-phase `disposeInstance`, typed `Disposer` entries
- `src/effect/instance-state.ts` — `make()` accepts optional `{ phase }` and passes it through
- `src/bus/index.ts` — registers with `{ phase: "late" }`

## Testing

- All existing tests pass (`bun test ./test/effect/ ./test/bus/ ./test/server/session-prompt-busy.test.ts` — 33 pass, 0 fail)
- Type check passes (`bun typecheck`)