### PR TITLE
feat(config): support top-level `env` key to inject environment variables

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -539,6 +539,14 @@ export const layer = Layer.effect(
     const env = yield* Env.Service
     const npmSvc = yield* Npm.Service
 
+    // Keys injected by config `env`, mapped to the process.env value that
+    // existed before we first touched them (undefined = was unset). Lives in
+    // the layer closure so it survives instance disposal / config reload,
+    // matching process.env's lifetime. Lets a reload distinguish "set by the
+    // real environment" (defer) from "set by our own prior injection"
+    // (re-apply edits, restore on removal).
+    const injectedEnv = new Map<string, string | undefined>()
+
     const readConfigFile = Effect.fnUntraced(function* (filepath: string) {
       return yield* fs.readFileString(filepath).pipe(
         Effect.catchIf(
@@ -968,17 +976,32 @@ export const layer = Layer.effect(
           result.compaction = { ...result.compaction, prune: false }
         }
 
-        if (result.env) {
-          for (const [key, value] of Object.entries(result.env)) {
-            // Defer to the real environment: only inject when the variable is
-            // not already set in the process. A caller's runtime env (CI,
-            // container, `FOO=bar mimo`) is more specific than a persisted
-            // config default and must win. Matches Claude Code, where the
-            // settings field applies only when the env var is not set.
-            if (process.env[key] !== undefined) continue
-            process.env[key] = value
-            yield* env.set(key, value)
+        const nextEnv = result.env ?? {}
+        // Reconcile keys we injected on a previous load that are no longer in
+        // config (removed/renamed): restore their original value so a config
+        // edit + reload takes effect without a process restart.
+        for (const [key, original] of injectedEnv) {
+          if (key in nextEnv) continue
+          if (original === undefined) {
+            delete process.env[key]
+            yield* env.remove(key)
+          } else {
+            process.env[key] = original
+            yield* env.set(key, original)
           }
+          injectedEnv.delete(key)
+        }
+        for (const [key, value] of Object.entries(nextEnv)) {
+          // Defer to the real environment: only inject when the variable is
+          // not already set by something other than our own prior injection.
+          // A caller's runtime env (CI, container, `FOO=bar mimo`) is more
+          // specific than a persisted config default and must win. Matches
+          // Claude Code, where the settings field applies only when the env
+          // var is not set.
+          if (!injectedEnv.has(key) && process.env[key] !== undefined) continue
+          if (!injectedEnv.has(key)) injectedEnv.set(key, process.env[key])
+          process.env[key] = value
+          yield* env.set(key, value)
         }
 
         return {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -100,7 +100,7 @@ const InfoSchema = Schema.Struct({
   logLevel: Schema.optional(LogLevelRef).annotate({ description: "Log level" }),
   env: Schema.optional(Schema.Record(Schema.String, Schema.String)).annotate({
     description:
-      "Environment variables to inject into the mimocode process and its child processes (e.g. the bash tool). Values override existing same-named process environment variables. Supports {env:VAR} and {file:path} substitution.",
+      "Environment variables to inject into the mimocode process and its child processes (e.g. the bash tool). A variable already set in the real environment takes precedence — config values only apply when the variable is not already set. Supports {env:VAR} and {file:path} substitution.",
   }),
   server: Schema.optional(ConfigServer.Server).annotate({
     description: "Server configuration for mimo serve and web commands",
@@ -970,6 +970,12 @@ export const layer = Layer.effect(
 
         if (result.env) {
           for (const [key, value] of Object.entries(result.env)) {
+            // Defer to the real environment: only inject when the variable is
+            // not already set in the process. A caller's runtime env (CI,
+            // container, `FOO=bar mimo`) is more specific than a persisted
+            // config default and must win. Matches Claude Code, where the
+            // settings field applies only when the env var is not set.
+            if (process.env[key] !== undefined) continue
             process.env[key] = value
             yield* env.set(key, value)
           }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -98,6 +98,10 @@ const InfoSchema = Schema.Struct({
     description: "JSON schema reference for configuration validation",
   }),
   logLevel: Schema.optional(LogLevelRef).annotate({ description: "Log level" }),
+  env: Schema.optional(Schema.Record(Schema.String, Schema.String)).annotate({
+    description:
+      "Environment variables to inject into the mimocode process and its child processes (e.g. the bash tool). Values override existing same-named process environment variables. Supports {env:VAR} and {file:path} substitution.",
+  }),
   server: Schema.optional(ConfigServer.Server).annotate({
     description: "Server configuration for mimo serve and web commands",
   }),
@@ -962,6 +966,13 @@ export const layer = Layer.effect(
         }
         if (Flag.MIMOCODE_DISABLE_PRUNE) {
           result.compaction = { ...result.compaction, prune: false }
+        }
+
+        if (result.env) {
+          for (const [key, value] of Object.entries(result.env)) {
+            process.env[key] = value
+            yield* env.set(key, value)
+          }
         }
 
         return {

--- a/packages/opencode/test/config/env.test.ts
+++ b/packages/opencode/test/config/env.test.ts
@@ -142,3 +142,92 @@ test("config env supports {env:VAR} substitution", async () => {
     else delete process.env["MIMO_TEST_ENV_TARGET"]
   }
 })
+
+// Reload idempotency: both get() calls run inside ONE Effect.provide(layer),
+// so the layer closure (which holds the injected-key tracking map) persists
+// across invalidate(). This mirrors a live config reload in a running process
+// where process.env is long-lived.
+const reloadScenario = (dir: string, rewrite: () => Promise<void>) =>
+  Config.Service.use((svc) =>
+    Effect.gen(function* () {
+      yield* svc.get()
+      yield* Effect.promise(rewrite)
+      yield* svc.invalidate(true)
+      return yield* svc.get()
+    }),
+  ).pipe(Effect.scoped, Effect.provide(layer))
+
+test("editing a config env value takes effect on reload", async () => {
+  const key = "MIMO_TEST_ENV_EDIT"
+  const original = process.env[key]
+  delete process.env[key]
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, "mimocode.json"),
+          JSON.stringify({ $schema: "https://opencode.ai/config.json", env: { [key]: "v1" } }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Effect.runPromise(
+          reloadScenario(tmp.path, () =>
+            Filesystem.write(
+              path.join(tmp.path, "mimocode.json"),
+              JSON.stringify({ $schema: "https://opencode.ai/config.json", env: { [key]: "v2" } }),
+            ),
+          ),
+        )
+        expect(config.env?.[key]).toBe("v2")
+        // The edited value replaces our own prior injection, not treated as a
+        // pre-existing real env var.
+        expect(process.env[key]).toBe("v2")
+      },
+    })
+  } finally {
+    if (original !== undefined) process.env[key] = original
+    else delete process.env[key]
+  }
+})
+
+test("removing a config env key restores original on reload", async () => {
+  const key = "MIMO_TEST_ENV_REMOVE"
+  const original = process.env[key]
+  delete process.env[key]
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, "mimocode.json"),
+          JSON.stringify({ $schema: "https://opencode.ai/config.json", env: { [key]: "injected" } }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Effect.runPromise(
+          reloadScenario(tmp.path, () =>
+            Filesystem.write(
+              path.join(tmp.path, "mimocode.json"),
+              JSON.stringify({ $schema: "https://opencode.ai/config.json", env: {} }),
+            ),
+          ),
+        )
+        // Was unset before injection → removing the config key unsets it again,
+        // rather than leaving the stale "injected" value behind.
+        expect(process.env[key]).toBeUndefined()
+      },
+    })
+  } finally {
+    if (original !== undefined) process.env[key] = original
+    else delete process.env[key]
+  }
+})

--- a/packages/opencode/test/config/env.test.ts
+++ b/packages/opencode/test/config/env.test.ts
@@ -44,10 +44,10 @@ afterEach(async () => {
   await clear(true)
 })
 
-test("config env injects into process.env and Env service, overriding existing vars", async () => {
+test("config env injects new vars but defers to existing process env vars", async () => {
   const originalNew = process.env["MIMO_TEST_ENV_NEW"]
-  const originalOverride = process.env["MIMO_TEST_ENV_OVERRIDE"]
-  process.env["MIMO_TEST_ENV_OVERRIDE"] = "before"
+  const originalExisting = process.env["MIMO_TEST_ENV_EXISTING"]
+  process.env["MIMO_TEST_ENV_EXISTING"] = "from-real-env"
   delete process.env["MIMO_TEST_ENV_NEW"]
 
   try {
@@ -59,7 +59,7 @@ test("config env injects into process.env and Env service, overriding existing v
             $schema: "https://opencode.ai/config.json",
             env: {
               MIMO_TEST_ENV_NEW: "hello123",
-              MIMO_TEST_ENV_OVERRIDE: "after",
+              MIMO_TEST_ENV_EXISTING: "from-config",
             },
           }),
         )
@@ -82,24 +82,25 @@ test("config env injects into process.env and Env service, overriding existing v
         // config field is parsed
         expect(result.config.env).toEqual({
           MIMO_TEST_ENV_NEW: "hello123",
-          MIMO_TEST_ENV_OVERRIDE: "after",
+          MIMO_TEST_ENV_EXISTING: "from-config",
         })
 
-        // injected into process.env (what the bash tool reads)
+        // new var injected into process.env (what the bash tool reads)
         expect(process.env["MIMO_TEST_ENV_NEW"]).toBe("hello123")
-        // overrides existing process env var
-        expect(process.env["MIMO_TEST_ENV_OVERRIDE"]).toBe("after")
+        // real env var takes precedence — config value must NOT clobber it
+        expect(process.env["MIMO_TEST_ENV_EXISTING"]).toBe("from-real-env")
 
-        // injected into the Env service
+        // new var injected into the Env service
         expect(result.envState["MIMO_TEST_ENV_NEW"]).toBe("hello123")
-        expect(result.envState["MIMO_TEST_ENV_OVERRIDE"]).toBe("after")
+        // Env service also reflects the real env value, not the config default
+        expect(result.envState["MIMO_TEST_ENV_EXISTING"]).toBe("from-real-env")
       },
     })
   } finally {
     if (originalNew !== undefined) process.env["MIMO_TEST_ENV_NEW"] = originalNew
     else delete process.env["MIMO_TEST_ENV_NEW"]
-    if (originalOverride !== undefined) process.env["MIMO_TEST_ENV_OVERRIDE"] = originalOverride
-    else delete process.env["MIMO_TEST_ENV_OVERRIDE"]
+    if (originalExisting !== undefined) process.env["MIMO_TEST_ENV_EXISTING"] = originalExisting
+    else delete process.env["MIMO_TEST_ENV_EXISTING"]
   }
 })
 

--- a/packages/opencode/test/config/env.test.ts
+++ b/packages/opencode/test/config/env.test.ts
@@ -1,0 +1,143 @@
+import { test, expect, afterEach } from "bun:test"
+import { Effect, Layer, Option } from "effect"
+import { NodeFileSystem, NodePath } from "@effect/platform-node"
+import { Config } from "../../src/config"
+import { EffectFlock } from "@mimo-ai/shared/util/effect-flock"
+import { Auth } from "../../src/auth"
+import { Account } from "../../src/account/account"
+import { AppFileSystem } from "@mimo-ai/shared/filesystem"
+import { Env } from "../../src/env"
+import { tmpdir } from "../fixture/fixture"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Instance } from "../../src/project/instance"
+import { Filesystem } from "../../src/util"
+import { Npm } from "@/npm"
+import path from "path"
+
+const infra = CrossSpawnSpawner.defaultLayer.pipe(
+  Layer.provideMerge(Layer.mergeAll(NodeFileSystem.layer, NodePath.layer)),
+)
+
+const emptyAccount = Layer.mock(Account.Service)({
+  active: () => Effect.succeed(Option.none()),
+  activeOrg: () => Effect.succeed(Option.none()),
+})
+
+const emptyAuth = Layer.mock(Auth.Service)({
+  all: () => Effect.succeed({}),
+})
+
+const layer = Config.layer.pipe(
+  Layer.provide(EffectFlock.defaultLayer),
+  Layer.provide(AppFileSystem.defaultLayer),
+  Layer.provideMerge(Env.defaultLayer),
+  Layer.provide(emptyAuth),
+  Layer.provide(emptyAccount),
+  Layer.provideMerge(infra),
+  Layer.provide(Npm.defaultLayer),
+)
+
+const clear = (wait = false) =>
+  Effect.runPromise(Config.Service.use((svc) => svc.invalidate(wait)).pipe(Effect.scoped, Effect.provide(layer)))
+
+afterEach(async () => {
+  await clear(true)
+})
+
+test("config env injects into process.env and Env service, overriding existing vars", async () => {
+  const originalNew = process.env["MIMO_TEST_ENV_NEW"]
+  const originalOverride = process.env["MIMO_TEST_ENV_OVERRIDE"]
+  process.env["MIMO_TEST_ENV_OVERRIDE"] = "before"
+  delete process.env["MIMO_TEST_ENV_NEW"]
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, "mimocode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            env: {
+              MIMO_TEST_ENV_NEW: "hello123",
+              MIMO_TEST_ENV_OVERRIDE: "after",
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const result = await Effect.runPromise(
+          Config.Service.use((svc) =>
+            Effect.gen(function* () {
+              const config = yield* svc.get()
+              const envState = yield* (yield* Env.Service).all()
+              return { config, envState }
+            }),
+          ).pipe(Effect.scoped, Effect.provide(layer)),
+        )
+
+        // config field is parsed
+        expect(result.config.env).toEqual({
+          MIMO_TEST_ENV_NEW: "hello123",
+          MIMO_TEST_ENV_OVERRIDE: "after",
+        })
+
+        // injected into process.env (what the bash tool reads)
+        expect(process.env["MIMO_TEST_ENV_NEW"]).toBe("hello123")
+        // overrides existing process env var
+        expect(process.env["MIMO_TEST_ENV_OVERRIDE"]).toBe("after")
+
+        // injected into the Env service
+        expect(result.envState["MIMO_TEST_ENV_NEW"]).toBe("hello123")
+        expect(result.envState["MIMO_TEST_ENV_OVERRIDE"]).toBe("after")
+      },
+    })
+  } finally {
+    if (originalNew !== undefined) process.env["MIMO_TEST_ENV_NEW"] = originalNew
+    else delete process.env["MIMO_TEST_ENV_NEW"]
+    if (originalOverride !== undefined) process.env["MIMO_TEST_ENV_OVERRIDE"] = originalOverride
+    else delete process.env["MIMO_TEST_ENV_OVERRIDE"]
+  }
+})
+
+test("config env supports {env:VAR} substitution", async () => {
+  const originalSource = process.env["MIMO_TEST_ENV_SOURCE"]
+  const originalTarget = process.env["MIMO_TEST_ENV_TARGET"]
+  process.env["MIMO_TEST_ENV_SOURCE"] = "substituted-value"
+  delete process.env["MIMO_TEST_ENV_TARGET"]
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, "mimocode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            env: {
+              MIMO_TEST_ENV_TARGET: "{env:MIMO_TEST_ENV_SOURCE}",
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Effect.runPromise(
+          Config.Service.use((svc) => svc.get()).pipe(Effect.scoped, Effect.provide(layer)),
+        )
+        expect(config.env?.["MIMO_TEST_ENV_TARGET"]).toBe("substituted-value")
+        expect(process.env["MIMO_TEST_ENV_TARGET"]).toBe("substituted-value")
+      },
+    })
+  } finally {
+    if (originalSource !== undefined) process.env["MIMO_TEST_ENV_SOURCE"] = originalSource
+    else delete process.env["MIMO_TEST_ENV_SOURCE"]
+    if (originalTarget !== undefined) process.env["MIMO_TEST_ENV_TARGET"] = originalTarget
+    else delete process.env["MIMO_TEST_ENV_TARGET"]
+  }
+})


