### PR TITLE
fix: force re-allow skill dirs after user config merge

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -449,19 +449,18 @@ export const layer = Layer.effect(
           item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))
         }
 
-        // Ensure Truncate.GLOB is allowed unless explicitly configured
+        // Ensure Truncate.GLOB and skill directories are allowed unless explicitly configured
         for (const name in agents) {
           const agent = agents[name]
-          const explicit = agent.permission.some((r) => {
-            if (r.permission !== "external_directory") return false
-            if (r.action !== "deny") return false
-            return r.pattern === Truncate.GLOB
-          })
-          if (explicit) continue
+          const globs = whitelistedDirs.filter(
+            (glob) =>
+              !agent.permission.some((r) => r.permission === "external_directory" && r.action === "deny" && r.pattern === glob),
+          )
+          if (globs.length === 0) continue
 
           agents[name].permission = Permission.merge(
             agents[name].permission,
-            Permission.fromConfig({ external_directory: { [Truncate.GLOB]: "allow" } }),
+            Permission.fromConfig({ external_directory: Object.fromEntries(globs.map((g) => [g, "allow" as const])) }),
           )
         }
 

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -655,6 +655,51 @@ description: Permission skill.
   }
 })
 
+test("skill directories are allowed even when user denies external_directory globally", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    config: {
+      permission: {
+        external_directory: "deny",
+      },
+    },
+    init: async (dir) => {
+      const skillDir = path.join(dir, ".mimocode", "skill", "perm-skill")
+      await Bun.write(
+        path.join(skillDir, "SKILL.md"),
+        `---
+name: perm-skill
+description: Permission skill.
+---
+
+# Permission Skill
+`,
+      )
+    },
+  })
+
+  const home = process.env.HOME
+  const userProfile = process.env.USERPROFILE
+  process.env.HOME = tmp.path
+  process.env.USERPROFILE = tmp.path
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const build = await load(tmp.path, (svc) => svc.get("build"))
+        const skillDir = path.join(tmp.path, ".mimocode", "skill", "perm-skill")
+        const target = path.join(skillDir, "reference", "notes.md")
+        expect(Permission.evaluate("external_directory", target, build!.permission).action).toBe("allow")
+        expect(Permission.evaluate("external_directory", "/some/other/path", build!.permission).action).toBe("deny")
+      },
+    })
+  } finally {
+    process.env.HOME = home
+    process.env.USERPROFILE = userProfile
+  }
+})
+
 test("defaultAgent returns build when no default_agent config", async () => {
   await using tmp = await tmpdir()
   await Instance.provide({


### PR DESCRIPTION
## Summary

Fixes #1535

When `external_directory` is set to default deny (`"*": "deny"`), the last-match-wins semantics of `Permission.evaluate` (which uses `findLast`) cause the user's wildcard rule to override the default skill directory whitelists — blocking compose skills and builtin skills from loading.

## Changes

- Extended the existing `Truncate.GLOB` force-allow pattern to also cover all discovered skill directories. After user config is merged, skill dir allow rules are re-appended to the end of the permission array so they become the last matching rule.
- Users can still explicitly deny specific skill paths (the force-allow is skipped when the user targets the exact skill glob pattern).
- Added a regression test for the reported scenario (`external_directory: "deny"` + skill dir access).

## How it works

```
Permission merge order: [...defaults, ...user_config]
evaluate():            findLast(rule => matches)
```

Before this fix, user's `"*": "deny"` was the last matching rule for skill paths → denied.
After this fix, skill dir allows are re-appended after user config → they become the last match → allowed.

This is the same mechanism already used for `Truncate.GLOB` (tool output directory).