### PR TITLE
feat(skill): add builtin mimocode self-documentation skill

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
@@ -34,11 +34,11 @@ Config file (JSON or JSONC), discovered by walking up from cwd:
 - **Project**: `.mimocode/mimocode.json` (or `.jsonc`)
 - **Global**: `~/.config/mimocode/mimocode.json`
 
-Add `"$schema": "https://opencode.ai/config.json"` for editor validation. All top-level keys are optional; project config merges over global.
+Add `"$schema": "https://mimo.xiaomi.com/mimocode/config.json"` for editor validation. All top-level keys are optional; project config merges over global.
 
 ```jsonc
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/config.json",
   "model": "provider/model",
   "permission": { "external_directory": { "/tmp/**": "allow" } }
 }

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
@@ -51,6 +51,10 @@ For the full key reference (model, provider, mcp, permission, agent, checkpoint,
 
 For task-oriented walkthroughs — signing in & choosing a model, making memory remember project rules, writing custom slash commands, remapping keybinds, adding MCP servers, and using compose mode — see @reference/guide.md. For authoring and running **dynamic workflows** (the in-script API, where to save `.js` workflow files, and the `workflow` tool) see @reference/workflows.md.
 
+**Built-in workflows** (runnable by name via the `workflow` tool, no file needed):
+- **`compose`** — deterministic spec→ship pipeline (brainstorm → design → implement/TDD → verify → review → merge), auto-parallelized across per-task worktrees. Pass `args.task`.
+- **`deep-research`** — parallel web search → source extraction → adversarial cross-check → cited report. Pass the question as `args`.
+
 ## Where Things Live On Disk
 
 Base dirs follow `MIMOCODE_HOME` (if set, absolute) else XDG. Data typically lives at `~/.local/share/mimocode/` (memory, logs, extracted builtin skills), config at `~/.config/mimocode/`, cache at `~/.cache/mimocode/`. See @reference/config.md for the full layout and env vars.

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
@@ -25,6 +25,7 @@ MiMoCode (CLI binary `mimo`) is an agentic coding tool with a terminal UI, built
 | **Voice input** | Streaming ASR (TenVAD + MiMo ASR); needs `sox` | `/voice` |
 | **Dream** | Consolidates recent traces into project memory | `/dream` |
 | **Distill** | Packages repeated manual workflows into skills/subagents/commands | `/distill` |
+| **Dynamic workflows** | JS scripts that orchestrate many subagents deterministically (fan-out, pipelines, nesting); built-ins `compose` & `deep-research` | `.mimocode/workflows/*.js` + `workflow` tool |
 | **Skills / self-extension** | Add tools, hooks, skills under `.mimocode/` | see the `self-extend` skill |
 | **MCP** | Local & remote Model Context Protocol servers | `mcp` config + `mimo mcp` |
 
@@ -48,7 +49,7 @@ For the full key reference (model, provider, mcp, permission, agent, checkpoint,
 
 ## How-To Guide
 
-For task-oriented walkthroughs — signing in & choosing a model, making memory remember project rules, writing custom slash commands, remapping keybinds, adding MCP servers, and using compose mode — see @reference/guide.md.
+For task-oriented walkthroughs — signing in & choosing a model, making memory remember project rules, writing custom slash commands, remapping keybinds, adding MCP servers, and using compose mode — see @reference/guide.md. For authoring and running **dynamic workflows** (the in-script API, where to save `.js` workflow files, and the `workflow` tool) see @reference/workflows.md.
 
 ## Where Things Live On Disk
 

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: mimocode
+description: Use when the user asks what MiMoCode can do, how a feature works (memory, checkpoints, agents, subagents, tasks, compose, voice, dream/distill, goal), how to configure it, where config/data lives, which config key controls a behavior, what CLI or slash commands exist, or how to enable/disable/tune something — the self-documenting reference for MiMoCode itself.
+---
+
+# MiMoCode
+
+You are MiMoCode. This skill lets you explain your own features, tell users how to use them, and help configure yourself. When a user asks "what can you do", "how do I set X", "where does Y live", or "how does Z work", answer from here — don't guess.
+
+## Identity
+
+MiMoCode (CLI binary `mimo`) is an agentic coding tool with a terminal UI, built as a fork of OpenCode. Beyond OpenCode's core (multi-provider, TUI, LSP, MCP, plugins) it adds: persistent memory, intelligent context management, subagent orchestration, goal-driven autonomous loops, compose workflows, and self-improvement via dream/distill.
+
+## Feature Map
+
+| Feature | What it is | How to reach it |
+|---------|-----------|-----------------|
+| **Agents** | `build` (default, full tools), `plan` (read-only analysis), `compose` (specs-driven orchestration) | `Tab` cycles primary agents |
+| **Subagents** | Primary agent spawns `general`/`explore` helpers, parallel + background, with lifecycle/cancel | automatic; `actor` tooling |
+| **Persistent memory** | SQLite FTS5 across sessions: `MEMORY.md`, `checkpoint.md`, `notes.md`, `tasks/<id>/progress.md` | auto-injected on resume |
+| **Context management** | Auto-checkpoints, context reconstruction near limit, budgeted injection | automatic; tune via `checkpoint`/`compaction` config |
+| **Task tree** | `T1`, `T1.1`… tree, integrated with checkpoints | `task` tooling |
+| **Goal / stop condition** | Judge model verifies a stop condition before the agent halts | `/goal` |
+| **Compose mode** | Structured spec→ship lifecycle with built-in plan/tdd/debug/review/verify/merge skills | `compose` agent |
+| **Voice input** | Streaming ASR (TenVAD + MiMo ASR); needs `sox` | `/voice` |
+| **Dream** | Consolidates recent traces into project memory | `/dream` |
+| **Distill** | Packages repeated manual workflows into skills/subagents/commands | `/distill` |
+| **Skills / self-extension** | Add tools, hooks, skills under `.mimocode/` | see the `self-extend` skill |
+| **MCP** | Local & remote Model Context Protocol servers | `mcp` config + `mimo mcp` |
+
+## Configuration Basics
+
+Config file (JSON or JSONC), discovered by walking up from cwd:
+- **Project**: `.mimocode/mimocode.json` (or `.jsonc`)
+- **Global**: `~/.config/mimocode/mimocode.json`
+
+Add `"$schema": "https://opencode.ai/config.json"` for editor validation. All top-level keys are optional; project config merges over global.
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "provider/model",
+  "permission": { "external_directory": { "/tmp/**": "allow" } }
+}
+```
+
+For the full key reference (model, provider, mcp, permission, agent, checkpoint, compaction, memory, dream, distill, voice, workflow, experimental, and more) see @reference/config.md.
+
+## Where Things Live On Disk
+
+Base dirs follow `MIMOCODE_HOME` (if set, absolute) else XDG. Data typically lives at `~/.local/share/mimocode/` (memory, logs, extracted builtin skills), config at `~/.config/mimocode/`, cache at `~/.cache/mimocode/`. See @reference/config.md for the full layout and env vars.
+
+## Commands
+
+`mimo` subcommands (`mcp`, `run`, `agent`, `models`, `providers`, `upgrade`, `stats`, `export`/`import`, `github`/`pr`, `serve`, …) and slash commands (`/goal`, `/dream`, `/distill`, `/voice`, `/loop`, `/connect`, `/<skill-name>`) are documented in @reference/commands.md.
+
+## Helping the User Configure
+
+When asked to change a behavior:
+1. Identify the config key from @reference/config.md.
+2. Read the existing `.mimocode/mimocode.json` (project) or global config if present — don't clobber it.
+3. Edit minimally: add or change only the relevant key, preserving `$schema` and other settings.
+4. State which file you changed and whether it needs a restart (config is re-read on next turn for most keys; TUI plugins need restart).
+
+Don't invent config keys. If a requested behavior has no key, say so and suggest the closest supported option or the `self-extend` route (a hook/tool).
+
+## Answering Feature Questions
+
+- Confirm the feature exists in the map above before describing it.
+- Give the trigger (command / key / config), then a one-line how.
+- For extending capabilities (new tools/hooks/skills), defer to the `self-extend` skill rather than duplicating it.
+- If unsure whether a detail is current, verify against the config schema or README rather than asserting.

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
@@ -25,6 +25,7 @@ MiMoCode (CLI binary `mimo`) is an agentic coding tool with a terminal UI, built
 | **Voice input** | Streaming ASR (TenVAD + MiMo ASR); needs `sox` | `/voice` |
 | **Dream** | Consolidates recent traces into project memory | `/dream` |
 | **Distill** | Packages repeated manual workflows into skills/subagents/commands | `/distill` |
+| **Scheduled prompts** | Cron/loop: inject a prompt on a schedule or repeating loop (UTC, 5-field) | `cron` tool · `/loop` · `/loops` |
 | **Dynamic workflows** | JS scripts that orchestrate many subagents deterministically (fan-out, pipelines, nesting); built-ins `compose` & `deep-research` | `.mimocode/workflows/*.js` + `workflow` tool |
 | **Skills / self-extension** | Add tools, hooks, skills under `.mimocode/` | see the `self-extend` skill |
 | **MCP** | Local & remote Model Context Protocol servers | `mcp` config + `mimo mcp` |
@@ -49,7 +50,7 @@ For the full key reference (model, provider, mcp, permission, agent, checkpoint,
 
 ## How-To Guide
 
-For task-oriented walkthroughs — signing in & choosing a model, making memory remember project rules, writing custom slash commands, remapping keybinds, adding MCP servers, and using compose mode — see @reference/guide.md. For authoring and running **dynamic workflows** (the in-script API, where to save `.js` workflow files, and the `workflow` tool) see @reference/workflows.md.
+For task-oriented walkthroughs — signing in & choosing a model, making memory remember project rules, writing custom slash commands, remapping keybinds, adding MCP servers, scheduling prompts (cron/loop), and using compose mode — see @reference/guide.md. For authoring and running **dynamic workflows** (the in-script API, where to save `.js` workflow files, and the `workflow` tool) see @reference/workflows.md.
 
 **Built-in workflows** (runnable by name via the `workflow` tool, no file needed):
 - **`compose`** — deterministic spec→ship pipeline (brainstorm → design → implement/TDD → verify → review → merge), auto-parallelized across per-task worktrees. Pass `args.task`.

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
@@ -44,7 +44,11 @@ Add `"$schema": "https://mimo.xiaomi.com/mimocode/config.json"` for editor valid
 }
 ```
 
-For the full key reference (model, provider, mcp, permission, agent, checkpoint, compaction, memory, dream, distill, voice, workflow, experimental, and more) see @reference/config.md.
+For the full key reference (model, provider, mcp, permission, agent, checkpoint, compaction, memory, dream, distill, voice, workflow, experimental, command, keybinds, and more) see @reference/config.md. For the permission model (per-tool allow/ask/deny rules) see @reference/permissions.md.
+
+## How-To Guide
+
+For task-oriented walkthroughs — signing in & choosing a model, making memory remember project rules, writing custom slash commands, remapping keybinds, adding MCP servers, and using compose mode — see @reference/guide.md.
 
 ## Where Things Live On Disk
 

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/SKILL.md
@@ -15,7 +15,7 @@ MiMoCode (CLI binary `mimo`) is an agentic coding tool with a terminal UI, built
 
 | Feature | What it is | How to reach it |
 |---------|-----------|-----------------|
-| **Agents** | `build` (default, full tools), `plan` (read-only analysis), `compose` (specs-driven orchestration) | `Tab` cycles primary agents |
+| **Agents / modes** | `build` (default, full tools), `plan` (read-only analysis), `compose` (specs-driven orchestration), plus custom modes you define | `Tab` cycles primary agents; add your own via `.mimocode/agent/<name>.md` (see @reference/guide.md) |
 | **Subagents** | Primary agent spawns `general`/`explore` helpers, parallel + background, with lifecycle/cancel | automatic; `actor` tooling |
 | **Persistent memory** | SQLite FTS5 across sessions: `MEMORY.md`, `checkpoint.md`, `notes.md`, `tasks/<id>/progress.md` | auto-injected on resume |
 | **Context management** | Auto-checkpoints, context reconstruction near limit, budgeted injection | automatic; tune via `checkpoint`/`compaction` config |

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/commands.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/commands.md
@@ -37,8 +37,8 @@ Run `mimo <command> --help` for flags on any command.
 | `/dream` | Scan recent traces, extract durable knowledge into project memory, prune stale entries |
 | `/distill` | Detect repeated manual workflows and package high-confidence ones into skills/subagents/commands |
 | `/voice` | Toggle streaming voice input (needs `sox`; MiMo-logged-in users) |
-| `/loop` | Run the built-in loop skill (autonomous iteration) |
-| `/loops` | Manage / view loops |
+| `/loop` | `[interval] <prompt>` — schedule a repeating prompt (also runs once now); maps the interval to a cron job |
+| `/loops` | List scheduled cron/loop jobs; `/loops cancel <id>` stops one |
 | `/connect` | Sign in to a provider (e.g. OpenRouter) |
 | `/<skill-name>` | Invoke any available skill directly by name |
 

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/commands.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/commands.md
@@ -1,0 +1,53 @@
+# MiMoCode Commands Reference
+
+## CLI (`mimo <command>`)
+
+Invoked from the shell. `mimo` with no command opens the TUI.
+
+| Command | Purpose |
+|---------|---------|
+| `mimo` | Launch the interactive TUI |
+| `mimo run` | Headless, non-interactive run (scripting/eval) |
+| `mimo mcp` | Manage / inspect MCP servers |
+| `mimo agent` | Manage agents |
+| `mimo models` | List available models |
+| `mimo providers` | List / manage providers |
+| `mimo account` (console) | Account / login console |
+| `mimo upgrade` | Update to the latest version |
+| `mimo uninstall` | Uninstall MiMoCode |
+| `mimo serve` | Run the server |
+| `mimo stats` | Usage statistics |
+| `mimo export` / `mimo import` | Export / import sessions |
+| `mimo session` | Manage sessions |
+| `mimo github` / `mimo pr` | GitHub / pull-request integration |
+| `mimo generate` | Code generation entry |
+| `mimo plugin` (plug) | Manage plugins |
+| `mimo db` | Database utilities |
+| `mimo acp` / `mimo attach` | ACP / attach to a running session |
+| `mimo debug` | Debug utilities |
+| `mimo completion` | Generate shell completion script |
+
+Run `mimo <command> --help` for flags on any command.
+
+## Slash commands (inside the TUI)
+
+| Command | Purpose |
+|---------|---------|
+| `/goal` | Set a stop condition; a judge model verifies it's truly met before the agent halts (prevents premature stops in autonomous work) |
+| `/dream` | Scan recent traces, extract durable knowledge into project memory, prune stale entries |
+| `/distill` | Detect repeated manual workflows and package high-confidence ones into skills/subagents/commands |
+| `/voice` | Toggle streaming voice input (needs `sox`; MiMo-logged-in users) |
+| `/loop` | Run the built-in loop skill (autonomous iteration) |
+| `/loops` | Manage / view loops |
+| `/connect` | Sign in to a provider (e.g. OpenRouter) |
+| `/<skill-name>` | Invoke any available skill directly by name |
+
+## Keybindings
+
+- `Tab` — cycle primary agents (build → plan → compose).
+- Other keybinds are configurable; the keybinds config module governs them.
+
+## Notes
+
+- The web command is currently disabled; TUI is the supported interface.
+- Voice ASR (`mimo-v2.5-asr`) is MiMo-platform only; voice control (`mimo-v2.5`) also runs on OpenRouter and compatible relays via the `voice` config (see config.md and the README voice section).

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
@@ -30,7 +30,10 @@ Memory files live under `~/.local/share/mimocode/memory/`:
 
 - `MIMOCODE_HOME` — override all base dirs (absolute path).
 - `MIMOCODE_CONFIG_DIR` — extra config directory to search.
-- `MIMOCODE_PURE` — pure mode.
+- `MIMOCODE_PURE` — run without external plugins (same as `mimo --pure`). Does **not** change models or Claude Code inheritance.
+- `MIMOCODE_MIMO_ONLY` — pure-MiMo mode: don't inherit Claude Code settings (CLAUDE.md, `~/.claude/skills`), don't read provider API keys from env, fall back to the mimo-auto model.
+- `MIMOCODE_DISABLE_LOG_ROTATION` — keep a single growing log file instead of rotating.
+- `MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT` — retries when a model emits a tool call as prose markup instead of a structured call (default 2).
 - `MIMOCODE_DISABLE_BUILTIN_SKILLS`, `_COMPOSE_SKILLS`, `_EXTERNAL_SKILLS`, `_CLAUDE_CODE_SKILLS`, `_CODEX_SKILLS`, `_OPENCODE_SKILLS`, `_PROJECT_CONFIG`, `_CLAUDE_IMPORT` — feature toggles.
 
 ## Top-level config keys

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
@@ -8,7 +8,7 @@ Config is JSON or JSONC. MiMoCode discovers it by walking up from the cwd to the
 - Global: `~/.config/mimocode/mimocode.json` (XDG config dir)
 - Extra config dirs are also searched via `$MIMOCODE_CONFIG_DIR`.
 
-Project config merges **over** global. Always include `"$schema": "https://opencode.ai/config.json"` for validation.
+Project config merges **over** global. Always include `"$schema": "https://mimo.xiaomi.com/mimocode/config.json"` for validation.
 
 ## On-disk data layout
 
@@ -119,7 +119,7 @@ All optional.
 
 ```jsonc
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/config.json",
   "model": "anthropic/claude-opus-4-8",
   "small_model": "anthropic/claude-haiku",
   "dream": { "auto": true, "interval_days": 3 },

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
@@ -1,0 +1,132 @@
+# MiMoCode Configuration Reference
+
+## File locations & precedence
+
+Config is JSON or JSONC. MiMoCode discovers it by walking up from the cwd to the worktree root, then falls back to global.
+
+- Project: `.mimocode/mimocode.json` or `.mimocode/mimocode.jsonc`
+- Global: `~/.config/mimocode/mimocode.json` (XDG config dir)
+- Extra config dirs are also searched via `$MIMOCODE_CONFIG_DIR`.
+
+Project config merges **over** global. Always include `"$schema": "https://opencode.ai/config.json"` for validation.
+
+## On-disk data layout
+
+Base directories resolve from `MIMOCODE_HOME` if set (must be absolute → `<home>/{data,cache,config,state}`), otherwise from XDG:
+
+| Kind | Default location | Holds |
+|------|------------------|-------|
+| data | `~/.local/share/mimocode/` | memory, logs, `builtin_skills/<version>/`, bin |
+| config | `~/.config/mimocode/` | global `mimocode.json` |
+| cache | `~/.cache/mimocode/` | caches, downloaded bins |
+| state | `~/.local/state/mimocode/` | runtime state |
+
+Memory files live under `~/.local/share/mimocode/memory/`:
+- `projects/global/MEMORY.md` — project memory
+- `sessions/<id>/checkpoint.md`, `notes.md`, `tasks/<id>/progress.md`
+- `global/MEMORY.md` — cross-project user preferences
+
+## Environment variables & flags
+
+- `MIMOCODE_HOME` — override all base dirs (absolute path).
+- `MIMOCODE_CONFIG_DIR` — extra config directory to search.
+- `MIMOCODE_PURE` — pure mode.
+- `MIMOCODE_DISABLE_BUILTIN_SKILLS`, `_COMPOSE_SKILLS`, `_EXTERNAL_SKILLS`, `_CLAUDE_CODE_SKILLS`, `_CODEX_SKILLS`, `_OPENCODE_SKILLS`, `_PROJECT_CONFIG`, `_CLAUDE_IMPORT` — feature toggles.
+
+## Top-level config keys
+
+All optional.
+
+### Models & providers
+| Key | Purpose |
+|-----|---------|
+| `model` | Primary model, `provider/model` (e.g. `anthropic/claude-2`) |
+| `small_model` | Model for cheap tasks like title generation |
+| `model_groups` | Named capability tiers (e.g. ultra/standard/lite); usable anywhere a model string is |
+| `provider` | Custom provider configs & model overrides |
+| `enabled_providers` / `disabled_providers` | Allowlist / blocklist providers |
+
+### Agents
+| Key | Purpose |
+|-----|---------|
+| `default_agent` | Primary agent when none specified (falls back to `build`) |
+| `agent` | Per-agent config: `plan`, `build`, `general`, `explore`, `title`, `summary`, `compaction`, plus custom |
+| `username` | Display name in conversations |
+
+### Tools, skills, MCP, extensions
+| Key | Purpose |
+|-----|---------|
+| `skills` | `paths[]` extra skill folders + `urls[]` remote skill indexes |
+| `mcp` | MCP servers: `local` (command/env) or `remote` (url/headers/oauth); `{ "enabled": false }` disables one |
+| `tools` | Record of tool-id → boolean enable/disable |
+| `tool.invocation_style` | `json` (default) or `shell`; `tool.invocation_style_by_tool` for per-tool override |
+| `command` | Custom slash commands |
+| `plugin` | Plugin specs |
+| `formatter`, `lsp` | Formatter & language-server config |
+| `instructions` | Extra instruction files/globs to include |
+| `permission` | Permission rules incl. `external_directory` allowlist |
+
+### Context management
+| Key | Purpose |
+|-----|---------|
+| `compaction.auto` | Auto-compact when context full (default true) |
+| `compaction.prune` | Prune old tool outputs (default true) |
+| `compaction.tail_turns` | Recent user turns kept verbatim (default 2) |
+| `compaction.preserve_recent_tokens` | Max recent tokens kept verbatim |
+| `compaction.reserved` | Token buffer to avoid overflow |
+| `checkpoint.thresholds` | Context-fill triggers, e.g. `["40%","60%","80%"]` |
+| `checkpoint.reserved` | Token buffer for checkpoint ops (default 20000) |
+| `checkpoint.max_writer_failures` | Consecutive writer failures before pausing (default 3) |
+| `checkpoint.fork` | Fork parent prefix into writer session for cache reuse (default false) |
+| `checkpoint.push_caps.*` | Per-section token caps for rebuild context (tasks_ledger, focus_task, checkpoint, memory, notes, global, recent_user, …) |
+| `checkpoint.task_archive_days` | Days before done/abandoned tasks filtered out (default 7) |
+| `checkpoint.memory_search_score_floor` | BM25 relative floor for memory search (default 0.15) |
+| `memory.cc_index` | Index Claude Code memory under scope `cc` (default false; see privacy note in schema) |
+| `history` | Conversation-history FTS index config |
+
+### Autonomous / self-improvement
+| Key | Purpose |
+|-----|---------|
+| `dream.auto` / `dream.interval_days` | Auto memory consolidation on session start (default true / 7 days) |
+| `distill.auto` / `distill.interval_days` | Auto workflow packaging (default true / 30 days) |
+| `voice.asr_model` | ASR model (default `xiaomi/mimo-v2.5-asr`) |
+| `voice.control_model` | Voice control model (default `xiaomi/mimo-v2.5`) |
+| `compose` | Compose mode config (`docs` dir default `docs/compose`, `docs_absolute`) |
+| `workflow.maxConcurrentAgents` | Process-wide subagent concurrency ceiling (default min(16, 2×cores)) |
+| `workflow.maxDepth` | Max workflow nesting depth (default 8) |
+
+### Experimental
+| Key | Purpose |
+|-----|---------|
+| `experimental.maxMode` | `max` agent runs N parallel reasoning candidates, judge picks winner (`candidates`, default 5) |
+| `experimental.batch_tool` | Enable the batch tool |
+| `experimental.predict_next_prompt` | Inline ghost-text next-prompt prediction (default on) |
+| `experimental.continue_loop_on_deny` | Keep looping when a tool call is denied |
+| `experimental.primary_tools` | Tools restricted to primary agents |
+| `experimental.mcp_timeout` | MCP request timeout (ms) |
+
+### Misc
+| Key | Purpose |
+|-----|---------|
+| `autoupdate` | `true` / `false` / `"notify"` |
+| `share` | `"manual"` / `"auto"` / `"disabled"` |
+| `snapshot` | Filesystem snapshot tracking for undo/redo (default true) |
+| `logLevel` | Log verbosity |
+| `server` | Config for `mimo serve` |
+| `enterprise.url` | Enterprise endpoint |
+
+## Example: common tweaks
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-opus-4-8",
+  "small_model": "anthropic/claude-haiku",
+  "dream": { "auto": true, "interval_days": 3 },
+  "compaction": { "tail_turns": 3 },
+  "permission": { "external_directory": { "/tmp/**": "allow" } },
+  "mcp": {
+    "my-server": { "type": "local", "command": ["node", "server.js"] }
+  }
+}
+```

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
@@ -41,7 +41,7 @@ All optional.
 | Key | Purpose |
 |-----|---------|
 | `model` | Primary model, `provider/model` (e.g. `anthropic/claude-2`) |
-| `small_model` | Explicit model for cheap tasks (title generation, etc.); if unset, routes through the `lite` group. `provider/model` |
+| `small_model` | **Legacy / not recommended** — carried over from OpenCode for back-compat. Prefer configuring the `lite` group instead. If set, its literal `provider/model` still wins for cheap tasks (title generation, etc.); if unset, cheap tasks route through the `lite` group |
 | `model_groups` | Named capability tiers usable anywhere a model string is accepted — see [Model groups](#model-groups) |
 | `provider` | Custom provider configs & model overrides |
 | `enabled_providers` / `disabled_providers` | Allowlist / blocklist providers |
@@ -74,7 +74,7 @@ Each group maps a name to either a single default model (string shorthand) or an
 - A ref without `/` is a group name. If configured, MiMoCode is **provider-aware**: it prefers a member on the caller's current provider, otherwise falls back to the group's `default`.
 - `ultra`, `standard`, `lite` are **built-in tier names**. If you reference one but haven't configured it, it silently falls back to the default model (zero-config never errors).
 - Any other unconfigured name errors with fuzzy suggestions of your defined groups.
-- `small_model` interplay: an explicit `small_model` literal wins; otherwise cheap-task selection resolves the `lite` group (then the built-in fallback).
+- Cheap-task (small) model: **configure the `lite` group** — that is the recommended path. The legacy `small_model` literal, if set, still takes precedence for back-compat, but is not recommended for new configs.
 
 Use groups when you want one label (`"standard"`) to map to different concrete models per provider, or to swap tiers globally without editing every agent/model reference.
 
@@ -153,7 +153,7 @@ Use groups when you want one label (`"standard"`) to map to different concrete m
 {
   "$schema": "https://mimo.xiaomi.com/mimocode/config.json",
   "model": "anthropic/claude-opus-4-8",
-  "small_model": "anthropic/claude-haiku",
+  "model_groups": { "lite": "anthropic/claude-haiku" },
   "dream": { "auto": true, "interval_days": 3 },
   "compaction": { "tail_turns": 3 },
   "permission": { "external_directory": { "/tmp/**": "allow" } },

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
@@ -34,6 +34,8 @@ Memory files live under `~/.local/share/mimocode/memory/`:
 - `MIMOCODE_MIMO_ONLY` — pure-MiMo mode: don't inherit Claude Code settings (CLAUDE.md, `~/.claude/skills`), don't read provider API keys from env, fall back to the mimo-auto model.
 - `MIMOCODE_DISABLE_LOG_ROTATION` — keep a single growing log file instead of rotating.
 - `MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT` — retries when a model emits a tool call as prose markup instead of a structured call (default 2).
+- `MIMOCODE_EXPERIMENTAL_CRON` — scheduled prompts (cron/loop); **on by default**. `MIMOCODE_DISABLE_CRON` kills it at runtime. Tune loop keepalive with `MIMOCODE_LOOP_KEEPALIVE_BUDGET` (default 1) and `MIMOCODE_LOOP_KEEPALIVE_DELAY_S` (default 1200).
+- `MIMOCODE_EXPERIMENTAL_TOKEN_EFFICIENCY_HEURISTIC` — shape-based compaction of bash output to save tokens; off by default.
 - `MIMOCODE_DISABLE_BUILTIN_SKILLS`, `_COMPOSE_SKILLS`, `_EXTERNAL_SKILLS`, `_CLAUDE_CODE_SKILLS`, `_CODEX_SKILLS`, `_OPENCODE_SKILLS`, `_PROJECT_CONFIG`, `_CLAUDE_IMPORT` — feature toggles.
 
 ## Top-level config keys

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
@@ -41,10 +41,42 @@ All optional.
 | Key | Purpose |
 |-----|---------|
 | `model` | Primary model, `provider/model` (e.g. `anthropic/claude-2`) |
-| `small_model` | Model for cheap tasks like title generation |
-| `model_groups` | Named capability tiers (e.g. ultra/standard/lite); usable anywhere a model string is |
+| `small_model` | Explicit model for cheap tasks (title generation, etc.); if unset, routes through the `lite` group. `provider/model` |
+| `model_groups` | Named capability tiers usable anywhere a model string is accepted — see [Model groups](#model-groups) |
 | `provider` | Custom provider configs & model overrides |
 | `enabled_providers` / `disabled_providers` | Allowlist / blocklist providers |
+
+### Model groups
+
+`model_groups` lets you define named capability tiers and reference them by name (e.g. `"ultra"`) anywhere a `provider/model` string is accepted — the `model` key, an agent's model, the `actor` subagent `model` argument, and workflow model tiers.
+
+Each group maps a name to either a single default model (string shorthand) or an object with a `default` plus optional member `models`:
+
+```jsonc
+{
+  "$schema": "https://mimo.xiaomi.com/mimocode/config.json",
+  "model_groups": {
+    // string shorthand: the group IS its default model
+    "lite": "anthropic/claude-haiku",
+    // object form: a default plus alternates on other providers
+    "standard": {
+      "default": "anthropic/claude-sonnet",
+      "models": ["anthropic/claude-sonnet", "openrouter/xiaomi/mimo-v2.5"]
+    },
+    "ultra": "anthropic/claude-opus-4-8"
+  },
+  "model": "standard"
+}
+```
+
+**Resolution rules:**
+- A ref containing `/` is a literal `provider/model` and is used as-is.
+- A ref without `/` is a group name. If configured, MiMoCode is **provider-aware**: it prefers a member on the caller's current provider, otherwise falls back to the group's `default`.
+- `ultra`, `standard`, `lite` are **built-in tier names**. If you reference one but haven't configured it, it silently falls back to the default model (zero-config never errors).
+- Any other unconfigured name errors with fuzzy suggestions of your defined groups.
+- `small_model` interplay: an explicit `small_model` literal wins; otherwise cheap-task selection resolves the `lite` group (then the built-in fallback).
+
+Use groups when you want one label (`"standard"`) to map to different concrete models per provider, or to swap tiers globally without editing every agent/model reference.
 
 ### Agents
 | Key | Purpose |

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/config.md
@@ -90,6 +90,8 @@ Use groups when you want one label (`"standard"`) to map to different concrete m
 | `agent` | Per-agent config: `plan`, `build`, `general`, `explore`, `title`, `summary`, `compaction`, plus custom |
 | `username` | Display name in conversations |
 
+Prefer a markdown file (`.mimocode/agent/<name>.md`, body = system prompt) for defining a custom agent/mode — see the "Custom agents & modes" section in @guide.md. Use the `agent` config key for short, inline per-agent overrides.
+
 ### Tools, skills, MCP, extensions
 | Key | Purpose |
 |-----|---------|

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/guide.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/guide.md
@@ -75,6 +75,12 @@ Compose is a specs-driven orchestration agent: it coordinates built-in skills (p
 
 Artifacts land under `docs/compose/` by default (`specs/`, `plans/`, `reports/`). Change the location with `compose.docs`; set `compose.docs_absolute: true` to anchor a relative path to the worktree root.
 
+For well-defined tasks that split into independent subtasks, prefer the deterministic **`compose` workflow** (fire-and-forget, auto-parallelized) over the agent — see @workflows.md.
+
+## Jupyter notebooks
+
+The `notebook-edit` tool edits `.ipynb` cells directly (replace / insert / delete a single cell) while preserving the surrounding JSON, outputs, and metadata — prefer it over raw text edits on notebooks.
+
 ## Extending MiMoCode
 
 To add tools, hooks, or skills, use the `self-extend` skill — it covers writing `.mimocode/tools/*.ts`, `.mimocode/hooks/*.ts`, and `.mimocode/skills/*/SKILL.md`, all hot-reloaded on the next turn.

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/guide.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/guide.md
@@ -81,6 +81,29 @@ For well-defined tasks that split into independent subtasks, prefer the determin
 
 The `notebook-edit` tool edits `.ipynb` cells directly (replace / insert / delete a single cell) while preserving the surrounding JSON, outputs, and metadata — prefer it over raw text edits on notebooks.
 
+## Scheduled prompts (cron) & loops
+
+**Cron** schedules a prompt to be injected into a session on a recurring or one-shot basis. It is driven by the `cron` tool (no `/cron` slash command); `MIMOCODE_EXPERIMENTAL_CRON` is **on by default** (kill switch: `MIMOCODE_DISABLE_CRON`).
+
+The `cron` tool has six verbs:
+
+| Verb | Purpose |
+|------|---------|
+| `schedule` | Add a job: `cron` (5-field expression), `prompt`, optional `one_shot`, `durable`, `session_id` |
+| `loop` | Arm a repeating loop by `delay_seconds` (clamped 60–3600) + `prompt` |
+| `list` | List jobs (filter by `kind`, `durable_only`) |
+| `get` | Show one job by `id` |
+| `rename` | Replace a job's prompt body |
+| `delete` (alias `cancel`) | Remove a job by `id` |
+
+- **Expressions are 5-field** (`minute hour dom month dow`) and evaluated in **UTC** — there is no timezone config.
+- **Durable** jobs persist to `<project>/.mimocode/scheduled_tasks.json` and survive restart; non-durable jobs live only for the session.
+- When a job fires, the prompt is injected with an `[cron fire @ <ISO>]` prefix; the TUI shows a `🕒 cron fire` clock-row before the reply.
+
+**Loop** — `/loop [interval] <prompt>` (a built-in skill) is a friendly front end: it parses an interval (e.g. `30m`, `2h`), maps it to a recurring cron job, and also runs the prompt once immediately. Manage loops with `/loops` (lists jobs; `/loops cancel <id>` stops one). Loops auto-stop after a keepalive budget of missed turns or a 7-day max age.
+
+`/loop` (cadence) and `/goal` (stop condition) are complementary and independent: `/goal` decides *whether* an autonomous agent may stop; `/loop` decides *how often* it runs.
+
 ## Extending MiMoCode
 
 To add tools, hooks, or skills, use the `self-extend` skill — it covers writing `.mimocode/tools/*.ts`, `.mimocode/hooks/*.ts`, and `.mimocode/skills/*/SKILL.md`, all hot-reloaded on the next turn.

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/guide.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/guide.md
@@ -1,0 +1,80 @@
+# MiMoCode Usage Guide
+
+How-to for the features users most often ask about. For config keys see @config.md; for permissions see @permissions.md; for commands see @commands.md.
+
+## Getting started & auth
+
+1. **Sign in** — `mimo account login <url>` runs a device flow: it prints a URL + code and opens your browser. `/connect` does the same from inside the TUI (e.g. to add OpenRouter). Other account subcommands: `logout`, `switch`, `orgs`, `open`, `console`.
+2. **Pick a model** — set `"model": "provider/model"` in config, or switch live in the TUI model dialog. Provider API keys are auto-detected from environment variables (unless `MIMOCODE_MIMO_ONLY=1`).
+3. **List what's available** — `mimo models`, `mimo providers`.
+
+## Memory: making MiMoCode remember
+
+Memory persists across sessions and is auto-injected on resume, so the agent doesn't relearn project context.
+
+- **Project rules / architecture** — edit `MEMORY.md` (project memory). Durable rules go under `## Rules`, design decisions under `## Architecture decisions`. The agent may also write here at checkpoint time.
+- **`/dream`** — scans recent session traces, promotes durable knowledge into `MEMORY.md`, and prunes stale entries. Runs automatically per `dream.interval_days` (default 7).
+- **Checkpoints** (`checkpoint.md`) are maintained *only* by the checkpoint-writer subagent — don't hand-edit them.
+- **Scratch notes** (`notes.md`) are the agent's free-form scratchpad.
+- To make a rule stick immediately without waiting for a checkpoint, just tell the agent — it can edit `MEMORY.md` directly.
+
+Tune memory behavior with `checkpoint.*`, `compaction.*`, and `memory.cc_index` (see @config.md).
+
+## Custom slash commands
+
+Drop a markdown file at `.mimocode/command/<name>.md` (or `.mimocode/commands/`, `.claude/command(s)/` are also read). The frontmatter configures it; the body is the prompt template.
+
+```markdown
+---
+description: Review the current diff for security issues
+agent: build
+model: standard
+subtask: false
+---
+Review the staged diff. Focus on: $ARGUMENTS
+```
+
+- Invoke with `/name your args here`.
+- Placeholders: `$ARGUMENTS` (all args), `$1`, `$2`, … (positional). If none are present, args are appended.
+- `agent` picks which agent runs it; `model` accepts a `provider/model` or a group name; `subtask: true` runs it as a subagent.
+
+Commands hot-reload on the next turn.
+
+## Keybinds
+
+All TUI keybinds are remappable under the `keybinds` config. The leader key defaults to `ctrl+x`, so `<leader>` in a binding means "press ctrl+x then …".
+
+Common defaults: `Tab` cycle agents · `<leader>n` new session · `<leader>l` list sessions · `<leader>e` open external editor · `<leader>t` themes · `<leader>b` toggle sidebar · `ctrl+r` rename session. Set a binding to `"none"` to disable it.
+
+```jsonc
+{ "keybinds": { "session_new": "<leader>c", "sidebar_toggle": "none" } }
+```
+
+## MCP servers
+
+Add servers under the `mcp` key. Two kinds:
+
+```jsonc
+{
+  "mcp": {
+    // local: spawn a process over stdio
+    "fs": { "type": "local", "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "."] },
+    // remote: connect to an HTTP endpoint (OAuth auto-detected; set "oauth": false to disable)
+    "docs": { "type": "remote", "url": "https://mcp.example.com", "headers": { "Authorization": "Bearer ..." } },
+    // disable one without deleting it
+    "old": { "enabled": false }
+  }
+}
+```
+
+Inspect/manage with `mimo mcp`. Request timeout defaults to 5000ms (`timeout` per server, or `experimental.mcp_timeout` globally).
+
+## Compose mode
+
+Compose is a specs-driven orchestration agent: it coordinates built-in skills (plan, tdd, debug, review, verify, merge) across the full spec→ship lifecycle. Switch to it with `Tab`.
+
+Artifacts land under `docs/compose/` by default (`specs/`, `plans/`, `reports/`). Change the location with `compose.docs`; set `compose.docs_absolute: true` to anchor a relative path to the worktree root.
+
+## Extending MiMoCode
+
+To add tools, hooks, or skills, use the `self-extend` skill — it covers writing `.mimocode/tools/*.ts`, `.mimocode/hooks/*.ts`, and `.mimocode/skills/*/SKILL.md`, all hot-reloaded on the next turn.

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/guide.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/guide.md
@@ -40,6 +40,41 @@ Review the staged diff. Focus on: $ARGUMENTS
 
 Commands hot-reload on the next turn.
 