### PR DESCRIPTION
## Summary

Adds a top-level `env` config key to `mimocode.json` (`Record<string,string>`) that injects environment variables into the mimocode process and its child processes (e.g. the bash tool) — so you can define env vars in config instead of `.bashrc`. Matches Claude Code's `env` semantics.

- **Schema**: new `env` key in `InfoSchema` (`src/config/config.ts`).
- **Injection**: after the merged config is finalized in `loadInstanceState`, each entry is written to **both** `process.env` (what the bash tool reads via `bash.ts`) and the **`Env` service**.
- **Precedence**: a variable already set in the **real environment wins**. Config `env` only supplies a value when the variable is not already set.
- **Reload-safe**: edits and removals in `mimocode.json` take effect on config reload (no process restart needed).
- **Substitution**: `{env:VAR}` / `{file:path}` work inside values for free (substitution runs before parse).

### Precedence rationale (config env vs real env var)

From first principles, the more specific / runtime-closer signal should win: **CLI flag > environment variable > config file > default**. An environment variable is set by the *caller* at launch (CI runner, container, `direnv`, `FOO=bar mimo`) and expresses "for this run, use this"; a config file is a persisted, shareable default expressing "normally use this". So a real env var must take precedence over the config default — otherwise a repo-committed `mimocode.json` could silently clobber a CI-injected secret or a user's one-off `HTTPS_PROXY=... mimo`.

