### PR TITLE
fix: replace stale OpenCode wording with MiMo Code in /init prompt

### DIFF
--- a/packages/opencode/src/command/template/initialize.txt
+++ b/packages/opencode/src/command/template/initialize.txt
@@ -1,6 +1,6 @@
 Create or update `AGENTS.md` for this repository.
 
-The goal is a compact instruction file that helps future OpenCode sessions avoid mistakes and ramp up quickly. Every line should answer: "Would an agent likely miss this without help?" If not, leave it out.
+The goal is a compact instruction file that helps future MiMo Code sessions avoid mistakes and ramp up quickly. Every line should answer: "Would an agent likely miss this without help?" If not, leave it out.
 
 User-provided focus or constraints (honor these):
 $ARGUMENTS
@@ -12,7 +12,7 @@ Read the highest-value sources first:
 - build, test, lint, formatter, typecheck, and codegen config
 - CI workflows and pre-commit / task runner config
 - existing instruction files (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules/`, `.cursorrules`, `.github/copilot-instructions.md`)
-- repo-local OpenCode config such as `opencode.json`
+- repo-local MiMo Code config such as `mimocode.json`
 
 If architecture is still unclear after reading config and docs, inspect a small number of representative code files to find the real entrypoints, package boundaries, and execution flow. Prefer reading the files that explain how the system is wired together over random leaf files.
 
@@ -57,7 +57,7 @@ Exclude:
 - long tutorials or exhaustive file trees
 - obvious language conventions
 - speculative claims or anything you could not verify
-- content better stored in another file referenced via `opencode.json` `instructions`
+- content better stored in another file referenced via `mimocode.json` `instructions`
 
 When in doubt, omit.
 


### PR DESCRIPTION
Fixes #1538 - Replace stale OpenCode wording with MiMo Code in /init prompt template.

Changes:
- 'future OpenCode sessions' → 'future MiMo Code sessions'
- 'repo-local OpenCode config such as opencode.json' → 'repo-local MiMo Code config such as mimocode.json'
- 'referenced via opencode.json instructions' → 'referenced via mimocode.json instructions'