+## Custom agents & modes (file-based system prompts)
+
+A "mode" is just a **primary agent** with its own system prompt. To give MiMoCode a custom mode (e.g. a `general` chat mode alongside the coding-focused `build`), drop a markdown file — no code, no server changes. The frontmatter is config; the **markdown body becomes the agent's system prompt**.
+
+```markdown
+---
+description: A friendly general-purpose assistant for everyday chat and Q&A
+mode: primary
+temperature: 0.7
+---
+You are "General" — a warm, concise, general-purpose assistant.
+Keep replies short unless asked to elaborate; you are not focused on coding.
+```
+
+Where to put the file (all hot-reloaded on the next turn; `.claude/agent(s)` are also read):
+
+| Path | Scope |
+|------|-------|
+| `.mimocode/agent/<name>.md` (or `agents/`) | project agent — most common |
+| `.mimocode/mode/<name>.md` (or `modes/`) | project mode — same as an agent forced to `mode: primary` |
+| `~/.config/mimocode/agent/<name>.md` | global agent, available in every project |
+
+Frontmatter fields (all optional except that the body should be non-empty):
+
+- `mode` — `primary` (selectable with `Tab`, replaces the base prompt for the session), `subagent` (spawnable by a primary via the `actor`/`task` tools), or `all`. Files under `mode/` are always primary.
+- `model` — a `provider/model` or a group name (`ultra`/`standard`/`lite`); `variant`, `temperature`, `top_p` tune generation.
+- `description` — when to use it (shown in the `@` autocomplete for subagents).
+- `permission`, `tool_allowlist`, `tools`, `steps`, `color`, `hidden` — see @config.md.
+
+**How it reaches the model:** for a primary agent the body is used as the base system prompt in place of the model's default prompt; the usual environment/skills/instructions blocks are still appended. Selecting the mode is session-scoped — the TUI `Tab` picker or, over the SDK, the `agent` field on `session.prompt`. So a desktop/SDK client switches modes by sending `agent: "general"` vs `agent: "build"` per session; the prompt itself lives in the file, server-side.
+
+Verify a file loaded with `mimo agent list` — your agent shows up with its `(primary)` / `(subagent)` mode.
+
+Config-file alternative: instead of a `.md` file you can inline an agent under the `agent` config key (`agent.<name>.prompt`, plus `model`, `mode`, …); the markdown form is preferred for anything beyond a couple of lines.
+
 ## Keybinds
 
 All TUI keybinds are remappable under the `keybinds` config. The leader key defaults to `ctrl+x`, so `<leader>` in a binding means "press ctrl+x then …".

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/permissions.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/permissions.md
@@ -21,11 +21,12 @@ A permission rule is **either** a single action string, **or** a glob-keyed map 
   "permission": {
     // whole-tool action
     "webfetch": "allow",
-    // glob-keyed: match on the tool's path/command argument
+    // glob-keyed: match on the tool's path/command argument.
+    // Later rules win, so put the catch-all FIRST and specifics after it.
     "bash": {
+      "*": "ask",
       "git *": "allow",
-      "rm -rf *": "deny",
-      "*": "ask"
+      "rm -rf *": "deny"
     }
   }
 }