This matches Claude Code: its docs state *"the environment variable takes precedence… The settings field applies when the environment variable is not set."*

### Reload semantics

The TUI worker reloads config on change via `Config.invalidate()`, so config edits are expected to take effect without a restart. Because `process.env` is process-global and outlives instance disposal, the feature tracks which keys it injected (and their pre-injection value) in the config layer closure. On reload:

- **Edited** value → re-applied (our prior write is not mistaken for a real env var).
- **Removed / renamed** key → restored to its original value (unset if it had none).
- A genuinely pre-existing **real** env var → still wins, never touched.

### Background

Upstream opencode does **not** support a top-level `env` key — it only has read-side `{env:VAR}`/`{file:path}` substitution and scoped injection for `mcp.*.environment` / `formatter.*.environment` / `lsp.*.env`. This PR adds the process-wide capability.

### Example

```jsonc
{
  "$schema": "https://mimo.xiaomi.com/mimocode/config.json",
  "env": {
    "HTTP_PROXY": "http://127.0.0.1:7890",
    "MY_TOKEN": "{env:UPSTREAM_TOKEN}"
  }
}
```

## Test Plan

- [x] New `test/config/env.test.ts` (4 tests): new-var injection into `process.env` + `Env` service; real env var takes precedence; `{env:VAR}` substitution; **reload** — edited value applies, removed key restores original.
- [x] Existing `test/config/config.test.ts` — 85 tests pass (no regressions).
- [x] `bun typecheck` clean (exit 0).