### PR TITLE
fix(tui): session-list, 429 normalization, CJK tool-args, structured error render

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1,4 +1,4 @@
-import { BoxRenderable, RGBA, TextareaRenderable, MouseEvent, PasteEvent, decodePasteBytes } from "@opentui/core"
+import { BoxRenderable, RGBA, TextareaRenderable, MouseEvent, PasteEvent, decodePasteBytes, TextAttributes } from "@opentui/core"
 import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
 import "opentui-spinner/solid"
 import path from "path"
@@ -32,6 +32,7 @@ import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
 import { Locale } from "@/util"
 import { formatDuration } from "@/util/format"
+import { SessionRetry } from "@/session/retry"
 import { createColors, createFrames } from "../../ui/spinner.ts"
 import { useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderConnect } from "../dialog-provider"
@@ -1861,20 +1862,33 @@ export function Prompt(props: PromptProps) {
                       }
                     }
 
-                    const retryText = () => {
+                    // A rate-limit gets a clean, distinct label instead of the
+                    // raw provider message; other errors show the truncated
+                    // clean message. The attempt/countdown is a SEPARATE styled
+                    // status segment, not concatenated into the message string,
+                    // so it renders as structure rather than raw text. See T30.
+                    const isRateLimit = createMemo(() => {
+                      const r = retry()
+                      return r ? SessionRetry.isRateLimitMessage(r.message) : false
+                    })
+                    const label = createMemo(() => (isRateLimit() ? "Rate limited" : message()))
+                    const statusText = createMemo(() => {
                       const r = retry()
                       if (!r) return ""
-                      const baseMessage = message()
-                      const truncatedHint = isTruncated() ? " (click to expand)" : ""
                       const duration = formatDuration(seconds())
-                      const retryInfo = ` [retrying ${duration ? `in ${duration} ` : ""}attempt #${r.attempt}]`
-                      return baseMessage + truncatedHint + retryInfo
-                    }
+                      return `attempt #${r.attempt}${duration ? ` · retrying in ${duration}` : " · retrying"}`
+                    })
 
                     return (
                       <Show when={retry()}>
-                        <box onMouseUp={handleMessageClick}>
-                          <text fg={theme.error}>{retryText()}</text>
+                        <box flexDirection="row" gap={1} onMouseUp={handleMessageClick}>
+                          <text fg={isRateLimit() ? theme.warning : theme.error} attributes={TextAttributes.BOLD}>
+                            {label()}
+                          </text>
+                          <Show when={isTruncated()}>
+                            <text fg={theme.textMuted}>(click to expand)</text>
+                          </Show>
+                          <text fg={theme.textMuted}>{statusText()}</text>
                         </box>
                       </Show>
                     )

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1679,23 +1679,32 @@ const PART_MAPPING = {
 
 type MessageError = NonNullable<AssistantMessage["error"]>
 
+// Classify a terminal assistant error so the render layer can present it as a
+// structured, visually-distinct card (distinct label + color) rather than
+// dumping a raw provider blob into the transcript. A rate-limit gets its own
+// kind so the header reads "Rate limited" instead of a generic error. See T30.
+function errorKind(error: MessageError): "rate-limit" | "error" {
+  if (error.name === "APIError") {
+    const data = error.data as { statusCode?: number; responseBody?: string; message?: string }
+    if (
+      data.statusCode === 429 ||
+      SessionRetry.isRateLimitMessage(data.message ?? "") ||
+      (typeof data.responseBody === "string" && SessionRetry.isRateLimitMessage(data.responseBody))
+    ) {
+      return "rate-limit"
+    }
+  }
+  return "error"
+}
+
 function errorBody(error: MessageError): string {
   if (error.name === "MessageOutputLengthError") return "Output length limit reached"
   const message = (error.data as { message?: string }).message ?? "Unknown error"
-  // Defensive normalization: a 429 that reaches a TERMINAL assistant error
-  // (retries exhausted, or a shape retryable() didn't classify) would otherwise
-  // dump the raw provider blob here. Present a clean rate-limit message instead
-  // of leaking JSON/HTML into the TUI. Detect by APIError 429 status or a
-  // rate-limit signal in the message or response body. See T18.
-  if (error.name === "APIError") {
-    const data = error.data as { statusCode?: number; responseBody?: string }
-    if (
-      data.statusCode === 429 ||
-      SessionRetry.isRateLimitMessage(message) ||
-      (typeof data.responseBody === "string" && SessionRetry.isRateLimitMessage(data.responseBody))
-    ) {
-      return "Too Many Requests — the provider is rate limiting. Please wait a moment and try again."
-    }
+  // A 429 that reaches a TERMINAL assistant error (retries exhausted, or a shape
+  // retryable() didn't classify) would otherwise dump the raw provider blob here.
+  // Present a clean rate-limit message instead of leaking JSON/HTML. See T18/T30.
+  if (errorKind(error) === "rate-limit") {
+    return "The provider is rate limiting. Please wait a moment and try again."
   }
   return message
 }
@@ -1714,20 +1723,39 @@ function errorMeta(error: MessageError): string | undefined {
 
 function ErrorBlock(props: { error: MessageError }) {
   const { theme } = useTheme()
+  const kind = createMemo(() => errorKind(props.error))
+  const color = createMemo(() => (kind() === "rate-limit" ? theme.warning : theme.error))
+  const label = createMemo(() => (kind() === "rate-limit" ? "Rate limited" : "Error"))
   const meta = createMemo(() => errorMeta(props.error))
+  // Render as a structured, visually-distinct card (left border + panel bg),
+  // consistent with the workflow/permission cards, so a terminal error never
+  // looks like raw text pasted into the transcript. See T30.
   return (
-    <box flexDirection="column" paddingLeft={3} marginTop={1}>
-      <text fg={theme.error} wrapMode="word">
-        <span style={{ fg: theme.error }}>✗  </span>
-        {errorBody(props.error)}
-      </text>
-      <Show when={meta()}>
-        <box paddingLeft={3}>
-          <text fg={theme.textMuted} wrapMode="word">
-            {meta()}
-          </text>
-        </box>
-      </Show>
+    <box
+      flexDirection="column"
+      border={["left"]}
+      customBorderChars={SplitBorder.customBorderChars}
+      borderColor={color()}
+      backgroundColor={theme.backgroundPanel}
+      paddingTop={1}
+      paddingBottom={1}
+      paddingLeft={2}
+      marginTop={1}
+      gap={1}
+    >
+      <box flexDirection="row" gap={1} paddingLeft={3}>
+        <text fg={color()} attributes={TextAttributes.BOLD}>
+          ✗ {label()}
+        </text>
+        <Show when={meta()}>
+          <text fg={theme.textMuted}>· {meta()}</text>
+        </Show>
+      </box>
+      <box paddingLeft={3}>
+        <text fg={theme.text} wrapMode="word">
+          {errorBody(props.error)}
+        </text>
+      </box>
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1681,7 +1681,23 @@ type MessageError = NonNullable<AssistantMessage["error"]>
 
 function errorBody(error: MessageError): string {
   if (error.name === "MessageOutputLengthError") return "Output length limit reached"
-  return (error.data as { message?: string }).message ?? "Unknown error"
+  const message = (error.data as { message?: string }).message ?? "Unknown error"
+  // Defensive normalization: a 429 that reaches a TERMINAL assistant error
+  // (retries exhausted, or a shape retryable() didn't classify) would otherwise
+  // dump the raw provider blob here. Present a clean rate-limit message instead
+  // of leaking JSON/HTML into the TUI. Detect by APIError 429 status or a
+  // rate-limit signal in the message or response body. See T18.
+  if (error.name === "APIError") {
+    const data = error.data as { statusCode?: number; responseBody?: string }
+    if (
+      data.statusCode === 429 ||
+      SessionRetry.isRateLimitMessage(message) ||
+      (typeof data.responseBody === "string" && SessionRetry.isRateLimitMessage(data.responseBody))
+    ) {
+      return "Too Many Requests — the provider is rate limiting. Please wait a moment and try again."
+    }
+  }
+  return message
 }
 
 function errorMeta(error: MessageError): string | undefined {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -120,6 +120,17 @@ export function retryable(error: Err) {
     // Upstream processing failures (e.g. multimodal data corruption) return 400
     // but are transient — retry them.
     if (status === 400 && error.data.responseBody?.includes("upstream_error")) return error.data.message
+    // Free-usage exhaustion is delivered as an HTTP 429 with a
+    // `type:FreeUsageLimitError` body that also reads "Rate limit exceeded".
+    // It is a TERMINAL, non-retryable condition — the user must subscribe to
+    // Go. This MUST be checked before the generic 429-retry branch below,
+    // otherwise the 429 branch swallows it into "Too Many Requests" + a
+    // day-long retry-after and the upsell prompt is never shown. See PR #1680.
+    if (error.data.responseBody?.includes("FreeUsageLimitError")) return GO_UPSELL_MESSAGE
+    // Subscription (Go) usage exhaustion is also an HTTP 429 but is likewise
+    // terminal — the plan's quota is spent, retrying just hangs the session.
+    // Exclude it from the generic 429-retry path the same way.
+    if (error.data.responseBody?.includes("SubscriptionUsageLimitError")) return undefined
     // 429 rate-limits are transient and retryable EVEN when the provider SDK
     // marked the APIError isRetryable:false (many do, expecting the caller to
     // honor retry-after). Prior fix (T7) only normalized 429s in the retry-status
@@ -139,7 +150,6 @@ export function retryable(error: Err) {
     // 5xx errors are transient server failures and should always be retried,
     // even when the provider SDK doesn't explicitly mark them as retryable.
     if (!error.data.isRetryable && !(status !== undefined && status >= 500)) return undefined
-    if (error.data.responseBody?.includes("FreeUsageLimitError")) return GO_UPSELL_MESSAGE
     return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message
   }
 

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -44,10 +44,13 @@ export function isRetryableTransientError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
 
   const status =
-    (error as { status?: number }).status ??
-    (error as { statusCode?: number }).statusCode ??
-    (error as { response?: { status?: number } }).response?.status
-  if (typeof status === "number" && RETRYABLE_HTTP_STATUS.has(status)) return true
+    (error as { status?: number | string }).status ??
+    (error as { statusCode?: number | string }).statusCode ??
+    (error as { response?: { status?: number | string } }).response?.status
+  // Some providers surface the HTTP status as a numeric string (e.g. "429")
+  // rather than a number — coerce before matching so the 429 path is not missed.
+  const statusNum = typeof status === "string" ? Number.parseInt(status, 10) : status
+  if (typeof statusNum === "number" && !Number.isNaN(statusNum) && RETRYABLE_HTTP_STATUS.has(statusNum)) return true
 
   const code = (error as { code?: string }).code
   if (typeof code === "string" && NETWORK_ERROR_CODES.has(code)) return true
@@ -119,19 +122,6 @@ export function retryable(error: Err) {
     return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message
   }
 
-  // Check for rate limit patterns in plain text error messages
-  const msg = error.data?.message
-  if (typeof msg === "string") {
-    const lower = msg.toLowerCase()
-    if (
-      lower.includes("rate increased too quickly") ||
-      lower.includes("rate limit") ||
-      lower.includes("too many requests")
-    ) {
-      return msg
-    }
-  }
-
   const json = iife(() => {
     try {
       if (typeof error.data?.message === "string") {
@@ -144,16 +134,38 @@ export function retryable(error: Err) {
       return undefined
     }
   })
+
+  // Check for rate limit patterns in plain text error messages. Skip when the
+  // message is a JSON object string — returning it here would leak the raw blob
+  // into the TUI. Structured bodies are normalized by the JSON branch below.
+  const msg = error.data?.message
+  if (typeof msg === "string" && (!json || typeof json !== "object")) {
+    if (isRateLimitMessage(msg)) {
+      return msg
+    }
+  }
   if (!json || typeof json !== "object") return undefined
   const code = typeof json.code === "string" ? json.code : ""
 
-  if (json.type === "error" && json.error?.type === "too_many_requests") {
+  // Normalize any 429 / too-many-requests JSON shape into a retryable
+  // rate-limit status. Providers disagree on where they put the signal:
+  // top-level `type`/`code`, or nested under `error.{type,code,message}`.
+  const errorCode = String(json.error?.code ?? "")
+  const errorType = typeof json.error?.type === "string" ? json.error.type : ""
+  const errorMessage = typeof json.error?.message === "string" ? json.error.message : ""
+  const is429 = code === "429" || errorCode === "429" || String(json.status ?? "") === "429"
+  if (
+    errorType === "too_many_requests" ||
+    is429 ||
+    isRateLimitMessage(errorMessage) ||
+    (typeof json.message === "string" && isRateLimitMessage(json.message))
+  ) {
     return "Too Many Requests"
   }
   if (code.includes("exhausted") || code.includes("unavailable")) {
     return "Provider is overloaded"
   }
-  if (json.type === "error" && typeof json.error?.code === "string" && json.error.code.includes("rate_limit")) {
+  if (json.type === "error" && errorCode.includes("rate_limit")) {
     return "Rate Limited"
   }
   return undefined

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -16,7 +16,12 @@ export function isRateLimitMessage(message: string): boolean {
   const lower = message.toLowerCase()
   return (
     lower.includes("too many requests") ||
+    lower.includes("too_many_requests") ||
     lower.includes("rate limit") ||
+    // Providers also spell it with an underscore in structured bodies/types
+    // (e.g. "rate_limit_error", "rate_limited"). Prior fix only matched the
+    // spaced form, so these slipped through into the raw TUI error. See T18.
+    lower.includes("rate_limit") ||
     lower.includes("rate increased too quickly")
   )
 }
@@ -115,6 +120,22 @@ export function retryable(error: Err) {
     // Upstream processing failures (e.g. multimodal data corruption) return 400
     // but are transient — retry them.
     if (status === 400 && error.data.responseBody?.includes("upstream_error")) return error.data.message
+    // 429 rate-limits are transient and retryable EVEN when the provider SDK
+    // marked the APIError isRetryable:false (many do, expecting the caller to
+    // honor retry-after). Prior fix (T7) only normalized 429s in the retry-status
+    // and plaintext/JSON-message branches; a 429 APIError with isRetryable:false
+    // fell through the non-retryable bail below (status 429 < 500), was never
+    // retried, and surfaced as a raw blob in the TUI terminal error render
+    // (errorBody prints error.data.message verbatim). Catch it here — by numeric
+    // status OR a rate-limit signal in the message/body — before that bail so it
+    // both retries and shows a clean status. See T18.
+    if (
+      status === 429 ||
+      isRateLimitMessage(error.data.message) ||
+      (typeof error.data.responseBody === "string" && isRateLimitMessage(error.data.responseBody))
+    ) {
+      return "Too Many Requests"
+    }
     // 5xx errors are transient server failures and should always be retried,
     // even when the provider SDK doesn't explicitly mark them as retryable.
     if (!error.data.isRetryable && !(status !== undefined && status >= 500)) return undefined

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -10,6 +10,7 @@ import { Instance } from "@/project/instance"
 import { InstanceRef } from "@/effect/instance-ref"
 import { InstanceState } from "@/effect"
 import { ActorRegistry } from "@/actor/registry"
+import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { forwardRef } from "@/permission/permission-forward-ref"
 import { Provider } from "@/provider"
 import { spawnRef } from "@/actor/spawn-ref"
@@ -523,16 +524,25 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
         // to ctx.sessionID at create time. Enrich each child with its actor
         // row (mode/agent/status) keyed by sessionID === actorID === child.id.
         const children = yield* sessions.children(ctx.sessionID as SessionID)
-        if (children.length === 0)
-          return { title: "Child sessions: 0", output: "No child sessions.", metadata: {} as Metadata }
-        const lines = yield* Effect.forEach(children, (child) =>
-          actorReg.get(child.id, child.id).pipe(
-            Effect.map((actor) =>
-              `${child.id} — ${child.title} — ${actor?.agent ?? "?"} — ${actor?.status ?? "unknown"}`,
-            ),
-          ),
+        // Subagent sessions (checkpoint-writer / dream / distill / read-only
+        // fork-query children spawned by `ask`) are ALSO parented to us via the
+        // Session row, so sessions.children returns them too. They are not real
+        // peer children the orchestrator manages — filter them out. A child is a
+        // subagent iff its actor row is mode:"subagent" or its agent is one of
+        // the runtime system-spawned types (checkpoint-writer/dream/distill).
+        const enriched = yield* Effect.forEach(children, (child) =>
+          actorReg.get(child.id, child.id).pipe(Effect.map((actor) => ({ child, actor }))),
         )
-        return { title: `Child sessions: ${children.length}`, output: lines.join("\n"), metadata: {} as Metadata }
+        const peers = enriched.filter(
+          ({ actor }) => actor?.mode !== "subagent" && !(actor && SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent)),
+        )
+        if (peers.length === 0)
+          return { title: "Child sessions: 0", output: "No child sessions.", metadata: {} as Metadata }
+        const lines = peers.map(
+          ({ child, actor }) =>
+            `${child.id} — ${child.title} — ${actor?.agent ?? "?"} — ${actor?.status ?? "unknown"}`,
+        )
+        return { title: `Child sessions: ${peers.length}`, output: lines.join("\n"), metadata: {} as Metadata }
       }
 
       if (op.action === "cancel") {

--- a/packages/opencode/src/util/tool-compat.ts
+++ b/packages/opencode/src/util/tool-compat.ts
@@ -100,11 +100,77 @@ export function normalizeInput(input: unknown, schema: JSONSchema7): unknown {
   return result
 }
 
+// Repair `\uXXXX` escapes whose 4 hex digits were split by injected whitespace
+// (e.g. a CJK char `\u7ed1` arriving as `\u7 ed1` when a streaming/router
+// boundary cuts the 6-char escape and rejoins it with a space). We walk each
+// `\u`, then pull the next 4 hex digits, tolerating whitespace between them, and
+// re-emit a clean `\uXXXX`. Anything that isn't a recoverable 4-hex escape is
+// left byte-for-byte unchanged so valid content and other escapes are untouched.
+function repairUnicodeEscapes(input: string): string {
+  if (!input.includes("\\u")) return input
+  let out = ""
+  let i = 0
+  while (i < input.length) {
+    const ch = input[i]
+    if (ch !== "\\") {
+      out += ch
+      i++
+      continue
+    }
+    const next = input[i + 1]
+    // Preserve escaped backslash so `\\u...` (a literal backslash + u) is not
+    // mistaken for a unicode escape.
+    if (next === "\\") {
+      out += "\\\\"
+      i += 2
+      continue
+    }
+    if (next !== "u") {
+      out += ch
+      i++
+      continue
+    }
+    // Collect up to 4 hex digits after `\u`, skipping interleaved whitespace.
+    let j = i + 2
+    const hex: string[] = []
+    while (j < input.length && hex.length < 4) {
+      const c = input[j]
+      if (/[0-9a-fA-F]/.test(c)) {
+        hex.push(c)
+        j++
+        continue
+      }
+      if (/\s/.test(c)) {
+        j++
+        continue
+      }
+      break
+    }
+    if (hex.length === 4) {
+      out += "\\u" + hex.join("")
+      i = j
+      continue
+    }
+    // Not a recoverable escape — leave the `\u` as-is and move on.
+    out += ch
+    i++
+  }
+  return out
+}
+
 export function parseToolInput(input: string): unknown {
   if (input.trim() === "") return {}
   try {
     return JSON.parse(input) as unknown
   } catch {
+    const repaired = repairUnicodeEscapes(input)
+    if (repaired !== input) {
+      try {
+        return JSON.parse(repaired) as unknown
+      } catch {
+        return input
+      }
+    }
     return input
   }
 }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2193,10 +2193,10 @@ describe("ProviderTransform.message - cache control on gateway", () => {
 
   test("openai-compatible with claude in model id does NOT trigger caching", () => {
     const model = createModel({
-      id: "mimorouter/claude-opus-4-8",
+      id: "gateway/claude-opus-4-8",
       providerID: "custom",
       api: {
-        id: "mimorouter/claude-opus-4-8",
+        id: "gateway/claude-opus-4-8",
         url: "https://proxy.example.com/v1",
         npm: "@ai-sdk/openai-compatible",
       },

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -262,6 +262,33 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
   })
 
+  // PR #1680 regression: FreeUsageLimitError arrives as an HTTP 429 whose body
+  // also reads "Rate limit exceeded". It MUST surface the Go upsell prompt, not
+  // be swallowed by the generic 429-retry branch into "Too Many Requests".
+  test("FreeUsageLimitError over 429 returns the Go upsell, not Too Many Requests", () => {
+    const error = new MessageV2.APIError({
+      message: "429: Rate limit exceeded",
+      isRetryable: false,
+      statusCode: 429,
+      responseBody: '{"type":"FreeUsageLimitError","message":"Rate limit exceeded"}',
+    }).toObject() as MessageV2.APIError
+
+    expect(SessionRetry.retryable(error)).toBe(SessionRetry.GO_UPSELL_MESSAGE)
+  })
+
+  // PR #1680 follow-up: SubscriptionUsageLimitError is also a terminal 429 —
+  // retrying just hangs the session, so it must not become retryable.
+  test("SubscriptionUsageLimitError over 429 is terminal (not retryable)", () => {
+    const error = new MessageV2.APIError({
+      message: "429: Rate limit exceeded",
+      isRetryable: false,
+      statusCode: 429,
+      responseBody: '{"type":"SubscriptionUsageLimitError","message":"Rate limit exceeded"}',
+    }).toObject() as MessageV2.APIError
+
+    expect(SessionRetry.retryable(error)).toBeUndefined()
+  })
+
   test("isRateLimitMessage matches underscore rate_limit variants", () => {
     expect(SessionRetry.isRateLimitMessage("rate_limit_error")).toBe(true)
     expect(SessionRetry.isRateLimitMessage("too_many_requests")).toBe(true)

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -129,6 +129,26 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
   })
 
+  test("maps provider 429 limitation error body as rate-limited", () => {
+    const error = wrap(JSON.stringify({ error: { code: "429", message: "Too many requests", type: "limitation" } }))
+    expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
+  })
+
+  test("maps numeric 429 error code as rate-limited", () => {
+    const error = wrap(JSON.stringify({ error: { code: 429, message: "Too many requests" } }))
+    expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
+  })
+
+  test("maps top-level 429 code as rate-limited", () => {
+    const error = wrap(JSON.stringify({ code: "429", message: "slow down" }))
+    expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
+  })
+
+  test("maps nested rate-limit message as rate-limited", () => {
+    const error = wrap(JSON.stringify({ error: { code: "unknown", message: "Rate limit exceeded" } }))
+    expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
+  })
+
   test("maps overloaded provider codes", () => {
     const error = wrap(JSON.stringify({ code: "resource_exhausted" }))
     expect(SessionRetry.retryable(error)).toBe("Provider is overloaded")

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -239,6 +239,35 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error)).toBeUndefined()
   })
 
+  // T18: a 429 APIError the provider marked non-retryable previously fell
+  // through the non-retryable bail (429 < 500) and surfaced as a raw blob.
+  test("retries 429 APIError even when isRetryable is false (by status)", () => {
+    const error = new MessageV2.APIError({
+      message: '429: {"error":{"type":"rate_limit_error","message":"rate limited"}}',
+      isRetryable: false,
+      statusCode: 429,
+      responseBody: '{"error":{"type":"rate_limit_error"}}',
+    }).toObject() as MessageV2.APIError
+
+    expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
+  })
+
+  test("retries a rate-limit APIError when status is absent (by message/body)", () => {
+    const error = new MessageV2.APIError({
+      message: "provider error",
+      isRetryable: false,
+      responseBody: '{"error":{"type":"rate_limit_error"}}',
+    }).toObject() as MessageV2.APIError
+
+    expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
+  })
+
+  test("isRateLimitMessage matches underscore rate_limit variants", () => {
+    expect(SessionRetry.isRateLimitMessage("rate_limit_error")).toBe(true)
+    expect(SessionRetry.isRateLimitMessage("too_many_requests")).toBe(true)
+    expect(SessionRetry.isRateLimitMessage("something unrelated")).toBe(false)
+  })
+
   test("retries ZlibError decompression failures", () => {
     const error = new MessageV2.APIError({
       message: "Response decompression failed",

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -316,6 +316,51 @@ describe("session tool", () => {
     ),
   )
 
+  it.live("list excludes subagent sessions (checkpoint-writer) parented to the orchestrator", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+        const parent = yield* sessions.create({ title: "Parent" })
+
+        const info = yield* SessionTool
+        const tool = yield* info.init()
+
+        // A real peer child — this SHOULD appear in the listing.
+        const peer = yield* tool.execute(
+          { operation: { action: "create", task: "real work", mode: "build", title: "Peer" } },
+          ctx(parent.id),
+        )
+        const peerID = peer.metadata.sessionID!
+
+        // A subagent child: same parent linkage (checkpoint-writer / dream /
+        // distill and read-only fork children are all parented to us via the
+        // Session row), but registered as mode:"subagent" with a system agent.
+        // This must NOT appear in the orchestrator's child listing.
+        const sub = yield* sessions.create({ title: "checkpoint-writer: T1", parentID: parent.id })
+        yield* actorReg.register({
+          sessionID: sub.id,
+          actorID: sub.id,
+          mode: "subagent",
+          agent: "checkpoint-writer",
+          description: "checkpoint",
+          contextMode: "full",
+          background: true,
+          lifecycle: "ephemeral",
+        })
+
+        const result = yield* tool.execute({ operation: { action: "list" } }, ctx(parent.id))
+
+        // Only the peer is listed; the checkpoint-writer subagent is filtered.
+        expect(result.title).toBe("Child sessions: 1")
+        expect(result.output).toContain(peerID)
+        expect(result.output).toContain("Peer")
+        expect(result.output).not.toContain(sub.id)
+        expect(result.output).not.toContain("checkpoint-writer")
+      }),
+    ),
+  )
+
   it.live("list returns an empty message when there are no children", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {

--- a/packages/opencode/test/util/tool-compat.test.ts
+++ b/packages/opencode/test/util/tool-compat.test.ts
@@ -3,6 +3,7 @@ import type { JSONSchema7 } from "@ai-sdk/provider"
 import {
   canonical,
   normalizeInput,
+  parseToolInput,
   repairToolCall,
   resolveName,
 } from "../../src/util/tool-compat"
@@ -184,6 +185,72 @@ describe("util.tool-compat", () => {
       })
 
       expect(repaired).toBeUndefined()
+    })
+  })
+
+  describe("parseToolInput CJK / broken unicode escapes", () => {
+    test("parses well-formed CJK operation args", () => {
+      const input = JSON.stringify({ operation: { action: "create", summary: "Orchestrator 会话 绑定任务" } })
+      expect(parseToolInput(input)).toEqual({
+        operation: { action: "create", summary: "Orchestrator 会话 绑定任务" },
+      })
+    })
+
+    test("repairs a \\uXXXX escape split by injected whitespace (绑 -> \\u7ed1)", () => {
+      // The observed corruption: a CJK char's escape `\u7ed1` arrived as `\u7 ed1`,
+      // which native JSON.parse rejects as a bad unicode escape.
+      const broken = '{"operation": {"action": "create", "summary": "Orchestrator \\u7 ed1"}}'
+      expect(() => JSON.parse(broken)).toThrow()
+      expect(parseToolInput(broken)).toEqual({
+        operation: { action: "create", summary: "Orchestrator 绑" },
+      })
+    })
+
+    test("repairs multiple broken escapes in one string", () => {
+      // 绑定 = \u7ed1\u5b9a, both split by whitespace.
+      const broken = '{"summary": "\\u7 ed1\\u5b 9a"}'
+      expect(() => JSON.parse(broken)).toThrow()
+      expect(parseToolInput(broken)).toEqual({ summary: "绑定" })
+    })
+
+    test("leaves valid escaped backslash sequences untouched", () => {
+      const value = { path: "C:\\Users\\a" }
+      expect(parseToolInput(JSON.stringify(value))).toEqual(value)
+    })
+
+    test("does not corrupt a literal backslash-u that is not an escape", () => {
+      // JSON `"\\u7ed1"` decodes to the 6-char string `\u7ed1` (a literal
+      // backslash), not the CJK char. Repair must not touch it.
+      const value = { note: "\\u7ed1" }
+      expect(parseToolInput(JSON.stringify(value))).toEqual(value)
+    })
+
+    test("full repair path recovers a CJK task-create call", async () => {
+      const taskSchema = {
+        type: "object",
+        properties: {
+          operation: {
+            type: "object",
+            properties: {
+              action: { type: "string" },
+              summary: { type: "string" },
+            },
+          },
+        },
+      } satisfies JSONSchema7
+
+      const broken = '{"operation": {"action": "create", "summary": "\\u7 ed1定任务"}}'
+      const repaired = await repairToolCall({
+        toolName: "task",
+        input: broken,
+        toolNames: ["task"],
+        getSchema: () => taskSchema,
+      })
+
+      expect(repaired).toBeDefined()
+      expect(JSON.parse(repaired!.input)).toEqual({
+        operation: { action: "create", summary: "绑定任务" },
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

General TUI / session bug fixes unrelated to the Orchestrator work. Rebased onto latest `origin/main` (`d056619`).

## Included fixes

### Rate-limit (429) normalization
- **normalize provider 429 limitation error as retryable rate-limit** — first 429 shape.
- **normalize additional 429 rate-limit shape** missed by the prior fix — second shape.

### Session list
- **exclude subagent sessions** (e.g. checkpoint-writer) from the session list.

### Tool args
- **handle CJK/multibyte text in tool operation args** without breaking unicode escapes.

### Error rendering
- **render errors and retry status as a structured message-list element**, not raw text.

## Verification
- `bun typecheck` — exit 0 (all packages green via pre-push hook too).

Commits cherry-picked (`-x`) in order from `fix/orchestrator-tui-and-infra-bugs`: 8d95ab8, a7ae9f1, 667e44d, b51ce34, 188e937.