### PR TITLE
feat: add registry sync script for Chinese npm mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ MiMo Auto is built in as a free-for-limited-time channel, so you can start with 
 curl -fsSL https://mimo.xiaomi.com/install | bash
 
 # Or install via npm (all platforms)
-# Mirror registries (e.g. cnpm/taobao) may have delayed platform package sync
-npm install -g @mimo-ai/cli --registry https://registry.npmjs.org
+npm install -g @mimo-ai/cli
 
 # Run
 mimo

--- a/README.zh.md
+++ b/README.zh.md
@@ -29,8 +29,7 @@ MiMoCode 是一个终端原生的 AI 编程助手。它能读写代码、执行�
 curl -fsSL https://mimo.xiaomi.com/install | bash
 
 # 或通过 npm 安装（全平台）
-# 镜像源（如 cnpm/淘宝源）平台包同步可能滞后，建议使用官方源
-npm install -g @mimo-ai/cli --registry https://registry.npmjs.org
+npm install -g @mimo-ai/cli
 
 # 运行
 mimo

--- a/script/sync-registry.ts
+++ b/script/sync-registry.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env bun
+import { Script } from "@mimo-ai/script"
+
+const PACKAGES = [
+  "@mimo-ai/cli",
+  "@mimo-ai/mimocode-darwin-arm64",
+  "@mimo-ai/mimocode-darwin-x64",
+  "@mimo-ai/mimocode-darwin-x64-baseline",
+  "@mimo-ai/mimocode-linux-arm64",
+  "@mimo-ai/mimocode-linux-arm64-musl",
+  "@mimo-ai/mimocode-linux-x64",
+  "@mimo-ai/mimocode-linux-x64-baseline",
+  "@mimo-ai/mimocode-linux-x64-musl",
+  "@mimo-ai/mimocode-linux-x64-baseline-musl",
+  "@mimo-ai/mimocode-windows-arm64",
+  "@mimo-ai/mimocode-windows-x64",
+  "@mimo-ai/mimocode-windows-x64-baseline",
+]
+
+const REGISTRIES = {
+  npmmirror: {
+    name: "npmmirror (淘宝)",
+    registry: "https://registry.npmmirror.com",
+    syncUrl: "https://registry-direct.npmmirror.com",
+    type: "sync-api" as const,
+  },
+  tencent: {
+    name: "腾讯云",
+    registry: "https://mirrors.cloud.tencent.com/npm",
+    type: "proxy" as const,
+  },
+  huawei: {
+    name: "华为云",
+    registry: "https://mirrors.huaweicloud.com/repository/npm",
+    type: "proxy" as const,
+  },
+}
+
+type RegistryKey = keyof typeof REGISTRIES
+
+const CONCURRENCY = 5
+const POLL_INTERVAL = 3000
+const POLL_TIMEOUT = 120000
+
+async function syncNpmmirror(packageName: string) {
+  const encoded = encodeURIComponent(packageName)
+  const url = `${REGISTRIES.npmmirror.syncUrl}/-/package/${encoded}/syncs`
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ skipDependencies: true, tips: "MiMoCode release sync" }),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    console.error(`  ✗ ${packageName}: ${res.status} ${text}`)
+    return null
+  }
+  const data = (await res.json()) as { ok: boolean; id?: string; logId?: string }
+  return data.id || data.logId || null
+}
+
+async function pollSyncStatus(packageName: string, taskId: string) {
+  const encoded = encodeURIComponent(packageName)
+  const start = Date.now()
+  while (Date.now() - start < POLL_TIMEOUT) {
+    await Bun.sleep(POLL_INTERVAL)
+    const res = await fetch(
+      `${REGISTRIES.npmmirror.syncUrl}/-/package/${encoded}/syncs/${taskId}`,
+    )
+    if (!res.ok) continue
+    const data = (await res.json()) as { state?: string }
+    if (data.state === "success") return "success"
+    if (data.state === "error") return "error"
+  }
+  return "timeout"
+}
+
+async function warmProxy(packageName: string, registry: { name: string; registry: string }) {
+  const encoded = encodeURIComponent(packageName)
+  const url = `${registry.registry}/${encoded}`
+  const res = await fetch(url, { method: "GET" })
+  if (res.ok) {
+    console.log(`  ✓ ${packageName} → ${registry.name}`)
+  } else {
+    console.error(`  ✗ ${packageName} → ${registry.name}: ${res.status}`)
+  }
+  await res.text()
+}
+
+async function runConcurrent<T>(items: T[], concurrency: number, fn: (item: T) => Promise<void>) {
+  const queue = [...items]
+  const workers = Array.from({ length: concurrency }, async () => {
+    while (queue.length > 0) {
+      const item = queue.shift()!
+      await fn(item)
+    }
+  })
+  await Promise.all(workers)
+}
+
+async function syncToNpmmirror() {
+  console.log(`\n▶ Syncing to npmmirror (${REGISTRIES.npmmirror.syncUrl})`)
+  console.log(`  Triggering sync for ${PACKAGES.length} packages...\n`)
+
+  const tasks: { pkg: string; taskId: string }[] = []
+  await runConcurrent(PACKAGES, CONCURRENCY, async (name) => {
+    const taskId = await syncNpmmirror(name)
+    if (taskId) {
+      console.log(`  ↻ ${name} → queued (${taskId})`)
+      tasks.push({ pkg: name, taskId })
+    }
+  })
+
+  if (tasks.length === 0) {
+    console.log("  No sync tasks created.")
+    return
+  }
+
+  console.log(`\n  Polling ${tasks.length} sync tasks...`)
+  await runConcurrent(tasks, CONCURRENCY, async (task) => {
+    const result = await pollSyncStatus(task.pkg, task.taskId)
+    const icon = result === "success" ? "✓" : result === "error" ? "✗" : "⏱"
+    console.log(`  ${icon} ${task.pkg}: ${result}`)
+  })
+}
+
+async function syncToProxy(key: RegistryKey) {
+  const registry = REGISTRIES[key]
+  if (registry.type !== "proxy") return
+  console.log(`\n▶ Warming cache on ${registry.name} (${registry.registry})`)
+  await runConcurrent(PACKAGES, CONCURRENCY, (name) => warmProxy(name, registry))
+}
+
+const target = process.argv[2] as RegistryKey | "all" | undefined
+
+if (target && target !== "all" && !(target in REGISTRIES)) {
+  console.error(`Unknown registry: ${target}`)
+  console.error(`Usage: sync-registry.ts [npmmirror|tencent|huawei|all]`)
+  process.exit(1)
+}
+
+console.log("═══ MiMoCode Registry Sync ═══")
+console.log(`Version: ${Script.version} (${Script.channel})`)
+console.log(`Packages: ${PACKAGES.length}`)
+
+if (!target || target === "all" || target === "npmmirror") {
+  await syncToNpmmirror()
+}
+if (!target || target === "all" || target === "tencent") {
+  await syncToProxy("tencent")
+}
+if (!target || target === "all" || target === "huawei") {
+  await syncToProxy("huawei")
+}
+
+console.log("\n═══ Done ═══")


### PR DESCRIPTION
## Summary

- 新增 `script/sync-registry.ts`，npm 发布后同步国内镜像源
  - npmmirror（淘宝）：调用 sync API 显式触发 optionalDependencies 同步
  - 腾讯云/华为云：GET 预热代理缓存
- README 去掉镜像源警告，不再要求用户指定 `--registry https://registry.npmjs.org`

## 背景

`@mimo-ai/cli` 的平台二进制包作为 optionalDependencies 发布。npmmirror 是全量复制架构，其 sync worker 对安装失败的可选依赖不会重试，导致国内用户通过淘宝源安装时缺少平台包。此脚本在每次 publish 后自动触发同步。

## 用法

```bash
export MIMOCODE_VERSION=0.1.x MIMOCODE_CHANNEL=latest
./script/sync-registry.ts              # 默认同步全部镜像
./script/sync-registry.ts npmmirror    # 仅淘宝
```