### PR TITLE
feat: enhance permission system with bash tool integration

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -444,6 +444,14 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
           }
 
           const current = info()
+          // Forced-ask permissions (bash_delete, …) never persist an allow rule
+          // server-side, so surfacing "Allow always" would be a UX trap: the
+          // click looks like durable trust but the next invocation still
+          // prompts. Offer only "once" and "reject" for those.
+          const options: Record<string, string> =
+            props.request.permission === "bash_delete"
+              ? { once: "Allow once", reject: "Reject" }
+              : { once: "Allow once", always: "Allow always", reject: "Reject" }
 
           const header = () => (
             <box flexDirection="column" gap={0}>
@@ -465,7 +473,7 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
               title="Permission required"
               header={header()}
               body={current.body}
-              options={{ once: "Allow once", always: "Allow always", reject: "Reject" }}
+              options={options}
               escapeKey="reject"
               fullscreen
               onSelect={(option) => {

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -166,6 +166,15 @@ export function evaluate(permission: string, pattern: string, ...rulesets: Rules
   return evalRule(permission, pattern, ...rulesets)
 }
 
+// Permissions whose "allow" outcome must ALWAYS come from an explicit human ask.
+// A wildcard rule like `permissions.allow: ["*"]` (or a stored `{permission:"*",
+// pattern:"*", action:"allow"}` approval) MUST NOT be able to pre-authorize
+// these — the whole point of a forced-ask permission is that the intent to
+// perform an irreversible action must be recorded in-band, not inherited from
+// a broad blanket rule. Explicit deny still wins; the tool-side env opt-out
+// (e.g. MIMOCODE_AUTO_APPROVE_DELETE for bash_delete) is the only bypass.
+const FORCED_ASK = new Set(["bash_delete"])
+
 export class Service extends Context.Service<Service, Interface>()("@opencode/Permission") {}
 
 export const layer = Layer.effect(
@@ -200,6 +209,8 @@ export const layer = Layer.effect(
       const { ruleset, ...request } = input
       let needsAsk = false
 
+      const forced = FORCED_ASK.has(request.permission)
+
       for (const pattern of request.patterns) {
         // Evaluate the ruleset ALONE first. An explicit deny here must win
         // outright — a persisted approval (e.g. an edit approved "always" in
@@ -210,6 +221,13 @@ export const layer = Layer.effect(
           return yield* new DeniedError({
             ruleset: ruleset.filter((rule) => Wildcard.match(request.permission, rule.permission)),
           })
+        }
+        // Forced-ask permissions skip both allow short-circuits: neither the
+        // ruleset nor the persisted approvals can pre-authorize them. They
+        // always land in the human ask flow below (unless denied above).
+        if (forced) {
+          needsAsk = true
+          continue
         }
         if (ruleAction === "allow") continue
         if (evaluate(request.permission, pattern, approved).action === "allow") continue
@@ -369,6 +387,12 @@ export const layer = Layer.effect(
 
       yield* Deferred.succeed(existing.deferred, undefined)
       if (input.reply === "once") return
+      // Forced-ask permissions never persist an approval — even if the caller
+      // (or a future permission type) accidentally passes a non-empty `always`
+      // list, the promise of "human must confirm every time" trumps it.
+      // Treating "always" as "once" for these keeps the UI reply path a no-op
+      // instead of writing a rule that ask() would just ignore next call.
+      if (FORCED_ASK.has(existing.info.permission)) return
 
       for (const pattern of existing.info.always) {
         approved.push({

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -358,17 +358,19 @@ const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) 
 })
 
 // Secondary confirmation for irreversible deletion commands. Uses its own
-// permission type ("bash_delete") so a broad `bash: allow` rule can't silently
-// pre-approve it. `MIMOCODE_AUTO_APPROVE_DELETE=true` skips the ask entirely
-// for callers who explicitly opt out of the extra prompt.
+// permission type ("bash_delete"), which the Permission layer flags as
+// forced-ask: no `allow` rule (not even a broad `"*": allow`) can silently
+// pre-approve it — only an explicit `deny` blocks. `always` is empty because
+// a persisted "allow all deletes" rule is exactly what forced-ask exists to
+// prevent. The delete UI shows the full command, so this ask FULLY replaces
+// the regular bash/external_directory prompts when it fires (see the caller
+// below) — deletion is authorized in a single, unambiguous confirmation.
 const askDelete = Effect.fn("BashTool.askDelete")(function* (ctx: Tool.Context, scan: Scan, command: string) {
-  if (Flag.MIMOCODE_AUTO_APPROVE_DELETE) return
-  if (scan.deletes.size === 0) return
   const patterns = Array.from(scan.deletes)
   yield* ctx.ask({
     permission: "bash_delete",
     patterns,
-    always: ["*"],
+    always: [],
     metadata: { command, deletes: patterns },
   })
 })
@@ -757,8 +759,17 @@ export const BashTool = Tool.define(
               const root = yield* parse(params.command, ps)
               const scan = yield* collect(root, cwd, ps, shell)
               if (!Instance.containsPath(cwd)) scan.dirs.add(cwd)
-              yield* ask(ctx, scan)
-              yield* askDelete(ctx, scan, params.command)
+              // Delete-containing commands are authorized by askDelete alone —
+              // the delete UI shows the full command (including any external
+              // paths it touches), so a separate bash/external_directory
+              // prompt would just be a second confirmation of the same thing.
+              // MIMOCODE_AUTO_APPROVE_DELETE trusts deletes and falls back to
+              // the regular ask (where a `bash: deny` rule still blocks).
+              if (scan.deletes.size > 0 && !Flag.MIMOCODE_AUTO_APPROVE_DELETE) {
+                yield* askDelete(ctx, scan, params.command)
+              } else {
+                yield* ask(ctx, scan)
+              }
 
               // Interactive mode: hand terminal to user for direct interaction
               if (params.interactive) {

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -782,6 +782,109 @@ it.live("ask - persisted approval does not override ruleset deny", () =>
   }),
 )
 
+// Forced-ask (bash_delete) tests — irreversible actions must not be
+// pre-authorized by allow rules. Only an explicit deny short-circuits, and
+// only the env-var opt-out (checked tool-side) skips the ask entirely.
+
+it.live("ask - bash_delete stays pending even when ruleset has wildcard allow", () =>
+  withDir({ git: true }, () =>
+    Effect.gen(function* () {
+      const fiber = yield* ask({
+        sessionID: SessionID.make("session_test"),
+        permission: "bash_delete",
+        patterns: ["rm foo.txt"],
+        metadata: {},
+        always: [],
+        ruleset: [{ permission: "*", pattern: "*", action: "allow" }],
+      }).pipe(Effect.forkScoped)
+
+      const items = yield* waitForPending(1)
+      expect(items).toHaveLength(1)
+      expect(items[0].permission).toBe("bash_delete")
+      yield* rejectAll()
+      yield* Fiber.await(fiber)
+    }),
+  ),
+)
+
+it.live("ask - bash_delete stays pending even with explicit bash_delete allow", () =>
+  withDir({ git: true }, () =>
+    Effect.gen(function* () {
+      // Even a named allow rule cannot pre-authorize a forced-ask permission.
+      // The env-var opt-out (MIMOCODE_AUTO_APPROVE_DELETE, tool-side) is the
+      // only bypass; the permission layer itself refuses to honor allow.
+      const fiber = yield* ask({
+        sessionID: SessionID.make("session_test"),
+        permission: "bash_delete",
+        patterns: ["rm foo.txt"],
+        metadata: {},
+        always: [],
+        ruleset: [{ permission: "bash_delete", pattern: "*", action: "allow" }],
+      }).pipe(Effect.forkScoped)
+
+      yield* waitForPending(1)
+      yield* rejectAll()
+      yield* Fiber.await(fiber)
+    }),
+  ),
+)
+
+it.live("ask - bash_delete respects explicit deny", () =>
+  withDir({ git: true }, () =>
+    Effect.gen(function* () {
+      const err = yield* fail(
+        ask({
+          sessionID: SessionID.make("session_test"),
+          permission: "bash_delete",
+          patterns: ["rm foo.txt"],
+          metadata: {},
+          always: [],
+          ruleset: [{ permission: "bash_delete", pattern: "*", action: "deny" }],
+        }),
+      )
+      expect(err).toBeInstanceOf(Permission.DeniedError)
+    }),
+  ),
+)
+
+it.live("reply - always for bash_delete does not persist a rule", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped({ git: true })
+    const run = withProvided(dir)
+
+    // Session 1: approve bash_delete "always". Even if the caller passes a
+    // non-empty `always`, no rule should reach the approved store.
+    const fiber = yield* ask({
+      id: PermissionID.make("per_forced_ask_persist"),
+      sessionID: SessionID.make("session_approve"),
+      permission: "bash_delete",
+      patterns: ["rm foo.txt"],
+      metadata: {},
+      always: ["*"],
+      ruleset: [],
+    }).pipe(run, Effect.forkScoped)
+
+    yield* waitForPending(1).pipe(run)
+    yield* reply({ requestID: PermissionID.make("per_forced_ask_persist"), reply: "always" }).pipe(run)
+    yield* Fiber.join(fiber)
+
+    // Session 2: a fresh bash_delete ask must still be pending — the previous
+    // "always" reply must NOT have been persisted.
+    const fiber2 = yield* ask({
+      sessionID: SessionID.make("session_next"),
+      permission: "bash_delete",
+      patterns: ["rm bar.txt"],
+      metadata: {},
+      always: [],
+      ruleset: [],
+    }).pipe(run, Effect.forkScoped)
+
+    yield* waitForPending(1).pipe(run)
+    yield* rejectAll().pipe(run)
+    yield* Fiber.await(fiber2)
+  }),
+)
+
 it.live("reply - reject cancels all pending for same session", () =>
   withDir({ git: true }, () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -294,7 +294,7 @@ describe("tool.bash permissions", () => {
     })
   })
 
-  each("asks for bash_delete when running rm inside the project", async () => {
+  each("asks for bash_delete only (no bash prompt) when running rm inside the project", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
         await Bun.write(path.join(dir, "victim.txt"), "x")
@@ -318,6 +318,9 @@ describe("tool.bash permissions", () => {
         expect(deleteReq).toBeDefined()
         expect(deleteReq!.patterns).toContain("rm victim.txt")
         expect(deleteReq!.metadata.command).toBe("rm victim.txt")
+        // The delete UI shows the full command → a separate `bash` ask would
+        // just be a second confirmation of the same thing.
+        expect(requests.find((r) => r.permission === "bash")).toBeUndefined()
       },
     })
   })
@@ -341,8 +344,10 @@ describe("tool.bash permissions", () => {
             ),
           ),
         ).rejects.toThrow(err.message)
-        const bashReq = requests.find((r) => r.permission === "bash")
-        expect(bashReq).toBeDefined()
+        const deleteReq = requests.find((r) => r.permission === "bash_delete")
+        expect(deleteReq).toBeDefined()
+        expect(deleteReq!.patterns).toContain("git reset --hard HEAD")
+        expect(requests.find((r) => r.permission === "bash")).toBeUndefined()
       },
     })
   })


### PR DESCRIPTION
## Summary
- Add permission checking logic to bash tool
- Update permission index with new permission types  
- Enhance TUI permission route display
- Add comprehensive tests for permission system

## Changes
- Modified files:
  - src/cli/cmd/tui/routes/session/permission.tsx
  - src/permission/index.ts
  - src/tool/bash.ts
  - test/permission/next.test.ts
  - test/tool/bash.test.ts

## Testing
- Added 103 lines of new tests for permission system
- All existing tests pass