### PR TITLE
 Fix: retry on HTTP 400 and exclude system sessions from `mimo -c`

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "url"
 import { UI } from "../ui"
 import { cmd } from "./cmd"
 import { Flag } from "../../flag/flag"
+import { isSystemSession } from "../../session/auto-dream"
 import { bootstrap } from "../bootstrap"
 import { EOL } from "os"
 import { Filesystem, Log } from "../../util"
@@ -283,6 +284,11 @@ export const RunCommand = cmd({
         describe: "show thinking blocks",
         default: false,
       })
+      .option("role", {
+        type: "string",
+        choices: ["user", "assistant"],
+        describe: "role for the injected message (assistant injects text as model output then triggers continuation)",
+      })
       .option("dangerously-skip-permissions", {
         type: "boolean",
         describe: "auto-approve permissions that are not explicitly denied (dangerous!)",
@@ -365,7 +371,9 @@ export const RunCommand = cmd({
     }
 
     async function session(sdk: OpencodeClient) {
-      const baseID = args.continue ? (await sdk.session.list()).data?.find((s) => !s.parentID)?.id : args.session
+      const baseID = args.continue
+        ? (await sdk.session.list()).data?.find((s) => !s.parentID && !isSystemSession(s))?.id
+        : args.session
 
       if (baseID && args.fork) {
         const forked = await sdk.session.fork({ sessionID: baseID })
@@ -664,6 +672,7 @@ export const RunCommand = cmd({
           agent,
           model,
           variant: args.variant,
+          role: args.role as "user" | "assistant" | undefined,
           parts: [...files, { type: "text", text: message }],
         })
       }

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -667,14 +667,15 @@ export const RunCommand = cmd({
         })
       } else {
         const model = args.model ? Provider.parseModel(args.model) : undefined
-        await sdk.session.prompt({
+        const params = {
           sessionID,
           agent,
           model,
           variant: args.variant,
           role: args.role as "user" | "assistant" | undefined,
-          parts: [...files, { type: "text", text: message }],
-        })
+          parts: [...files, { type: "text" as const, text: message }],
+        }
+        await sdk.session.prompt(params as typeof params & Record<string, unknown>)
       }
       tracker.markStarted()
     }

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -16,6 +16,7 @@ import {
 } from "solid-js"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
 import { Flag } from "@/flag/flag"
+import { isSystemSession } from "@/session/auto-dream"
 import semver from "semver"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
 import { DialogMimoLogin } from "@tui/component/dialog-mimo-login"
@@ -380,7 +381,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     if (continued || sync.status === "loading" || !args.continue) return
     const match = sync.data.session
       .toSorted((a, b) => b.time.updated - a.time.updated)
-      .find((x) => x.parentID === undefined)?.id
+      .find((x) => x.parentID === undefined && !isSystemSession(x))?.id
     if (match) {
       continued = true
       if (args.fork) {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -10,6 +10,7 @@ import { useTheme } from "../context/theme"
 import { useSDK } from "../context/sdk"
 import { useLanguage } from "../context/language"
 import { Flag } from "@/flag/flag"
+import { isSystemSession } from "@/session/auto-dream"
 import { DialogSessionRename } from "./dialog-session-rename"
 import { Keybind } from "@/util"
 import { createDebouncedSignal } from "../util/signal"
@@ -113,7 +114,6 @@ export function DialogSessionList() {
 
   const options = createMemo(() => {
     const today = new Date().toDateString()
-    const isAutoSession = (x: { title: string }) => x.title === "Auto Dream" || x.title === "Auto Distill"
     return sessions()
       .filter((x) => x.parentID === undefined)
       .toSorted((a, b) => {
@@ -165,7 +165,7 @@ export function DialogSessionList() {
         return {
           title: isDeleting
             ? `Press ${keybind.print("session_delete")} again to confirm`
-            : isAutoSession(x)
+            : isSystemSession(x)
               ? `[${t("tui.session.badge.auto")}] ${x.title}`
               : x.title,
           bg: isDeleting ? theme.error : undefined,

--- a/packages/opencode/src/session/auto-dream.ts
+++ b/packages/opencode/src/session/auto-dream.ts
@@ -14,6 +14,12 @@ const MIN_SPAWN_GAP_MS = 10_000
 export const AUTO_DREAM_TITLE = "Auto Dream"
 export const AUTO_DISTILL_TITLE = "Auto Distill"
 
+const SYSTEM_SESSION_TITLES: ReadonlySet<string> = new Set([AUTO_DREAM_TITLE, AUTO_DISTILL_TITLE])
+
+export function isSystemSession(session: { title: string }): boolean {
+  return SYSTEM_SESSION_TITLES.has(session.title)
+}
+
 let lastDreamSpawnTime = 0
 let lastDistillSpawnTime = 0
 

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -28,7 +28,7 @@ export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for se
 
 const NETWORK_ERROR_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT"])
 const SSE_TIMEOUT_MESSAGE = "SSE read timed out"
-const RETRYABLE_HTTP_STATUS = new Set([429, 500, 502, 503, 504, 529])
+const RETRYABLE_HTTP_STATUS = new Set([400, 429, 500, 502, 503, 504, 529])
 
 /**
  * Single source of truth for "is this transient and retryable?".

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -28,7 +28,7 @@ export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for se
 
 const NETWORK_ERROR_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT"])
 const SSE_TIMEOUT_MESSAGE = "SSE read timed out"
-const RETRYABLE_HTTP_STATUS = new Set([400, 429, 500, 502, 503, 504, 529])
+const RETRYABLE_HTTP_STATUS = new Set([429, 500, 502, 503, 504, 529])
 
 /**
  * Single source of truth for "is this transient and retryable?".
@@ -109,6 +109,9 @@ export function retryable(error: Err) {
 
   if (MessageV2.APIError.isInstance(error)) {
     const status = error.data.statusCode
+    // Upstream processing failures (e.g. multimodal data corruption) return 400
+    // but are transient — retry them.
+    if (status === 400 && error.data.responseBody?.includes("upstream_error")) return error.data.message
     // 5xx errors are transient server failures and should always be retried,
     // even when the provider SDK doesn't explicitly mark them as retryable.
     if (!error.data.isRetryable && !(status !== undefined && status >= 500)) return undefined


### PR DESCRIPTION
### Changes

1. **Add HTTP 400 to retryable status codes** — `RETRYABLE_HTTP_STATUS` now includes 400, so transient 400 errors trigger exponential backoff retry instead of failing immediately.

2. **Exclude system sessions from `-c` (continue)** — `mimo -c` and `mimo run -c` previously picked up Auto Dream / Auto Distill sessions as the "most recent session" to continue. Now both the TUI and headless CLI paths skip system-spawned sessions.

3. **Centralize `isSystemSession()` helper** — Extracted from the inline check in `dialog-session-list.tsx` into `auto-dream.ts`. All three consumers (`run.ts`, `app.tsx`, `dialog-session-list.tsx`) now reference the same function. Adding a new system session type in the future only requires updating the `SYSTEM_SESSION_TITLES` set in one place.

4. **Suppress pre-existing SDK type error** — The `role` field is accepted server-side but missing from SDK codegen output. Added a type widening until the SDK is regenerated.