### PR TITLE
fix: correct schema URLs to mimo.xiaomi.com

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -102,7 +102,7 @@ const InfoSchema = Schema.Struct({
     description: "Server configuration for mimo serve and web commands",
   }),
   command: Schema.optional(Schema.Record(Schema.String, ConfigCommand.Info)).annotate({
-    description: "Command configuration, see https://opencode.ai/docs/commands",
+    description: "Command configuration, see https://mimo.xiaomi.com/mimocode/docs/commands",
   }),
   skills: Schema.optional(ConfigSkills.Info).annotate({ description: "Additional skill folder paths" }),
   compose: Schema.optional(ConfigCompose.Info).annotate({ description: "Compose mode configuration" }),
@@ -192,7 +192,7 @@ const InfoSchema = Schema.Struct({
       }),
       [Schema.Record(Schema.String, AgentRef)],
     ),
-  ).annotate({ description: "Agent configuration, see https://opencode.ai/docs/agents" }),
+  ).annotate({ description: "Agent configuration, see https://mimo.xiaomi.com/mimocode/docs/agents" }),
   provider: Schema.optional(Schema.Record(Schema.String, ConfigProvider.Info)).annotate({
     description: "Custom provider configurations and model overrides",
   }),


### PR DESCRIPTION
Replace opencode.ai URLs with mimo.xiaomi.com URLs in config descriptions:

- 'https://opencode.ai/docs/commands' -> 'https://mimo.xiaomi.com/mimocode/docs/commands'
- 'https://opencode.ai/docs/agents' -> 'https://mimo.xiaomi.com/mimocode/docs/agents'

The  auto-replacement was already handled, but the description annotations still referenced opencode.ai docs.