### PR TITLE
feat(provider,tui): default models to image-capable + per-model vision toggle

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -40,6 +40,20 @@ export function DialogModel(props: { providerID?: string }) {
   const modelName = (providerID: string, modelID: string) =>
     modelID === "mimo-auto" ? t("tui.model.mimo_auto.name") : Model.name(sync.data.provider, providerID, modelID)
 
+  // Vision is the default, so tagging every model would be pure noise. Flag
+  // only the minority that CANNOT read images (the noteworthy case). Toggle a
+  // model's image capability with ctrl+o.
+  const visionTag = (providerID: string, modelID: string) => {
+    const model = sync.data.provider.find((p) => p.id === providerID)?.models[modelID]
+    if (!model) return undefined
+    return model.capabilities.input.image ? undefined : "text-only"
+  }
+  const withVision = (providerID: string, modelID: string, description: string | undefined) => {
+    const tag = visionTag(providerID, modelID)
+    if (!tag) return description
+    return description ? `${description} · ${tag}` : tag
+  }
+
   const showExtra = createMemo(() => connected() && !props.providerID)
 
   const options = createMemo(() => {
@@ -174,7 +188,7 @@ export function DialogModel(props: { providerID?: string }) {
           map(([model, info]) => ({
             value: { providerID: provider.id, modelID: model },
             title: info.name ?? model,
-            description: undefined as string | undefined,
+            description: withVision(provider.id, model, undefined),
             category: connected() ? provider.name : undefined,
             disabled: provider.id === "opencode" && model.includes("-nano"),
             footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
@@ -279,6 +293,15 @@ export function DialogModel(props: { providerID?: string }) {
             local.model.toggleFavorite(v)
           },
         },
+        {
+          keybind: keybind.all.model_vision_toggle?.[0],
+          title: "Toggle vision",
+          onTrigger: (option) => {
+            const v = option.value as { providerID: string; modelID: string }
+            if (v.modelID === ADD_MODEL_SENTINEL) return
+            void toggleVision({ sdk, sync, toast, providerID: v.providerID, modelID: v.modelID })
+          },
+        },
       ]}
       onFilter={setQuery}
       flat={true}
@@ -332,4 +355,61 @@ async function runAddModelWizard(opts: {
   await sdk.client.instance.dispose()
   await sync.bootstrap()
   dialog.replace(() => <DialogModel providerID={providerID} />)
+}
+
+// Toggle whether a model accepts image input by editing its
+// modalities.input in mimocode.json, then live-reload so the change applies
+// immediately. Preserves the model's other input modalities.
+async function toggleVision(opts: {
+  sdk: ReturnType<typeof useSDK>
+  sync: ReturnType<typeof useSync>
+  toast: ToastContext
+  providerID: string
+  modelID: string
+}) {
+  const { sdk, sync, toast, providerID, modelID } = opts
+
+  const provider = sync.data.provider.find((p) => p.id === providerID)
+  const model = provider?.models[modelID]
+  if (!model) {
+    toast.show({ variant: "error", message: `Model ${providerID}/${modelID} not found` })
+    return
+  }
+
+  const current = model.capabilities.input
+  const nextImage = !current.image
+  // Rebuild the input modality list from current capabilities, flipping image.
+  const modalities = (["text", "audio", "image", "video", "pdf"] as const).filter((m) =>
+    m === "image" ? nextImage : current[m],
+  )
+
+  const patch = {
+    provider: {
+      [providerID]: {
+        models: {
+          [modelID]: {
+            modalities: { input: modalities, output: [] as string[] },
+          },
+        },
+      },
+    },
+  }
+  // Preserve declared output modalities if any (config re-merges over models.dev).
+  patch.provider[providerID].models[modelID].modalities.output = (
+    ["text", "audio", "image", "video", "pdf"] as const
+  ).filter((m) => model.capabilities.output[m])
+
+  const updateRes = await sdk.client.global.config.update({ config: patch as any })
+  if (updateRes.error) {
+    toast.show({ variant: "error", message: JSON.stringify(updateRes.error) })
+    return
+  }
+
+  await sdk.client.instance.dispose()
+  await sync.bootstrap()
+  toast.show({
+    variant: nextImage ? "success" : "info",
+    message: `${model.name ?? modelID}: image input ${nextImage ? "enabled" : "disabled"}`,
+    duration: 3000,
+  })
 }

--- a/packages/opencode/src/config/keybinds.ts
+++ b/packages/opencode/src/config/keybinds.ts
@@ -33,6 +33,7 @@ const KeybindsSchema = Schema.Struct({
   stash_delete: keybind("ctrl+d", "Delete stash entry"),
   model_provider_list: keybind("ctrl+a", "Open provider list from model dialog"),
   model_favorite_toggle: keybind("ctrl+f", "Toggle model favorite status"),
+  model_vision_toggle: keybind("ctrl+o", "Toggle whether the model accepts image input"),
   session_share: keybind("none", "Share current session"),
   session_unshare: keybind("none", "Unshare current session"),
   session_interrupt: keybind("escape", "Interrupt current session"),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1024,7 +1024,10 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
       input: {
         text: model.modalities?.input?.includes("text") ?? false,
         audio: model.modalities?.input?.includes("audio") ?? false,
-        image: model.modalities?.input?.includes("image") ?? false,
+        // Default to image-capable when modalities are unspecified: most current
+        // models accept image input, and a false negative silently strips images.
+        // Set modalities.input WITHOUT "image" to explicitly mark a text-only model.
+        image: model.modalities?.input?.includes("image") ?? true,
         video: model.modalities?.input?.includes("video") ?? false,
         pdf: model.modalities?.input?.includes("pdf") ?? false,
       },
@@ -1194,7 +1197,9 @@ const layer: Layer.Layer<
                 input: {
                   text: model.modalities?.input?.includes("text") ?? existingModel?.capabilities.input.text ?? true,
                   audio: model.modalities?.input?.includes("audio") ?? existingModel?.capabilities.input.audio ?? false,
-                  image: model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? false,
+                  // Default to image-capable when unspecified anywhere (config + models.dev).
+                  // Declare modalities.input without "image" to mark a text-only model.
+                  image: model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? true,
                   video: model.modalities?.input?.includes("video") ?? existingModel?.capabilities.input.video ?? false,
                   pdf: model.modalities?.input?.includes("pdf") ?? existingModel?.capabilities.input.pdf ?? false,
                 },

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1083,6 +1083,49 @@ test("model modalities default correctly", async () => {
       const model = providers[ProviderID.make("test-provider")].models["test-model"]
       expect(model.capabilities.input.text).toBe(true)
       expect(model.capabilities.output.text).toBe(true)
+      // Image input defaults to true when modalities are unspecified (a model is
+      // assumed vision-capable unless it explicitly declares modalities without "image").
+      expect(model.capabilities.input.image).toBe(true)
+      // Other non-text modalities still default to false.
+      expect(model.capabilities.input.audio).toBe(false)
+      expect(model.capabilities.input.pdf).toBe(false)
+    },
+  })
+})
+
+test("explicit text-only modalities disable image input", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "test-provider": {
+              name: "Test",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "text-only": {
+                  name: "Text Only",
+                  tool_call: true,
+                  limit: { context: 8000, output: 2000 },
+                  modalities: { input: ["text"], output: ["text"] },
+                },
+              },
+              options: { apiKey: "test" },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const model = providers[ProviderID.make("test-provider")].models["text-only"]
+      expect(model.capabilities.input.image).toBe(false)
     },
   })
 })
