### PR TITLE
fix: correct config schema doc URLs to mimo.xiaomi.com

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -106,7 +106,7 @@ const InfoSchema = Schema.Struct({
     description: "Server configuration for mimo serve and web commands",
   }),
   command: Schema.optional(Schema.Record(Schema.String, ConfigCommand.Info)).annotate({
-    description: "Command configuration, see https://opencode.ai/docs/commands",
+    description: "Command configuration, see https://mimo.xiaomi.com/mimocode/commands",
   }),
   skills: Schema.optional(ConfigSkills.Info).annotate({ description: "Additional skill folder paths" }),
   compose: Schema.optional(ConfigCompose.Info).annotate({ description: "Compose mode configuration" }),
@@ -196,7 +196,7 @@ const InfoSchema = Schema.Struct({
       }),
       [Schema.Record(Schema.String, AgentRef)],
     ),
-  ).annotate({ description: "Agent configuration, see https://opencode.ai/docs/agents" }),
+  ).annotate({ description: "Agent configuration, see https://mimo.xiaomi.com/mimocode/agents" }),
   provider: Schema.optional(Schema.Record(Schema.String, ConfigProvider.Info)).annotate({
     description: "Custom provider configurations and model overrides",
   }),


### PR DESCRIPTION
## Summary

- Replace stale `opencode.ai` doc URLs in config schema annotations with the correct `mimo.xiaomi.com` equivalents
- Correct URL paths: `/mimocode/commands` and `/mimocode/agents` (without `/docs/` segment)

## Context

Supersedes #1609 — that PR correctly identified the problem (residual `opencode.ai` URLs in description annotations) but used incorrect replacement URLs (`/mimocode/docs/commands` and `/mimocode/docs/agents`) which return **404**.

Verified correct URLs:
| URL | Status |
|-----|--------|
| `https://mimo.xiaomi.com/mimocode/commands` | 200 |
| `https://mimo.xiaomi.com/mimocode/agents` | 200 |
| `https://mimo.xiaomi.com/mimocode/docs/commands` (used in #1609) | 404 |
| `https://mimo.xiaomi.com/mimocode/docs/agents` (used in #1609) | 404 |

## Changes

```diff
- description: "Command configuration, see https://opencode.ai/docs/commands"
+ description: "Command configuration, see https://mimo.xiaomi.com/mimocode/commands"

- description: "Agent configuration, see https://opencode.ai/docs/agents"
+ description: "Agent configuration, see https://mimo.xiaomi.com/mimocode/agents"
```

Closes #1609