### PR TITLE
feat(lsp) add LSP tool with sendRequest read-only whitelist

### DIFF
--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -16,6 +16,8 @@ import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 
 const log = Log.create({ service: "lsp" })
 
+const fileExtension = (file: string) => path.parse(file).ext || file
+
 export const Event = {
   Updated: BusEvent.define("lsp.updated", z.object({})),
 }
@@ -121,10 +123,10 @@ const filterExperimentalServers = (servers: Record<string, LSPServer.Info>) => {
       log.info("LSP server pyright is disabled because MIMOCODE_EXPERIMENTAL_LSP_TY is enabled")
       delete servers["pyright"]
     }
-  } else {
-    if (servers["ty"]) {
-      delete servers["ty"]
-    }
+    return
+  }
+  if (servers["ty"]) {
+    delete servers["ty"]
   }
 }
 
@@ -143,15 +145,16 @@ export interface Interface {
   readonly hasClients: (file: string) => Effect.Effect<boolean>
   readonly touchFile: (input: string, waitForDiagnostics?: boolean) => Effect.Effect<void>
   readonly diagnostics: () => Effect.Effect<Record<string, LSPClient.Diagnostic[]>>
-  readonly hover: (input: LocInput) => Effect.Effect<any>
-  readonly definition: (input: LocInput) => Effect.Effect<any[]>
-  readonly references: (input: LocInput) => Effect.Effect<any[]>
-  readonly implementation: (input: LocInput) => Effect.Effect<any[]>
+  readonly hover: (input: LocInput) => Effect.Effect<unknown>
+  readonly definition: (input: LocInput) => Effect.Effect<unknown[]>
+  readonly references: (input: LocInput) => Effect.Effect<unknown[]>
+  readonly implementation: (input: LocInput) => Effect.Effect<unknown[]>
   readonly documentSymbol: (uri: string) => Effect.Effect<(DocumentSymbol | Symbol)[]>
   readonly workspaceSymbol: (query: string) => Effect.Effect<Symbol[]>
-  readonly prepareCallHierarchy: (input: LocInput) => Effect.Effect<any[]>
-  readonly incomingCalls: (input: LocInput) => Effect.Effect<any[]>
-  readonly outgoingCalls: (input: LocInput) => Effect.Effect<any[]>
+  readonly prepareCallHierarchy: (input: LocInput) => Effect.Effect<unknown[]>
+  readonly incomingCalls: (input: LocInput) => Effect.Effect<unknown[]>
+  readonly outgoingCalls: (input: LocInput) => Effect.Effect<unknown[]>
+  readonly sendRequest: (file: string, method: string, params: unknown) => Effect.Effect<unknown>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/LSP") {}
@@ -169,7 +172,9 @@ export const layer = Layer.effect(
 
         if (!cfg.lsp) {
           log.info("all LSPs are disabled")
-        } else {
+        }
+
+        if (cfg.lsp) {
           for (const server of Object.values(LSPServer)) {
             servers[server.id] = server
           }
@@ -234,7 +239,7 @@ export const layer = Layer.effect(
       }
       const s = yield* InstanceState.get(state)
       return yield* Effect.promise(async () => {
-        const extension = path.parse(file).ext || file
+        const extension = fileExtension(file)
         const result: LSPClient.Info[] = []
 
         async function schedule(server: LSPServer.Info, root: string, key: string) {
@@ -351,7 +356,7 @@ export const layer = Layer.effect(
       const ctx = yield* InstanceState.context
       const s = yield* InstanceState.get(state)
       return yield* Effect.promise(async () => {
-        const extension = path.parse(file).ext || file
+        const extension = fileExtension(file)
         for (const server of Object.values(s.servers)) {
           if (server.extensions.length && !server.extensions.includes(extension)) continue
           const root = await server.root(file, ctx)
@@ -374,7 +379,7 @@ export const layer = Layer.effect(
             return wait
           }),
         ).catch((err) => {
-          log.error("failed to touch file", { err, file: input })
+          log.error("failed to touch file", { error: err, file: input })
         }),
       )
     })
@@ -410,7 +415,7 @@ export const layer = Layer.effect(
             textDocument: { uri: pathToFileURL(input.file).href },
             position: { line: input.line, character: input.character },
           })
-          .catch(() => null),
+          .catch(() => []),
       )
       return results.flat().filter(Boolean)
     })
@@ -435,7 +440,7 @@ export const layer = Layer.effect(
             textDocument: { uri: pathToFileURL(input.file).href },
             position: { line: input.line, character: input.character },
           })
