### PR TITLE
fix(urgent): defer vision model resolution to environment() call time

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1701,8 +1701,7 @@ const layer: Layer.Layer<
       const cfg = yield* config.get()
       // Explicit vision_model literal wins. getModel raises ModelNotFoundError as
       // a defect, so a misconfigured vision_model must not propagate — catch it and
-      // fall back to the smart default. (This runs at SystemPrompt layer construction,
-      // so an uncaught defect would fail session startup, not just image reads.)
+      // fall back to the smart default.
       if (cfg.vision_model) {
         const parsed = parseModel(cfg.vision_model)
         const explicit = yield* getModel(parsed.providerID, parsed.modelID).pipe(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -277,7 +277,7 @@ export const layer = Layer.effect(
         if (!captureSession) return empty
         const [skills, env, instructions] = yield* Effect.all([
           sys.skills(ag),
-          Effect.sync(() => sys.environment(model, captureSession.time.created)),
+          sys.environment(model, captureSession.time.created),
           instruction.system().pipe(Effect.orDie),
         ])
         // (checkpoint-writer never requests json_schema output, so STRUCTURED_OUTPUT_SYSTEM_PROMPT
@@ -3208,7 +3208,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             const [skills, env, instructions] = yield* Effect.all([
               sys.skills(agent),
-              Effect.sync(() => sys.environment(model, session.time.created)),
+              sys.environment(model, session.time.created),
               instruction.system().pipe(Effect.orDie),
             ])
             // Surface which instruction files (CLAUDE.md, AGENTS.md, ...) were loaded.

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -40,7 +40,7 @@ export function provider(model: Provider.Model) {
 }
 
 export interface Interface {
-  readonly environment: (model: Provider.Model, now: number) => string[]
+  readonly environment: (model: Provider.Model, now: number) => Effect.Effect<string[]>
   readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
 }
 
@@ -50,27 +50,10 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const skill = yield* Skill.Service
-
     const provider = yield* Provider.Service
-    const preferred = yield* provider.getVisionModel().pipe(Effect.orElseSucceed(() => undefined))
-    const visionModels = yield* provider
-      .list()
-      .pipe(
-        Effect.map((providers) =>
-          sortVisionModels(
-            Object.values(providers)
-              .flatMap((info) => Object.values(info.models))
-              .filter((m) => m.capabilities.input.image === true),
-          )
-            .map((m) => `${m.providerID}/${m.id}`)
-            .slice(0, 3),
-        ),
-      )
-      .pipe(Effect.orElseSucceed(() => [] as string[]))
-    const preferredRef = preferred ? `${preferred.providerID}/${preferred.id}` : visionModels[0]
 
     return Service.of({
-      environment(model, now) {
+      environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model, now: number) {
         const project = Instance.project
         const base = [
           [
@@ -85,13 +68,31 @@ export const layer = Layer.effect(
             // Anchored to the session's creation time (not request time) so this block
             // stays byte-identical across every turn of a session — including ones that
             // cross midnight — keeping it inside the Anthropic cached system prefix.
-            // Both the runLoop and checkpoint prefix-capture paths pass the same value.
             `  Today's date: ${new Date(now).toDateString()}`,
             `</env>`,
           ].join("\n"),
           `IMPORTANT: Your response must ALWAYS strictly follow the same major language as the user.`,
         ]
-        if (!model.capabilities.input.image)
+        if (!model.capabilities.input.image) {
+          // NOTE: vision models are resolved per-call (lazy). If provider list changes
+          // mid-session, this block may differ between turns and break cached system prefix.
+          // In practice provider config is stable within a session.
+          const preferred = yield* provider.getVisionModel().pipe(Effect.orElseSucceed(() => undefined))
+          const visionModels = yield* provider
+            .list()
+            .pipe(
+              Effect.map((providers) =>
+                sortVisionModels(
+                  Object.values(providers)
+                    .flatMap((info) => Object.values(info.models))
+                    .filter((m) => m.capabilities.input.image === true),
+                )
+                  .map((m) => `${m.providerID}/${m.id}`)
+                  .slice(0, 3),
+              ),
+            )
+            .pipe(Effect.orElseSucceed(() => [] as string[]))
+          const preferredRef = preferred ? `${preferred.providerID}/${preferred.id}` : visionModels[0]
           base.push(
             [
               `<vision-capability>`,
@@ -103,8 +104,9 @@ export const layer = Layer.effect(
               `If instead you need a file's raw binary structure (not its visual content), use a shell tool such as \`hexdump -C <path>\`, NOT the read tool.`,
             ].join("\n"),
           )
+        }
         return base
-      },
+      }),
 
       skills: Effect.fn("SystemPrompt.skills")(function* (agent: Agent.Info) {
         if (Permission.disabled(["skill"], agent.permission).has("skill")) return

--- a/packages/opencode/test/installation/no-instance.test.ts
+++ b/packages/opencode/test/installation/no-instance.test.ts
@@ -1,8 +1,20 @@
 import { expect, test } from "bun:test"
+import { Effect } from "effect"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Installation } from "../../src/installation"
+import { SystemPrompt } from "../../src/session/system"
 
 test("Installation.method() works without Instance context (mimo upgrade scenario)", async () => {
   const method = await AppRuntime.runPromise(Installation.Service.use((svc) => svc.method()))
   expect(typeof method).toBe("string")
+})
+
+test("SystemPrompt layer constructs without Instance context", async () => {
+  const svc = await AppRuntime.runPromise(
+    Effect.gen(function* () {
+      return yield* SystemPrompt.Service
+    }).pipe(Effect.provide(SystemPrompt.layer)),
+  )
+  expect(svc.environment).toBeDefined()
+  expect(svc.skills).toBeDefined()
 })

--- a/packages/opencode/test/installation/no-instance.test.ts
+++ b/packages/opencode/test/installation/no-instance.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { Installation } from "../../src/installation"
+
+test("Installation.method() works without Instance context (mimo upgrade scenario)", async () => {
+  const method = await AppRuntime.runPromise(Installation.Service.use((svc) => svc.method()))
+  expect(typeof method).toBe("string")
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1313,8 +1313,8 @@ test("getVisionModel returns undefined when no vision-capable model exists", asy
 })
 
 // Regression: getModel raises ModelNotFoundError as a DEFECT. A misconfigured
-// vision_model must not propagate that defect (it runs at SystemPrompt layer
-// construction → would fail session startup). It should fall back to the smart
+// vision_model must not propagate that defect (it runs at SystemPrompt.environment()
+// call time → would fail the current request). It should fall back to the smart
 // default instead of throwing.
 test("getVisionModel falls back to smart default when vision_model is misconfigured", async () => {
   await using tmp = await tmpdir({

--- a/packages/opencode/test/tool/actor.test.ts
+++ b/packages/opencode/test/tool/actor.test.ts
@@ -562,9 +562,9 @@ describe("Actor tool subagent_type enum (F36)", () => {
         expect(Object.keys(flat.properties)).toEqual(["operation"])
         expect(flat.required).toEqual(["operation"])
         // The operation node must carry type:"object" (the .meta fix) so models
-        // don't stringify the envelope, and must retain its inner 6-way union.
+        // don't stringify the envelope, and must retain its inner 7-way union.
         expect(flat.properties.operation.type).toBe("object")
-        expect((flat.properties.operation.oneOf ?? flat.properties.operation.anyOf).length).toBe(6)
+        expect((flat.properties.operation.oneOf ?? flat.properties.operation.anyOf).length).toBe(7)
       }),
     ),
   )


### PR DESCRIPTION
## URGENT — Regression blocks `mimo upgrade` on all platforms

**P0 regression** from #1513. All CLI commands without project context crash:

```
Error: Unexpected error
No context found for instance
```

## Root Cause

`session/system.ts` layer construction eagerly called `provider.list()` and `provider.getVisionModel()` to pre-compute vision model hints. These trigger Config -> Instance dependency chain, crashing CLI commands that run without Instance context (`mimo upgrade`, `mimo uninstall`, etc.).

## Fix (proper, not workaround)

Changed `environment()` from sync (`=> string[]`) to Effect (`=> Effect<string[]>`), moving vision model resolution into the function body. Now it only executes when a session actually calls `environment()` — never during layer construction.

- **No `catchDefect` needed** — the root cause (eager computation) is eliminated
- **No over-broad catch** — Provider errors in sessions will still surface normally  
- **Lazy by design** — vision models are only resolved when building a system prompt

## Changes

- `session/system.ts`: `environment` returns `Effect<string[]>`, vision resolution moved inside
- `session/prompt.ts`: 2 call sites updated from `Effect.sync(() => sys.environment(...))` to `sys.environment(...)`
- `provider/provider.ts`: removed stale comment referencing layer-construction-time execution
- `test/installation/no-instance.test.ts`: regression tests — verifies AppRuntime and SystemPrompt layer construct without Instance
- `test/provider/provider.test.ts`: fixed stale comment referencing old layer-construction behavior

## Verification

- [x] `bun typecheck` passes
- [x] `bun run dev upgrade` no longer crashes
- [x] Regression tests pass (Installation.method + SystemPrompt layer construction)