### PR TITLE
feat(skill): add drive-mimo builtin skill

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/drive-mimo/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/drive-mimo/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: drive-mimo
-description: Use when you need to programmatically drive another MiMoCode (mimo) process — supports both headless `mimo run` with JSON events and interactive TUI via tmux for full terminal interaction testing. Reach for it to script, test, or automate a separate mimo instance and validate its behavior from parseable evidence.
+description: Use when you need to programmatically drive another MiMoCode (mimo) process — supports both headless `mimo run` with JSON events and interactive TUI via tmux for full terminal interaction testing. Covers driving either an installed `mimo` binary or a dev build launched from source with `bun dev` (for debugging mimocode itself). Reach for it to script, test, or automate a separate mimo instance and validate its behavior from parseable evidence.
 ---
 
 # Drive MiMo
 
 ## Overview
 
-Two modes for driving a separate `mimo` process:
+Two **interfaces** for driving a separate mimo process:
 
-| Mode | Command | Use when |
+| Interface | Command | Use when |
 |------|---------|----------|
 | **Headless** | `mimo run --format json` | Scripted tasks, CI, event validation |
 | **TUI** | `mimo` in tmux | Interactive flow, permission dialogs, keybindings, visual regression |
@@ -18,14 +18,67 @@ Two modes for driving a separate `mimo` process:
 
 Always drive an *isolated* instance: give each run a fresh `MIMOCODE_HOME` and a throwaway workspace so it never touches your own config, memory, or session DB.
 
+### Two ways to launch — orthogonal to interface
+
+The interface (headless vs TUI, above) is *what you drive*. How the process is
+**launched** is a separate axis — either can be launched either way:
+
+| Launcher | Command | Use when |
+|----------|---------|----------|
+| **Installed binary** | `mimo …` | Testing a released/installed build |
+| **Dev (from source)** | `bun dev …` | Debugging mimocode itself — runs `src/index.ts` directly, no build step, picks up local code changes |
+
+Everything below uses `mimo` for brevity. To drive a **dev build** instead,
+substitute `bun dev` for `mimo` and run from the repo root — every flag,
+JSON event, and tmux technique is identical. See the Dev Mode section.
+
 ## Prerequisites
 
 ```bash
-# mimo binary must be on PATH
+# mimo binary must be on PATH (installed-binary launcher)
 which mimo || echo "mimo not found on PATH"
 
-# tmux (for TUI mode)
+# OR: dev launcher — run from the mimocode repo root, needs bun
+which bun || echo "bun not found — needed for dev mode"
+
+# tmux (for TUI interface)
 which tmux || echo "tmux not found — install it for TUI mode"
+```
+
+---
+
+## Dev Mode (debugging mimocode itself)
+
+When the goal is to debug **mimocode's own code**, launch from source with
+`bun dev` instead of the installed `mimo` binary. It runs
+`packages/opencode/src/index.ts` directly — no build step — so local edits take
+effect on the next launch.
+
+**Key facts:**
+
+- Run from the **repo root**. `bun dev` == `bun run dev`.
+- It is the dev equivalent of the `mimo` command: same CLI, same subcommands
+  and flags. `bun dev --help`, `bun dev run …`, `bun dev serve`, etc.
+- Args pass straight through, so **both interfaces work under dev**:
+  - Headless: `bun dev run --format json --dangerously-skip-permissions …`
+  - TUI:      `bun dev <workspace>` (positional workspace arg, as with `mimo`)
+- If `MIMOCODE_HOME` is not set, dev defaults it to a repo-local `.dev-home`
+  dir. For an isolated driven run, set `MIMOCODE_HOME=$(mktemp -d)` explicitly
+  just like with the binary.
+
+**Substitution rule:** anywhere Part 1 / Part 2 / Part 3 below say `mimo`,
+replace it with `bun dev` (invoked from the repo root) to drive a dev build.
+
+```bash
+# Headless, dev build (from repo root)
+REPO=/path/to/mimocode/checkout   # your local mimocode repo root
+MIMOCODE_HOME=$(mktemp -d) bun --cwd "$REPO" dev run \
+  --format json --dangerously-skip-permissions --dir "$WORKSPACE" \
+  < "$PROMPT" > /tmp/mimo-dev.jsonl 2>&1
+
+# TUI, dev build in tmux (from repo root)
+tmux new-session -d -s "$SESSION" -x 120 -y 30 \
+  "cd $REPO && MIMOCODE_HOME=$(mktemp -d) MIMOCODE_PURE=true bun dev $WORKSPACE; sleep 999"
 ```
 
 ---

