### PR TITLE
fix: allow worktree directories under Global.Path.data

### DIFF
--- a/packages/opencode/src/server/routes/instance/middleware.ts
+++ b/packages/opencode/src/server/routes/instance/middleware.ts
@@ -33,7 +33,7 @@ export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler
         Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR
           ? Filesystem.resolve(path.join(Global.Path.data, "orchestrator"))
           : undefined
-      if (!Filesystem.contains(cwd, directory) && directory !== orchestrator) {
+      if (!Filesystem.contains(cwd, directory) && directory !== orchestrator && !Filesystem.contains(Global.Path.data, directory)) {
         return c.json({ error: "Access denied: directory must be within the server's working directory" }, 403)
       }
     }


### PR DESCRIPTION
Fixes #1504 - Allow worktree directories under Global.Path.data

Worktrees are stored at Global.Path.data/worktree/<projectId>/, not under the project working directory. The server middleware auth check was rejecting worktree paths.

This fix adds Global.Path.data as an allowed directory alongside the orchestrator path.

Previous PR #1507 had merge conflicts, this is a clean rebase onto upstream/main.