### PR TITLE
fix: use roots filter when continuing last session

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -365,7 +365,7 @@ export const RunCommand = cmd({
     }
 
     async function session(sdk: OpencodeClient) {
-      const baseID = args.continue ? (await sdk.session.list()).data?.find((s) => !s.parentID)?.id : args.session
+      const baseID = args.continue ? (await sdk.session.list({ roots: true })).data?.[0]?.id : args.session
 
       if (baseID && args.fork) {
         const forked = await sdk.session.fork({ sessionID: baseID })


### PR DESCRIPTION
Fixes #1484 - Auto Dream session hijacks mimo -c (continue last session)

When using mimo -c (or --continue), the code now uses roots: true to filter root sessions only, and takes the first result (most recently updated). This prevents auto-dream/distill sessions from being selected as the last session since they have parentID set.

Previously, the code used .find((s) => !s.parentID) on unfiltered results, which could return sessions in unexpected order depending on the database query.