--- a/packages/opencode/src/skill/builtin/.bundle/drive-mimo/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/drive-mimo/SKILL.md
@@ -1,0 +1,380 @@
+---
+name: drive-mimo
+description: Use when you need to programmatically drive another MiMoCode (mimo) process — supports both headless `mimo run` with JSON events and interactive TUI via tmux for full terminal interaction testing. Reach for it to script, test, or automate a separate mimo instance and validate its behavior from parseable evidence.
+---
+
+# Drive MiMo
+
+## Overview
+
+Two modes for driving a separate `mimo` process:
+
+| Mode | Command | Use when |
+|------|---------|----------|
+| **Headless** | `mimo run --format json` | Scripted tasks, CI, event validation |
+| **TUI** | `mimo` in tmux | Interactive flow, permission dialogs, keybindings, visual regression |
+
+**Core principle:** Every run produces parseable evidence. No eyeballing.
+
+Always drive an *isolated* instance: give each run a fresh `MIMOCODE_HOME` and a throwaway workspace so it never touches your own config, memory, or session DB.
+
+## Prerequisites
+
+```bash
+# mimo binary must be on PATH
+which mimo || echo "mimo not found on PATH"
+
+# tmux (for TUI mode)
+which tmux || echo "tmux not found — install it for TUI mode"
+```
+
+---
+
+## Part 1: Headless Mode (`mimo run`)
+
+### Launch
+
+```bash
+PROMPT=$(mktemp -t mimo-drive.XXXXXX)
+cat >"$PROMPT" <<'EOF'
+Your task here.
+EOF
+
+MIMOCODE_HOME=$(mktemp -d) mimo run \
+  --format json \
+  --dangerously-skip-permissions \
+  --dir "$WORKSPACE" \
+  < "$PROMPT" > /tmp/mimo-out.jsonl 2>&1
+
+EXIT=$?
+```
+
+### Key flags
+
+| Flag | Purpose |
+|------|---------|
+| `--format json` | Structured JSONL events to stdout |
+| `--dangerously-skip-permissions` | Auto-approve all permissions |
+| `--model provider/model` | Override model |
+| `--agent compose` | Use compose agent |
+| `--session SID` | Continue existing session |
+| `--continue` | Continue last session |
+| `--file path` | Attach file to message |
+| `--dir path` | Working directory |
+
+### JSON event types
+
+```
+{"type":"session.id","session":{"id":"ses_abc"}}
+{"type":"text","text":"I'll create the file..."}
+{"type":"reasoning","reasoning":"The user wants..."}
+{"type":"tool_use","tool":{"name":"write","input":{...}}}
+{"type":"tool_result","tool":{"name":"write","output":"..."}}
+{"type":"error","error":"Permission denied"}
+{"type":"session.status","status":{"type":"idle"}}
+```
+
+`session.status` with `type: "idle"` = completion signal.
+
+### Validation patterns
+
+```bash
+# Exit code
+[ $EXIT -eq 0 ] || echo "FAIL: exit $EXIT"
+
+# No errors
+grep -q '"type":"error"' /tmp/mimo-out.jsonl && echo "FAIL: errors found"
+
+# Reached completion
+grep -q '"session.status"' /tmp/mimo-out.jsonl || echo "FAIL: never completed"
+
+# Tool was used
+grep -q '"name":"write"' /tmp/mimo-out.jsonl || echo "FAIL: write tool not called"
+
+# Text output contains expected string
+grep '"type":"text"' /tmp/mimo-out.jsonl | jq -r '.text' | grep -q "expected"
+```
+
+### Timeout
+
+```bash
+timeout 120 mimo run --format json --dangerously-skip-permissions < "$PROMPT"
+[ $? -eq 124 ] && echo "FAIL: timed out"
+```
+
+---
+
+## Part 2: TUI Mode (tmux)
+
+### Isolation variables
+
+| Variable | Purpose |
+|---|---|
+| `MIMOCODE_HOME` | **Required.** Fresh `mktemp -d` per run. Sandboxes DB, config, cache. |
+| `MIMOCODE_PURE=true` | Disable external plugins. |
+| `MIMOCODE_DISABLE_GIT=true` | Skip git ops if workspace isn't a real repo. |
+
+### Launch TUI in tmux
+
+```bash
+# Create isolated environment
+MHOME=$(mktemp -d)
+WORKSPACE=$(mktemp -d)
+SESSION="mimo-drive-$$"
+
+# Launch mimo TUI in tmux (workspace is a positional arg, NOT --dir)
+tmux new-session -d -s "$SESSION" -x 120 -y 30 \
+  "MIMOCODE_HOME=$MHOME MIMOCODE_PURE=true mimo $WORKSPACE; sleep 999"
+
+# Wait for the TUI to render its input prompt
+scripts/wait-for-text.sh -t "$SESSION:0.0" -p "$PROMPT_RE" -T 15
+```
+
+Where `PROMPT_RE` is a language-neutral pattern for the input prompt. The
+prompt placeholder is localized, so match on the stable markers rather than a
+localized string:
+
+```bash
+# Matches the prompt line regardless of UI language:
+#   the ">" input caret, the "Ask" English placeholder, or a "/" command hint
+PROMPT_RE='>|Ask|/[a-z]'
+```
+
+If a run's UI language is known and fixed, you may match its literal
+placeholder instead — but prefer the neutral pattern for portability.
+
+### Send input
+
+```bash
+# Type a message (literal text, then Enter)
+tmux send-keys -t "$SESSION:0.0" -l -- "Create a file called hello.txt with content 'world'"
+tmux send-keys -t "$SESSION:0.0" Enter
+
+# Special keys
+tmux send-keys -t "$SESSION:0.0" C-c          # Cancel
+tmux send-keys -t "$SESSION:0.0" C-d          # EOF
+tmux send-keys -t "$SESSION:0.0" Escape       # Escape
+tmux send-keys -t "$SESSION:0.0" Tab          # Tab completion
+tmux send-keys -t "$SESSION:0.0" Up           # History up
+tmux send-keys -t "$SESSION:0.0" Down         # History down
+tmux send-keys -t "$SESSION:0.0" Enter        # Submit
+```
+
+### Capture output
+
+```bash
+# Current screen
+tmux capture-pane -t "$SESSION:0.0" -p
+
+# Full scrollback
+tmux capture-pane -t "$SESSION:0.0" -p -S -
+
+# Last 50 lines
+tmux capture-pane -t "$SESSION:0.0" -p -S -50
+```
+
+### Wait for state changes
+
+```bash
+# Wait for agent to start processing
+scripts/wait-for-text.sh -t "$SESSION:0.0" -p "thinking\|reading\|writing" -T 30
+
+# Wait for tool permission prompt
+scripts/wait-for-text.sh -t "$SESSION:0.0" -p "Allow\|Deny\|permission\|approve" -T 30
+
+# Wait for completion
+scripts/wait-for-text.sh -t "$SESSION:0.0" -p "completed\|done\|finished\|idle" -T 120
+
+# Wait for error
+scripts/wait-for-text.sh -t "$SESSION:0.0" -p "error\|failed\|Error" -T 30
+
+# Custom regex
+scripts/wait-for-text.sh -t "$SESSION:0.0" -p "hello\.txt.*world" -T 30
+```
+
+### Handle permission dialogs
+
+```bash
+# Wait for permission prompt, then approve
+scripts/wait-for-text.sh -t "$SESSION:0.0" -p "Allow\|approve" -T 30
+tmux send-keys -t "$SESSION:0.0" -l -- "y"
+tmux send-keys -t "$SESSION:0.0" Enter
+
+# Or deny
+tmux send-keys -t "$SESSION:0.0" -l -- "n"
+tmux send-keys -t "$SESSION:0.0" Enter
+```
+
+### Multi-turn interaction
+
+```bash
+# Turn 1: send initial message
+tmux send-keys -t "$SESSION:0.0" -l -- "Create a TypeScript file that adds two numbers"
+tmux send-keys -t "$SESSION:0.0" Enter
+scripts/wait-for-text.sh -t "$SESSION:0.0" -p "completed\|done" -T 120
+
+# Turn 2: follow-up
+tmux send-keys -t "$SESSION:0.0" -l -- "Now add a test for it"
+tmux send-keys -t "$SESSION:0.0" Enter
+scripts/wait-for-text.sh -t "$SESSION:0.0" -p "completed\|done" -T 120
+
+# Verify result
+tmux capture-pane -t "$SESSION:0.0" -p -S - | grep -i "pass\|fail"
+```
+
+### Cleanup
+
+```bash
+tmux kill-session -t "$SESSION" 2>/dev/null
+rm -rf "$MHOME" "$WORKSPACE"
+```
+
+---
+
+## Part 3: Scenarios
+
+### S1: Smoke (headless)
+
+```bash
+test_smoke() {
+  local P=$(mktemp) MHOME=$(mktemp -d)
+  echo "Say hello" > "$P"
+  MIMOCODE_HOME=$MHOME mimo run --format json --dangerously-skip-permissions \
+    < "$P" > /tmp/s1.jsonl 2>&1
+  local E=$?
+  rm -rf "$MHOME" "$P"
+  [ $E -eq 0 ] && grep -q '"type":"text"' /tmp/s1.jsonl && echo "PASS" || echo "FAIL"
+}
+```
+
+### S2: Tool use (headless)
+
+```bash
+test_tool_use() {
+  local P=$(mktemp) MHOME=$(mktemp -d) WS=$(mktemp -d)
+  echo 'Create file test.txt with content "hello"' > "$P"
+  MIMOCODE_HOME=$MHOME mimo run --format json --dangerously-skip-permissions --dir "$WS" \
+    < "$P" > /tmp/s2.jsonl 2>&1
+  local E=$?
+  local OK=true
+  [ $E -ne 0 ] && OK=false
+  ! grep -q '"name":"write"' /tmp/s2.jsonl && OK=false
+  [ ! -f "$WS/test.txt" ] && OK=false
+  rm -rf "$MHOME" "$WS" "$P"
+  $OK && echo "PASS" || echo "FAIL"
+}
+```
+
+### S3: TUI interactive flow
+
+```bash
+test_tui_interactive() {
+  local MHOME=$(mktemp -d) WS=$(mktemp -d) SID="mimo-s3-$$"
+  local PROMPT_RE='>|Ask|/[a-z]'
+  tmux new-session -d -s "$SID" -x 120 -y 30 "MIMOCODE_HOME=$MHOME MIMOCODE_PURE=true mimo $WS; sleep 999"
+
+  # Wait for prompt
+  scripts/wait-for-text.sh -t "$SID:0.0" -p "$PROMPT_RE" -T 15 || { echo "FAIL: no prompt"; tmux kill-session -t $SID; return 1; }
+
+  # Send task
+  tmux send-keys -t "$SID:0.0" -l -- "Create hello.txt with content 'world'"
+  tmux send-keys -t "$SID:0.0" Enter
+
+  # Wait for completion (agent shows elapsed time like "· 9.8s")
+  scripts/wait-for-text.sh -t "$SID:0.0" -p "· [0-9]" -T 120 || { echo "FAIL: no completion"; tmux kill-session -t $SID; return 1; }
+
+  # Verify file
+  [ -f "$WS/hello.txt" ] && echo "PASS" || echo "FAIL"
+  tmux kill-session -t "$SID" 2>/dev/null
+  rm -rf "$MHOME" "$WS"
+}
+```
+
+### S4: TUI permission handling
+
+```bash
+test_tui_permission() {
+  local MHOME=$(mktemp -d) WS=$(mktemp -d) SID="mimo-s4-$$"
+  local PROMPT_RE='>|Ask|/[a-z]'
+  tmux new-session -d -s "$SID" -x 120 -y 30 "MIMOCODE_HOME=$MHOME MIMOCODE_PURE=true mimo $WS; sleep 999"
+
+  scripts/wait-for-text.sh -t "$SID:0.0" -p "$PROMPT_RE" -T 15
+
+  # Ask for something that needs permission (no --dangerously-skip-permissions in TUI)
+  tmux send-keys -t "$SID:0.0" -l -- "Run the command: echo hello"
+  tmux send-keys -t "$SID:0.0" Enter
+
+  # Wait for permission prompt
+  scripts/wait-for-text.sh -t "$SID:0.0" -p "Allow\|approve\|permission\|y/n" -T 30 || { echo "FAIL: no permission prompt"; tmux kill-session -t $SID; return 1; }
+
+  # Approve
+  tmux send-keys -t "$SID:0.0" -l -- "y"
+  tmux send-keys -t "$SID:0.0" Enter
+
+  # Wait for completion
+  scripts/wait-for-text.sh -t "$SID:0.0" -p "· [0-9]" -T 60
+
+  tmux capture-pane -t "$SID:0.0" -p | grep -q "hello" && echo "PASS" || echo "FAIL"
+  tmux kill-session -t "$SID" 2>/dev/null
+  rm -rf "$MHOME" "$WS"
+}
+```
+
+### S5: TUI keybindings
+
+```bash
+test_tui_keybindings() {
+  local MHOME=$(mktemp -d) WS=$(mktemp -d) SID="mimo-s5-$$"
+  local PROMPT_RE='>|Ask|/[a-z]'
+  tmux new-session -d -s "$SID" -x 120 -y 30 "MIMOCODE_HOME=$MHOME MIMOCODE_PURE=true mimo $WS; sleep 999"
+
+  scripts/wait-for-text.sh -t "$SID:0.0" -p "$PROMPT_RE" -T 15
+
+  # Test Ctrl+C cancels input
+  tmux send-keys -t "$SID:0.0" -l -- "some partial input"
+  tmux send-keys -t "$SID:0.0" C-c
+
+  # Screen should still show prompt (not exit)
+  sleep 1
+  tmux capture-pane -t "$SID:0.0" -p | grep -qE "$PROMPT_RE" && echo "PASS: Ctrl+C didn't exit" || echo "FAIL: Ctrl+C exited"
+
+  # Test Escape
+  tmux send-keys -t "$SID:0.0" Escape
+  sleep 0.5
+
+  tmux kill-session -t "$SID" 2>/dev/null
+  rm -rf "$MHOME" "$WS"
+}
+```
+
+---
+
+## Batch Runner
+
+```bash
+run_all() {
+  local PASS=0 FAIL=0 RESULTS=()
+  for fn in test_smoke test_tool_use test_tui_interactive test_tui_permission test_tui_keybindings; do
+    echo "--- $fn ---"
+    if $fn 2>/dev/null; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); RESULTS+=("$fn: FAIL"); fi
+  done
+  echo "=== $PASS passed, $FAIL failed ==="
+  [ ${#RESULTS[@]} -gt 0 ] && printf '  %s\n' "${RESULTS[@]}"
+  [ $FAIL -eq 0 ]
+}
+```
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Headless run | `MIMOCODE_HOME=$(mktemp -d) mimo run --format json --dangerously-skip-permissions "prompt"` |
+| TUI launch | `tmux new-session -d -s test -x 120 -y 30 "MIMOCODE_HOME=$(mktemp -d) mimo $WORKSPACE; sleep 999"` |
+| Send text | `tmux send-keys -t test:0.0 -l -- "text" && tmux send-keys -t test:0.0 Enter` |
+| Capture screen | `tmux capture-pane -t test:0.0 -p -S -` |
+| Wait for text | `scripts/wait-for-text.sh -t test:0.0 -p "pattern" -T 30` |
+| Send Ctrl+C | `tmux send-keys -t test:0.0 C-c` |
+| Approve permission | `tmux send-keys -t test:0.0 -l -- "y" && tmux send-keys -t test:0.0 Enter` |
+| Cleanup | `tmux kill-session -t test && rm -rf $MHOME` |

