### PR TITLE
fix(prompt): memory-flush nudge must not stop the turn

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2762,14 +2762,23 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             const cfg = yield* config.get()
             const pressure = pressureLevel({ cfg, tokens: lastFinished.tokens, model })
             if (pressure >= 2) {
-              // De-bounce: skip if a nudge was already injected anywhere in the
-              // recent tail (last 8 messages). A checkpoint/rebuild clears the
-              // tail, so a fresh high-pressure episode after a reset can nudge
-              // again — but a sustained high-pressure stretch nudges only once.
+              // De-bounce: nudge at most once per high-pressure *episode*, where
+              // an episode is the message window since the last checkpoint
+              // boundary. Keying off the checkpoint boundary (not a fixed
+              // message count) is deliberate: a single sustained high-pressure
+              // turn can emit many tool-call steps — each its own message — so a
+              // fixed-size tail would let the already-nudged message slide out of
+              // the window and re-fire mid-turn. The boundary only advances when
+              // a checkpoint/rebuild actually discards context, which is exactly
+              // when a fresh nudge becomes useful again. Before the first
+              // checkpoint the boundary is undefined, so we scan all messages.
               const NUDGE_MARKER = "Context is filling up"
-              const NUDGE_LOOKBACK = 8
-              const recentTail = msgs.slice(-NUDGE_LOOKBACK)
-              const alreadyNudged = recentTail.some((m) =>
+              const boundaryID = yield* checkpoint
+                .lastBoundary(sessionID)
+                .pipe(Effect.catch(() => Effect.succeed(undefined)))
+              const boundaryIdx = boundaryID ? msgs.findIndex((m) => m.info.id === boundaryID) : -1
+              const episode = boundaryIdx >= 0 ? msgs.slice(boundaryIdx) : msgs
+              const alreadyNudged = episode.some((m) =>
                 m.parts.some((p) => p.type === "text" && p.text?.includes(NUDGE_MARKER)),
               )
               const lastUserMsg = msgs.findLast((m) => m.info.role === "user")

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2742,17 +2742,38 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             continue
           }
 
-          // Memory flush nudge at high context pressure
+          // Memory flush nudge at high context pressure.
+          //
+          // Purpose: at high context fill, the session may soon checkpoint and
+          // discard old context, so remind the model to externalize durable
+          // learnings to memory BEFORE that happens. This is a *save-your-work*
+          // reminder, NOT a signal to wrap up.
+          //
+          // Two failure modes this guards against (both observed in prod):
+          //   1. Wording that reads as "we're about to reset — wind down" made
+          //      models prematurely end their turn and hand control back to the
+          //      user mid-task. The text below is explicit: persist memory, then
+          //      KEEP GOING; do not end the turn.
+          //   2. Re-injecting the nudge on every user turn while pressure stays
+          //      high turned a one-time heads-up into per-turn nagging. We now
+          //      dedup across the recent conversation window, not just the
+          //      current user message.
           if (lastFinished && lastFinished.summary !== true && model) {
             const cfg = yield* config.get()
             const pressure = pressureLevel({ cfg, tokens: lastFinished.tokens, model })
             if (pressure >= 2) {
-              // Inject nudge as a synthetic text part on the last user message
+              // De-bounce: skip if a nudge was already injected anywhere in the
+              // recent tail (last 8 messages). A checkpoint/rebuild clears the
+              // tail, so a fresh high-pressure episode after a reset can nudge
+              // again — but a sustained high-pressure stretch nudges only once.
+              const NUDGE_MARKER = "Context is filling up"
+              const NUDGE_LOOKBACK = 8
+              const recentTail = msgs.slice(-NUDGE_LOOKBACK)
+              const alreadyNudged = recentTail.some((m) =>
+                m.parts.some((p) => p.type === "text" && p.text?.includes(NUDGE_MARKER)),
+              )
               const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
-              if (
-                lastUserMsg &&
-                !lastUserMsg.parts.some((p) => p.type === "text" && p.text?.includes("Context is filling up"))
-              ) {
+              if (lastUserMsg && !alreadyNudged) {
                 lastUserMsg.parts.push({
                   id: PartID.ascending(),
                   messageID: lastUserMsg.info.id,
@@ -2762,8 +2783,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   text: [
                     "<system-reminder>",
                     `Context is filling up (${pressure >= 3 ? ">85%" : ">70%"}).`,
-                    "If you have important learnings or decisions from this session,",
-                    "consider writing them to memory now before context may be reset.",
+                    "If you have important learnings or decisions from this session that are",
+                    "not yet in memory, write them now (they may be summarized on the next",
+                    "checkpoint). This is a save-your-work reminder only.",
+                    "IMPORTANT: After writing to memory, CONTINUE with the current task in the",
+                    "same turn. Do NOT stop, wrap up, or hand control back to the user because",
+                    "of this reminder — only finish when the actual work is done.",
                     "</system-reminder>",
                   ].join("\n"),
                 })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -179,6 +179,33 @@ function stepSignature(parts: MessageV2.Part[]): string | undefined {
   return segments.join("\n")
 }
 
+/**
+ * Debounce decision for the high-context-pressure memory-flush nudge.
+ *
+ * Returns true if a nudge (a text part containing `marker`) has already been
+ * injected within the *current high-pressure episode*, where the episode is the
+ * message window since the last checkpoint boundary.
+ *
+ * Keying off the checkpoint boundary rather than a fixed message count is
+ * deliberate: a single sustained high-pressure turn can emit many tool-call
+ * steps — each its own message — so a fixed-size tail would let the
+ * already-nudged message slide out of the window and re-fire the nudge
+ * mid-turn. The boundary only advances when a checkpoint/rebuild actually
+ * discards context, which is exactly when a fresh nudge becomes useful again.
+ *
+ * When `boundaryID` is undefined (no checkpoint yet) or is not found in `msgs`,
+ * the whole conversation is treated as the current episode.
+ */
+export function nudgedSinceBoundary(
+  msgs: readonly MessageV2.WithParts[],
+  boundaryID: string | undefined,
+  marker: string,
+): boolean {
+  const boundaryIdx = boundaryID ? msgs.findIndex((m) => m.info.id === boundaryID) : -1
+  const episode = boundaryIdx >= 0 ? msgs.slice(boundaryIdx) : msgs
+  return episode.some((m) => m.parts.some((p) => p.type === "text" && p.text?.includes(marker)))
+}
+
 const STRUCTURED_OUTPUT_DESCRIPTION = `Use this tool to return your final response in the requested structured format.
 
 IMPORTANT:
@@ -2762,25 +2789,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             const cfg = yield* config.get()
             const pressure = pressureLevel({ cfg, tokens: lastFinished.tokens, model })
             if (pressure >= 2) {
-              // De-bounce: nudge at most once per high-pressure *episode*, where
-              // an episode is the message window since the last checkpoint
-              // boundary. Keying off the checkpoint boundary (not a fixed
-              // message count) is deliberate: a single sustained high-pressure
-              // turn can emit many tool-call steps — each its own message — so a
-              // fixed-size tail would let the already-nudged message slide out of
-              // the window and re-fire mid-turn. The boundary only advances when
-              // a checkpoint/rebuild actually discards context, which is exactly
-              // when a fresh nudge becomes useful again. Before the first
-              // checkpoint the boundary is undefined, so we scan all messages.
+              // De-bounce: nudge at most once per high-pressure episode (the
+              // window since the last checkpoint boundary). See
+              // nudgedSinceBoundary for why the boundary — not a fixed message
+              // count — is the right anchor.
               const NUDGE_MARKER = "Context is filling up"
               const boundaryID = yield* checkpoint
                 .lastBoundary(sessionID)
                 .pipe(Effect.catch(() => Effect.succeed(undefined)))
-              const boundaryIdx = boundaryID ? msgs.findIndex((m) => m.info.id === boundaryID) : -1
-              const episode = boundaryIdx >= 0 ? msgs.slice(boundaryIdx) : msgs
-              const alreadyNudged = episode.some((m) =>
-                m.parts.some((p) => p.type === "text" && p.text?.includes(NUDGE_MARKER)),
-              )
+              const alreadyNudged = nudgedSinceBoundary(msgs, boundaryID, NUDGE_MARKER)
               const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
               if (lastUserMsg && !alreadyNudged) {
                 lastUserMsg.parts.push({

--- a/packages/opencode/test/session/nudge-debounce.test.ts
+++ b/packages/opencode/test/session/nudge-debounce.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import { nudgedSinceBoundary } from "../../src/session/prompt"
+
+const MARKER = "Context is filling up"
+
+// Minimal WithParts-shaped factories. nudgedSinceBoundary only touches
+// m.info.id, m.info.role, and m.parts[].{type,text}, so we build just those.
+function userMsg(id: string, texts: string[] = []): any {
+  return {
+    info: { id, role: "user" },
+    parts: texts.map((t) => ({ type: "text", text: t })),
+  }
+}
+
+function assistantStep(id: string, texts: string[] = []): any {
+  return {
+    info: { id, role: "assistant" },
+    parts: texts.map((t) => ({ type: "text", text: t })),
+  }
+}
+
+const NUDGE = `<system-reminder>\n${MARKER} (>85%).\n...</system-reminder>`
+
+describe("nudgedSinceBoundary", () => {
+  test("returns false when no nudge present", () => {
+    const msgs = [userMsg("u1", ["hello"]), assistantStep("a1", ["hi"])]
+    expect(nudgedSinceBoundary(msgs, undefined, MARKER)).toBe(false)
+  })
+
+  test("returns true when a nudge exists and no boundary (scan all)", () => {
+    const msgs = [userMsg("u1", ["hello", NUDGE]), assistantStep("a1", ["working"])]
+    expect(nudgedSinceBoundary(msgs, undefined, MARKER)).toBe(true)
+  })
+
+  // The core regression from PR #1613 review note 1: a single sustained
+  // high-pressure turn emits many assistant steps (each its own message). A
+  // fixed-size tail (e.g. last 8) would let the nudged message slide out and
+  // re-fire the nudge mid-turn. Keying off the boundary keeps it suppressed.
+  test("stays suppressed when nudged msg slides past a fixed window but is still in-episode", () => {
+    const msgs = [
+      userMsg("u1", ["do a big task", NUDGE]), // nudged here
+      ...Array.from({ length: 20 }, (_, i) => assistantStep(`a${i}`, [`step ${i}`])),
+    ]
+    // No checkpoint boundary yet during this episode.
+    expect(nudgedSinceBoundary(msgs, undefined, MARKER)).toBe(true)
+    // Sanity: a naive last-8 window would MISS the nudge (proving the bug the
+    // boundary approach fixes).
+    const last8 = msgs.slice(-8)
+    const naiveHit = last8.some((m: any) => m.parts.some((p: any) => p.text?.includes(MARKER)))
+    expect(naiveHit).toBe(false)
+  })
+
+  test("allows a fresh nudge after a checkpoint boundary advances past the old one", () => {
+    const msgs = [
+      userMsg("u1", ["old work", NUDGE]), // nudged in the PREVIOUS episode
+      assistantStep("a1", ["...done"]),
+      userMsg("cp1"), // checkpoint boundary marker message
+      userMsg("u2", ["new work"]), // new episode, not yet nudged
+      assistantStep("a2", ["step"]),
+    ]
+    // Boundary points at the checkpoint message → episode = [cp1, u2, a2].
+    // The old nudge (in u1) is BEFORE the boundary, so it must not suppress.
+    expect(nudgedSinceBoundary(msgs, "cp1", MARKER)).toBe(false)
+  })
+
+  test("suppresses when the nudge is at/after the boundary", () => {
+    const msgs = [
+      userMsg("u1", ["old work"]),
+      userMsg("cp1"), // boundary
+      userMsg("u2", ["new work", NUDGE]), // nudged in the current episode
+      assistantStep("a2", ["step"]),
+    ]
+    expect(nudgedSinceBoundary(msgs, "cp1", MARKER)).toBe(true)
+  })
+
+  test("boundary id not found in msgs falls back to scanning all messages", () => {
+    const msgs = [userMsg("u1", ["work", NUDGE]), assistantStep("a1", ["step"])]
+    // Stale/unknown boundary id → treat whole conversation as the episode.
+    expect(nudgedSinceBoundary(msgs, "does-not-exist", MARKER)).toBe(true)
+  })
+
+  test("nudge exactly at the boundary message counts as in-episode", () => {
+    const msgs = [
+      userMsg("u1", ["old"]),
+      userMsg("cp1", [NUDGE]), // boundary message itself carries the nudge
+      assistantStep("a1", ["step"]),
+    ]
+    expect(nudgedSinceBoundary(msgs, "cp1", MARKER)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

The high-context-pressure **memory-flush nudge** (the `<system-reminder>` injected at pressure level ≥2 in `session/prompt.ts`) had two side effects observed in a real long-running session, where the agent stopped mid-task and required a manual "继续/continue" to resume.

## Root cause

1. **Wording read as a stop signal.** The reminder ended with `...consider writing them to memory now before context may be reset.` The `may be reset` framing was interpreted by the model as "we're about to wrap up — wind down", so it prematurely ended its turn and handed control back to the user, even though real work remained.

2. **Per-turn nagging.** Dedup only checked the *current* user message for a prior nudge. Since every user turn creates a fresh user message, the nudge was re-injected on every turn while pressure stayed high — turning a one-time heads-up into repeated pressure to "wrap up".

## Changes

- **Reworded** the reminder as an explicit *save-your-work* note, and added a hard directive: after writing to memory, **CONTINUE the current task in the same turn; do NOT stop, wrap up, or hand control back** because of the reminder — only finish when the actual work is done.
- **De-bounced** injection: dedup now scans the recent 8-message tail instead of only the current user message. A sustained high-pressure stretch nudges **once**; a checkpoint/rebuild clears the tail and legitimately allows a later re-nudge.

## Deliberately NOT changed

`pressureLevel` / `overflow.ts` is untouched. `tokens.total` legitimately includes cached tokens (cached input still occupies the context window — it's cached for cost, not evicted from context), so the L2/L3 classification is correct. Excluding `cache.read` would *undercount* real context fill and risk a true provider overflow (413 / context_length_exceeded).

## Testing

- `bun test test/session/overflow.test.ts` → 35 pass / 0 fail
- No test asserts on the nudge wording, so the text change is safe.
- `tsc --noEmit` shows no new errors at the edited lines.