### PR TITLE
fix(opencode): update init prompt branding

### DIFF
--- a/packages/opencode/src/command/template/initialize.txt
+++ b/packages/opencode/src/command/template/initialize.txt
@@ -1,6 +1,6 @@
 Create or update `AGENTS.md` for this repository.
 
-The goal is a compact instruction file that helps future OpenCode sessions avoid mistakes and ramp up quickly. Every line should answer: "Would an agent likely miss this without help?" If not, leave it out.
+The goal is a compact instruction file that helps future MiMoCode sessions avoid mistakes and ramp up quickly. Every line should answer: "Would an agent likely miss this without help?" If not, leave it out.
 
 User-provided focus or constraints (honor these):
 $ARGUMENTS
@@ -12,7 +12,7 @@ Read the highest-value sources first:
 - build, test, lint, formatter, typecheck, and codegen config
 - CI workflows and pre-commit / task runner config
 - existing instruction files (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules/`, `.cursorrules`, `.github/copilot-instructions.md`)
-- repo-local OpenCode config such as `opencode.json`
+- repo-local MiMoCode config such as `mimocode.json`
 
 If architecture is still unclear after reading config and docs, inspect a small number of representative code files to find the real entrypoints, package boundaries, and execution flow. Prefer reading the files that explain how the system is wired together over random leaf files.
 
@@ -57,7 +57,7 @@ Exclude:
 - long tutorials or exhaustive file trees
 - obvious language conventions
 - speculative claims or anything you could not verify
-- content better stored in another file referenced via `opencode.json` `instructions`
+- content better stored in another file referenced via `mimocode.json` `instructions`
 
 When in doubt, omit.
 


### PR DESCRIPTION
### Issue for this PR

Refs #1538

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates the built-in `/init` prompt to replace stale OpenCode/opencode.json wording with MiMoCode/mimocode.json wording.

The related issue also notes that `/init <focus or constraints>` fills the `$ARGUMENTS` section; if appropriate, please document this command usage in the official docs.

### How did you verify your code works?

- Checked `origin/main` still contains the stale wording.
- Ran `git diff --check`.
- Did not run typecheck successfully because local `bun typecheck` fails with missing `tsgo`; this is a prompt text-only change.

### Screenshots / recordings

Not applicable; prompt text-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR