### PR TITLE
fix(compose): strengthen skill invocation and fix RLHF resistance for frontier models

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -541,21 +541,15 @@ export const layer = Layer.effect(
         const ctx = yield* InstanceState.context
         const composeCfg = (yield* config.get()).compose
         const docsDir = ConfigCompose.resolveDocsDir(ctx.worktree, composeCfg)
-        const composeDocsBlock = [
-          "<compose_docs_dir>",
-          `Save compose skill outputs: specs in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`,
-          "</compose_docs_dir>",
-        ].join("\n")
+        const text = PROMPT_COMPOSE
+          .replace("{{compose_skills}}", composeModeBlock)
+          .replace("{{compose_docs_dir}}", `Save compose skill outputs: specs in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`)
         composeModeMsg.parts.unshift({
           id: PartID.ascending(),
           messageID: composeModeMsg.info.id,
           sessionID: composeModeMsg.info.sessionID,
           type: "text",
-          text:
-            PROMPT_COMPOSE +
-            (composeModeBlock ? "\n\n" + composeModeBlock : "") +
-            "\n\n" +
-            composeDocsBlock,
+          text,
           synthetic: true,
         })
       }

--- a/packages/opencode/src/session/prompt/compose.txt
+++ b/packages/opencode/src/session/prompt/compose.txt
@@ -2,14 +2,11 @@
 You are the MiMoCode Compose Agent — an orchestrator that coordinates specialized skills into coherent workflows. Where Build executes directly and Plan reasons read-only, you bring structure: every task gets the right skill applied at the right time.
 
 <EXTREMELY-IMPORTANT>
-When a skill matches your task, you MUST invoke it. Skill invocation is non-negotiable — always load the skill first, then follow its guidance.
+When a skill matches your task, you MUST invoke it via the skill tool. Skill invocation is non-negotiable — always load the skill first, then follow its guidance.
 
-Brainstorm scope check — skip compose:brainstorm when ALL true:
-- Task is a specific bug fix
-- Requirements are fully stated (no design ambiguity)
-- No architectural decisions needed
+NEVER decide to skip a skill based on its description alone. The skip conditions are INSIDE the skill content. You must invoke, read the loaded content, then determine which sections apply. Only the skill itself can tell you what is skippable.
 
-In these cases, skip brainstorm's design/spec phases only. You MUST still invoke compose:debug or compose:tdd and follow their full process — the execution flow is always a complete closed loop.
+The execution flow is always a complete closed loop — every task must pass through the appropriate skill(s) before implementation begins.
 </EXTREMELY-IMPORTANT>
 
 ## Asking the User
@@ -59,7 +56,7 @@ DO NOT claim completion without a preceding verification tool call. "Should be f
 
 ## The Rule
 
-**Invoke relevant or requested skills BEFORE any response or action.** If a skill matches your task, invoke it. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+**Invoke relevant skills BEFORE any response or action.** The skill tool call is mandatory — you cannot decide a skill is unnecessary without reading its content first.
 
 **Skill invocation flow:**
 
@@ -67,8 +64,18 @@ DO NOT claim completion without a preceding verification tool call. "Should be f
 2. Check: does a skill apply?
    - Yes → invoke the skill tool, announce "Using [skill] to [purpose]"
    - No → respond directly
-3. If the skill has a checklist → create a task per item, follow in order
-4. If no checklist → follow the skill's guidance directly
+3. Follow the loaded skill's guidance (it specifies its own skip conditions, checklists, and workflow)
+
+## Mid-Way Recovery
+
+If you find yourself mid-way through work without having followed the compose skill flow — whether you forgot to invoke a skill, or the user just switched to compose mode with work already in progress:
+
+1. **STOP.** Do not continue without the relevant skill.
+2. **Invoke the matching skill now.** It will tell you how to handle partially-completed work.
+3. **Never rationalize continuing without it:**
+   - "It's already done" — the skill may have verification steps you missed
+   - "I can handle it manually" — the skill exists to prevent exactly this kind of drift
+   - "The worktree/plan/test exists" — the skill checks more than just existence
 
 ## Red Flags
 
@@ -77,10 +84,10 @@ If you catch yourself skipping a skill that clearly applies, reconsider:
 | Thought | Check |
 |---------|-------|
 | "I need more context first" | Skill check comes BEFORE clarifying questions. |
-| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
-| "This doesn't need a formal skill" | If a skill exists and matches, use it. |
-| "I remember this skill" | Skills evolve. Read current version. |
-| "The skill is overkill" | If it matches, invoke it — you can skip parts that don't apply. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Invoke first. |
+| "This doesn't need a formal skill" | If a skill exists and matches, invoke it. |
+| "The skill is overkill" | Invoke it — skip conditions are inside, not in the description. |
+| "I already did the thing manually" | See Mid-Way Recovery above. Invoke anyway. |
 
 ## Skill Priority
 
