### PR TITLE
fix(tui): hide internal subagent child sessions from the session list

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -847,8 +847,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             sdk.client.session.actors({ sessionID }),
             sdk.client.session.task({ sessionID }),
             // children aren't in the root-only session list; fetch them so the
-            // session dialog can show the current session's child sessions
-            sdk.client.session.children({ sessionID }).catch(() => undefined),
+            // session dialog can show the current session's child sessions.
+            // visible: true hides internal machinery children (checkpoint-writer
+            // hosts, ask-tool forks, workflow subagent sessions) — only peer
+            // sessions the user should see are returned.
+            sdk.client.session.children({ sessionID, visible: true }).catch(() => undefined),
           ])
           setStore(
             produce((draft) => {

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -201,11 +201,21 @@ export const SessionRoutes = lazy(() =>
           sessionID: Session.ChildrenInput,
         }),
       ),
+      validator(
+        "query",
+        z.object({
+          visible: z.coerce
+            .boolean()
+            .optional()
+            .meta({ description: "Only return user-visible children (peer sessions); hides internal subagent hosts" }),
+        }),
+      ),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
+        const visible = c.req.valid("query").visible
         return jsonRequest("SessionRoutes.children", c, function* () {
           const session = yield* Session.Service
-          return yield* session.children(sessionID)
+          return yield* session.children(sessionID, { visible })
         })
       },
     )

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -12,6 +12,7 @@ import { Database, NotFoundError, eq, and, gte, isNull, desc, like, inArray, lt 
 import { SyncEvent } from "../sync"
 import type { SQL } from "../storage"
 import { PartTable, SessionTable, MessageTable } from "./session.sql"
+import { ActorRegistryTable } from "../actor/actor.sql"
 import { ProjectTable } from "../project/project.sql"
 import { Storage } from "@/storage"
 import { Log } from "../util"
@@ -388,7 +389,7 @@ export interface Interface {
      */
     agentID?: string
   }) => Effect.Effect<MessageV2.WithParts[]>
-  readonly children: (parentID: SessionID) => Effect.Effect<Info[]>
+  readonly children: (parentID: SessionID, options?: { visible?: boolean }) => Effect.Effect<Info[]>
   readonly remove: (sessionID: SessionID) => Effect.Effect<void>
   readonly updateMessage: <T extends MessageV2.Info>(msg: T) => Effect.Effect<T>
   readonly removeMessage: (input: { sessionID: SessionID; messageID: MessageID }) => Effect.Effect<MessageID>
@@ -496,7 +497,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
       return fromRow(row)
     })
 
