### PR TITLE
feat(skill): add PDF export/compilation to research-paper-writing

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/research-paper-writing/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/research-paper-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-paper-writing
-description: Write, rewrite, and polish academic papers (ML/CV/NLP style). Use when the user drafts or revises Abstract, Introduction, Related Work, Method, Experiments, or Conclusion; asks "does this flow / 这段通顺吗 / polish this paragraph"; turns bullet points or a Chinese draft into publication-quality English; runs a pre-submission self-review or reviewer-style critique; or fixes paper figures/tables/LaTeX formatting. Trigger on mentions of paper, draft, camera-ready, rebuttal-facing revision, CVPR/ICCV/NeurIPS/ICLR/ACL-style venues, or .tex files being edited for a paper.
+description: Write, rewrite, and polish academic papers (ML/CV/NLP style). Use when the user drafts or revises Abstract, Introduction, Related Work, Method, Experiments, or Conclusion; asks "does this flow / 这段通顺吗 / polish this paragraph"; turns bullet points or a Chinese draft into publication-quality English; runs a pre-submission self-review or reviewer-style critique; fixes paper figures/tables/LaTeX formatting; or compiles/converts the paper to PDF (LaTeX build, 编译PDF, 转成PDF). Trigger on mentions of paper, draft, camera-ready, rebuttal-facing revision, CVPR/ICCV/NeurIPS/ICLR/ACL-style venues, or .tex files being edited for a paper.
 ---
 
 # Research Paper Writing
@@ -21,6 +21,7 @@ Match the user's situation and load ONLY the needed reference (do not preload al
 | Draft or rewrite Experiments; fix tables | Claim→experiment mapping, table rules | `references/experiments.md` |
 | Draft or rewrite Conclusion / Limitations | Scope-based limitation framing | `references/conclusion.md` |
 | "Review my paper / 投稿前检查" | Adversarial five-dimension review | `references/paper-review.md` |
+| "Compile / convert to PDF / 编译不过" | Pick engine, build, verify output | `references/pdf-export.md` |
 | Bullet points / Chinese notes → English section | Treat as section drafting; get facts first, then draft | the matching section guide |
 
 If the user's draft lives in files (`.tex`, `.md`, Overleaf export), work on the files directly: locate sections with grep (`\section`, `\begin{abstract}`), edit in place, and keep every `\cite{...}`, `\ref{...}`, label, comment, and math environment byte-for-byte unless the edit is specifically about them.
@@ -83,4 +84,5 @@ If any of these are missing and not recoverable from context, ask — at most 3 
 - `references/conclusion.md` — limitation framing that doesn't invite rejection
 - `references/paper-review.md` — adversarial five-dimension review checklist
 - `references/paragraph-flow.md` — paragraph clarity test, reverse outlining, transitions
+- `references/pdf-export.md` — compiling LaTeX/Markdown to PDF, engine choice, failure fixes, output verification
 - `references/examples/` — annotated LaTeX examples cited from the section guides

--- a/packages/opencode/src/skill/builtin/.bundle/research-paper-writing/references/pdf-export.md
+++ b/packages/opencode/src/skill/builtin/.bundle/research-paper-writing/references/pdf-export.md
@@ -1,0 +1,83 @@
+# Converting the Paper to PDF
+
+Route by source format, compile, then always verify the output PDF before reporting success.
+
+## LaTeX project → PDF
+
+### 1. Pick the engine
+
+| Situation | Engine |
+|---|---|
+| Standard venue template (CVPR/ICCV/NeurIPS/ICLR/ACL) | `pdflatex` — templates assume it; do not switch engines |
+| Paper contains CJK text, or needs system fonts (`fontspec`) | `xelatex` (or `lualatex`) |
+| Unsure | Check the template's comments / `% !TEX program =` line; default to `pdflatex` |
+
+### 2. Compile with latexmk (preferred)
+
+`latexmk` handles the multi-pass dance (LaTeX → bibliography → LaTeX ×2) automatically:
+
+```bash
+latexmk -pdf main.tex                 # pdflatex engine
+latexmk -xelatex main.tex             # xelatex engine
+latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex   # CI / unattended
+```
+
+If `latexmk` is unavailable, run the passes manually:
+
+```bash
+pdflatex main.tex
+bibtex main          # or: biber main  (check \usepackage[backend=...]{biblatex})
+pdflatex main.tex
+pdflatex main.tex    # second pass resolves cross-references
+```
+
+Use `bibtex` when the paper loads `natbib` / plain `\bibliography{...}`; use `biber` only when `biblatex` with `backend=biber` is declared.
+
+### 3. Find the main file
+
+The entry point is the `.tex` file containing `\documentclass`:
+
+```bash
+grep -l "\\\\documentclass" *.tex
+```
+
+Always compile from the directory containing the main file so relative `\input`, figure, and `.bib` paths resolve.
+
+### 4. Common failures
+
+| Symptom | Fix |
+|---|---|
+| `! LaTeX Error: File 'xxx.sty' not found` | `tlmgr install xxx` (TeX Live) or install the package via the distro's manager. Tell the user which package was missing. |
+| `Undefined control sequence` | Usually a missing `\usepackage` or an engine mismatch (e.g. `fontspec` under pdflatex). |
+| Citations show as `[?]` / refs as `??` | Bibliography pass didn't run or failed — rerun the full sequence; check the `.blg` log for bad `.bib` entries. |
+| Compile hangs waiting for input | Add `-interaction=nonstopmode`; then read the `.log` for the first `!` error. |
+| Stale/corrupt aux state after fixing errors | `latexmk -C` to clean, then recompile. |
+| No TeX installed | macOS: `brew install --cask mactex-no-gui` (large) or `basictex` + `tlmgr` per-package. Linux: `apt install texlive-latex-extra texlive-fonts-recommended`. Or offer the pandoc/Typst route below. |
+
+Never "fix" a compile error by deleting content, commenting out `\cite`/`\ref`, or removing packages the paper uses — find the root cause or report it.
+
+## Markdown / plain-text draft → PDF
+
+Use pandoc when the draft is `.md`:
+
+```bash
+pandoc draft.md -o draft.pdf --pdf-engine=xelatex \
+  -V geometry:margin=1in -V fontsize=11pt
+```
+
+- CJK content: add `-V CJKmainfont="Songti SC"` (macOS) or another installed CJK font.
+- Citations in the draft (`[@key]` + `.bib`): add `--citeproc --bibliography=refs.bib`.
+- No TeX installed and installing is not an option: `pandoc draft.md -o draft.html` then print to PDF via headless Chrome (`chrome --headless --print-to-pdf=draft.pdf draft.html`), and say the typography is approximate.
+
+This route is for previews and internal drafts. For an actual submission, the paper must be compiled from the venue's LaTeX template — offer to set that up instead of shipping a pandoc PDF.
+
+## Verify before reporting success
+
+A zero exit code is not enough. Check:
+
+1. **PDF exists and opens** — e.g. `pdfinfo main.pdf` (page count sane, not 0 bytes).
+2. **No unresolved references** — `grep -c "??"` on extracted text, or grep the `.log` for `LaTeX Warning: Reference .* undefined` and `Citation .* undefined`. Report the exact undefined keys.
+3. **Page limit** — compare page count against the venue limit if known; flag overflow.
+4. **Camera-ready extras** (only when the user says camera-ready): fonts embedded (`pdffonts main.pdf` — every row should say "yes" under emb), and file size within the venue's cap.
+
+Report the result as: output path, page count, and any warnings that need the user's attention (undefined refs, overfull hboxes worth fixing, page overflow).


### PR DESCRIPTION
## Summary
- Add `pdf-export.md` reference covering LaTeX/Markdown-to-PDF compilation
- Update SKILL.md routing table with PDF export/compilation row
- Engine coverage: pdflatex, xelatex, lualatex, pandoc
- Includes failure diagnosis and output verification steps

## Changes
- `src/skill/builtin/.bundle/research-paper-writing/SKILL.md` — updated description, routing table, reference list
- `src/skill/builtin/.bundle/research-paper-writing/references/pdf-export.md` — new reference file