@@ -60,6 +61,6 @@ Ask before every file edit:
 
 ## Notes
 
-- Rules are evaluated in your original insertion order; put specific patterns before the `*` catch-all.
+- Rules are evaluated in your original insertion order and **the last matching rule wins**. Put the `*` catch-all **first** and more specific patterns after it — a `*` placed last would shadow everything above it (e.g. a trailing `"*": "ask"` makes preceding `allow`/`deny` rules dead code).
 - `external_directory` governs reads/writes outside the project working directory — by default these prompt, so MiMoCode never silently widens scope.
 - Permissions cannot be modified by custom tools/hooks — they are the one system the self-extension surface can't override.

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/permissions.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/permissions.md
@@ -1,0 +1,65 @@
+# MiMoCode Permissions Reference
+
+Permissions gate what the agent may do without asking. Configure them under the top-level `permission` key.
+
+## Actions
+
+Every rule resolves to one of three actions:
+
+| Action | Meaning |
+|--------|---------|
+| `allow` | Run without prompting |
+| `ask` | Prompt the user for confirmation (default for risky ops) |
+| `deny` | Block entirely |
+
+## Two shapes
+
+A permission rule is **either** a single action string, **or** a glob-keyed map of action strings (for tools whose argument is a path or command):
+
+```jsonc
+{
+  "permission": {
+    // whole-tool action
+    "webfetch": "allow",
+    // glob-keyed: match on the tool's path/command argument
+    "bash": {
+      "git *": "allow",
+      "rm -rf *": "deny",
+      "*": "ask"
+    }
+  }
+}
+```
+
+A bare string at the top level (`"permission": "allow"`) becomes `{ "*": action }` — a blanket default for everything.
+
+## Configurable tools
+
+Path/command-keyed (accept the glob-map form): `read`, `edit`, `glob`, `grep`, `list`, `bash`, `task`, `actor`, `external_directory`, `lsp`, `skill`.
+
+Simple action-only: `question`, `webfetch`, `websearch`, `codesearch`, `doom_loop`.
+
+Unknown keys fall through to a catch-all record, so future/custom tools can be named too.
+
+## Common recipes
+
+Auto-allow read-only git and block destructive shell:
+```jsonc
+{ "permission": { "bash": { "git status": "allow", "git log *": "allow", "git diff *": "allow", "rm -rf *": "deny" } } }
+```
+
+Allow the system temp dir (opt-in; has known risks — temp is world-writable):
+```jsonc
+{ "permission": { "external_directory": { "/tmp/**": "allow" } } }
+```
+
+Ask before every file edit:
+```jsonc
+{ "permission": { "edit": "ask" } }
+```
+
+## Notes
+
+- Rules are evaluated in your original insertion order; put specific patterns before the `*` catch-all.
+- `external_directory` governs reads/writes outside the project working directory — by default these prompt, so MiMoCode never silently widens scope.
+- Permissions cannot be modified by custom tools/hooks — they are the one system the self-extension surface can't override.

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/workflows.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/workflows.md
@@ -1,0 +1,112 @@
+# MiMoCode Dynamic Workflows Reference
+
+Dynamic workflows let you orchestrate many subagents **deterministically** from a small JavaScript script — fan-out, pipelines, nested workflows — instead of driving each subagent by hand. The script runs in a sandbox; you call `agent()` to spawn work and combine results with plain JS.
+
+## Where to write workflow files
+
+Save a workflow as a `.js` file in either directory (searched nearest-first, walking up from cwd to the worktree root; project overrides parent):
+
+```
+.mimocode/workflows/<name>.js      # preferred
+.claude/workflows/<name>.js        # also read
+```
+
+The file name (minus `.js`) is **not** the workflow's identity — the `meta.name` inside is. Names must match `[A-Za-z0-9._-]+`.
+
+## Required script shape
+
+Every workflow **must begin** with a `meta` export (a pure data literal — it is parsed, not executed):
+
+```js
+export const meta = {
+  name: "triage-issues",              // required, non-empty
+  description: "Triage open issues",   // required, non-empty
+  whenToUse: "when the backlog needs sorting",  // optional
+  phases: [{ title: "Fetch" }, { title: "Classify" }],  // optional
+  model: "standard",                   // optional default model for agents
+}
+
+export default async function () {
+  // ... orchestration ...
+  return result   // becomes the workflow's result
+}
+```
+
+Only `name` and `description` are required. The body is ordinary async JS with the sandbox globals below.
+
+## In-script API (sandbox globals)
+
+| Global | Signature | Returns |
+|--------|-----------|---------|
+| `agent(prompt, opts?)` | spawn one subagent | Promise → its deliverable (text, or a validated object if `opts.schema`), or **`null`** on failure. Never throws. |
+| `parallel(thunks)` | run an array of `() => Promise` concurrently | `Promise<any[]>` (a throwing thunk rejects the batch) |
+| `pipeline(items, ...stages)` | run each item through sequential stages, items in parallel | `Promise<any[]>` |
+| `workflow(nameOrScript, args?, opts?)` | run a child workflow as its own sub-run and await it | Promise → child result, or `null` on runtime failure |
+| `readFile(path)` | read a workspace file | `Promise<string \| null>` (null if absent) |
+| `writeFile(path, content)` | write a workspace file (auto-creates dirs) | `Promise<void>` |
+| `glob(pattern)` | list matching workspace paths (relative, sorted) | `Promise<string[]>` |
+| `exists(path)` | whether a workspace path exists | `Promise<boolean>` |
+| `phase(title)` | mark a progress phase | — |
+| `log(message)` | emit a progress line | — |
+| `args` | the JSON value passed when the workflow started | (value) |
+
+File primitives are **jailed to the workspace root** (the worktree by default, or the `workspace` you pass at run). `..`/absolute escapes throw. Use `glob()` to enumerate work units — don't spawn an agent just to list files.
+
+### `agent()` options
+
+```js
+const out = await agent("Summarize src/parser.ts", {
+  agentType: "explore",      // subagent type; default "general"
+  model: "lite",             // provider/model literal OR a group/tier name
+  tools: ["read", "grep"],   // tool allowlist; omit to inherit
+  schema: { type: "object", properties: { bug: { type: "string" } }, required: ["bug"] },
+  isolation: "worktree",     // run in a fresh isolated worktree
+  label: "parser-scan",      // observability tag
+  timeoutMs: 120000,         // per-call timeout; on timeout resolves null
+})
+```
+
+With `schema`, the deliverable is a **validated object** (never prose). Without it, you get the agent's final text.
+
+## Determinism constraints
+
+The sandbox removes non-deterministic APIs so a run can be replayed/resumed identically: no `Date`, `crypto`, `fetch`, timers, or `process`; `Math.random` is a seeded PRNG. Do network/time-dependent work **inside** `agent()` (a real subagent), not in the orchestration script.
+
+## Running a workflow
+
+Use the `workflow` tool (or ask the agent to run one):
+
+| Operation | Purpose |
+|-----------|---------|
+| `run` | Start and block until terminal; provide `name` (a saved/built-in workflow) **or** `script` (inline JS). Optional `args`, `workspace`, `async`. |
+| `status` | Snapshot a run by `run_id` without blocking |
+| `wait` | Block on a run's result (optional `timeout_ms`) |
+| `cancel` | Best-effort cancel a running workflow |
+| `resume` | Re-launch a persisted run under the same `run_id` (journal replay makes it convergent) |
+
+- `async: false` (default) streams the transcript inline and returns the result.
+- `async: true` returns a `run_id` immediately; the result arrives as an inbox notification.
+- Provide **either** `name` **or** `script`, never both.
+
+### Built-in workflows
+
+Runnable by `name` without writing a file:
+
+- **`compose`** — full spec→ship pipeline (brainstorm → design → implement in parallel worktrees → verify → review → report → merge). Pass `args.task`.
+- **`deep-research`** — parallel web search → source extraction → adversarial cross-check → cited report. Pass the refined question as `args`.
+
+## Semantics worth knowing
+
+- **Failed `agent()` resolves to `null`, never throws** — check for null; a hung agent is cancelled and also yields `null` so it can't stall a `parallel`/`pipeline` barrier.
+- **Failed child `workflow()` resolves to `null`** for runtime failures, but **structural faults throw** and propagate up the whole tree: cycle detected (a saved name calling itself), nesting past `maxDepth`, or an unknown workflow name.
+- **Concurrency** is one process-wide semaphore sized by `workflow.maxConcurrentAgents`; a per-run value can only narrow it. Excess `agent()` calls queue automatically.
+- **Communicate between workflows by dataflow** — return a value from a child and pass it as `args` to the next, or write a shared file with `writeFile` and read it later. Workflows don't message each other directly.
+
+## Config knobs (`workflow.*`)
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `maxConcurrentAgents` | `min(16, 2×cores)` | Process-wide ceiling on concurrent subagents across all runs (incl. nested). No upper clamp — set deliberately. |
+| `maxDepth` | `8` | Max `workflow()`-calls-`workflow()` nesting; exceeding fails the run |
+| `maxLifecycleAgents` | `1000` | Hard ceiling on total agents one run spawns over its life; over-cap `agent()` → `null` |
+| `scriptDeadlineMs` | `43200000` (12h) | Wall-clock budget for the whole script; enforced as a hard kill |

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/workflows.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode/reference/workflows.md
@@ -92,8 +92,15 @@ Use the `workflow` tool (or ask the agent to run one):
 
 Runnable by `name` without writing a file:
 
