### PR TITLE
fix: remove Read-Host from installer and set UTF-8 encoding for upgrade spawn

### DIFF
--- a/install-utf8.ps1
+++ b/install-utf8.ps1
@@ -110,8 +110,6 @@ if ($MajMin -match '^\d+\.\d+\.\d+$') {
         Write-Host "WARNING: Installing v$Version via install.ps1 will cause 'mimo upgrade' to not function properly." -ForegroundColor Yellow
         Write-Host "This is a known limitation for versions before 0.1.5." -ForegroundColor Yellow
         Write-Host ""
-        $confirm = Read-Host "Continue anyway? [y/N]"
-        if ($confirm -ne 'y' -and $confirm -ne 'Y') { Exit-Install 0 }
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -109,8 +109,6 @@ if ($MajMin -match '^\d+\.\d+\.\d+$') {
         Write-Host "WARNING: Installing v$Version via install.ps1 will cause 'mimo upgrade' to not function properly." -ForegroundColor Yellow
         Write-Host "This is a known limitation for versions before 0.1.5." -ForegroundColor Yellow
         Write-Host ""
-        $confirm = Read-Host "Continue anyway? [y/N]"
-        if ($confirm -ne 'y' -and $confirm -ne 'Y') { Exit-Install 0 }
     }
 }
 

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -52,7 +52,6 @@ export const Flag = {
   MIMOCODE_CONFIG_CONTENT: process.env["MIMOCODE_CONFIG_CONTENT"],
 
   MIMOCODE_DISABLE_AUTOUPDATE: truthy("MIMOCODE_DISABLE_AUTOUPDATE"),
-  MIMOCODE_INSTALL_SCRIPT_URL: process.env["MIMOCODE_INSTALL_SCRIPT_URL"],
 
   // Defaults to false (rotation enabled). When enabled, the active log file is
   // never archived to <name>.log.<stamp> on hitting MAX_FILE_SIZE — it grows in

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -52,6 +52,7 @@ export const Flag = {
   MIMOCODE_CONFIG_CONTENT: process.env["MIMOCODE_CONFIG_CONTENT"],
 
   MIMOCODE_DISABLE_AUTOUPDATE: truthy("MIMOCODE_DISABLE_AUTOUPDATE"),
+  MIMOCODE_INSTALL_SCRIPT_URL: process.env["MIMOCODE_INSTALL_SCRIPT_URL"],
 
   // Defaults to false (rotation enabled). When enabled, the active log file is
   // never archived to <name>.log.<stamp> on hitting MAX_FILE_SIZE — it grows in

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -32,6 +32,7 @@ import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
 import { DbCommand } from "./cli/cmd/db"
 import path from "path"
+import { readdirSync, unlinkSync } from "fs"
 import { Global } from "./global"
 import { JsonMigration } from "./storage"
 import { Database } from "./storage"
@@ -164,6 +165,18 @@ const cli = yargs(args)
       } catch (e) {
         Log.Default.warn("claude-import failed", { e: errorMessage(e) })
       }
+    }
+
+    // Clean up stale .old_* files left by Windows in-place upgrades
+    if (process.platform === "win32") {
+      try {
+        const binDir = path.dirname(process.execPath)
+        for (const entry of readdirSync(binDir)) {
+          if (entry.startsWith("mimo.exe.old_")) {
+            try { unlinkSync(path.join(binDir, entry)) } catch {}
+          }
+        }
+      } catch {}
     }
   })
   .usage("")

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -6,7 +6,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import z from "zod"
 import path from "path"
 import os from "os"
-import { renameSync, copyFileSync, rmSync, unlinkSync } from "fs"
+import { renameSync, copyFileSync, rmSync, unlinkSync, existsSync } from "fs"
 import { BusEvent } from "@/bus/bus-event"
 import { Flag } from "../flag/flag"
 import { Log } from "../util"
@@ -184,9 +184,16 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
 
         // Replace in-place: Windows allows renaming a running exe
         const stagedExe = path.join(stageDir, "mimo.exe")
+        if (!existsSync(stagedExe))
+          return { code: 1 as ChildProcessSpawner.ExitCode, stdout: "", stderr: "staged binary not found at " + stagedExe }
         const oldExe = targetExe + `.old_${pid}`
         renameSync(targetExe, oldExe)
-        copyFileSync(stagedExe, targetExe)
+        try {
+          copyFileSync(stagedExe, targetExe)
+        } catch (e) {
+          renameSync(oldExe, targetExe)
+          throw e
+        }
         rmSync(stageDir, { recursive: true, force: true })
         try { unlinkSync(oldExe) } catch {}
 
@@ -256,7 +263,7 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
             "",
           )
           const version = (yield* text(["curl", "-fsSL", `${base}/releases/latest`])).trim().replace(/^v/, "")