--- a/packages/opencode/src/skill/builtin/.bundle/drive-mimo/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/drive-mimo/SKILL.md
@@ -45,6 +45,11 @@ which bun || echo "bun not found — needed for dev mode"
 which tmux || echo "tmux not found — install it for TUI mode"
 ```
 
+> **Running the `wait-for-text.sh` helper:** invoke it as
+> `bash scripts/wait-for-text.sh …` from this skill's directory. The extracted
+> copy is not marked executable, so calling it directly (`scripts/wait-for-text.sh`)
+> would fail with "Permission denied" — always prefix with `bash`.
+
 ---
 
 ## Dev Mode (debugging mimocode itself)
@@ -117,36 +122,56 @@ EXIT=$?
 
 ### JSON event types
 
+`--format json` writes one JSON object per line. **Every** event has the shape
+`{"type": ..., "timestamp": <ms>, "sessionID": "ses_...", ...payload}` — the
+`sessionID` is a field on each event, not a standalone event. The payload for
+most events is nested under `part`.
+
+Emitted event types (from the run event stream):
+
 ```
-{"type":"session.id","session":{"id":"ses_abc"}}
-{"type":"text","text":"I'll create the file..."}
-{"type":"reasoning","reasoning":"The user wants..."}
-{"type":"tool_use","tool":{"name":"write","input":{...}}}
-{"type":"tool_result","tool":{"name":"write","output":"..."}}
-{"type":"error","error":"Permission denied"}
-{"type":"session.status","status":{"type":"idle"}}
+{"type":"step_start","timestamp":...,"sessionID":"ses_abc","part":{...}}
+{"type":"text","timestamp":...,"sessionID":"ses_abc","part":{"type":"text","text":"I'll create the file...","time":{...}}}
+{"type":"reasoning","timestamp":...,"sessionID":"ses_abc","part":{"type":"reasoning","text":"The user wants..."}}
+{"type":"tool_use","timestamp":...,"sessionID":"ses_abc","part":{"type":"tool","tool":"write","state":{"status":"completed",...}}}
+{"type":"step_finish","timestamp":...,"sessionID":"ses_abc","part":{...}}
+{"type":"error","timestamp":...,"sessionID":"ses_abc","error":{...}}
 ```
 
-`session.status` with `type: "idle"` = completion signal.
+Notes that matter for parsing:
+
+- **No `session.id`, no `tool_result`, no `session.status` event.** A `tool_use`
+  is emitted **once** per tool part when it reaches `completed` or `error` — the
+  result/output is inside `part.state`, there is no separate result event.
+- **`tool_use` identifies the tool via `part.tool`** (a bare string, e.g.
+  `"tool":"write"`) — there is no `.tool.name` and no top-level `.name`.
+- **`text` / `reasoning` text lives at `part.text`**, not top-level `.text`.
+- **`reasoning` is only emitted when `--thinking` is passed.** Without it, no
+  reasoning events appear.
+- **Completion is not a stream event.** The process finishes when the run
+  completes; the reliable completion signal is **process exit** (exit code 0),
+  not any line in the JSONL.
 
 ### Validation patterns
 
 ```bash