-- **`compose`** — full spec→ship pipeline (brainstorm → design → implement in parallel worktrees → verify → review → report → merge). Pass `args.task`.
+- **`compose`** — full spec→ship pipeline (brainstorm → design → implement (TDD) → verify → review → merge). Pass `args.task`. Auto-parallelizes independent subtasks into per-task worktrees and chains each phase's structured output to the next. Re-running on existing docs reuses them and scopes the fan-out to the actual diff (incremental amend).
 - **`deep-research`** — parallel web search → source extraction → adversarial cross-check → cited report. Pass the refined question as `args`.
+
+### `compose` workflow vs `compose` agent
+
+Both drive the same spec→ship lifecycle, but choose by task shape:
+
+- **`compose` workflow** (this, deterministic code) — best when requirements are **well-defined** and the task **decomposes into independent subtasks**. It fans out to parallel worktrees and runs **non-interactively to completion** — fire-and-forget.
+- **`compose` agent** (conversational, switch with `Tab`) — best for **exploratory or ambiguous** work where you want to redirect mid-flow, answer questions, or inject judgment between steps.
 
 ## Semantics worth knowing
 
@@ -101,6 +108,10 @@ Runnable by `name` without writing a file:
 - **Failed child `workflow()` resolves to `null`** for runtime failures, but **structural faults throw** and propagate up the whole tree: cycle detected (a saved name calling itself), nesting past `maxDepth`, or an unknown workflow name.
 - **Concurrency** is one process-wide semaphore sized by `workflow.maxConcurrentAgents`; a per-run value can only narrow it. Excess `agent()` calls queue automatically.
 - **Communicate between workflows by dataflow** — return a value from a child and pass it as `args` to the next, or write a shared file with `writeFile` and read it later. Workflows don't message each other directly.
