### PR TITLE
fix(task): prevent subagents from stealing task ownership via start

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -385,7 +385,16 @@ export const TaskTool = Tool.define<typeof parameters, Metadata, TaskRegistry.Se
       }
 
       if (op.action === "start") {
-        const result = yield* reg.start({ session_id: sessionID, id: op.id, owner: ctx.actorID ?? ctx.agent, event_summary: op.event_summary })
+        // A subagent starting a task owned by someone else must NOT steal
+        // ownership: the completion gate filters by owner, so an accidental
+        // handoff traps the subagent in "finish tasks you own" re-entry for
+        // tasks that belong to the main agent. Intentional handoff stays
+        // available to internal callers (actor auto-start in spawn.ts).
+        const caller = ctx.actorID ?? ctx.agent
+        const existing = yield* reg.get({ session_id: sessionID, id: op.id })
+        const isSubagent = ctx.actorID !== undefined && ctx.actorID !== "main"
+        const keepOwner = isSubagent && existing?.owner != null && existing.owner !== caller
+        const result = yield* reg.start({ session_id: sessionID, id: op.id, owner: keepOwner ? undefined : caller, event_summary: op.event_summary })
         return {
           title: `Task ${op.id}: ${result.status}`,
           output: `start → ${result.status}`,

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -101,6 +101,66 @@ describe("task tool", () => {
     ),
   )
 
+  it.live("subagent start on a task owned by another actor does not steal ownership", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const session = yield* Session.Service
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* session.create({ title: "Test" })
+        const t = yield* reg.create({ session_id: sess.id, summary: "main's task", owner: "main" })
+        const info = yield* TaskTool
+        const tool = yield* info.init()
+        yield* tool.execute(
+          { operation: { action: "start", id: t.id } },
+          { ...ctx(sess.id), actorID: "explore-1" },
+        )
+        const after = yield* reg.get({ session_id: sess.id, id: t.id })
+        expect(after?.status).toBe("in_progress")
+        expect(after?.owner).toBe("main")
+      }),
+    ),
+  )
+
+  it.live("subagent start on its own task sets it as owner", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const session = yield* Session.Service
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* session.create({ title: "Test" })
+        const t = yield* reg.create({ session_id: sess.id, summary: "unowned" })
+        const info = yield* TaskTool
+        const tool = yield* info.init()
+        yield* tool.execute(
+          { operation: { action: "start", id: t.id } },
+          { ...ctx(sess.id), actorID: "explore-1" },
+        )
+        const after = yield* reg.get({ session_id: sess.id, id: t.id })
+        expect(after?.status).toBe("in_progress")
+        expect(after?.owner).toBe("explore-1")
+      }),
+    ),
+  )
+
+  it.live("main start on a subagent-owned task still takes over (handoff preserved)", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const session = yield* Session.Service
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* session.create({ title: "Test" })
+        const t = yield* reg.create({ session_id: sess.id, summary: "orphan", owner: "explore-1" })
+        const info = yield* TaskTool
+        const tool = yield* info.init()
+        yield* tool.execute(
+          { operation: { action: "start", id: t.id } },
+          { ...ctx(sess.id), actorID: "main" },
+        )
+        const after = yield* reg.get({ session_id: sess.id, id: t.id })
+        expect(after?.status).toBe("in_progress")
+        expect(after?.owner).toBe("main")
+      }),
+    ),
+  )
+
   it.live("rejects old flat JSON shape", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {


### PR DESCRIPTION
A subagent calling `task start` on a task owned by another actor (e.g. main) implicitly transferred ownership, so the subagent completion gate (owner-filtered) then trapped it in system-reminder re-entry loops for tasks it never created. Keep the original owner when a subagent starts someone else's task; main handoff and spawn auto-start are unaffected.