### PR TITLE
fix(tui): hide sidebar toggle strip when sidebar auto-collapses on narrow terminals

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1340,16 +1340,18 @@ export function Session() {
           </Show>
           <Toast />
         </box>
-        <SidebarToggleButton
-          visible={sidebarVisible()}
-          onToggle={() => {
-            batch(() => {
-              const isVisible = sidebarVisible()
-              setSidebar(() => (isVisible ? "hide" : "auto"))
-              setSidebarOpen(!isVisible)
-            })
-          }}
-        />
+        <Show when={wide() || sidebarVisible()}>
+          <SidebarToggleButton
+            visible={sidebarVisible()}
+            onToggle={() => {
+              batch(() => {
+                const isVisible = sidebarVisible()
+                setSidebar(() => (isVisible ? "hide" : "auto"))
+                setSidebarOpen(!isVisible)
+              })
+            }}
+          />
+        </Show>
         <Show when={sidebarVisible()}>
           <Switch>
             <Match when={wide()}>


### PR DESCRIPTION

The SidebarToggleButton was rendered unconditionally, so narrow terminals (width <= 120) that auto-hide the sidebar still showed the 3-column collapsed strip with the expand arrow. Gate it behind wide() || sidebarVisible() to restore the original full-hide behavior; the narrow force-open overlay case keeps the button for closing.

