### PR TITLE
fix(tui): filter compose: skills from slash autocomplete in build mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -6,6 +6,7 @@ import { createMemo, createResource, createEffect, onMount, onCleanup, Index, Sh
 import { createStore } from "solid-js/store"
 import { useSDK } from "@tui/context/sdk"
 import { useSync } from "@tui/context/sync"
+import { useLocal } from "@tui/context/local"
 import { getScrollAcceleration } from "../../util/scroll"
 import { useTuiConfig } from "../../context/tui-config"
 import { useTheme, selectedForeground } from "@tui/context/theme"
@@ -84,6 +85,7 @@ export function Autocomplete(props: {
 }) {
   const sdk = useSDK()
   const sync = useSync()
+  const local = useLocal()
   const command = useCommandDialog()
   const lang = useLanguage()
   const { theme } = useTheme()
@@ -370,6 +372,7 @@ export function Autocomplete(props: {
 
     for (const serverCommand of sync.data.command) {
       if (serverCommand.source === "skill" && !Flag.MIMOCODE_ENABLE_SLASH_SKILLS) continue
+      if (serverCommand.source === "skill" && serverCommand.name.startsWith("compose:") && local.agent.current()?.name !== "compose") continue
       const label = serverCommand.source === "mcp" ? ":mcp" : ""
       results.push({
         display: "/" + serverCommand.name + label,


### PR DESCRIPTION
## Summary

- When `MIMOCODE_ENABLE_SLASH_SKILLS=1` is set, `compose:` prefixed skills leaked into the `/` autocomplete for non-compose agents (build/plan mode)
- Added filtering in autocomplete.tsx to skip `compose:` skills unless the current agent is "compose", matching the existing pattern in `dialog-skill.tsx`

## Root Cause

#1555 introduced the `MIMOCODE_ENABLE_SLASH_SKILLS` flag to gate skill-source commands in the `/` autocomplete, but only checked whether slash skills were globally enabled without filtering agent-specific skills like `compose:*`.

## Fix

Added a single filter line after the existing flag check:
```ts
if (serverCommand.source === "skill" && serverCommand.name.startsWith("compose:") && local.agent.current()?.name !== "compose") continue
```

## Compatibility with #1654

#1654 flips `MIMOCODE_ENABLE_SLASH_SKILLS` → `MIMOCODE_DISABLE_SLASH_SKILLS` (enabled by default). This fix is on an independent line and does not conflict — the compose filter works regardless of which flag controls the overall slash-skills visibility.