### PR TITLE
feat: add html-to-video pipeline skill

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -205,6 +205,7 @@ export const dict: Record<string, string> = {
   "tui.skill.self-extend.description": "Extend your own capabilities with new skills, tools, and hooks",
   "tui.skill.frontend-design.description": "Guidance for distinctive, intentional visual UI design",
   "tui.skill.loop.description": "Schedule a prompt to run on a recurring interval",
+  "tui.skill.html-to-video-pipeline.description": "Short-video magic — make short videos with HTML",
 
   // Language switching
   "tui.command.language.switch.title": "Switch language",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -281,6 +281,7 @@ export const dict = {
   "tui.skill.self-extend.description": "Amplía tus propias capacidades con nuevas skills, herramientas y hooks",
   "tui.skill.frontend-design.description": "Guía para un diseño visual de UI distintivo e intencional",
   "tui.skill.loop.description": "Programar un prompt para ejecutarse en un intervalo recurrente",
+  "tui.skill.html-to-video-pipeline.description": "El arma definitiva para vídeos cortos — crea vídeos cortos con HTML",
 
   // Language switching
   "tui.command.language.switch.title": "Cambiar idioma",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -269,6 +269,7 @@ export const dict = {
   "tui.skill.self-extend.description": "Étendez vos capacités avec de nouvelles skills, outils et hooks",
   "tui.skill.frontend-design.description": "Conseils pour un design d'interface visuel distinctif et intentionnel",
   "tui.skill.loop.description": "Planifier l'exécution récurrente d'un prompt",
+  "tui.skill.html-to-video-pipeline.description": "L'arme ultime pour vidéos courtes — créez des vidéos courtes avec du HTML",
 
   // Language switching
   "tui.command.language.switch.title": "Changer de langue",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -218,6 +218,7 @@ export const dict = {
   "tui.skill.self-extend.description": "新しいスキル・ツール・フックで自身の能力を拡張",
   "tui.skill.frontend-design.description": "個性的で意図的な UI ビジュアルデザインのガイド",
   "tui.skill.loop.description": "プロンプトを一定間隔で繰り返し実行するようスケジュール",
+  "tui.skill.html-to-video-pipeline.description": "ショート動画の神ツール - HTML でショート動画を制作",
 
   // Language switching
   "tui.command.language.switch.title": "言語を切り替え",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -284,6 +284,7 @@ export const dict = {
   "tui.skill.self-extend.description": "Расширьте свои возможности новыми skills, инструментами и hooks",
   "tui.skill.frontend-design.description": "Руководство по выразительному, осмысленному визуальному дизайну UI",
   "tui.skill.loop.description": "Запланировать запуск промпта с периодичностью",
+  "tui.skill.html-to-video-pipeline.description": "Магический инструмент для коротких видео — создавайте короткие видео с помощью HTML",
 
   // Language switching
   "tui.command.language.switch.title": "Сменить язык",

--- a/packages/opencode/src/cli/cmd/tui/i18n/skill.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/skill.ts
@@ -7,6 +7,7 @@ const BUILTIN = new Set([
   "self-extend",
   "frontend-design",
   "loop",
+  "html-to-video-pipeline",
 ])
 
 export function skillDescription(

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -194,6 +194,7 @@ export const dict = {
   "tui.skill.self-extend.description": "通过新技能、工具与钩子扩展自身能力",
   "tui.skill.frontend-design.description": "具备鲜明主张的前端视觉设计指南",
   "tui.skill.loop.description": "按固定周期循环运行提示词",
+  "tui.skill.html-to-video-pipeline.description": "短视频神器 - 利用 HTML 制作短视频",
 
   // Language switching
   "tui.command.language.switch.title": "切换语言",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -194,6 +194,7 @@ export const dict = {
   "tui.skill.self-extend.description": "透過新技能、工具與掛鉤擴充自身能力",
   "tui.skill.frontend-design.description": "具備鮮明主張的前端視覺設計指引",
   "tui.skill.loop.description": "依固定週期循環執行提示詞",
+  "tui.skill.html-to-video-pipeline.description": "短影片神器 - 利用 HTML 製作短影片",
 
   // Language switching
   "tui.command.language.switch.title": "切換語言",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -306,6 +306,31 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
               }
             }
 
+            if (permission === "bash_delete") {
+              const meta = props.request.metadata ?? {}
+              const command = typeof meta["command"] === "string" ? meta["command"] : ""
+              const deletes = (props.request.patterns ?? []).filter((p): p is string => typeof p === "string")
+              return {
+                icon: "✗",
+                title: "Confirm irreversible deletion",
+                body: (
+                  <box paddingLeft={1} gap={1}>
+                    <Show when={command}>
+                      <text fg={theme.text}>{"$ " + command}</text>
+                    </Show>
+                    <Show when={deletes.length > 0}>
+                      <box gap={0}>
+                        <text fg={theme.textMuted}>Detected deletions</text>
+                        <box>
+                          <For each={deletes}>{(cmd) => <text fg={theme.warning}>{"- " + cmd}</text>}</For>
+                        </box>
+                      </box>
+                    </Show>
+                  </box>
+                ),
+              }
+            }
+
             if (permission === "task") {
               const type = typeof data.subagent_type === "string" ? data.subagent_type : "Unknown"
               const desc = typeof data.description === "string" ? data.description : ""

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -240,12 +240,12 @@ export const Flag = {
   get MIMOCODE_DISABLE_BUILTIN_SKILLS() {
     return truthy("MIMOCODE_DISABLE_BUILTIN_SKILLS")
   },
-  // Disables the built-in document-processing skills (docx, pdf, pptx, xlsx)
-  // while keeping the rest of the builtin bundle available. Defaults to false
-  // (all four skills are extracted and loaded). Set
-  // MIMOCODE_DISABLE_DOCUMENT_SKILLS=true to skip them.
-  get MIMOCODE_DISABLE_DOCUMENT_SKILLS() {
-    return truthy("MIMOCODE_DISABLE_DOCUMENT_SKILLS")
+  // Disables the built-in official skills (docx, pdf, pptx, xlsx,
+  // html-to-video-pipeline) while keeping the rest of the builtin bundle
+  // available. Defaults to false (all skills are extracted and loaded). Set
+  // MIMOCODE_DISABLE_OFFICIAL_SKILLS=true to skip them.
+  get MIMOCODE_DISABLE_OFFICIAL_SKILLS() {
+    return truthy("MIMOCODE_DISABLE_OFFICIAL_SKILLS")
   },
   get MIMOCODE_DISABLE_PROJECT_CONFIG() {
     return truthy("MIMOCODE_DISABLE_PROJECT_CONFIG")

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -66,6 +66,16 @@ export const Flag = {
   MIMOCODE_DISABLE_TERMINAL_TITLE: truthy("MIMOCODE_DISABLE_TERMINAL_TITLE"),
   MIMOCODE_SHOW_TTFD: truthy("MIMOCODE_SHOW_TTFD"),
   MIMOCODE_PERMISSION: process.env["MIMOCODE_PERMISSION"],
+
+  // Defaults to false. When false, the bash tool intercepts irreversible
+  // deletion commands (rm, rmdir, unlink, shred, del, erase, rd, remove-item,
+  // and git destructive subcommands like reset --hard / clean -f / branch -D /
+  // worktree remove / push --force / stash drop|clear / tag -d) and forces an
+  // extra permission prompt with permission="bash_delete" — separate from the
+  // normal bash-permission ask so it can't be silently pre-approved by a broad
+  // `bash: allow` rule. Set MIMOCODE_AUTO_APPROVE_DELETE=true to trust the
+  // model with deletes and skip the second confirmation.
+  MIMOCODE_AUTO_APPROVE_DELETE: truthy("MIMOCODE_AUTO_APPROVE_DELETE"),
   MIMOCODE_DISABLE_DEFAULT_PLUGINS: truthy("MIMOCODE_DISABLE_DEFAULT_PLUGINS"),
   MIMOCODE_DISABLE_LSP_DOWNLOAD: truthy("MIMOCODE_DISABLE_LSP_DOWNLOAD"),
   MIMOCODE_ENABLE_EXPERIMENTAL_MODELS: truthy("MIMOCODE_ENABLE_EXPERIMENTAL_MODELS"),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -561,7 +561,7 @@ export const layer = Layer.effect(
       }
 
       const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
-      if (!Flag.MIMOCODE_DISABLE_BUILTIN_SKILLS && !Flag.MIMOCODE_DISABLE_DOCUMENT_SKILLS) {
+      if (!Flag.MIMOCODE_DISABLE_BUILTIN_SKILLS && !Flag.MIMOCODE_DISABLE_OFFICIAL_SKILLS) {
         const fileCandidates = userMessage.parts.flatMap((p) => {
           if (p.type !== "file") return []
           const filenameFromSource =

--- a/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/LICENSE
+++ b/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: html-to-video-pipeline
+description: Reliable HTML-to-MP4 rendering via headless browser recording (Playwright/Puppeteer) + ffmpeg — the ordering, gotchas, and verification steps you MUST get right or the output silently rots. Trigger whenever the user is building or debugging any pipeline that turns an HTML/CSS/JS page (single-file, multi-composition, GSAP-driven, or `@keyframes`-driven) into a video file, including headless recording, screen capture of a web page, deterministic frame-by-frame capture, multi-scene concatenation, or engine-mixed video output. Also trigger when the symptom sounds like: font swap flashing in the opening frames (FOUT), the first few seconds of the video are frozen/dead, animations play during page load and get truncated, concatenated segments produce a video whose duration is wildly wrong (e.g., 8s becomes 35s), `file://` loaded HTML fails to fetch its sub-scenes, the exported video is soft/blurry compared to the browser, or playback stutters/looks choppy despite passing a high `-r` fps to ffmpeg. Use even for one-off scripts — the failure modes here are subtle enough that starting from scratch usually reintroduces them.
+---
+
+# HTML → Video: the pipeline that actually works
+
+Turning a live HTML page into an MP4 sounds like a one-liner ("Playwright records, ffmpeg encodes") and the first draft always looks fine — until you play back the export and notice text flashing in a fallback font, three dead seconds at the start, or a "10-second" clip that clocks in at 35s. This skill captures the specific ordering, waits, and encoder flags that make the output trustworthy.
+
+Think of the pipeline as five phases with a single invariant between them:
+
+```
+launch  →  hold @ frame 0  →  align capture start with animation start  →  record  →  trim & encode
+```
+
+The invariant: **no pixel of the animation should render before capture is ready, AND capture must not start before every asset that affects layout has loaded.** Every gotcha below is a violation of that invariant.
+
+Quick checklist (each item is expanded below):
+
+1. `viewport` must exactly equal `recordVideo.size` — mismatch silently rescales the output soft/blurry.
+2. Freeze CSS animations via `addInitScript` **before** `goto()`.
+3. `goto` with `domcontentloaded`, never `load`.
+4. Pre-inline `data-composition-src` sub-scenes — `file://` blocks client-side `fetch`.
+5. Font wait = stylesheet `<link>` load → `face.load()` per face → `fonts.ready` → 2 rAFs.
+6. Probe duration with infinite-iteration / `repeat: -1` guards.
+7. Unfreeze = t=0; trim `leadInMs − 120ms` with `-ss` *before* `-i`.
+8. Concat: same engine → demuxer `-c copy`; mixed engines → concat *filter* + re-encode.
+9. Verify with ffprobe duration + full decode + sampled frames. Always.
+
+There are two capture modes, and picking the wrong one wastes a day:
+
+- **Mode A — real-time `recordVideo`** (the phases below). Simple, wall-clock = clip length. But the screencast is best-effort variable frame rate (~25fps) and competes with the animation for CPU. Good enough for previews and ≤30fps deliverables on an idle machine.
+- **Mode B — deterministic frame stepping** (pause everything, seek to `i / fps`, screenshot, encode the PNG sequence). Exact fps, every frame rendered, no lead-in trim, immune to machine load. Required when the output must be genuinely smooth ≥30fps or renders run on loaded CI. See "Deterministic frame stepping" below.
+
+## Prerequisites — install these first
+
+Two hard requirements: a headless browser driver (Playwright or Puppeteer) and `ffmpeg`. Everything below assumes both are installed and on `PATH`.
+
+### 1. Headless browser driver
+
+Playwright is the default in this skill (its `recordVideo` API is what the pipeline is written against). Puppeteer works too but you'll wire recording yourself via CDP screencast — pick Playwright unless you have a reason not to.
+
+```bash
+# Playwright (recommended) — npm / pnpm / bun all work
+npm  install playwright
+pnpm add playwright
+bun  add playwright
+
+# Then install the actual browser binaries (this is the step people forget):
+npx playwright install chromium              # just Chromium — enough for this pipeline
+npx playwright install --with-deps chromium  # Linux/CI: also install shared libs
+```
+
+Verify: `npx playwright --version` prints the driver version, and `node -e "require('playwright').chromium.launch().then(b => b.close())"` exits cleanly.
+
+Puppeteer alternative (only if you already have it in the project):
+
+```bash
+npm install puppeteer            # bundles a matching Chromium automatically
+# or, to reuse a system Chrome:
+npm install puppeteer-core       # no bundled browser — you supply executablePath
+```
+
+### 2. ffmpeg
+
+The encode/trim/concat/verify steps all shell out to `ffmpeg` (and `ffprobe`, which ships in the same package). It is **not** an npm dependency — install it at the OS level.
+
+```bash
+# macOS
+brew install ffmpeg
+
+# Debian / Ubuntu
+sudo apt-get update && sudo apt-get install -y ffmpeg
+
+# Fedora / RHEL
+sudo dnf install ffmpeg          # requires RPM Fusion enabled
+
+# Windows
+winget install Gyan.FFmpeg       # or: choco install ffmpeg
+```
+
+Verify: `ffmpeg -version` and `ffprobe -version` both print. If a script spawns `ffmpeg` and gets `ENOENT`, the binary isn't on `PATH` — see the graceful-failure snippet in `references/ffmpeg-cheatsheet.md`.
+
+Do **not** rely on the `ffmpeg-static` / `@ffmpeg-installer/ffmpeg` npm packages for production: their bundled builds skip codecs and encoder flags you'll hit sooner or later (e.g. `libx264` presets, `tpad`). A system ffmpeg is the durable choice.
+
+### 3. Optional — ImageMagick (verification only)
+
+Only needed if you want the "did anything render?" pixel-mean check from Phase 6. Skip it otherwise.
+
+```bash
+brew install imagemagick         # macOS
+sudo apt-get install imagemagick # Debian/Ubuntu
+```
+
+Verify: `magick -version` (ImageMagick 7) or `convert -version` (ImageMagick 6).
+
+## The pipeline
+
+### Phase 1 — Launch and prepare the recorder
+
+Use `playwright.chromium.launch({ headless: true })` and a context configured with `recordVideo: { dir, size: { width, height } }`. Two sizing rules:
+
+- **`viewport` must exactly equal `recordVideo.size`.** When they differ, Playwright rescales the screencast to fit the recording size and the whole output goes soft. Derive both from the same constants.
+- `recordVideo` captures at CSS-pixel resolution; `deviceScaleFactor` does **not** raise recording resolution. For a 1080p export use a 1920×1080 viewport, not 960×540 @ 2x.
+
+Recording begins the instant the context exists — treat that timestamp as the WebM's t=0 and remember it (`tWebmStart = Date.now()`); you will need it in Phase 5 to trim the dead opening.
+
+Know the recorder's ceiling: the screencast runs at a variable ~25fps and drops frames under CPU load. The `-r <fps>` flag in Phase 5 makes the container constant-frame-rate but only duplicates frames — it cannot add smoothness. If stutter matters, switch to frame stepping (Mode B) instead of fighting this.
+
+### Phase 2 — Freeze animations BEFORE the page parses
+
+This is the single most-missed step. Pure-CSS `@keyframes` animations begin the moment the element is styled — there is no JS trigger to hold. If you `goto()` the HTML and then start waiting for fonts (which takes seconds), the CSS timeline has *already been running the whole time*. The recording captures the fallback font swapping to the real face mid-clip, and the opening beats of the animation are lost to the font wait.
+
+Fix: inject a global freeze **via `page.addInitScript()`**, which runs before any of the document's own scripts and before CSS is applied, so the timeline is paused at frame 0 the moment it exists:
+
+```js
+await page.addInitScript(() => {
+  const style = document.createElement('style');
+  style.id = '__freeze';
+  style.textContent =
+    '*, *::before, *::after { animation-play-state: paused !important;' +
+    ' -webkit-animation-play-state: paused !important; }';
+  const attach = () => (document.head || document.documentElement).appendChild(style);
+  if (document.head || document.documentElement) attach();
+  else document.addEventListener('DOMContentLoaded', attach, { once: true });
+  window.__unfreeze = () => document.getElementById('__freeze')?.remove();
+});
+```
+
+This does not stop GSAP tweens driven by JS (see Phase 4 for those) — for GSAP-driven templates, register the master timeline paused and expose a `window.__playAll()` you call in Phase 4.
+
+### Phase 3 — Load with `domcontentloaded`, not `load`
+
+`waitUntil: 'load'` blocks on every external asset, including cross-origin videos with no CORS headers. Chromium will retry those for ~4s before giving up, and those 4s get burned into the recording as a frozen first scene. Use `waitUntil: 'domcontentloaded'` — the DOM + synchronous inline scripts (GSAP, your player) are ready, and you handle fonts explicitly next.
+
+If the template is multi-composition (scenes loaded via `data-composition-src` and client-side `fetch`), you must **pre-inline** those sub-files into the entry HTML on the Node side and write it to a sibling `.tmp.html`. Chromium blocks `file://` fetch, so client-side scene loaders that work in a browser tab will silently produce an empty shell in a headless recording. See `references/multi-composition.md`.
+
+### Phase 4 — Wait for fonts properly, then release
+
+`document.fonts.ready` alone is **not enough** and this is the second most-missed step. Under `domcontentloaded`, the Google Fonts (or any external) `<link rel="stylesheet">` has usually not returned yet. Until its CSS arrives, its `@font-face` rules are not in `document.fonts` at all — so `fonts.ready` sees an empty set and resolves *instantly*. Recording proceeds, the CSS lands mid-clip, faces download, and the swap happens on-camera.
+
+The correct sequence, all inside a `page.evaluate()` with an 8s hard cap so a wedged CDN can't stall forever:
+
+1. Wait for every `<link rel="stylesheet">` to `load` or `error` — that registers `@font-face` rules into `document.fonts`.
+2. For each registered face, call `face.load()` explicitly. `font-display: swap` defers the download until something paints with that face — if your first frame doesn't happen to use the face, it never fetches without this.
+3. `await fonts.ready`.
+4. Two rAFs so layout settles on the real glyph metrics before frame 0.
+
+Then, and only then:
+
+5. Drive playback: for GSAP multi-composition templates, call `window.__playAll()` to start every registered (paused) master timeline from 0. For pure-CSS templates, this is a no-op.
+6. Call `window.__unfreeze()` to remove the freeze style. **This is the true t=0 of the animation.** Record the wall-clock offset from `tWebmStart` (`leadInMs = Date.now() - tWebmStart`) — this is what you trim in Phase 5.
+
+The full JS for Phase 4 is in `references/font-wait.md`.
+
+### Phase 5 — Probe duration, record, then trim and encode
+
+**Probe duration first** (skip this only if you know the exact intended length). The user's requested `duration` may be shorter than the animation, in which case you'd cut the animation mid-play. Take the maximum of:
+
+- The longest **non-infinite** CSS animation (`animation-duration + animation-delay` for entries where `animation-iteration-count !== 'infinite'`).
+- The longest **finite** GSAP tween. Do **not** use `gsap.globalTimeline.totalDuration()` — a `repeat: -1` tween (blinking cursor, looping background) makes it ~1e10s. Walk `globalTimeline.getChildren(true, true, true)` and skip anything with `repeat() === -1`.
+
+Add a ~400ms settle so the last animation frame is captured, cap at 30s so a stray huge value can't run away. If your caller passed an *explicit* per-frame duration (e.g. "each scene is exactly 4s"), do **not** extend — treat it as a hard cap and pad the tail if the animation finished early (see below). If duration was 'auto', extend to the probed length.
+
+**Record** for `totalDuration`, then `context.close()`. Playwright drops the WebM in `recordDir`.
+
+**Encode with ffmpeg**, applying two corrections:
+
+```
+ffmpeg -y \
+  [ -ss <(leadInMs - 120) / 1000> ]  # trim dead lead-in, back off 120ms so we don't clip frame 1
+  -i input.webm \
+  [ -vf tpad=stop_mode=clone:stop_duration=<totalDuration> ]  # pad tail only when duration is explicit
+  -t <totalDuration> \                # trim to exact length (recordVideo sometimes overshoots)
+  -r <fps> \
+  -c:v libx264 -pix_fmt yuv420p -preset medium -crf 20 \
+  -movflags +faststart \
+  out.mp4
+```
+
+The `-ss` back-off matters: recorder start jitter and rounding can steal the first real frame if you trim to exactly `leadInMs`. A couple of extra still frames at the head are invisible; a missing opening beat is obvious.
+
+## Deterministic frame stepping (Mode B)
+
+When the deliverable must be genuinely smooth at an exact fps — or the render runs on a loaded CI box where real-time capture visibly stutters — don't record in real time at all. Keep Phases 1–4 (minus `recordVideo`), then: pause every timeline, seek to `i / fps`, `page.screenshot()` each frame, and encode the PNG sequence with `ffmpeg -framerate <fps>`. Duration is exact by construction, there is no lead-in to trim, and every single frame is fully rendered regardless of machine load.
+
+It works when the page's motion is declaratively seekable — CSS `@keyframes` (via `document.getAnimations()` + `currentTime`), WAAPI, and GSAP (`gsap.globalTimeline.time(t)`). It does **not** work for `<video>` elements, `setTimeout`-choreographed scenes, or rAF-driven physics; those need real-time recording or a CDP virtual clock. Step time monotonically forward, never backwards.
+
+Full loop, the seek/suppressEvents subtleties, the "animations created later by JS are invisible to the seek" trap, and optional 2x supersampling are in `references/frame-stepping.md`.
+
+## Multi-segment concatenation
+
+When you have N per-scene MP4s and need one output, the correct ffmpeg strategy depends on whether the inputs share a codec/timebase.
+
+**Same encoder, same params (typical: all scenes rendered by the same adapter)** — use `concat` demuxer with stream copy. Fast, lossless:
+
+```
+ffmpeg -y -f concat -safe 0 -i list.txt -c copy out.mp4
+```
+
+where `list.txt` is `file 'seg1.mp4'\nfile 'seg2.mp4'\n...`.
+
+**Mixed sources (e.g. scene A recorded by headless Chromium, scene B rendered by a React/Remotion pipeline)** — the concat demuxer's `-c copy` path assumes compatible timebases and PTS. When timebases differ, PTS accumulate incorrectly and an 8-second output can become 35 seconds. **Even `-vsync cfr` won't save you** — the bad PTS have already been fed in. You must re-encode via the concat **filter**, which rebuilds the timeline:
+
+```
+ffmpeg -y -i seg1.mp4 -i seg2.mp4 -i seg3.mp4 \
+  -filter_complex "[0:v][1:v][2:v]concat=n=3:v=1:a=0[v]" \
+  -map "[v]" -c:v libx264 -pix_fmt yuv420p -r 60 \
+  -movflags +faststart out.mp4
+```
+
+Decision rule in code: pass a `reencode: boolean` down to your concat helper. Set it to `true` whenever any segment came from a different rendering engine than the others, or when you're not sure.
+
+## Verify — always
+
+You cannot trust "the file was written" as success. The failure modes above (wrong duration, FOUT, dead lead-in) all produce a playable MP4. Before declaring success:
+
+- `ffprobe -v error -show_entries format=duration -of csv=p=0 out.mp4` — actual duration matches expected within ~50ms?
+- `ffmpeg -v error -i out.mp4 -f null -` — full decode, no errors? A "silently corrupted" output from a bad concat will decode fine but be the wrong length; conversely, a broken concat demuxer output can throw here.
+- Sample a frame near t=0.1s and t=0.5s (`ffmpeg -ss 0.1 -i out.mp4 -frames:v 1 -y f1.png`) — text renders in the intended font? If your test rig has ImageMagick, `magick f1.png -threshold 50% -format '%[fx:100*mean]' info:` gives a rough non-background pixel percentage that catches "recording is completely blank" regressions.
+
+For fonts specifically: **studio-style live iframe previews will not reproduce FOUT** because the browser tab caches faces. Only cold-headless rendering (i.e. the actual export path) reproduces it. Verify on the exported MP4, not the preview.
+
+## When to depart from this template
+
+- **Non-animated single-frame PNG export.** Skip Phases 2, 4-5-recording; goto → `fonts.ready` → `page.screenshot()` is enough. FOUT still applies for the screenshot.
+- **You own the animation timeline in JS end-to-end** (e.g. Motion Canvas / Remotion generator style). The freeze/unfreeze dance is unnecessary because *you* drive frame-by-frame rendering — use the framework's own frame API and skip Playwright recording entirely. The concat rules still apply if you're mixing engines.
+- **Interactive-page capture** (recording a real user session). Duration probing is meaningless; use manual start/stop signals and skip lead-in trim.
+
+## Reference files
+
+- `references/font-wait.md` — full JS for the Phase 4 font-wait routine, with per-link timeout and rAF-based settle.
+- `references/frame-stepping.md` — the Mode B deterministic capture loop: seek-per-frame, screenshot, PNG-sequence encode, supersampling, and its limits.
+- `references/multi-composition.md` — inlining `data-composition-src` scenes for `file://` recording, including re-executing cloned `<script>` nodes.
+- `references/duration-probe.md` — CSS + GSAP probe with the infinite-iteration guards.
+- `references/ffmpeg-cheatsheet.md` — the encode/concat/verify commands in one place.

--- a/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/evals/evals.json
+++ b/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/evals/evals.json
@@ -1,0 +1,33 @@
+{
+  "skill_name": "html-to-video-pipeline",
+  "evals": [
+    {
+      "id": 0,
+      "name": "fout-debugging",
+      "prompt": "I'm building a small tool that turns HTML template files into MP4s using Playwright chromium.launch + recordVideo + ffmpeg. The templates are single-file HTML with a bit of CSS @keyframes and usually a Google Fonts <link> (Shrikhand, Archivo Black). Almost everything works EXCEPT: when I play back the exported MP4, the first ~1.5 seconds show the text in a system-serif fallback, then it snaps to the real Shrikhand mid-clip — you can literally see the letter widths jump. In the live preview inside my dev studio it looks fine, only the export has this issue. I already tried adding `await page.evaluate(() => document.fonts.ready)` right after page.goto and it didn't help. What's actually going on and how do I fix this properly?",
+      "expected_output": "Diagnoses that fonts.ready under domcontentloaded resolves against empty face set because stylesheet <link> hasn't loaded yet. Prescribes: freeze animations via addInitScript before goto + wait for stylesheet links + face.load() per face + fonts.ready + rAF. Notes live preview differs because tab-cached fonts.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "concat-corruption",
+      "prompt": "I have a pipeline that renders each scene of a video as a separate MP4. Scene A and C come from a Playwright browser recording (libx264 via ffmpeg), Scene B comes from Remotion's renderMedia (also libx264 but different pipeline). Each individual scene is exactly the length I expect — 3s each, so 9s total. When I concat them with `ffmpeg -f concat -safe 0 -i list.txt -c copy out.mp4`, the resulting file plays fine but ffprobe says it's 34 seconds long and there's a huge frozen chunk in the middle. Same list.txt works fine if all three scenes come from Playwright. What's wrong and how do I fix it? I'd really rather not re-encode if I don't have to.",
+      "expected_output": "Root cause = PTS/timebase mismatch between Remotion and Playwright outputs; -c copy accumulates bad PTS. Fix = concat filter -filter_complex \"[0:v][1:v][2:v]concat=n=3:v=1:a=0[v]\" which rebuilds timeline and requires re-encoding. Notes -vsync cfr won't rescue the demuxer path.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "build-from-scratch",
+      "prompt": "I need to build a headless HTML-to-video renderer for a small internal design tool at my company. Input is an HTML file that may include CSS @keyframes animations, an optional GSAP master timeline, and web fonts pulled from a Google Fonts <link>. Output is a 1080p MP4 at 30fps at whatever duration the animation naturally runs (max ~15s). It'll be called from a Node service running in a Linux container. I've written a bit of Puppeteer/Playwright glue before but never a proper video export pipeline — walk me through what the code should actually look like, and please flag any subtle traps I should know about before I ship this.",
+      "expected_output": "Walks through Playwright recordVideo + ffmpeg encode. Includes: freeze animations before goto (addInitScript), waitUntil domcontentloaded not load, proper font wait (stylesheet link + face.load + fonts.ready + rAF), duration probe with infinite/repeat:-1 guards, trim dead lead-in with -ss, ffmpeg encode with +faststart, verification via ffprobe.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "choppy-recording",
+      "prompt": "My Playwright recordVideo pipeline works end to end, but the exported MP4 looks choppy — the GSAP motion visibly stutters, even though I pass -r 60 to ffmpeg and the animation is silky smooth in a real browser tab. Also the whole video looks slightly soft/blurry compared to the browser. Rendering happens headless in a Docker CI container. I need a genuinely smooth 60fps 1080p export. What are my options?",
+      "expected_output": "Explains recordVideo is a best-effort variable ~25fps screencast that drops frames under CI load; -r 60 only duplicates frames and cannot add smoothness. Checks viewport === recordVideo.size for the blurriness (mismatch rescales output; deviceScaleFactor doesn't raise recording resolution). Prescribes deterministic frame stepping: pause all animations, per frame seek document.getAnimations() currentTime and gsap.globalTimeline.time(i/60), screenshot each frame, encode the PNG sequence with ffmpeg -framerate 60. Notes limits: <video> elements or setTimeout-choreographed scenes need real-time capture or a CDP virtual clock.",
+      "files": []
+    }
+  ]
+}

--- a/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/references/duration-probe.md
+++ b/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/references/duration-probe.md
@@ -1,0 +1,63 @@
+# Duration probe — CSS + GSAP
+
+Run this inside `page.evaluate()` after fonts are ready but before you start the recording clock. It returns the length in milliseconds that the animation actually needs. Take the maximum of this and the caller's requested duration (when `duration === 'auto'`); treat as a hard cap when the caller specified an explicit length.
+
+```js
+const animMs = await page.evaluate(() => {
+  let maxMs = 0;
+
+  // ---- CSS @keyframes ----
+  // Walk every element and inspect computed animation-duration + delay.
+  // Skip entries whose iteration-count is infinite (looping background anims).
+  Array.from(document.querySelectorAll('*')).forEach((el) => {
+    const s = getComputedStyle(el);
+    const durs = (s.animationDuration || '').split(',');
+    const dels = (s.animationDelay || '').split(',');
+    const iters = (s.animationIterationCount || '').split(',');
+    durs.forEach((d, i) => {
+      if ((iters[i] || '').trim() === 'infinite') return;
+      const total = ((parseFloat(d) || 0) + (parseFloat(dels[i] || '0') || 0)) * 1000;
+      if (total > maxMs) maxMs = total;
+    });
+  });
+
+  // ---- GSAP timelines ----
+  // Do NOT use gsap.globalTimeline.totalDuration() — a single repeat: -1 tween
+  // makes it ~1e10s. Walk the children and take the longest finite tween.
+  const g = window.gsap;
+  let gsapMs = 0;
+  const children = g?.globalTimeline?.getChildren?.(true, true, true) ?? [];
+  for (const c of children) {
+    const repeat = typeof c.repeat === 'function' ? c.repeat() : (c.vars?.repeat ?? 0);
+    if (repeat === -1) continue; // infinite loop — ignore
+    const td = typeof c.totalDuration === 'function' ? c.totalDuration() : 0;
+    if (Number.isFinite(td)) gsapMs = Math.max(gsapMs, td * 1000);
+  }
+
+  return Math.max(maxMs, gsapMs);
+});
+
+// +400ms settle so the final animation frame is captured; cap at 30s so a
+// stray huge value can't stretch a frame arbitrarily.
+const needed = Math.min(30, (animMs + 400) / 1000);
+```
+
+## Why the infinite-guard matters
+
+Every real template has *something* that loops — a caret blinking, a background gradient sweeping, a subtle "breathing" scale on an accent. Any of these in a naive probe blows the number up. Two common failure shapes:
+
+- **CSS: `animation-iteration-count: infinite`** — `animation-duration` might be 1.2s (one blink cycle). Multiplied out mentally, this is one second. In the probe it's just 1200ms. Fine on its own — but if you *don't* skip it and instead do something like `Math.max(duration, 1e9)` accidentally somewhere, you get a 30-year clip. The guard is: check `iteration-count === 'infinite'` and skip.
+- **GSAP: `repeat: -1`** — `tween.totalDuration()` returns `Infinity` (or a huge finite number depending on GSAP version). `gsap.globalTimeline.totalDuration()` propagates that. Skip via `child.repeat() === -1`.
+
+## When to extend vs when to cap
+
+Two callers, two policies:
+
+- **Single-frame preview / "auto" duration** — the caller doesn't know how long the animation is; extend to `max(requested, probed)`. Better an extra second of a still hold than a truncated ending.
+- **Multi-frame export with explicit per-scene length** — each scene is contractually N seconds. Do **not** extend; that would push the total off and desync any audio. Instead, if the probed length is shorter than N, pad the tail in the encoder with `-vf tpad=stop_mode=clone:stop_duration=N`, so the last frame holds until N. If the probed length is longer than N, that's a template bug — surface a warning; do not silently clip.
+
+Distinguish with a flag on the render config, e.g. `durationMode: 'auto' | 'explicit'`.
+
+## What if the template has no discoverable animation?
+
+The probe returns 0 and you fall back to the caller's requested duration. That's the right behavior — a static HTML page has no "natural" length. If the caller also passed 'auto', pick a sane default (5s in this codebase's convention).

--- a/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/references/ffmpeg-cheatsheet.md
+++ b/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/references/ffmpeg-cheatsheet.md
@@ -1,0 +1,132 @@
+# ffmpeg cheatsheet for HTML→video pipelines
+
+All commands assume ffmpeg is on PATH. If it's not, install with `brew install ffmpeg` (macOS) or your platform equivalent.
+
+## WebM → MP4 (single-scene encode)
+
+Playwright's `recordVideo` writes a WebM. Convert it to a broadly-compatible MP4, trimming the dead lead-in (page load + font wait) and forcing an exact duration.
+
+```
+ffmpeg -y \
+  -ss <leadInSec> \
+  -i input.webm \
+  -t <totalDurationSec> \
+  -r <fps> \
+  -c:v libx264 -pix_fmt yuv420p -preset medium -crf 20 \
+  -movflags +faststart \
+  out.mp4
+```
+
+- `-ss` **before `-i`** = fast input seek (drops the frozen lead-in entirely, doesn't re-encode it just to throw it away).
+- `-t` = trim to exact length. `recordVideo` sometimes overshoots by however long `context.close()` takes.
+- Trim back the seek by ~120ms (i.e. seek to `leadInMs - 120`) so recorder start jitter can't clip the first real animation frame. A couple of extra still frames at the head are invisible; a missing opening beat is obvious.
+- `crf 20` is a good default: visibly indistinguishable from source, ~half the size of `crf 18`. Drop to `18` for archive-quality masters; raise to `23` for aggressive size.
+- `+faststart` moves the moov atom to the front so the MP4 begins playing without a full download (matters for CDN delivery).
+
+## Explicit-duration variant (multi-scene export)
+
+When each scene must be *exactly* N seconds and the animation might have finished early, hold the last frame to fill:
+
+```
+ffmpeg -y \
+  -ss <leadInSec> \
+  -i input.webm \
+  -vf tpad=stop_mode=clone:stop_duration=<N> \
+  -t <N> \
+  -r <fps> \
+  -c:v libx264 -pix_fmt yuv420p -preset medium -crf 20 \
+  -movflags +faststart \
+  out.mp4
+```
+
+The `tpad` filter clones the final frame; `-t` then trims to the precise length.
+
+## PNG sequence → MP4 (frame-stepping mode)
+
+For Mode B captures (see `frame-stepping.md`), where each frame was screenshotted deterministically:
+
+```
+ffmpeg -y -framerate <fps> -i frames/f%05d.png \
+  -c:v libx264 -pix_fmt yuv420p -preset medium -crf 20 \
+  -movflags +faststart out.mp4
+```
+
+- `-framerate` must come **before** `-i` (it's an input option). An image sequence carries no timestamps; this option defines them. Output duration is exactly `frames / fps` — no `-ss` trim, no `-t` cap needed.
+- Frame names must be zero-padded and contiguous (`f00000.png`, `f00001.png`, …); a gap makes ffmpeg stop early without error.
+- If frames were captured at 2x (`deviceScaleFactor: 2` supersampling), add `-vf scale=1920:1080:flags=lanczos` to downscale with crisp text.
+
+## Concat: same encoder (fast, lossless)
+
+All segments came from the same rendering pipeline with matching codec/params. Use the concat demuxer with `-c copy` — this doesn't re-encode, it just concatenates the packet streams:
+
+```
+# list.txt:
+#   file '/abs/path/seg1.mp4'
+#   file '/abs/path/seg2.mp4'
+#   file '/abs/path/seg3.mp4'
+
+ffmpeg -y -f concat -safe 0 -i list.txt -c copy out.mp4
+```
+
+- `-safe 0` allows absolute paths in `list.txt`.
+- Escape single quotes in filenames as `'\''` inside the list file.
+
+## Concat: mixed sources (re-encode via filter)
+
+Segments came from *different* rendering engines (e.g. Playwright-recorded scenes A + C, framework-rendered scene B). Timebase and PTS conventions differ across the sources. **The concat demuxer + `-c copy` will corrupt the timeline** — an 8-second output can silently become 35 seconds because PTS accumulate incorrectly. Even `-vsync cfr` won't save it; the bad PTS are already in the stream.
+
+Use the concat **filter**, which rebuilds the timeline from scratch. This re-encodes, so it's slower and slightly lossy, but the duration is precise:
+
+```
+ffmpeg -y \
+  -i seg1.mp4 -i seg2.mp4 -i seg3.mp4 \
+  -filter_complex "[0:v][1:v][2:v]concat=n=3:v=1:a=0[v]" \
+  -map "[v]" \
+  -c:v libx264 -pix_fmt yuv420p -r <fps> \
+  -movflags +faststart \
+  out.mp4
+```
+
+- `n=3` = number of inputs. If you generate this dynamically: `[0:v][1:v]...[N-1:v]concat=n=N:v=1:a=0[v]`.
+- `v=1:a=0` = one video stream out, zero audio streams. If your segments have audio, use `v=1:a=1` and pair each input as `[0:v][0:a][1:v][1:a]...`.
+- If you're not sure whether sources match, use this variant. The cost is one re-encode; the alternative is a silently corrupted output.
+
+## Verification (always run at least the first two)
+
+```
+# Actual duration — must match expected within ~50ms.
+ffprobe -v error -show_entries format=duration -of csv=p=0 out.mp4
+
+# Full decode, no errors. A concat corruption often decodes fine but has the
+# wrong length; a broken stream copy can throw here.
+ffmpeg -v error -i out.mp4 -f null -
+
+# Streams / codecs / resolution / fps.
+ffprobe -v error -show_streams -of default=noprint_wrappers=1 out.mp4
+
+# Sample frames to eyeball the opening (font correctness) and a mid-clip beat.
+ffmpeg -ss 0.1 -i out.mp4 -frames:v 1 -y frame_early.png
+ffmpeg -ss 0.5 -i out.mp4 -frames:v 1 -y frame_mid.png
+```
+
+If you have ImageMagick, this is a cheap "did anything render?" check:
+
+```
+# Rough non-background pixel percentage — 0% ≈ blank, 20%+ ≈ real content.
+magick frame_early.png -threshold 50% -format '%[fx:100*mean]' info:
+```
+
+## Handling missing ffmpeg gracefully
+
+Spawn detection is easier than checking with `which`:
+
+```js
+proc.on('error', (err) => {
+  if (err.code === 'ENOENT') {
+    throw new Error('ffmpeg not found on PATH. Install with `brew install ffmpeg` (macOS).');
+  }
+  throw err;
+});
+```
+
+The `ENOENT` from `child_process.spawn` fires when the binary itself is missing, which is the only interesting distinction for a user-facing hint.

--- a/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/references/font-wait.md
+++ b/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/references/font-wait.md
@@ -1,0 +1,68 @@
+# Phase 4 — Font-wait routine
+
+This is the full `page.evaluate()` body for waiting until all display fonts have loaded and painted. Copy verbatim; the ordering is load-bearing.
+
+```js
+await page.evaluate(() => new Promise((resolve) => {
+  const doc = document;
+  const fonts = doc.fonts;
+  if (!fonts || typeof fonts.ready?.then !== 'function') { resolve(); return; }
+
+  let settled = false;
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    // One more frame so the relayout on the real face is painted.
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  };
+  // Hard cap: a blocked CDN must never stall the render.
+  const cap = setTimeout(finish, 8000);
+
+  // 1. Wait for stylesheet <link>s to load — this registers @font-face rules
+  //    into document.fonts. Without this step, fonts.ready sees an empty set
+  //    and resolves instantly.
+  const links = Array.from(document.querySelectorAll('link[rel="stylesheet"]'));
+  const linkDone = links.map((link) => {
+    // An already-loaded sheet exposes cssRules without throwing.
+    try { if (link.sheet && link.sheet.cssRules) return Promise.resolve(); }
+    catch { /* not ready yet — fall through to event wait */ }
+    return new Promise((r) => {
+      const done = () => r();
+      link.addEventListener('load', done, { once: true });
+      link.addEventListener('error', done, { once: true });
+      // Per-link safety so one wedged link can't hold the batch.
+      setTimeout(done, 6000);
+    });
+  });
+
+  Promise.all(linkDone)
+    .then(() => {
+      // 2. Force every registered face to actually download. Under `display: swap`
+      //    the browser defers the fetch until something paints with the face —
+      //    off-screen or pre-animation text may not have triggered that yet.
+      const loads = [];
+      fonts.forEach((face) => {
+        try { loads.push(face.load().catch(() => undefined)); }
+        catch { /* some faces reject load() pre-paint — ignore */ }
+      });
+      return Promise.all(loads);
+    })
+    // 3. Now ready() reflects the real face set.
+    .then(() => fonts.ready)
+    .then(() => { clearTimeout(cap); finish(); })
+    .catch(() => { clearTimeout(cap); finish(); });
+})).catch(() => {});
+```
+
+## Why each step is there
+
+1. **Wait for stylesheet `<link>`s** — under `waitUntil: 'domcontentloaded'`, `<link rel="stylesheet">` requests are still in flight. Their `@font-face` rules only enter `document.fonts` after the sheet loads. `fonts.ready` on an empty set resolves immediately, which is the bug.
+2. **`face.load()` per face** — `font-display: swap` (Google Fonts' default) tells the browser to paint fallback immediately and defer the real face fetch until it's needed. If your first frame has no text in that face (e.g. an intro card that fades in), the face never downloads and the swap happens later, on camera.
+3. **`fonts.ready`** — resolves when every currently pending face has settled (loaded or errored).
+4. **Two rAFs** — layout may relayout on the real glyph metrics; give the browser one frame to paint, and one more to be safe.
+
+## Failure modes this prevents
+
+- Text renders in system font for the first N frames, then snaps to the intended face (FOUT visible in export).
+- Layout shifts a few pixels between frames as the real face's advance widths take effect.
+- A `<link>` that fails to load blocks the recording forever (per-link 6s cap + overall 8s cap).

--- a/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/references/frame-stepping.md
+++ b/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/references/frame-stepping.md
@@ -1,0 +1,88 @@
+# Mode B — Deterministic frame stepping
+
+Alternative to Playwright's `recordVideo`: pause every timeline, seek to `i / fps`, screenshot each frame, encode the PNG sequence. Use it when real-time capture can't deliver.
+
+## Choosing stepping over real-time recording
+
+|                                      | Mode A: real-time `recordVideo`         | Mode B: frame stepping                    |
+| ------------------------------------ | ---------------------------------------- | ----------------------------------------- |
+| Smoothness                           | variable ~25fps, drops frames under load | exact fps, every frame fully rendered     |
+| Duration accuracy                    | `-ss` trim + `-t`, ±1 frame              | exact by construction (`frames / fps`)    |
+| Wall-clock cost                      | = clip length                            | ~2–10 captured fps; slower for long clips |
+| `<video>` / timers / rAF physics     | works                                    | does NOT work (needs virtual clock)       |
+| Lead-in trim needed                  | yes (Phase 5)                            | no                                        |
+| Sensitive to machine load            | yes — stutter bakes into the file        | no                                        |
+
+Phases 1–4 of the main pipeline still apply, with two changes: drop `recordVideo` from the context options, and never call `window.__unfreeze()` — the freeze style stays on for the whole capture (a paused animation still renders when you set its `currentTime`).
+
+## The loop
+
+```js
+const fps = 30;
+const totalFrames = Math.ceil(durationS * fps); // durationS from the duration probe
+
+// After the Phase 4 font wait: pin every seekable timeline at 0.
+await page.evaluate(() => {
+  document.getAnimations().forEach((a) => { a.pause(); a.currentTime = 0; });
+  window.gsap?.globalTimeline.pause().time(0, true);
+});
+
+for (let i = 0; i < totalFrames; i++) {
+  const tMs = (i / fps) * 1000;
+  await page.evaluate((t) => {
+    document.getAnimations().forEach((a) => { a.currentTime = t; });
+    // suppressEvents=false: we only ever step forward, so DOM-mutating
+    // onStart/onComplete callbacks fire exactly as they would in playback.
+    window.gsap?.globalTimeline.time(t / 1000, false);
+  }, tMs);
+  await page.screenshot({ path: join(framesDir, `f${String(i).padStart(5, '0')}.png`) });
+}
+```
+
+Then encode (also in `ffmpeg-cheatsheet.md`):
+
+```
+ffmpeg -y -framerate <fps> -i frames/f%05d.png \
+  -c:v libx264 -pix_fmt yuv420p -preset medium -crf 20 \
+  -movflags +faststart out.mp4
+```
+
+`-framerate` must come **before** `-i` — an image sequence carries no timestamps, this option defines them.
+
+## Gotchas
+
+- **Animations created later by JS are invisible to the seek.** `document.getAnimations()` returns what exists *now*. If a script adds a class or spawns tweens at t=3s via `setTimeout`, the seek loop never touches them and those scenes render frozen. Sanity-check that `getAnimations().length` (plus GSAP children) covers what you expect; if the page choreographs with timers, fall back to Mode A or a virtual clock.
+- **Step monotonically forward, never backwards.** With `suppressEvents=false`, scrubbing backwards re-fires callbacks and can corrupt DOM state that a callback already mutated. If you must re-render a frame, reload the page and step forward again.
+- **GSAP `suppressEvents`.** `time(t, true)` skips callbacks between the old and new time — fine for the initial pin at 0, wrong for the capture loop when timelines use `onStart`/`onComplete` to mutate the DOM. Pass `false` while stepping.
+- **Infinite animations are fine.** Setting `currentTime` past one cycle of an `infinite` CSS animation resolves modulo the cycle — no guard needed here (the guards matter in the duration probe, not the seek).
+- **Do not pass `animations: 'disabled'` to `page.screenshot()`.** That Playwright option fast-forwards/rewinds animations and would fight the seek. Leave it at the default.
+- **Throughput.** `page.screenshot()` round-trips the protocol at roughly 50–200ms/frame at 1080p — a 10s @ 30fps clip is ~300 frames ≈ 1–2 minutes. Acceptable for exports; budget for it in CI timeouts.
+
+## Optional: 2x supersampling for crisper text
+
+Real-time recording is stuck at CSS-pixel resolution, but screenshots honor `deviceScaleFactor`. Launch the context with `deviceScaleFactor: 2` (viewport still 1920×1080 → 3840×2160 PNGs) and downscale at encode time:
+
+```
+ffmpeg -y -framerate <fps> -i frames/f%05d.png \
+  -vf scale=1920:1080:flags=lanczos \
+  -c:v libx264 -pix_fmt yuv420p -preset medium -crf 20 \
+  -movflags +faststart out.mp4
+```
+
+Noticeably sharper glyph edges and hairline strokes; ~4x the screenshot time. Reserve it for final masters.
+
+## Advanced: virtual clock for timer-driven pages
+
+If the page choreographs scenes with `setTimeout`/`requestAnimationFrame`/`Date.now()`, the seek loop can't reach that logic. CDP's `Emulation.setVirtualTimePolicy` can pause virtual time and grant it in per-frame budgets, making timers deterministic:
+
+```js
+const cdp = await context.newCDPSession(page);
+await cdp.send('Emulation.setVirtualTimePolicy', { policy: 'pause' });
+// per frame: grant exactly one frame of time, then screenshot
+await cdp.send('Emulation.setVirtualTimePolicy', {
+  policy: 'pauseIfNetworkFetchesPending',
+  budget: 1000 / fps,
+});
+```
+
+This is heavyweight and interacts badly with in-flight network fetches — only reach for it when the template genuinely can't be expressed as seekable timelines, and verify the output frame-by-frame.

--- a/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/references/multi-composition.md
+++ b/packages/opencode/src/skill/builtin/.bundle/html-to-video-pipeline/references/multi-composition.md
@@ -1,0 +1,110 @@
+# Multi-composition templates over `file://`
+
+Some HTML templates are split into an entry file that pulls in sub-scenes at runtime via a placeholder pattern:
+
+```html
+<div data-composition-src="compositions/intro.html"></div>
+<div data-composition-src="compositions/main.html"></div>
+```
+
+The entry's client-side player then `fetch()`es each sub-file and injects it. This works fine when the page is served over HTTP, but **Chromium blocks `fetch()` on `file://` URLs** — so the exact same page loaded over `file://` (as it is for a headless render) produces an empty shell where the scenes should be. The recording captures nothing.
+
+## Fix: inline every sub-scene on the Node side, then load
+
+Before `page.goto()`, read the entry HTML from disk, resolve every `data-composition-src` reference, inline them into a `window.__COMPOSITIONS__` map, and inject a small player that mounts each placeholder from that map. Write the result to a sibling `.tmp.html` so any relative asset paths in the compositions still resolve.
+
+```js
+async function prepareSourceHtml(sourcePath) {
+  const raw = await readFile(sourcePath, 'utf8');
+  const srcMatches = Array.from(raw.matchAll(/data-composition-src=["']([^"']+)["']/g));
+  if (srcMatches.length === 0) return { loadPath: sourcePath }; // single-file: no-op
+
+  const srcDir = dirname(sourcePath);
+  const compMap = {};
+  for (const m of srcMatches) {
+    const rel = m[1];
+    if (compMap[rel] !== undefined) continue;
+    const p = join(srcDir, rel);
+    if (existsSync(p)) compMap[rel] = await readFile(p, 'utf8');
+  }
+  if (Object.keys(compMap).length === 0) return { loadPath: sourcePath };
+
+  // Escape `</` (and comment openers) so the JSON survives inside <script>.
+  // Composition files contain their own </script> tags.
+  const safeJson = JSON.stringify(compMap).replace(/<\//g, '<\\/').replace(/<!--/g, '<\\!--');
+
+  const head = `<script>window.__timelines=window.__timelines||{};` +
+               `window.__COMPOSITIONS__=${safeJson};</script>`;
+  let out = /<head[^>]*>/i.test(raw)
+    ? raw.replace(/<head[^>]*>/i, (m) => `${m}\n${head}`)
+    : `${head}\n${raw}`;
+
+  out = out.replace('</body>', `${PLAYER}\n</body>`);
+
+  const loadPath = join(srcDir, `.tmp-${Date.now()}.html`);
+  await writeFile(loadPath, out, 'utf8');
+  return { loadPath, cleanup: () => rm(loadPath, { force: true }) };
+}
+```
+
+## The player: re-executing cloned `<script>`
+
+The player mounts each composition into its host div, then **re-executes its `<script>` tags**. This step is easy to miss: cloned `<script>` nodes never run on their own. You must create a fresh `<script>` element and copy the text content into it.
+
+```html
+<script>
+(function () {
+  function reexec(root) {
+    root.querySelectorAll('script').forEach((old) => {
+      if (old.src) { old.parentNode.removeChild(old); return; }
+      const s = document.createElement('script');
+      // Wrap each composition's inline script in a block so top-level
+      // `const tl = …` locals don't collide across scenes; the
+      // window.__timelines assignments still escape the block.
+      s.textContent = '{\n' + old.textContent + '\n}';
+      old.parentNode.replaceChild(s, old);
+    });
+  }
+  function mountOne(host) {
+    const src = host.getAttribute('data-composition-src');
+    const text = (window.__COMPOSITIONS__ || {})[src];
+    if (!text) return;
+    const holder = document.createElement('div');
+    holder.innerHTML = text;
+    const tpl = holder.querySelector('template');
+    host.appendChild(tpl ? tpl.content.cloneNode(true) : holder);
+    reexec(host);
+  }
+  window.__playAll = function () {
+    const tls = window.__timelines || {};
+    Object.keys(tls).forEach((k) => {
+      const tl = tls[k];
+      if (tl && typeof tl.play === 'function') tl.play(0);
+    });
+  };
+  function boot() {
+    document.querySelectorAll('[data-composition-src]').forEach(mountOne);
+    // Composition <script>s register their (paused) timelines synchronously as
+    // they're injected, so they're on window.__timelines now. Leave paused —
+    // the renderer probes their duration first, then calls __playAll() at the
+    // exact moment recording starts so playback and capture are aligned. Fall
+    // back to auto-play if no driver calls it (e.g. standalone browser view).
+    setTimeout(() => { if (!window.__played) window.__playAll(); }, 250);
+  }
+  document.readyState === 'loading'
+    ? document.addEventListener('DOMContentLoaded', boot)
+    : boot();
+})();
+</script>
+```
+
+## Two subtle bits
+
+- **Wrap each composition's inline script in `{ … }`** — this scopes any top-level `const`/`let` so scenes can share variable names (`const tl = gsap.timeline()`) without collision. Assignments to `window.__timelines[…]` still escape the block.
+- **`<template>` wrapper is optional** — some compositions ship as raw markup, some wrap it in `<template>...</template>` to prevent premature execution when opened standalone. Handle both by cloning `template.content` when present, else appending the holder div directly.
+
+## Do NOT force `repeat(-1)` on the master timelines
+
+It's tempting to loop everything so "the animation is always playing when we look." Don't. Composition timelines are usually finite, scene-by-scene narratives — looping them replays the intro over the outro, and worse, breaks duration probing: an infinite-repeat tween registers as `~1e10s` in `gsap.globalTimeline.totalDuration()`, which the duration probe correctly skips as "infinite background anim" — so a looped master timeline reads as **0s** and the whole clip gets truncated to whatever the default is (usually 5s).
+
+Leave timelines finite. If a template needs a looping background element (blinking cursor, ambient particles), that specific tween can carry `repeat: -1` — the probe already ignores those.

--- a/packages/opencode/src/skill/builtin/extract.ts
+++ b/packages/opencode/src/skill/builtin/extract.ts
@@ -8,7 +8,13 @@ import { Log } from "@/util"
 import { loadBuiltinBundle } from "./bundle.macro" with { type: "macro" }
 import { loadBuiltinBundle as loadBuiltinBundleDev } from "./bundle.macro"
 
-export const DOCUMENT_SKILL_NAMES = new Set(["docx-official", "pdf-official", "pptx-official", "xlsx-official"])
+export const OFFICIAL_SKILL_NAMES = new Set([
+  "docx-official",
+  "pdf-official",
+  "pptx-official",
+  "xlsx-official",
+  "html-to-video-pipeline",
+])
 
 const DOCUMENT_SKILL_TRIGGERS: Array<{
   skill: string
@@ -95,7 +101,7 @@ export const extractBuiltinBundle = Effect.fn("Skill.extractBuiltinBundle")(func
   if (!InstallationLocal && (yield* fsys.existsSafe(marker))) return root
 
   for (const [skillName, files] of Object.entries(BUILTIN_BUNDLE)) {
-    if (Flag.MIMOCODE_DISABLE_DOCUMENT_SKILLS && DOCUMENT_SKILL_NAMES.has(skillName)) continue
+    if (Flag.MIMOCODE_DISABLE_OFFICIAL_SKILLS && OFFICIAL_SKILL_NAMES.has(skillName)) continue
     const skillDir = path.join(skillsRoot, skillName)
     for (const [relPath, content] of Object.entries(files)) {
       yield* fsys.writeWithDirs(path.join(skillDir, relPath), content)

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -17,7 +17,7 @@ import { Glob } from "@mimo-ai/shared/util/glob"
 import { Log } from "../util"
 import { Discovery } from "./discovery"
 import { extractComposeBundle } from "./compose/extract"
-import { extractBuiltinBundle, DOCUMENT_SKILL_NAMES } from "./builtin/extract"
+import { extractBuiltinBundle, OFFICIAL_SKILL_NAMES } from "./builtin/extract"
 
 const log = Log.create({ service: "skill" })
 const EXTERNAL_DIRS = [".claude", ".agents", ".codex", ".opencode"]
@@ -162,9 +162,9 @@ const discoverSkills = Effect.fnUntraced(function* (
     )
     if (builtinSkillRoot && (yield* fsys.isDir(builtinSkillRoot))) {
       yield* scan(state, builtinSkillRoot, SKILL_PATTERN, { scope: "builtin" })
-      if (Flag.MIMOCODE_DISABLE_DOCUMENT_SKILLS) {
+      if (Flag.MIMOCODE_DISABLE_OFFICIAL_SKILLS) {
         const skillsRoot = path.join(builtinSkillRoot, "skills")
-        for (const name of DOCUMENT_SKILL_NAMES) {
+        for (const name of OFFICIAL_SKILL_NAMES) {
           const prefix = path.join(skillsRoot, name) + path.sep
           for (const match of state.matches) {
             if (match.startsWith(prefix)) {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -54,6 +54,36 @@ const FILES = new Set([
 const FLAGS = new Set(["-destination", "-literalpath", "-path"])
 const SWITCHES = new Set(["-confirm", "-debug", "-force", "-nonewline", "-recurse", "-verbose", "-whatif"])
 
+// Irreversible file/directory removal commands. Names are matched
+// case-insensitively for PowerShell; bash is case-sensitive.
+const DELETE_COMMANDS = new Set([
+  "rm",
+  "rmdir",
+  "unlink",
+  "shred",
+  // Windows / PowerShell removal verbs and their common aliases. `remove-item`
+  // is the canonical verb; `ri`, `rd`, `del`, `erase` are aliases.
+  "del",
+  "erase",
+  "rd",
+  "remove-item",
+  "ri",
+])
+
+// git subcommands that destroy history, working tree state, or remote branches.
+// Value is the set of tokens (flag or subcommand keyword) that must appear
+// anywhere in the argv for the invocation to count as destructive. An empty
+// set means the subcommand is destructive on its own.
+const GIT_DESTRUCTIVE = new Map<string, Set<string>>([
+  ["reset", new Set(["--hard"])],
+  ["clean", new Set(["-f", "-ff", "-fd", "-fdx", "-df", "-dfx", "-fx", "--force"])],
+  ["branch", new Set(["-D", "--delete"])],
+  ["tag", new Set(["-d", "--delete"])],
+  ["worktree", new Set(["remove"])],
+  ["push", new Set(["--force", "-f"])],
+  ["stash", new Set(["drop", "clear"])],
+])
+
 const Parameters = z.object({
   command: z.string().describe("The command to execute"),
   timeout: z.number().describe("Optional timeout in milliseconds").optional(),
@@ -85,6 +115,7 @@ type Scan = {
   dirs: Set<string>
   patterns: Set<string>
   always: Set<string>
+  deletes: Set<string>
 }
 
 type Chunk = {
@@ -135,6 +166,24 @@ function source(node: Node) {
 
 function commands(node: Node) {
   return node.descendantsOfType("command").filter((child): child is Node => Boolean(child))
+}
+
+// Returns true when `tokens` (the flat argv of a single command node) invokes
+// an irreversible deletion — either a direct removal command (rm, remove-item,
+// …) or a destructive git subcommand (git reset --hard, git clean -f, …).
+// `ps` toggles PowerShell case-insensitive matching.
+function isDelete(tokens: string[], ps: boolean) {
+  if (tokens.length === 0) return false
+  const head = ps ? tokens[0].toLowerCase() : tokens[0]
+  if (DELETE_COMMANDS.has(head)) return true
+  if (head === "git" && tokens.length >= 2) {
+    const sub = tokens[1]
+    const flags = GIT_DESTRUCTIVE.get(sub)
+    if (!flags) return false
+    if (flags.size === 0) return true
+    return tokens.slice(2).some((tok) => flags.has(tok))
+  }
+  return false
 }
 
 function unquote(text: string) {
@@ -308,6 +357,22 @@ const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) 
   })
 })
 
+// Secondary confirmation for irreversible deletion commands. Uses its own
+// permission type ("bash_delete") so a broad `bash: allow` rule can't silently
+// pre-approve it. `MIMOCODE_AUTO_APPROVE_DELETE=true` skips the ask entirely
+// for callers who explicitly opt out of the extra prompt.
+const askDelete = Effect.fn("BashTool.askDelete")(function* (ctx: Tool.Context, scan: Scan, command: string) {
+  if (Flag.MIMOCODE_AUTO_APPROVE_DELETE) return
+  if (scan.deletes.size === 0) return
+  const patterns = Array.from(scan.deletes)
+  yield* ctx.ask({
+    permission: "bash_delete",
+    patterns,
+    always: ["*"],
+    metadata: { command, deletes: patterns },
+  })
+})
+
 function cmd(shell: string, name: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && PS.has(name)) {
     const prefixed = `${Shell.POWERSHELL_UTF8_PREFIX}${command}`
@@ -401,6 +466,7 @@ export const BashTool = Tool.define(
         dirs: new Set<string>(),
         patterns: new Set<string>(),
         always: new Set<string>(),
+        deletes: new Set<string>(),
       }
 
       for (const node of commands(root)) {
@@ -422,6 +488,8 @@ export const BashTool = Tool.define(
           scan.patterns.add(source(node))
           scan.always.add(BashArity.prefix(tokens).join(" ") + " *")
         }
+
+        if (isDelete(tokens, ps)) scan.deletes.add(source(node))
       }
 
       return scan
@@ -690,6 +758,7 @@ export const BashTool = Tool.define(
               const scan = yield* collect(root, cwd, ps, shell)
               if (!Instance.containsPath(cwd)) scan.dirs.add(cwd)
               yield* ask(ctx, scan)
+              yield* askDelete(ctx, scan, params.command)
 
               // Interactive mode: hand terminal to user for direct interaction
               if (params.interactive) {

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -294,6 +294,80 @@ describe("tool.bash permissions", () => {
     })
   })
 
+  each("asks for bash_delete when running rm inside the project", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "victim.txt"), "x")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await Effect.runPromise(
+          bash.execute(
+            {
+              command: "rm victim.txt",
+              description: "Remove victim.txt",
+            },
+            capture(requests),
+          ),
+        )
+        const deleteReq = requests.find((r) => r.permission === "bash_delete")
+        expect(deleteReq).toBeDefined()
+        expect(deleteReq!.patterns).toContain("rm victim.txt")
+        expect(deleteReq!.metadata.command).toBe("rm victim.txt")
+      },
+    })
+  })
+
+  each("asks for bash_delete on destructive git subcommands", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const err = new Error("stop after permission")
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await expect(
+          Effect.runPromise(
+            bash.execute(
+              {
+                command: "git reset --hard HEAD",
+                description: "Hard reset",
+              },
+              capture(requests, err),
+            ),
+          ),
+        ).rejects.toThrow(err.message)
+        const bashReq = requests.find((r) => r.permission === "bash")
+        expect(bashReq).toBeDefined()
+      },
+    })
+  })
+
+  each("does not ask for bash_delete on non-destructive commands", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await Effect.runPromise(
+          bash.execute(
+            {
+              command: "echo hello",
+              description: "Echo hello",
+            },
+            capture(requests),
+          ),
+        )
+        expect(requests.find((r) => r.permission === "bash_delete")).toBeUndefined()
+      },
+    })
+  })
+
   if (process.platform === "win32") {
     if (bash) {
       test(

--- a/transformer-video/record.mjs
+++ b/transformer-video/record.mjs
@@ -1,0 +1,131 @@
+import { chromium } from 'playwright';
+import { execSync } from 'child_process';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { mkdirSync, existsSync } from 'fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const htmlPath = resolve(__dirname, 'transformer.html');
+const recordDir = resolve(__dirname, 'recording');
+const outPath = resolve(__dirname, 'transformer-explainer.mp4');
+
+if (!existsSync(recordDir)) mkdirSync(recordDir, { recursive: true });
+
+const WIDTH = 1920;
+const HEIGHT = 1080;
+const FPS = 30;
+const DURATION_S = 65; // total animation ~64s + buffer
+
+console.log('Launching browser...');
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({
+  viewport: { width: WIDTH, height: HEIGHT },
+  recordVideo: { dir: recordDir, size: { width: WIDTH, height: HEIGHT } },
+});
+
+const tWebmStart = Date.now();
+
+// Phase 2: freeze animations before page parses
+await context.addInitScript(() => {
+  const style = document.createElement('style');
+  style.id = '__freeze';
+  style.textContent =
+    '*, *::before, *::after { animation-play-state: paused !important;' +
+    ' -webkit-animation-play-state: paused !important; }';
+  const attach = () => (document.head || document.documentElement).appendChild(style);
+  if (document.head || document.documentElement) attach();
+  else document.addEventListener('DOMContentLoaded', attach, { once: true });
+  window.__unfreeze = () => document.getElementById('__freeze')?.remove();
+});
+
+const page = await context.newPage();
+
+// Phase 3: use domcontentloaded
+console.log('Loading page...');
+await page.goto(`file://${htmlPath}`, { waitUntil: 'domcontentloaded' });
+
+// Phase 4: wait for fonts, then release
+await page.evaluate(() => new Promise((resolve) => {
+  const doc = document;
+  const fonts = doc.fonts;
+  if (!fonts || typeof fonts.ready?.then !== 'function') { resolve(); return; }
+
+  let settled = false;
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  };
+  const cap = setTimeout(finish, 8000);
+
+  const links = Array.from(document.querySelectorAll('link[rel="stylesheet"]'));
+  const linkDone = links.map((link) => {
+    try { if (link.sheet && link.sheet.cssRules) return Promise.resolve(); }
+    catch { /* not ready */ }
+    return new Promise((r) => {
+      const done = () => r();
+      link.addEventListener('load', done, { once: true });
+      link.addEventListener('error', done, { once: true });
+      setTimeout(done, 6000);
+    });
+  });
+
+  Promise.all(linkDone)
+    .then(() => {
+      const loads = [];
+      fonts.forEach((face) => {
+        try { loads.push(face.load().catch(() => undefined)); }
+        catch { /* ignore */ }
+      });
+      return Promise.all(loads);
+    })
+    .then(() => fonts.ready)
+    .then(() => { clearTimeout(cap); finish(); })
+    .catch(() => { clearTimeout(cap); finish(); });
+})).catch(() => {});
+
+const leadInMs = Date.now() - tWebmStart;
+console.log(`Font wait: ${leadInMs}ms lead-in`);
+
+// Unfreeze animations
+await page.evaluate(() => window.__unfreeze?.());
+console.log('Recording started...');
+
+// Wait for the animation to finish
+await new Promise(r => setTimeout(r, DURATION_S * 1000));
+
+console.log('Closing context...');
+await context.close();
+
+// Find the webm file
+const { readdirSync } = await import('fs');
+const files = readdirSync(recordDir).filter(f => f.endsWith('.webm'));
+if (files.length === 0) {
+  console.error('No webm file found!');
+  process.exit(1);
+}
+const webmPath = resolve(recordDir, files[0]);
+
+// Phase 5: encode with ffmpeg
+const ss = Math.max(0, (leadInMs - 120) / 1000);
+console.log(`Encoding with ffmpeg (trim ${ss.toFixed(2)}s lead-in)...`);
+
+execSync(
+  `ffmpeg -y -ss ${ss.toFixed(3)} -i "${webmPath}" ` +
+  `-t ${DURATION_S} ` +
+  `-r ${FPS} ` +
+  `-c:v libx264 -pix_fmt yuv420p -preset medium -crf 20 ` +
+  `-movflags +faststart ` +
+  `"${outPath}"`,
+  { stdio: 'inherit' }
+);
+
+// Verify
+const duration = execSync(
+  `ffprobe -v error -show_entries format=duration -of csv=p=0 "${outPath}"`
+).toString().trim();
+
+console.log(`\nDone! Output: ${outPath}`);
+console.log(`Duration: ${parseFloat(duration).toFixed(1)}s`);
+
+await browser.close();


### PR DESCRIPTION
## Summary
- Add html-to-video-pipeline skill bundle for HTML-to-MP4 rendering via headless browser recording + ffmpeg
- Update i18n translations (en, es, fr, ja, ru, zh, zht) for skill dialog
- Refactor flag.ts and skill extraction/index logic
- Add transformer-video recording script