### PR TITLE
fix: add .cron-lock to auto-generated .mimocode/.gitignore

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -640,7 +640,7 @@ export const layer = Layer.effect(
         yield* fs
           .writeFileString(
             gitignore,
-            ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"),
+            ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore", ".cron-lock"].join("\n"),
           )
           .pipe(
             Effect.catchIf(


### PR DESCRIPTION
## Summary

- Adds `.cron-lock` to the auto-generated `.mimocode/.gitignore` template in `ensureGitignore`
- The `.cron-lock` file contains runtime state (PID + timestamp) and should never be committed

Closes #1622