### PR TITLE
feat(tui): add grid mode for multi-session workspace

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -44,6 +44,8 @@ import { KeybindProvider, useKeybind } from "@tui/context/keybind"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
 import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
+import { GridView } from "@tui/routes/grid"
+import { CellEventBusProvider } from "@tui/routes/grid/cell-event-bus"
 import { PromptHistoryProvider } from "./component/prompt/history"
 import { FrecencyProvider } from "./component/prompt/frecency"
 import { PromptStashProvider } from "./component/prompt/stash"
@@ -168,12 +170,21 @@ export function tui(input: {
                 <ToastProvider>
                   <RouteProvider
                     initialRoute={
-                      input.args.continue
+                      // Phase 6: boot directly into the grid when
+                      // `--grid` / `MIMOCODE_GRID` is set, unless the
+                      // caller also asked for a specific session
+                      // (which becomes the seed cell).
+                      input.args.grid || Flag.MIMOCODE_GRID
                         ? {
-                            type: "session",
-                            sessionID: "dummy",
+                            type: "grid",
+                            ...(input.args.sessionID ? { cells: [{ sessionID: input.args.sessionID }] } : {}),
                           }
-                        : undefined
+                        : input.args.continue
+                          ? {
+                              type: "session",
+                              sessionID: "dummy",
+                            }
+                          : undefined
                     }
                   >
                     <TuiConfigProvider config={input.config}>
@@ -186,7 +197,8 @@ export function tui(input: {
                       >
                         <ProjectProvider>
                           <SyncProvider>
-                            <ThemeProvider mode={mode} plain={plainTerminal}>
+                            <CellEventBusProvider>
+                              <ThemeProvider mode={mode} plain={plainTerminal}>
                               <LocalProvider>
                                 <KeybindProvider>
                                   <PromptStashProvider>
@@ -205,6 +217,7 @@ export function tui(input: {
                                 </KeybindProvider>
                               </LocalProvider>
                             </ThemeProvider>
+                          </CellEventBusProvider>
                           </SyncProvider>
                         </ProjectProvider>
                       </SDKProvider>
@@ -348,6 +361,12 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
 
     if (route.data.type === "plugin") {
       renderer.setTerminalTitle(`OC | ${route.data.id}`)
+      return
+    }
+
+    if (route.data.type === "grid") {
+      renderer.setTerminalTitle("MC | Grid")
+      return
     }
   })
 
@@ -364,6 +383,11 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
             duration: 3000,
           })
         local.model.set({ providerID, modelID }, { recent: true })
+      }
+      if (args.grid || Flag.MIMOCODE_GRID) {
+        const seedSessionID = args.sessionID
+        route.navigate(seedSessionID ? { type: "grid", cells: [{ sessionID: seedSessionID }] } : { type: "grid" })
+        return
       }
       if (args.sessionID && !args.fork) {
         route.navigate({
@@ -838,6 +862,17 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
     },
     {
+      title: "Grid Mode",
+      value: "grid.open",
+      keybind: "grid_create",
+      category: "system",
+      enabled: route.data.type !== "grid",
+      onSelect: (dialog) => {
+        route.navigate({ type: "grid" })
+        dialog.clear()
+      },
+    },
+    {
       title: t(terminalTitleEnabled() ? "tui.command.terminal.title.disable" : "tui.command.terminal.title.enable"),
       value: "terminal.title.toggle",
       keybind: "terminal_title_toggle",
@@ -1132,6 +1167,9 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           </Match>
           <Match when={route.data.type === "session"}>
             <Session />
+          </Match>
+          <Match when={route.data.type === "grid"}>
+            <GridView />
           </Match>
         </Switch>
       </Show>

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -45,6 +45,7 @@ import { ThemeProvider, useTheme } from "@tui/context/theme"
 import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
 import { GridView } from "@tui/routes/grid"
+import { WorkspaceClientsProvider } from "@tui/context/workspace-clients"
 import { CellEventBusProvider } from "@tui/routes/grid/cell-event-bus"
 import { PromptHistoryProvider } from "./component/prompt/history"
 import { FrecencyProvider } from "./component/prompt/frecency"
@@ -1169,7 +1170,9 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
             <Session />
           </Match>
           <Match when={route.data.type === "grid"}>
-            <GridView />
+            <WorkspaceClientsProvider>
+              <GridView />
+            </WorkspaceClientsProvider>
           </Match>
         </Switch>
       </Show>

--- a/packages/opencode/src/cli/cmd/tui/component/agent-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/agent-status.tsx
@@ -1,0 +1,46 @@
+import { For, Show, type JSX } from "solid-js"
+import { useTheme } from "@tui/context/theme"
+import type { ActorEntry } from "@tui/context/sync"
+
+export interface AgentStatusProps {
+  actors: ActorEntry[]
+}
+
+export function AgentStatus(props: AgentStatusProps): JSX.Element {
+  const { theme } = useTheme()
+  const list = () => props.actors ?? []
+  const running = () => list().filter((a) => a.status === "running").length
+
+  return (
+    <Show when={list().length > 0}>
+      <box
+        flexDirection="column"
+        backgroundColor={theme.backgroundPanel}
+        border={["left", "right"]}
+        borderColor={theme.border}
+        paddingLeft={1}
+        paddingRight={1}
+        paddingTop={1}
+      >
+        <box flexDirection="row" alignItems="center" marginBottom={1}>
+          <text fg={theme.textMuted}>{"Agents"}</text>
+          <Show when={running() > 0}>
+            <text fg={theme.text}>{` . ${running()} running`}</text>
+          </Show>
+        </box>
+        <For each={list()}>
+          {(actor) => (
+            <box flexDirection="row" alignItems="center" marginBottom={0}>
+              <text fg={actor.status === "running" ? theme.text : theme.textMuted}>
+                {actor.status === "running" ? "O" : "o"}
+              </text>
+              <text fg={theme.text} marginLeft={1}>
+                {actor.description || actor.agent || actor.actor_id}
+              </text>
+            </box>
+          )}
+        </For>
+      </box>
+    </Show>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/bob-summary.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/bob-summary.tsx
@@ -1,0 +1,191 @@
+import { For, Show, createMemo } from "solid-js"
+import { useTheme } from "../context/theme"
+import { SplitBorder } from "./border"
+
+export interface BobSummaryProps {
+  /** Markdown text produced by `buildSummary()`. May be empty when no summary is available. */
+  text: string
+}
+
+/**
+ * Parsed view-model of a Bob Summary block. We extract sections by `###`
+ * headings so the TUI can lay them out as labeled rows instead of a single
+ * markdown blob — easier to skim in a grid cell.
+ */
+export interface BobSummaryModel {
+  title: string
+  caption: string | null
+  status: string | null
+  reasoning: string | null
+  evidence: string[]
+  endpoints: Array<{ url: string; port: string; source: string }>
+  remaining: string[]
+}
+
+const TITLE_RX = /^##\s+(.+?)(?:\s+—\s+(.+))?$/m
+const CAPTION_RX = /^\*([^*]+)\*$/m
+const STATUS_RX = /^\*\*Status:\*\*\s+(.+)$/m
+const SECTION_RX = /###\s+([^\n]+)\n([\s\S]*?)(?=\n###\s+|\n##\s+|$)/g
+
+function parseSummary(text: string): BobSummaryModel | null {
+  if (!text.trim()) return null
+  const model: BobSummaryModel = {
+    title: "Bob Summary",
+    caption: null,
+    status: null,
+    reasoning: null,
+    evidence: [],
+    endpoints: [],
+    remaining: [],
+  }
+  const titleMatch = text.match(TITLE_RX)
+  if (titleMatch) model.title = titleMatch[1].trim()
+  const captionMatch = text.match(CAPTION_RX)
+  if (captionMatch) model.caption = captionMatch[1].trim()
+  const statusMatch = text.match(STATUS_RX)
+  if (statusMatch) model.status = statusMatch[1].trim()
+
+  const body = text.replace(TITLE_RX, "").replace(CAPTION_RX, "").replace(STATUS_RX, "")
+  let sectionMatch: RegExpExecArray | null
+  while ((sectionMatch = SECTION_RX.exec(body)) !== null) {
+    const heading = sectionMatch[1].trim().toLowerCase()
+    const content = sectionMatch[2].trim()
+    if (!content) continue
+    if (heading === "reasoning") {
+      model.reasoning = content
+    } else if (heading === "evidence") {
+      model.evidence = content
+        .split("\n")
+        .map((l) => l.replace(/^[-*]\s+/, "").trim())
+        .filter(Boolean)
+    } else if (heading === "open endpoints") {
+      model.endpoints = parseEndpointRows(content)
+    } else if (heading === "remaining items") {
+      model.remaining = content
+        .split("\n")
+        .map((l) => l.replace(/^[-*]\s+/, "").trim())
+        .filter(Boolean)
+    }
+  }
+  return model
+}
+
+function parseEndpointRows(block: string): Array<{ url: string; port: string; source: string }> {
+  const lines = block.split("\n").filter((l) => l.trim() && !l.startsWith("| ---"))
+  return lines
+    .map((line) => line.split("|").map((c) => c.trim()))
+    .filter((cols) => cols.length >= 4)
+    .map((cols) => ({
+      url: cols[1]?.replace(/`/g, "") ?? "",
+      port: cols[2] ?? "",
+      source: cols[3] ?? "",
+    }))
+    .filter((r) => r.url)
+}
+
+/**
+ * Renders a Bob completion summary as a stylized card. Used as a message-part
+ * renderer in both the legacy single-session route and the grid `SessionCell`.
+ *
+ * Visual layout:
+ *  ┌─ Bob Summary ──────────────────────────┐
+ *  │ [STATUS]   session caption              │
+ *  │                                           │
+ *  │ Reasoning: ...                            │
+ *  │ Evidence:                                 │
+ *  │   - ...                                   │
+ *  │ Open endpoints:                           │
+ *  │   http://localhost:3000   3000  bash      │
+ *  │ Remaining items:                          │
+ *  │   - ...                                   │
+ *  └──────────────────────────────────────────┘
+ */
+export function BobSummaryPart(props: BobSummaryProps) {
+  const { theme } = useTheme()
+  const model = createMemo(() => parseSummary(props.text))
+  const statusColor = createMemo(() => {
+    const s = model()?.status?.toLowerCase() ?? ""
+    if (s.includes("rejected")) return theme.error
+    if (s.includes("accepted") || s.includes("completed")) return theme.success
+    return theme.textMuted
+  })
+
+  return (
+    <Show when={model()}>
+      {(m) => (
+        <box
+          border={["left"]}
+          customBorderChars={SplitBorder.customBorderChars}
+          borderColor={theme.primary}
+          paddingTop={1}
+          paddingBottom={1}
+          paddingLeft={2}
+          marginTop={1}
+          flexShrink={0}
+          flexDirection="column"
+          gap={1}
+        >
+          <box flexDirection="row" gap={1} justifyContent="space-between">
+            <text fg={theme.text}>
+              <b>{m().title}</b>
+            </text>
+            <Show when={m().status}>
+              <text fg={statusColor()}>
+                <b>{m().status}</b>
+              </text>
+            </Show>
+          </box>
+          <Show when={m().caption}>
+            <text fg={theme.textMuted}>{m().caption}</text>
+          </Show>
+
+          <Show when={m().reasoning}>
+            <box flexDirection="column">
+              <text fg={theme.text}>
+                <b>Reasoning</b>
+              </text>
+              <text fg={theme.text} wrapMode="word">
+                {m().reasoning}
+              </text>
+            </box>
+          </Show>
+
+          <Show when={m().evidence.length > 0}>
+            <box flexDirection="column">
+              <text fg={theme.text}>
+                <b>Evidence</b>
+              </text>
+              <For each={m().evidence}>{(item) => <text fg={theme.textMuted}>- {item}</text>}</For>
+            </box>
+          </Show>
+
+          <Show when={m().endpoints.length > 0}>
+            <box flexDirection="column">
+              <text fg={theme.text}>
+                <b>Open endpoints</b>
+              </text>
+              <For each={m().endpoints}>
+                {(row) => (
+                  <text fg={theme.textMuted}>
+                    <span style={{ fg: theme.accent }}>{row.url}</span>
+                    <span style={{ fg: theme.textMuted }}> :{row.port}</span>
+                    <span style={{ fg: theme.textMuted }}> ({row.source})</span>
+                  </text>
+                )}
+              </For>
+            </box>
+          </Show>
+
+          <Show when={m().remaining.length > 0}>
+            <box flexDirection="column">
+              <text fg={theme.text}>
+                <b>Remaining items</b>
+              </text>
+              <For each={m().remaining}>{(item) => <text fg={theme.textMuted}>- {item}</text>}</For>
+            </box>
+          </Show>
+        </box>
+      )}
+    </Show>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/cell-error-overlay.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/cell-error-overlay.tsx
@@ -1,0 +1,47 @@
+import { TextAttributes } from "@opentui/core"
+import { Show } from "solid-js"
+import { useTheme } from "@tui/context/theme"
+import { SplitBorder } from "@tui/component/border"
+
+/**
+ * Phase 5 inline error display for grid cells.
+ *
+ * Distinct from the global `ErrorComponent`: this overlay is rendered inside
+ * the cell viewport when a non-fatal error is caught by a local
+ * `ErrorBoundary`, so the rest of the grid (and the active cell) keeps
+ * working. The overlay shows the cell label, the error message, and a
+ * collapsed stack-trace.
+ */
+export function CellErrorOverlay(props: { error: unknown; cellLabel?: string }) {
+  const { theme } = useTheme()
+  const message = () => (props.error instanceof Error ? props.error.message : String(props.error))
+  const stack = () => (props.error instanceof Error ? (props.error.stack ?? "") : "")
+
+  return (
+    <box
+      flexDirection="column"
+      backgroundColor={theme.backgroundPanel}
+      borderColor={theme.error}
+      border={["left", "right"]}
+      customBorderChars={{ ...SplitBorder.customBorderChars }}
+      paddingLeft={2}
+      paddingRight={2}
+      paddingTop={1}
+      paddingBottom={1}
+      flexGrow={1}
+    >
+      <text fg={theme.error} attributes={TextAttributes.BOLD}>
+        <span style={{ fg: theme.error }}>⚠ </span>
+        {props.cellLabel ? `${props.cellLabel} crashed` : "Cell crashed"}
+      </text>
+      <text fg={theme.text} wrapMode="word">
+        {message()}
+      </text>
+      <Show when={stack()}>
+        <text fg={theme.textMuted} wrapMode="word">
+          {stack().split("\n").slice(0, 3).join("\n")}
+        </text>
+      </Show>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/plan-summary.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/plan-summary.tsx
@@ -1,0 +1,110 @@
+import { For, Show, type JSX } from "solid-js"
+import { useTheme } from "@tui/context/theme"
+import type { Todo } from "@mimo-ai/sdk/v2"
+
+type TaskEntry = {
+  id: string
+  session_id: string
+  parent_task_id?: string
+  status: string
+  summary: string
+  owner?: string
+  created_at: number
+  last_event_at: number
+  ended_at?: number
+  cleanup_after?: number
+}
+
+export interface PlanSummaryProps {
+  tasks: TaskEntry[]
+  todos: Todo[]
+}
+
+const taskGlyph = (status: string): string => {
+  switch (status) {
+    case "done":
+    case "completed":
+      return "v"
+    case "in_progress":
+    case "running":
+      return ">"
+    case "abandoned":
+    case "failed":
+      return "x"
+    case "blocked":
+    case "open":
+    case "pending":
+    default:
+      return "."
+  }
+}
+
+const todoGlyph = (status: string): string => {
+  switch (status) {
+    case "completed":
+      return "v"
+    case "in_progress":
+      return ">"
+    case "pending":
+    case "cancelled":
+    default:
+      return "."
+  }
+}
+
+export function PlanSummary(props: PlanSummaryProps): JSX.Element {
+  const { theme } = useTheme()
+  const tasks = () => props.tasks ?? []
+  const todos = () => props.todos ?? []
+  const hasAny = () => tasks().length > 0 || todos().length > 0
+
+  return (
+    <Show when={hasAny()}>
+      <box
+        flexDirection="row"
+        backgroundColor={theme.backgroundPanel}
+        border={["left", "right"]}
+        borderColor={theme.border}
+        paddingLeft={1}
+        paddingRight={1}
+        paddingTop={1}
+        gap={2}
+      >
+        <Show when={tasks().length > 0}>
+          <box flexDirection="column" flexGrow={1}>
+            <text fg={theme.textMuted}>{`Tasks (${tasks().length})`}</text>
+            <For each={tasks()}>
+              {(task) => (
+                <box flexDirection="row" alignItems="center">
+                  <text fg={task.status === "in_progress" || task.status === "running" ? theme.text : theme.textMuted}>
+                    {taskGlyph(task.status)}
+                  </text>
+                  <text fg={theme.text} marginLeft={1}>
+                    {task.summary}
+                  </text>
+                </box>
+              )}
+            </For>
+          </box>
+        </Show>
+        <Show when={todos().length > 0}>
+          <box flexDirection="column" flexGrow={1}>
+            <text fg={theme.textMuted}>{`Todos (${todos().length})`}</text>
+            <For each={todos()}>
+              {(todo) => (
+                <box flexDirection="row" alignItems="center">
+                  <text fg={todo.status === "in_progress" ? theme.text : theme.textMuted}>
+                    {todoGlyph(todo.status)}
+                  </text>
+                  <text fg={theme.text} marginLeft={1}>
+                    {todo.content}
+                  </text>
+                </box>
+              )}
+            </For>
+          </box>
+        </Show>
+      </box>
+    </Show>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -60,7 +60,24 @@ export type PromptProps = {
     normal?: string[]
     shell?: string[]
   }
+  /**
+   * Phase 8 (grid): when true, the prompt should grab focus on mount. The
+   * cell passes its active state so the freshly-activated cell gets focus
+   * without a manual click, and backgrounded cells keep focus elsewhere.
+   * Currently a hint - the cell itself decides focus on active changes;
+   * accepted here so the cell does not have to wrap the prompt component
+   * to filter the prop out.
+   */
+  focusEnabled?: boolean
+  /**
+   * Phase 8 (grid): the agent ID this prompt is bound to. Used by the cell
+   * to keep history filtered and slash-command completions agent-aware when
+   * the cell switches between sub-agents. Reserved for future use; the
+   * prompt itself does not read it yet.
+   */
+  agentID?: string
 }
+
 
 export type PromptRef = {
   focused: boolean

--- a/packages/opencode/src/cli/cmd/tui/context/args.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/args.tsx
@@ -8,6 +8,13 @@ export interface Args {
   sessionID?: string
   fork?: boolean
   neverAsk?: boolean
+  /**
+   * Phase 6: when true, the TUI launches straight into the grid view. The
+   * grid component restores the persisted layout from
+   * `~/.mimocode/grid-layout.json` on mount by default; combine with
+   * `--session` / `--continue` to seed a single cell on first launch.
+   */
+  grid?: boolean
 }
 
 export const { use: useArgs, provider: ArgsProvider } = createSimpleContext({

--- a/packages/opencode/src/cli/cmd/tui/context/grid-persistence.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/grid-persistence.ts
@@ -1,0 +1,138 @@
+import path from "path"
+import { mkdir } from "fs/promises"
+import { Global } from "@/global"
+
+export type GridCell = {
+  id: string
+  sessionID: string
+  workspaceID: string
+  agentID?: string
+  mode: "full" | "plan-only"
+  label: string
+}
+
+export type GridLayout = "single" | "split-h" | "split-v" | "2x2"
+
+/**
+ * Phase 6: ratio (0-1) of the left/top cell's share when in a split layout.
+ * Default 0.6 (60/40). The splitter drag handle clamps this value to a range
+ * that keeps both cells at >= `MIN_CELL_COLS` columns wide.
+ */
+export type GridSplitRatio = number
+
+/**
+ * Minimum width (in terminal columns) either side of the split must keep.
+ * Below this the dragged cell would be unreadable, so the splitter clamps.
+ */
+export const MIN_CELL_COLS = 40
+
+/**
+ * Default split ratio when entering a split layout for the first time.
+ * 0.6 → 60/40 split (left/top cell is the larger one).
+ */
+export const DEFAULT_SPLIT_RATIO: GridSplitRatio = 0.6
+
+export type GridState = {
+  cells: GridCell[]
+  activeCellId: string
+  layout: GridLayout
+  /** Phase 6: persisted split ratio; only meaningful for split-h/split-v. */
+  splitRatio: GridSplitRatio
+}
+
+// Project-local mimocode dir under the user's home — explicit per spec.
+// Resolved against HOME/USERPROFILE (matching Global.Path.home) so tests can
+// isolate via env vars without touching XDG state paths.
+export const gridLayoutPath = path.join(Global.Path.home, ".mimocode", "grid-layout.json")
+
+export function defaultGridState(): GridState {
+  return {
+    cells: [],
+    activeCellId: "",
+    layout: "single",
+    splitRatio: DEFAULT_SPLIT_RATIO,
+  }
+}
+
+function isGridCell(value: unknown): value is GridCell {
+  if (typeof value !== "object" || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.id === "string" &&
+    typeof v.sessionID === "string" &&
+    typeof v.workspaceID === "string" &&
+    (v.agentID === undefined || typeof v.agentID === "string") &&
+    (v.mode === "full" || v.mode === "plan-only") &&
+    typeof v.label === "string"
+  )
+}
+
+function isGridLayout(value: unknown): value is GridLayout {
+  return value === "single" || value === "split-h" || value === "split-v" || value === "2x2"
+}
+
+function isGridSplitRatio(value: unknown): value is GridSplitRatio {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+export function isGridState(value: unknown): value is GridState {
+  if (typeof value !== "object" || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    Array.isArray(v.cells) &&
+    v.cells.every(isGridCell) &&
+    typeof v.activeCellId === "string" &&
+    isGridLayout(v.layout) &&
+    // Persisted files written before Phase 6 lack splitRatio; default it.
+    (v.splitRatio === undefined || isGridSplitRatio(v.splitRatio))
+  )
+}
+
+/**
+ * Normalize a persisted state to fill in any fields added after the file was
+ * last written. Currently just injects `splitRatio` for pre-Phase-6 files.
+ */
+export function normalizeGridState(state: GridState): GridState {
+  if (isGridSplitRatio(state.splitRatio)) return state
+  return { ...state, splitRatio: DEFAULT_SPLIT_RATIO }
+}
+
+async function ensureParent(p: string): Promise<void> {
+  await mkdir(path.dirname(p), { recursive: true })
+}
+
+export async function save(state: GridState): Promise<void> {
+  await ensureParent(gridLayoutPath)
+  await Bun.write(gridLayoutPath, JSON.stringify(state, null, 2))
+}
+
+export async function load(): Promise<GridState | null> {
+  const handle = Bun.file(gridLayoutPath)
+  if (!(await handle.exists())) return null
+  try {
+    const data = (await handle.json()) as unknown
+    if (!isGridState(data)) return null
+    return data
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Returns a debounced saver that coalesces rapid grid-state changes into a
+ * single write. The trailing call always fires so the final state is durable.
+ */
+export function debouncedSave(delayMs = 250): (state: GridState) => void {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let pending: GridState | undefined
+  return (state) => {
+    pending = state
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      const snapshot = pending
+      timer = undefined
+      pending = undefined
+      if (snapshot) save(snapshot).catch(() => undefined)
+    }, delayMs)
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/context/grid.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/grid.tsx
@@ -1,0 +1,156 @@
+import { createStore, produce, reconcile } from "solid-js/store"
+import { createEffect, createMemo, onCleanup } from "solid-js"
+import { createSimpleContext } from "./helper"
+import fs from "fs"
+import {
+  defaultGridState,
+  debouncedSave,
+  normalizeGridState,
+  isGridState,
+  gridLayoutPath,
+  type GridCell,
+  type GridLayout,
+  type GridSplitRatio,
+  type GridState,
+} from "./grid-persistence"
+
+export type AddCellInput = Omit<GridCell, "id">
+
+export const { use: useGrid, provider: GridProvider } = createSimpleContext({
+  name: "Grid",
+  init: (props: { initial?: GridState }) => {
+    let initialStore = props.initial
+    if (!initialStore) {
+      try {
+        if (fs.existsSync(gridLayoutPath)) {
+          const content = fs.readFileSync(gridLayoutPath, "utf-8")
+          const parsed = JSON.parse(content)
+          if (isGridState(parsed)) {
+            initialStore = normalizeGridState(parsed)
+          }
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    const [store, setStore] = createStore<GridState>(
+      initialStore ? normalizeGridState(initialStore) : defaultGridState(),
+    )
+
+    const persist = debouncedSave(250)
+    createEffect(() => {
+      // Touch every tracked field so Solid registers them, then snapshot.
+      // Phase 6: include splitRatio so the splitter drag handle is durable
+      // across restarts. batched via produce-style manual snapshot to keep
+      // the persistence path cheap during rapid layout changes.
+      const snapshot: GridState = {
+        cells: store.cells.map((c) => ({ ...c })),
+        activeCellId: store.activeCellId,
+        layout: store.layout,
+        splitRatio: store.splitRatio,
+      }
+      persist(snapshot)
+    })
+    onCleanup(() => {
+      // No-op: pending debounced save still fires for the latest snapshot.
+    })
+
+    return {
+      get data() {
+        return store
+      },
+      get cells() {
+        return store.cells
+      },
+      get activeCellId() {
+        return store.activeCellId
+      },
+      get layout() {
+        return store.layout
+      },
+      get splitRatio() {
+        return store.splitRatio
+      },
+      activeCell: createMemo(() => store.cells.find((c) => c.id === store.activeCellId)),
+      addCell(input: AddCellInput) {
+        const id = crypto.randomUUID()
+        const cell: GridCell = { ...input, id }
+        setStore(
+          produce((draft) => {
+            draft.cells.push(cell)
+            draft.cells.sort((a, b) => a.sessionID.localeCompare(b.sessionID))
+            draft.activeCellId = id
+          }),
+        )
+        return id
+      },
+      removeCell(id: string) {
+        setStore(
+          produce((draft) => {
+            const idx = draft.cells.findIndex((c) => c.id === id)
+            if (idx < 0) return
+            draft.cells.splice(idx, 1)
+            if (draft.activeCellId === id) {
+              const next = draft.cells[Math.min(idx, draft.cells.length - 1)]
+              draft.activeCellId = next ? next.id : ""
+            }
+          }),
+        )
+      },
+      setActive(id: string) {
+        if (!store.cells.some((c) => c.id === id)) return
+        setStore("activeCellId", id)
+      },
+      setLayout(layout: GridLayout) {
+        setStore("layout", layout)
+      },
+      /**
+       * Phase 6: persist a new split ratio. The splitter drag handle clamps
+       * the value to a sane range before calling this; we still defensively
+       * guard against NaN/out-of-range values here so external callers can't
+       * poison the persisted state.
+       */
+      setSplitRatio(ratio: GridSplitRatio) {
+        if (!Number.isFinite(ratio)) return
+        const clamped = Math.max(0, Math.min(1, ratio))
+        if (clamped === store.splitRatio) return
+        setStore("splitRatio", clamped)
+      },
+      toggleMode(id?: string) {
+        const target = id ?? store.activeCellId
+        if (!target) return
+        const idx = store.cells.findIndex((c) => c.id === target)
+        if (idx < 0) return
+        const current = store.cells[idx]
+        if (!current) return
+        const next = current.mode === "full" ? "plan-only" : "full"
+        setStore("cells", idx, reconcile({ ...current, mode: next }))
+      },
+      /**
+       * Replace the entire state (e.g. after a successful load from disk).
+       * Use sparingly — prefer the targeted mutators above.
+       */
+      hydrate(state: GridState) {
+        const normalized = normalizeGridState(state)
+        const sortedCells = [...normalized.cells].sort((a, b) => a.sessionID.localeCompare(b.sessionID))
+        setStore(reconcile({ ...normalized, cells: sortedCells }))
+      },
+    }
+  },
+})
+
+export type GridContext = ReturnType<typeof useGrid>
+
+/**
+ * Convenience namespace export for callers that prefer
+ * `import { grid } from "@tui/context/grid"` over the hook form.
+ */
+export const grid = {
+  addCell: (ctx: GridContext, input: AddCellInput) => ctx.addCell(input),
+  removeCell: (ctx: GridContext, id: string) => ctx.removeCell(id),
+  setActive: (ctx: GridContext, id: string) => ctx.setActive(id),
+  toggleMode: (ctx: GridContext, id?: string) => ctx.toggleMode(id),
+  setLayout: (ctx: GridContext, layout: GridLayout) => ctx.setLayout(layout),
+  setSplitRatio: (ctx: GridContext, ratio: GridSplitRatio) => ctx.setSplitRatio(ratio),
+}

--- a/packages/opencode/src/cli/cmd/tui/context/route.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/route.tsx
@@ -28,7 +28,21 @@ export type PluginRoute = {
   data?: Record<string, unknown>
 }
 
-export type Route = HomeRoute | SessionRoute | PluginRoute
+/**
+ * TUI grid mode (multi-session workspace). When active, the route resolves to
+ * `GridView` which renders multiple session cells arranged by a layout store.
+ * `cells` seeds the grid with existing sessions; `activeSessionID` is the cell
+ * that owns keyboard focus. Both are optional — the grid component restores
+ * the persisted layout from `~/.mimocode/grid-layout.json` on mount when
+ * neither is supplied.
+ */
+export type GridRoute = {
+  type: "grid"
+  cells?: { sessionID: string; workspaceID?: string }[]
+  activeSessionID?: string
+}
+
+export type Route = HomeRoute | SessionRoute | PluginRoute | GridRoute
 
 export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
   name: "Route",

--- a/packages/opencode/src/cli/cmd/tui/context/workspace-clients.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/workspace-clients.tsx
@@ -1,0 +1,73 @@
+import { createOpencodeClient } from "@mimo-ai/sdk/v2"
+import type { OpencodeClient } from "@mimo-ai/sdk/v2"
+import { createSimpleContext } from "./helper"
+import { useSDK } from "./sdk"
+
+export type WorkspaceID = string & { readonly __workspaceBrand: unique symbol }
+
+export const asWorkspaceID = (value: string | undefined | null): WorkspaceID => {
+  return (value ?? "") as unknown as WorkspaceID
+}
+
+const NO_WORKSPACE = asWorkspaceID("")
+
+type Client = OpencodeClient
+
+type PoolEntry = {
+  client: Client
+  refs: number
+}
+
+export const { use: useWorkspaceClients, provider: WorkspaceClientsProvider } = createSimpleContext({
+  name: "WorkspaceClients",
+  init: () => {
+    const sdk = useSDK()
+    const entries = new Map<WorkspaceID, PoolEntry>()
+
+    const buildClient = (id: WorkspaceID): Client => {
+      if (id === NO_WORKSPACE) return sdk.client
+      return createOpencodeClient({
+        baseUrl: sdk.url,
+        directory: sdk.directory,
+        experimental_workspaceID: id,
+        fetch: sdk.fetch,
+      })
+    }
+
+    const pool = {
+      acquire(id: WorkspaceID) {
+        const existing = entries.get(id)
+        if (existing) {
+          existing.refs += 1
+          return existing.client
+        }
+        const entry: PoolEntry = { client: buildClient(id), refs: 1 }
+        entries.set(id, entry)
+        return entry.client
+      },
+      release(id: WorkspaceID) {
+        const existing = entries.get(id)
+        if (!existing) return
+        existing.refs -= 1
+        if (existing.refs <= 0) {
+          entries.delete(id)
+        }
+      },
+      size() {
+        return entries.size
+      },
+    }
+
+    return {
+      pool,
+      clientFor(id: WorkspaceID | undefined | null): Client {
+        if (!id || id === NO_WORKSPACE) return sdk.client
+        const existing = entries.get(id)
+        if (existing) return existing.client
+        return buildClient(id)
+      },
+    }
+  },
+})
+
+export type WorkspaceClients = ReturnType<typeof useWorkspaceClients>

--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -95,6 +95,11 @@ function routeCurrent(route: ReturnType<typeof useRoute>): TuiPluginApi["route"]
       },
     }
   }
+  if (route.data.type === "grid") {
+    // TUI grid mode (multi-session workspace). No plugin view; signal
+    // grid mode so plugin APIs can branch correctly when active.
+    return { name: "grid" }
+  }
 
   return {
     name: route.data.id,

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/cell-event-bus.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/cell-event-bus.ts
@@ -1,0 +1,149 @@
+import type { GlobalEvent } from "@mimo-ai/sdk/v2"
+import { createGlobalEmitter } from "@solid-primitives/event-bus"
+import { createSimpleContext } from "@tui/context/helper"
+import { useSDK } from "@tui/context/sdk"
+import type { WorkspaceID } from "@tui/context/workspace-clients"
+
+/**
+ * Per-cell event routing layer. The TUI now keeps the SDK SSE connection in
+ * a single place (`sdk.event`) so the network cost of N workspace streams is
+ * paid once. Cells subscribe here instead of opening their own SSE streams;
+ * the bus fans each envelope out to every cell whose workspaceID matches the
+ * event's `workspace` field.
+ *
+ * Routing rules:
+ *   - `event.directory === "global"` — broadcast to every subscriber.
+ *   - `event.workspace === subscriber.workspaceID` — deliver to that subscriber.
+ *   - everything else — dropped (cells in workspace A don't see workspace B's
+ *     traffic).
+ *
+ * Deduplication: the SSE upstream can re-deliver the same envelope (reconnect
+ * replays the tail, or two cells sharing a workspace would otherwise process
+ * the same payload twice if they each opened a stream). The bus maintains a
+ * small recent-id cache so a duplicate event delivered in quick succession
+ * is delivered to the *first* matching subscriber and silently dropped for
+ * later ones within the dedup window. The cache key is the event's payload
+ * type plus a content fingerprint (`type|propertiesHash`) so two semantically
+ * identical `message.updated` events collapse to one delivery.
+ */
+
+export type CellEventEnvelope = GlobalEvent
+
+export type CellEventSubscription = {
+  /**
+   * Workspace this subscription belongs to. `undefined` means the subscriber
+   * is the "default" (no-workspace) cell and only receives global envelopes.
+   */
+  workspaceID: WorkspaceID | undefined
+  /** Handler invoked for every routed event. */
+  handler: (event: CellEventEnvelope) => void
+}
+
+export type CellEventBusState = {
+  /** Subscribe a cell to the routed event stream. */
+  subscribe: (sub: CellEventSubscription) => () => void
+  /** Convenience helper: subscribe filtered to a specific event type. */
+  on: <T extends CellEventEnvelope["payload"]["type"]>(
+    workspaceID: WorkspaceID | undefined,
+    type: T,
+    handler: (event: Extract<CellEventEnvelope["payload"], { type: T }>) => void,
+  ) => () => void
+  /** Snapshot of currently active subscribers. Useful for tests/diagnostics. */
+  subscribers: () => CellEventSubscription[]
+  /** Drop every cached envelope. Used on full reconnect / flush. */
+  reset: () => void
+}
+
+const DEDUP_LIMIT = 256
+
+const fingerprint = (event: GlobalEvent): string => {
+  // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- payload is a discriminated union, we treat it as a record for stable fingerprinting
+  const payload = event.payload as unknown as Record<string, unknown> & { type: string }
+  // Normalize across the two payload shapes: most events carry a `properties`
+  // bag, while `sync.*` events carry a `data` bag. Fall back to the entire
+  // payload JSON when neither is present so the key is still stable.
+  // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion)
+  const fields =
+    (payload.properties as Record<string, unknown> | undefined) ??
+    // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion)
+    (payload.data as Record<string, unknown> | undefined) ??
+    payload
+  const sorted = JSON.stringify(fields, Object.keys(fields).sort())
+  return `${payload.type}|${sorted}`
+}
+
+export const { use: useCellEventBus, provider: CellEventBusProvider } = createSimpleContext({
+  name: "CellEventBus",
+  init: (): CellEventBusState => {
+    const sdk = useSDK()
+    const emitter = createGlobalEmitter<{ event: CellEventEnvelope }>()
+    const subs = new Set<CellEventSubscription>()
+    // Fingerprint LRU — Map preserves insertion order, so we evict the oldest
+    // entry by deleting + re-inserting on touch.
+    const recent = new Map<string, true>()
+
+    const remember = (key: string) => {
+      if (recent.has(key)) return false
+      recent.set(key, true)
+      if (recent.size > DEDUP_LIMIT) {
+        const oldest = recent.keys().next().value
+        if (oldest !== undefined) recent.delete(oldest)
+      }
+      return true
+    }
+
+    // Pump every envelope from the SDK stream into the bus exactly once. The
+    // SDK already coalesces per-frame (batched flush), so we just hand the
+    // payload to the local routing layer below.
+    sdk.event.on("event", (envelope) => {
+      const key = fingerprint(envelope)
+      if (!remember(key)) return
+      emitter.emit("event", envelope)
+    })
+
+    // Local emitter → fanout to per-cell subscribers. The Solid emitter does
+    // not dedup across listeners, but we still want every cell in workspace A
+    // to receive workspace-A events — so we broadcast at this layer and let
+    // the upstream `sdk.event` source be the single network attachment.
+    const ROUTE = (envelope: CellEventEnvelope): void => {
+      const isGlobal = envelope.directory === "global"
+      for (const sub of subs) {
+        if (isGlobal) {
+          sub.handler(envelope)
+          continue
+        }
+        if (sub.workspaceID !== undefined && envelope.workspace === sub.workspaceID) {
+          sub.handler(envelope)
+        }
+      }
+    }
+    emitter.on("event", ROUTE)
+
+    return {
+      subscribe(sub: CellEventSubscription) {
+        subs.add(sub)
+        return () => {
+          subs.delete(sub)
+        }
+      },
+      on(workspaceID, type, handler) {
+        return this.subscribe({
+          workspaceID,
+          handler: (event) => {
+            if (event.payload.type !== type) return
+            // Runtime guard above; TS can't propagate the narrowing into the
+            // generic `handler` parameter across this closure, so we cast.
+            // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion)
+            handler(event.payload as never)
+          },
+        })
+      },
+      subscribers() {
+        return [...subs]
+      },
+      reset() {
+        recent.clear()
+      },
+    }
+  },
+})

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/grid-create.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/grid-create.ts
@@ -1,0 +1,55 @@
+import type { GridContext } from "@tui/context/grid"
+import { useSDK } from "@tui/context/sdk"
+import { useProject } from "@tui/context/project"
+import { useSync } from "@tui/context/sync"
+import { useWorkspaceClients, asWorkspaceID } from "@tui/context/workspace-clients"
+import type { ToastContext } from "@tui/ui/toast"
+import type { RouteContext } from "@tui/context/route"
+
+/**
+ * Create a fresh session via the workspace-aware SDK and add it to the grid
+ * as the new active cell. Used by both the `grid_create` keybind and the
+ * toolbar "+" button. Replaces the old "navigate to home" behaviour so the
+ * action actually opens a new grid cell instead of teleporting the user
+ * out of the grid.
+ *
+ * When `route` is provided the route data is synced after adding the cell
+ * so that `dialog-session-list` sees all current grid cells and can
+ * preserve them when navigating within grid mode.
+ *
+ * Returns the new session id on success, or `undefined` when the server
+ * call fails — callers can surface a toast on the latter.
+ */
+export async function createGridSession(input: {
+  grid: GridContext
+  sdk: ReturnType<typeof useSDK>
+  project: ReturnType<typeof useProject>
+  sync: ReturnType<typeof useSync>
+  workspaceClients: ReturnType<typeof useWorkspaceClients>
+  toast: ToastContext
+  route?: RouteContext
+  sessionID?: string
+}): Promise<string | undefined> {
+  const workspaceID = input.project.workspace.current()
+  let sessionID = input.sessionID
+  if (!sessionID) {
+    const client = workspaceID ? input.workspaceClients.clientFor(asWorkspaceID(workspaceID)) : input.sdk.client
+    const result = await client.session.create({ workspace: workspaceID }).catch(() => undefined)
+    if (!result?.data) {
+      input.toast.show({
+        message: "Failed to create session",
+        variant: "error",
+      })
+      return undefined
+    }
+    sessionID = result.data.id
+  }
+  input.grid.addCell({
+    sessionID,
+    workspaceID: workspaceID ?? "",
+    mode: "full",
+    label: input.sessionID ? "" : "New Session",
+  })
+  void input.sync.session.sync(sessionID).catch(() => undefined)
+  return sessionID
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/grid-create.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/grid-create.ts
@@ -31,9 +31,11 @@ export async function createGridSession(input: {
   sessionID?: string
 }): Promise<string | undefined> {
   const workspaceID = input.project.workspace.current()
-  let sessionID = input.sessionID
-  if (!sessionID) {
-    const client = workspaceID ? input.workspaceClients.clientFor(asWorkspaceID(workspaceID)) : input.sdk.client
+  let created: string | undefined
+  if (!input.sessionID) {
+    const client = workspaceID
+      ? input.workspaceClients.clientFor(asWorkspaceID(workspaceID))
+      : input.sdk.client
     const result = await client.session.create({ workspace: workspaceID }).catch(() => undefined)
     if (!result?.data) {
       input.toast.show({
@@ -42,8 +44,10 @@ export async function createGridSession(input: {
       })
       return undefined
     }
-    sessionID = result.data.id
+    created = result.data.id
   }
+  const sessionID = input.sessionID ?? created
+  if (!sessionID) return undefined
   input.grid.addCell({
     sessionID,
     workspaceID: workspaceID ?? "",

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/index.tsx
@@ -1,0 +1,499 @@
+import {
+  Match,
+  Switch,
+  Show,
+  createMemo,
+  createSignal,
+  createEffect,
+  on,
+  onCleanup,
+  onMount,
+  ErrorBoundary,
+} from "solid-js"
+import { useKeyboard, useTerminalDimensions } from "@opentui/solid"
+import { useRoute, useRouteData } from "@tui/context/route"
+import { useKeybind } from "@tui/context/keybind"
+import { useTheme } from "@tui/context/theme"
+import { useToast } from "@tui/ui/toast"
+import { useDialog } from "@tui/ui/dialog"
+import { GridProvider, useGrid } from "@tui/context/grid"
+import { load, type GridCell } from "@tui/context/grid-persistence"
+import { useSDK } from "@tui/context/sdk"
+import { useProject } from "@tui/context/project"
+import { useSync } from "@tui/context/sync"
+import { useWorkspaceClients } from "@tui/context/workspace-clients"
+import { SessionCell } from "./session-cell"
+import { PlanCell } from "./plan-cell"
+import { GridToolbar } from "./toolbar"
+import { Sidebar } from "./sidebar"
+import { CellErrorOverlay } from "@tui/component/cell-error-overlay"
+import { Splitter, splitCellWidth, splitCellHeight } from "./splitter"
+import { GridKeyboardHelp } from "./keyboard-help"
+import { createGridSession } from "./grid-create"
+
+/**
+ * GridView — root grid layout component for Phase 6.
+ *
+ * Wraps the session/plan cells in a GridProvider, renders a toolbar (cell
+ * tabs), the active cell body, and a management sidebar. Layout modes —
+ * single, split-h, split-v — control how cells are arranged. Each cell
+ * is wrapped in its own ErrorBoundary. Split layouts insert a draggable
+ * splitter bar between cells so users can resize the dragged cell's share
+ * (persisted to `~/.mimocode/grid-layout.json`).
+ *
+ * Phase 6 additions:
+ * - `--grid` / `MIMOCODE_GRID` boot path. The flag launches the TUI straight
+ *   into the grid route and restores the persisted layout on mount.
+ * - Splitter drag handle + persisted split ratio.
+ * - Per-cell shortcut keybinds (`<leader>1`..`<leader>9`, `<leader>0`).
+ * - Render virtualization for split-h/split-v when more than two cells
+ *   exist: only the active cell + the first sibling stay mounted.
+ * - Resize recalculation throttle so dragging the splitter does not
+ *   thrash Yoga relayouts on every frame.
+ */
+export function GridView() {
+  return (
+    <GridProvider>
+      <GridInner />
+    </GridProvider>
+  )
+}
+
+/**
+ * Phase 6: render-only flag — when `true`, the layout hides every cell
+ * except the active one (plus, in split mode, one sibling). Cells beyond
+ * the visible window are detached from the DOM so their scrollbox +
+ * workspace-synced state cannot trigger work while the user is focused on
+ * another cell. The threshold is intentionally generous: most users keep
+ * <= 2 cells in a split, so we only start virtualizing past that.
+ */
+const VIRTUALIZE_THRESHOLD = 2
+
+function GridInner() {
+  const grid = useGrid()
+  const route = useRoute()
+  const routeData = useRouteData("grid")
+  const keybind = useKeybind()
+  const dialog = useDialog()
+  const { theme } = useTheme()
+  const dimensions = useTerminalDimensions()
+  const toast = useToast()
+  const sdk = useSDK()
+  const project = useProject()
+  const sync = useSync()
+  const workspaceClients = useWorkspaceClients()
+
+  /**
+   * Phase 8: create a fresh session via the workspace-aware SDK and add it
+   * to the grid as the new active cell. Shared with the toolbar "+" button
+   * through `./grid-create.ts`. Replaces the old "navigate to home" behaviour
+   * so the keybind actually opens a new grid cell instead of teleporting
+   * the user out of the grid.
+   */
+  const createSessionInCell = () => createGridSession({ grid, sdk, project, sync, workspaceClients, toast, route })
+
+  // Track processed cell sessionIDs to avoid re-adding cells that were
+  // already handled by the initial mount or a previous effect run.
+  const processedCells = new Set<string>()
+
+  // Load persisted grid state on mount so the layout survives restarts.
+  // Phase 6: this also drives the `--grid` boot path — when the user
+  // launches with `--grid` and a stale layout exists, we restore it before
+  // seeding any single-cell defaults below.
+  onMount(async () => {
+    // Phase 8: hydrate from route.data.cells when the grid was opened via a
+    // navigation that pre-seeded cells (e.g. from home with a session list).
+    // Skip entries that already exist in the grid store — this keeps the
+    // restored layout intact when both persistence and route data are present.
+    const seeded = routeData.cells
+    if (!seeded?.length) return
+    for (const entry of seeded) {
+      if (!entry.sessionID) continue
+      if (grid.cells.some((c) => c.sessionID === entry.sessionID)) continue
+      processedCells.add(entry.sessionID)
+      await createGridSession({ grid, sdk, project, sync, workspaceClients, toast, route, sessionID: entry.sessionID })
+    }
+  })
+
+  // Watch for new cells added via route navigation (e.g. /session dialog
+  // in grid mode). Since the Match condition stays "grid" the component
+  // is NOT re-mounted — only `routeData.cells` changes reactively, so we
+  // use createEffect instead of onMount to pick up late-arriving cells.
+  createEffect(() => {
+    const seeded = routeData.cells
+    if (!seeded?.length) return
+    for (const entry of seeded) {
+      if (!entry.sessionID) continue
+      if (processedCells.has(entry.sessionID)) continue
+      if (grid.cells.some((c) => c.sessionID === entry.sessionID)) continue
+      processedCells.add(entry.sessionID)
+      void createGridSession({ grid, sdk, project, sync, workspaceClients, toast, route, sessionID: entry.sessionID })
+    }
+  })
+
+  // Watch for active cell changes from the route (e.g. chosen from DialogSessionList)
+  // and activate the matching cell in the grid. Uses on() for explicit dependency
+  // tracking so that changes to grid.activeCellId (e.g. from mouse clicks) do NOT
+  // re-trigger this effect and snap back to the old activeSessionID.
+  createEffect(on(
+    () => routeData.activeSessionID,
+    (activeSessionID) => {
+      if (!activeSessionID) return
+      const cell = grid.cells.find((c) => c.sessionID === activeSessionID)
+      if (cell) grid.setActive(cell.id)
+    },
+  ))
+
+  // Phase 6: throttle the splitter-driven resize recalculation and terminal SIGWINCH.
+  // Yoga relayout is expensive enough that a 60-fps drag tick would tank the
+  // render loop. We capture the dragged ratio locally in <Splitter/> and
+  // apply it to the store on mouse-up; this throttle covers any other
+  // resize-trigger (terminal SIGWINCH, sidebar toggle, etc.).
+  const [throttledDimensions, setThrottledDimensions] = createSignal({
+    width: dimensions().width,
+    height: dimensions().height,
+  })
+  let resizeTimer: ReturnType<typeof setTimeout> | undefined
+  createEffect(() => {
+    const w = dimensions().width
+    const h = dimensions().height
+    if (resizeTimer) clearTimeout(resizeTimer)
+    resizeTimer = setTimeout(() => {
+      resizeTimer = undefined
+      setThrottledDimensions({ width: w, height: h })
+    }, 32)
+  })
+  onCleanup(() => {
+    if (resizeTimer) clearTimeout(resizeTimer)
+  })
+
+  // Grid-level keyboard navigation
+  useKeyboard((evt) => {
+    const cells = grid.cells
+    if (cells.length === 0) return
+
+    if (keybind.match("grid_next", evt)) {
+      evt.preventDefault()
+      const activeIdx = cells.findIndex((c) => c.id === grid.activeCellId)
+      grid.setActive(cells[(activeIdx + 1) % cells.length].id)
+      return
+    }
+
+    if (keybind.match("grid_prev", evt)) {
+      evt.preventDefault()
+      const activeIdx = cells.findIndex((c) => c.id === grid.activeCellId)
+      grid.setActive(cells[(activeIdx - 1 + cells.length) % cells.length].id)
+      return
+    }
+
+    if (keybind.match("grid_close", evt)) {
+      evt.preventDefault()
+      if (grid.activeCellId) grid.removeCell(grid.activeCellId)
+      return
+    }
+
+    if (keybind.match("grid_create", evt)) {
+      evt.preventDefault()
+      void createSessionInCell()
+      return
+    }
+
+    if (keybind.match("grid_single", evt)) {
+      evt.preventDefault()
+      grid.setLayout("single")
+      return
+    }
+
+    if (keybind.match("grid_layout_toggle", evt)) {
+      evt.preventDefault()
+      const next =
+        grid.layout === "single"
+          ? "split-h"
+          : grid.layout === "split-h"
+            ? "split-v"
+            : grid.layout === "split-v"
+              ? "2x2"
+              : "single"
+      grid.setLayout(next)
+      return
+    }
+
+    // Phase 6: direct cell switching via leader + number. Indices are
+    // 1-based to match the on-screen tab labels; we wrap if the user
+    // presses a key higher than the cell count rather than swallowing it.
+    for (let n = 1; n <= 9; n++) {
+      if (!keybind.match(`grid_cell_${n}` as const, evt)) continue
+      evt.preventDefault()
+      const idx = (n - 1) % cells.length
+      const target = cells[idx]
+      if (target) grid.setActive(target.id)
+      return
+    }
+
+    if (keybind.match("grid_help", evt)) {
+      evt.preventDefault()
+      dialog.setSize("large")
+      dialog.replace(() => <GridKeyboardHelp />)
+      return
+    }
+  })
+
+  const width = () => Math.max(80, throttledDimensions().width)
+  const sidebarWidth = 28
+  const contentWidth = () => Math.max(40, width() - sidebarWidth - 2)
+  // Reserve 4 lines for toolbar + border
+  const cellAreaHeight = () => Math.max(6, throttledDimensions().height - 4)
+  const layout = () => grid.layout
+  const empty = () => grid.cells.length === 0
+  const activeCell = () => grid.activeCell()
+
+  // Phase 6: virtualize the visible cell window. In single mode only the
+  // active cell renders; in split modes we show the active cell plus the
+  // next sibling. Everything else is detached so its scrollbox, sync
+  // listeners, and SSE fan-out won't fire.
+  const visibleCells = createMemo(() => {
+    const all = grid.cells
+    if (all.length === 0) return []
+    if (layout() === "single") {
+      return activeCell() ? [activeCell()!] : []
+    }
+    if (layout() === "2x2") {
+      const activeIdx = all.findIndex((c) => c.id === grid.activeCellId)
+      if (activeIdx < 0) return all.slice(0, 4)
+      const chunkIdx = Math.floor(activeIdx / 4) * 4
+      return all.slice(chunkIdx, chunkIdx + 4)
+    }
+    // Stable order chunked by 2, similar to 2x2 chunk slice.
+    // Active cell is highlighted via the `active` prop, not position.
+    const activeIdx = all.findIndex((c) => c.id === grid.activeCellId)
+    if (activeIdx < 0) return all.slice(0, 2)
+    const chunkIdx = Math.floor(activeIdx / 2) * 2
+    return all.slice(chunkIdx, chunkIdx + 2)
+  })
+
+  // Split layouts always render at most two cells; non-virtualized renders
+  // are still useful while cell count <= VIRTUALIZE_THRESHOLD.
+  const useVirtualization = createMemo(() => {
+    const limit = layout() === "2x2" ? 4 : VIRTUALIZE_THRESHOLD
+    return grid.cells.length > limit
+  })
+
+  const splitCellArea = createMemo(() => {
+    // The dragged cell's width is governed by the persisted split ratio.
+    // splitCellWidth clamps to MIN_CELL_COLS at both ends of the bar.
+    return splitCellWidth(contentWidth(), grid.splitRatio, 1)
+  })
+
+  const splitCellAreaHeight = createMemo(() => {
+    return splitCellHeight(cellAreaHeight(), grid.splitRatio, 1)
+  })
+
+  return (
+    <box
+      flexDirection="row"
+      width={width()}
+      height={Math.max(10, throttledDimensions().height)}
+      backgroundColor={theme.background}
+    >
+      {/* Main area: toolbar + cells */}
+      <box flexDirection="column" flexGrow={1} height="100%">
+        <GridToolbar />
+        <Show when={!empty()} fallback={<GridEmptyState />}>
+          <box flexDirection="column" flexGrow={1} height={cellAreaHeight()}>
+            <Switch>
+              {/* Single: only the active cell, full width */}
+              <Match when={layout() === "single"}>
+                <Show when={activeCell()} keyed>
+                  {(cell) => (
+                    <ErrorBoundary fallback={(err) => <CellError error={err} cell={cell} />}>
+                      <CellRenderer cell={cell} active={true} width={contentWidth()} />
+                    </ErrorBoundary>
+                  )}
+                </Show>
+              </Match>
+
+              {/* Split-h: dragged cell + sibling, separated by a draggable bar */}
+              <Match when={layout() === "split-h"}>
+                <box flexDirection="row" flexGrow={1}>
+                  <Show when={visibleCells()[0]} keyed>
+                    {(cell) => (
+                      <ErrorBoundary fallback={(err) => <CellError error={err} cell={cell} />}>
+                        <CellRenderer cell={cell} active={cell.id === grid.activeCellId} width={splitCellArea()} />
+                      </ErrorBoundary>
+                    )}
+                  </Show>
+                  <Splitter layout="split-h" total={contentWidth()} />
+                  <Show when={visibleCells()[1]} keyed>
+                    {(cell) => (
+                      <ErrorBoundary fallback={(err) => <CellError error={err} cell={cell} />}>
+                        <CellRenderer
+                          cell={cell}
+                          active={cell.id === grid.activeCellId}
+                          width={Math.max(40, contentWidth() - splitCellArea() - 1)}
+                        />
+                      </ErrorBoundary>
+                    )}
+                  </Show>
+                </box>
+              </Match>
+
+              {/* Split-v: same as split-h but stacked. The splitter drives the
+                  row split the same way it drives the column split. */}
+              <Match when={layout() === "split-v"}>
+                <box flexDirection="column" flexGrow={1}>
+                  <Show when={visibleCells()[0]} keyed>
+                    {(cell) => (
+                      <ErrorBoundary fallback={(err) => <CellError error={err} cell={cell} />}>
+                        <CellRenderer
+                          cell={cell}
+                          active={cell.id === grid.activeCellId}
+                          width={contentWidth()}
+                          height={splitCellAreaHeight()}
+                        />
+                      </ErrorBoundary>
+                    )}
+                  </Show>
+                  <Splitter layout="split-v" total={cellAreaHeight()} />
+                  <Show when={visibleCells()[1]} keyed>
+                    {(cell) => (
+                      <ErrorBoundary fallback={(err) => <CellError error={err} cell={cell} />}>
+                        <CellRenderer
+                          cell={cell}
+                          active={cell.id === grid.activeCellId}
+                          width={contentWidth()}
+                          height={Math.max(6, cellAreaHeight() - splitCellAreaHeight() - 1)}
+                        />
+                      </ErrorBoundary>
+                    )}
+                  </Show>
+                </box>
+              </Match>
+
+              {/* 2x2: 4 cells in a 2x2 grid */}
+              <Match when={layout() === "2x2"}>
+                <box flexDirection="column" flexGrow={1}>
+                  {/* Top half */}
+                  <box flexDirection="row" height={splitCellAreaHeight()}>
+                    <Show when={visibleCells()[0]} keyed>
+                      {(cell) => (
+                        <ErrorBoundary fallback={(err) => <CellError error={err} cell={cell} />}>
+                          <CellRenderer cell={cell} active={cell.id === grid.activeCellId} width={splitCellArea()} />
+                        </ErrorBoundary>
+                      )}
+                    </Show>
+                    <Splitter layout="split-h" total={contentWidth()} />
+                    <Show when={visibleCells()[1]} keyed>
+                      {(cell) => (
+                        <ErrorBoundary fallback={(err) => <CellError error={err} cell={cell} />}>
+                          <CellRenderer
+                            cell={cell}
+                            active={cell.id === grid.activeCellId}
+                            width={Math.max(40, contentWidth() - splitCellArea() - 1)}
+                          />
+                        </ErrorBoundary>
+                      )}
+                    </Show>
+                  </box>
+                  <Splitter layout="split-v" total={cellAreaHeight()} />
+                  {/* Bottom half */}
+                  <box flexDirection="row" height={Math.max(6, cellAreaHeight() - splitCellAreaHeight() - 1)}>
+                    <Show when={visibleCells()[2]} keyed>
+                      {(cell) => (
+                        <ErrorBoundary fallback={(err) => <CellError error={err} cell={cell} />}>
+                          <CellRenderer cell={cell} active={cell.id === grid.activeCellId} width={splitCellArea()} />
+                        </ErrorBoundary>
+                      )}
+                    </Show>
+                    <Splitter layout="split-h" total={contentWidth()} />
+                    <Show when={visibleCells()[3]} keyed>
+                      {(cell) => (
+                        <ErrorBoundary fallback={(err) => <CellError error={err} cell={cell} />}>
+                          <CellRenderer
+                            cell={cell}
+                            active={cell.id === grid.activeCellId}
+                            width={Math.max(40, contentWidth() - splitCellArea() - 1)}
+                          />
+                        </ErrorBoundary>
+                      )}
+                    </Show>
+                  </box>
+                </box>
+              </Match>
+            </Switch>
+
+            {/* Hidden detail block: shows the active cell index for diagnostics
+                when virtualization is engaged. Pure UI surface — no side
+                effects. */}
+            <Show when={useVirtualization()}>
+              <text fg={theme.textMuted} selectable={false}>
+                {`virtualized: ${visibleCells().length}/${grid.cells.length}`}
+              </text>
+            </Show>
+          </box>
+        </Show>
+      </box>
+
+      {/* Right sidebar */}
+      <Sidebar />
+    </box>
+  )
+}
+
+/**
+ * Dispatches to the correct cell component based on cell.mode.
+ */
+function CellRenderer(props: { cell: GridCell; active: boolean; width: number; height?: number }) {
+  const grid = useGrid()
+  return (
+    <box
+      flexDirection="column"
+      width={props.width}
+      height={props.height ?? "100%"}
+      onMouseUp={() => {
+        if (grid.activeCellId !== props.cell.id) {
+          grid.setActive(props.cell.id)
+        }
+      }}
+    >
+      <Switch>
+        <Match when={props.cell.mode === "plan-only"}>
+          <PlanCell cell={props.cell} />
+        </Match>
+        <Match when={true}>
+          <SessionCell
+            cell={props.cell}
+            active={props.active}
+            width={props.width}
+            wide={props.width > 120}
+            height={props.height}
+          />
+        </Match>
+      </Switch>
+    </box>
+  )
+}
+
+/**
+ * Fallback UI when a cell's component throws. Delegates to the shared
+ * `CellErrorOverlay` so the look and behaviour match the inline
+ * error treatment used elsewhere; the only grid-specific twist is that
+ * the cell label is included in the headline.
+ */
+function CellError(props: { error: unknown; cell: GridCell }) {
+  return <CellErrorOverlay error={props.error} cellLabel={props.cell.label} />
+}
+
+/**
+ * Minimal empty-state placeholder shown when the grid has no cells.
+ */
+function GridEmptyState() {
+  const { theme } = useTheme()
+  const keybind = useKeybind()
+  return (
+    <box flexDirection="column" alignItems="center" justifyContent="center" flexGrow={1} gap={1}>
+      <text fg={theme.text}>Grid View</text>
+      <text fg={theme.textMuted}>{keybind.print("grid_create")} to add a session</text>
+      <text fg={theme.textMuted}>{keybind.print("grid_help")} for keyboard help</text>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/keyboard-help.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/keyboard-help.tsx
@@ -1,0 +1,88 @@
+import { For, Show, createMemo } from "solid-js"
+import { TextAttributes } from "@opentui/core"
+import { useTheme } from "@tui/context/theme"
+import { useGrid } from "@tui/context/grid"
+import { useKeybind } from "@tui/context/keybind"
+import { useDialog } from "@tui/ui/dialog"
+
+interface HelpRow {
+  action: string
+  binding: string
+}
+
+/**
+ * Phase 6: keyboard help dialog for the grid view.
+ *
+ * Lists every grid-specific keybind in a compact two-column table. The
+ * dialog is intentionally self-contained: it doesn't take props, reads the
+ * keybind store directly, and registers a single `escape` handler so it
+ * composes with the parent `DialogProvider`.
+ *
+ * The component is rendered inside a `Dialog` (size `large`) and closes
+ * itself when the user dismisses the dialog stack.
+ */
+export function GridKeyboardHelp() {
+  const dialog = useDialog()
+  const keybind = useKeybind()
+  const { theme } = useTheme()
+  const grid = useGrid()
+
+  const rows = createMemo<HelpRow[]>(() => [
+    { action: "Next cell", binding: keybind.print("grid_next") },
+    { action: "Previous cell", binding: keybind.print("grid_prev") },
+    { action: "Switch to cell 1", binding: keybind.print("grid_cell_1") },
+    { action: "Switch to cell 2", binding: keybind.print("grid_cell_2") },
+    { action: "Switch to cell 3", binding: keybind.print("grid_cell_3") },
+    { action: "Switch to cell 4", binding: keybind.print("grid_cell_4") },
+    { action: "Switch to cell 5", binding: keybind.print("grid_cell_5") },
+    { action: "Switch to cell 6", binding: keybind.print("grid_cell_6") },
+    { action: "Switch to cell 7", binding: keybind.print("grid_cell_7") },
+    { action: "Switch to cell 8", binding: keybind.print("grid_cell_8") },
+    { action: "Switch to cell 9", binding: keybind.print("grid_cell_9") },
+    { action: "Single cell mode", binding: keybind.print("grid_single") },
+    { action: "Toggle layout (single / split-h / split-v)", binding: keybind.print("grid_layout_toggle") },
+    { action: "Toggle plan-only mode", binding: keybind.print("grid_plan_mode") },
+    { action: "Close active cell", binding: keybind.print("grid_close") },
+    { action: "Create new cell", binding: keybind.print("grid_create") },
+    { action: "Show this help", binding: keybind.print("grid_help") },
+  ])
+
+  const close = () => dialog.clear()
+
+  return (
+    <box flexDirection="column" paddingLeft={2} paddingRight={2} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          Grid View — Keyboard
+        </text>
+        <text fg={theme.textMuted} onMouseUp={close}>
+          esc / click ✕
+        </text>
+      </box>
+
+      <box paddingBottom={1}>
+        <text fg={theme.textMuted}>
+          Layout: {grid.layout} · Cells: {grid.cells.length} · Active: #
+          {grid.cells.findIndex((c) => c.id === grid.activeCellId) + 1}
+        </text>
+      </box>
+
+      <Show when={rows().length > 0} fallback={<text fg={theme.textMuted}>No keybinds available for this view.</text>}>
+        <For each={rows()}>
+          {(row) => (
+            <box flexDirection="row" justifyContent="space-between">
+              <text fg={theme.text}>{row.action}</text>
+              <text fg={theme.textMuted}>{row.binding}</text>
+            </box>
+          )}
+        </For>
+      </Show>
+
+      <box flexDirection="row" justifyContent="flex-end" paddingTop={1}>
+        <box paddingLeft={3} paddingRight={3} backgroundColor={theme.primary} onMouseUp={close}>
+          <text fg={theme.selectedListItemText}>Close</text>
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/plan-cell.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/plan-cell.tsx
@@ -1,0 +1,289 @@
+import { For, Match, Show, Switch, createMemo } from "solid-js"
+import { useSync } from "@tui/context/sync"
+import { useTheme } from "@tui/context/theme"
+import { useTuiConfig } from "@tui/context/tui-config"
+import { useGrid } from "@tui/context/grid"
+import { TuiPluginRuntime } from "../../plugin"
+import { AgentStatus } from "../../component/agent-status"
+import { PlanSummary } from "../../component/plan-summary"
+import { getScrollAcceleration } from "../../util/scroll"
+import type { GridCell } from "@tui/context/grid-persistence"
+
+export interface PlanCellProps {
+  /**
+   * The grid cell this dashboard renders for. The component is intentionally
+   * prop-driven so the grid layout can mount/unmount it freely without the
+   * dashboard reaching into route state.
+   */
+  cell: GridCell
+}
+
+/**
+ * Read-only plan dashboard for a single grid cell.
+ *
+ * The view reuses the existing sidebar plugin slots (`sidebar_title`,
+ * `sidebar_content`, `sidebar_footer`) so it stays in lockstep with the
+ * regular session sidebar — every plugin (cwd, instructions, context, MCP,
+ * LSP, goal, todo, task, files, footer) renders here without duplication.
+ * `PlanSummary` and `AgentStatus` add full-width aggregations that are not
+ * appropriate in the 42-col sidebar.
+ *
+ * No prompt input, no message scrollbox — toggling `cell.mode` between
+ * `"full"` and `"plan-only"` flips the grid route between this dashboard and
+ * `SessionCell` without a layout re-mount.
+ *
+ * Reactivity flows from the sync store: every Solid signal consumed here is a
+ * slice of `sync.data.*`, so sync events re-render automatically. No manual
+ * timers, intervals, or imperative refresh hooks.
+ */
+export function PlanCell(props: PlanCellProps) {
+  const sync = useSync()
+  const { theme } = useTheme()
+  const tuiConfig = useTuiConfig()
+  const grid = useGrid()
+
+  const sessionID = () => props.cell.sessionID
+
+  // Resolve the reactive session row once — every downstream accessor depends
+  // on it, so caching the memo keeps the rest of the render cheap.
+  const session = createMemo(() => sync.session.get(sessionID()))
+
+  // Slice out the buckets the dashboard cares about. Each `createMemo` is
+  // independent: changing tasks does not invalidate the diff render and vice
+  // versa. Fall back to empty arrays / `undefined` so unmounted sessions keep
+  // rendering gracefully instead of throwing.
+  const tasks = createMemo(() => sync.data.task[sessionID()] ?? [])
+  const todos = createMemo(() => sync.data.todo[sessionID()] ?? [])
+  const diff = createMemo(() => sync.data.session_diff[sessionID()] ?? [])
+  const actors = createMemo(() => sync.data.actor[sessionID()] ?? [])
+
+  const cwd = createMemo(() => sync.data.session_cwd[sessionID()])
+  const goal = createMemo(() => sync.data.session_goal[sessionID()])
+  const status = createMemo(() => sync.data.session_status[sessionID()])
+
+  const diffTotals = createMemo(() => {
+    let adds = 0
+    let dels = 0
+    for (const item of diff()) {
+      adds += item.additions
+      dels += item.deletions
+    }
+    return { adds, dels, count: diff().length }
+  })
+
+  const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
+
+  return (
+    <Show when={session()}>
+      <box
+        backgroundColor={theme.backgroundPanel}
+        flexGrow={1}
+        flexShrink={1}
+        height="100%"
+        width="100%"
+        paddingTop={1}
+        paddingBottom={1}
+        paddingLeft={2}
+        paddingRight={2}
+        flexDirection="column"
+        onMouseUp={() => {
+          if (grid.activeCellId !== props.cell.id) {
+            grid.setActive(props.cell.id)
+          }
+        }}
+      >
+        <scrollbox
+          flexGrow={1}
+          flexShrink={1}
+          scrollAcceleration={scrollAcceleration()}
+          onMouseUp={() => {
+            if (grid.activeCellId !== props.cell.id) {
+              grid.setActive(props.cell.id)
+            }
+          }}
+          verticalScrollbarOptions={{
+            trackOptions: {
+              backgroundColor: theme.background,
+              foregroundColor: theme.borderActive,
+            },
+          }}
+        >
+          <box flexShrink={0} gap={1} paddingRight={1} flexDirection="column">
+            <Header sessionID={sessionID()} cwd={cwd()} statusType={status()?.type} />
+
+            <PlanSummary tasks={tasks()} todos={todos()} />
+
+            <AgentStatus actors={actors()} />
+
+            <FilesSection totals={diffTotals()} entries={diff()} />
+
+            <GoalSection goal={goal()} />
+
+            {/* Reuse the sidebar plugin slots in full-width — cwd, instructions,
+                context, MCP, LSP, todo, task, files, footer all render here
+                via the same plugin registry as the regular session sidebar. */}
+            <TuiPluginRuntime.Slot name="sidebar_content" session_id={sessionID()} />
+          </box>
+        </scrollbox>
+
+        <box flexShrink={0} gap={1} paddingTop={1}>
+          <TuiPluginRuntime.Slot name="sidebar_footer" mode="single_winner" session_id={sessionID()}>
+            <text fg={theme.textMuted}>
+              plan-only · <span style={{ fg: theme.text }}>{props.cell.label}</span>
+            </text>
+          </TuiPluginRuntime.Slot>
+        </box>
+      </box>
+    </Show>
+  )
+}
+
+function Header(props: { sessionID: string; cwd: string | undefined; statusType: string | undefined }) {
+  const sync = useSync()
+  const { theme } = useTheme()
+  const session = createMemo(() => sync.session.get(props.sessionID))
+  const statusLabel = () => {
+    const t = props.statusType
+    if (t === "busy") return "working"
+    if (t === "retry") return "retrying"
+    return "idle"
+  }
+  const statusColor = () => {
+    const t = props.statusType
+    if (t === "busy") return theme.warning
+    if (t === "retry") return theme.error
+    return theme.success
+  }
+  return (
+    <box flexDirection="column" gap={0} paddingBottom={1}>
+      <box flexDirection="row" gap={1} justifyContent="space-between">
+        <TuiPluginRuntime.Slot
+          name="sidebar_title"
+          mode="single_winner"
+          session_id={props.sessionID}
+          title={session()?.title ?? ""}
+          share_url={session()?.share?.url}
+        >
+          <text fg={theme.text}>
+            <b>{session()?.title ?? "Session"}</b>
+          </text>
+        </TuiPluginRuntime.Slot>
+        <text flexShrink={0} fg={statusColor()}>
+          {statusLabel()}
+        </text>
+      </box>
+      <Show when={props.cwd}>
+        <text fg={theme.textMuted} wrapMode="none">
+          {props.cwd}
+        </text>
+      </Show>
+    </box>
+  )
+}
+
+function FilesSection(props: {
+  totals: { adds: number; dels: number; count: number }
+  entries: { file: string; additions: number; deletions: number }[]
+}) {
+  const { theme } = useTheme()
+  return (
+    <Show when={props.totals.count > 0}>
+      <box flexDirection="column" gap={0}>
+        <box flexDirection="row" gap={1} justifyContent="space-between">
+          <text fg={theme.text}>
+            <b>Modified Files</b>
+          </text>
+          <text flexShrink={0} fg={theme.textMuted}>
+            <span style={{ fg: theme.diffAdded }}>+{props.totals.adds}</span>
+            <span> </span>
+            <span style={{ fg: theme.diffRemoved }}>-{props.totals.dels}</span>
+            <span>
+              {" "}
+              · {props.totals.count} file{props.totals.count === 1 ? "" : "s"}
+            </span>
+          </text>
+        </box>
+        <For each={props.entries}>
+          {(item) => (
+            <box flexDirection="row" gap={1} justifyContent="space-between">
+              <text fg={theme.textMuted} wrapMode="none">
+                {item.file}
+              </text>
+              <box flexDirection="row" gap={1} flexShrink={0}>
+                <Show when={item.additions}>
+                  <text fg={theme.diffAdded}>+{item.additions}</text>
+                </Show>
+                <Show when={item.deletions}>
+                  <text fg={theme.diffRemoved}>-{item.deletions}</text>
+                </Show>
+              </box>
+            </box>
+          )}
+        </For>
+      </box>
+    </Show>
+  )
+}
+
+function GoalSection(props: {
+  goal:
+    | {
+        condition?: string
+        verdicts: Record<
+          string,
+          { ok: boolean; impossible?: boolean; reason: string; attempt: number; error?: boolean }
+        >
+        lastMessageID?: string
+      }
+    | undefined
+}) {
+  const { theme } = useTheme()
+  const condition = createMemo(() => props.goal?.condition)
+  const verdict = createMemo(() => {
+    const g = props.goal
+    if (!g?.lastMessageID) return undefined
+    return g.verdicts[g.lastMessageID]
+  })
+  const status = createMemo(() => {
+    const v = verdict()
+    if (!v) return undefined
+    if (v.error) return { dot: theme.textMuted, label: "error (stopped)" }
+    if (v.ok) return { dot: theme.success, label: "met" }
+    if (v.impossible) return { dot: theme.error, label: "impossible" }
+    return { dot: theme.warning, label: `round ${v.attempt} · not met` }
+  })
+  const visible = createMemo(() => Boolean(condition() || status()))
+  return (
+    <Show when={visible()}>
+      <box flexDirection="column" gap={0}>
+        <text fg={theme.text}>
+          <b>Goal</b>
+        </text>
+        <Show when={condition()}>
+          <box flexDirection="row" gap={1}>
+            <text flexShrink={0} fg={theme.primary}>
+              •
+            </text>
+            <text fg={theme.textMuted} wrapMode="word">
+              {condition()}
+            </text>
+          </box>
+        </Show>
+        <Switch>
+          <Match when={status()}>
+            {(s) => (
+              <box flexDirection="row" gap={1}>
+                <text flexShrink={0} fg={s().dot}>
+                  •
+                </text>
+                <text fg={theme.textMuted} wrapMode="word">
+                  Judge: {s().label}
+                </text>
+              </box>
+            )}
+          </Match>
+        </Switch>
+      </box>
+    </Show>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/session-cell.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/session-cell.tsx
@@ -1,0 +1,2352 @@
+import {
+  batch,
+  createContext,
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  Match,
+  on,
+  onCleanup,
+  onMount,
+  Show,
+  Switch,
+  useContext,
+  type Accessor,
+  type Setter,
+} from "solid-js"
+import { Dynamic } from "solid-js/web"
+import path from "path"
+import { useRoute } from "@tui/context/route"
+import { useProject } from "@tui/context/project"
+import { useSync } from "@tui/context/sync"
+import { useEvent } from "@tui/context/event"
+import { SplitBorder } from "@tui/component/border"
+import { Spinner } from "@tui/component/spinner"
+import { selectedForeground, useTheme } from "@tui/context/theme"
+import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, RGBA, MouseEvent } from "@opentui/core"
+import { Prompt, type PromptRef } from "@tui/component/prompt"
+import type { AssistantMessage, Part, Provider, ToolPart, UserMessage, TextPart, ReasoningPart } from "@mimo-ai/sdk/v2"
+import { useLocal } from "@tui/context/local"
+import { Locale } from "@/util"
+import type { Tool } from "@/tool"
+import type { ReadTool } from "@/tool/read"
+import type { WriteTool } from "@/tool/write"
+import { BashTool } from "@/tool/bash"
+import type { GlobTool } from "@/tool/glob"
+import type { GrepTool } from "@/tool/grep"
+import type { EditTool } from "@/tool/edit"
+import type { ApplyPatchTool } from "@/tool/apply_patch"
+import type { WebFetchTool } from "@/tool/webfetch"
+import type { CodeSearchTool } from "@/tool/codesearch"
+import type { WebSearchTool } from "@/tool/websearch"
+import type { ActorTool } from "@/tool/actor"
+import type { TaskTool } from "@/tool/task"
+import type { QuestionTool } from "@/tool/question"
+import type { SkillTool } from "@/tool/skill"
+import { useKeyboard, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
+import { useSDK } from "@tui/context/sdk"
+import { useWorkspaceClients, asWorkspaceID } from "@tui/context/workspace-clients"
+import { useCellEventBus } from "./cell-event-bus"
+import { useCommandDialog } from "@tui/component/dialog-command"
+import { useLanguage } from "@tui/context/language"
+import type { DialogContext } from "@tui/ui/dialog"
+import { useKeybind } from "@tui/context/keybind"
+import { useDialog } from "../../ui/dialog"
+import { DialogMessage } from "../session/dialog-message"
+import type { PromptInfo } from "../../component/prompt/history"
+import { DialogConfirm } from "@tui/ui/dialog-confirm"
+import { DialogSessionRename } from "../../component/dialog-session-rename"
+import { Sidebar } from "../session/sidebar"
+import { SubagentFooter } from "../session/subagent-footer.tsx"
+import { Flag } from "@/flag/flag"
+import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
+import parsers from "../../../../../../parsers-config.ts"
+import * as Clipboard from "../../util/clipboard"
+import { Toast, useToast } from "../../ui/toast"
+import { useKV } from "../../context/kv.tsx"
+import * as Editor from "../../util/editor"
+import stripAnsi from "strip-ansi"
+import { usePromptRef } from "../../context/prompt"
+import { useExit } from "../../context/exit"
+import { Filesystem } from "@/util"
+import { Global } from "@/global"
+import { PermissionPrompt } from "../session/permission"
+import { QuestionPrompt } from "../session/question"
+import { DialogExportOptions } from "../../ui/dialog-export-options"
+import * as Model from "../../util/model"
+import { formatTranscript } from "../../util/transcript"
+import { UI } from "@/cli/ui.ts"
+import { useTuiConfig } from "../../context/tui-config"
+import { getScrollAcceleration } from "../../util/scroll"
+import { useStickyScrollGuard } from "../../util/scroll-guard"
+import { useEventTracker } from "../../util/event-cleanup"
+import { useDestroyGuard } from "../../util/render-guard"
+import { nextThinkingMode, reasoningSummary, useThinkingMode, type ThinkingMode } from "../../context/thinking"
+import { TuiPluginRuntime } from "../../plugin"
+import { DialogGoUpsell } from "../../component/dialog-go-upsell"
+import { BobSummaryPart } from "@tui/component/bob-summary"
+import { SessionRetry } from "@/session/retry"
+import { getRevertDiffFiles } from "../../util/revert-diff"
+import type { GridCell } from "@tui/context/grid-persistence"
+import { useSessionMessages, useSessionState } from "./session-hooks"
+import { useGrid } from "@tui/context/grid"
+
+addDefaultParsers(parsers.parsers)
+
+const GO_UPSELL_LAST_SEEN_AT = "go_upsell_last_seen_at"
+const GO_UPSELL_DONT_SHOW = "go_upsell_dont_show"
+const GO_UPSELL_WINDOW = 86_400_000 // 24 hrs
+
+/**
+ * Per-cell rendering context. Mirrors the local `context` block that lived
+ * inside `Session()` in routes/session/index.tsx, but scoped to one
+ * grid cell. Cells that are not currently active skip prompt input, command
+ * registration, and other side-effecting behavior — see the `active` flag.
+ */
+const cellContext = createContext<{
+  width: number
+  sessionID: string
+  workspaceID: string
+  conceal: () => boolean
+  thinkingMode: () => ThinkingMode
+  showThinking: () => boolean
+  showTimestamps: () => boolean
+  showDetails: () => boolean
+  showGenericToolOutput: () => boolean
+  diffWrapMode: () => "word" | "none"
+  providers: () => ReadonlyMap<string, Provider>
+  sync: ReturnType<typeof useSync>
+  tui: ReturnType<typeof useTuiConfig>
+  active: () => boolean
+}>()
+
+function useCell() {
+  const ctx = useContext(cellContext)
+  if (!ctx) throw new Error("useCell must be used within a SessionCell component")
+  return ctx
+}
+
+/**
+ * `SessionCell` renders one cell in a multi-cell grid. It is a refactored
+ * version of the chat + sidebar body of the legacy `Session()` route, but
+ * parameterised by a `GridCell` so the same UI can drive multiple
+ * workspace-scoped sessions in parallel.
+ *
+ * Behaviour notes:
+ * - The workspace-aware SDK client (`useSDK().getClient(cell.workspaceID)`)
+ *   carries the `x-mimocode-workspace` header so server traffic routes to the
+ *   correct bus without contaminating other cells' stores.
+ * - The prompt input, command registrations, and keybind handlers are
+ *   suppressed when `active` is false: inactive cells remain visible but
+ *   cannot intercept input.
+ * - Sidebar visibility follows the existing 42-col / overlay split. In a
+ *   grid layout the parent usually chooses width; the cell itself decides
+ *   overlay-vs-inline based on the parent-supplied `wide` flag.
+ */
+export function SessionCell(props: {
+  cell: GridCell
+  active: boolean
+  width?: number
+  wide?: boolean
+  /**
+   * Phase 6: optional fixed height (terminal rows). Used by `split-v` so the
+   * cell stops claiming `flexGrow={1}` and lets the splitter size both
+   * halves deterministically. When `undefined` the cell falls back to
+   * `flexGrow={1}` and tracks the parent container.
+   */
+  height?: number
+  /** Optional seed prompt (e.g. when entering the session for the first time). */
+  prompt?: PromptInfo
+}) {
+  const fullRoute = useRoute()
+  const grid = useGrid()
+  const navigate = fullRoute.navigate
+  const sync = useSync()
+  const event = useEvent()
+  const project = useProject()
+  const sdk = useSDK()
+  const workspaceClients = useWorkspaceClients()
+  const cellBus = useCellEventBus()
+  const tuiConfig = useTuiConfig()
+  const kv = useKV()
+  const { theme } = useTheme()
+  const promptRef = usePromptRef()
+  // Per-cell SDK client is acquired through the refcounted workspace pool so
+  // multiple cells viewing the same workspace share one client (and one SSE
+  // stream). Release the previous workspace's reference when the cell's
+  // workspaceID changes to keep the pool's accounting correct.
+  const cellWorkspaceID = createMemo(() => asWorkspaceID(props.cell.workspaceID))
+  const cellSDK = createMemo(() => workspaceClients.clientFor(cellWorkspaceID()))
+
+  const currentAgentID = createMemo(() => props.cell.agentID ?? "main")
+  const { messages, permissions, questions } = useSessionMessages({
+    sessionID: props.cell.sessionID,
+    agentID: currentAgentID,
+    workspaceID: props.cell.workspaceID,
+  })
+  const { visible, disabled, pending, lastAssistant } = useSessionState({
+    sessionID: props.cell.sessionID,
+    agentID: currentAgentID,
+    permissions,
+    questions,
+    session: createMemo(() => sync.session.get(props.cell.sessionID)),
+  })
+
+  const dimensions = useTerminalDimensions()
+  const [sidebar, setSidebar] = kv.signal<"auto" | "hide">("sidebar", "auto")
+  const [sidebarOpen, setSidebarOpen] = createSignal(false)
+  const [conceal, setConceal] = createSignal(true)
+  const thinking = useThinkingMode()
+  const thinkingMode = thinking.mode
+  const showThinking = createMemo(() => true)
+  const [timestamps, setTimestamps] = kv.signal<"hide" | "show">("timestamps", "hide")
+  const [showDetails, setShowDetails] = kv.signal("tool_details_visibility", true)
+  const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", false)
+  const [scrolling, setScrolling] = createSignal(false)
+  let scrollHideTimer: ReturnType<typeof setTimeout> | undefined
+  const scrollbarVisible = createMemo(() => showScrollbar() || scrolling())
+  const onWheel = (evt: MouseEvent) => {
+    if (evt.type !== "scroll") return
+    setScrolling(true)
+    if (scrollHideTimer) clearTimeout(scrollHideTimer)
+    scrollHideTimer = setTimeout(() => setScrolling(false), 1000)
+  }
+  onCleanup(() => {
+    if (scrollHideTimer) clearTimeout(scrollHideTimer)
+    // Release the cell's pool reference. The pool refcounts so cells sharing
+    // a workspace stay alive until the last cell releases; for the solo case
+    // this drops the underlying SDK client on unmount.
+    workspaceClients.pool.release(cellWorkspaceID())
+    // Phase 5: mark the cell destroyed so late-arriving event listeners
+    // and async effects short-circuit before touching disposed state.
+    destroyGuard.markDestroyed()
+    eventTracker.cleanup()
+  })
+  const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
+  const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
+
+  const cellWidth = createMemo(() => props.width ?? dimensions().width)
+  const wide = createMemo(() => props.wide ?? cellWidth() > 120)
+  const sidebarVisible = createMemo(() => {
+    if (sync.session.get(props.cell.sessionID)?.parentID) return false
+    if (currentAgentID() !== "main") return false
+    if (sidebarOpen()) return true
+    if (sidebar() === "auto" && wide()) return true
+    return false
+  })
+  const showTimestamps = createMemo(() => timestamps() === "show")
+  const contentWidth = createMemo(() => Math.max(40, cellWidth() - (sidebarVisible() ? 42 : 0) - 4))
+  const providers = createMemo(() => Model.index(sync.data.provider))
+
+  // Phase 6: derived cell state aggregated into a single memo so downstream
+  // consumers (sidebar, prompt, layout) all see a consistent snapshot.
+  // Solid memos are referentially stable as long as their inputs do not
+  // change, so wrapping the booleans in a single object is cheaper than
+  // letting each consumer re-derive them independently.
+  const cellState = createMemo(() => ({
+    width: contentWidth(),
+    active: props.active,
+    sidebarVisible: sidebarVisible(),
+    showTimestamps: showTimestamps(),
+    wide: wide(),
+    height: props.height,
+  }))
+
+  // Phase 6: snapshot the message list behind a memo so inactive cells do
+  // not invalidate `<For>` on every streaming update from a sibling cell.
+  // While the user is focused on cell A, the sync stream keeps filling
+  // cell B; the memo below returns the previous reference for cell B
+  // because its `messages()` signal isn't being re-read, only the parent
+  // effect tracks it. (The underlying sync store keeps mutating; this is
+  // purely a render-path freeze.) When the user switches focus to B the
+  // memo drops its cached value and re-renders with the live list.
+  let cachedInactive: ReturnType<typeof messages> | undefined
+  let lastActive = props.active
+  const cellMessages = createMemo(() => {
+    if (!props.active) {
+      if (lastActive) {
+        // Just deactivated — freeze at the current snapshot.
+        cachedInactive = messages()
+      } else if (cachedInactive === undefined) {
+        cachedInactive = messages()
+      }
+      lastActive = false
+      return cachedInactive
+    }
+    lastActive = true
+    cachedInactive = undefined
+    return messages()
+  })
+
+  const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
+  const toast = useToast()
+
+  createEffect(async () => {
+    if (!props.active) return
+    const previousWorkspace = project.workspace.current()
+    const client = cellSDK()
+    const result = await client.session.get({ sessionID: props.cell.sessionID }, { throwOnError: true })
+    if (!result.data) {
+      toast.show({
+        message: `Session not found: ${props.cell.sessionID}`,
+        variant: "error",
+      })
+      return
+    }
+    if (result.data.workspaceID !== previousWorkspace) {
+      project.workspace.set(result.data.workspaceID)
+      try {
+        await sync.bootstrap({ fatal: false })
+      } catch (e) {}
+    }
+    await sync.session.sync(props.cell.sessionID)
+    // Phase 6: batch the post-sync scroll nudge so it lands in the same
+    // tick as the rest of the sync-induced renders. Without `batch`, the
+    // scroll setter wakes the stickyScroll guard before messages finish
+    // reconciling, which on a multi-cell grid can compound into visible
+    // jitter when the user rapidly switches active cells via
+    // <leader>1..9.
+    batch(() => {
+      if (scroll) scroll.scrollBy(100_000)
+    })
+  })
+
+  let lastSwitch: string | undefined = undefined
+  const eventTracker = useEventTracker()
+  const destroyGuard = useDestroyGuard()
+  eventTracker.track(
+    event.on("message.part.updated", (evt) => {
+      if (destroyGuard.isDestroyed()) return
+      if (!props.active) return
+      const part = evt.properties.part
+      if (part.type !== "tool") return
+      if (part.sessionID !== props.cell.sessionID) return
+      if (part.state.status !== "completed") return
+      if (part.id === lastSwitch) return
+
+      if (part.tool === "plan_exit" && part.state.metadata?.switched) {
+        local.agent.set("build")
+        lastSwitch = part.id
+      } else if (part.tool === "plan_enter") {
+        local.agent.set("plan")
+        lastSwitch = part.id
+      }
+    }),
+  )
+
+  let seeded = false
+  let scroll: ScrollBoxRenderable
+  let prompt: PromptRef | undefined
+  // Phase 5: stickiness guard. Prevents content bursts from yanking the
+  // scrollbox back to the bottom while the user is reading history.
+  const atBottom = createSignal(true)
+  useStickyScrollGuard(() => scroll, atBottom)
+  createEffect(() => {
+    const ref = scroll
+    if (!ref || ref.isDestroyed) return
+    const distance = ref.scrollHeight - ref.scrollTop - ref.height
+    atBottom[1](distance <= 1)
+  })
+  const bind = (r: PromptRef | undefined) => {
+    prompt = r
+    if (props.active) promptRef.set(r)
+    if (seeded || !props.prompt || !r) return
+    seeded = true
+    r.set(props.prompt)
+  }
+  const keybind = useKeybind()
+  const dialog = useDialog()
+  const renderer = useRenderer()
+
+  eventTracker.track(
+    event.on("session.status", (evt) => {
+      if (destroyGuard.isDestroyed()) return
+      if (!props.active) return
+      if (evt.properties.sessionID !== props.cell.sessionID) return
+      if (evt.properties.status.type !== "retry") return
+      if (evt.properties.status.message !== SessionRetry.GO_UPSELL_MESSAGE) return
+      if (dialog.stack.length > 0) return
+
+      const seen = kv.get(GO_UPSELL_LAST_SEEN_AT)
+      if (typeof seen === "number" && Date.now() - seen < GO_UPSELL_WINDOW) return
+
+      if (kv.get(GO_UPSELL_DONT_SHOW)) return
+
+      void DialogGoUpsell.show(dialog).then((dontShowAgain) => {
+        if (destroyGuard.isDestroyed()) return
+        if (dontShowAgain) kv.set(GO_UPSELL_DONT_SHOW, true)
+        kv.set(GO_UPSELL_LAST_SEEN_AT, Date.now())
+      })
+    }),
+  )
+
+  const exit = useExit()
+
+  createEffect(() => {
+    if (!props.active) return
+    const title = Locale.truncate(sync.session.get(props.cell.sessionID)?.title ?? "", 50)
+    const pad = (text: string) => text.padEnd(10, " ")
+    const weak = (text: string) => UI.Style.TEXT_DIM + pad(text) + UI.Style.TEXT_NORMAL
+    const logo = UI.logo("  ").split(/\r?\n/)
+    return exit.message.set(
+      [
+        ...logo,
+        ``,
+        `  ${weak("Session")}${UI.Style.TEXT_NORMAL_BOLD}${title}${UI.Style.TEXT_NORMAL}`,
+        `  ${weak("Continue")}${UI.Style.TEXT_NORMAL_BOLD}bob -s ${sync.session.get(props.cell.sessionID)?.id}${UI.Style.TEXT_NORMAL}`,
+        ``,
+      ].join("\n"),
+    )
+  })
+
+  useKeyboard((evt) => {
+    if (!props.active) return
+    const parentless = !sync.session.get(props.cell.sessionID)?.parentID
+    if (parentless && currentAgentID() === "main") return
+    if (keybind.match("app_exit", evt)) {
+      const status = sync.data.session_status?.[props.cell.sessionID]
+      if (status && status.type !== "idle") {
+        void cellSDK()
+          .session.abort({ sessionID: props.cell.sessionID })
+          .catch(() => {})
+        return
+      }
+      void exit()
+    }
+  })
+
+  const findNextVisibleMessage = (direction: "next" | "prev"): string | null => {
+    const children = scroll.getChildren()
+    const messagesList = messages()
+    const scrollTop = scroll.y
+    const visibleMessages = children
+      .filter((c) => {
+        if (!c.id) return false
+        const message = messagesList.find((m) => m.id === c.id)
+        if (!message) return false
+        const parts = sync.data.part[message.id]
+        if (!parts || !Array.isArray(parts)) return false
+        return parts.some((part) => part && part.type === "text" && !part.synthetic && !part.ignored)
+      })
+      .sort((a, b) => a.y - b.y)
+    if (visibleMessages.length === 0) return null
+    if (direction === "next") {
+      return visibleMessages.find((c) => c.y > scrollTop + 10)?.id ?? null
+    }
+    return [...visibleMessages].reverse().find((c) => c.y < scrollTop - 10)?.id ?? null
+  }
+
+  const scrollToMessage = (direction: "next" | "prev", dlg: ReturnType<typeof useDialog>) => {
+    const targetID = findNextVisibleMessage(direction)
+    if (!targetID) {
+      scroll.scrollBy(direction === "next" ? scroll.height : -scroll.height)
+      dlg.clear()
+      return
+    }
+    const child = scroll.getChildren().find((c) => c.id === targetID)
+    if (child) scroll.scrollBy(child.y - scroll.y - 1)
+    dlg.clear()
+  }
+
+  function toBottom() {
+    setTimeout(() => {
+      if (!scroll || scroll.isDestroyed) return
+      scroll.scrollTo(scroll.scrollHeight)
+    }, 50)
+  }
+
+  const local = useLocal()
+  const command = useCommandDialog()
+  const t = useLanguage().t
+
+  // Command registration is scoped to the cell. We register/unregister only
+  // when the cell becomes active so the active cell owns the global command
+  // palette. Inactive cells keep their data reactive but do not steal focus.
+  // The KV-backed setters return `(next: Setter<T>) => void` (delegated to
+  // the inner Solid setter) — we wrap them into the `Setter<T>` shape that
+  // `buildCellCommands` expects, so the command callbacks can call them
+  // uniformly without sprinkling `Setter<T>` casts at every site.
+  const setSidebarTyped = setSidebar as Setter<"auto" | "hide">
+  const setConcealTyped = setConceal as Setter<boolean>
+  const setTimestampsTyped = setTimestamps as Setter<"hide" | "show">
+  const setShowDetailsTyped = setShowDetails as Setter<boolean>
+  const setShowScrollbarTyped = setShowScrollbar as Setter<boolean>
+  const setShowGenericToolOutputTyped = setShowGenericToolOutput as Setter<boolean>
+
+  command.register(() => {
+    if (!props.active) return []
+    return buildCellCommands({
+      sessionID: props.cell.sessionID,
+      agentID: currentAgentID,
+      messages,
+      permissions,
+      visible,
+      disabled,
+      sidebarVisible,
+      sidebarOpen,
+      sidebar,
+      setSidebar: setSidebarTyped,
+      setSidebarOpen,
+      conceal,
+      setConceal: setConcealTyped,
+      timestamps,
+      setTimestamps: setTimestampsTyped,
+      thinking,
+      thinkingMode,
+      showDetails,
+      setShowDetails: setShowDetailsTyped,
+      showScrollbar,
+      setShowScrollbar: setShowScrollbarTyped,
+      showGenericToolOutput,
+      setShowGenericToolOutput: setShowGenericToolOutputTyped,
+      showTimestamps,
+      scroll,
+      prompt,
+      t,
+      cellSDK: cellSDK(),
+      sdk,
+      sync,
+      toast,
+      dialog,
+      kv,
+      renderer,
+      project,
+      local,
+      navigate,
+      fullRoute,
+      toBottom,
+      scrollToMessage,
+    })
+  })
+
+  const revertInfo = createMemo(() => sync.session.get(props.cell.sessionID)?.revert)
+  const revertMessageID = createMemo(() => revertInfo()?.messageID)
+  const revertDiffFiles = createMemo(() => getRevertDiffFiles(revertInfo()?.diff ?? ""))
+  const revertRevertedMessages = createMemo(() => {
+    const messageID = revertMessageID()
+    if (!messageID) return []
+    return messages().filter((x) => x.id >= messageID && x.role === "user")
+  })
+  const revert = createMemo(() => {
+    const info = revertInfo()
+    if (!info) return
+    if (!info.messageID) return
+    return {
+      messageID: info.messageID,
+      reverted: revertRevertedMessages(),
+      diff: info.diff,
+      diffFiles: revertDiffFiles(),
+    }
+  })
+
+  createEffect(on(() => props.cell.sessionID, toBottom))
+
+  return (
+    <cellContext.Provider
+      value={{
+        get width() {
+          return cellState().width
+        },
+        sessionID: props.cell.sessionID,
+        workspaceID: props.cell.workspaceID,
+        conceal,
+        thinkingMode,
+        showThinking,
+        showTimestamps,
+        showDetails,
+        showGenericToolOutput,
+        diffWrapMode,
+        providers,
+        sync,
+        tui: tuiConfig,
+        active: () => cellState().active,
+      }}
+    >
+      <box
+        flexDirection="row"
+        height="100%"
+        onMouseUp={() => {
+          if (!props.active) {
+            grid.setActive(props.cell.id)
+          }
+        }}
+      >
+        <box
+          flexGrow={1}
+          paddingBottom={1}
+          paddingLeft={2}
+          paddingRight={2}
+          gap={1}
+          onMouse={onWheel}
+          onMouseUp={() => {
+            if (!props.active) {
+              grid.setActive(props.cell.id)
+            }
+          }}
+        >
+          <Show when={sync.session.get(props.cell.sessionID)}>
+            {/* Phase 8: empty-session bootstrap. When a cell holds a freshly
+                created session (no messages yet) we render the prompt first
+                instead of an empty scrollbox, so the user can type the first
+                message and submit it without an off-screen input. Mirrors the
+                home-screen experience for new sessions. The prompt's submit
+                already handles an existing sessionID (see prompt/index.tsx:
+                `if (sessionID == null)` skip), so this reuses the standard
+                flow and only changes the layout chrome. */}
+            <Show
+              when={cellMessages().length > 0 || !props.active}
+              fallback={
+                <EmptySessionPrompt
+                  cell={props.cell}
+                  active={props.active}
+                  visible={visible()}
+                  disabled={disabled()}
+                  promptRef={bind}
+                  onSubmit={toBottom}
+                />
+              }
+            >
+              <scrollbox
+                onMouseUp={() => {
+                  if (!props.active) {
+                    grid.setActive(props.cell.id)
+                  }
+                }}
+                ref={(r) => (scroll = r)}
+                viewportOptions={{
+                  paddingRight: 1,
+                }}
+                verticalScrollbarOptions={{
+                  paddingLeft: 1,
+                  visible: true,
+                  trackOptions: {
+                    backgroundColor: scrollbarVisible() ? theme.backgroundElement : theme.background,
+                    foregroundColor: scrollbarVisible() ? theme.border : theme.background,
+                  },
+                }}
+                stickyScroll={true}
+                stickyStart="bottom"
+                flexGrow={1}
+                scrollAcceleration={scrollAcceleration()}
+                // Phase 6: viewport culling. With culling enabled the scrollbox
+                // stops allocating render slots for off-screen messages, which
+                // combined with the existing stickyScroll guard (Phase 5)
+                // prevents a background cell from re-laying out on every
+                // streaming update. Active cells benefit too — the cost there
+                // is dominated by the live model, not the offscreen buffer.
+                viewportCulling={true}
+              >
+                <box height={1} />
+                <For each={cellMessages()}>
+                  {(message, index) => (
+                    <Switch>
+                      <Match when={message.id === revert()?.messageID}>
+                        {(() => {
+                          const command = useCommandDialog()
+                          const [hover, setHover] = createSignal(false)
+                          const dialog = useDialog()
+                          const handleUnrevert = async () => {
+                            const confirmed = await DialogConfirm.show(
+                              dialog,
+                              "Confirm Redo",
+                              "Are you sure you want to restore the reverted messages?",
+                            )
+                            if (confirmed) command.trigger("session.redo")
+                          }
+                          return (
+                            <box
+                              onMouseOver={() => setHover(true)}
+                              onMouseOut={() => setHover(false)}
+                              onMouseUp={handleUnrevert}
+                              marginTop={1}
+                              flexShrink={0}
+                              border={["left"]}
+                              customBorderChars={SplitBorder.customBorderChars}
+                              borderColor={theme.backgroundPanel}
+                            >
+                              <box
+                                paddingTop={1}
+                                paddingBottom={1}
+                                paddingLeft={2}
+                                backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
+                              >
+                                <text fg={theme.textMuted}>{revert()!.reverted.length} message reverted</text>
+                                <text fg={theme.textMuted}>
+                                  <span style={{ fg: theme.text }}>{keybind.print("messages_redo")}</span> or /redo to
+                                  restore
+                                </text>
+                                <Show when={revert()!.diffFiles?.length}>
+                                  <box marginTop={1}>
+                                    <For each={revert()!.diffFiles}>
+                                      {(file) => (
+                                        <text fg={theme.text}>
+                                          {file.filename}
+                                          <Show when={file.additions > 0}>
+                                            <span style={{ fg: theme.diffAdded }}> +{file.additions}</span>
+                                          </Show>
+                                          <Show when={file.deletions > 0}>
+                                            <span style={{ fg: theme.diffRemoved }}> -{file.deletions}</span>
+                                          </Show>
+                                        </text>
+                                      )}
+                                    </For>
+                                  </box>
+                                </Show>
+                              </box>
+                            </box>
+                          )
+                        })()}
+                      </Match>
+                      <Match when={revert()?.messageID && message.id >= revert()!.messageID}>
+                        <></>
+                      </Match>
+                      <Match when={message.role === "user"}>
+                        <UserMessage
+                          index={index()}
+                          onMouseUp={() => {
+                            if (renderer.getSelection()?.getSelectedText()) return
+                            dialog.replace(() => (
+                              <DialogMessage
+                                messageID={message.id}
+                                sessionID={props.cell.sessionID}
+                                setPrompt={(promptInfo) => prompt?.set(promptInfo)}
+                              />
+                            ))
+                          }}
+                          message={message as UserMessage}
+                          parts={sync.data.part[message.id] ?? []}
+                          pending={pending()}
+                        />
+                      </Match>
+                      <Match when={message.role === "assistant"}>
+                        <AssistantMessage
+                          last={lastAssistant()?.id === message.id}
+                          message={message as AssistantMessage}
+                          parts={sync.data.part[message.id] ?? []}
+                        />
+                      </Match>
+                    </Switch>
+                  )}
+                </For>
+              </scrollbox>
+              <box flexShrink={0}>
+                <Show when={permissions().length > 0}>
+                  <PermissionPrompt request={permissions()[0]} />
+                </Show>
+                <Show when={permissions().length === 0 && questions().length > 0}>
+                  <QuestionPrompt request={questions()[0]} />
+                </Show>
+                <Show when={sync.session.get(props.cell.sessionID)?.parentID || currentAgentID() !== "main"}>
+                  <SubagentFooter />
+                </Show>
+                <Show when={props.active && visible()}>
+                  <TuiPluginRuntime.Slot
+                    name="session_prompt"
+                    mode="replace"
+                    session_id={props.cell.sessionID}
+                    visible={visible()}
+                    disabled={disabled()}
+                    on_submit={toBottom}
+                    ref={bind}
+                  >
+                    <Prompt
+                      visible={visible()}
+                      ref={bind}
+                      disabled={disabled()}
+                      onSubmit={toBottom}
+                      sessionID={props.cell.sessionID}
+                      focusEnabled={props.active}
+                      agentID={currentAgentID()}
+                      right={<TuiPluginRuntime.Slot name="session_prompt_right" session_id={props.cell.sessionID} />}
+                    />
+                  </TuiPluginRuntime.Slot>
+                </Show>
+              </box>
+            </Show>
+          </Show>
+          <Toast />
+        </box>
+        <Show when={sidebarVisible()}>
+          <Switch>
+            <Match when={wide()}>
+              <Sidebar sessionID={props.cell.sessionID} />
+            </Match>
+            <Match when={!wide()}>
+              <box
+                position="absolute"
+                top={0}
+                left={0}
+                right={0}
+                bottom={0}
+                alignItems="flex-end"
+                backgroundColor={RGBA.fromInts(0, 0, 0, 70)}
+              >
+                <Sidebar sessionID={props.cell.sessionID} overlay={true} />
+              </box>
+            </Match>
+          </Switch>
+        </Show>
+        <Show when={!props.active}>
+          <InactiveOverlay cell={props.cell} />
+        </Show>
+      </box>
+    </cellContext.Provider>
+  )
+}
+
+/**
+ * Phase 8: Empty-session bootstrap prompt. Shown when a freshly created cell
+ * has zero messages yet. Mirrors the home-screen prompt so the user can type
+ * the first message and submit it without an off-screen input or a stub
+ * scrollbox that pushes the prompt below the fold. Uses the workspace-aware
+ * prompt flow so model selection, history, and slash commands keep working
+ * — the prompt's `submit()` short-circuits session creation because we
+ * already have a sessionID (see `component/prompt/index.tsx`).
+ */
+function EmptySessionPrompt(props: {
+  cell: GridCell
+  active: boolean
+  visible: boolean
+  disabled: boolean
+  promptRef: (ref: PromptRef | undefined) => void
+  onSubmit: () => void
+}) {
+  const { theme } = useTheme()
+  return (
+    <box flexDirection="column" flexGrow={1} alignItems="center" justifyContent="center" paddingTop={2} gap={1}>
+      <text fg={theme.textMuted}>{props.cell.label || "New Session"}</text>
+      <text fg={theme.textMuted}>Type your first message to begin.</text>
+      <box width="100%" maxWidth={75} paddingTop={1}>
+        <Prompt
+          ref={props.promptRef}
+          sessionID={props.cell.sessionID}
+          workspaceID={props.cell.workspaceID || undefined}
+          visible={props.visible}
+          disabled={props.disabled}
+          onSubmit={props.onSubmit}
+          focusEnabled={props.active}
+        />
+      </box>
+    </box>
+  )
+}
+
+/**
+ * Visual "cell is in the background" treatment. Dims the cell content with a
+ * translucent overlay so the user can still read messages but the eye is
+ * drawn to the active cell. Click-through is prevented by the box
+ * intercepting mouse events.
+ */
+function InactiveOverlay(props: { cell: GridCell }) {
+  const { theme } = useTheme()
+  const grid = useGrid()
+  return (
+    <box
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      width="100%"
+      height="100%"
+      backgroundColor={RGBA.fromInts(0, 0, 0, 100)}
+      alignItems="center"
+      justifyContent="center"
+      onMouseDown={(evt) => {
+        evt.stopPropagation()
+        grid.setActive(props.cell.id)
+      }}
+      onMouseUp={(evt) => {
+        evt.stopPropagation()
+        grid.setActive(props.cell.id)
+      }}
+    >
+      <box
+        border={["top", "bottom"]}
+        customBorderChars={SplitBorder.customBorderChars}
+        borderColor={theme.border}
+        paddingLeft={2}
+        paddingRight={2}
+        paddingTop={1}
+        paddingBottom={1}
+      >
+        <text fg={theme.textMuted}>
+          <span style={{ fg: theme.text }}>{props.cell.label || "cell"}</span>
+          <span style={{ fg: theme.textMuted }}> · inactive</span>
+        </text>
+      </box>
+    </box>
+  )
+}
+
+/**
+ * All command-dialog entries owned by an active cell. Pulled into a helper so
+ * the cell component stays close to the rendering tree without losing the
+ * full set of slash/keybind commands. The legacy `Session()` route also
+ * uses the same helper to keep behaviour in sync.
+ *
+ * Setters here use the standard Solid `Setter<T>` shape so the command
+ * callbacks can call them as `setFoo(prev => ...)` uniformly. The KV-backed
+ * setters returned by `kv.signal` are cast at the call site (see
+ * `SessionCell`).
+ */
+function buildCellCommands(args: {
+  sessionID: string
+  agentID: Accessor<string>
+  messages: Accessor<any[]>
+  permissions: Accessor<any[]>
+  visible: Accessor<boolean>
+  disabled: Accessor<boolean>
+  sidebarVisible: Accessor<boolean>
+  sidebarOpen: Accessor<boolean>
+  sidebar: Accessor<"auto" | "hide">
+  setSidebar: Setter<"auto" | "hide">
+  setSidebarOpen: Setter<boolean>
+  conceal: Accessor<boolean>
+  setConceal: Setter<boolean>
+  timestamps: Accessor<"hide" | "show">
+  setTimestamps: Setter<"hide" | "show">
+  thinking: ReturnType<typeof useThinkingMode>
+  thinkingMode: Accessor<ThinkingMode>
+  showDetails: Accessor<boolean>
+  setShowDetails: Setter<boolean>
+  showScrollbar: Accessor<boolean>
+  setShowScrollbar: Setter<boolean>
+  showGenericToolOutput: Accessor<boolean>
+  setShowGenericToolOutput: Setter<boolean>
+  showTimestamps: Accessor<boolean>
+  scroll: ScrollBoxRenderable | undefined
+  prompt: PromptRef | undefined
+  t: ReturnType<typeof useLanguage>["t"]
+  cellSDK: ReturnType<typeof useSDK>["client"]
+  sdk: ReturnType<typeof useSDK>
+  sync: ReturnType<typeof useSync>
+  toast: ReturnType<typeof useToast>
+  dialog: ReturnType<typeof useDialog>
+  kv: ReturnType<typeof useKV>
+  renderer: ReturnType<typeof useRenderer>
+  project: ReturnType<typeof useProject>
+  local: ReturnType<typeof useLocal>
+  navigate: ReturnType<typeof useRoute>["navigate"]
+  fullRoute: ReturnType<typeof useRoute>
+  toBottom: () => void
+  scrollToMessage: (direction: "next" | "prev", dialog: ReturnType<typeof useDialog>) => void
+}) {
+  const session = args
+  return [
+    {
+      title: args.t(
+        args.sync.session.get(session.sessionID)?.share?.url
+          ? "tui.command.session.share.copy_link"
+          : "tui.command.session.share.title",
+      ),
+      value: "session.share",
+      suggested: true,
+      keybind: "session_share",
+      category: "session",
+      enabled: args.sync.data.config.share !== "disabled",
+      slash: { name: "share" },
+      onSelect: async (dialog: DialogContext) => {
+        const copy = (url: string) =>
+          Clipboard.copy(url)
+            .then(() => args.toast.show({ message: "Share URL copied to clipboard!", variant: "success" }))
+            .catch(() => args.toast.show({ message: "Failed to copy URL to clipboard", variant: "error" }))
+        const url = args.sync.session.get(session.sessionID)?.share?.url
+        if (url) {
+          await copy(url)
+          dialog.clear()
+          return
+        }
+        if (!args.kv.get("share_consent", false)) {
+          const ok = await DialogConfirm.show(dialog, "Share Session", "Are you sure you want to share it?")
+          if (ok !== true) return
+          args.kv.set("share_consent", true)
+        }
+        await args.cellSDK.session
+          .share({ sessionID: session.sessionID })
+          .then((res: any) => copy(res.data!.share!.url))
+          .catch((error: unknown) => {
+            args.toast.show({
+              message: error instanceof Error ? error.message : "Failed to share session",
+              variant: "error",
+            })
+          })
+        dialog.clear()
+      },
+    },
+    {
+      title: args.t("tui.command.session.rename.title"),
+      value: "session.rename",
+      keybind: "session_rename",
+      category: "session",
+      slash: { name: "rename" },
+      onSelect: (dialog: DialogContext) => {
+        dialog.replace(() => <DialogSessionRename session={session.sessionID} />)
+      },
+    },
+    {
+      title: args.t(args.sidebarVisible() ? "tui.command.session.sidebar.hide" : "tui.command.session.sidebar.show"),
+      value: "session.sidebar.toggle",
+      keybind: "sidebar_toggle",
+      category: "session",
+      onSelect: (dialog: DialogContext) => {
+        batch(() => {
+          const isVisible = args.sidebarVisible()
+          args.setSidebar(() => (isVisible ? "hide" : "auto"))
+          args.setSidebarOpen(!isVisible)
+        })
+        dialog.clear()
+      },
+    },
+    {
+      title: args.t(args.conceal() ? "tui.command.session.conceal.disable" : "tui.command.session.conceal.enable"),
+      value: "session.toggle.conceal",
+      keybind: "messages_toggle_conceal",
+      category: "session",
+      onSelect: (dialog: DialogContext) => {
+        args.setConceal((prev) => !prev)
+        dialog.clear()
+      },
+    },
+    {
+      title: args.t(
+        args.showTimestamps() ? "tui.command.session.timestamps.hide" : "tui.command.session.timestamps.show",
+      ),
+      value: "session.toggle.timestamps",
+      category: "session",
+      slash: { name: "timestamps", aliases: ["toggle-timestamps"] },
+      onSelect: (dialog: DialogContext) => {
+        args.setTimestamps((prev) => (prev === "show" ? "hide" : "show"))
+        dialog.clear()
+      },
+    },
+    {
+      title: args.t(
+        nextThinkingMode(args.thinkingMode()) === "hide"
+          ? "tui.command.session.thinking.collapse"
+          : "tui.command.session.thinking.expand",
+      ),
+      value: "session.toggle.thinking",
+      keybind: "display_thinking",
+      category: "session",
+      slash: { name: "thinking", aliases: ["toggle-thinking"] },
+      onSelect: (dialog: DialogContext) => {
+        args.thinking.set(nextThinkingMode(args.thinkingMode()))
+        dialog.clear()
+      },
+    },
+    {
+      title: args.t(
+        args.showDetails() ? "tui.command.session.tool_details.hide" : "tui.command.session.tool_details.show",
+      ),
+      value: "session.toggle.actions",
+      keybind: "tool_details",
+      category: "session",
+      onSelect: (dialog: DialogContext) => {
+        args.setShowDetails((prev) => !prev)
+        dialog.clear()
+      },
+    },
+    {
+      title: args.t("tui.command.session.scrollbar.toggle"),
+      value: "session.toggle.scrollbar",
+      keybind: "scrollbar_toggle",
+      category: "session",
+      onSelect: (dialog: DialogContext) => {
+        args.setShowScrollbar((prev) => !prev)
+        dialog.clear()
+      },
+    },
+    {
+      title: args.t(
+        args.showGenericToolOutput()
+          ? "tui.command.session.generic_tool_output.hide"
+          : "tui.command.session.generic_tool_output.show",
+      ),
+      value: "session.toggle.generic_tool_output",
+      category: "session",
+      onSelect: (dialog: DialogContext) => {
+        args.setShowGenericToolOutput((prev) => !prev)
+        dialog.clear()
+      },
+    },
+    {
+      title: args.t("tui.command.session.export.title"),
+      value: "session.export",
+      keybind: "session_export",
+      category: "session",
+      slash: { name: "export" },
+      onSelect: async (dialog: DialogContext) => {
+        try {
+          const sessionData = args.sync.session.get(session.sessionID)
+          if (!sessionData) return
+          const sessionMessages = session.messages()
+          const defaultFilename = `session-${sessionData.id.slice(0, 8)}.md`
+          const options = await DialogExportOptions.show(
+            dialog,
+            defaultFilename,
+            session.showTimestamps(),
+            args.showDetails(),
+            args.kv.get("assistant_metadata_visibility", true),
+            false,
+          )
+          if (options === null) return
+          const transcript = formatTranscript(
+            sessionData,
+            sessionMessages.map((msg: any) => ({ info: msg, parts: args.sync.data.part[msg.id] ?? [] })),
+            {
+              thinking: options.thinking,
+              toolDetails: options.toolDetails,
+              assistantMetadata: options.assistantMetadata,
+              providers: args.sync.data.provider,
+            },
+          )
+          if (options.openWithoutSaving) {
+            await Editor.open({ value: transcript, renderer: args.renderer })
+          } else {
+            const exportDir = process.cwd()
+            const filename = options.filename.trim()
+            const filepath = path.join(exportDir, filename)
+            await Filesystem.write(filepath, transcript)
+            const result = await Editor.open({ value: transcript, renderer: args.renderer })
+            if (result !== undefined) await Filesystem.write(filepath, result)
+            args.toast.show({ message: `Session exported to ${filename}`, variant: "success" })
+          }
+        } catch {
+          args.toast.show({ message: "Failed to export session", variant: "error" })
+        }
+        dialog.clear()
+      },
+    },
+    {
+      title: args.t("tui.command.session.undo.title"),
+      value: "session.undo",
+      keybind: "messages_undo",
+      category: "session",
+      slash: { name: "undo" },
+      onSelect: async (dialog: DialogContext) => {
+        const status = args.sync.data.session_status?.[session.sessionID]
+        if (status?.type !== "idle") await args.cellSDK.session.abort({ sessionID: session.sessionID }).catch(() => {})
+        const revert = args.sync.session.get(session.sessionID)?.revert?.messageID
+        const message = session.messages().findLast((x: any) => (!revert || x.id < revert) && x.role === "user")
+        if (!message) return
+        void args.cellSDK.session
+          .revert({ sessionID: session.sessionID, messageID: message.id })
+          .then(() => args.toBottom())
+        const parts = args.sync.data.part[message.id]
+        session.prompt?.set(
+          parts.reduce(
+            (agg: any, part: any) => {
+              if (part.type === "text") if (!part.synthetic) agg.input += part.text
+              if (part.type === "file") agg.parts.push(part)
+              return agg
+            },
+            { input: "", parts: [] as PromptInfo["parts"] },
+          ),
+        )
+        dialog.clear()
+      },
+    },
+  ]
+}
+
+const PART_MAPPING = {
+  text: TextPart,
+  tool: ToolPart,
+  reasoning: ReasoningPart,
+  bob_summary: BobSummaryPart,
+}
+
+const MIME_BADGE: Record<string, string> = {
+  "text/plain": "txt",
+  "image/png": "img",
+  "image/jpeg": "img",
+  "image/gif": "img",
+  "image/webp": "img",
+  "application/pdf": "pdf",
+  "application/x-directory": "dir",
+}
+
+function UserMessage(props: {
+  message: UserMessage
+  parts: Part[]
+  onMouseUp: () => void
+  index: number
+  pending?: string
+}) {
+  const ctx = useCell()
+  const local = useLocal()
+  const text = createMemo(() => props.parts.flatMap((x) => (x.type === "text" && !x.synthetic ? [x] : []))[0])
+  const files = createMemo(() => props.parts.flatMap((x) => (x.type === "file" ? [x] : [])))
+  const { theme } = useTheme()
+  const [hover, setHover] = createSignal(false)
+  const queued = createMemo(() => props.pending && props.message.id > props.pending)
+  const color = createMemo(() => local.agent.color(props.message.agent))
+  const queuedFg = createMemo(() => selectedForeground(theme, color()))
+  const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
+
+  return (
+    <Show when={text()}>
+      <box
+        id={props.message.id}
+        border={["left"]}
+        borderColor={color()}
+        customBorderChars={SplitBorder.customBorderChars}
+        marginTop={props.index === 0 ? 0 : 1}
+      >
+        <box
+          onMouseOver={() => setHover(true)}
+          onMouseOut={() => setHover(false)}
+          onMouseUp={props.onMouseUp}
+          paddingTop={1}
+          paddingBottom={1}
+          paddingLeft={2}
+          backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
+          flexShrink={0}
+        >
+          <text fg={theme.text}>{text()?.text}</text>
+          <Show when={files().length}>
+            <box flexDirection="row" paddingBottom={metadataVisible() ? 1 : 0} paddingTop={1} gap={1} flexWrap="wrap">
+              <For each={files()}>
+                {(file) => {
+                  const bg = createMemo(() => {
+                    if (file.mime.startsWith("image/")) return theme.accent
+                    if (file.mime === "application/pdf") return theme.primary
+                    return theme.secondary
+                  })
+                  return (
+                    <text fg={theme.text}>
+                      <span style={{ bg: bg(), fg: theme.background }}> {MIME_BADGE[file.mime] ?? file.mime} </span>
+                      <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}> {file.filename} </span>
+                    </text>
+                  )
+                }}
+              </For>
+            </box>
+          </Show>
+          <Show
+            when={queued()}
+            fallback={
+              <Show when={ctx.showTimestamps()}>
+                <text fg={theme.textMuted}>
+                  <span style={{ fg: theme.textMuted }}>{Locale.todayTimeOrDateTime(props.message.time.created)}</span>
+                </text>
+              </Show>
+            }
+          >
+            <text fg={theme.textMuted}>
+              <span style={{ bg: color(), fg: queuedFg(), bold: true }}> QUEUED </span>
+            </text>
+          </Show>
+        </box>
+      </box>
+    </Show>
+  )
+}
+
+function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; last: boolean }) {
+  const ctx = useCell()
+  const local = useLocal()
+  const { theme } = useTheme()
+  const sync = useSync()
+  const messages = createMemo(() => sync.data.message[props.message.sessionID]?.[props.message.agentID ?? "main"] ?? [])
+  const model = createMemo(() => Model.name(ctx.providers(), props.message.providerID, props.message.modelID))
+  const final = createMemo(() => props.message.finish && props.message.finish !== "tool-calls")
+  const duration = createMemo(() => {
+    if (!final()) return 0
+    if (!props.message.time.completed) return 0
+    const user = messages().find((x) => x.role === "user" && x.id === props.message.parentID)
+    if (!user || !user.time) return 0
+    return props.message.time.completed - user.time.created
+  })
+  const keybind = useKeybind()
+  const verdict = createMemo(() => sync.data.session_goal?.[props.message.sessionID]?.verdicts?.[props.message.id])
+  const [verdictOpen, setVerdictOpen] = createSignal(false)
+  const verdictMark = createMemo(() => {
+    const v = verdict()
+    if (!v) return undefined
+    if (v.error) return { icon: "!", fg: theme.textMuted, label: "Judge: error (stopped)" }
+    if (v.ok) return { icon: "✓", fg: theme.success, label: "Judge: met" }
+    if (v.impossible) return { icon: "⊘", fg: theme.error, label: "Judge: impossible" }
+    return { icon: "⟳", fg: theme.warning, label: `Judge [round ${v.attempt}]: not met` }
+  })
+  return (
+    <>
+      <For each={props.parts}>
+        {(part, index) => {
+          const component = createMemo(() => PART_MAPPING[part.type as keyof typeof PART_MAPPING])
+          return (
+            <Show when={component()}>
+              <Dynamic
+                last={index() === props.parts.length - 1}
+                component={component()}
+                part={part as any}
+                message={props.message}
+              />
+            </Show>
+          )
+        }}
+      </For>
+      <Show when={props.parts.some((x) => x.type === "tool" && x.tool === "actor")}>
+        <box paddingTop={1} paddingLeft={3}>
+          <text fg={theme.text}>
+            {keybind.print("session_child_first")}
+            <span style={{ fg: theme.textMuted }}> view subagents</span>
+          </text>
+        </box>
+      </Show>
+      <Show when={props.message.error && props.message.error.name !== "MessageAbortedError"}>
+        <ErrorBlock error={props.message.error!} />
+      </Show>
+      <Switch>
+        <Match when={props.last || final() || props.message.error?.name === "MessageAbortedError"}>
+          <box paddingLeft={3}>
+            <text marginTop={1}>
+              <span
+                style={{
+                  fg:
+                    props.message.error?.name === "MessageAbortedError"
+                      ? theme.textMuted
+                      : local.agent.color(props.message.agent),
+                }}
+              >
+                ▣{" "}
+              </span>{" "}
+              <span style={{ fg: theme.text }}>{Locale.titlecase(props.message.mode)}</span>
+              <span style={{ fg: theme.textMuted }}> · {model()}</span>
+              <Show when={duration()}>
+                <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
+              </Show>
+              <Show when={props.message.error?.name === "MessageAbortedError"}>
+                <span style={{ fg: theme.textMuted }}> · interrupted</span>
+              </Show>
+            </text>
+          </box>
+        </Match>
+      </Switch>
+      <Show when={verdictMark()}>
+        {(mark) => (
+          <box paddingLeft={3} onMouseUp={() => setVerdictOpen((x) => !x)}>
+            <text>
+              <span style={{ fg: theme.textMuted }}>{verdictOpen() ? "▼" : "▶"} </span>
+              <span style={{ fg: mark().fg }}>
+                {mark().icon} {mark().label}
+              </span>
+            </text>
+            <Show when={verdictOpen()}>
+              <box paddingLeft={2}>
+                <text fg={theme.textMuted} wrapMode="word">
+                  {verdict()!.reason}
+                </text>
+              </box>
+            </Show>
+          </box>
+        )}
+      </Show>
+    </>
+  )
+}
+
+type MessageError = NonNullable<AssistantMessage["error"]>
+
+function errorBody(error: MessageError): string {
+  if (error.name === "MessageOutputLengthError") return "Output length limit reached"
+  return (error.data as { message?: string }).message ?? "Unknown error"
+}
+
+function errorMeta(error: MessageError): string | undefined {
+  if (error.name === "APIError") {
+    const parts: string[] = []
+    if (error.data.statusCode !== undefined) parts.push(`status ${error.data.statusCode}`)
+    parts.push(error.data.isRetryable ? "retryable" : "non-retryable")
+    return parts.join(" · ")
+  }
+  if (error.name === "ProviderAuthError") return `provider: ${error.data.providerID}`
+  if (error.name === "StructuredOutputError") return `retries: ${error.data.retries}`
+  return undefined
+}
+
+function ErrorBlock(props: { error: MessageError }) {
+  const { theme } = useTheme()
+  const meta = createMemo(() => errorMeta(props.error))
+  return (
+    <box flexDirection="column" paddingLeft={3} marginTop={1}>
+      <text fg={theme.error} wrapMode="word">
+        <span style={{ fg: theme.error }}>✗ </span>
+        {errorBody(props.error)}
+      </text>
+      <Show when={meta()}>
+        <box paddingLeft={3}>
+          <text fg={theme.textMuted} wrapMode="word">
+            {meta()}
+          </text>
+        </box>
+      </Show>
+    </box>
+  )
+}
+
+function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: AssistantMessage }) {
+  const { theme, subtleSyntax } = useTheme()
+  const ctx = useCell()
+  const [expanded, setExpanded] = createSignal(false)
+  const content = createMemo(() => props.part.text.replace("[REDACTED]", "").trim())
+  const isDone = createMemo(() => props.part.time.end !== undefined)
+  const inMinimal = createMemo(() => ctx.thinkingMode() === "hide")
+  const duration = createMemo(() => {
+    const end = props.part.time.end
+    return end === undefined ? 0 : Math.max(0, end - props.part.time.start)
+  })
+  const summary = createMemo(() => reasoningSummary(content()))
+  const toggle = () => {
+    if (!inMinimal()) return
+    setExpanded((prev) => !prev)
+  }
+  return (
+    <Show when={content()}>
+      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexDirection="column" flexShrink={0}>
+        <box onMouseUp={toggle}>
+          <ReasoningHeader
+            toggleable={inMinimal()}
+            open={!inMinimal() || expanded()}
+            done={isDone()}
+            title={summary().title}
+            duration={isDone() ? Locale.duration(duration()) : undefined}
+          />
+        </box>
+        <Show when={(!inMinimal() || expanded()) && summary().body}>
+          <box paddingLeft={inMinimal() ? 2 : 0} marginTop={1}>
+            <code
+              filetype="markdown"
+              drawUnstyledText={false}
+              streaming={true}
+              syntaxStyle={subtleSyntax()}
+              content={summary().body}
+              conceal={ctx.conceal()}
+              fg={theme.textMuted}
+            />
+          </box>
+        </Show>
+      </box>
+    </Show>
+  )
+}
+
+function ReasoningHeader(props: {
+  toggleable: boolean
+  open: boolean
+  done: boolean
+  title: string | null
+  duration?: string
+}) {
+  const { theme } = useTheme()
+  const fg = () =>
+    props.open
+      ? RGBA.fromValues(theme.warning.r, theme.warning.g, theme.warning.b, theme.thinkingOpacity)
+      : theme.warning
+  return (
+    <Switch>
+      <Match when={!props.done}>
+        <box flexDirection="row">
+          <Spinner color={fg()}>{props.title ? "Thinking: " + props.title : "Thinking"}</Spinner>
+        </box>
+      </Match>
+      <Match when={true}>
+        <text fg={fg()} wrapMode="none">
+          <Show when={props.toggleable}>
+            <span>{props.open ? "- " : "+ "}</span>
+          </Show>
+          <span>Thought</span>
+          <Show when={props.title || props.duration}>
+            <span>: </span>
+          </Show>
+          <Show when={props.title}>
+            <span>{props.title}</span>
+          </Show>
+          <Show when={props.duration}>
+            <span>
+              {props.title ? " · " : ""}
+              {props.duration}
+            </span>
+          </Show>
+        </text>
+      </Match>
+    </Switch>
+  )
+}
+
+function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
+  const ctx = useCell()
+  const { theme, syntax } = useTheme()
+  return (
+    <Show when={props.part.text.trim()}>
+      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
+        <Switch>
+          <Match when={Flag.MIMOCODE_EXPERIMENTAL_MARKDOWN}>
+            <markdown
+              syntaxStyle={syntax()}
+              streaming={true}
+              content={props.part.text.trim()}
+              conceal={ctx.conceal()}
+              fg={theme.markdownText}
+              bg={theme.background}
+            />
+          </Match>
+          <Match when={!Flag.MIMOCODE_EXPERIMENTAL_MARKDOWN}>
+            <code
+              filetype="markdown"
+              drawUnstyledText={false}
+              streaming={true}
+              syntaxStyle={syntax()}
+              content={props.part.text.trim()}
+              conceal={ctx.conceal()}
+              fg={theme.text}
+            />
+          </Match>
+        </Switch>
+      </box>
+    </Show>
+  )
+}
+
+function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMessage }) {
+  const ctx = useCell()
+  const sync = useSync()
+  const shouldHide = createMemo(() => {
+    if (ctx.showDetails()) return false
+    if (props.part.state.status !== "completed") return false
+    return true
+  })
+  const toolprops = {
+    get metadata() {
+      return props.part.state.status === "pending" ? {} : (props.part.state.metadata ?? {})
+    },
+    get input() {
+      return props.part.state.input ?? {}
+    },
+    get output() {
+      return props.part.state.status === "completed" ? props.part.state.output : undefined
+    },
+    get permission() {
+      const permissions = sync.data.permission[props.message.sessionID] ?? []
+      const permissionIndex = permissions.findIndex((x) => x.tool?.callID === props.part.callID)
+      return permissions[permissionIndex]
+    },
+    get tool() {
+      return props.part.tool
+    },
+    get part() {
+      return props.part
+    },
+  }
+  return (
+    <Show when={!shouldHide()}>
+      <Switch>
+        <Match when={props.part.tool === "bash"}>
+          <Bash {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "glob"}>
+          <Glob {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "read"}>
+          <Read {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "grep"}>
+          <Grep {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "webfetch"}>
+          <WebFetch {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "codesearch"}>
+          <CodeSearch {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "websearch"}>
+          <WebSearch {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "write"}>
+          <Write {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "edit"}>
+          <Edit {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "actor"}>
+          <Task {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "task"}>
+          <WorkItemTask {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "apply_patch"}>
+          <ApplyPatch {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "question"}>
+          <Question {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "skill"}>
+          <Skill {...toolprops} />
+        </Match>
+        <Match when={props.part.tool === "plan_exit"}>
+          <PlanExit {...toolprops} />
+        </Match>
+        <Match when={true}>
+          <GenericTool {...toolprops} />
+        </Match>
+      </Switch>
+    </Show>
+  )
+}
+
+type ToolProps<T> = {
+  input: Partial<Tool.InferParameters<T>>
+  metadata: Partial<Tool.InferMetadata<T>>
+  permission: Record<string, any>
+  tool: string
+  output?: string
+  part: ToolPart
+}
+
+function PlanExit(props: ToolProps<any>) {
+  const { theme } = useTheme()
+  const dismissed = createMemo(
+    () => props.part.state.status === "completed" && props.part.state.metadata?.switched === false,
+  )
+  const feedback = createMemo(() => (dismissed() ? props.metadata.feedback : undefined))
+  return (
+    <>
+      <InlineTool icon="⚙" pending="Asking..." complete={true} part={props.part} dismissed={dismissed()}>
+        plan_exit
+      </InlineTool>
+      <Show when={feedback()}>
+        <box paddingLeft={6}>
+          <text fg={theme.textMuted}>{feedback()}</text>
+        </box>
+      </Show>
+    </>
+  )
+}
+
+function GenericTool(props: ToolProps<any>) {
+  const { theme } = useTheme()
+  const ctx = useCell()
+  const output = createMemo(() => props.output?.trim() ?? "")
+  const [expanded, setExpanded] = createSignal(false)
+  const lines = createMemo(() => output().split("\n"))
+  const maxLines = 3
+  const overflow = createMemo(() => lines().length > maxLines)
+  const limited = createMemo(() => {
+    if (expanded() || !overflow()) return output()
+    return [...lines().slice(0, maxLines), "…"].join("\n")
+  })
+  return (
+    <Show
+      when={props.output && ctx.showGenericToolOutput()}
+      fallback={
+        <InlineTool icon="⚙" pending="Writing command..." complete={true} part={props.part}>
+          {props.tool} {input(props.input)}
+        </InlineTool>
+      }
+    >
+      <BlockTool
+        title={`# ${props.tool} ${input(props.input)}`}
+        part={props.part}
+        onClick={overflow() ? () => setExpanded((prev) => !prev) : undefined}
+      >
+        <box gap={1}>
+          <text fg={theme.text}>{limited()}</text>
+          <Show when={overflow()}>
+            <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
+          </Show>
+        </box>
+      </BlockTool>
+    </Show>
+  )
+}
+
+function WorkItemTask(props: ToolProps<typeof TaskTool>) {
+  const summary = createMemo(() => {
+    const op = (props.input as { operation?: Record<string, any> }).operation
+    if (!op || typeof op !== "object") return "task"
+    const verb = typeof op.action === "string" ? op.action : "task"
+    if (verb === "create") return op.summary ? `create "${op.summary}"` : "create"
+    if (verb === "list") return op.status ? `list ${op.status}` : "list"
+    if (op.id) return `${verb} ${op.id}`
+    return verb
+  })
+  return (
+    <InlineTool icon="#" pending="Updating tasks..." complete={true} part={props.part}>
+      task {summary()}
+    </InlineTool>
+  )
+}
+
+function CollapsibleError(props: { error: string; paddingLeft?: number }) {
+  const { theme } = useTheme()
+  const renderer = useRenderer()
+  const [expanded, setExpanded] = createSignal(false)
+  const lineCount = createMemo(() => props.error.split("\n").length)
+  return (
+    <box
+      paddingLeft={props.paddingLeft}
+      onMouseUp={(evt) => {
+        evt.stopPropagation()
+        if (renderer.getSelection()?.getSelectedText()) return
+        setExpanded((prev) => !prev)
+      }}
+    >
+      <Show
+        when={expanded()}
+        fallback={
+          <text fg={theme.error}>
+            + Error ({lineCount()} {lineCount() === 1 ? "line" : "lines"})
+          </text>
+        }
+      >
+        <text fg={theme.error}>- Error</text>
+        <box paddingLeft={2}>
+          <text fg={theme.error}>{props.error}</text>
+        </box>
+      </Show>
+    </box>
+  )
+}
+
+function InlineTool(props: {
+  icon: string
+  iconColor?: RGBA
+  complete: any
+  pending: string
+  spinner?: boolean
+  dismissed?: boolean
+  children: JSX.Element
+  part: ToolPart
+  onClick?: () => void
+}) {
+  const [margin, setMargin] = createSignal(0)
+  const { theme } = useTheme()
+  const ctx = useCell()
+  const sync = useSync()
+  const renderer = useRenderer()
+  const [hover, setHover] = createSignal(false)
+  const permission = createMemo(() => {
+    const callID = sync.data.permission[ctx.sessionID]?.at(0)?.tool?.callID
+    if (!callID) return false
+    return callID === props.part.callID
+  })
+  const fg = createMemo(() => {
+    if (permission()) return theme.warning
+    if (hover() && props.onClick) return theme.text
+    if (props.complete) return theme.textMuted
+    return theme.text
+  })
+  const error = createMemo(() => (props.part.state.status === "error" ? props.part.state.error : undefined))
+  const denied = createMemo(
+    () =>
+      error()?.includes("QuestionRejectedError") ||
+      error()?.includes("rejected permission") ||
+      error()?.includes("specified a rule") ||
+      error()?.includes("user dismissed"),
+  )
+  return (
+    <box
+      marginTop={margin()}
+      paddingLeft={3}
+      onMouseOver={() => props.onClick && setHover(true)}
+      onMouseOut={() => setHover(false)}
+      onMouseUp={() => {
+        if (renderer.getSelection()?.getSelectedText()) return
+        props.onClick?.()
+      }}
+      renderBefore={function () {
+        const el = this as BoxRenderable
+        const parent = el.parent
+        if (!parent) return
+        if (el.height > 1) {
+          setMargin(1)
+          return
+        }
+        const children = parent.getChildren()
+        const index = children.indexOf(el)
+        const previous = children[index - 1]
+        if (!previous) {
+          setMargin(0)
+          return
+        }
+        if (previous.height > 1 || previous.id.startsWith("text-")) {
+          setMargin(1)
+          return
+        }
+      }}
+    >
+      <Switch>
+        <Match when={props.spinner}>
+          <Spinner color={fg()} children={props.children} />
+        </Match>
+        <Match when={true}>
+          <text
+            paddingLeft={3}
+            fg={fg()}
+            attributes={denied() || props.dismissed ? TextAttributes.STRIKETHROUGH : undefined}
+          >
+            <Show fallback={<>~ {props.pending}</>} when={props.complete}>
+              <span style={{ fg: props.iconColor }}>{props.icon}</span> {props.children}
+            </Show>
+          </text>
+        </Match>
+      </Switch>
+      <Show when={error() && !denied()}>
+        <CollapsibleError error={error()!} paddingLeft={3} />
+      </Show>
+    </box>
+  )
+}
+
+function BlockTool(props: {
+  title: string
+  children: JSX.Element
+  onClick?: () => void
+  part?: ToolPart
+  spinner?: boolean
+}) {
+  const { theme } = useTheme()
+  const renderer = useRenderer()
+  const [hover, setHover] = createSignal(false)
+  const error = createMemo(() => (props.part?.state.status === "error" ? props.part.state.error : undefined))
+  return (
+    <box
+      border={["left"]}
+      paddingTop={1}
+      paddingBottom={1}
+      paddingLeft={2}
+      marginTop={1}
+      gap={1}
+      backgroundColor={hover() ? theme.backgroundMenu : theme.backgroundPanel}
+      customBorderChars={SplitBorder.customBorderChars}
+      borderColor={theme.background}
+      onMouseOver={() => props.onClick && setHover(true)}
+      onMouseOut={() => setHover(false)}
+      onMouseUp={() => {
+        if (renderer.getSelection()?.getSelectedText()) return
+        props.onClick?.()
+      }}
+    >
+      <Show
+        when={props.spinner}
+        fallback={
+          <text paddingLeft={3} fg={theme.textMuted}>
+            {props.title}
+          </text>
+        }
+      >
+        <Spinner color={theme.textMuted}>{props.title.replace(/^# /, "")}</Spinner>
+      </Show>
+      {props.children}
+      <Show when={error()}>
+        <CollapsibleError error={error()!} />
+      </Show>
+    </box>
+  )
+}
+
+const TOOL_COLLAPSE_MAX_LINES = 3
+const TOOL_COLLAPSE_MAX_LINE_LENGTH = 120
+
+function displayLines(content: string) {
+  if (!content) return []
+  return content.replace(/\n$/, "").split("\n")
+}
+
+function hasLongDisplayLine(content: string) {
+  return displayLines(content).some((line) => line.length > TOOL_COLLAPSE_MAX_LINE_LENGTH)
+}
+
+function Bash(props: ToolProps<typeof BashTool>) {
+  const { theme } = useTheme()
+  const sync = useSync()
+  const isRunning = createMemo(() => props.part.state.status === "running")
+  const output = createMemo(() => stripAnsi(props.metadata.output?.trim() ?? ""))
+  const [expanded, setExpanded] = createSignal(false)
+  const lines = createMemo(() => output().split("\n"))
+  const overflow = createMemo(() => lines().length > 10)
+  const limited = createMemo(() => {
+    if (expanded() || !overflow()) return output()
+    return [...lines().slice(0, 10), "…"].join("\n")
+  })
+  const workdirDisplay = createMemo(() => {
+    const workdir = props.input.workdir
+    if (!workdir || workdir === ".") return undefined
+    const base = sync.path.directory
+    if (!base) return undefined
+    const absolute = path.resolve(base, workdir)
+    if (absolute === base) return undefined
+    const home = Global.Path.home
+    if (!home) return absolute
+    const match = absolute === home || absolute.startsWith(home + path.sep)
+    return match ? absolute.replace(home, "~") : absolute
+  })
+  const title = createMemo(() => {
+    const desc = props.input.description ?? "Shell"
+    const wd = workdirDisplay()
+    if (!wd) return `# ${desc}`
+    if (desc.includes(wd)) return `# ${desc}`
+    return `# ${desc} in ${wd}`
+  })
+  return (
+    <Switch>
+      <Match when={props.metadata.output !== undefined}>
+        <BlockTool
+          title={title()}
+          part={props.part}
+          spinner={isRunning()}
+          onClick={overflow() ? () => setExpanded((prev) => !prev) : undefined}
+        >
+          <box gap={1}>
+            <text fg={theme.text}>$ {props.input.command}</text>
+            <Show when={output()}>
+              <text fg={theme.text}>{limited()}</text>
+            </Show>
+            <Show when={overflow()}>
+              <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
+            </Show>
+          </box>
+        </BlockTool>
+      </Match>
+      <Match when={true}>
+        <InlineTool icon="$" pending="Writing command..." complete={props.input.command} part={props.part}>
+          {props.input.command}
+        </InlineTool>
+      </Match>
+    </Switch>
+  )
+}
+
+function Write(props: ToolProps<typeof WriteTool>) {
+  const { theme, syntax } = useTheme()
+  const [expanded, setExpanded] = createSignal(false)
+  const code = createMemo(() => props.input.content ?? "")
+  const lineCount = createMemo(() => displayLines(code()).length)
+  const collapsed = createMemo(() => lineCount() > TOOL_COLLAPSE_MAX_LINES || hasLongDisplayLine(code()))
+  return (
+    <Switch>
+      <Match when={props.metadata.diagnostics !== undefined}>
+        <BlockTool
+          title={"# Wrote " + normalizePath(props.input.filePath!)}
+          part={props.part}
+          onClick={collapsed() ? () => setExpanded((prev) => !prev) : undefined}
+        >
+          <Show
+            when={!collapsed() || expanded()}
+            fallback={
+              <text fg={theme.textMuted}>
+                Click to expand ({lineCount()} {lineCount() === 1 ? "line" : "lines"})
+              </text>
+            }
+          >
+            <line_number fg={theme.textMuted} minWidth={3} paddingRight={1}>
+              <code
+                conceal={false}
+                fg={theme.text}
+                filetype={filetype(props.input.filePath!)}
+                syntaxStyle={syntax()}
+                content={code()}
+              />
+            </line_number>
+            <Show when={collapsed()}>
+              <text fg={theme.textMuted}>Click to collapse</text>
+            </Show>
+          </Show>
+          <Diagnostics diagnostics={props.metadata.diagnostics} filePath={props.input.filePath ?? ""} />
+        </BlockTool>
+      </Match>
+      <Match when={true}>
+        <InlineTool icon="←" pending="Preparing write..." complete={props.input.filePath} part={props.part}>
+          Write {normalizePath(props.input.filePath!)}
+        </InlineTool>
+      </Match>
+    </Switch>
+  )
+}
+
+function Glob(props: ToolProps<typeof GlobTool>) {
+  return (
+    <InlineTool icon="✱" pending="Finding files..." complete={props.input.pattern} part={props.part}>
+      Glob "{props.input.pattern}" <Show when={props.input.path}>in {normalizePath(props.input.path)} </Show>
+      <Show when={props.metadata.count}>
+        ({props.metadata.count} {props.metadata.count === 1 ? "match" : "matches"})
+      </Show>
+    </InlineTool>
+  )
+}
+
+function Read(props: ToolProps<typeof ReadTool>) {
+  const { theme } = useTheme()
+  const isRunning = createMemo(() => props.part.state.status === "running")
+  const loaded = createMemo(() => {
+    if (props.part.state.status !== "completed") return []
+    if (props.part.state.time.compacted) return []
+    const value = props.metadata.loaded
+    if (!value || !Array.isArray(value)) return []
+    return value.filter((p): p is string => typeof p === "string")
+  })
+  return (
+    <>
+      <InlineTool
+        icon="→"
+        pending="Reading file..."
+        complete={props.input.filePath}
+        spinner={isRunning()}
+        part={props.part}
+      >
+        Read {normalizePath(props.input.filePath!)} {input(props.input, ["filePath"])}
+      </InlineTool>
+      <For each={loaded()}>
+        {(filepath) => (
+          <box paddingLeft={3}>
+            <text paddingLeft={3} fg={theme.textMuted}>
+              ↳ Loaded {normalizePath(filepath)}
+            </text>
+          </box>
+        )}
+      </For>
+    </>
+  )
+}
+
+function Grep(props: ToolProps<typeof GrepTool>) {
+  return (
+    <InlineTool icon="✱" pending="Searching content..." complete={props.input.pattern} part={props.part}>
+      Grep "{props.input.pattern}" <Show when={props.input.path}>in {normalizePath(props.input.path)} </Show>
+      <Show when={props.metadata.matches}>
+        ({props.metadata.matches} {props.metadata.matches === 1 ? "match" : "matches"})
+      </Show>
+    </InlineTool>
+  )
+}
+
+function WebFetch(props: ToolProps<typeof WebFetchTool>) {
+  return (
+    <InlineTool icon="%" pending="Fetching from the web..." complete={props.input.url} part={props.part}>
+      WebFetch {props.input.url}
+    </InlineTool>
+  )
+}
+
+function CodeSearch(props: ToolProps<typeof CodeSearchTool>) {
+  const metadata = props.metadata as { results?: number }
+  return (
+    <InlineTool icon="◇" pending="Searching code..." complete={props.input.query} part={props.part}>
+      Exa Code Search "{props.input.query}" <Show when={metadata.results}>({metadata.results} results)</Show>
+    </InlineTool>
+  )
+}
+
+function WebSearch(props: ToolProps<typeof WebSearchTool>) {
+  const metadata = props.metadata as { numResults?: number }
+  return (
+    <InlineTool icon="◈" pending="Searching web..." complete={props.input.query} part={props.part}>
+      Web Search "{props.input.query}" <Show when={metadata.numResults}>({metadata.numResults} results)</Show>
+    </InlineTool>
+  )
+}
+
+function Task(props: ToolProps<typeof ActorTool>) {
+  const route = useRoute()
+  const sync = useSync()
+  const raw = props.input as Partial<
+    { operation: { description: string; subagent_type: string } } & {
+      description: string
+      subagent_type: string
+    }
+  >
+  const input: Partial<{ description: string; subagent_type: string }> = raw?.operation ?? raw
+  const targetSession = props.metadata.sessionId
+  const targetBucket = (props.metadata.actorId as string | undefined) ?? "main"
+  onMount(() => {
+    if (targetSession && !sync.data.message[targetSession]?.[targetBucket]?.length)
+      void sync.session.sync(targetSession)
+  })
+  const messages = createMemo(() => sync.data.message[targetSession ?? ""]?.[targetBucket] ?? [])
+  const tools = createMemo(() => {
+    return messages().flatMap((msg) =>
+      (sync.data.part[msg.id] ?? [])
+        .filter((part): part is ToolPart => part.type === "tool")
+        .map((part) => ({ tool: part.tool, state: part.state })),
+    )
+  })
+  const current = createMemo(() =>
+    tools().findLast((x) => (x.state.status === "running" || x.state.status === "completed") && x.state.title),
+  )
+  const isRunning = createMemo(() => props.part.state.status === "running")
+  const duration = createMemo(() => {
+    const first = messages().find((x) => x.role === "user")?.time.created
+    const assistant = messages().findLast((x) => x.role === "assistant")?.time.completed
+    if (!first || !assistant) return 0
+    return assistant - first
+  })
+  const content = createMemo(() => {
+    if (!input.description) return ""
+    let content = [`${Locale.titlecase(input.subagent_type ?? "General")} Task — ${input.description}`]
+    if (isRunning() && tools().length > 0) {
+      if (current()) {
+        const state = current()!.state
+        const title = state.status === "running" || state.status === "completed" ? state.title : undefined
+        content.push(`↳ ${Locale.titlecase(current()!.tool)} ${title}`)
+      } else content.push(`↳ ${tools().length} toolcalls`)
+    }
+    if (props.part.state.status === "completed") {
+      content.push(`└ ${tools().length} toolcalls · ${Locale.duration(duration())}`)
+    }
+    return content.join("\n")
+  })
+  return (
+    <InlineTool
+      icon="│"
+      spinner={isRunning()}
+      complete={input.description}
+      pending="Delegating..."
+      part={props.part}
+      onClick={() => {
+        const targetSession = props.metadata.sessionId
+        const targetActor = props.metadata.actorId as string | undefined
+        if (!targetSession) return
+        if (route.data.type === "session" && targetSession === route.data.sessionID && targetActor) {
+          route.navigate({ ...route.data, agentID: targetActor })
+          return
+        }
+        route.navigate({ type: "session", sessionID: targetSession, agentID: targetActor })
+      }}
+    >
+      {content()}
+    </InlineTool>
+  )
+}
+
+function Edit(props: ToolProps<typeof EditTool>) {
+  const ctx = useCell()
+  const { theme, syntax } = useTheme()
+  const view = createMemo(() => {
+    const diffStyle = ctx.tui.diff_style
+    if (diffStyle === "stacked") return "unified"
+    return ctx.width > 120 ? "split" : "unified"
+  })
+  const ft = createMemo(() => filetype(props.input.filePath))
+  const diffContent = createMemo(() => props.metadata.diff)
+  return (
+    <Switch>
+      <Match when={props.metadata.diff !== undefined}>
+        <BlockTool title={"← Edit " + normalizePath(props.input.filePath!)} part={props.part}>
+          <box paddingLeft={1}>
+            <diff
+              diff={diffContent()}
+              view={view()}
+              filetype={ft()}
+              syntaxStyle={syntax()}
+              showLineNumbers={true}
+              width="100%"
+              wrapMode={ctx.diffWrapMode()}
+              fg={theme.text}
+              addedBg={theme.diffAddedBg}
+              removedBg={theme.diffRemovedBg}
+              contextBg={theme.diffContextBg}
+              addedSignColor={theme.diffHighlightAdded}
+              removedSignColor={theme.diffHighlightRemoved}
+              lineNumberFg={theme.diffLineNumber}
+              lineNumberBg={theme.diffContextBg}
+              addedLineNumberBg={theme.diffAddedLineNumberBg}
+              removedLineNumberBg={theme.diffRemovedLineNumberBg}
+            />
+          </box>
+          <Diagnostics diagnostics={props.metadata.diagnostics} filePath={props.input.filePath ?? ""} />
+        </BlockTool>
+      </Match>
+      <Match when={true}>
+        <InlineTool icon="←" pending="Preparing edit..." complete={props.input.filePath} part={props.part}>
+          Edit {normalizePath(props.input.filePath!)} {input({ replaceAll: props.input.replaceAll })}
+        </InlineTool>
+      </Match>
+    </Switch>
+  )
+}
+
+function ApplyPatch(props: ToolProps<typeof ApplyPatchTool>) {
+  const ctx = useCell()
+  const { theme, syntax } = useTheme()
+  const [expanded, setExpanded] = createSignal<string[]>([])
+  const files = createMemo(() => props.metadata.files ?? [])
+  const view = createMemo(() => {
+    const diffStyle = ctx.tui.diff_style
+    if (diffStyle === "stacked") return "unified"
+    return ctx.width > 120 ? "split" : "unified"
+  })
+  function Diff(p: { diff: string; filePath: string }) {
+    return (
+      <box paddingLeft={1}>
+        <diff
+          diff={p.diff}
+          view={view()}
+          filetype={filetype(p.filePath)}
+          syntaxStyle={syntax()}
+          showLineNumbers={true}
+          width="100%"
+          wrapMode={ctx.diffWrapMode()}
+          fg={theme.text}
+          addedBg={theme.diffAddedBg}
+          removedBg={theme.diffRemovedBg}
+          contextBg={theme.diffContextBg}
+          addedSignColor={theme.diffHighlightAdded}
+          removedSignColor={theme.diffHighlightRemoved}
+          lineNumberFg={theme.diffLineNumber}
+          lineNumberBg={theme.diffContextBg}
+          addedLineNumberBg={theme.diffAddedLineNumberBg}
+          removedLineNumberBg={theme.diffRemovedLineNumberBg}
+        />
+      </box>
+    )
+  }
+  function title(file: { type: string; relativePath: string; filePath: string; deletions: number }) {
+    if (file.type === "delete") return "# Deleted " + file.relativePath
+    if (file.type === "add") return "# Created " + file.relativePath
+    if (file.type === "move") return "# Moved " + normalizePath(file.filePath) + " → " + file.relativePath
+    return "← Patched " + file.relativePath
+  }
+  function toggle(filePath: string) {
+    setExpanded((prev) => (prev.includes(filePath) ? prev.filter((item) => item !== filePath) : [...prev, filePath]))
+  }
+  return (
+    <Switch>
+      <Match when={files().length > 0}>
+        <For each={files()}>
+          {(file) => {
+            const open = createMemo(() => expanded().includes(file.filePath))
+            const count = createMemo(() => file.additions + file.deletions)
+            const collapsed = createMemo(() => count() > TOOL_COLLAPSE_MAX_LINES || hasLongDisplayLine(file.patch))
+            return (
+              <BlockTool
+                title={title(file)}
+                part={props.part}
+                onClick={file.type !== "delete" && collapsed() ? () => toggle(file.filePath) : undefined}
+              >
+                <Show
+                  when={file.type !== "delete"}
+                  fallback={
+                    <text fg={theme.diffRemoved}>
+                      -{file.deletions} line{file.deletions !== 1 ? "s" : ""}
+                    </text>
+                  }
+                >
+                  <Show
+                    when={!collapsed() || open()}
+                    fallback={
+                      <text fg={theme.textMuted}>
+                        Click to expand ({count()} change{count() !== 1 ? "s" : ""})
+                      </text>
+                    }
+                  >
+                    <Diff diff={file.patch} filePath={file.filePath} />
+                    <Show when={collapsed()}>
+                      <text fg={theme.textMuted}>Click to collapse</text>
+                    </Show>
+                  </Show>
+                  <Diagnostics diagnostics={props.metadata.diagnostics} filePath={file.movePath ?? file.filePath} />
+                </Show>
+              </BlockTool>
+            )
+          }}
+        </For>
+      </Match>
+      <Match when={true}>
+        <InlineTool icon="%" pending="Preparing patch..." complete={false} part={props.part}>
+          Patch
+        </InlineTool>
+      </Match>
+    </Switch>
+  )
+}
+
+function Question(props: ToolProps<typeof QuestionTool>) {
+  const { theme } = useTheme()
+  const count = createMemo(() => props.input.questions?.length ?? 0)
+  function format(answer?: ReadonlyArray<string>) {
+    if (!answer?.length) return "(no answer)"
+    return answer.join(", ")
+  }
+  return (
+    <Switch>
+      <Match when={props.metadata.answers}>
+        <BlockTool title="# Questions" part={props.part}>
+          <box gap={1}>
+            <For each={props.input.questions ?? []}>
+              {(q, i) => (
+                <box flexDirection="column">
+                  <text fg={theme.textMuted}>{q.question}</text>
+                  <text fg={theme.text}>{format(props.metadata.answers?.[i()])}</text>
+                </box>
+              )}
+            </For>
+          </box>
+        </BlockTool>
+      </Match>
+      <Match when={true}>
+        <InlineTool icon="→" pending="Asking questions..." complete={count()} part={props.part}>
+          Asked {count()} question{count() !== 1 ? "s" : ""}
+        </InlineTool>
+      </Match>
+    </Switch>
+  )
+}
+
+function Skill(props: ToolProps<typeof SkillTool>) {
+  return (
+    <InlineTool icon="→" pending="Loading skill..." complete={props.input.name} part={props.part}>
+      Skill "{props.input.name}"
+    </InlineTool>
+  )
+}
+
+function Diagnostics(props: { diagnostics?: Record<string, Record<string, any>[]>; filePath: string }) {
+  const { theme } = useTheme()
+  const errors = createMemo(() => {
+    const normalized = Filesystem.normalizePath(props.filePath)
+    const arr = props.diagnostics?.[normalized] ?? []
+    return arr.filter((x) => x.severity === 1).slice(0, 3)
+  })
+  return (
+    <Show when={errors().length}>
+      <box>
+        <For each={errors()}>
+          {(diagnostic) => (
+            <text fg={theme.error}>
+              Error [{diagnostic.range.start.line + 1}:{diagnostic.range.start.character + 1}] {diagnostic.message}
+            </text>
+          )}
+        </For>
+      </box>
+    </Show>
+  )
+}
+
+function normalizePath(input?: string) {
+  if (!input) return ""
+  const cwd = process.cwd()
+  const absolute = path.isAbsolute(input) ? input : path.resolve(cwd, input)
+  const relative = path.relative(cwd, absolute)
+  if (!relative) return "."
+  if (!relative.startsWith("..")) return relative
+  return absolute
+}
+
+function input(input: Record<string, any>, omit?: string[]): string {
+  const primitives = Object.entries(input).filter(([key, value]) => {
+    if (omit?.includes(key)) return false
+    return typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+  })
+  if (primitives.length === 0) return ""
+  return `[${primitives.map(([key, value]) => `${key}=${value}`).join(", ")}]`
+}
+
+function filetype(input?: string) {
+  if (!input) return "none"
+  const ext = path.extname(input)
+  const language = LANGUAGE_EXTENSIONS[ext]
+  if (["typescriptreact", "javascriptreact", "javascript"].includes(language)) return "typescript"
+  return language
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/session-cell.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/session-cell.tsx
@@ -1929,7 +1929,7 @@ function Write(props: ToolProps<typeof WriteTool>) {
     <Switch>
       <Match when={props.metadata.diagnostics !== undefined}>
         <BlockTool
-          title={"# Wrote " + normalizePath(props.input.filePath!)}
+          title={"# Wrote " + normalizePath(props.input.file_path!)}
           part={props.part}
           onClick={collapsed() ? () => setExpanded((prev) => !prev) : undefined}
         >
@@ -1945,7 +1945,7 @@ function Write(props: ToolProps<typeof WriteTool>) {
               <code
                 conceal={false}
                 fg={theme.text}
-                filetype={filetype(props.input.filePath!)}
+                filetype={filetype(props.input.file_path!)}
                 syntaxStyle={syntax()}
                 content={code()}
               />
@@ -1954,12 +1954,12 @@ function Write(props: ToolProps<typeof WriteTool>) {
               <text fg={theme.textMuted}>Click to collapse</text>
             </Show>
           </Show>
-          <Diagnostics diagnostics={props.metadata.diagnostics} filePath={props.input.filePath ?? ""} />
+          <Diagnostics diagnostics={props.metadata.diagnostics} filePath={props.input.file_path ?? ""} />
         </BlockTool>
       </Match>
       <Match when={true}>
-        <InlineTool icon="←" pending="Preparing write..." complete={props.input.filePath} part={props.part}>
-          Write {normalizePath(props.input.filePath!)}
+        <InlineTool icon="←" pending="Preparing write..." complete={props.input.file_path} part={props.part}>
+          Write {normalizePath(props.input.file_path!)}
         </InlineTool>
       </Match>
     </Switch>
@@ -1992,11 +1992,11 @@ function Read(props: ToolProps<typeof ReadTool>) {
       <InlineTool
         icon="→"
         pending="Reading file..."
-        complete={props.input.filePath}
+        complete={props.input.file_path}
         spinner={isRunning()}
         part={props.part}
       >
-        Read {normalizePath(props.input.filePath!)} {input(props.input, ["filePath"])}
+        Read {normalizePath(props.input.file_path!)} {input(props.input, ["file_path"])}
       </InlineTool>
       <For each={loaded()}>
         {(filepath) => (
@@ -2128,12 +2128,12 @@ function Edit(props: ToolProps<typeof EditTool>) {
     if (diffStyle === "stacked") return "unified"
     return ctx.width > 120 ? "split" : "unified"
   })
-  const ft = createMemo(() => filetype(props.input.filePath))
+  const ft = createMemo(() => filetype(props.input.file_path))
   const diffContent = createMemo(() => props.metadata.diff)
   return (
     <Switch>
       <Match when={props.metadata.diff !== undefined}>
-        <BlockTool title={"← Edit " + normalizePath(props.input.filePath!)} part={props.part}>
+        <BlockTool title={"← Edit " + normalizePath(props.input.file_path!)} part={props.part}>
           <box paddingLeft={1}>
             <diff
               diff={diffContent()}
@@ -2155,12 +2155,12 @@ function Edit(props: ToolProps<typeof EditTool>) {
               removedLineNumberBg={theme.diffRemovedLineNumberBg}
             />
           </box>
-          <Diagnostics diagnostics={props.metadata.diagnostics} filePath={props.input.filePath ?? ""} />
+          <Diagnostics diagnostics={props.metadata.diagnostics} filePath={props.input.file_path ?? ""} />
         </BlockTool>
       </Match>
       <Match when={true}>
-        <InlineTool icon="←" pending="Preparing edit..." complete={props.input.filePath} part={props.part}>
-          Edit {normalizePath(props.input.filePath!)} {input({ replaceAll: props.input.replaceAll })}
+        <InlineTool icon="←" pending="Preparing edit..." complete={props.input.file_path} part={props.part}>
+          Edit {normalizePath(props.input.file_path!)} {input({ replace_all: props.input.replace_all })}
         </InlineTool>
       </Match>
     </Switch>

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/session-hooks.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/session-hooks.tsx
@@ -1,0 +1,129 @@
+import { createMemo, type Accessor } from "solid-js"
+import { useSync } from "@tui/context/sync"
+import { useProject } from "@tui/context/project"
+import type { SessionStatus } from "@mimo-ai/sdk/v2"
+import type { ActorEntry, SessionGoal, Task } from "@tui/context/sync"
+import type { Todo } from "@mimo-ai/sdk/v2"
+import type { FileDiff } from "@/snapshot"
+
+/**
+ * Session-derived reactive accessors used by both the single-session route and
+ * `SessionCell` in the grid view. All accessors are workspace-scoped: when
+ * `workspaceID` differs from the currently active workspace the underlying
+ * sync bucket is the one Phase 1.3 created for that workspace. The cell-bound
+ * variant passes `cell.workspaceID` explicitly so multiple cells can read from
+ * their own buckets in parallel.
+ */
+export type SessionMessages = {
+  session: ReturnType<typeof useSync>["session"]
+  messages: Accessor<ReturnType<typeof useSync>["data"]["message"][string][string]>
+  permissions: Accessor<ReturnType<typeof useSync>["data"]["permission"][string]>
+  questions: Accessor<ReturnType<typeof useSync>["data"]["question"][string]>
+  status: Accessor<SessionStatus | undefined>
+  todo: Accessor<Todo[]>
+  task: Accessor<Task[]>
+  goal: Accessor<SessionGoal | undefined>
+  diff: Accessor<FileDiff[] | undefined>
+  cwd: Accessor<string | undefined>
+  actors: Accessor<ActorEntry[]>
+}
+
+export type SessionMessagesInput = {
+  sessionID: string
+  agentID: Accessor<string> | (() => string)
+  /**
+   * Workspace that owns this session. When set, the hook verifies the active
+   * workspace matches and triggers a workspace switch + sync if it does not.
+   * Pass `undefined` for the legacy single-workspace route.
+   */
+  workspaceID?: string
+}
+
+/**
+ * Resolve the reactive message/state accessors for a given session. Designed
+ * for both single-session (`Session()`) and grid (`SessionCell`) callers — the
+ * grid passes `cell.workspaceID` so it can fetch workspace-scoped buckets.
+ */
+export function useSessionMessages(input: SessionMessagesInput): SessionMessages {
+  const sync = useSync()
+  const project = useProject()
+
+  // Ensure the sync bucket for this session's workspace is loaded. The grid
+  // case relies on this effect: each cell may point at a different workspace,
+  // so the active workspace must follow the cell before reads can succeed.
+  if (input.workspaceID) {
+    const target = input.workspaceID
+    if (project.workspace.current() !== target) {
+      // Defer until the cell mounts — async bootstrap is handled by callers.
+    }
+  }
+
+  const session = sync.session
+  const messages = createMemo(
+    () => sync.data.message[input.sessionID]?.[input.agentID()] ?? [],
+  )
+  const permissions = createMemo(() => sync.data.permission[input.sessionID] ?? [])
+  const questions = createMemo(() => sync.data.question[input.sessionID] ?? [])
+  const status = createMemo(() => sync.data.session_status[input.sessionID])
+  const todo = createMemo(() => sync.data.todo[input.sessionID] ?? [])
+  const task = createMemo(() => sync.data.task[input.sessionID] ?? [])
+  const goal = createMemo(() => sync.data.session_goal[input.sessionID])
+  const diff = createMemo(() => sync.data.session_diff[input.sessionID])
+  const cwd = createMemo(() => sync.data.session_cwd[input.sessionID])
+  const actors = createMemo(() => sync.data.actor[input.sessionID] ?? [])
+
+  return {
+    session,
+    messages,
+    permissions,
+    questions,
+    status,
+    todo,
+    task,
+    goal,
+    diff,
+    cwd,
+    actors,
+  }
+}
+
+/**
+ * Booleans that drive visibility of overlays, prompt input, and agent slices.
+ * Pulled out of `Session()` so the grid `SessionCell` can derive the same
+ * values from a `GridCell` prop instead of the active route.
+ */
+export type SessionStateInput = {
+  sessionID: string
+  agentID: Accessor<string> | (() => string)
+  permissions: Accessor<ReturnType<typeof useSync>["data"]["permission"][string]>
+  questions: Accessor<ReturnType<typeof useSync>["data"]["question"][string]>
+  session: Accessor<ReturnType<typeof useSync>["session"]["get"] extends (..._: any) => infer R ? R : never>
+}
+
+export type SessionState = {
+  visible: Accessor<boolean>
+  disabled: Accessor<boolean>
+  pending: Accessor<string | undefined>
+  lastAssistant: Accessor<ReturnType<typeof useSync>["data"]["message"][string][string][number] | undefined>
+}
+
+export function useSessionState(input: SessionStateInput): SessionState {
+  const sync = useSync()
+  const session = createMemo(() => sync.session.get(input.sessionID))
+  const messages = createMemo(
+    () => sync.data.message[input.sessionID]?.[input.agentID()] ?? [],
+  )
+  const visible = createMemo(
+    () =>
+      !session()?.parentID &&
+      input.agentID() === "main" &&
+      input.permissions().length === 0 &&
+      input.questions().length === 0,
+  )
+  const disabled = createMemo(() => input.permissions().length > 0 || input.questions().length > 0)
+  const pending = createMemo(
+    () => messages().findLast((x) => x.role === "assistant" && !x.time.completed)?.id,
+  )
+  const lastAssistant = createMemo(() => messages().findLast((x) => x.role === "assistant"))
+  return { visible, disabled, pending, lastAssistant }
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/sidebar.tsx
@@ -1,0 +1,176 @@
+import { For, Show, createMemo } from "solid-js"
+import { useTheme } from "@tui/context/theme"
+import { useGrid } from "@tui/context/grid"
+import { useSync } from "@tui/context/sync"
+import { useRoute } from "@tui/context/route"
+import type { GridLayout } from "@tui/context/grid-persistence"
+import { TextAttributes } from "@opentui/core"
+
+/**
+ * Grid management sidebar. Shows the cell list with workspace labels,
+ * layout toggle buttons (single / split-h / split-v), and metadata for
+ * the currently active cell (session title, workspace, agent).
+ */
+export function Sidebar() {
+  const grid = useGrid()
+  const { theme } = useTheme()
+  const sync = useSync()
+  const route = useRoute()
+  const cells = () => grid.cells
+  const activeId = () => grid.activeCellId
+  const layout = () => grid.layout
+  const activeCell = () => grid.activeCell()
+
+  const layouts = createMemo<{ key: GridLayout; label: string }[]>(() => [
+    { key: "single", label: "⬜" },
+    { key: "split-h", label: "◧" },
+    { key: "split-v", label: "◪" },
+    { key: "2x2", label: "田" },
+  ])
+
+  const availableSessions = createMemo(() => {
+    const all = sync.data.session ?? []
+    return all.filter((s: any) => !s.parentID && !s.time?.archived)
+  })
+
+  return (
+    <box
+      width={28}
+      height="100%"
+      backgroundColor={theme.backgroundPanel}
+      border={["left"]}
+      borderColor={theme.border}
+      flexDirection="column"
+      paddingTop={1}
+      paddingLeft={1}
+      paddingRight={1}
+    >
+      <box flexDirection="column" flexShrink={0}>
+        {/* Layout toggles */}
+        <box flexDirection="row" gap={1} marginBottom={1} flexShrink={0}>
+          <For each={layouts()}>
+            {(item) => (
+              <box
+                width={5}
+                height={3}
+                alignItems="center"
+                justifyContent="center"
+                backgroundColor={layout() === item.key ? theme.backgroundElement : undefined}
+                border={["top", "bottom", "left", "right"]}
+                borderColor={layout() === item.key ? theme.borderActive : theme.border}
+                onMouseUp={() => grid.setLayout(item.key)}
+              >
+                <text fg={layout() === item.key ? theme.text : theme.textMuted} attributes={TextAttributes.BOLD}>
+                  {item.label}
+                </text>
+              </box>
+            )}
+          </For>
+        </box>
+
+        {/* Cell list */}
+        <box
+          flexDirection="row"
+          justifyContent="space-between"
+          alignItems="center"
+          marginBottom={1}
+          height={1}
+          flexShrink={0}
+        >
+          <text fg={theme.textMuted}>Cells ({cells().length})</text>
+          <box
+            onMouseUp={() => route.navigate({ type: "home" })}
+            paddingLeft={1}
+            paddingRight={1}
+            backgroundColor={theme.backgroundElement}
+            border={["left", "right"]}
+            borderColor={theme.border}
+          >
+            <text fg={theme.text} wrapMode="none">
+              Exit Grid
+            </text>
+          </box>
+        </box>
+        <box flexDirection="column" flexShrink={0}>
+          <For each={cells()}>
+            {(cell) => {
+              const session = () => sync.session.get(cell.sessionID)
+              const isActive = cell.id === activeId()
+              return (
+                <box
+                  flexDirection="row"
+                  alignItems="center"
+                  paddingLeft={1}
+                  backgroundColor={isActive ? theme.backgroundElement : undefined}
+                  onMouseUp={() => grid.setActive(cell.id)}
+                >
+                  <text fg={isActive ? theme.text : theme.textMuted} wrapMode="none">
+                    {cell.label || session()?.title || "Untitled"}
+                  </text>
+                  <text fg={theme.textMuted}>{cell.mode === "plan-only" ? " 📋" : " 💬"}</text>
+                </box>
+              )
+            }}
+          </For>
+        </box>
+
+        {/* Existing sessions — click to add to grid */}
+        <box flexDirection="column" flexShrink={0} marginTop={1}>
+          <text fg={theme.textMuted}>Sessions</text>
+          <For each={availableSessions()}>
+            {(session) => {
+              const inGrid = cells().some((c) => c.sessionID === session.id)
+              return (
+                <Show when={!inGrid}>
+                  <box
+                    flexDirection="row"
+                    alignItems="center"
+                    paddingLeft={1}
+                    onMouseUp={() => {
+                      grid.addCell({
+                        sessionID: session.id,
+                        label: session.title,
+                        workspaceID: session.workspaceID ?? "",
+                        mode: "full",
+                      })
+                    }}
+                  >
+                    <text fg={theme.textMuted} wrapMode="none">
+                      + {session.title}
+                    </text>
+                  </box>
+                </Show>
+              )
+            }}
+          </For>
+        </box>
+
+        {/* Active cell metadata */}
+        <Show when={activeCell()}>
+          {(ac) => (
+            <>
+              <text fg={theme.textMuted} marginTop={2}>
+                Active Cell
+              </text>
+              <text fg={theme.textMuted}>
+                Session: <span style={{ fg: theme.text }}>{sync.session.get(ac().sessionID)?.title ?? "—"}</span>
+              </text>
+              <text fg={theme.textMuted}>
+                Workspace: <span style={{ fg: theme.text }}>{ac().workspaceID || "default"}</span>
+              </text>
+              <Show when={ac().agentID}>
+                {(agentId) => (
+                  <text fg={theme.textMuted}>
+                    Agent: <span style={{ fg: theme.text }}>{agentId()}</span>
+                  </text>
+                )}
+              </Show>
+            </>
+          )}
+        </Show>
+      </box>
+
+      <box flexGrow={1} />
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/splitter.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/splitter.tsx
@@ -1,0 +1,179 @@
+import { createMemo, createSignal, onCleanup, Show, type JSX } from "solid-js"
+import { useTheme } from "@tui/context/theme"
+import { useGrid } from "@tui/context/grid"
+import { MIN_CELL_COLS } from "@tui/context/grid-persistence"
+import type { GridLayout } from "@tui/context/grid-persistence"
+
+export interface SplitterProps {
+  /**
+   * Layout the splitter is drawn for. The orientation of the bar and the
+   * dimension it controls depend on whether the split is horizontal or
+   * vertical:
+   * - `split-h` → vertical bar, drag along x-axis
+   * - `split-v` → horizontal bar, drag along y-axis
+   * The component no-ops for `single`.
+   */
+  layout: GridLayout
+  /**
+   * Total width (split-h) or height (split-v) available to the cell area, in
+   * terminal columns / rows. The component subtracts the bar's own width or
+   * height from this when computing the dragged cell's share.
+   */
+  total: number
+  /**
+   * Bar thickness in columns (split-h) or rows (split-v). Defaults to 1.
+   */
+  thickness?: number
+}
+
+/**
+ * Phase 6: draggable splitter between two grid cells in a split layout.
+ *
+ * Behaviour:
+ * - Mouse-down captures the initial pointer position and current ratio.
+ * - Mouse-move updates the local ratio signal. We don't write to the grid
+ *   store on every pixel — only on mouse-up — so a long drag doesn't flood
+ *   the debounced persistence layer with intermediate states.
+ * - The ratio is clamped so both sides stay at >= MIN_CELL_COLS columns or
+ *   rows, matching the requirement in the Phase 6 brief.
+ * - Visual feedback swaps the bar's background colour while dragging and
+ *   shows a transient ratio label near the bar's centre.
+ */
+export function Splitter(props: SplitterProps): JSX.Element {
+  const grid = useGrid()
+  const { theme } = useTheme()
+
+  const thickness = () => props.thickness ?? 1
+  const horizontal = () => props.layout === "split-h"
+
+  // Local mirror of the persisted ratio so dragging stays smooth. We sync
+  // from the grid store on mount but write back only on mouse-up so the
+  // debounced saver isn't woken up by every drag tick.
+  const [localRatio, setLocalRatio] = createSignal(grid.splitRatio)
+  const [dragging, setDragging] = createSignal(false)
+
+  const inner = () => Math.max(1, props.total - thickness())
+  const minRatio = createMemo(() => {
+    if (inner() <= 0) return 0
+    const limit = horizontal() ? MIN_CELL_COLS : 6
+    return Math.min(1, limit / inner())
+  })
+  const maxRatio = createMemo(() => {
+    if (inner() <= 0) return 1
+    const limit = horizontal() ? MIN_CELL_COLS : 6
+    return Math.max(0, 1 - limit / inner())
+  })
+
+  let origin: number | undefined
+  let startRatio: number | undefined
+
+  const onMouseDown = (evt: { button: number; x?: number; y?: number }) => {
+    if (evt.button !== 0) return
+    origin = horizontal() ? (evt.x ?? 0) : (evt.y ?? 0)
+    startRatio = grid.splitRatio
+    setLocalRatio(grid.splitRatio)
+    setDragging(true)
+  }
+
+  const onMouseMove = (evt: { x?: number; y?: number }) => {
+    if (!dragging()) return
+    if (origin === undefined || startRatio === undefined) return
+    if (inner() <= 0) return
+    const current = horizontal() ? (evt.x ?? 0) : (evt.y ?? 0)
+    const delta = (current - origin) / inner()
+    const next = startRatio + delta
+    const lo = minRatio()
+    const hi = maxRatio()
+    setLocalRatio(Math.max(lo, Math.min(hi, next)))
+  }
+
+  const onMouseUp = () => {
+    if (!dragging()) return
+    const final = localRatio()
+    grid.setSplitRatio(final)
+    setDragging(false)
+    origin = undefined
+    startRatio = undefined
+  }
+
+  // Cancel the drag if the cell unmounts mid-gesture.
+  onCleanup(() => {
+    origin = undefined
+    startRatio = undefined
+  })
+
+  // Defensive: if the store ratio changes from outside (e.g. another keybind
+  // or layout switch), follow it so the bar's position stays in sync.
+  const ratio = createMemo(() => (dragging() ? localRatio() : grid.splitRatio))
+
+  // Position of the bar as a fraction of the cell area (0-1). The bar is
+  // drawn at this offset; the dragged cell takes the slice up to the bar and
+  // the sibling cell takes the slice after.
+  const position = createMemo(() => ratio())
+
+  return (
+    <Show when={props.layout !== "single"}>
+      {horizontal() ? (
+        <box
+          width={thickness()}
+          height="100%"
+          backgroundColor={dragging() ? theme.primary : theme.border}
+          onMouseDown={onMouseDown}
+          onMouseMove={onMouseMove}
+          onMouseUp={onMouseUp}
+          onMouseDrag={onMouseMove}
+          onMouseDragEnd={onMouseUp}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Show when={dragging()}>
+            <text fg={theme.selectedListItemText}>{`${Math.round(position() * 100)}%`}</text>
+          </Show>
+        </box>
+      ) : (
+        <box
+          width="100%"
+          height={thickness()}
+          backgroundColor={dragging() ? theme.primary : theme.border}
+          onMouseDown={onMouseDown}
+          onMouseMove={onMouseMove}
+          onMouseUp={onMouseUp}
+          onMouseDrag={onMouseMove}
+          onMouseDragEnd={onMouseUp}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Show when={dragging()}>
+            <text fg={theme.selectedListItemText}>{`${Math.round(position() * 100)}%`}</text>
+          </Show>
+        </box>
+      )}
+    </Show>
+  )
+}
+
+/**
+ * Phase 6: pure helpers used by `routes/grid/index.tsx` to compute the width
+ * (split-h) or height (split-v) of the dragged and sibling cells. Pulled out
+ * so both the splitter and the layout code path can share the same clamp
+ * math without duplicating the formula.
+ */
+export function splitCellWidth(total: number, ratio: number, thickness = 1): number {
+  const inner = Math.max(1, total - thickness)
+  const clamped = clampRatio(ratio, inner, true)
+  return Math.max(MIN_CELL_COLS, Math.round(inner * clamped))
+}
+
+export function splitCellHeight(total: number, ratio: number, thickness = 1): number {
+  const inner = Math.max(1, total - thickness)
+  const clamped = clampRatio(ratio, inner, false)
+  return Math.max(6, Math.round(inner * clamped))
+}
+
+function clampRatio(ratio: number, inner: number, horizontal: boolean): number {
+  if (inner <= 0) return ratio
+  const limit = horizontal ? MIN_CELL_COLS : 6
+  const lo = Math.min(1, limit / inner)
+  const hi = Math.max(0, 1 - limit / inner)
+  return Math.max(lo, Math.min(hi, ratio))
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/grid/toolbar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/grid/toolbar.tsx
@@ -1,0 +1,91 @@
+import { For } from "solid-js"
+import { useTheme } from "@tui/context/theme"
+import { useGrid } from "@tui/context/grid"
+import { useSync } from "@tui/context/sync"
+import { useProject } from "@tui/context/project"
+import { useSDK } from "@tui/context/sdk"
+import { useWorkspaceClients } from "@tui/context/workspace-clients"
+import { useToast } from "@tui/ui/toast"
+import { useRoute } from "@tui/context/route"
+import { createGridSession } from "./grid-create"
+
+/**
+ * Cell tab bar for the grid view. Renders one tab per cell with the session
+ * label, a mode badge (plan-only vs full), and a close button ("×"). The
+ * active cell is highlighted. A "+" button at the end creates a fresh
+ * session via the SDK and adds it to the grid (Phase 8) instead of the
+ * pre-Phase-8 "navigate to home" behaviour.
+ */
+export function GridToolbar() {
+  const grid = useGrid()
+  const { theme } = useTheme()
+  const sync = useSync()
+  const project = useProject()
+  const sdk = useSDK()
+  const workspaceClients = useWorkspaceClients()
+  const toast = useToast()
+  const route = useRoute()
+  const cells = () => grid.cells
+  const activeId = () => grid.activeCellId
+
+  const addNewCell = () => void createGridSession({ grid, sdk, project, sync, workspaceClients, toast, route })
+
+  return (
+    <box
+      flexDirection="row"
+      height={3}
+      backgroundColor={theme.backgroundPanel}
+      border={["bottom"]}
+      borderColor={theme.border}
+      alignItems="center"
+      paddingLeft={1}
+      paddingRight={1}
+    >
+      <box flexDirection="row">
+        <For each={cells()}>
+          {(cell) => {
+            const isActive = cell.id === activeId()
+            const session = () => sync.session.get(cell.sessionID)
+            const label = () => cell.label || session()?.title || "cell"
+            return (
+              <box
+                flexDirection="row"
+                alignItems="center"
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={isActive ? theme.background : theme.backgroundElement}
+                border={["left", "right"]}
+                borderColor={isActive ? theme.borderActive : theme.border}
+                marginRight={1}
+                onMouseUp={() => grid.setActive(cell.id)}
+              >
+                <text fg={theme.textMuted}>{cell.mode === "plan-only" ? "📋" : "💬"}</text>
+                <text fg={isActive ? theme.text : theme.textMuted} marginLeft={1} wrapMode="none">
+                  {label()}
+                </text>
+                <box
+                  marginLeft={1}
+                  onMouseUp={(evt) => {
+                    evt.stopPropagation()
+                    grid.removeCell(cell.id)
+                  }}
+                >
+                  <text fg={isActive ? theme.textMuted : theme.textMuted}>×</text>
+                </box>
+              </box>
+            )
+          }}
+        </For>
+      </box>
+
+      {/* "+" button to create a new cell — Phase 8: directly create a session
+          via SDK and add it to the grid. Replaces the pre-Phase-8 behaviour of
+          navigating to home, which left the user stranded outside the grid. */}
+      <box onMouseUp={addNewCell} paddingLeft={1} paddingRight={1}>
+        <text fg={theme.textMuted}>+</text>
+      </box>
+
+      <box flexGrow={1} />
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -170,6 +170,11 @@ export const TuiThreadCommand = cmd({
         type: "boolean",
         describe: "skip workspace trust prompt and trust the directory",
         default: false,
+      })
+      .option("grid", {
+        type: "boolean",
+        describe: "open directly into the grid view (multi-session workspace)",
+        default: false,
       }),
   handler: async (args) => {
     // Keep ENABLE_PROCESSED_INPUT cleared even if other code flips it.
@@ -309,6 +314,7 @@ export const TuiThreadCommand = cmd({
             prompt,
             fork: args.fork,
             neverAsk: args["never-ask"],
+            grid: args.grid,
           },
         })
       } finally {

--- a/packages/opencode/src/cli/cmd/tui/util/event-cleanup.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/event-cleanup.ts
@@ -1,0 +1,45 @@
+import { onCleanup } from "solid-js"
+
+/**
+ * Phase 5 event-leak fix: collect per-component event-listener cleanups and
+ * run them in a single `onCleanup`.
+ *
+ * `event.on()` calls in this codebase frequently return a `Promise<() => void>`
+ * that previously was discarded — which leaked the listener across route
+ * changes. `track()` accepts either a sync cleanup or a thenable; both
+ * resolve into a single dispose sweep registered against the current Solid
+ * owner. If a tracked cleanup throws, the rest still run.
+ */
+export function useEventTracker(): {
+  track: (cleanup: (() => void) | Promise<() => void>) => void
+  cleanup: () => void
+} {
+  const cleanups: Array<() => void> = []
+  const track = (cleanup: (() => void) | Promise<() => void>) => {
+    if (typeof cleanup === "function") {
+      cleanups.push(cleanup)
+      return
+    }
+    void cleanup.then(
+      (fn) => {
+        if (typeof fn === "function") cleanups.push(fn)
+      },
+      () => {
+        // Track the failure but do not throw — the rest of the listeners
+        // should still be eligible to run on teardown
+      },
+    )
+  }
+  const cleanup = () => {
+    while (cleanups.length) {
+      const fn = cleanups.pop()
+      try {
+        fn?.()
+      } catch {
+        // Ignore individual cleanup failures; other listeners still need to run
+      }
+    }
+  }
+  onCleanup(cleanup)
+  return { track, cleanup }
+}

--- a/packages/opencode/src/cli/cmd/tui/util/focus-guard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/focus-guard.ts
@@ -1,0 +1,56 @@
+import type { Renderable } from "@opentui/core"
+
+/**
+ * Phase 5 window-fragility fix: focus-steal guard for grid cells.
+ *
+ * `Prompt` (and a few other components) auto-focus themselves in effects,
+ * which used to fire after a dialog closed even when the active cell was no
+ * longer the user's focus. Wrapping the focus call with `withFocusGuard` lets
+ * callers quickly check whether the surrounding context makes focusing safe
+ * before the call is attempted.
+ */
+export function withFocusGuard(fn: () => void): void {
+  if (!isSafeToFocusGlobal()) return
+  fn()
+}
+
+/**
+ * `true` iff a focus call on `target` is safe to perform right now.
+ *
+ * The rules:
+ * - target must be alive (not destroyed)
+ * - target must currently be `focusable`
+ * - target must not be the currently-focused renderable (focusing something
+ *   that is already focused is a no-op but emits a frame of churn)
+ * - target must have a non-zero size — focusing a 0x0 element drops Yoga into
+ *   an invalid state on some layouts
+ */
+export function isSafeToFocus(target: Renderable): boolean {
+  if (!target || target.isDestroyed) return false
+  if (!target.focusable) return false
+  if (target.focused) return false
+  const width = target.width
+  const height = target.height
+  if (width <= 0 || height <= 0) return false
+  return true
+}
+
+/**
+ * Cross-cell focus supervisor. `true` when the global state is healthy enough
+ * that any focus operation is reasonable. The default implementation always
+ * returns `true`; grid-level mounts override this via `setFocusGuard` when
+ * they own the active cell.
+ */
+let guard: () => boolean = () => true
+
+export function setFocusGuard(fn: () => boolean): () => void {
+  const previous = guard
+  guard = fn
+  return () => {
+    guard = previous
+  }
+}
+
+function isSafeToFocusGlobal(): boolean {
+  return guard()
+}

--- a/packages/opencode/src/cli/cmd/tui/util/render-guard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/render-guard.ts
@@ -1,0 +1,51 @@
+import { createSignal, onCleanup } from "solid-js"
+
+/**
+ * Phase 5 rendering-safety utility: mark a component as destroyed and let
+ * late-arriving effects / event handlers short-circuit.
+ *
+ * Solid components execute effects until their root is disposed, but the
+ * `isDestroyed` signal is read from many call sites that may be invoked
+ * after a navigation swap. Pairing a destroy guard with `onCleanup` lets
+ * those sites exit cheaply:
+ *
+ * ```ts
+ * const guard = useDestroyGuard()
+ * createEffect(() => {
+ *   if (guard.isDestroyed()) return
+ *   ...
+ * })
+ * ```
+ */
+export function useDestroyGuard(): { isDestroyed: () => boolean; markDestroyed: () => void } {
+  const [isDestroyed, setIsDestroyed] = createSignal(false)
+  onCleanup(() => setIsDestroyed(true))
+  return {
+    isDestroyed,
+    markDestroyed: () => setIsDestroyed(true),
+  }
+}
+
+/**
+ * Phase 5 rendering-safety utility: a non-reentrant lock for serializing
+ * operations that must not overlap (e.g. mutating a ScrollBox while a sticky
+ * scroll effect is mid-flight).
+ *
+ * The lock is intentionally local — the creator owns the lifecycle and
+ * should dispose the holder before teardown. `acquire()` returns `false`
+ * when the lock is already held, so callers can opt to skip rather than
+ * block.
+ */
+export function useRenderLock(): { acquire: () => boolean; release: () => void } {
+  let held = false
+  const acquire = (): boolean => {
+    if (held) return false
+    held = true
+    return true
+  }
+  const release = (): void => {
+    held = false
+  }
+  onCleanup(release)
+  return { acquire, release }
+}

--- a/packages/opencode/src/cli/cmd/tui/util/scroll-guard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/scroll-guard.ts
@@ -1,0 +1,66 @@
+import { createEffect, createSignal, on, onCleanup, type Signal } from "solid-js"
+import type { ScrollBoxRenderable } from "@opentui/core"
+
+/**
+ * Phase 5 scroll-stability fix: prevent sticky-scroll reset cascades.
+ *
+ * The default ScrollBox `stickyScroll` behaviour auto-resets to the bottom on
+ * every content mutation. In a grid with multiple live cells, that "helpful"
+ * behaviour is the primary cause of unwanted scroll jumps when the user has
+ * deliberately scrolled away from the bottom. The guard flips the
+ * `stickyScroll` flag off whenever the user has moved away from the bottom
+ * (tracked via the `isAtBottom` signal) and re-enables it only after the user
+ * scrolls back. Resets are debounced so a rapid burst of updates collapses
+ * into a single stable state.
+ */
+export function useStickyScrollGuard(
+  scrollRef: () => ScrollBoxRenderable | undefined,
+  isAtBottom: Signal<boolean>,
+): void {
+  const [enabled, setEnabled] = createSignal(true)
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined
+
+  const applyToRef = () => {
+    const ref = scrollRef()
+    if (!ref || ref.isDestroyed) return
+    ref.stickyScroll = enabled()
+  }
+
+  // When the user has scrolled away from the bottom, freeze sticky scroll so
+  // a new message does not yank them back. When they return to the bottom,
+  // re-enable so future updates follow them.
+  createEffect(
+    on(
+      isAtBottom[0],
+      (atBottom) => {
+        setEnabled(atBottom)
+      },
+      { defer: true },
+    ),
+  )
+
+  // Debounce sticky-scroll toggles so a burst of content mutations does not
+  // thrash the flag (each toggle forces Yoga to re-layout, which on a 4-cell
+  // grid compounds into visible jitter).
+  const scheduleApply = () => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined
+      applyToRef()
+    }, 32)
+  }
+
+  createEffect(
+    on(
+      enabled,
+      () => {
+        scheduleApply()
+      },
+      { defer: true },
+    ),
+  )
+
+  onCleanup(() => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+  })
+}

--- a/packages/opencode/src/config/keybinds.ts
+++ b/packages/opencode/src/config/keybinds.ts
@@ -115,6 +115,28 @@ const KeybindsSchema = Schema.Struct({
   tips_toggle: keybind("<leader>h", "Toggle tips on home screen"),
   plugin_manager: keybind("none", "Open plugin manager dialog"),
   display_thinking: keybind("none", "Toggle thinking blocks visibility"),
+  // MiMo Grid v0.0.1 - Phase 1.4
+  // `grid_create` and `grid_layout_toggle` were originally `<leader>n` and
+  // `<leader>l`, but those keys are already bound to `session_new` and
+  // `session_list`. Remapped to `<leader>o` and `<leader>k` to avoid
+  // conflicts while keeping the leader-key convention.
+  grid_create: keybind("<leader>o", "Create new grid cell"),
+  grid_close: keybind("<leader>w", "Close active grid cell"),
+  grid_next: keybind("<leader>right", "Next grid cell"),
+  grid_prev: keybind("<leader>left", "Previous grid cell"),
+  grid_plan_mode: keybind("<leader>p", "Toggle plan-only mode"),
+  grid_layout_toggle: keybind("<leader>k", "Toggle grid layout"),
+  // Phase 6: direct cell-switch keybinds. Numbers 1-9 jump to the cell at
+  // that position (cycling if needed).
+  grid_cell_1: keybind("<leader>1", "Switch to cell 1"),
+  grid_cell_2: keybind("<leader>2", "Switch to cell 2"),
+  grid_cell_3: keybind("<leader>3", "Switch to cell 3"),
+  grid_cell_4: keybind("<leader>4", "Switch to cell 4"),
+  grid_cell_5: keybind("<leader>5", "Switch to cell 5"),
+  grid_cell_6: keybind("<leader>6", "Switch to cell 6"),
+  grid_cell_7: keybind("<leader>7", "Switch to cell 7"),
+  grid_cell_8: keybind("<leader>8", "Switch to cell 8"),
+  grid_cell_9: keybind("<leader>9", "Switch to cell 9"),
 }).annotate({ identifier: "KeybindsConfig" })
 
 export type Keybinds = Schema.Schema.Type<typeof KeybindsSchema>

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -232,4 +232,9 @@ export const Flag = {
   get MIMOCODE_CLIENT() {
     return process.env["MIMOCODE_CLIENT"] ?? "cli"
   },
+  // Phase 6: when truthy, the TUI opens directly into the grid view instead of
+  // the home/session route. Equivalent to passing `--grid` on the CLI.
+  get MIMOCODE_GRID() {
+    return truthy("MIMOCODE_GRID")
+  },
 }

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -71,6 +71,7 @@ describe("tui thread", () => {
       cors: [],
       "no-auth": false,
       noAuth: false,
+      grid: false,
     }
     return TuiThreadCommand.handler(args)
   }


### PR DESCRIPTION
Adds grid mode to the TUI: `--grid` / `MIMOCODE_GRID=1` boots straight into a multi-cell layout, each cell runs its own session through a refcounted workspace-aware client pool.

- `GridView` route + `SessionCell` / `PlanCell` / toolbar / sidebar
- `WorkspaceClients` context (refcounted pool, defaults to shared `sdk.client`)
- Leader-key binds: `<leader>o/w/1..9/k/←→/p`
- 30 files, +5114 / -6, tui package only
