### PR TITLE
fix: merge consecutive system messages for openai-compatible providers

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -51,6 +51,34 @@ function normalizeMessages(
   model: Provider.Model,
   _options: Record<string, unknown>,
 ): ModelMessage[] {
+  // vLLM/Qwen chat templates only accept a single leading system message.
+  // MiMoCode produces multiple system messages (agent prompt + memory instructions),
+  // so collapse consecutive leading system messages into one for openai-compatible providers.
+  //
+  // Design note: the merged message intentionally drops providerOptions from individual
+  // system messages. This is safe because (1) system messages are constructed without
+  // providerOptions in llm.ts, and (2) applyCaching runs AFTER normalizeMessages and
+  // does not apply to @ai-sdk/openai-compatible (supportsCacheMarkers returns false).
+  // If a future change adds providerOptions to system messages before this point,
+  // the merge logic must be updated to preserve them.
+  if (model.api.npm === "@ai-sdk/openai-compatible") {
+    let lastSystemIdx = -1
+    for (let i = 0; i < msgs.length; i++) {
+      if (msgs[i].role !== "system") break
+      lastSystemIdx = i
+    }
+    if (lastSystemIdx > 0) {
+      const merged: ModelMessage = {
+        role: "system",
+        content: msgs
+          .slice(0, lastSystemIdx + 1)
+          .map((m) => (typeof m.content === "string" ? m.content : ""))
+          .join("\n\n"),
+      }
+      msgs = [merged, ...msgs.slice(lastSystemIdx + 1)]
+    }
+  }
+
   // Anthropic rejects messages with empty content - filter out empty string messages
   // and remove empty text/reasoning parts from array content
   if (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/amazon-bedrock") {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3565,3 +3565,101 @@ describe("ProviderTransform.schema - openai discriminated-union flatten", () => 
     expect(result.anyOf).toBeUndefined()
   })
 })
+
+describe("ProviderTransform.message - merge consecutive system messages for openai-compatible", () => {
+  const vllmModel = {
+    id: ModelID.make("qwen/qwen3-235b-a22b"),
+    providerID: ProviderID.make("custom"),
+    api: {
+      id: "qwen3-235b-a22b",
+      url: "http://localhost:8000/v1",
+      npm: "@ai-sdk/openai-compatible",
+    },
+    name: "Qwen3 235B",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 128000, output: 8192 },
+    status: "active",
+    options: {},
+    headers: {},
+  } as any
+
+  test("two consecutive system messages are merged into one", () => {
+    const msgs = [
+      { role: "system", content: "You are a coding assistant." },
+      { role: "system", content: "Memory instructions here." },
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, vllmModel, {})
+    const systemMsgs = result.filter((m) => m.role === "system")
+    expect(systemMsgs).toHaveLength(1)
+    expect(systemMsgs[0].content).toBe("You are a coding assistant.\n\nMemory instructions here.")
+    expect(result).toHaveLength(2)
+    expect(result[1].role).toBe("user")
+  })
+
+  test("three consecutive system messages are merged into one", () => {
+    const msgs = [
+      { role: "system", content: "Agent prompt." },
+      { role: "system", content: "Memory block." },
+      { role: "system", content: "Plugin additions." },
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, vllmModel, {})
+    const systemMsgs = result.filter((m) => m.role === "system")
+    expect(systemMsgs).toHaveLength(1)
+    expect(systemMsgs[0].content).toBe("Agent prompt.\n\nMemory block.\n\nPlugin additions.")
+    expect(result).toHaveLength(2)
+  })
+
+  test("single system message is left untouched", () => {
+    const msgs = [
+      { role: "system", content: "You are a coding assistant." },
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, vllmModel, {})
+    const systemMsgs = result.filter((m) => m.role === "system")
+    expect(systemMsgs).toHaveLength(1)
+    expect(systemMsgs[0].content).toBe("You are a coding assistant.")
+  })
+
+  test("@ai-sdk/openai provider is not affected by the merge", () => {
+    const openaiModel = {
+      ...vllmModel,
+      providerID: ProviderID.make("openai"),
+      api: { id: "gpt-4o", url: "https://api.openai.com/v1", npm: "@ai-sdk/openai" },
+    }
+    const msgs = [
+      { role: "system", content: "System prompt A." },
+      { role: "system", content: "System prompt B." },
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, openaiModel, {})
+    const systemMsgs = result.filter((m) => m.role === "system")
+    expect(systemMsgs).toHaveLength(2)
+  })
+
+  test("empty messages array is a no-op", () => {
+    const result = ProviderTransform.message([], vllmModel, {})
+    expect(result).toHaveLength(0)
+  })
+
+  test("no system messages is a no-op", () => {
+    const msgs = [{ role: "user", content: [{ type: "text", text: "Hello" }] }] as any[]
+    const result = ProviderTransform.message(msgs, vllmModel, {})
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe("user")
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1614. Closes #1049. Supersedes #61.
Related: #1621.

vLLM/Qwen chat templates only accept a single leading system message, but MiMoCode produces multiple (agent prompt + memory instructions). This causes `"System message must be at the beginning"` errors for local deployments using `@ai-sdk/openai-compatible`.

## Changes

- In `ProviderTransform.normalizeMessages`, collapse consecutive leading system messages into one (joined with `\n\n`) for `@ai-sdk/openai-compatible` providers only
- Other providers (`@ai-sdk/openai`, `@ai-sdk/anthropic`, etc.) are unaffected
- Added design note explaining why `providerOptions` can be safely dropped at this pipeline stage

## Tests

6 new test cases covering:
- 2 system messages merged → 1
- 3 system messages merged → 1
- Single system message untouched (no-op)
- `@ai-sdk/openai` provider unaffected (scoping)
- Empty messages array (no-op)
- No system messages present (no-op)

All 168 tests in `transform.test.ts` pass.