### PR TITLE
feat: recommend native installer for npm/pnpm/bun users

### DIFF
--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -69,24 +69,24 @@ function findBinary() {
 }
 
 function printMigrationNotice() {
-  const isWin = os.platform() === "win32"
-  const install = isWin
+  const install = os.platform() === "win32"
     ? "irm https://mimo.xiaomi.com/install.ps1 | iex"
     : "curl -fsSL https://mimo.xiaomi.com/install | bash"
-
-  const yellow = "\x1b[33m"
-  const bold = "\x1b[1m"
-  const reset = "\x1b[0m"
-
   console.log()
-  console.log(`${yellow}${bold}  ⚡ Recommended: use native installer${reset}`)
-  console.log(`     Consider removing the npm package and installing natively for faster auto-updates:`)
-  console.log(`     ${install}`)
+  console.log("  Recommended: install MiMoCode natively for a better install and upgrade experience:")
+  console.log(`    ${install}`)
   console.log()
 }
 
 async function main() {
   printMigrationNotice()
+
+  if (os.platform() === "win32") {
+    // On Windows the bin/mimo wrapper finds the binary via node_modules traversal.
+    // Skipping the .mimocode cache avoids creating an extensionless PE file that
+    // may trigger antivirus false-positives.
+    return
+  }
 
   try {
     const { binaryPath } = findBinary()
@@ -97,7 +97,7 @@ async function main() {
     } catch {
       fs.copyFileSync(binaryPath, target)
     }
-    if (os.platform() !== "win32") fs.chmodSync(target, 0o755)
+    fs.chmodSync(target, 0o755)
   } catch (error) {
     console.error("Failed to setup mimocode binary:", error.message)
     process.exit(1)

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -68,17 +68,42 @@ function findBinary() {
   }
 }
 
-async function main() {
+function isChineseLocale() {
+  const lang = process.env.LANG || process.env.LC_ALL || process.env.LC_MESSAGES || process.env.LANGUAGE || ""
+  if (/^zh/i.test(lang)) return true
   try {
-    if (os.platform() === "win32") {
-      // On Windows, the .exe is already included in the package and bin field points to it
-      // No postinstall setup needed
-      console.log("Windows detected: binary setup not needed (using packaged .exe)")
-      return
-    }
+    const locale = Intl.DateTimeFormat().resolvedOptions().locale
+    if (/^zh/i.test(locale)) return true
+  } catch {}
+  return false
+}
 
-    // On non-Windows platforms, just verify the binary package exists
-    // Don't replace the wrapper script - it handles binary execution
+function printMigrationNotice() {
+  const isWin = os.platform() === "win32"
+  const install = isWin
+    ? "irm https://mimo.xiaomi.com/install.ps1 | iex"
+    : "curl -fsSL https://mimo.xiaomi.com/install | bash"
+
+  const zh = isChineseLocale()
+  const title = zh ? "建议使用原生安装方式" : "Recommended: use native installer"
+  const msg = zh
+    ? `建议卸载 npm 包后通过原生方式安装，以获得更快的自动更新体验：\n     ${install}`
+    : `Consider removing the npm package and installing natively for faster auto-updates:\n     ${install}`
+
+  const yellow = "\x1b[33m"
+  const bold = "\x1b[1m"
+  const reset = "\x1b[0m"
+
+  console.log()
+  console.log(`${yellow}${bold}  ⚡ ${title}${reset}`)
+  console.log(`     ${msg}`)
+  console.log()
+}
+
+async function main() {
+  printMigrationNotice()
+
+  try {
     const { binaryPath } = findBinary()
     const target = path.join(__dirname, "bin", ".mimocode")
     if (fs.existsSync(target)) fs.unlinkSync(target)
@@ -87,7 +112,7 @@ async function main() {
     } catch {
       fs.copyFileSync(binaryPath, target)
     }
-    fs.chmodSync(target, 0o755)
+    if (os.platform() !== "win32") fs.chmodSync(target, 0o755)
   } catch (error) {
     console.error("Failed to setup mimocode binary:", error.message)
     process.exit(1)

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -68,35 +68,20 @@ function findBinary() {
   }
 }
 
-function isChineseLocale() {
-  const lang = process.env.LANG || process.env.LC_ALL || process.env.LC_MESSAGES || process.env.LANGUAGE || ""
-  if (/^zh/i.test(lang)) return true
-  try {
-    const locale = Intl.DateTimeFormat().resolvedOptions().locale
-    if (/^zh/i.test(locale)) return true
-  } catch {}
-  return false
-}
-
 function printMigrationNotice() {
   const isWin = os.platform() === "win32"
   const install = isWin
     ? "irm https://mimo.xiaomi.com/install.ps1 | iex"
     : "curl -fsSL https://mimo.xiaomi.com/install | bash"
 
-  const zh = isChineseLocale()
-  const title = zh ? "建议使用原生安装方式" : "Recommended: use native installer"
-  const msg = zh
-    ? `建议卸载 npm 包后通过原生方式安装，以获得更快的自动更新体验：\n     ${install}`
-    : `Consider removing the npm package and installing natively for faster auto-updates:\n     ${install}`
-
   const yellow = "\x1b[33m"
   const bold = "\x1b[1m"
   const reset = "\x1b[0m"
 
   console.log()
-  console.log(`${yellow}${bold}  ⚡ ${title}${reset}`)
-  console.log(`     ${msg}`)
+  console.log(`${yellow}${bold}  ⚡ Recommended: use native installer${reset}`)
+  console.log(`     Consider removing the npm package and installing natively for faster auto-updates:`)
+  console.log(`     ${install}`)
   console.log()
 }
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1004,14 +1004,20 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
 
   event.on("installation.update-available", async (evt) => {
     const version = evt.properties.version
+    const method = evt.properties.method
+    const isPkgManager = method === "npm" || method === "pnpm" || method === "bun"
 
     const skipped = kv.get("skipped_version")
     if (skipped && !semver.gt(version, skipped)) return
 
+    const confirmMsg = isPkgManager
+      ? t("tui.toast.update_available.confirm", { version }) + "\n" + t("tui.toast.native_installer_tip")
+      : t("tui.toast.update_available.confirm", { version })
+
     const choice = await DialogConfirm.show(
       dialog,
       t("tui.toast.update_available.title"),
-      t("tui.toast.update_available.confirm", { version }),
+      confirmMsg,
       "skip",
     )
 
@@ -1050,10 +1056,14 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   })
 
   event.on("installation.updated", (evt) => {
+    const isPkgManager = evt.properties.method === "npm" || evt.properties.method === "pnpm" || evt.properties.method === "bun"
+    const msg = isPkgManager
+      ? t("tui.toast.updated.message", { version: evt.properties.version }) + " " + t("tui.toast.native_installer_tip")
+      : t("tui.toast.updated.message", { version: evt.properties.version })
     toast.show({
       variant: "success",
       title: t("tui.toast.updated.title"),
-      message: t("tui.toast.updated.message", { version: evt.properties.version }),
+      message: msg,
       duration: 10000,
     })
   })

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -312,7 +312,7 @@ export const dict: Record<string, string> = {
   "tui.toast.update_available.success": "Successfully updated to MiMoCode v{{version}}. Please restart the application.",
   "tui.toast.updated.title": "Auto-updated",
   "tui.toast.updated.message": "Patch update applied: v{{version}}. Restart to use the new version. Disable via autoupdate: false in config.",
-  "tui.toast.native_installer_tip": "Tip: native installer (curl/PowerShell) is recommended for faster updates.",
+  "tui.toast.native_installer_tip": "Tip: native installer (curl/PowerShell) is recommended for a better experience.",
   "tui.sidebar.instructions": "Instructions",
   "tui.sidebar.cwd": "Working Directory",
   "tui.toast.unknown_error": "An unknown error has occurred",

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -312,6 +312,7 @@ export const dict: Record<string, string> = {
   "tui.toast.update_available.success": "Successfully updated to MiMoCode v{{version}}. Please restart the application.",
   "tui.toast.updated.title": "Auto-updated",
   "tui.toast.updated.message": "Patch update applied: v{{version}}. Restart to use the new version. Disable via autoupdate: false in config.",
+  "tui.toast.native_installer_tip": "Tip: native installer (curl/PowerShell) is recommended for faster updates.",
   "tui.sidebar.instructions": "Instructions",
   "tui.sidebar.cwd": "Working Directory",
   "tui.toast.unknown_error": "An unknown error has occurred",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -379,7 +379,7 @@ export const dict = {
   "tui.toast.update_available.success": "Se actualizó a MiMoCode v{{version}}. Por favor reinicie la aplicación.",
   "tui.toast.updated.title": "Actualizado automáticamente",
   "tui.toast.updated.message": "Parche aplicado automáticamente: v{{version}}. Reinicie para usar la nueva versión. Desactive con autoupdate: false en la configuración.",
-  "tui.toast.native_installer_tip": "Consejo: se recomienda el instalador nativo (curl/PowerShell) para actualizaciones más rápidas.",
+  "tui.toast.native_installer_tip": "Consejo: se recomienda el instalador nativo (curl/PowerShell) para una mejor experiencia.",
   "tui.sidebar.instructions": "Instrucciones",
   "tui.sidebar.cwd": "Directorio de trabajo",
   "tui.toast.unknown_error": "Ha ocurrido un error desconocido",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -379,6 +379,7 @@ export const dict = {
   "tui.toast.update_available.success": "Se actualizó a MiMoCode v{{version}}. Por favor reinicie la aplicación.",
   "tui.toast.updated.title": "Actualizado automáticamente",
   "tui.toast.updated.message": "Parche aplicado automáticamente: v{{version}}. Reinicie para usar la nueva versión. Desactive con autoupdate: false en la configuración.",
+  "tui.toast.native_installer_tip": "Consejo: se recomienda el instalador nativo (curl/PowerShell) para actualizaciones más rápidas.",
   "tui.sidebar.instructions": "Instrucciones",
   "tui.sidebar.cwd": "Directorio de trabajo",
   "tui.toast.unknown_error": "Ha ocurrido un error desconocido",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -368,7 +368,7 @@ export const dict = {
   "tui.toast.update_available.success": "Mis à jour vers MiMoCode v{{version}}. Veuillez redémarrer l'application.",
   "tui.toast.updated.title": "Mis à jour automatiquement",
   "tui.toast.updated.message": "Correctif appliqué automatiquement : v{{version}}. Redémarrez pour utiliser la nouvelle version. Désactivez avec autoupdate: false dans la configuration.",
-  "tui.toast.native_installer_tip": "Conseil : l'installateur natif (curl/PowerShell) est recommandé pour des mises à jour plus rapides.",
+  "tui.toast.native_installer_tip": "Conseil : l'installateur natif (curl/PowerShell) est recommandé pour une meilleure expérience.",
   "tui.sidebar.instructions": "Instructions",
   "tui.sidebar.cwd": "Répertoire de travail",
   "tui.toast.unknown_error": "Une erreur inconnue s'est produite",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -368,6 +368,7 @@ export const dict = {
   "tui.toast.update_available.success": "Mis à jour vers MiMoCode v{{version}}. Veuillez redémarrer l'application.",
   "tui.toast.updated.title": "Mis à jour automatiquement",
   "tui.toast.updated.message": "Correctif appliqué automatiquement : v{{version}}. Redémarrez pour utiliser la nouvelle version. Désactivez avec autoupdate: false dans la configuration.",
+  "tui.toast.native_installer_tip": "Conseil : l'installateur natif (curl/PowerShell) est recommandé pour des mises à jour plus rapides.",
   "tui.sidebar.instructions": "Instructions",
   "tui.sidebar.cwd": "Répertoire de travail",
   "tui.toast.unknown_error": "Une erreur inconnue s'est produite",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -315,7 +315,7 @@ export const dict = {
   "tui.toast.update_available.success": "MiMoCode v{{version}} に更新しました。アプリケーションを再起動してください。",
   "tui.toast.updated.title": "自動更新済み",
   "tui.toast.updated.message": "パッチ更新を自動適用しました：v{{version}}。再起動後に有効になります。設定で autoupdate: false を指定すると無効にできます。",
-  "tui.toast.native_installer_tip": "ヒント：より高速な更新のため、ネイティブインストーラー（curl/PowerShell）の使用を推奨します。",
+  "tui.toast.native_installer_tip": "ヒント：より良いインストール・更新体験のため、ネイティブインストーラー（curl/PowerShell）を推奨します。",
   "tui.sidebar.instructions": "インストラクション",
   "tui.sidebar.cwd": "作業ディレクトリ",
   "tui.toast.unknown_error": "不明なエラーが発生しました",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -315,6 +315,7 @@ export const dict = {
   "tui.toast.update_available.success": "MiMoCode v{{version}} に更新しました。アプリケーションを再起動してください。",
   "tui.toast.updated.title": "自動更新済み",
   "tui.toast.updated.message": "パッチ更新を自動適用しました：v{{version}}。再起動後に有効になります。設定で autoupdate: false を指定すると無効にできます。",
+  "tui.toast.native_installer_tip": "ヒント：より高速な更新のため、ネイティブインストーラー（curl/PowerShell）の使用を推奨します。",
   "tui.sidebar.instructions": "インストラクション",
   "tui.sidebar.cwd": "作業ディレクトリ",
   "tui.toast.unknown_error": "不明なエラーが発生しました",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -383,6 +383,7 @@ export const dict = {
   "tui.toast.update_available.success": "Обновлено до MiMoCode v{{version}}. Пожалуйста, перезапустите приложение.",
   "tui.toast.updated.title": "Автообновление выполнено",
   "tui.toast.updated.message": "Патч применён автоматически: v{{version}}. Перезапустите для использования новой версии. Отключите через autoupdate: false в конфигурации.",
+  "tui.toast.native_installer_tip": "Совет: рекомендуется использовать нативный установщик (curl/PowerShell) для более быстрых обновлений.",
   "tui.sidebar.instructions": "Инструкции",
   "tui.sidebar.cwd": "Рабочий каталог",
   "tui.toast.unknown_error": "Произошла неизвестная ошибка",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -383,7 +383,7 @@ export const dict = {
   "tui.toast.update_available.success": "Обновлено до MiMoCode v{{version}}. Пожалуйста, перезапустите приложение.",
   "tui.toast.updated.title": "Автообновление выполнено",
   "tui.toast.updated.message": "Патч применён автоматически: v{{version}}. Перезапустите для использования новой версии. Отключите через autoupdate: false в конфигурации.",
-  "tui.toast.native_installer_tip": "Совет: рекомендуется использовать нативный установщик (curl/PowerShell) для более быстрых обновлений.",
+  "tui.toast.native_installer_tip": "Совет: рекомендуется нативный установщик (curl/PowerShell) для лучшего опыта установки и обновления.",
   "tui.sidebar.instructions": "Инструкции",
   "tui.sidebar.cwd": "Рабочий каталог",
   "tui.toast.unknown_error": "Произошла неизвестная ошибка",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -300,6 +300,7 @@ export const dict = {
   "tui.toast.update_available.success": "已更新到 MiMoCode v{{version}}，请重启应用。",
   "tui.toast.updated.title": "已自动更新",
   "tui.toast.updated.message": "已自动应用补丁更新：v{{version}}。重启后生效。可在配置中设置 autoupdate: false 关闭自动更新。",
+  "tui.toast.native_installer_tip": "提示：推荐使用原生安装方式（curl/PowerShell）以获得更快的更新体验。",
   "tui.sidebar.instructions": "指令文件",
   "tui.sidebar.cwd": "工作目录",
   "tui.toast.unknown_error": "发生未知错误",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -300,7 +300,7 @@ export const dict = {
   "tui.toast.update_available.success": "已更新到 MiMoCode v{{version}}，请重启应用。",
   "tui.toast.updated.title": "已自动更新",
   "tui.toast.updated.message": "已自动应用补丁更新：v{{version}}。重启后生效。可在配置中设置 autoupdate: false 关闭自动更新。",
-  "tui.toast.native_installer_tip": "提示：推荐使用原生安装方式（curl/PowerShell）以获得更快的更新体验。",
+  "tui.toast.native_installer_tip": "提示：推荐使用原生安装方式（curl/PowerShell）以获得更好的安装和更新体验。",
   "tui.sidebar.instructions": "指令文件",
   "tui.sidebar.cwd": "工作目录",
   "tui.toast.unknown_error": "发生未知错误",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -300,6 +300,7 @@ export const dict = {
   "tui.toast.update_available.success": "已更新到 MiMoCode v{{version}}，請重新啟動應用程式。",
   "tui.toast.updated.title": "已自動更新",
   "tui.toast.updated.message": "已自動套用修補更新：v{{version}}。重新啟動後生效。可在設定中設置 autoupdate: false 關閉自動更新。",
+  "tui.toast.native_installer_tip": "提示：建議使用原生安裝方式（curl/PowerShell）以獲得更快的更新體驗。",
   "tui.sidebar.instructions": "指令檔案",
   "tui.sidebar.cwd": "工作目錄",
   "tui.toast.unknown_error": "發生未知錯誤",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -300,7 +300,7 @@ export const dict = {
   "tui.toast.update_available.success": "已更新到 MiMoCode v{{version}}，請重新啟動應用程式。",
   "tui.toast.updated.title": "已自動更新",
   "tui.toast.updated.message": "已自動套用修補更新：v{{version}}。重新啟動後生效。可在設定中設置 autoupdate: false 關閉自動更新。",
-  "tui.toast.native_installer_tip": "提示：建議使用原生安裝方式（curl/PowerShell）以獲得更快的更新體驗。",
+  "tui.toast.native_installer_tip": "提示：建議使用原生安裝方式（curl/PowerShell）以獲得更好的安裝和更新體驗。",
   "tui.sidebar.instructions": "指令檔案",
   "tui.sidebar.cwd": "工作目錄",
   "tui.toast.unknown_error": "發生未知錯誤",

--- a/packages/opencode/src/cli/upgrade.ts
+++ b/packages/opencode/src/cli/upgrade.ts
@@ -18,7 +18,7 @@ export async function upgrade() {
   if (!latest) return
 
   if (Flag.MIMOCODE_ALWAYS_NOTIFY_UPDATE) {
-    await Bus.publish(Installation.Event.UpdateAvailable, { version: latest })
+    await Bus.publish(Installation.Event.UpdateAvailable, { version: latest, method })
     return
   }
 
@@ -28,13 +28,13 @@ export async function upgrade() {
   const kind = Installation.getReleaseType(InstallationVersion, latest)
 
   if (config.autoupdate === "notify" || kind !== "patch") {
-    await Bus.publish(Installation.Event.UpdateAvailable, { version: latest })
+    await Bus.publish(Installation.Event.UpdateAvailable, { version: latest, method })
     return
   }
 
   if (method === "unknown") return
   await AppRuntime.runPromise(Installation.Service.use((svc) => svc.upgrade(method, latest)))
-    .then(() => Bus.publish(Installation.Event.Updated, { version: latest }))
+    .then(() => Bus.publish(Installation.Event.Updated, { version: latest, method }))
     .catch((err) => {
       log.warn("auto-upgrade failed", { method, target: latest, error: String(err) })
     })

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -26,12 +26,14 @@ export const Event = {
     "installation.updated",
     z.object({
       version: z.string(),
+      method: z.string().optional(),
     }),
   ),
   UpdateAvailable: BusEvent.define(
     "installation.update-available",
     z.object({
       version: z.string(),
+      method: z.string().optional(),
     }),
   ),
 }

--- a/packages/opencode/test/installation/postinstall.test.ts
+++ b/packages/opencode/test/installation/postinstall.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import fs from "fs"
+import path from "path"
+import os from "os"
+
+const SCRIPT_PATH = path.join(import.meta.dirname, "../../script/postinstall.mjs")
+
+describe("postinstall", () => {
+  const platform = os.platform() === "win32" ? "windows" : os.platform() === "darwin" ? "darwin" : "linux"
+  const arch = os.arch()
+  const binaryName = platform === "windows" ? "mimo.exe" : "mimo"
+  const packageName = `@mimo-ai/mimocode-${platform}-${arch}`
+
+  test("creates .mimocode binary cache from platform package", async () => {
+    await using tmp = await tmpdir()
+    const dir = tmp.path
+
+    const binDir = path.join(dir, "bin")
+    fs.mkdirSync(binDir)
+
+    const pkgBinDir = path.join(dir, "node_modules", packageName, "bin")
+    fs.mkdirSync(pkgBinDir, { recursive: true })
+    fs.writeFileSync(path.join(dir, "node_modules", packageName, "package.json"), JSON.stringify({ name: packageName }))
+
+    const fakeBinary = Buffer.from("FAKE_BINARY_CONTENT")
+    fs.writeFileSync(path.join(pkgBinDir, binaryName), fakeBinary)
+
+    fs.copyFileSync(SCRIPT_PATH, path.join(dir, "postinstall.mjs"))
+
+    const result = Bun.spawnSync(["node", "postinstall.mjs"], {
+      cwd: dir,
+      env: { ...process.env, NODE_PATH: path.join(dir, "node_modules") },
+    })
+
+    expect(result.exitCode).toBe(0)
+
+    const cached = path.join(binDir, ".mimocode")
+    expect(fs.existsSync(cached)).toBe(true)
+    expect(fs.readFileSync(cached)).toEqual(fakeBinary)
+  })
+
+  test("prints migration notice to stdout", async () => {
+    await using tmp = await tmpdir()
+    const dir = tmp.path
+
+    const binDir = path.join(dir, "bin")
+    fs.mkdirSync(binDir)
+    const pkgBinDir = path.join(dir, "node_modules", packageName, "bin")
+    fs.mkdirSync(pkgBinDir, { recursive: true })
+    fs.writeFileSync(path.join(dir, "node_modules", packageName, "package.json"), JSON.stringify({ name: packageName }))
+    fs.writeFileSync(path.join(pkgBinDir, binaryName), "binary")
+
+    fs.copyFileSync(SCRIPT_PATH, path.join(dir, "postinstall.mjs"))
+
+    const result = Bun.spawnSync(["node", "postinstall.mjs"], {
+      cwd: dir,
+      env: { ...process.env, NODE_PATH: path.join(dir, "node_modules") },
+    })
+
+    const stdout = result.stdout.toString()
+    expect(stdout).toContain("Recommended: install MiMoCode natively for a better")
+    expect(stdout).toContain(os.platform() === "win32" ? "    irm" : "    curl")
+  })
+
+  test("exits with error when binary package is missing", async () => {
+    await using tmp = await tmpdir()
+    const dir = tmp.path
+
+    fs.mkdirSync(path.join(dir, "bin"))
+    fs.copyFileSync(SCRIPT_PATH, path.join(dir, "postinstall.mjs"))
+
+    const result = Bun.spawnSync(["node", "postinstall.mjs"], {
+      cwd: dir,
+      env: { ...process.env, NODE_PATH: path.join(dir, "node_modules") },
+    })
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout.toString()).toContain("Recommended: install MiMoCode natively")
+  })
+
+  test("skips binary cache on windows but still prints notice", () => {
+    const source = fs.readFileSync(SCRIPT_PATH, "utf8")
+    const mainBody = source.slice(source.indexOf("async function main()"))
+    // Windows skip must come AFTER printMigrationNotice()
+    const noticeIdx = mainBody.indexOf("printMigrationNotice()")
+    const winCheckIdx = mainBody.indexOf("os.platform() === \"win32\"")
+    expect(noticeIdx).toBeGreaterThan(-1)
+    expect(winCheckIdx).toBeGreaterThan(noticeIdx)
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -18,6 +18,70 @@ export type EventGlobalDisposed = {
   }
 }
 
+export type EventTuiPromptAppend = {
+  type: "tui.prompt.append"
+  properties: {
+    text: string
+  }
+}
+
+export type EventTuiCommandExecute = {
+  type: "tui.command.execute"
+  properties: {
+    command:
+      | "session.list"
+      | "session.new"
+      | "session.share"
+      | "session.interrupt"
+      | "session.compact"
+      | "session.page.up"
+      | "session.page.down"
+      | "session.line.up"
+      | "session.line.down"
+      | "session.half.page.up"
+      | "session.half.page.down"
+      | "session.first"
+      | "session.last"
+      | "prompt.clear"
+      | "prompt.submit"
+      | "agent.cycle"
+      | string
+  }
+}
+
+export type EventTuiToastShow = {
+  type: "tui.toast.show"
+  properties: {
+    title?: string
+    message: string
+    variant: "info" | "success" | "warning" | "error"
+    /**
+     * Duration in milliseconds
+     */
+    duration?: number
+  }
+}
+
+export type EventTuiSessionSelect = {
+  type: "tui.session.select"
+  properties: {
+    /**
+     * Session ID to navigate to
+     */
+    sessionID: string
+  }
+}
+
+export type EventTuiInstructionsLoaded = {
+  type: "tui.instructions.loaded"
+  properties: {
+    /**
+     * Display labels of loaded instruction files: worktree-relative path, ~-path, or absolute
+     */
+    files: Array<string>
+  }
+}
+
 export type EventActorRegistered = {
   type: "actor.registered"
   properties: {
@@ -117,70 +181,6 @@ export type EventTaskUpdated = {
       cleanup_after?: number
     }
     kind: "started" | "unstarted" | "blocked" | "unblocked" | "done" | "abandoned" | "renamed"
-  }
-}
-
-export type EventTuiPromptAppend = {
-  type: "tui.prompt.append"
-  properties: {
-    text: string
-  }
-}
-
-export type EventTuiCommandExecute = {
-  type: "tui.command.execute"
-  properties: {
-    command:
-      | "session.list"
-      | "session.new"
-      | "session.share"
-      | "session.interrupt"
-      | "session.compact"
-      | "session.page.up"
-      | "session.page.down"
-      | "session.line.up"
-      | "session.line.down"
-      | "session.half.page.up"
-      | "session.half.page.down"
-      | "session.first"
-      | "session.last"
-      | "prompt.clear"
-      | "prompt.submit"
-      | "agent.cycle"
-      | string
-  }
-}
-
-export type EventTuiToastShow = {
-  type: "tui.toast.show"
-  properties: {
-    title?: string
-    message: string
-    variant: "info" | "success" | "warning" | "error"
-    /**
-     * Duration in milliseconds
-     */
-    duration?: number
-  }
-}
-
-export type EventTuiSessionSelect = {
-  type: "tui.session.select"
-  properties: {
-    /**
-     * Session ID to navigate to
-     */
-    sessionID: string
-  }
-}
-
-export type EventTuiInstructionsLoaded = {
-  type: "tui.instructions.loaded"
-  properties: {
-    /**
-     * Display labels of loaded instruction files: worktree-relative path, ~-path, or absolute
-     */
-    files: Array<string>
   }
 }
 
@@ -376,6 +376,7 @@ export type EventInstallationUpdated = {
   type: "installation.updated"
   properties: {
     version: string
+    method?: string
   }
 }
 
@@ -383,6 +384,7 @@ export type EventInstallationUpdateAvailable = {
   type: "installation.update-available"
   properties: {
     version: string
+    method?: string
   }
 }
 
@@ -833,6 +835,7 @@ export type EventSessionCompacted = {
   type: "session.compacted"
   properties: {
     sessionID: string
+    agentID?: string
   }
 }
 
@@ -1509,6 +1512,11 @@ export type GlobalEvent = {
   payload:
     | EventServerConnected
     | EventGlobalDisposed
+    | EventTuiPromptAppend
+    | EventTuiCommandExecute
+    | EventTuiToastShow
+    | EventTuiSessionSelect
+    | EventTuiInstructionsLoaded
     | EventActorRegistered
     | EventActorStatus
     | EventActorStuck
@@ -1516,11 +1524,6 @@ export type GlobalEvent = {
     | EventInboxArrived
     | EventTaskCreated
     | EventTaskUpdated
-    | EventTuiPromptAppend
-    | EventTuiCommandExecute
-    | EventTuiToastShow
-    | EventTuiSessionSelect
-    | EventTuiInstructionsLoaded
     | EventMetricsModelCall
     | EventMetricsToolCall
     | EventMetricsAgentRequest
@@ -1992,6 +1995,10 @@ export type Config = {
    * Small model to use for tasks like title generation in the format of provider/model
    */
   small_model?: string
+  /**
+   * Model to use for image/vision subagent tasks in the format of provider/model. If unset, a vision-capable model is chosen automatically (in-house models preferred, then cheapest).
+   */
+  vision_model?: string
   /**
    * Named model groups (capability tiers, e.g. ultra/standard/lite). Each group has a default model and optional member models. A group name can be used anywhere a provider/model string is accepted.
    */
@@ -2694,6 +2701,11 @@ export type File = {
 export type Event =
   | EventServerConnected
   | EventGlobalDisposed
+  | EventTuiPromptAppend
+  | EventTuiCommandExecute
+  | EventTuiToastShow
+  | EventTuiSessionSelect
+  | EventTuiInstructionsLoaded
   | EventActorRegistered
   | EventActorStatus
   | EventActorStuck
@@ -2701,11 +2713,6 @@ export type Event =
   | EventInboxArrived
   | EventTaskCreated
   | EventTaskUpdated
-  | EventTuiPromptAppend
-  | EventTuiCommandExecute
-  | EventTuiToastShow
-  | EventTuiSessionSelect
-  | EventTuiInstructionsLoaded
   | EventMetricsModelCall
   | EventMetricsToolCall
   | EventMetricsAgentRequest


### PR DESCRIPTION
## Summary

Follow-up to #1551. Encourages npm/pnpm/bun users to switch to the native installer (curl/PowerShell) for better auto-update experience.

**Two touchpoints:**

1. **`postinstall.mjs`** — prints a plain-text two-liner recommending `curl`/PowerShell install (no ANSI colors, no locale detection). Shown before binary setup so it's visible even when the platform package is missing. Windows skips binary cache creation (unchanged behavior, comment corrected).
2. **TUI update notifications** — appends a "native installer recommended" tip to the update-available dialog and auto-updated toast, only when install method is npm/pnpm/bun (i18n in 7 locales).

## Changes

- `packages/opencode/script/postinstall.mjs` — migration notice + corrected Windows skip comment
- `packages/opencode/src/cli/upgrade.ts` — pass `method` to update events
- `packages/opencode/src/installation/index.ts` — add optional `method` field to event schemas
- `packages/opencode/src/cli/cmd/tui/app.tsx` — conditional native installer tip
- `packages/opencode/src/cli/cmd/tui/i18n/{en,zh,zht,ja,fr,ru,es}.ts` — `tui.toast.native_installer_tip`
- `packages/sdk/js/src/v2/gen/types.gen.ts` — regenerated
- `packages/opencode/test/installation/postinstall.test.ts` — new tests

## Test Plan

- **Unit tests**: `bun test test/installation/postinstall.test.ts` — 4 tests: binary cache creation, notice output, error-on-missing-binary, Windows skip ordering
- **TUI**: Set `MIMOCODE_ALWAYS_NOTIFY_UPDATE=1` with npm-installed binary to see tip in update dialog
- **Typecheck**: verified by pre-push hook (all 12 packages pass)