### PR TITLE
fix(tui): reclaim the toggle button's 4 columns on narrow terminals (#1626)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -236,7 +236,14 @@ export function Session() {
   const sidebarDocked = createMemo(() => sidebarVisible() && wide())
   const toggleSidebar = () => setSidebar(() => sidebarToggle(sidebar(), wide()))
   const showTimestamps = createMemo(() => timestamps() === "show")
-  const contentWidth = createMemo(() => dimensions().width - (sidebarDocked() ? SIDEBAR_WIDTH : 0) - 4)
+  const contentWidth = createMemo(
+    () =>
+      dimensions().width -
+      (sidebarDocked() ? SIDEBAR_WIDTH : 0) -
+      // Only the in-flow button (docked layout, main agent) reserves columns; on
+      // narrow terminals no button renders in flow and the content reclaims the width.
+      (sidebarAllowed() && wide() ? 4 : 0),
+  )
   const providers = createMemo(() => Model.index(sync.data.provider))
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))


### PR DESCRIPTION
## Summary

Fixes #1626 (main content reclaims the full width when the sidebar is hidden).

The docked toggle button only renders in the layout flow when `sidebarAllowed && wide()`. On narrow terminals it either floats inside the absolute overlay, or (when the sidebar is hidden) does not render at all — yet `contentWidth` unconditionally reserved 4 columns, wasting horizontal space on phone-sized terminals.

`contentWidth` now reserves the button's 4-column footprint only when the in-flow button actually renders:

```ts
dimensions().width - (sidebarDocked() ? SIDEBAR_WIDTH : 0) - (sidebarAllowed() && wide() ? 4 : 0)
```

This composes with the existing docked/overlay layout:
- docked sidebar (wide + visible): `SIDEBAR_WIDTH + 4` reserved — unchanged
- wide + hidden: 4 reserved for the reopen button — unchanged
- narrow + visible or hidden: 0 reserved — content reclaims the width (#1626)

## Verification

- `tsc --noEmit` clean for `routes/session`
- `oxlint` on the changed file: no new warnings (43 pre-existing only)
- change is a layout-reclaim only; button visibility rules from #1541/#1637 untouched

Only `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` is changed.