-          if (version) return version
+          if (/^\d+\.\d+\.\d+/.test(version)) return version
           return yield* Effect.die(new Error("failed to resolve latest version from FDS"))
         }
 

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -149,7 +149,7 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
           if (process.platform === "win32") {
             return yield* upgradeCurlWindows(target)
           }
-          const response = yield* httpOk.execute(HttpClientRequest.get("https://mimo.xiaomi.com/install"))
+          const response = yield* httpOk.execute(HttpClientRequest.get(Flag.MIMOCODE_INSTALL_SCRIPT_URL ?? "https://mimo.xiaomi.com/install"))
           const body = yield* response.text
           const bodyBytes = new TextEncoder().encode(body)
           const proc = ChildProcess.make("bash", [], {
@@ -176,7 +176,7 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
 
         // Download new version to staging dir (reuses install.ps1 logic)
         const downloadResult = yield* run(
-          ["powershell.exe", "-NoProfile", "-NonInteractive", "-ep", "Bypass", "-c", "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; irm https://mimo.xiaomi.com/install.ps1 | iex"],
+          ["powershell.exe", "-NoProfile", "-NonInteractive", "-ep", "Bypass", "-c", `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; irm ${Flag.MIMOCODE_INSTALL_SCRIPT_URL ?? "https://mimo.xiaomi.com/install.ps1"} | iex`],
           { env: { MIMOCODE_INSTALL_DIR: stageDir, VERSION: target } },
         )
         if (downloadResult.code !== 0) return downloadResult

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -149,7 +149,7 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
           if (process.platform === "win32") {
             return yield* upgradeCurlWindows(target)
           }
-          const response = yield* httpOk.execute(HttpClientRequest.get(Flag.MIMOCODE_INSTALL_SCRIPT_URL ?? "https://mimo.xiaomi.com/install"))
+          const response = yield* httpOk.execute(HttpClientRequest.get(process.env.MIMOCODE_INSTALL_SCRIPT_URL ?? "https://mimo.xiaomi.com/install"))
           const body = yield* response.text
           const bodyBytes = new TextEncoder().encode(body)
           const proc = ChildProcess.make("bash", [], {
@@ -175,7 +175,7 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
         const stageDir = path.join(os.tmpdir(), `mimocode_upgrade_${pid}`)
 
         // Download new version to staging dir (reuses install.ps1 logic)
-        const installScriptUrl = Flag.MIMOCODE_INSTALL_SCRIPT_URL ?? "https://mimo.xiaomi.com/install.ps1"
+        const installScriptUrl = process.env.MIMOCODE_INSTALL_SCRIPT_URL ?? "https://mimo.xiaomi.com/install.ps1"
         const downloadResult = yield* run(
           ["powershell.exe", "-NoProfile", "-NonInteractive", "-ep", "Bypass", "-c", "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; irm $env:INSTALL_SCRIPT_URL | iex"],
           { env: { MIMOCODE_INSTALL_DIR: stageDir, VERSION: target, INSTALL_SCRIPT_URL: installScriptUrl } },

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -6,8 +6,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import z from "zod"
 import path from "path"
 import os from "os"
-import { spawnSync } from "child_process"
-import { writeFileSync } from "fs"
+import { renameSync, copyFileSync, rmSync, unlinkSync } from "fs"
 import { BusEvent } from "@/bus/bus-event"
 import { Flag } from "../flag/flag"
 import { Log } from "../util"
@@ -176,30 +175,22 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
         const stageDir = path.join(os.tmpdir(), `mimocode_upgrade_${pid}`)
 
         // Download new version to staging dir (reuses install.ps1 logic)
+        const installScriptUrl = Flag.MIMOCODE_INSTALL_SCRIPT_URL ?? "https://mimo.xiaomi.com/install.ps1"
         const downloadResult = yield* run(
-          ["powershell.exe", "-NoProfile", "-NonInteractive", "-ep", "Bypass", "-c", `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; irm ${Flag.MIMOCODE_INSTALL_SCRIPT_URL ?? "https://mimo.xiaomi.com/install.ps1"} | iex`],
-          { env: { MIMOCODE_INSTALL_DIR: stageDir, VERSION: target } },
+          ["powershell.exe", "-NoProfile", "-NonInteractive", "-ep", "Bypass", "-c", "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; irm $env:INSTALL_SCRIPT_URL | iex"],
+          { env: { MIMOCODE_INSTALL_DIR: stageDir, VERSION: target, INSTALL_SCRIPT_URL: installScriptUrl } },
         )
         if (downloadResult.code !== 0) return downloadResult
 
-        // Write replacement script to a temp file with paths inlined
+        // Replace in-place: Windows allows renaming a running exe
         const stagedExe = path.join(stageDir, "mimo.exe")
-        const scriptPath = path.join(os.tmpdir(), `mimocode_updater_${pid}.ps1`)
-        const scriptContent = [
-          `while (Get-Process -Id ${pid} -ErrorAction SilentlyContinue) { Start-Sleep -Milliseconds 200 }`,
-          `for ($i = 0; $i -lt 50; $i++) { try { Move-Item -LiteralPath '${stagedExe}' -Destination '${targetExe}' -Force -ErrorAction Stop; break } catch { Start-Sleep -Milliseconds 200 } }`,
-          `Remove-Item -LiteralPath '${stageDir}' -Force -Recurse -ErrorAction SilentlyContinue`,
-          `Remove-Item -LiteralPath '${scriptPath}' -Force -ErrorAction SilentlyContinue`,
-        ].join("\r\n")
-        writeFileSync(scriptPath, scriptContent)
+        const oldExe = targetExe + `.old_${pid}`
+        renameSync(targetExe, oldExe)
+        copyFileSync(stagedExe, targetExe)
+        rmSync(stageDir, { recursive: true, force: true })
+        try { unlinkSync(oldExe) } catch {}
 
-        // Launch updater via WMI — creates a process outside the current Job Object
-        // so it survives after the parent mimo process exits
-        spawnSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-ep", "Bypass", "-Command",
-          `[void](Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="powershell.exe -NoProfile -NonInteractive -ep Bypass -WindowStyle Hidden -File '${scriptPath}'"})`,
-        ], { stdio: "ignore", windowsHide: true })
-
-        log.info("scheduled Windows upgrade via WMI", { target, pid, stageDir, scriptPath })
+        log.info("upgraded Windows binary in-place", { target, pid, oldExe })
         return { code: 0 as ChildProcessSpawner.ExitCode, stdout: "", stderr: "" }
       })
 

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -176,7 +176,7 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
 
         // Download new version to staging dir (reuses install.ps1 logic)
         const downloadResult = yield* run(
-          ["powershell.exe", "-NoProfile", "-NonInteractive", "-ep", "Bypass", "-c", "irm https://mimo.xiaomi.com/install.ps1 | iex"],
+          ["powershell.exe", "-NoProfile", "-NonInteractive", "-ep", "Bypass", "-c", "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; irm https://mimo.xiaomi.com/install.ps1 | iex"],
           { env: { MIMOCODE_INSTALL_DIR: stageDir, VERSION: target } },
         )
         if (downloadResult.code !== 0) return downloadResult

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -6,7 +6,8 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import z from "zod"
 import path from "path"
 import os from "os"
-import { spawn as nodeSpawn } from "child_process"
+import { spawnSync } from "child_process"
+import { writeFileSync } from "fs"
 import { BusEvent } from "@/bus/bus-event"
 import { Flag } from "../flag/flag"
 import { Log } from "../util"
@@ -181,22 +182,24 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
         )
         if (downloadResult.code !== 0) return downloadResult
 
