### PR TITLE
feat(tui): add clickable sidebar toggle button at content edge

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -124,6 +124,25 @@ function use() {
   return ctx
 }
 
+function SidebarToggleButton(props: { visible: boolean; onToggle: () => void }) {
+  const { theme } = useTheme()
+  const [hover, setHover] = createSignal(false)
+  return (
+    <box
+      width={3}
+      height="100%"
+      justifyContent="flex-start"
+      alignItems="center"
+      backgroundColor={hover() ? theme.backgroundElement : undefined}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
+      onMouseUp={() => props.onToggle()}
+    >
+      <text fg={hover() ? theme.text : theme.textMuted}>{props.visible ? "▶" : "◀"}</text>
+    </box>
+  )
+}
+
 export function Session() {
   const route = useRouteData("session")
   const fullRoute = useRoute()
@@ -1119,6 +1138,7 @@ export function Session() {
               />
             }
           >
+          
           <Show when={session()}>
             <scrollbox
               ref={(r) => (scroll = r)}
@@ -1272,6 +1292,16 @@ export function Session() {
           </Show>
           <Toast />
         </box>
+        <SidebarToggleButton
+          visible={sidebarVisible()}
+          onToggle={() => {
+            batch(() => {
+              const isVisible = sidebarVisible()
+              setSidebar(() => (isVisible ? "hide" : "auto"))
+              setSidebarOpen(!isVisible)
+            })
+          }}
+        />
         <Show when={sidebarVisible()}>
           <Switch>
             <Match when={wide()}>


### PR DESCRIPTION
## Summary

在 TUI 主内容区右侧边缘添加了一个可点击的侧边栏折叠/展开按钮，方便用户通过鼠标操作切换侧边栏显示状态，无需记忆快捷键。

## Changes

- 新增 `SidebarToggleButton` 组件，位于主内容区与侧边栏之间
- 宽度 3 列，顶部对齐，鼠标悬停时高亮
- 侧边栏展开时显示 `▶`（点击折叠），折叠时显示 `◀`（点击展开）
- 点击状态与现有 `Ctrl+X B` 快捷键共享同一持久化逻辑