### PR TITLE
fix: mark all subagents as non-interactive for permission asks

### DIFF
--- a/packages/opencode/src/agent/config.ts
+++ b/packages/opencode/src/agent/config.ts
@@ -32,5 +32,5 @@ export function decideAskRouting(input: {
   if (isOrchestratorPeer && input.sessionParentID) {
     return { interactive: true, forward: { parentSessionID: input.sessionParentID } }
   }
-  return { interactive: !input.askActor?.background }
+  return { interactive: !input.askActor?.background && input.askActor?.mode !== "subagent" }
 }


### PR DESCRIPTION
All subagents (whether 'run' sync or 'spawn' background) are non-interactive: they have no attached human to reply to permission prompts, so an ask that would block must fail clean with DeniedError instead of hanging.

Previously, only SYSTEM_SPAWNED_AGENT_TYPES and background actors were marked non-interactive. This caused sync subagents (run operation) to hang indefinitely when they triggered a permission ask, because they were treated as interactive actors waiting for user confirmation.

This fix modifies the decideAskRouting function to check askActor.mode === 'subagent' in addition to askActor.background.