### PR TITLE
fix: gracefully skip broken file tools instead of crashing the session

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -30,6 +30,7 @@ import { WebSearchTool } from "./websearch"
 import { CodeSearchTool } from "./codesearch"
 import { Flag } from "@/flag/flag"
 import { Log } from "@/util"
+import { errorMessage } from "@/util/error"
 import { LspTool } from "./lsp"
 import * as Truncate from "./truncate"
 import { ApplyPatchTool } from "./apply_patch"
@@ -195,7 +196,14 @@ export const layer = Layer.effect(
           const namespace = path.basename(match, path.extname(match))
           // `match` is an absolute filesystem path from `Glob.scanSync(..., { absolute: true })`.
           // Import it as `file://` so Node on Windows accepts the dynamic import.
-          const mod = yield* Effect.promise(() => import(`${pathToFileURL(match).href}?v=${Date.now()}`))
+          const mod = yield* Effect.tryPromise({
+            try: () => import(`${pathToFileURL(match).href}?v=${Date.now()}`),
+            catch: (err) => err,
+          }).pipe(Effect.catch((err) => {
+            log.error("failed to load file tool, skipping", { path: match, error: errorMessage(err) })
+            return Effect.succeed(undefined)
+          }))
+          if (!mod) continue
           for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
             custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
           }


### PR DESCRIPTION
A syntax error or missing dependency in a .mimocode/tools/*.ts file previously caused the entire tool registry init to fail (unhandled Effect.promise defect), preventing any session from starting.

Change Effect.promise → Effect.tryPromise + Effect.catch to match the existing pattern in file hook loading (plugin/index.ts:425-431): log the error and skip the broken tool, allowing the session to proceed with remaining tools functional.