### PR TITLE
feat: implement actor_id resume in run/spawn + fix turnCount

### DIFF
--- a/packages/opencode/src/actor/turn.ts
+++ b/packages/opencode/src/actor/turn.ts
@@ -14,6 +14,7 @@ export const runTurn = <A, E>(
     Effect.gen(function* () {
       const reg = yield* ActorRegistry.Service
       yield* reg.updateStatus(sessionID, actorID, { status: "running" }).pipe(Effect.ignore)
+      yield* reg.updateTurn(sessionID, actorID).pipe(Effect.ignore)
       // Run work interruptibly so it can be cancelled by Fiber.interrupt.
       // Effect.exit captures the outcome without re-raising, letting us
       // write status unconditionally before propagating the cause.

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -20,6 +20,8 @@ import { TaskID } from "@/task/schema"
 import { SessionCheckpoint } from "@/session/checkpoint"
 import { inboxServiceRef } from "@/inbox/inbox-ref"
 import { Effect, Deferred } from "effect"
+import { EffectLogger } from "@/effect"
+import { runTurn } from "@/actor/turn"
 
 export interface ActorPromptOps {
   cancel(sessionID: SessionID): void
@@ -555,6 +557,8 @@ export const ActorTool = Tool.define(
               inboxID: sendResult.inboxID,
               receiver_actor_id: op.to_actor_id,
               receiver_session_id: targetSid,
+              sessionId: targetSid,
+              actorId: op.to_actor_id,
             } as Record<string, any>,
           }
         }
@@ -731,6 +735,73 @@ export const ActorTool = Tool.define(
             if (!existing) {
               effectiveTaskId = undefined
               taskNotice = `note: task_id "${op.task_id}" does not exist in this session; ran ad-hoc. Create it with the \`task\` tool first, or omit task_id.`
+            }
+          }
+        }
+
+        if (op.actor_id) {
+          const found = yield* findActor(op.actor_id)
+          if (found?.entry.status === "idle") {
+            const promptOps = (ctx.extra as any)?.promptOps as ActorPromptOps | undefined
+            if (!promptOps) {
+              return yield* Effect.fail(new Error("Actor prompt operations unavailable — cannot resume actor"))
+            }
+            const promptInput: SessionPrompt.PromptInput = {
+              sessionID: ctx.sessionID,
+              agent: op.subagent_type,
+              agentID: op.actor_id,
+              parts: [{ type: "text", text: prompt }],
+              model,
+              ...(op.output_schema
+                ? { format: { type: "json_schema" as const, schema: op.output_schema, retryCount: 2 } }
+                : {}),
+              ...(effectiveTaskId ? { task_id: effectiveTaskId } : {}),
+            }
+
+            yield* ctx.metadata({
+              title: op.description,
+              metadata: {
+                sessionId: ctx.sessionID,
+                actorId: op.actor_id,
+                model,
+              },
+            })
+
+            if (op.action === "spawn") {
+              Effect.runFork(
+                runTurn(ctx.sessionID, op.actor_id, promptOps.prompt(promptInput)).pipe(
+                  Effect.provideService(ActorRegistry.Service, actorRegistry),
+                  Effect.provide(EffectLogger.layer),
+                ),
+              )
+              return {
+                title: op.description,
+                metadata: { sessionId: ctx.sessionID, actorId: op.actor_id, model },
+                output:
+                  (taskNotice ? taskNotice + "\n" : "") +
+                  `Background actor resumed. actor_id: ${op.actor_id}\nThe result will be delivered as a notification when complete.`,
+              }
+            }
+
+            const resumed = yield* runTurn(
+              ctx.sessionID,
+              op.actor_id,
+              promptOps.prompt(promptInput),
+            ).pipe(Effect.provideService(ActorRegistry.Service, actorRegistry))
+            const textPart = resumed.parts.filter((part) => part.type === "text").at(-1)
+            const structured = resumed.info.role === "assistant" ? resumed.info.structured : undefined
+            const resultText = structured !== undefined ? JSON.stringify(structured) : (textPart?.text ?? "(no output)")
+            return {
+              title: op.description,
+              metadata: { sessionId: ctx.sessionID, actorId: op.actor_id, model } as Record<string, any>,
+              output: [
+                ...(taskNotice ? [taskNotice, ""] : []),
+                `actor_id: ${op.actor_id} (for resuming to continue this task if needed)`,
+                "",
+                `<actor_result status="success">`,
+                resultText,
+                "</actor_result>",
+              ].join("\n"),
             }
           }
         }

--- a/packages/opencode/test/tool/actor.test.ts
+++ b/packages/opencode/test/tool/actor.test.ts
@@ -249,13 +249,30 @@ describe("tool.actor", () => {
     ),
   )
 
-  it.live("execute resumes an existing task session from actor_id", () =>
+  it.live("execute resumes an idle subagent from actor_id", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
-        yield* installMockSpawn()
+        let spawns = 0
+        yield* installMockSpawn(() => {
+          spawns++
+        })
         const { chat, assistant } = yield* seed()
+        const registry = yield* ActorRegistry.Service
+        const actorID = yield* registry.allocateActorID(chat.id, "general")
+        yield* registry.register({
+          sessionID: chat.id,
+          actorID,
+          mode: "subagent",
+          agent: "general",
+          description: "inspect bug",
+          contextMode: "none",
+          background: false,
+          lifecycle: "ephemeral",
+        })
+        yield* registry.updateStatus(chat.id, actorID, { status: "idle", lastOutcome: "success" })
         const tool = yield* ActorTool
         const def = yield* tool.init()
+        const prompts: SessionPrompt.PromptInput[] = []
 
         const result = yield* def.execute(
           {
@@ -264,7 +281,7 @@ describe("tool.actor", () => {
               description: "inspect bug",
               prompt: "look into the cache key path",
               subagent_type: "general",
-              actor_id: "ses_missing", // v9: actor_id in run action is ignored — always creates new
+              actor_id: actorID,
             },
           },
           {
@@ -272,16 +289,21 @@ describe("tool.actor", () => {
             messageID: assistant.id,
             agent: "build",
             abort: new AbortController().signal,
-            extra: {},
+            extra: { promptOps: stubOps({ onPrompt: (input) => prompts.push(input), text: "resumed done" }) },
             messages: [],
             metadata: () => Effect.void,
             ask: () => Effect.void,
           },
         )
 
-        // v9: run always creates a new actor under the parent session
+        expect(spawns).toBe(0)
+        expect(prompts).toHaveLength(1)
+        expect(prompts[0]?.agentID).toBe(actorID)
+        expect(prompts[0]?.agent).toBe("general")
         expect(result.metadata.sessionId).toBe(chat.id)
-        expect(result.output).toContain("actor_id:")
+        expect(result.metadata.actorId).toBe(actorID)
+        expect(result.output).toContain(`actor_id: ${actorID}`)
+        expect(result.output).toContain("resumed done")
       }),
     ),
   )


### PR DESCRIPTION
Closes #1562

### Type of change

- [x] Bug fix
- [x] New feature

### What does this PR do?

Makes the `actor_id` parameter on `run`/`spawn` actually work. Previously it was dead code — the schema said "resume" but execute never read it.

When `actor_id` is provided and `findActor` finds an idle actor, the resume branch calls `promptOps.prompt({ agentID: actor_id })` instead of `actor.spawn()`. `run` blocks on the result; `spawn` fires a background fiber. Both are wrapped in `runTurn` so the registry updates status/lastOutcome and publishes `ActorStatusChanged` — without this, `wait` never resolves because it subscribes to that event.

Also fixes `turnCount` always being 0: `registry.updateTurn` was defined but never called. Added the call inside `runTurn` (shared entry point for all actor turns).

`spawn` resume provides `EffectLogger.layer` to the forked fiber to prevent Effect logs from going to stdout and corrupting the TUI.

### How did I verify your code works?

- `bun run typecheck` passes (12 packages)
- `bun test test/tool/actor.test.ts test/tool/actor-send.test.ts` — 18 pass, 0 fail
- End-to-end in TUI session:
  - `actor run` creates sidekick-N, `actor run` with `actor_id=sidekick-N` reuses it (same ID returned, conversation context preserved)
  - `actor spawn` with `actor_id` resumes in background, `wait` returns result + correct `turnCount` + `lastOutcome: success`
  - No stdout log pollution from spawn resume

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR