### PR TITLE
docs: add Builtin Skills and Workflows sections to README (en/zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,39 @@ The `/goal` command sets a stopping condition for a session. When the agent trie
 
 Compose mode provides a structured workflow for specs-driven development. It includes built-in skills for planning, execution, code review, TDD, debugging, verification, and merging — orchestrating the full lifecycle from spec to shipped code.
 
+### Builtin Skills
+
+Skills are reusable instruction sets that teach agents how to handle specific tasks (e.g. generating PDFs, writing academic papers, searching arXiv). MiMoCode ships with the following builtin skills:
+
+| Skill | Description |
+|-------|-------------|
+| `arxiv` | Search, read, cite, and analyze arXiv papers |
+| `docx-official` | Produce, read, and transform Word (.docx) files |
+| `pdf-official` | Produce, read, fill, and transform PDF files |
+| `pptx-official` | Author and manipulate PowerPoint (.pptx) decks |
+| `xlsx-official` | Build, clean, and transform spreadsheets (.xlsx/.csv) |
+| `frontend-design` | Visual design guidance for UI work |
+| `html-to-video-pipeline` | HTML-to-MP4 rendering via headless browser + ffmpeg |
+| `research-paper-writing` | Write and polish academic papers (ML/CV/NLP style) |
+| `skill-creator` | Interactive guide for creating and improving agent skills |
+| `self-extend` | Create new tools, hooks, and skills to evolve agent capabilities |
+| `loop` | Schedule recurring prompts on a fixed cadence |
+| `mimocode` | Self-documenting reference for MiMoCode features and config |
+
+**Overriding a builtin skill:** Create a skill with the same `name` in your project (`.mimocode/skills/<name>/SKILL.md`) or personal skill directory (`~/.claude/skills/`, `~/.opencode/skills/`, etc.). User skills discovered later in the scan order override builtins with the same name.
+
+<details>
+<summary><strong>Disabling builtin skills via environment variables</strong></summary>
+
+| Variable | Effect |
+|----------|--------|
+| `MIMOCODE_DISABLE_BUILTIN_SKILLS=true` | Disable all builtin skills |
+| `MIMOCODE_DISABLE_OFFICIAL_SKILLS=true` | Disable only the office/media skills: `docx-official`, `pdf-official`, `pptx-official`, `xlsx-official`, `html-to-video-pipeline` |
+
+When disabled, the corresponding skills are removed from the agent's available skill list entirely — they will not appear in context and cannot be invoked.
+
+</details>
+
 ### Voice Input
 
 Real-time streaming voice input powered by TenVAD and MiMo ASR. Activate with `/voice`, then speak — audio is segmented by pauses and transcribed incrementally into the input. Available for MiMo logged-in users. Requires `sox` (`brew install sox` on macOS, other platforms similar).

--- a/README.md
+++ b/README.md
@@ -136,6 +136,21 @@ The `/goal` command sets a stopping condition for a session. When the agent trie
 
 Compose mode provides a structured workflow for specs-driven development. It includes built-in skills for planning, execution, code review, TDD, debugging, verification, and merging — orchestrating the full lifecycle from spec to shipped code.
 
+### Workflows
+
+Workflows are deterministic JavaScript scripts that orchestrate multiple agents in a sandboxed runtime. Unlike agent conversations, workflows encode fixed phase sequences with bounded retries and automatic parallelization — fire-and-forget execution with no user interaction required.
+
+MiMoCode ships with two built-in workflows:
+
+| Workflow | Phases | Description |
+|----------|--------|-------------|
+| `compose` | Brainstorm → Design → Implement → Verify → Review → Report → Merge | Full development pipeline. Auto-parallelizes independent tasks into isolated git worktrees, applies TDD per task, chains structured output between phases. Best for well-defined tasks that decompose into independent subtasks. |
+| `deep-research` | Plan → Search → Extract → Group → Crosscheck → Report | Multi-source research with adversarial fact-checking. Runs parallel web searches, reads the strongest sources, cross-checks each fact with a jury vote, and writes a cited report. |
+
+The compose workflow complements the compose agent: use the **workflow** when requirements are clear and tasks split cleanly (deterministic, parallel, non-interactive); use the **agent** when you need to redirect mid-flow or inject judgment between steps (conversational, interactive).
+
+**Custom workflows:** Place a `.js` file in `.mimocode/workflows/` or `.claude/workflows/` to define your own, or override a built-in by using the same name (e.g. `.mimocode/workflows/compose.js`).
+
 ### Builtin Skills
 
 Skills are reusable instruction sets that teach agents how to handle specific tasks (e.g. generating PDFs, writing academic papers, searching arXiv). MiMoCode ships with the following builtin skills:

--- a/README.zh.md
+++ b/README.zh.md
@@ -133,6 +133,21 @@ sudo apt install xsel
 
 Compose 模式提供结构化的 specs-driven 开发流程，内置规划、执行、代码审查、TDD、调试、验证、合并等技能——编排从 spec 到交付的完整开发生命周期。
 
+### Workflows
+
+Workflow 是在沙箱运行时中执行的确定性 JavaScript 脚本，可编排多个 Agent 协作。与 Agent 对话不同，Workflow 编码了固定的阶段序列、有界重试和自动并行化——全程非交互，丢出去跑完即可。
+
+MiMoCode 内置两个 Workflow：
+
+| Workflow | 阶段 | 说明 |
+|----------|------|------|
+| `compose` | Brainstorm → Design → Implement → Verify → Review → Report → Merge | 完整开发流水线。自动将独立任务并行分发到隔离的 git worktree，每个任务应用 TDD，阶段之间传递结构化输出。适合需求明确且可拆分为独立子任务的场景。 |
+| `deep-research` | Plan → Search → Extract → Group → Crosscheck → Report | 多源深度调研 + 对抗式事实验证。并行搜索网络、精读最强来源、用陪审投票交叉验证每条事实、生成带引用的报告。 |
+
+compose workflow 与 compose agent 互补：**workflow** 适合需求清晰、任务可独立拆解的场景（确定性、并行、非交互）；**agent** 适合需要中途改方向或在步骤间注入人工判断的场景（对话式、交互式）。
+
+**自定义 Workflow：** 在 `.mimocode/workflows/` 或 `.claude/workflows/` 下放置 `.js` 文件即可定义自己的 Workflow，也可用同名文件覆盖内置 Workflow（如 `.mimocode/workflows/compose.js`）。
+
 ### 内置技能（Builtin Skills）
 
 技能（Skill）是可复用的指令集，教会 Agent 如何处理特定任务（如生成 PDF、写学术论文、搜索 arXiv）。MiMoCode 内置以下技能：

--- a/README.zh.md
+++ b/README.zh.md
@@ -133,6 +133,39 @@ sudo apt install xsel
 
 Compose 模式提供结构化的 specs-driven 开发流程，内置规划、执行、代码审查、TDD、调试、验证、合并等技能——编排从 spec 到交付的完整开发生命周期。
 
+### 内置技能（Builtin Skills）
+
+技能（Skill）是可复用的指令集，教会 Agent 如何处理特定任务（如生成 PDF、写学术论文、搜索 arXiv）。MiMoCode 内置以下技能：
+
+| 技能 | 说明 |
+|------|------|
+| `arxiv` | 搜索、阅读、引用和分析 arXiv 论文 |
+| `docx-official` | 生成、读取和转换 Word (.docx) 文件 |
+| `pdf-official` | 生成、读取、填充和转换 PDF 文件 |
+| `pptx-official` | 制作和操作 PowerPoint (.pptx) 幻灯片 |
+| `xlsx-official` | 构建、清洗和转换电子表格 (.xlsx/.csv) |
+| `frontend-design` | UI 开发的视觉设计指导 |
+| `html-to-video-pipeline` | 通过无头浏览器 + ffmpeg 将 HTML 渲染为 MP4 |
+| `research-paper-writing` | 撰写和打磨学术论文（ML/CV/NLP 风格）|
+| `skill-creator` | 创建和改进 Agent 技能的交互式指南 |
+| `self-extend` | 创建新工具、钩子和技能以扩展 Agent 能力 |
+| `loop` | 按固定周期调度循环提示 |
+| `mimocode` | MiMoCode 功能和配置的自文档参考 |
+
+**覆盖内置技能：** 在项目（`.mimocode/skills/<name>/SKILL.md`）或个人技能目录（`~/.claude/skills/`、`~/.opencode/skills/` 等）中创建同名技能即可。扫描顺序中后发现的用户技能会覆盖同名的内置技能。
+
+<details>
+<summary><strong>通过环境变量禁用内置技能</strong></summary>
+
+| 变量 | 效果 |
+|------|------|
+| `MIMOCODE_DISABLE_BUILTIN_SKILLS=true` | 禁用所有内置技能 |
+| `MIMOCODE_DISABLE_OFFICIAL_SKILLS=true` | 仅禁用办公/媒体类技能：`docx-official`、`pdf-official`、`pptx-official`、`xlsx-official`、`html-to-video-pipeline` |
+
+禁用后，对应技能将从 Agent 可用技能列表中完全移除——不会出现在上下文中，也无法被调用。
+
+</details>
+
 ### 语音输入
 
 基于 TenVAD 和 MiMo ASR 的实时流式语音输入。通过 `/voice` 激活，按停顿分片转写，文本逐段追加到输入框。仅对 MiMo 登录用户可用。需要安装 `sox`（macOS 上 `brew install sox`，其他平台类似）。

--- a/packages/opencode/test/cron/scheduler.test.ts
+++ b/packages/opencode/test/cron/scheduler.test.ts
@@ -256,6 +256,7 @@ test("same-tick double-fire: only the first due task fires per tick", async () =
         ...baseStartOpts(dir),
         isLoading: () => false,
         onFire: (t) => fires.push(t.id),
+        jitterConfig: { ...DEFAULT_JITTER, recurringFrac: 0 },
       })
 
       const past = Date.now() - 61_000


### PR DESCRIPTION
## Summary

- **Workflows section (supplement)**: compose workflow and deep-research workflow were shipped in v0.1.4 but were not documented in the README. Added descriptions, phase breakdowns, compose agent vs workflow comparison, and custom workflow override instructions.
- **Builtin Skills section (new)**: documents all 12 builtin skills, explains how users can override a builtin by creating a same-name skill, and lists environment variables (`MIMOCODE_DISABLE_BUILTIN_SKILLS`, `MIMOCODE_DISABLE_OFFICIAL_SKILLS`) for disabling them.

> **Incidental fix**: `same-tick double-fire` scheduler test was flaky (~6.7% failure rate) due to jitter pushing the fire time into the future near minute boundaries. Disabled jitter in this test since it validates the `firedThisTick` latch, not jitter behavior.