-# Exit code
+# Completion — the real signal is the exit code, not a stream event
 [ $EXIT -eq 0 ] || echo "FAIL: exit $EXIT"
 
 # No errors
 grep -q '"type":"error"' /tmp/mimo-out.jsonl && echo "FAIL: errors found"
 
-# Reached completion
-grep -q '"session.status"' /tmp/mimo-out.jsonl || echo "FAIL: never completed"
+# A specific tool was used (match part.tool, the bare string)
+grep -q '"tool":"write"' /tmp/mimo-out.jsonl || echo "FAIL: write tool not called"
 
-# Tool was used
-grep -q '"name":"write"' /tmp/mimo-out.jsonl || echo "FAIL: write tool not called"
+# Text output contains expected string (text is at .part.text)
+grep '"type":"text"' /tmp/mimo-out.jsonl | jq -r '.part.text' | grep -q "expected"
 
-# Text output contains expected string
-grep '"type":"text"' /tmp/mimo-out.jsonl | jq -r '.text' | grep -q "expected"
+# Robust tool check via jq (works regardless of key ordering)
+jq -e 'select(.type=="tool_use") | .part.tool=="write"' /tmp/mimo-out.jsonl >/dev/null \
+  || echo "FAIL: write tool not called"
 ```
+
 
 ### Timeout
 
@@ -180,7 +205,7 @@ tmux new-session -d -s "$SESSION" -x 120 -y 30 \
   "MIMOCODE_HOME=$MHOME MIMOCODE_PURE=true mimo $WORKSPACE; sleep 999"
 
 # Wait for the TUI to render its input prompt
-scripts/wait-for-text.sh -t "$SESSION:0.0" -p "$PROMPT_RE" -T 15
+bash scripts/wait-for-text.sh -t "$SESSION:0.0" -p "$PROMPT_RE" -T 15
 ```
 
 Where `PROMPT_RE` is a language-neutral pattern for the input prompt. The