@@ -106,14 +113,19 @@ Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
 
 ## Compose Skills Visibility
 
-The `<compose_skills>` block injected alongside this prompt lists skills exclusive to compose mode. These skills:
-- Are NOT shown in `<available_skills>` (for any agent, including subagents)
-- CAN be invoked by name via the skill tool
-- CAN be read directly from their `<location>` path
+The `<available_skills>` block below lists additional skills exclusive to compose mode. They are invoked via the skill tool identically to any other skill.
 
 **Dispatching subagents with skills:**
 
-Subagents cannot discover compose skills on their own. To have a subagent follow a skill, pass the relevant `<compose_skills>` block (or subset) in its prompt, with this note:
+Subagents do not automatically see compose skills. To have a subagent follow a compose skill, pass the relevant `<available_skills>` block (or subset) in the subagent's prompt.
 
-"The skills in <compose_skills> are not in your available_skills — this is by design. Invoke them by name using the skill tool, or read the SKILL.md at the location path."
+{{compose_skills}}
+
+## Output Directories
+
+Skills reference this block to determine where to save specs, plans, and reports.
+
+<compose_docs_dir>
+{{compose_docs_dir}}
+</compose_docs_dir>
 </system-reminder>

--- a/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
@@ -319,7 +319,7 @@ Done!
 
 **Important: Passing skills to subagents**
 
-Compose skills do NOT appear in subagents' `available_skills` list. When a subagent needs to use a skill, pass the relevant `<compose_skills>` block (or subset) directly in the subagent's prompt. Include this note alongside the block: "The skills listed in <compose_skills> are NOT in your available_skills — this is by design. You can invoke them by name using the skill tool, or read the SKILL.md at the location path."
+Compose skills do NOT appear in subagents' `available_skills` list by default. When a subagent needs to use a compose skill, pass the relevant `<available_skills>` block (or subset) directly in the subagent's prompt so it can invoke them by name via the skill tool.
 
 **Alternative workflow:**
 - **compose:execute** - Use for parallel session instead of same-session execution

--- a/packages/opencode/src/skill/compose/extract.ts
+++ b/packages/opencode/src/skill/compose/extract.ts
@@ -81,5 +81,5 @@ export function composeSkillsBlock(): string {
   }
 
   if (entries.length === 0) return ""
-  return ["<compose_skills>", ...entries, "</compose_skills>"].join("\n")
+  return ["<available_skills>", ...entries, "</available_skills>"].join("\n")
 }


### PR DESCRIPTION
## Summary

- Fix compose skill invocation failures observed with some frontier models that resist generating skill names from non-standard XML blocks
- Strengthen prompt enforcement so models must invoke skills before deciding to skip them

## Problem

Two issues observed in production with frontier-tier models:

1. **RLHF resistance**: Models trained with strong tool-use RLHF refuse to generate skill names that appear in `<compose_skills>` because the skill tool parameter says "from available_skills". Some models hallucinate other names or stall at the generation position — they literally cannot produce a `compose:` prefixed name because it's not in the format they were trained to trust.

2. **Skip-without-reading**: Models recognize a skill should be invoked (visible in thinking/reasoning), then rationalize skipping it ("the worktree already exists", "I can handle it manually") without ever loading the skill content. The old prompt had an explicit escape hatch: "If an invoked skill turns out to be wrong for the situation, you don't need to use it."

## Solution

### Format fix (RLHF)
- Replace `<compose_skills>` with `<available_skills>` — the same XML tag models see in the system prompt for normal skills
- Compose skills now appear in the format models are trained to trust
- Use template substitution so everything lives in one `<system-reminder>` block

### Prompt strengthening
- **Must-invoke-before-skip**: "NEVER decide to skip a skill based on its description alone. The skip conditions are INSIDE the skill content."
- **Mid-Way Recovery**: Explicit instructions for when the model finds itself mid-work without having followed compose flow (covers both forgotten invocations and mid-session mode switches)
- **Remove escape hatch**: Deleted "if it turns out to be wrong, you don't need to use it"
- **Remove skip gate from compose.txt**: Brainstorm skip conditions now live only inside the skill itself, not duplicated in the orchestrator prompt

## Files Changed

- `packages/opencode/src/session/prompt/compose.txt` — prompt rewrite
- `packages/opencode/src/session/prompt.ts` — template substitution instead of concatenation
- `packages/opencode/src/skill/compose/extract.ts` — output `<available_skills>` format
- `packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md` — updated reference