@@ -1288,12 +1331,12 @@ test("getVisionModel prefers in-house model over cheaper non-in-house", async ()
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      // mimo-vision (cost 100, in-house) beats vendor-cheap-vision (cost 1);
-      // vendor-text is text-only and excluded entirely.
+      // In-house (mimo) beats any cheaper external vision model. With image
+      // input now defaulting on, other mimo catalog models also qualify as
+      // vision-capable, so assert the winner is in-house rather than a specific id.
       const model = await getVisionModel()
       expect(model).toBeDefined()
       expect(String(model?.providerID)).toBe("mimo")
-      expect(String(model?.id)).toBe("mimo-vision")
     },
   })
 })


### PR DESCRIPTION
Flip the terminal fallback for capabilities.input.image from false to true in both model-build paths (fromModelsDevModel and the config merge): when neither models.dev metadata nor config declares modalities, a model is now assumed vision-capable instead of silently stripping images. A model is text-only only when it explicitly declares modalities.input without "image".

Adds a per-model vision toggle to the TUI model picker (ctrl+o, since ctrl+i collides with Tab in terminals): it rewrites the model's modalities.input in mimocode.json and live-reloads. Since vision is now the default, the row indicator flags only the minority that are text-only rather than tagging every vision model.

Updates provider tests: assert the new image=true default and text-only opt-out; the "prefers in-house vision model" test now asserts the winning provider rather than a specific id (more mimo models qualify as vision now).