### PR TITLE
fix(provider): treat non-empty provider models config as implicit whitelist

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1378,6 +1378,10 @@ const layer: Layer.Layer<
           }
 
           const configProvider = cfg.provider?.[providerID]
+          // A non-empty `models` config acts as an implicit whitelist: only the
+          // configured model IDs are shown, hiding the rest of the models.dev catalog.
+          const configModels = configProvider?.models ? Object.keys(configProvider.models) : undefined
+          const implicitWhitelist = configModels && configModels.length > 0 ? configModels : undefined
 
           for (const [modelID, model] of Object.entries(provider.models)) {
             model.api.id = model.api.id ?? model.id ?? modelID
@@ -1390,7 +1394,8 @@ const layer: Layer.Layer<
             if (model.status === "deprecated") delete provider.models[modelID]
             if (
               (configProvider?.blacklist && configProvider.blacklist.includes(modelID)) ||
-              (configProvider?.whitelist && !configProvider.whitelist.includes(modelID))
+              (configProvider?.whitelist && !configProvider.whitelist.includes(modelID)) ||
+              (implicitWhitelist && !implicitWhitelist.includes(modelID))
             )
               delete provider.models[modelID]
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1380,8 +1380,8 @@ const layer: Layer.Layer<
           const configProvider = cfg.provider?.[providerID]
           // A non-empty `models` config acts as an implicit whitelist: only the
           // configured model IDs are shown, hiding the rest of the models.dev catalog.
-          const configModels = configProvider?.models ? Object.keys(configProvider.models) : undefined
-          const implicitWhitelist = configModels && configModels.length > 0 ? configModels : undefined
+          const configModelKeys = Object.keys(configProvider?.models ?? {})
+          const implicitWhitelist = configModelKeys.length > 0 ? configModelKeys : undefined
 
           for (const [modelID, model] of Object.entries(provider.models)) {
             model.api.id = model.api.id ?? model.id ?? modelID

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -253,6 +253,40 @@ test("custom model alias via config", async () => {
   })
 })
 
+test("non-empty models config acts as implicit whitelist", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              models: {
+                "claude-sonnet-4-20250514": {
+                  name: "Only Sonnet",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.anthropic]).toBeDefined()
+      const models = Object.keys(providers[ProviderID.anthropic].models)
+      expect(models).toEqual(["claude-sonnet-4-20250514"])
+    },
+  })
+})
+
 test("custom provider with npm package", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
## Summary

A provider's `models` config previously only augmented/overrode entries merged on top of the full models.dev catalog, so configuring a single model still surfaced every other model for that provider in the picker. Now a **non-empty `provider.<id>.models` map acts as an implicit whitelist** — only the configured model IDs are shown, hiding the rest of the catalog.

Split out of #1513 (vision paste) as an independent, semantically-distinct model-visibility change so it can be reviewed and released on its own.

## Behavior change / release note

⚠️ This changes model visibility:

- Populating `provider.<id>.models` with a subset (e.g. to tweak options on one model) now **hides** the other catalog models for that provider from the picker. Users who relied on `models` as an augment-only map should list all models they want visible, or use explicit `whitelist`/`blacklist`.
- **Empty `models: {}` is a no-op** (guarded) — it does not hide the catalog.
- Config-defined models are always in their own implicit whitelist (keyed by the same map key), so they never delete themselves.
- **Interaction with explicit `whitelist`**: when both `whitelist` and a non-empty `models` are set, they now **intersect** (a model must satisfy both to remain). Previously `models` did no filtering, so `whitelist: [A,B]` + `models: {A}` showed both A and B; now only A survives. Explicit whitelist/blacklist behavior in isolation is unchanged.

## Test Plan

- [x] `bun typecheck` clean
- [x] `bun test test/provider/provider.test.ts` — full suite passes (80), incl. whitelist tests (3) and the existing config-model-alias test