### PR TITLE
fix(tui): stop left/right arrow propagation in permission and questio…

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -575,6 +575,7 @@ function Prompt<const T extends Record<string, string>>(props: {
 
     if (evt.name === "left" || evt.name == "h") {
       evt.preventDefault()
+      evt.stopPropagation()
       const idx = keys.indexOf(store.selected)
       const next = keys[(idx - 1 + keys.length) % keys.length]
       setStore("selected", next)
@@ -582,6 +583,7 @@ function Prompt<const T extends Record<string, string>>(props: {
 
     if (evt.name === "right" || evt.name == "l") {
       evt.preventDefault()
+      evt.stopPropagation()
       const idx = keys.indexOf(store.selected)
       const next = keys[(idx + 1) % keys.length]
       setStore("selected", next)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -210,11 +210,13 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
 
     if (evt.name === "left" || evt.name === "h") {
       evt.preventDefault()
+      evt.stopPropagation()
       selectTab((store.tab - 1 + tabs()) % tabs())
     }
 
     if (evt.name === "right" || evt.name === "l") {
       evt.preventDefault()
+      evt.stopPropagation()
       selectTab((store.tab + 1) % tabs())
     }
 


### PR DESCRIPTION
- Add evt.stopPropagation() to left/right key handlers in PermissionPrompt
- Add evt.stopPropagation() to left/right key handlers in QuestionPrompt
- Prevents arrow key events from propagating to CommandProvider which would trigger unintended subAgent navigation via session_child_cycle

### Issue for this PR

Closes #1547 1547

### Type of change

- [√ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

What does this PR do?
When a permission prompt or question prompt is shown, pressing left/right arrow keys to switch options triggers subAgent navigation instead, because CommandProvider's global useKeyboard handler matches session_child_cycle/session_child_cycle_reverse (bound to bare left/right) before the prompt's own handler runs.
These prompts are rendered inline inside the session component, not via the Dialog system, so CommandProvider's dialog.stack.length > 0 guard doesn't skip them.
Fix: add evt.stopPropagation() in both prompts' left/right key handlers to prevent the event from reaching CommandProvider.

How did you verify your code works?
- [x] Ran bun typecheck — passes (12/12 packages)
- Test infra has pre-existing failures (timeouts on LLM integration tests) unrelated to this change
- Built binary: mimo --version outputs 0.0.0-fix/...

Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Maybe upgrade the opencode version can fix this problem, opencode use keymapping.