+
+## Watching a run (TUI)
+
+A running workflow shows a bounded inline panel (capped to ~12 lines) with live spinner, phase, and status counters. After a workflow tool message, the `view workflow agents` keybind opens the full-screen workflow page — message-style cards per agent, colored status counters, and drill-down into each subagent's (and nested workflow's) full conversation, with scroll position preserved across navigation.
 
 ## Config knobs (`workflow.*`)
 


### PR DESCRIPTION
## Summary

Adds a built-in `mimocode` skill so the agent can answer feature, usage, and configuration questions about MiMoCode itself — instead of guessing. It ships automatically (bundled into `packages/opencode/src/skill/builtin/.bundle/` and extracted alongside `self-extend`/`loop`) and is overridable by a user skill of the same name.

## What's included

- **`SKILL.md`** — identity, a feature map, config-workflow guidance, and pointers to the reference docs.
- **`reference/config.md`** — file precedence, on-disk layout, env vars, and every top-level config key grouped by concern, plus a dedicated **model groups** section and `lite`-over-`small_model` guidance.
- **`reference/commands.md`** — `mimo` CLI subcommands and slash commands.
- **`reference/permissions.md`** — allow/ask/deny actions, action-string vs glob-keyed rules, per-tool coverage, common recipes.
- **`reference/guide.md`** — task-oriented how-tos: auth/getting-started, memory, custom commands, keybinds, MCP setup, compose mode, Jupyter, and **cron scheduled prompts & loops**.
- **`reference/workflows.md`** — dynamic workflows: where to save `.js` files, the in-script API, `agent()` options, the `workflow` tool, built-in `compose`/`deep-research`, and the compose workflow-vs-agent distinction.

## Notes

- Content is up to date through v0.1.4 releases plus the latest rebased features (cron/loop).
- `$schema` points to `https://mimo.xiaomi.com/mimocode/config.json`.
- Every documented fact was verified against source (config schema, tool definitions, workflow runtime, cron subsystem) — no invented API.

## Verification

Static: file structure, frontmatter, loader logic, and all `@reference/*` cross-links confirmed. The bundle compiles at build time; a full end-to-end check (skill appears in `<available_skills>`) would require launching the TUI.