-          .catch(() => null),
+          .catch(() => []),
       )
       return results.flat().filter(Boolean)
     })
@@ -495,6 +500,12 @@ export const layer = Layer.effect(
       return yield* callHierarchyRequest(input, "callHierarchy/outgoingCalls")
     })
 
+    const sendRequest = Effect.fn("LSP.sendRequest")(function* (file: string, method: string, params: unknown) {
+      return yield* run(file, (client) =>
+        client.connection.sendRequest(method, params).catch(() => null)
+      )
+    })
+
     return Service.of({
       init,
       status,
@@ -510,6 +521,7 @@ export const layer = Layer.effect(
       prepareCallHierarchy,
       incomingCalls,
       outgoingCalls,
+      sendRequest,
     })
   }),
 )

--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -9,6 +9,19 @@ import { pathToFileURL } from "url"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 
+const SEND_REQUEST_WHITELIST = new Set([
+  "textDocument/codeAction",
+  "textDocument/completion",
+  "textDocument/signatureHelp",
+  "textDocument/foldingRange",
+  "textDocument/documentLink",
+  "textDocument/semanticTokens/full",
+  "textDocument/semanticTokens/range",
+  "textDocument/semanticTokens/full/delta",
+  "textDocument/declaration",
+  "textDocument/typeDefinition",
+])
+
 const operations = [
   "goToDefinition",
   "findReferences",
@@ -19,7 +32,18 @@ const operations = [
   "prepareCallHierarchy",
   "incomingCalls",
   "outgoingCalls",
+  "sendRequest",
 ] as const
+
+const parameters = z.object({
+  operation: z.enum(operations).describe("The LSP operation to perform"),
+  file_path: z.string().optional().describe("The absolute or relative path to the file (required for all operations except workspaceSymbol)"),
+  line: z.number().int().min(1).optional().describe("The line number (1-based, as shown in editors)"),
+  character: z.number().int().min(1).optional().describe("The character offset (1-based, as shown in editors)"),
+  method: z.string().optional().describe("The LSP method name for sendRequest (e.g. \"textDocument/codeAction\")"),
+  params: z.record(z.string(), z.unknown()).optional().describe("The parameters for the LSP method when using sendRequest"),
+  query: z.string().optional().describe("The symbol name or partial name to search for (workspaceSymbol only)"),
+})
 
 export const LspTool = Tool.define(
   "lsp",
@@ -29,61 +53,71 @@ export const LspTool = Tool.define(
 
     return {
       description: DESCRIPTION,
-      parameters: z.object({
-        operation: z.enum(operations).describe("The LSP operation to perform"),
-        file_path: z.string().describe("The absolute or relative path to the file"),
-        line: z.number().int().min(1).describe("The line number (1-based, as shown in editors)"),
-        character: z.number().int().min(1).describe("The character offset (1-based, as shown in editors)"),
-      }),
+      parameters,
       execute: (
-        args: { operation: (typeof operations)[number]; file_path: string; line: number; character: number },
+        args: z.infer<typeof parameters>,
         ctx: Tool.Context,
       ) =>
         Effect.gen(function* () {
-          const file = path.isAbsolute(args.file_path) ? args.file_path : path.join(Instance.directory, args.file_path)
-          yield* assertExternalDirectoryEffect(ctx, file)
           yield* ctx.ask({ permission: "lsp", patterns: ["*"], always: ["*"], metadata: {} })
 
-          const uri = pathToFileURL(file).href
-          const position = { file, line: args.line - 1, character: args.character - 1 }
-          const relPath = path.relative(Instance.worktree, file)
-          const title = `${args.operation} ${relPath}:${args.line}:${args.character}`
+          // workspaceSymbol searches across all LSP clients and doesn't need a file
+          if (args.operation === "workspaceSymbol") {
+            const result = yield* lsp.workspaceSymbol(args.query || "")
+            return {
+              title: `workspaceSymbol ${args.query || ""}`,
+              metadata: { result },
+              output: result.length === 0 ? "No results found for workspaceSymbol" : JSON.stringify(result, null, 2),
+            }
+          }
 
-          const exists = yield* fs.existsSafe(file)
-          if (!exists) throw new Error(`File not found: ${file}`)
+          if (!args.file_path) throw new Error("file_path is required for this operation")
 
-          const available = yield* lsp.hasClients(file)
-          if (!available) throw new Error("No LSP server available for this file type.")
+          const file = path.isAbsolute(args.file_path) ? args.file_path : path.join(Instance.directory, args.file_path)
+          yield* assertExternalDirectoryEffect(ctx, file)
+
+          const line = args.line ?? 1
+          const character = args.character ?? 1
+          const position = { file, line: line - 1, character: character - 1 }
+          const relativePath = path.relative(Instance.worktree, file)
+          const title =
+            args.operation === "sendRequest"
+              ? `${args.operation} ${relativePath} ${args.method ?? ""}`
+              : `${args.operation} ${relativePath}:${line}:${character}`
+
+          if (!(yield* fs.existsSafe(file))) throw new Error(`File not found: ${file}`)
+          if (!(yield* lsp.hasClients(file))) throw new Error("No LSP server available for this file type.")
 
           yield* lsp.touchFile(file, true)
 
-          const result: unknown[] = yield* (() => {
-            switch (args.operation) {
-              case "goToDefinition":
-                return lsp.definition(position)
-              case "findReferences":
-                return lsp.references(position)
-              case "hover":
-                return lsp.hover(position)
-              case "documentSymbol":
-                return lsp.documentSymbol(uri)
-              case "workspaceSymbol":
-                return lsp.workspaceSymbol("")
-              case "goToImplementation":
-                return lsp.implementation(position)
-              case "prepareCallHierarchy":
-                return lsp.prepareCallHierarchy(position)
-              case "incomingCalls":
-                return lsp.incomingCalls(position)
-              case "outgoingCalls":
-                return lsp.outgoingCalls(position)
-            }
-          })()
+          const ops = {
+            goToDefinition: () => lsp.definition(position),
+            findReferences: () => lsp.references(position),
+            hover: () => lsp.hover(position),
+            documentSymbol: () => lsp.documentSymbol(pathToFileURL(file).href),
+            sendRequest: () => {
+              const method = args.method ?? ""
+              if (!SEND_REQUEST_WHITELIST.has(method)) {
+                throw new Error(`Method "${method}" is not in the sendRequest read-only whitelist`)
+              }
+              return lsp.sendRequest(file, method, args.params ?? {})
+            },
+            goToImplementation: () => lsp.implementation(position),
+            prepareCallHierarchy: () => lsp.prepareCallHierarchy(position),
+            incomingCalls: () => lsp.incomingCalls(position),
+            outgoingCalls: () => lsp.outgoingCalls(position),
+          }
+          const result: unknown = yield* ops[args.operation]()
+
+          const output =
+            Array.isArray(result) && result.length === 0
+              ? `No results found for ${args.operation}`
+              : JSON.stringify(result, null, 2)
 
           return {
             title,
             metadata: { result },
-            output: result.length === 0 ? `No results found for ${args.operation}` : JSON.stringify(result, null, 2),
+            output,
           }
         }),
     }

--- a/packages/opencode/src/tool/lsp.txt
+++ b/packages/opencode/src/tool/lsp.txt
@@ -10,10 +10,19 @@ Supported operations:
 - prepareCallHierarchy: Get call hierarchy item at a position (functions/methods)
 - incomingCalls: Find all functions/methods that call the function at a position
 - outgoingCalls: Find all functions/methods called by the function at a position
+- sendRequest: Send a read-only LSP request to the server. Only safe, read-only methods are allowed (e.g. textDocument/codeAction, textDocument/completion, textDocument/signatureHelp, textDocument/foldingRange, textDocument/documentLink, textDocument/semanticTokens/full, textDocument/semanticTokens/range, textDocument/semanticTokens/full/delta, textDocument/declaration, textDocument/typeDefinition). Dangerous methods like workspace/executeCommand and workspace/applyEdit are blocked.
 
-All operations require:
-- file_path: The file to operate on
+Most operations require:
+- file_path: The absolute or relative path to the file
 - line: The line number (1-based, as shown in editors)
 - character: The character offset (1-based, as shown in editors)
+
+The workspaceSymbol operation requires:
+- query: The symbol name or partial name to search for. Always provide it — most language servers return no results for an empty query.
+
+The sendRequest operation requires:
+- file_path: The file to determine which LSP server to target
+- method: The LSP method name (e.g. "textDocument/codeAction")
+- params: The parameters for the LSP method
 
 Note: LSP servers must be configured for the file type. If no server is available, an error will be returned.

--- a/packages/opencode/test/actor/cancel-cascade.test.ts
+++ b/packages/opencode/test/actor/cancel-cascade.test.ts
@@ -106,6 +106,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/actor/poststop-progress-write-permission.repro.test.ts
+++ b/packages/opencode/test/actor/poststop-progress-write-permission.repro.test.ts
@@ -122,6 +122,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/actor/spawn-lifecycle.test.ts
+++ b/packages/opencode/test/actor/spawn-lifecycle.test.ts
@@ -106,6 +106,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/actor/spawn-no-deadlock.test.ts
+++ b/packages/opencode/test/actor/spawn-no-deadlock.test.ts
@@ -106,6 +106,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/actor/spawn-notification.test.ts
+++ b/packages/opencode/test/actor/spawn-notification.test.ts
@@ -109,6 +109,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/actor/spawn-task-autostart.test.ts
+++ b/packages/opencode/test/actor/spawn-task-autostart.test.ts
@@ -108,6 +108,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -112,6 +112,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/inbox/fork-agent-compat.test.ts
+++ b/packages/opencode/test/inbox/fork-agent-compat.test.ts
@@ -122,6 +122,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -157,6 +157,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -111,6 +111,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/session/text-loop-integration.test.ts
+++ b/packages/opencode/test/session/text-loop-integration.test.ts
@@ -109,6 +109,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/tool/whitelist.test.ts
+++ b/packages/opencode/test/tool/whitelist.test.ts
@@ -106,6 +106,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/workflow/lib.ts
+++ b/packages/opencode/test/workflow/lib.ts
@@ -100,6 +100,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 

--- a/packages/opencode/test/workflow/tool.test.ts
+++ b/packages/opencode/test/workflow/tool.test.ts
@@ -114,6 +114,7 @@ const lsp = Layer.succeed(
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
+    sendRequest: () => Effect.succeed(undefined),
   }),
 )
 


### PR DESCRIPTION
### Issue for this PR

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement

### What does this PR do?

Added a new `lsp` tool that exposes Language Server Protocol features to AI agents. The tool supports 10 operations: goToDefinition, findReferences, hover, documentSymbol, workspaceSymbol, goToImplementation, prepareCallHierarchy, incomingCalls, outgoingCalls, and sendRequest.

The `sendRequest` operation acts as an escape hatch for arbitrary LSP methods but is gated by a read-only method whitelist (`SEND_REQUEST_WHITELIST`) that blocks destructive operations like `workspace/executeCommand` and `workspace/applyEdit`.

Code quality improvements include replacing `any` with `unknown` in the LSP Interface, unifying error handling patterns, refactoring a switch statement to a dispatch map, and extracting the parameters schema with `z.infer`.

### How did you verify your code works?

The LSP tool is gated behind the `MIMOCODE_EXPERIMENTAL_LSP_TOOL` flag. To enable it, set the environment variable before launching the TUI:

```bash
MIMOCODE_EXPERIMENTAL_LSP_TOOL=1 mimo
```

1. `bun typecheck` passes cleanly
2. `bun test test/tool/whitelist.test.ts` — 3 pass, 0 fail
3. Tested in TUI with a C# project using csharp-ls:
   - completion and signatureHelp work correctly
   - sendRequest whitelist blocks `workspace/executeCommand` as expected
   - sendRequest allows `textDocument/completion` and `textDocument/semanticTokens/full`
4. Tested in TUI on MiMo-Code project itself (TypeScript):
   - `documentSymbol` on `lsp.ts` returns 52 symbols with full structure
   - `workspaceSymbol` query works (no false positives)

### Screenshots / recordings

N/A — CLI tool change, no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
