### PR TITLE
feat: auto-detect document skills when office files are attached

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -54,6 +54,7 @@ import {
   TEXT_NGRAM_RECOVERY_REPLAN,
 } from "../session/prompt/text-ngram-detection"
 import { composeSkillsBlock } from "@/skill/compose/extract"
+import { builtinSkillRoot, matchDocumentSkills } from "@/skill/builtin/extract"
 import { ToolRegistry } from "../tool"
 import { MCP } from "../mcp"
 import { LSP } from "../lsp"
@@ -560,6 +561,32 @@ export const layer = Layer.effect(
       }
 
       const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
+      if (!Flag.MIMOCODE_DISABLE_BUILTIN_SKILLS && !Flag.MIMOCODE_DISABLE_DOCUMENT_SKILLS) {
+        const fileCandidates = userMessage.parts.flatMap((p) => {
+          if (p.type !== "file") return []
+          const filenameFromSource =
+            p.source?.type === "file" && p.source.path ? path.basename(p.source.path) : undefined
+          return [{ mime: p.mime, filename: p.filename ?? filenameFromSource }]
+        })
+        const skills = matchDocumentSkills(fileCandidates)
+        if (skills.length > 0) {
+          const root = builtinSkillRoot()
+          const entries = skills.map((skill) => `- ${skill}: ${path.join(root, skill, "SKILL.md")}`).join("\n")
+          const part = yield* sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: userMessage.info.id,
+            sessionID: userMessage.info.sessionID,
+            type: "text",
+            text: `<system-reminder>
+The user's message attaches office document file(s). The following built-in skill(s) may be relevant for producing, reading, or transforming these files. You are recommended to consult the SKILL.md when it fits the task — prefer using these skills over ad-hoc approaches when applicable:
+${entries}
+</system-reminder>`,
+            synthetic: true,
+          })
+          userMessage.parts.push(part)
+        }
+      }
+
       if (input.agent.name !== "plan" && assistantMessage?.info.agent === "plan") {
         const plan = Session.plan(input.session)
         if (!(yield* fsys.existsSafe(plan))) return input.messages

--- a/packages/opencode/src/skill/builtin/extract.ts
+++ b/packages/opencode/src/skill/builtin/extract.ts
@@ -10,6 +10,67 @@ import { loadBuiltinBundle as loadBuiltinBundleDev } from "./bundle.macro"
 
 export const DOCUMENT_SKILL_NAMES = new Set(["docx-official", "pdf-official", "pptx-official", "xlsx-official"])
 
+const DOCUMENT_SKILL_TRIGGERS: Array<{
+  skill: string
+  mimes: readonly string[]
+  filenameRe: RegExp
+}> = [
+  {
+    skill: "pdf-official",
+    mimes: ["application/pdf"],
+    filenameRe: /\.pdf$/i,
+  },
+  {
+    skill: "docx-official",
+    mimes: [
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+      "application/msword",
+    ],
+    filenameRe: /\.(docx|dotx)$/i,
+  },
+  {
+    skill: "xlsx-official",
+    mimes: [
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+      "application/vnd.ms-excel",
+      "application/vnd.ms-excel.sheet.macroenabled.12",
+      "text/csv",
+      "text/tab-separated-values",
+    ],
+    filenameRe: /\.(xlsx|xlsm|xltx|csv|tsv)$/i,
+  },
+  {
+    skill: "pptx-official",
+    mimes: [
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "application/vnd.ms-powerpoint",
+    ],
+    filenameRe: /\.pptx$/i,
+  },
+]
+
+export function builtinSkillRoot() {
+  return path.join(GlobalPath.data, "builtin_skills", InstallationVersion, "skills")
+}
+
+export function matchDocumentSkills(candidates: Array<{ mime?: string; filename?: string }>): string[] {
+  const hits = new Set<string>()
+  for (const candidate of candidates) {
+    for (const trigger of DOCUMENT_SKILL_TRIGGERS) {
+      if (candidate.mime && trigger.mimes.includes(candidate.mime)) {
+        hits.add(trigger.skill)
+        continue
+      }
+      if (candidate.filename && trigger.filenameRe.test(candidate.filename)) {
+        hits.add(trigger.skill)
+      }
+    }
+  }
+  return DOCUMENT_SKILL_TRIGGERS.filter((t) => hits.has(t.skill)).map((t) => t.skill)
+}
+
 function safeLoadBuiltinBundle() {
   try {
     return loadBuiltinBundle()
@@ -27,14 +88,15 @@ const log = Log.create({ service: "skill.builtin" })
 export const extractBuiltinBundle = Effect.fn("Skill.extractBuiltinBundle")(function* (
   fsys: AppFileSystem.Interface,
 ) {
-  const root = path.join(GlobalPath.data, "builtin_skills", InstallationVersion)
+  const skillsRoot = builtinSkillRoot()
+  const root = path.dirname(skillsRoot)
   const marker = path.join(root, ".extracted")
 
   if (!InstallationLocal && (yield* fsys.existsSafe(marker))) return root
 
   for (const [skillName, files] of Object.entries(BUILTIN_BUNDLE)) {
     if (Flag.MIMOCODE_DISABLE_DOCUMENT_SKILLS && DOCUMENT_SKILL_NAMES.has(skillName)) continue
-    const skillDir = path.join(root, "skills", skillName)
+    const skillDir = path.join(skillsRoot, skillName)
     for (const [relPath, content] of Object.entries(files)) {
       yield* fsys.writeWithDirs(path.join(skillDir, relPath), content)
     }


### PR DESCRIPTION
## Summary

- Add automatic document skill detection when users attach office files (docx, pdf, pptx, xlsx)
- Match files by MIME type and filename extension patterns
- Inject system reminder with relevant skill paths to guide the assistant

## Changes

- `src/skill/builtin/extract.ts`: Add DOCUMENT_SKILL_TRIGGERS config with MIME/regex patterns, builtinSkillRoot() helper, and matchDocumentSkills() function
- `src/session/prompt.ts`: Call skill matching on user-attached files and inject synthetic system reminder part

## Motivation

When users attach office documents, the assistant should automatically know which built-in skills are available for handling those file types, rather than requiring manual skill invocation.
