### PR TITLE
feat(skill): config option to control which default skill directories are scanned

### DIFF
--- a/packages/opencode/src/config/skills.ts
+++ b/packages/opencode/src/config/skills.ts
@@ -2,7 +2,32 @@ import { Schema } from "effect"
 import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
+export const Sources = Schema.Struct({
+  builtin: Schema.optional(Schema.Boolean).annotate({
+    description: "Load skills bundled with the mimocode binary. Defaults to true.",
+  }),
+  compose: Schema.optional(Schema.Boolean).annotate({
+    description: "Load MiMoCode Compose skills bundled with the mimocode binary. Defaults to true.",
+  }),
+  claude: Schema.optional(Schema.Boolean).annotate({
+    description: "Scan .claude/skills in the home directory and the project tree. Defaults to true.",
+  }),
+  agents: Schema.optional(Schema.Boolean).annotate({
+    description: "Scan .agents/skills in the home directory and the project tree. Defaults to true.",
+  }),
+  codex: Schema.optional(Schema.Boolean).annotate({
+    description: "Scan .codex/skills in the home directory and the project tree. Defaults to true.",
+  }),
+  opencode: Schema.optional(Schema.Boolean).annotate({
+    description: "Scan .opencode/skills in the home directory and the project tree. Defaults to true.",
+  }),
+})
+export type Sources = Schema.Schema.Type<typeof Sources>
+
 export const Info = Schema.Struct({
+  sources: Schema.optional(Sources).annotate({
+    description: "Enable or disable the default skill sources scanned on startup",
+  }),
   paths: Schema.optional(Schema.Array(Schema.String)).annotate({
     description: "Additional paths to skill folders",
   }),

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -154,9 +154,12 @@ const discoverSkills = Effect.fnUntraced(function* (
   worktree: string,
 ) {
   const state: ScanState = { matches: new Set(), dirs: new Set() }
+  const cfg = yield* config.get()
+  const sources = cfg.skills?.sources
+  const enabled = (source: keyof NonNullable<typeof sources>) => sources?.[source] !== false
 
   // Extract builtin skills to disk first (user skills with same name override)
-  if (!Flag.MIMOCODE_DISABLE_BUILTIN_SKILLS) {
+  if (!Flag.MIMOCODE_DISABLE_BUILTIN_SKILLS && enabled("builtin")) {
     const builtinSkillRoot = yield* extractBuiltinBundle(fsys).pipe(
       Effect.catch(() => Effect.succeed(undefined)),
     )
@@ -166,7 +169,7 @@ const discoverSkills = Effect.fnUntraced(function* (
   }
 
   // Extract compose skills to disk (user skills with same name override)
-  if (!Flag.MIMOCODE_DISABLE_COMPOSE_SKILLS) {
+  if (!Flag.MIMOCODE_DISABLE_COMPOSE_SKILLS && enabled("compose")) {
     const composeSkillRoot = yield* extractComposeBundle(fsys).pipe(
       Effect.catch(() => Effect.succeed(undefined)),
     )
@@ -177,9 +180,10 @@ const discoverSkills = Effect.fnUntraced(function* (
 
   if (!Flag.MIMOCODE_DISABLE_EXTERNAL_SKILLS) {
     const externalDirs = EXTERNAL_DIRS.filter((dir) => {
-      if (dir === ".claude" && Flag.MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS) return false
-      if (dir === ".codex" && Flag.MIMOCODE_DISABLE_CODEX_SKILLS) return false
-      if (dir === ".opencode" && Flag.MIMOCODE_DISABLE_OPENCODE_SKILLS) return false
+      if (dir === ".claude") return !Flag.MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS && enabled("claude")
+      if (dir === ".agents") return enabled("agents")
+      if (dir === ".codex") return !Flag.MIMOCODE_DISABLE_CODEX_SKILLS && enabled("codex")
+      if (dir === ".opencode") return !Flag.MIMOCODE_DISABLE_OPENCODE_SKILLS && enabled("opencode")
       return true
     })
 
@@ -203,7 +207,6 @@ const discoverSkills = Effect.fnUntraced(function* (
     yield* scan(state, dir, MIMOCODE_SKILL_PATTERN)
   }
 
-  const cfg = yield* config.get()
   for (const item of cfg.skills?.paths ?? []) {
     const expanded = item.startsWith("~/") ? path.join(os.homedir(), item.slice(2)) : item
     const dir = path.isAbsolute(expanded) ? expanded : path.join(directory, expanded)

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -408,6 +408,143 @@ description: A skill in the .agents/skills directory.
     ),
   )
 
+  it.live("skips .claude/skills when sources.claude is false", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all([
+              Bun.write(
+                path.join(dir, ".claude", "skills", "claude-skill", "SKILL.md"),
+                `---
+name: claude-skill
+description: A skill in the .claude/skills directory.
+---
+
+# Claude Skill
+`,
+              ),
+              Bun.write(
+                path.join(dir, ".agents", "skills", "agent-skill", "SKILL.md"),
+                `---
+name: agent-skill
+description: A skill in the .agents/skills directory.
+---
+
+# Agent Skill
+`,
+              ),
+            ]),
+          )
+
+          const skill = yield* Skill.Service
+          const list = yield* skill.all()
+          expect(list.length).toBe(1)
+          expect(list[0].name).toBe("agent-skill")
+        }),
+      { git: true, config: { skills: { sources: { claude: false } } } },
+    ),
+  )
+
+  it.live("skips .codex/skills when sources.codex is false", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, ".codex", "skills", "codex-skill", "SKILL.md"),
+              `---
+name: codex-skill
+description: A skill in the .codex/skills directory.
+---
+
+# Codex Skill
+`,
+            ),
+          )
+
+          const skill = yield* Skill.Service
+          expect(yield* skill.all()).toEqual([])
+        }),
+      { git: true, config: { skills: { sources: { codex: false } } } },
+    ),
+  )
+
+  it.live("skips .agents/skills when sources.agents is false", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, ".agents", "skills", "agent-skill", "SKILL.md"),
+              `---
+name: agent-skill
+description: A skill in the .agents/skills directory.
+---
+
+# Agent Skill
+`,
+            ),
+          )
+
+          const skill = yield* Skill.Service
+          expect(yield* skill.all()).toEqual([])
+        }),
+      { git: true, config: { skills: { sources: { agents: false } } } },
+    ),
+  )
+
+  it.live("skips global ~/.claude/skills when sources.claude is false", () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() =>
+          tmpdir({
+            git: true,
+            config: { skills: { sources: { claude: false } } },
+          }),
+        ),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+
+      yield* withHome(
+        tmp.path,
+        Effect.gen(function* () {
+          yield* Effect.promise(() => createGlobalSkill(tmp.path))
+          yield* Effect.gen(function* () {
+            const skill = yield* Skill.Service
+            expect(yield* skill.all()).toEqual([])
+          }).pipe(provideInstance(tmp.path))
+        }),
+      )
+    }),
+  )
+
+  it.live("keeps loading .claude/skills when sources leaves claude enabled", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, ".claude", "skills", "claude-skill", "SKILL.md"),
+              `---
+name: claude-skill
+description: A skill in the .claude/skills directory.
+---
+
+# Claude Skill
+`,
+            ),
+          )
+
+          const skill = yield* Skill.Service
+          const list = yield* skill.all()
+          expect(list.length).toBe(1)
+          expect(list[0].name).toBe("claude-skill")
+        }),
+      { git: true, config: { skills: { sources: { codex: false } } } },
+    ),
+  )
+
   it.live("properly resolves directories that skills live in", () =>
     provideTmpdirInstance(
       (dir) =>

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -19,15 +19,51 @@ OpenCode searches these locations:
 - Global Claude-compatible: `~/.claude/skills/<name>/SKILL.md`
 - Project agent-compatible: `.agents/skills/<name>/SKILL.md`
 - Global agent-compatible: `~/.agents/skills/<name>/SKILL.md`
+- Project Codex-compatible: `.codex/skills/<name>/SKILL.md`
+- Global Codex-compatible: `~/.codex/skills/<name>/SKILL.md`
 
 ---
 
 ## Understand discovery
 
 For project-local paths, OpenCode walks up from your current working directory until it reaches the git worktree.
-It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md` or `.agents/skills/*/SKILL.md` along the way.
+It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md`, `.agents/skills/*/SKILL.md`, or `.codex/skills/*/SKILL.md` along the way.
 
-Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md`, `~/.claude/skills/*/SKILL.md`, and `~/.agents/skills/*/SKILL.md`.
+Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md`, `~/.claude/skills/*/SKILL.md`, `~/.agents/skills/*/SKILL.md`, and `~/.codex/skills/*/SKILL.md`.
+
+---
+
+## Control skill sources
+
+If you also run Claude Code or Codex on the same machine, their skill directories are picked up too, and same-name skills from different tools can collide.
+Use `skills.sources` in `opencode.json` to turn individual sources off:
+
+```json
+{
+  "skills": {
+    "sources": {
+      "claude": false,
+      "codex": false
+    }
+  }
+}
+```
+
+Every source defaults to `true`. Available keys:
+
+| Key        | What it controls                                          |
+| ---------- | --------------------------------------------------------- |
+| `builtin`  | Skills bundled with the binary                            |
+| `compose`  | MiMoCode Compose skills bundled with the binary           |
+| `claude`   | `.claude/skills` in the home directory and project tree   |
+| `agents`   | `.agents/skills` in the home directory and project tree   |
+| `codex`    | `.codex/skills` in the home directory and project tree    |
+| `opencode` | `.opencode/skills` in the home directory and project tree |
+
+Disabling a source skips both its global (home directory) and project-local directories.
+To add extra directories beyond the defaults, use `skills.paths`; to fetch skills from a URL, use `skills.urls`.
+
+The environment variables `MIMOCODE_DISABLE_EXTERNAL_SKILLS`, `MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS`, `MIMOCODE_DISABLE_CODEX_SKILLS`, and `MIMOCODE_DISABLE_OPENCODE_SKILLS` still work and take precedence: a source disabled by an environment variable stays off regardless of config.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Fixes #1561

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

On startup MiMo-Code scans the skill directories of other agent tools: `~/.claude`, `~/.agents`, `~/.codex` and `~/.opencode`, plus their project-local counterparts. That is convenient, but on a machine where several of these tools are installed side by side it causes a real problem: two tools often ship a skill with the same name, and which copy wins depends on scan order. The duplicate only shows up as a log warning, so from the user's point of view the result looks random. Today the only way to turn a source off is an environment variable, and the `.agents` directory has no switch at all.

This PR adds a `skills.sources` section to the config, one boolean per source:

```json
{
  "skills": {
    "sources": {
      "claude": false,
      "codex": false
    }
  }
}
```

Available keys are `builtin`, `compose`, `claude`, `agents`, `codex` and `opencode`. Every key defaults to `true`, so nothing changes for existing setups — you only list the sources you want off. Disabling a source skips both its home-directory and project-local variants, because a half-disabled source would still produce the same name collisions. The existing `MIMOCODE_DISABLE_*` environment variables keep working and win over the config: they could only ever disable things, so an env-disabled source stays off no matter what the config says. Adding custom directories was already possible through `skills.paths`, so this PR deliberately does not duplicate that.

The docs page for skills got a new "Control skill sources" section, and while writing it I noticed the `.codex` locations were scanned by the code but missing from the docs, so they are listed now too.

One thing I intentionally left out: regenerating the JS SDK types. Running the SDK build script on a clean `main` already produces ~700 lines of unrelated churn (the checked-in generated file is behind the current OpenAPI output), and I did not want to bury a small feature in that. If you'd rather have the regen included here, say the word.

### How did you verify your code works?

Followed TDD: added five tests to the skill test suite first (disable `.claude`, `.codex`, `.agents` at project level, disable `.claude` at the global home level, and one making sure an unrelated `sources` entry does not affect other sources), watched four of them fail, then implemented the change and watched all of them pass. Full skill suite (18 tests), the config test suite and `bun typecheck` across all packages pass. Also verified manually that with no `sources` section behavior is byte-for-byte the old one, since every check defaults to enabled.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR