### PR TITLE
fix(session): scope memory instructions to checkpoint owners; collapse system prompt to one message

### DIFF
--- a/packages/opencode/src/actor/registry.ts
+++ b/packages/opencode/src/actor/registry.ts
@@ -74,6 +74,7 @@ export interface Interface {
   readonly renderForAgent: (sessionID: SessionID) => Effect.Effect<string>
   readonly agentTypeFor: (sessionID: SessionID, actorID: string) => Effect.Effect<string>
   readonly isSystemSpawned: (sessionID: SessionID, actorID: string) => Effect.Effect<boolean>
+  readonly servesCheckpoint: (sessionID: SessionID, actorID: string | undefined) => Effect.Effect<boolean>
   readonly allocateActorID: (sessionID: SessionID, agentType: string) => Effect.Effect<string>
 }
 
@@ -330,6 +331,25 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
       return SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent)
     })
 
+    // Whether this actor's context is maintained by the session checkpoint flow.
+    // Checkpoint serves main + peer only; subagents use per-actor compaction, and
+    // system-spawned agents (checkpoint-writer/dream/distill) maintain nothing.
+    // Single source of truth for both the memory-instructions gate (LLM.buildSystemArray)
+    // and the checkpoint self-trigger gate (SessionPrune.fireCheckpoints). Two
+    // orthogonal exclusions kept explicit (agent TYPE vs MODE) so a future system
+    // agent spawned as mode:"peer" can't silently slip back in — see prune.ts.
+    const servesCheckpoint = Effect.fn("ActorRegistry.servesCheckpoint")(function* (
+      sessionID: SessionID,
+      actorID: string | undefined,
+    ) {
+      // No agentID → main runLoop (or unregistered/race). Fail open: main and peer
+      // must never silently lose checkpoints / memory instructions.
+      if (!actorID) return true
+      if (yield* isSystemSpawned(sessionID, actorID)) return false
+      const actor = yield* get(sessionID, actorID)
+      return actor?.mode !== "subagent"
+    })
+
     const allocateActorID = Effect.fn("ActorRegistry.allocateActorID")(function* (
       sessionID: SessionID,
       agentType: string,
@@ -422,6 +442,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
       renderForAgent,
       agentTypeFor,
       isSystemSpawned,
+      servesCheckpoint,
       allocateActorID,
     })
   }),

--- a/packages/opencode/src/actor/registry.ts
+++ b/packages/opencode/src/actor/registry.ts
@@ -342,12 +342,16 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
       sessionID: SessionID,
       actorID: string | undefined,
     ) {
-      // No agentID → main runLoop (or unregistered/race). Fail open: main and peer
-      // must never silently lose checkpoints / memory instructions.
-      if (!actorID) return true
-      if (yield* isSystemSpawned(sessionID, actorID)) return false
+      // No agentID (or literal "main") → main runLoop. Fail open: main and peer
+      // must never silently lose checkpoints / memory instructions. "main" has no
+      // registry row, so short-circuit before the read.
+      if (!actorID || actorID === "main") return true
+      // Single read, two orthogonal exclusions derived from it: agent TYPE
+      // (system-spawned) and actor MODE (subagent). Unregistered/race → fail open.
       const actor = yield* get(sessionID, actorID)
-      return actor?.mode !== "subagent"
+      if (!actor) return true
+      if (SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent)) return false
+      return actor.mode !== "subagent"
     })
 
     const allocateActorID = Effect.fn("ActorRegistry.allocateActorID")(function* (

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -253,17 +253,19 @@ const live: Layer.Layer<
           .join("\n"),
       )
 
-      // v5: memory-instructions section. Teaches the main agent how/where/when
-      // to maintain `MEMORY.md` and `checkpoint.md` directly via Edit. Project
-      // ID is resolved from the ALS-bound Instance with a safe fallback to
+      // v5: memory-instructions section. Teaches the agent how/where/when to
+      // maintain `MEMORY.md` and `checkpoint.md` directly via Edit. Project ID is
+      // resolved from the ALS-bound Instance with a safe fallback to
       // `ProjectID.global` (mirrors the pattern in session/checkpoint.ts so the
       // path the prompt advertises matches the path the writer actually writes).
-      // Skip for system-spawned actors (e.g. checkpoint-writer): they shouldn't
-      // see the user-facing memory instructions.
-      const isSystemActor = input.agentID
-        ? yield* actorReg.isSystemSpawned(SessionID.make(input.sessionID), input.agentID)
-        : false
-      if (!isSystemActor) {
+      // Injected only for actors whose context the checkpoint flow serves —
+      // main + peer. Subagents (explore/general/compose) use per-actor compaction
+      // and have no checkpoint duty; system-spawned actors (checkpoint-writer et al.)
+      // are the writers themselves. Shares the exact `servesCheckpoint` judgement
+      // with SessionPrune.fireCheckpoints so the "who owns a checkpoint" and "who is
+      // taught about it" sets can never drift apart.
+      const servesCheckpoint = yield* actorReg.servesCheckpoint(SessionID.make(input.sessionID), input.agentID)
+      if (servesCheckpoint) {
         const projectID =
           (yield* Effect.try({
             try: () => Instance.current?.project?.id as ProjectID | undefined,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -281,20 +281,21 @@ const live: Layer.Layer<
         system.push(buildMemoryInstructions(SessionID.make(input.sessionID), projectID, yield* memory.root()))
       }
 
-      const header = system[0]
+      // Plugins still see the multi-part array (base prompt as [0], memory as a
+      // trailing element) so hooks that index or append parts keep working.
       yield* plugin.trigger(
         "experimental.chat.system.transform",
         { sessionID: input.sessionID, model: input.model },
         { system },
       )
-      // rejoin to maintain 2-part structure for caching if header unchanged
-      if (system.length > 2 && system[0] === header) {
-        const rest = system.slice(1)
-        system.length = 0
-        system.push(header, rest.join("\n"))
-      }
 
-      return system
+      // Collapse to a single system message. The historical 2-part split existed
+      // only to keep a byte-stable cache prefix separate from the memory block's
+      // per-session paths — but within a session those paths are fixed, so the
+      // whole thing is stable and one block caches just as well. One message also
+      // keeps the fork-prefix parity invariant trivial (nothing to misalign) and
+      // spares subagents/providers a stray extra system turn.
+      return system.length <= 1 ? system : [system.filter((x) => x).join("\n")]
     })
 
     const run = Effect.fn("LLM.run")(function* (input: StreamRequest) {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -294,8 +294,10 @@ const live: Layer.Layer<
       // per-session paths — but within a session those paths are fixed, so the
       // whole thing is stable and one block caches just as well. One message also
       // keeps the fork-prefix parity invariant trivial (nothing to misalign) and
-      // spares subagents/providers a stray extra system turn.
-      return system.length <= 1 ? system : [system.filter((x) => x).join("\n")]
+      // spares subagents/providers a stray extra system turn. Join with a blank
+      // line (\n\n) so adjacent markdown sections (base prompt, "# Memory system")
+      // don't run together into one heading.
+      return system.length <= 1 ? system : [system.filter((x) => x).join("\n\n")]
     })
 
     const run = Effect.fn("LLM.run")(function* (input: StreamRequest) {

--- a/packages/opencode/src/session/prune.ts
+++ b/packages/opencode/src/session/prune.ts
@@ -244,31 +244,20 @@ export const layer: Layer.Layer<
       promptOps: ActorPromptOps
       agentID?: string
     }) {
-      // Skip if this is a system-spawned actor — it's an internal subagent
-      // (e.g. checkpoint-writer) and should not itself trigger checkpoints.
-      if (input.agentID && (yield* actorReg.isSystemSpawned(input.sessionID, input.agentID))) {
-        return
-      }
-
-      // Kept separate from the isSystemSpawned skip above on purpose: that
-      // guard keys on AGENT TYPE (checkpoint-writer/dream/distill), this one
-      // keys on MODE. They are orthogonal invariants that merely overlap today
-      // (those agents happen to spawn as mode:"subagent"). Folding them into one
-      // boolean would silently re-enable self-triggering for any future
-      // system agent spawned as mode:"peer". The extra registry read is a local
-      // SQLite hit; correctness of the layering is worth more than saving it.
-      //
       // Checkpoint serves main/peer only; subagents use per-actor compaction
-      // (independent layers — see 2026-05-22-checkpoint-v8-design.md:71). A
-      // subagent shares the parent sessionID, so if it triggered a checkpoint
-      // the writer's unfiltered-stream watermark could land on the subagent's
-      // messages and the fork would capture the wrong parent system prompt.
-      // Gate on registry mode, NOT agentID: a peer's agentID is its child.id,
-      // not "main", so an agentID==="main" check would wrongly exclude peers.
-      // Unresolved actor (no agentID / unregistered / race) → fail open and
-      // fire: main and peer must never silently lose checkpoints.
-      const actor = input.agentID ? yield* actorReg.get(input.sessionID, input.agentID) : undefined
-      if (actor?.mode === "subagent") return
+      // (independent layers — see 2026-05-22-checkpoint-v8-design.md:71), and
+      // system-spawned agents (checkpoint-writer/dream/distill) are the writers
+      // themselves and must not self-trigger. Both exclusions live in the shared
+      // `servesCheckpoint` judgement (keyed on agent TYPE and MODE, kept orthogonal
+      // there so a future system agent spawned as mode:"peer" can't slip back in).
+      // It also shares the exact judgement with LLM.buildSystemArray's memory gate,
+      // so "who owns a checkpoint" and "who is taught about it" can never drift.
+      // A subagent shares the parent sessionID, so if it triggered a checkpoint the
+      // writer's unfiltered-stream watermark could land on the subagent's messages
+      // and the fork would capture the wrong parent system prompt. Unresolved actor
+      // (no agentID / unregistered / race) → servesCheckpoint fails open and fires:
+      // main and peer must never silently lose checkpoints.
+      if (!(yield* actorReg.servesCheckpoint(input.sessionID, input.agentID))) return
 
       // Lock: skip if a writer is already running for this session.
       // crossed Set is NOT incremented here — when the in-flight writer

--- a/packages/opencode/test/actor/registry.test.ts
+++ b/packages/opencode/test/actor/registry.test.ts
@@ -556,6 +556,116 @@ describe("ActorRegistry", () => {
     })
   })
 
+  describe("servesCheckpoint", () => {
+    test("true for undefined actorID (main runLoop)", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await withRegistry(tmp.path, async (rt) => {
+        const session = await rt.runPromise(Session.Service.use((svc) => svc.create()))
+        const result = await rt.runPromise(
+          ActorRegistry.Service.use((svc) => svc.servesCheckpoint(session.id, undefined)),
+        )
+        expect(result).toBe(true)
+      })
+    })
+
+    test("true for 'main' actorID", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await withRegistry(tmp.path, async (rt) => {
+        const session = await rt.runPromise(Session.Service.use((svc) => svc.create()))
+        const result = await rt.runPromise(
+          ActorRegistry.Service.use((svc) => svc.servesCheckpoint(session.id, "main")),
+        )
+        expect(result).toBe(true)
+      })
+    })
+
+    test("true for peer (agentID is child.id, mode peer)", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await withRegistry(tmp.path, async (rt) => {
+        const session = await rt.runPromise(Session.Service.use((svc) => svc.create()))
+        await rt.runPromise(
+          ActorRegistry.Service.use((svc) =>
+            svc.register({
+              sessionID: session.id,
+              actorID: "child-session-1",
+              mode: "peer",
+              agent: "build",
+              description: "x",
+              contextMode: "none",
+              background: true,
+              lifecycle: "ephemeral",
+            }),
+          ),
+        )
+        const result = await rt.runPromise(
+          ActorRegistry.Service.use((svc) => svc.servesCheckpoint(session.id, "child-session-1")),
+        )
+        expect(result).toBe(true)
+      })
+    })
+
+    test("false for subagent (explorer) — uses per-actor compaction", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await withRegistry(tmp.path, async (rt) => {
+        const session = await rt.runPromise(Session.Service.use((svc) => svc.create()))
+        await rt.runPromise(
+          ActorRegistry.Service.use((svc) =>
+            svc.register({
+              sessionID: session.id,
+              actorID: "explorer-1",
+              mode: "subagent",
+              agent: "explorer",
+              description: "x",
+              contextMode: "none",
+              background: false,
+              lifecycle: "ephemeral",
+            }),
+          ),
+        )
+        const result = await rt.runPromise(
+          ActorRegistry.Service.use((svc) => svc.servesCheckpoint(session.id, "explorer-1")),
+        )
+        expect(result).toBe(false)
+      })
+    })
+
+    test("false for checkpoint-writer (system-spawned)", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await withRegistry(tmp.path, async (rt) => {
+        const session = await rt.runPromise(Session.Service.use((svc) => svc.create()))
+        await rt.runPromise(
+          ActorRegistry.Service.use((svc) =>
+            svc.register({
+              sessionID: session.id,
+              actorID: "writer-1",
+              mode: "subagent",
+              agent: "checkpoint-writer",
+              description: "x",
+              contextMode: "full",
+              background: true,
+              lifecycle: "ephemeral",
+            }),
+          ),
+        )
+        const result = await rt.runPromise(
+          ActorRegistry.Service.use((svc) => svc.servesCheckpoint(session.id, "writer-1")),
+        )
+        expect(result).toBe(false)
+      })
+    })
+
+    test("true for unregistered actorID (fail open)", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await withRegistry(tmp.path, async (rt) => {
+        const session = await rt.runPromise(Session.Service.use((svc) => svc.create()))
+        const result = await rt.runPromise(
+          ActorRegistry.Service.use((svc) => svc.servesCheckpoint(session.id, "ghost-9")),
+        )
+        expect(result).toBe(true)
+      })
+    })
+  })
+
   describe("allocateActorID", () => {
     test("returns sequential <type>-<n>", async () => {
       await using tmp = await tmpdir({ git: true })

--- a/packages/opencode/test/session/bootstrap-skip-system.test.ts
+++ b/packages/opencode/test/session/bootstrap-skip-system.test.ts
@@ -38,6 +38,8 @@ const stubActorRegistry = Layer.succeed(
     agentTypeFor: () => Effect.succeed("main"),
     // Force the guard inside tryStartCheckpointWriter to fire by always reporting true.
     isSystemSpawned: () => Effect.succeed(true),
+    // System actor → does not serve checkpoint (mirrors isSystemSpawned=true here).
+    servesCheckpoint: () => Effect.succeed(false),
     allocateActorID: () => Effect.die("not used"),
   }),
 )

--- a/packages/opencode/test/session/llm-system-prompt.test.ts
+++ b/packages/opencode/test/session/llm-system-prompt.test.ts
@@ -185,6 +185,8 @@ describe("session.llm system prompt — memory-instructions guard", () => {
         const capture = await request
         const messages = capture.body.messages as Array<{ role: string; content: string }>
         const sysMsgs = messages.filter((m) => m.role === "system")
+        // buildSystemArray now collapses everything into a single system message.
+        expect(sysMsgs.length).toBe(1)
         const allSys = sysMsgs.map((m) => m.content).join("\n")
         expect(allSys).toContain("# Memory system")
       },


### PR DESCRIPTION
## Summary

The LLM request assembled the system prompt as two `{role:'system'}` messages, and injected the memory-instructions block into every actor except a small hardcoded blacklist. That blacklist let the memory block leak into normal subagents that have no business seeing it, and the two-message split existed only for a cache-stability reason that doesn't actually hold within a session. This PR fixes the gating and collapses the system prompt to a single message.

## Memory-instructions gating

The gate keyed on `isSystemSpawned` (a blacklist of checkpoint-writer/dream/distill), so anything *not* in that set — including `explore`/`general`/compose subagents — received the memory block. But those subagents use per-actor compaction and have no checkpoint duty; teaching them to maintain `MEMORY.md`/`checkpoint.md` is at best noise and at worst misleading.

The correct audience is exactly the set the checkpoint flow serves: **main + peer**. This is the same judgement `SessionPrune.fireCheckpoints` already makes, so the two were duplicating (and could drift from) each other.

Introduces `ActorRegistry.servesCheckpoint(sessionID, agentID)` as the single source of truth, wired into both the memory gate (`LLM.buildSystemArray`) and the checkpoint self-trigger gate (`fireCheckpoints`). It keeps the two orthogonal exclusions explicit — agent **type** (system-spawned) and actor **mode** (subagent) — so a future system agent spawned as `mode:"peer"` can't silently slip back in.

| Actor | mode | Gets memory block? |
|-------|------|--------------------|
| main | main | yes |
| peer (orchestrator child session) | peer | yes |
| subagent (explore/general/compose) | subagent | no — was **yes** (the bug) |
| checkpoint-writer / dream / distill | subagent | no |

Fork capture is unaffected: it builds with the parent's `main` agentID, so the memory block stays in the fork prefix and the parent/fork byte-parity invariant still holds.

## Single system message

`buildSystemArray` emitted a stable base block plus a separate memory block so a plugin-appended part couldn't fragment the cache prefix. But within a session the memory block's paths are fixed, so the whole thing is byte-stable and caches identically as one message — the split only ever bought cross-session prefix sharing, which never happens (KV cache is per-session). One message also makes the fork-prefix parity invariant trivial and spares subagents/providers a stray extra system turn.

The `experimental.chat.system.transform` plugin hook still fires against the multi-part array (so plugins that index or append parts keep working); the collapse happens after. Blocks join with `\n\n` so adjacent markdown sections don't fuse into one heading. The old 2-part rejoin guard is removed.

## Test plan

- New `servesCheckpoint` coverage in `registry.test.ts`: main (undefined + "main"), peer, subagent, checkpoint-writer, unregistered (fail-open).
- Existing `prune-skip-system.test.ts` already exercises all four gate outcomes and passes unchanged against the shared helper.
- `llm-system-prompt.test.ts` asserts exactly one system message and that the memory content still lands for main.
- `fork-prefix-invariant.test.ts` / `llm-request-prefix.test.ts` confirm parent/fork system parity survives the collapse.
- `bun typecheck` clean; provider `transform.test.ts` (cache breakpoints) green.