### PR TITLE
test: skip flaky cancel-interrupts-loop-queued-behind-shell

### DIFF
--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1403,7 +1403,8 @@ it.live.skip(
   30_000,
 )
 
-unix(
+// skip: flaky timing race — sleep(50) insufficient for shell to acquire run-state lock on slow CI
+it.live.skip(
   "cancel interrupts loop queued behind shell",
   () =>
     provideTmpdirInstance(


### PR DESCRIPTION
## Summary

Skip the flaky test `cancel interrupts loop queued behind shell` that fails intermittently on CI.

## Root cause

The test uses `Effect.sleep(50)` to wait for a shell to acquire the run-state lock before calling cancel. On slow CI runners, 50ms is insufficient — the cancel fires before the shell becomes "busy", making `run.cancel()` a no-op (it just sets status to idle without actually cancelling the fiber).

## Why skip instead of fix

- No deterministic wait signal is available in this test setup:
  - No `provideTmpdirServer` (so no `llm.wait(N)`)
  - No `withSh` + message polling pattern  
  - No `SessionStatus` observable to subscribe to
- Same pattern as the already-skipped test at line 1354: `"cancel finalizes interrupted bash tool output through normal truncation"`
- The underlying functionality (cancel propagation) is covered by the more robust `"cancel interrupts shell and resolves cleanly"` test which polls messages deterministically