### PR TITLE
feat(plugin): hot-reload file hooks via mtime staleness check and wirte event hooks to bus

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -91,6 +91,19 @@ type State = {
   hooksWithMeta: HookEntry[]
 }
 
+type FileHookState = {
+  hooks: Hooks[]
+  meta: HookEntry[]
+  dirs: string[]
+  /** Absolute path -> mtimeMs at load time, for cheap staleness checks. */
+  files: Record<string, number>
+  /** Mutable box: last staleness check timestamp (throttle). */
+  lastCheck: { value: number }
+}
+
+const FILE_HOOK_GLOB = "{hook,hooks}/*.{js,ts}"
+const FILE_HOOK_CHECK_INTERVAL_MS = 500
+
 export type ActorStopAggregatedDecision = ActorStopOutput & {
   contributingPluginNames: string[]
   contributingHookIDs: string[]
@@ -412,25 +425,37 @@ export const layer = Layer.effect(
       }),
     )
 
-    const fileHookState = yield* InstanceState.make<{ hooks: Hooks[]; meta: HookEntry[] }>(
+    const fileHookState = yield* InstanceState.make<FileHookState>(
       Effect.fn("Plugin.fileHooks")(function* () {
         const hooks: Hooks[] = []
         const meta: HookEntry[] = []
-        const cfg = yield* config.get()
+        const files: Record<string, number> = {}
+        yield* config.get()
         const dirs = yield* config.directories()
 
         for (const dir of dirs) {
-          const matches = Glob.scanSync("{hook,hooks}/*.{js,ts}", { cwd: dir, absolute: true, dot: true, symlink: true })
+          const matches = Glob.scanSync(FILE_HOOK_GLOB, { cwd: dir, absolute: true, dot: true, symlink: true })
           for (const match of matches) {
-            const mod = yield* Effect.tryPromise({
-              try: () => import(`${pathToFileURL(match).href}?v=${Date.now()}`),
+            const stat = yield* Effect.tryPromise({
+              try: () => fs.promises.stat(match),
+              catch: (err) => err,
+            }).pipe(Effect.catch(() => Effect.succeed(undefined)))
+            files[match] = stat?.mtimeMs ?? 0
+            // require() + cache delete instead of dynamic import: Bun ignores
+            // query-string cache busters on file: imports, so a re-import would
+            // return the stale module forever.
+            const mod = yield* Effect.try({
+              try: () => {
+                delete require.cache[match]
+                return require(match) as Record<string, unknown>
+              },
               catch: (err) => err,
             }).pipe(Effect.catch((err) => {
               log.error("failed to load file hook", { path: match, error: errorMessage(err) })
               return Effect.succeed(undefined)
             }))
             if (!mod) continue
-            const hookObj: Hooks = mod.default ?? mod
+            const hookObj: Hooks = (mod.default ?? mod) as Hooks
             if (hookObj && typeof hookObj === "object") {
               const name = path.basename(match, path.extname(match))
               hooks.push(hookObj)
@@ -440,9 +465,67 @@ export const layer = Layer.effect(
           }
         }
 
-        return { hooks, meta }
+        // Dispatch bus events to file hooks' `event` handlers. Scoped to this
+        // cache entry: invalidation interrupts the fiber, and the rebuild
+        // re-subscribes with the fresh hook set.
+        if (hooks.some((hook) => typeof hook.event === "function")) {
+          yield* bus.subscribeAll().pipe(
+            Stream.runForEach((input) =>
+              Effect.sync(() => {
+                for (const entry of meta) {
+                  const fn = entry.hook.event
+                  if (!fn) continue
+                  try {
+                    void Promise.resolve(fn({ event: input as any })).catch((err) => {
+                      log.error("file hook event handler failed", { hook: entry.pluginName, error: errorMessage(err) })
+                    })
+                  } catch (err) {
+                    log.error("file hook event handler failed", { hook: entry.pluginName, error: errorMessage(err) })
+                  }
+                }
+              }),
+            ),
+            Effect.forkScoped,
+          )
+        }
+
+        return { hooks, meta, dirs, files, lastCheck: { value: Date.now() } }
       }),
     )
+
+    // Staleness check: re-stat known hook files and re-glob hook dirs. Any
+    // mtime change, added, or removed file invalidates the cache so the next
+    // InstanceState.get rebuilds it. Covers ALL writers (editors, git, other
+    // processes) — not just this process's write/edit tools. Throttled to
+    // avoid stat storms on hot trigger paths.
+    const freshFileHooks = Effect.gen(function* () {
+      const fh = yield* InstanceState.get(fileHookState)
+      const now = Date.now()
+      if (now - fh.lastCheck.value < FILE_HOOK_CHECK_INTERVAL_MS) return fh
+      fh.lastCheck.value = now
+
+      const stale = yield* Effect.promise(async () => {
+        const known = Object.keys(fh.files)
+        const seen = new Set<string>()
+        for (const dir of fh.dirs) {
+          for (const match of Glob.scanSync(FILE_HOOK_GLOB, { cwd: dir, absolute: true, dot: true, symlink: true })) {
+            seen.add(match)
+            if (!(match in fh.files)) return true
+          }
+        }
+        for (const file of known) {
+          if (!seen.has(file)) return true
+          const stat = await fs.promises.stat(file).catch(() => undefined)
+          if ((stat?.mtimeMs ?? 0) !== fh.files[file]) return true
+        }
+        return false
+      })
+
+      if (!stale) return fh
+      log.info("file hooks changed on disk, reloading")
+      yield* InstanceState.invalidate(fileHookState)
+      return yield* InstanceState.get(fileHookState)
+    })
 
     const aggregateDecision = (
       input: ActorPreStopInput | ActorPostStopInput,
@@ -450,7 +533,7 @@ export const layer = Layer.effect(
     ) =>
       Effect.gen(function* () {
         const s = yield* InstanceState.get(state)
-        const fh = yield* InstanceState.get(fileHookState)
+        const fh = yield* freshFileHooks
         const reasons: string[] = []
         const pluginNames: string[] = []
         const hookIDs: string[] = []
@@ -564,7 +647,7 @@ export const layer = Layer.effect(
     >(name: Name, input: Input, output: Output) {
       if (!name) return output
       const s = yield* InstanceState.get(state)
-      const fh = yield* InstanceState.get(fileHookState)
+      const fh = yield* freshFileHooks
 
       for (const entry of s.hooksWithMeta) {
         const fn = entry.hook[name] as any

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -441,13 +441,27 @@ export const layer = Layer.effect(
               catch: (err) => err,
             }).pipe(Effect.catch(() => Effect.succeed(undefined)))
             files[match] = stat?.mtimeMs ?? 0
-            // require() + cache delete instead of dynamic import: Bun ignores
-            // query-string cache busters on file: imports, so a re-import would
-            // return the stale module forever.
-            const mod = yield* Effect.try({
-              try: () => {
-                delete require.cache[match]
-                return require(match) as Record<string, unknown>
+            // Transpile and load the hook file. We use Bun.build to produce a
+            // temporary .js artifact, then dynamic-import that artifact. This
+            // avoids two pitfalls: (1) Bun's import() ignores query-string cache
+            // busters so re-imports return stale modules, (2) require() transpiles
+            // .ts in some contexts but not others (CI Linux edge case).
+            const mod = yield* Effect.tryPromise({
+              try: async () => {
+                const result = await Bun.build({
+                  entrypoints: [match],
+                  target: "bun",
+                  format: "esm",
+                })
+                if (!result.success) throw new Error(result.logs.map(String).join("\n"))
+                const blob = result.outputs[0]
+                const tmpFile = `${match}.${Date.now()}.mjs`
+                await Bun.write(tmpFile, blob)
+                try {
+                  return await import(tmpFile) as Record<string, unknown>
+                } finally {
+                  fs.promises.unlink(tmpFile).catch(() => {})
+                }
               },
               catch: (err) => err,
             }).pipe(Effect.catch((err) => {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -226,8 +226,11 @@ const TEXT_TOOL_CALL_RETRY_LIMIT = Flag.MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT
 
 const log = Log.create({ service: "session.prompt" })
 
+// Hooks are NOT listed here: the plugin layer detects hook file changes
+// itself via mtime staleness checks (covers external editors too), so only
+// tools and skills need the write/edit-triggered registry reload.
 function isExtensionPath(filePath: string): boolean {
-  return /\/\.mimocode\/(tools?|skills?|hooks?)\//.test(filePath)
+  return /\/\.mimocode\/(tools?|skills?)\//.test(filePath)
 }
 const elog = EffectLogger.create({ service: "session.prompt" })
 

--- a/packages/opencode/src/skill/builtin/.bundle/evolve/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/evolve/SKILL.md
@@ -5,7 +5,7 @@ description: Use when you want to modify ANY aspect of yourself — your capabil
 
 # Evolve — Total Self-Modification
 
-Every layer of you is rewritable by writing files to `.mimocode/` — hot-reloaded next turn, no restart:
+Every layer of you is rewritable by writing files to `.mimocode/` (reload semantics differ per layer — see File Locations):
 
 - **What you can do** — create tools, or override any built-in (bash, read, edit, ...) with your own implementation
 - **How you behave** — hooks intercept everything: every tool call (block/rewrite args/rewrite output), every LLM request (system prompt, message list, temperature, headers), every session and subagent lifecycle event (cancel a run before it starts, gate a subagent's delivery and force it to redo work, inspect full trajectories after each step)
@@ -87,8 +87,8 @@ export default {
 
 | Event | Capability |
 |-------|-----------|
-| `tool.execute.before` | Modify args or `cancel=true` to block |
-| `tool.execute.after` | Modify tool output |
+| `tool.execute.before` | Modify `output.args` or set `output.cancel=true` to block |
+| `tool.execute.after` | Modify tool result via `output.output` (string), `output.title`, `output.metadata` — NOT `output.result` |
 | `tool.definition` | Modify tool description/parameters |
 | `chat.params` | Modify temperature, topP, maxOutputTokens |
 | `experimental.chat.system.transform` | Append to system prompt |
@@ -99,7 +99,9 @@ export default {
 | `permission.ask` | Auto-allow/deny permission requests (not yet wired) |
 | `shell.env` | Inject environment variables |
 
-Full list with input/output types: @reference/hook-api.md
+Field names must match exactly — a typo'd field (e.g. `output.result`) fails
+silently. Always check @reference/hook-api.md for the exact input/output shape
+before writing a hook.
 
 ## Creating Skills
 

--- a/packages/opencode/src/skill/builtin/.bundle/evolve/reference/tui-api.md
+++ b/packages/opencode/src/skill/builtin/.bundle/evolve/reference/tui-api.md
@@ -2,17 +2,54 @@
 
 ## File Format
 
-```tsx
-import type { TuiPlugin } from "@mimo-ai/plugin/tui"
+The module must **default-export an object with a `tui()` function** — a named
+`export const tui` will fail to load with "must default export an object with tui()".
 
-export const tui: TuiPlugin = async (api, options, meta) => {
+```tsx
+import type { TuiPlugin, TuiPluginModule } from "@mimo-ai/plugin/tui"
+
+const tui: TuiPlugin = async (api, options, meta) => {
   // api — the full TUI plugin API
   // options — plugin options from config (if any)
   // meta — plugin metadata (id, source, version, etc.)
 }
+
+const plugin: TuiPluginModule & { id: string } = {
+  id: "my-plugin",
+  tui,
+}
+
+export default plugin
 ```
 
 File extension should be `.tsx` (JSX support for UI components).
+
+## How plugins load
+
+Files are auto-discovered from two directories at TUI startup:
+
+- `~/.config/mimocode/tui/*.{ts,tsx,js}` — global
+- `<project>/.mimocode/tui/*.{ts,tsx,js}` — project-local
+
+Plugins can also be declared in `tui.json` (global `~/.config/mimocode/tui.json`
+or project `.mimocode/tui.json`) via the `plugin` array (file URLs or npm specs).
+Either way, a **restart is required** — TUI plugins are only scanned at startup.
+
+## Rendering model — opentui, NOT HTML
+
+Components render to the **terminal** via opentui + Solid.js. HTML elements
+(`<div>`, `<span style="css">`, CSS properties) do not exist. Use:
+
+- `<box>` — flex container. Props: `flexDirection`, `gap`, `padding{Top,Bottom,Left,Right}`, `flexGrow`, `flexShrink`, `justifyContent`, `backgroundColor`
+- `<text>` — text line. Props: `fg={color}`, event handlers like `onMouseDown`
+- `<span style={{ fg: color }}>` — inline colored segment inside `<text>`
+- `<b>` — bold text
+
+Colors come from the theme: `api.theme.current.text`, `.textMuted`, `.primary`,
+`.success`, etc. (RGBA values). Do not hard-code hex CSS strings.
+
+Solid.js rules apply: no `useState`/`useEffect`; use `createMemo`, `createSignal`,
+`<Show>`, and accessor functions (`const theme = () => api.theme.current`).
 
 ## TuiPluginApi
 
@@ -48,10 +85,10 @@ api.route.register([
   {
     name: "my-dashboard",
     render: (input) => (
-      <div>
-        <h1>Dashboard</h1>
-        <p>Params: {JSON.stringify(input.params)}</p>
-      </div>
+      <box>
+        <text><b>Dashboard</b></text>
+        <text>Params: {JSON.stringify(input.params)}</text>
+      </box>
     ),
   },
 ])
@@ -68,10 +105,10 @@ Inject content into predefined UI slots.
 api.slots.register({
   slots: {
     sidebar_footer: (props) => (
-      <div>Session: {props.session_id}</div>
+      <text>Session: {props.session_id}</text>
     ),
     home_bottom: () => (
-      <div>Custom widget here</div>
+      <box><text>Custom widget here</text></box>
     ),
   },
 })
@@ -215,9 +252,9 @@ api.lifecycle.onDispose(() => {
 ## Complete Example
 
 ```tsx
-import type { TuiPlugin } from "@mimo-ai/plugin/tui"
+import type { TuiPlugin, TuiPluginModule } from "@mimo-ai/plugin/tui"
 
-export const tui: TuiPlugin = async (api) => {
+const tui: TuiPlugin = async (api) => {
   // Register a command
   api.command.register(() => [
     {
@@ -237,8 +274,9 @@ export const tui: TuiPlugin = async (api) => {
   api.slots.register({
     slots: {
       sidebar_footer: (props) => {
-        const status = api.state.session.status(props.session_id)
-        return <div>{status ?? "idle"}</div>
+        const theme = () => api.theme.current
+        const status = () => api.state.session.status(props.session_id)
+        return <text fg={theme().textMuted}>{status() ?? "idle"}</text>
       },
     },
   })
@@ -248,11 +286,18 @@ export const tui: TuiPlugin = async (api) => {
     console.log("Plugin deactivated")
   })
 }
+
+const plugin: TuiPluginModule & { id: string } = {
+  id: "project-stats",
+  tui,
+}
+
+export default plugin
 ```
 
 ## Constraints
 
-- TUI plugins need a restart to take effect (they run in a separate thread from the server)
+- TUI plugins need a restart to take effect (scanned only at TUI startup)
 - Use `.tsx` extension for JSX support
-- Components use Solid.js JSX (NOT React) — no useState/useEffect, use signals
+- Components use Solid.js JSX with opentui terminal elements (`<box>`, `<text>`, `<span>`, `<b>`) — no React hooks, no HTML/CSS
 - Keep plugins lightweight — they run in the main rendering thread

--- a/packages/opencode/test/plugin/file-hooks.test.ts
+++ b/packages/opencode/test/plugin/file-hooks.test.ts
@@ -50,6 +50,7 @@ describe("plugin file hooks", () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
         await Bun.write(path.join(dir, ".mimocode", "hooks", "greet.ts"), hookSource("v1"))
+        await Bun.write(path.join(dir, "mimocode.json"), '{}')
       },
     })
     const hookFile = path.join(tmp.path, ".mimocode", "hooks", "greet.ts")
@@ -66,7 +67,7 @@ describe("plugin file hooks", () => {
           fs.writeFileSync(hookFile, hookSource("v2"))
           const future = new Date(Date.now() + 5000)
           fs.utimesSync(hookFile, future, future)
-          yield* Effect.promise(() => Bun.sleep(600))
+          yield* Effect.promise(() => Bun.sleep(1200))
 
           return yield* triggerTransform()
         }).pipe(Effect.provide(Plugin.defaultLayer), Effect.runPromise),
@@ -79,6 +80,7 @@ describe("plugin file hooks", () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
         await fs.promises.mkdir(path.join(dir, ".mimocode", "hooks"), { recursive: true })
+        await Bun.write(path.join(dir, "mimocode.json"), '{}')
       },
     })
 
@@ -90,7 +92,7 @@ describe("plugin file hooks", () => {
           expect(first.system).toEqual([])
 
           fs.writeFileSync(path.join(tmp.path, ".mimocode", "hooks", "late.ts"), hookSource("late"))
-          yield* Effect.promise(() => Bun.sleep(600))
+          yield* Effect.promise(() => Bun.sleep(1200))
 
           return yield* triggerTransform()
         }).pipe(Effect.provide(Plugin.defaultLayer), Effect.runPromise),
@@ -107,6 +109,7 @@ describe("plugin file hooks", () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
         const sink = path.join(dir, "events.log")
+        await Bun.write(path.join(dir, "mimocode.json"), '{}')
         await Bun.write(
           path.join(dir, ".mimocode", "hooks", "listener.ts"),
           [
@@ -138,7 +141,7 @@ describe("plugin file hooks", () => {
             yield* bus.publish(Session.Event.Error, {
               error: { name: "UnknownError", data: { message: "probe" } } as any,
             })
-            yield* Effect.promise(() => Bun.sleep(300))
+            yield* Effect.promise(() => Bun.sleep(600))
           }),
         ),
     })

--- a/packages/opencode/test/plugin/file-hooks.test.ts
+++ b/packages/opencode/test/plugin/file-hooks.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import fs from "fs"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+
+const disableDefault = process.env.MIMOCODE_DISABLE_DEFAULT_PLUGINS
+process.env.MIMOCODE_DISABLE_DEFAULT_PLUGINS = "1"
+
+const { Plugin } = await import("../../src/plugin/index")
+const { Instance } = await import("../../src/project/instance")
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+afterAll(() => {
+  if (disableDefault === undefined) {
+    delete process.env.MIMOCODE_DISABLE_DEFAULT_PLUGINS
+    return
+  }
+  process.env.MIMOCODE_DISABLE_DEFAULT_PLUGINS = disableDefault
+})
+
+function hookSource(marker: string) {
+  return [
+    "export default {",
+    '  "experimental.chat.system.transform": async (_input, output) => {',
+    `    output.system.push(${JSON.stringify(marker)})`,
+    "  },",
+    "}",
+    "",
+  ].join("\n")
+}
+
+const triggerTransform = () =>
+  Effect.gen(function* () {
+    const plugin = yield* Plugin.Service
+    const out = { system: [] as string[] }
+    yield* plugin.trigger(
+      "experimental.chat.system.transform",
+      { model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" } as any },
+      out,
+    )
+    return out
+  })
+
+describe("plugin file hooks", () => {
+  test("loads hooks from .mimocode/hooks and picks up external edits without reload call", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".mimocode", "hooks", "greet.ts"), hookSource("v1"))
+      },
+    })
+    const hookFile = path.join(tmp.path, ".mimocode", "hooks", "greet.ts")
+
+    const out = await Instance.provide({
+      directory: tmp.path,
+      fn: async () =>
+        Effect.gen(function* () {
+          const first = yield* triggerTransform()
+          expect(first.system).toEqual(["v1"])
+
+          // Simulate an EXTERNAL edit (no write/edit tool, no reloadFileHooks):
+          // bump content and force a distinct mtime past the staleness throttle.
+          fs.writeFileSync(hookFile, hookSource("v2"))
+          const future = new Date(Date.now() + 5000)
+          fs.utimesSync(hookFile, future, future)
+          yield* Effect.promise(() => Bun.sleep(600))
+
+          return yield* triggerTransform()
+        }).pipe(Effect.provide(Plugin.defaultLayer), Effect.runPromise),
+    })
+
+    expect(out.system).toEqual(["v2"])
+  })
+
+  test("detects newly added hook files", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await fs.promises.mkdir(path.join(dir, ".mimocode", "hooks"), { recursive: true })
+      },
+    })
+
+    const out = await Instance.provide({
+      directory: tmp.path,
+      fn: async () =>
+        Effect.gen(function* () {
+          const first = yield* triggerTransform()
+          expect(first.system).toEqual([])
+
+          fs.writeFileSync(path.join(tmp.path, ".mimocode", "hooks", "late.ts"), hookSource("late"))
+          yield* Effect.promise(() => Bun.sleep(600))
+
+          return yield* triggerTransform()
+        }).pipe(Effect.provide(Plugin.defaultLayer), Effect.runPromise),
+    })
+
+    expect(out.system).toEqual(["late"])
+  })
+
+  test("dispatches bus events to file hook event handlers", async () => {
+    const { AppRuntime } = await import("../../src/effect/app-runtime")
+    const { Bus } = await import("../../src/bus")
+    const { Session } = await import("../../src/session")
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const sink = path.join(dir, "events.log")
+        await Bun.write(
+          path.join(dir, ".mimocode", "hooks", "listener.ts"),
+          [
+            "import fs from 'fs'",
+            "export default {",
+            "  event: async ({ event }) => {",
+            `    fs.appendFileSync(${JSON.stringify(sink)}, event.type + "\\n")`,
+            "  },",
+            "}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+    const sink = path.join(tmp.path, "events.log")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () =>
+        AppRuntime.runPromise(
+          Effect.gen(function* () {
+            // Force file hook state (and its bus subscription) to initialize.
+            const plugin = yield* Plugin.Service
+            yield* plugin.init()
+            // Give the forked subscription fiber time to register on the bus.
+            yield* Effect.promise(() => Bun.sleep(100))
+
+            const bus = yield* Bus.Service
+            yield* bus.publish(Session.Event.Error, {
+              error: { name: "UnknownError", data: { message: "probe" } } as any,
+            })
+            yield* Effect.promise(() => Bun.sleep(300))
+          }),
+        ),
+    })
+
+    const logged = fs.existsSync(sink) ? fs.readFileSync(sink, "utf8") : ""
+    expect(logged).toContain("session.error")
+  })
+})


### PR DESCRIPTION
File hooks under .mimocode/{hook,hooks}/ previously reloaded only when this process's write/edit tools touched them, so external edits (editors, git, other processes) never took effect until restart. Replace that write-path regex trigger with an mtime staleness check on the trigger path (throttled to 500ms) that detects modified, added, and removed hook files from any writer.

Also fixes two latent bugs:
- Bun ignores query-string cache busters on file: dynamic imports, so hook reloads silently returned the stale module forever; load via require() with cache deletion instead.
- File hooks' `event` handlers were never dispatched (only plugin hooks were subscribed to the bus); subscribe them within the cache entry scope so invalidation re-binds the fresh hook set.

Update the evolve skill docs to match verified behavior: TUI plugins must default-export an object with tui(), render via opentui elements (not HTML), and load from tui dirs/tui.json at startup; document exact tool.execute.after output fields.