-        // Schedule replacement after exit
+        // Write replacement script to a temp file with paths inlined
         const stagedExe = path.join(stageDir, "mimo.exe")
-        const replaceScript = [
+        const scriptPath = path.join(os.tmpdir(), `mimocode_updater_${pid}.ps1`)
+        const scriptContent = [
           `while (Get-Process -Id ${pid} -ErrorAction SilentlyContinue) { Start-Sleep -Milliseconds 200 }`,
-          `for ($i = 0; $i -lt 50; $i++) { try { Move-Item -LiteralPath $env:STAGED_EXE -Destination $env:TARGET_EXE -Force -ErrorAction Stop; break } catch { Start-Sleep -Milliseconds 200 } }`,
-          `Remove-Item -LiteralPath $env:STAGE_DIR -Force -Recurse -ErrorAction SilentlyContinue`,
-        ].join("; ")
+          `for ($i = 0; $i -lt 50; $i++) { try { Move-Item -LiteralPath '${stagedExe}' -Destination '${targetExe}' -Force -ErrorAction Stop; break } catch { Start-Sleep -Milliseconds 200 } }`,
+          `Remove-Item -LiteralPath '${stageDir}' -Force -Recurse -ErrorAction SilentlyContinue`,
+          `Remove-Item -LiteralPath '${scriptPath}' -Force -ErrorAction SilentlyContinue`,
+        ].join("\r\n")
+        writeFileSync(scriptPath, scriptContent)
 
