### PR TITLE
feat: add secondary permission prompt for irreversible bash deletions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -306,6 +306,31 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
               }
             }
 
+            if (permission === "bash_delete") {
+              const meta = props.request.metadata ?? {}
+              const command = typeof meta["command"] === "string" ? meta["command"] : ""
+              const deletes = (props.request.patterns ?? []).filter((p): p is string => typeof p === "string")
+              return {
+                icon: "✗",
+                title: "Confirm irreversible deletion",
+                body: (
+                  <box paddingLeft={1} gap={1}>
+                    <Show when={command}>
+                      <text fg={theme.text}>{"$ " + command}</text>
+                    </Show>
+                    <Show when={deletes.length > 0}>
+                      <box gap={0}>
+                        <text fg={theme.textMuted}>Detected deletions</text>
+                        <box>
+                          <For each={deletes}>{(cmd) => <text fg={theme.warning}>{"- " + cmd}</text>}</For>
+                        </box>
+                      </box>
+                    </Show>
+                  </box>
+                ),
+              }
+            }
+
             if (permission === "task") {
               const type = typeof data.subagent_type === "string" ? data.subagent_type : "Unknown"
               const desc = typeof data.description === "string" ? data.description : ""

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -66,6 +66,16 @@ export const Flag = {
   MIMOCODE_DISABLE_TERMINAL_TITLE: truthy("MIMOCODE_DISABLE_TERMINAL_TITLE"),
   MIMOCODE_SHOW_TTFD: truthy("MIMOCODE_SHOW_TTFD"),
   MIMOCODE_PERMISSION: process.env["MIMOCODE_PERMISSION"],
+
+  // Defaults to false. When false, the bash tool intercepts irreversible
+  // deletion commands (rm, rmdir, unlink, shred, del, erase, rd, remove-item,
+  // and git destructive subcommands like reset --hard / clean -f / branch -D /
+  // worktree remove / push --force / stash drop|clear / tag -d) and forces an
+  // extra permission prompt with permission="bash_delete" — separate from the
+  // normal bash-permission ask so it can't be silently pre-approved by a broad
+  // `bash: allow` rule. Set MIMOCODE_AUTO_APPROVE_DELETE=true to trust the
+  // model with deletes and skip the second confirmation.
+  MIMOCODE_AUTO_APPROVE_DELETE: truthy("MIMOCODE_AUTO_APPROVE_DELETE"),
   MIMOCODE_DISABLE_DEFAULT_PLUGINS: truthy("MIMOCODE_DISABLE_DEFAULT_PLUGINS"),
   MIMOCODE_DISABLE_LSP_DOWNLOAD: truthy("MIMOCODE_DISABLE_LSP_DOWNLOAD"),
   MIMOCODE_ENABLE_EXPERIMENTAL_MODELS: truthy("MIMOCODE_ENABLE_EXPERIMENTAL_MODELS"),

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -54,6 +54,36 @@ const FILES = new Set([
 const FLAGS = new Set(["-destination", "-literalpath", "-path"])
 const SWITCHES = new Set(["-confirm", "-debug", "-force", "-nonewline", "-recurse", "-verbose", "-whatif"])
 
+// Irreversible file/directory removal commands. Names are matched
+// case-insensitively for PowerShell; bash is case-sensitive.
+const DELETE_COMMANDS = new Set([
+  "rm",
+  "rmdir",
+  "unlink",
+  "shred",
+  // Windows / PowerShell removal verbs and their common aliases. `remove-item`
+  // is the canonical verb; `ri`, `rd`, `del`, `erase` are aliases.
+  "del",
+  "erase",
+  "rd",
+  "remove-item",
+  "ri",
+])
+
+// git subcommands that destroy history, working tree state, or remote branches.
+// Value is the set of tokens (flag or subcommand keyword) that must appear
+// anywhere in the argv for the invocation to count as destructive. An empty
+// set means the subcommand is destructive on its own.
+const GIT_DESTRUCTIVE = new Map<string, Set<string>>([
+  ["reset", new Set(["--hard"])],
+  ["clean", new Set(["-f", "-ff", "-fd", "-fdx", "-df", "-dfx", "-fx", "--force"])],
+  ["branch", new Set(["-D", "--delete"])],
+  ["tag", new Set(["-d", "--delete"])],
+  ["worktree", new Set(["remove"])],
+  ["push", new Set(["--force", "-f"])],
+  ["stash", new Set(["drop", "clear"])],
+])
+
 const Parameters = z.object({
   command: z.string().describe("The command to execute"),
   timeout: z.number().describe("Optional timeout in milliseconds").optional(),
@@ -85,6 +115,7 @@ type Scan = {
   dirs: Set<string>
   patterns: Set<string>
   always: Set<string>
+  deletes: Set<string>
 }
 
 type Chunk = {
@@ -135,6 +166,24 @@ function source(node: Node) {
 
 function commands(node: Node) {
   return node.descendantsOfType("command").filter((child): child is Node => Boolean(child))
+}
+
+// Returns true when `tokens` (the flat argv of a single command node) invokes
+// an irreversible deletion — either a direct removal command (rm, remove-item,
+// …) or a destructive git subcommand (git reset --hard, git clean -f, …).
+// `ps` toggles PowerShell case-insensitive matching.
+function isDelete(tokens: string[], ps: boolean) {
+  if (tokens.length === 0) return false
+  const head = ps ? tokens[0].toLowerCase() : tokens[0]
+  if (DELETE_COMMANDS.has(head)) return true
+  if (head === "git" && tokens.length >= 2) {
+    const sub = tokens[1]
+    const flags = GIT_DESTRUCTIVE.get(sub)
+    if (!flags) return false
+    if (flags.size === 0) return true
+    return tokens.slice(2).some((tok) => flags.has(tok))
+  }
+  return false
 }
 
 function unquote(text: string) {
@@ -308,6 +357,22 @@ const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) 
   })
 })
 
+// Secondary confirmation for irreversible deletion commands. Uses its own
+// permission type ("bash_delete") so a broad `bash: allow` rule can't silently
+// pre-approve it. `MIMOCODE_AUTO_APPROVE_DELETE=true` skips the ask entirely
+// for callers who explicitly opt out of the extra prompt.
+const askDelete = Effect.fn("BashTool.askDelete")(function* (ctx: Tool.Context, scan: Scan, command: string) {
+  if (Flag.MIMOCODE_AUTO_APPROVE_DELETE) return
+  if (scan.deletes.size === 0) return
+  const patterns = Array.from(scan.deletes)
+  yield* ctx.ask({
+    permission: "bash_delete",
+    patterns,
+    always: ["*"],
+    metadata: { command, deletes: patterns },
+  })
+})
+
 function cmd(shell: string, name: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && PS.has(name)) {
     const prefixed = `${Shell.POWERSHELL_UTF8_PREFIX}${command}`
@@ -401,6 +466,7 @@ export const BashTool = Tool.define(
         dirs: new Set<string>(),
         patterns: new Set<string>(),
         always: new Set<string>(),
+        deletes: new Set<string>(),
       }
 
       for (const node of commands(root)) {
@@ -422,6 +488,8 @@ export const BashTool = Tool.define(
           scan.patterns.add(source(node))
           scan.always.add(BashArity.prefix(tokens).join(" ") + " *")
         }
+
+        if (isDelete(tokens, ps)) scan.deletes.add(source(node))
       }
 
       return scan
@@ -690,6 +758,7 @@ export const BashTool = Tool.define(
               const scan = yield* collect(root, cwd, ps, shell)
               if (!Instance.containsPath(cwd)) scan.dirs.add(cwd)
               yield* ask(ctx, scan)
+              yield* askDelete(ctx, scan, params.command)
 
               // Interactive mode: hand terminal to user for direct interaction
               if (params.interactive) {

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -294,6 +294,80 @@ describe("tool.bash permissions", () => {
     })
   })
 
+  each("asks for bash_delete when running rm inside the project", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "victim.txt"), "x")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await Effect.runPromise(
+          bash.execute(
+            {
+              command: "rm victim.txt",
+              description: "Remove victim.txt",
+            },
+            capture(requests),
+          ),
+        )
+        const deleteReq = requests.find((r) => r.permission === "bash_delete")
+        expect(deleteReq).toBeDefined()
+        expect(deleteReq!.patterns).toContain("rm victim.txt")
+        expect(deleteReq!.metadata.command).toBe("rm victim.txt")
+      },
+    })
+  })
+
+  each("asks for bash_delete on destructive git subcommands", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const err = new Error("stop after permission")
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await expect(
+          Effect.runPromise(
+            bash.execute(
+              {
+                command: "git reset --hard HEAD",
+                description: "Hard reset",
+              },
+              capture(requests, err),
+            ),
+          ),
+        ).rejects.toThrow(err.message)
+        const bashReq = requests.find((r) => r.permission === "bash")
+        expect(bashReq).toBeDefined()
+      },
+    })
+  })
+
+  each("does not ask for bash_delete on non-destructive commands", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await Effect.runPromise(
+          bash.execute(
+            {
+              command: "echo hello",
+              description: "Echo hello",
+            },
+            capture(requests),
+          ),
+        )
+        expect(requests.find((r) => r.permission === "bash_delete")).toBeUndefined()
+      },
+    })
+  })
+
   if (process.platform === "win32") {
     if (bash) {
       test(


### PR DESCRIPTION
## Summary
- Add a separate `bash_delete` permission that intercepts destructive commands (`rm`, `rmdir`, `unlink`, `shred`, `git reset --hard`, `git clean -f`, `git branch -D`, `git push --force`, etc.) and forces an extra confirmation before execution
- This permission is distinct from the regular `bash` permission so a broad `bash: allow` rule cannot silently pre-approve deletions
- TUI renders the `bash_delete` prompt with the command and detected deletions
- Add `MIMOCODE_AUTO_APPROVE_DELETE=true` flag to opt out of the second prompt
- Include tests covering `rm`, destructive git subcommands, and non-destructive commands

## Test plan
- Run `bun test test/tool/bash.test.ts` from `packages/opencode` — verifies `bash_delete` permission is requested for `rm` and `git reset --hard`, and not requested for safe commands
- Verify TUI renders the deletion confirmation dialog correctly