### PR TITLE
fix(provider): gate implicit whitelist behind opt-in only_configured_…

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -111,6 +111,10 @@ export class Info extends Schema.Class<Info>("ProviderConfig")({
     ),
   ),
   models: Schema.optional(Schema.Record(Schema.String, Model)),
+  only_configured_models: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "When true, show only the models listed in this provider's `models` map and hide the rest of the catalog (acts as an implicit whitelist). Defaults to false: `models` only augments/overrides the catalog without filtering it.",
+  }),
 }) {
   static readonly zod = zod(this)
 }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1378,10 +1378,13 @@ const layer: Layer.Layer<
           }
 
           const configProvider = cfg.provider?.[providerID]
-          // A non-empty `models` config acts as an implicit whitelist: only the
-          // configured model IDs are shown, hiding the rest of the models.dev catalog.
+          // Opt-in implicit whitelist: only when the provider sets
+          // `only_configured_models: true` does a non-empty `models` map hide the
+          // rest of the catalog. Default (false) preserves the augment-only
+          // behavior — `models` overrides/adds without filtering.
           const configModelKeys = Object.keys(configProvider?.models ?? {})
-          const implicitWhitelist = configModelKeys.length > 0 ? configModelKeys : undefined
+          const implicitWhitelist =
+            configProvider?.only_configured_models && configModelKeys.length > 0 ? configModelKeys : undefined
 
           for (const [modelID, model] of Object.entries(provider.models)) {
             model.api.id = model.api.id ?? model.id ?? modelID

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -253,7 +253,7 @@ test("custom model alias via config", async () => {
   })
 })
 
-test("non-empty models config acts as implicit whitelist", async () => {
+test("non-empty models config acts as implicit whitelist when only_configured_models is true", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -262,6 +262,7 @@ test("non-empty models config acts as implicit whitelist", async () => {
           $schema: "https://opencode.ai/config.json",
           provider: {
             anthropic: {
+              only_configured_models: true,
               models: {
                 "claude-sonnet-4-20250514": {
                   name: "Only Sonnet",
@@ -283,6 +284,43 @@ test("non-empty models config acts as implicit whitelist", async () => {
       expect(providers[ProviderID.anthropic]).toBeDefined()
       const models = Object.keys(providers[ProviderID.anthropic].models)
       expect(models).toEqual(["claude-sonnet-4-20250514"])
+    },
+  })
+})
+
+test("models config only augments the catalog by default (no only_configured_models)", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              models: {
+                "claude-sonnet-4-20250514": {
+                  name: "Renamed Sonnet",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.anthropic]).toBeDefined()
+      const models = Object.keys(providers[ProviderID.anthropic].models)
+      // Old (non-breaking) behavior: the configured model is still present AND
+      // other catalog models are NOT hidden.
+      expect(models).toContain("claude-sonnet-4-20250514")
+      expect(models.length).toBeGreaterThan(1)
     },
   })
 })

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -325,6 +325,38 @@ test("models config only augments the catalog by default (no only_configured_mod
   })
 })
 
+test("only_configured_models with no models map is a no-op (catalog stays intact)", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              only_configured_models: true,
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.anthropic]).toBeDefined()
+      const models = Object.keys(providers[ProviderID.anthropic].models)
+      // Empty/absent `models` ⇒ no implicit whitelist ⇒ full catalog remains.
+      expect(models).toContain("claude-sonnet-4-20250514")
+      expect(models.length).toBeGreaterThan(1)
+    },
+  })
+})
+
 test("custom provider with npm package", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
## Summary
Restores non-breaking behavior for `provider.<id>.models`. A previous change made a
non-empty `models` map implicitly hide the rest of the catalog (a breaking change to
model visibility). This PR gates that behavior behind an opt-in `only_configured_models` flag.

- `only_configured_models` absent/`false` (default): `models` only augments/overrides the
  catalog; all other models stay visible. Unchanged from today — no breaking change.
- `only_configured_models: true` + non-empty `models`: only the listed model IDs are shown.
- `true` + empty/absent `models`: no-op.
- With an explicit `whitelist`, the two intersect; explicit whitelist/blacklist in isolation is unchanged.

## Test Plan
- [x] `bun typecheck` clean
- [x] `bun test test/provider/provider.test.ts` — 77 pass, incl. opt-in-active and default-augment paths