-        const child = nodeSpawn("powershell.exe", ["-NoProfile", "-NonInteractive", "-ep", "Bypass", "-WindowStyle", "Hidden", "-Command", replaceScript], {
-          detached: true,
-          stdio: "ignore",
-          windowsHide: true,
-          env: { ...process.env, TARGET_EXE: targetExe, STAGED_EXE: stagedExe, STAGE_DIR: stageDir },
-        })
-        child.unref()
-        log.info("scheduled Windows upgrade", { target, pid, stageDir, updaterPid: child.pid })
+        // Launch updater via WMI — creates a process outside the current Job Object
+        // so it survives after the parent mimo process exits
+        spawnSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-ep", "Bypass", "-Command",
+          `[void](Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="powershell.exe -NoProfile -NonInteractive -ep Bypass -WindowStyle Hidden -File '${scriptPath}'"})`,
+        ], { stdio: "ignore", windowsHide: true })
+
+        log.info("scheduled Windows upgrade via WMI", { target, pid, stageDir, scriptPath })
         return { code: 0 as ChildProcessSpawner.ExitCode, stdout: "", stderr: "" }
       })
 

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -248,14 +248,16 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
         // }
 
         if (detectedMethod === "curl") {
-          const headers = yield* text([
-            "curl",
-            "-sI",
-            "https://github.com/XiaomiMiMo/MiMo-Code/releases/latest",
-          ])
-          const match = headers.match(/^location:.*\/tag\/v([0-9][^\s/]*)/im)
-          if (match) return match[1]
-          return yield* Effect.die(new Error("failed to resolve latest version from GitHub releases redirect"))
+          // Resolve the latest version from FDS, matching the source the install
+          // script downloads from (fast in mainland China). Override base via
+          // MIMO_FDS_BASE to mirror the install script.
+          const base = (process.env.MIMO_FDS_BASE || "https://mimocode.cnbj1.mi-fds.com/mimocode/mimocode").replace(
+            /\/+$/,
+            "",
+          )
+          const version = (yield* text(["curl", "-fsSL", `${base}/releases/latest`])).trim().replace(/^v/, "")
+          if (version) return version
+          return yield* Effect.die(new Error("failed to resolve latest version from FDS"))
         }
 
         if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm") {

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -192,7 +192,7 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
           copyFileSync(stagedExe, targetExe)
         } catch (e) {
           renameSync(oldExe, targetExe)
-          throw e
+          return { code: 1 as ChildProcessSpawner.ExitCode, stdout: "", stderr: "failed to copy staged binary: " + (e instanceof Error ? e.message : String(e)) }
         }
         rmSync(stageDir, { recursive: true, force: true })
         try { unlinkSync(oldExe) } catch {}

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -157,12 +157,12 @@ describe("installation", () => {
       expect(result).toBe("1.7.0")
     })
 
-    test("resolves version from GitHub releases redirect for curl method", async () => {
+    test("resolves version from FDS for curl method", async () => {
       const layer = testLayer(
         () => jsonResponse({}),
         (cmd, args) => {
-          if (cmd === "curl" && args.includes("https://github.com/XiaomiMiMo/MiMo-Code/releases/latest"))
-            return "HTTP/2 302\r\nlocation: https://github.com/XiaomiMiMo/MiMo-Code/releases/tag/v0.1.1\r\n"
+          if (cmd === "curl" && args.includes("https://mimocode.cnbj1.mi-fds.com/mimocode/mimocode/releases/latest"))
+            return "v0.1.1\n"
           return ""
         },
       )


### PR DESCRIPTION
## Summary

- Remove `Read-Host` confirmation prompt from the Windows installer scripts
- Set `[Console]::OutputEncoding = UTF-8` before spawning `install.ps1` during `mimo upgrade`
- Fix Windows binary replacement: use in-place rename instead of post-exit detached process (which was killed by Job Object)
- Add `MIMOCODE_INSTALL_SCRIPT_URL` flag for testing with a local install script
- Resolve latest version from FDS instead of GitHub releases redirect (cherry-picked from #1237)

## Rationale

**Read-Host removal**: Scripts invoked non-interactively (e.g. by `mimo upgrade`) must never call `Read-Host`. The old-version warning is informational only; a one-liner installer should not gate installation behind a confirmation prompt.

**In-place replacement**: The previous strategy spawned a detached PowerShell to replace the binary after exit. On Windows, the Job Object kills all child processes (including "detached" ones) when the parent exits. The new approach renames the running exe to `.old_<pid>` (Windows allows this), then copies the new binary in place — all synchronously during the upgrade.

**FDS version resolution**: Matches the source the install script downloads from (fast in mainland China).

## Supersedes

This PR includes the change from #1237 (`fix/upgrade-check-fds`). If this PR merges first, #1237 can be closed.

## Changes

| File | Change |
|------|--------|
| `install-utf8.ps1` | Remove Read-Host block, keep warning only |
| `install.ps1` | Regenerated (ASCII-safe) |
| `packages/opencode/src/flag/flag.ts` | Add `MIMOCODE_INSTALL_SCRIPT_URL` |
| `packages/opencode/src/installation/index.ts` | In-place rename replacement, UTF-8 encoding, FDS version check, env var for script URL |
| `packages/opencode/src/index.ts` | Cleanup stale `.old_*` files at startup |