### PR TITLE
chore: remove unused imports and afterEach in overflow test

### DIFF
--- a/packages/opencode/test/session/overflow.test.ts
+++ b/packages/opencode/test/session/overflow.test.ts
@@ -1,19 +1,14 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { isOverflow, pressureLevel, usable } from "../../src/session/overflow"
 import { Token } from "../../src/util"
 import { Session as SessionNs } from "../../src/session"
 import type { Provider } from "../../src/provider"
-import { Instance } from "../../src/project/instance"
 
 function mockCfg(opts?: { reserved?: number; auto?: boolean }) {
   return {
     compaction: { auto: opts?.auto ?? true, reserved: opts?.reserved },
   } as any
 }
-
-afterEach(async () => {
-  await Instance.disposeAll()
-})
 
 function createModel(opts: {
   context: number


### PR DESCRIPTION
## Summary
- Remove unused `afterEach` import from `bun:test`
- Remove unused `Instance` import from `../../src/project/instance`
- Remove unnecessary `afterEach` cleanup block that called `Instance.disposeAll()`