-    const children = Effect.fn("Session.children")(function* (parentID: SessionID) {
+    const children = Effect.fn("Session.children")(function* (parentID: SessionID, options?: { visible?: boolean }) {
       const rows = yield* db((d) =>
         d
           .select()
@@ -504,7 +505,22 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
           .where(and(eq(SessionTable.parent_id, parentID)))
           .all(),
       )
-      return rows.map(fromRow)
+      if (!options?.visible) return rows.map(fromRow)
+      if (!rows.length) return []
+      // visible: only children a user should see in session lists. Peer actors
+      // register under the child session with actor_id === session id; internal
+      // machinery children (checkpoint-writer hosts, ask-tool forks, workflow
+      // subagent sessions) register as mode "subagent" or have no actor row at
+      // all — both are filtered out.
+      const peerRows = yield* db((d) =>
+        d
+          .select({ session_id: ActorRegistryTable.session_id })
+          .from(ActorRegistryTable)
+          .where(and(inArray(ActorRegistryTable.session_id, rows.map((r) => r.id)), eq(ActorRegistryTable.mode, "peer")))
+          .all(),
+      )
+      const peers = new Set(peerRows.map((r) => r.session_id))
+      return rows.filter((r) => peers.has(r.id)).map(fromRow)
     })
 
     const remove: Interface["remove"] = Effect.fnUntraced(function* (sessionID: SessionID) {

--- a/packages/opencode/test/session/children-visible.test.ts
+++ b/packages/opencode/test/session/children-visible.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config"
+import { ActorRegistry } from "../../src/actor/registry"
+import { Log } from "../../src/util"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { Session } from "../../src/session"
+import type { SessionID } from "../../src/session/schema"
+import { testEffect } from "../lib/effect"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+
+void Log.init({ print: false })
+
+const env = Layer.mergeAll(
+  Session.defaultLayer,
+  ActorRegistry.defaultLayer,
+  Bus.layer,
+  Config.defaultLayer,
+  CrossSpawnSpawner.defaultLayer,
+)
+
+const it = testEffect(env)
+
+describe("session.children visible filter", () => {
+  it.live("visible: true returns only peer children, hides subagent hosts and orphans", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const session = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+
+        const parent = yield* session.create({ title: "parent" })
+
+        // 1. Peer child: has an actor row with mode "peer" keyed on its own id.
+        const peer = yield* session.create({ parentID: parent.id as SessionID, title: "peer child" })
+        yield* actorReg.register({
+          sessionID: peer.id as SessionID,
+          actorID: peer.id,
+          mode: "peer",
+          agent: "general",
+          description: "peer child",
+          contextMode: "none",
+          contextWatermark: undefined,
+          background: false,
+          lifecycle: "persistent",
+          tools: undefined,
+        })
+
+        // 2. Subagent host child (e.g. checkpoint-writer / ask fork / workflow agent).
+        const subagentHost = yield* session.create({ parentID: parent.id as SessionID, title: "checkpoint-writer: x" })
+        yield* actorReg.register({
+          sessionID: subagentHost.id as SessionID,
+          actorID: "checkpoint-writer-1",
+          mode: "subagent",
+          agent: "checkpoint-writer",
+          description: "writer",
+          contextMode: "none",
+          contextWatermark: undefined,
+          background: true,
+          lifecycle: "ephemeral",
+          tools: undefined,
+        })
+
+        // 3. Orphan child: no actor row at all.
+        const orphan = yield* session.create({ parentID: parent.id as SessionID, title: "orphan" })
+
+        const all = yield* session.children(parent.id as SessionID)
+        expect(all.map((s) => s.id).toSorted()).toEqual([peer.id, subagentHost.id, orphan.id].toSorted())
+
+        const visible = yield* session.children(parent.id as SessionID, { visible: true })
+        expect(visible.map((s) => s.id)).toEqual([peer.id])
+      }),
+    ),
+  )
+
+  it.live("visible: true with no children returns empty", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const session = yield* Session.Service
+        const parent = yield* session.create({ title: "lonely parent" })
+        const visible = yield* session.children(parent.id as SessionID, { visible: true })
+        expect(visible).toEqual([])
+      }),
+    ),
+  )
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1952,6 +1952,7 @@ export class Session2 extends HeyApiClient {
       sessionID: string
       directory?: string
       workspace?: string
+      visible?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1963,6 +1964,7 @@ export class Session2 extends HeyApiClient {
             { in: "path", key: "sessionID" },
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+            { in: "query", key: "visible" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1916,6 +1916,12 @@ export type Config = {
    */
   $schema?: string
   logLevel?: LogLevel
+  /**
+   * Environment variables to inject into the mimocode process and its child processes (e.g. the bash tool). A variable already set in the real environment takes precedence — config values only apply when the variable is not already set. Supports {env:VAR} and {file:path} substitution.
+   */
+  env?: {
+    [key: string]: string
+  }
   server?: ServerConfig
   /**
    * Command configuration, see https://opencode.ai/docs/commands
@@ -4250,6 +4256,10 @@ export type SessionChildrenData = {
   query?: {
     directory?: string
     workspace?: string
+    /**
+     * Only return user-visible children (peer sessions); hides internal subagent hosts
+     */
+    visible?: boolean
   }
   url: "/session/{sessionID}/children"
 }


### PR DESCRIPTION
The session list showed every child session of the current session, including internal machinery hosts (checkpoint-writer sessions, ask-tool forks, workflow subagent sessions) that users should never see.

Add a `visible` option to Session.children and the /children endpoint: when set, only children with a peer actor registration (mode "peer", actor_id = session id) are returned. Subagent hosts and orphan children with no actor row are filtered out. The TUI sync now requests visible children only; internal callers (recursive session removal) keep the unfiltered behavior.