@@ -230,26 +255,26 @@ tmux capture-pane -t "$SESSION:0.0" -p -S -50
 
 ```bash
 # Wait for agent to start processing
-scripts/wait-for-text.sh -t "$SESSION:0.0" -p "thinking\|reading\|writing" -T 30
+bash scripts/wait-for-text.sh -t "$SESSION:0.0" -p "thinking\|reading\|writing" -T 30
 
 # Wait for tool permission prompt
-scripts/wait-for-text.sh -t "$SESSION:0.0" -p "Allow\|Deny\|permission\|approve" -T 30
+bash scripts/wait-for-text.sh -t "$SESSION:0.0" -p "Allow\|Deny\|permission\|approve" -T 30
 
 # Wait for completion
-scripts/wait-for-text.sh -t "$SESSION:0.0" -p "completed\|done\|finished\|idle" -T 120
+bash scripts/wait-for-text.sh -t "$SESSION:0.0" -p "completed\|done\|finished\|idle" -T 120
 
 # Wait for error
-scripts/wait-for-text.sh -t "$SESSION:0.0" -p "error\|failed\|Error" -T 30
+bash scripts/wait-for-text.sh -t "$SESSION:0.0" -p "error\|failed\|Error" -T 30
 
 # Custom regex
-scripts/wait-for-text.sh -t "$SESSION:0.0" -p "hello\.txt.*world" -T 30
+bash scripts/wait-for-text.sh -t "$SESSION:0.0" -p "hello\.txt.*world" -T 30
 ```
 
 ### Handle permission dialogs
 
 ```bash
 # Wait for permission prompt, then approve
-scripts/wait-for-text.sh -t "$SESSION:0.0" -p "Allow\|approve" -T 30
+bash scripts/wait-for-text.sh -t "$SESSION:0.0" -p "Allow\|approve" -T 30
 tmux send-keys -t "$SESSION:0.0" -l -- "y"
 tmux send-keys -t "$SESSION:0.0" Enter
 
@@ -264,12 +289,12 @@ tmux send-keys -t "$SESSION:0.0" Enter
 # Turn 1: send initial message
 tmux send-keys -t "$SESSION:0.0" -l -- "Create a TypeScript file that adds two numbers"
 tmux send-keys -t "$SESSION:0.0" Enter
-scripts/wait-for-text.sh -t "$SESSION:0.0" -p "completed\|done" -T 120
+bash scripts/wait-for-text.sh -t "$SESSION:0.0" -p "completed\|done" -T 120
 
 # Turn 2: follow-up
 tmux send-keys -t "$SESSION:0.0" -l -- "Now add a test for it"
 tmux send-keys -t "$SESSION:0.0" Enter
-scripts/wait-for-text.sh -t "$SESSION:0.0" -p "completed\|done" -T 120
+bash scripts/wait-for-text.sh -t "$SESSION:0.0" -p "completed\|done" -T 120
 
 # Verify result
 tmux capture-pane -t "$SESSION:0.0" -p -S - | grep -i "pass\|fail"
@@ -311,7 +336,7 @@ test_tool_use() {
   local E=$?
   local OK=true
   [ $E -ne 0 ] && OK=false
-  ! grep -q '"name":"write"' /tmp/s2.jsonl && OK=false
+  ! grep -q '"tool":"write"' /tmp/s2.jsonl && OK=false
   [ ! -f "$WS/test.txt" ] && OK=false
   rm -rf "$MHOME" "$WS" "$P"
   $OK && echo "PASS" || echo "FAIL"
@@ -327,14 +352,14 @@ test_tui_interactive() {
   tmux new-session -d -s "$SID" -x 120 -y 30 "MIMOCODE_HOME=$MHOME MIMOCODE_PURE=true mimo $WS; sleep 999"
 
   # Wait for prompt
-  scripts/wait-for-text.sh -t "$SID:0.0" -p "$PROMPT_RE" -T 15 || { echo "FAIL: no prompt"; tmux kill-session -t $SID; return 1; }
+  bash scripts/wait-for-text.sh -t "$SID:0.0" -p "$PROMPT_RE" -T 15 || { echo "FAIL: no prompt"; tmux kill-session -t $SID; return 1; }
 
   # Send task
   tmux send-keys -t "$SID:0.0" -l -- "Create hello.txt with content 'world'"
   tmux send-keys -t "$SID:0.0" Enter
 
   # Wait for completion (agent shows elapsed time like "· 9.8s")
-  scripts/wait-for-text.sh -t "$SID:0.0" -p "· [0-9]" -T 120 || { echo "FAIL: no completion"; tmux kill-session -t $SID; return 1; }
+  bash scripts/wait-for-text.sh -t "$SID:0.0" -p "· [0-9]" -T 120 || { echo "FAIL: no completion"; tmux kill-session -t $SID; return 1; }
 
   # Verify file
   [ -f "$WS/hello.txt" ] && echo "PASS" || echo "FAIL"
@@ -351,21 +376,21 @@ test_tui_permission() {
   local PROMPT_RE='>|Ask|/[a-z]'
   tmux new-session -d -s "$SID" -x 120 -y 30 "MIMOCODE_HOME=$MHOME MIMOCODE_PURE=true mimo $WS; sleep 999"
 
-  scripts/wait-for-text.sh -t "$SID:0.0" -p "$PROMPT_RE" -T 15
+  bash scripts/wait-for-text.sh -t "$SID:0.0" -p "$PROMPT_RE" -T 15
 
   # Ask for something that needs permission (no --dangerously-skip-permissions in TUI)
   tmux send-keys -t "$SID:0.0" -l -- "Run the command: echo hello"
   tmux send-keys -t "$SID:0.0" Enter
 
   # Wait for permission prompt
-  scripts/wait-for-text.sh -t "$SID:0.0" -p "Allow\|approve\|permission\|y/n" -T 30 || { echo "FAIL: no permission prompt"; tmux kill-session -t $SID; return 1; }
+  bash scripts/wait-for-text.sh -t "$SID:0.0" -p "Allow\|approve\|permission\|y/n" -T 30 || { echo "FAIL: no permission prompt"; tmux kill-session -t $SID; return 1; }
 
   # Approve
   tmux send-keys -t "$SID:0.0" -l -- "y"
   tmux send-keys -t "$SID:0.0" Enter
 
   # Wait for completion
-  scripts/wait-for-text.sh -t "$SID:0.0" -p "· [0-9]" -T 60
+  bash scripts/wait-for-text.sh -t "$SID:0.0" -p "· [0-9]" -T 60
 
   tmux capture-pane -t "$SID:0.0" -p | grep -q "hello" && echo "PASS" || echo "FAIL"
   tmux kill-session -t "$SID" 2>/dev/null
@@ -381,7 +406,7 @@ test_tui_keybindings() {
   local PROMPT_RE='>|Ask|/[a-z]'
   tmux new-session -d -s "$SID" -x 120 -y 30 "MIMOCODE_HOME=$MHOME MIMOCODE_PURE=true mimo $WS; sleep 999"
 
-  scripts/wait-for-text.sh -t "$SID:0.0" -p "$PROMPT_RE" -T 15
+  bash scripts/wait-for-text.sh -t "$SID:0.0" -p "$PROMPT_RE" -T 15
 
   # Test Ctrl+C cancels input
   tmux send-keys -t "$SID:0.0" -l -- "some partial input"
@@ -427,7 +452,7 @@ run_all() {
 | TUI launch | `tmux new-session -d -s test -x 120 -y 30 "MIMOCODE_HOME=$(mktemp -d) mimo $WORKSPACE; sleep 999"` |
 | Send text | `tmux send-keys -t test:0.0 -l -- "text" && tmux send-keys -t test:0.0 Enter` |
 | Capture screen | `tmux capture-pane -t test:0.0 -p -S -` |
-| Wait for text | `scripts/wait-for-text.sh -t test:0.0 -p "pattern" -T 30` |
+| Wait for text | `bash scripts/wait-for-text.sh -t test:0.0 -p "pattern" -T 30` |
 | Send Ctrl+C | `tmux send-keys -t test:0.0 C-c` |
 | Approve permission | `tmux send-keys -t test:0.0 -l -- "y" && tmux send-keys -t test:0.0 Enter` |
 | Cleanup | `tmux kill-session -t test && rm -rf $MHOME` |

--- a/packages/opencode/src/skill/builtin/.bundle/drive-mimo/scripts/wait-for-text.sh
+++ b/packages/opencode/src/skill/builtin/.bundle/drive-mimo/scripts/wait-for-text.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: wait-for-text.sh -t target -p pattern [options]
+
+Poll a tmux pane for text and exit when found.
+
+Options:
+  -t, --target    tmux target (session:window.pane), required
+  -p, --pattern   regex pattern to look for, required
+  -F, --fixed     treat pattern as a fixed string (grep -F)
+  -T, --timeout   seconds to wait (integer, default: 15)
+  -i, --interval  poll interval in seconds (default: 0.5)
+  -l, --lines     number of history lines to inspect (integer, default: 1000)
+  -h, --help      show this help
+USAGE
+}
+
+target=""
+pattern=""
+grep_flag="-E"
+timeout=15
+interval=0.5
+lines=1000
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t|--target)   target="${2-}"; shift 2 ;;
+    -p|--pattern)  pattern="${2-}"; shift 2 ;;
+    -F|--fixed)    grep_flag="-F"; shift ;;
+    -T|--timeout)  timeout="${2-}"; shift 2 ;;
+    -i|--interval) interval="${2-}"; shift 2 ;;
+    -l|--lines)    lines="${2-}"; shift 2 ;;
+    -h|--help)     usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$target" || -z "$pattern" ]]; then
+  echo "target and pattern are required" >&2
+  usage
+  exit 1
+fi
+
+if ! [[ "$timeout" =~ ^[0-9]+$ ]]; then
+  echo "timeout must be an integer number of seconds" >&2
+  exit 1
+fi
+
+if ! [[ "$lines" =~ ^[0-9]+$ ]]; then
+  echo "lines must be an integer" >&2
+  exit 1
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux not found in PATH" >&2
+  exit 1
+fi
+
+start_epoch=$(date +%s)
+deadline=$((start_epoch + timeout))
+
+while true; do
+  pane_text="$(tmux capture-pane -p -J -t "$target" -S "-${lines}" 2>/dev/null || true)"
+
+  if printf '%s\n' "$pane_text" | grep $grep_flag -- "$pattern" >/dev/null 2>&1; then
+    exit 0
+  fi
+
+  now=$(date +%s)
+  if (( now >= deadline )); then
+    echo "Timed out after ${timeout}s waiting for pattern: $pattern" >&2
+    echo "Last ${lines} lines from $target:" >&2
+    printf '%s\n' "$pane_text" >&2
+    exit 1
+  fi
+
+  sleep "$interval"
+done

--- a/packages/opencode/src/skill/builtin/.bundle/drive-mimo/scripts/wait-for-text.sh
+++ b/packages/opencode/src/skill/builtin/.bundle/drive-mimo/scripts/wait-for-text.sh
@@ -54,6 +54,11 @@ if ! [[ "$lines" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+if ! [[ "$interval" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+  echo "interval must be a number of seconds" >&2
+  exit 1
+fi
+
 if ! command -v tmux >/dev/null 2>&1; then
   echo "tmux not found in PATH" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Adds a new builtin skill **`drive-mimo`** under `packages/opencode/src/skill/builtin/.bundle/drive-mimo/`, letting mimocode programmatically drive a *separate* mimo process for scripting, testing, and automation.
- Documents two orthogonal axes:
  - **Interface** — headless (`mimo run --format json`, JSONL events) vs interactive **TUI** via tmux (with a bundled `wait-for-text.sh` polling helper).
  - **Launcher** — installed `mimo` binary vs **dev build from source** (`bun dev`, no build step) for debugging mimocode itself. A substitution rule keeps every flag/event/tmux technique identical across launchers.
- Repackaged from the local `test-mimo-agent` skill with local info scrubbed: no absolute `/root` paths, no localized TUI strings (uses a language-neutral prompt regex), no session IDs — only generic placeholders.

## How it works
- The builtin-skill bundle macro auto-includes any `.bundle/<name>/` directory, so no code registration is needed; `extract.ts` materializes it to `~/.local/share/mimocode/builtin_skills/<version>/skills/drive-mimo/` at runtime.

## Verification
- Confirmed the bundle macro enumerates `drive-mimo` alongside the other builtin skills (2 files).
- Local-info scan (`/root`, `问点什么`, `ses_…`, home paths) comes back clean.
- Frontmatter parses; `wait-for-text.sh` passes `bash -n` syntax check.