### PR TITLE
feat(orchestrator): mode entry/nav, reliable relay + liveness/fan-in, grant persistence, prompt & UI polish

### DIFF
--- a/packages/opencode/migration/20260614000000_permission_grant/migration.sql
+++ b/packages/opencode/migration/20260614000000_permission_grant/migration.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `permission_grant` (
+  `parent_session_id` text NOT NULL,
+  `target` text NOT NULL,
+  `created_at` integer NOT NULL,
+  PRIMARY KEY(`parent_session_id`, `target`)
+);

--- a/packages/opencode/src/actor/events.ts
+++ b/packages/opencode/src/actor/events.ts
@@ -40,6 +40,22 @@ export const ActorStuck = BusEvent.define(
   }),
 )
 
+// Emitted by the T40 stall watchdog when a background peer/subagent transitions
+// into `stalled` liveness (running/pending but no turn advance past the stall
+// window) and the one-shot parent notification is pushed. Fires once per stall
+// episode — re-arms only after the child resumes (turnCount advances) or reaches
+// terminal. Observability hook for tests + TUI.
+export const ActorStalled = BusEvent.define(
+  "actor.stalled",
+  z.object({
+    sessionID: SessionID.zod,
+    actorID: z.string(),
+    description: z.string(),
+    lastTurnTime: z.number(),
+    stalledDuration: z.number(),
+  }),
+)
+
 export const WriterCachePerf = BusEvent.define(
   "writer.cache_perf",
   z.object({

--- a/packages/opencode/src/actor/group.ts
+++ b/packages/opencode/src/actor/group.ts
@@ -1,0 +1,211 @@
+import { Deferred, Effect } from "effect"
+import type { Bus } from "@/bus"
+import type { ActorRegistry } from "@/actor/registry"
+import type { Actor } from "@/actor/schema"
+import type { Session } from "@/session"
+import type { SessionID } from "@/session/schema"
+import { ActorStatusChanged } from "@/actor/events"
+import { parseReturnHeader } from "@/actor/return-header"
+
+// One member's terminal outcome within a joined dispatch group.
+export interface GroupMemberResult {
+  sessionID: SessionID
+  actorID: string
+  description?: string
+  agent?: string
+  // The aggregation bucket. "unknown" = the member was never a registered actor
+  // (bad id); it can never become terminal, so it does NOT block the barrier.
+  outcome: "success" | "failure" | "cancelled" | "unknown"
+  result?: string
+  error?: string
+  reportedStatus?: string
+  reportedSummary?: string
+}
+
+export interface JoinResult {
+  status: "complete" | "timeout"
+  total: number
+  counts: { success: number; failure: number; cancelled: number; unknown: number }
+  members: GroupMemberResult[]
+}
+
+export interface JoinDeps {
+  reg: ActorRegistry.Interface
+  sessions: Session.Interface
+  bus: Bus.Interface
+}
+
+const DEFAULT_TIMEOUT_MS = 600_000
+
+// A group member is terminal once its actor row is idle WITH an outcome. Unlike
+// the single-actor waiter (which ignores a persistent peer's idle/success so it
+// can keep relaying), fan-in counts EVERY terminal outcome — success, failure,
+// AND cancel (all three now flow through ActorTurn.runTurn / Actor.cancel and
+// publish ActorStatusChanged, per T41).
+function terminalOutcome(entry: Actor | undefined): "success" | "failure" | "cancelled" | undefined {
+  if (!entry) return undefined
+  if (entry.status !== "idle") return undefined
+  return entry.lastOutcome
+}
+
+type Member = { sessionID: SessionID; actorID: string }
+type Resolved = "success" | "failure" | "cancelled" | "unknown"
+
+// Fan-in barrier: register interest in a GROUP of child actors (each keyed by
+// its session id + actor id — for a peer both equal the child session id) and
+// resolve ONCE when EVERY member has reached a terminal state, returning an
+// aggregated per-member summary. Does NOT busy-wait: it subscribes to
+// ActorStatusChanged (the same notification path T41 drives) and re-snapshots
+// the group on each touching event. A member that is already terminal (or
+// unknown — a bad id that has no row and can never settle) at call time is
+// counted immediately; the barrier resolves synchronously if all are settled.
+//
+// Standalone Effect (mirrors forkQuery in tool/session.ts) rather than a Layer
+// service: it needs only the registry + session + bus interfaces the caller
+// already holds — so it adds no new layer dependency and no cycle. It takes the
+// INJECTED Bus.Interface (not the static Bus.subscribe) so it subscribes to the
+// exact same PubSub instance the ActorRegistry layer publishes ActorStatusChanged
+// on — the static builds its own runtime and would miss layer-emitted events.
+export function joinGroup(
+  deps: JoinDeps,
+  input: { members: Member[]; timeout_ms?: number },
+): Effect.Effect<JoinResult> {
+  return Effect.gen(function* () {
+    const timeoutMs = input.timeout_ms ?? DEFAULT_TIMEOUT_MS
+
+    // Dedup members by sessionID:actorID — a caller may list the same child
+    // twice; the barrier must count it once.
+    const seen = new Set<string>()
+    const members = input.members.filter((m) => {
+      const key = `${m.sessionID}:${m.actorID}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+
+    if (members.length === 0)
+      return {
+        status: "complete" as const,
+        total: 0,
+        counts: { success: 0, failure: 0, cancelled: 0, unknown: 0 },
+        members: [],
+      }
+
+    const lastAssistantText = (sessionID: SessionID, actorID: string) =>
+      Effect.gen(function* () {
+        const msgs = yield* deps.sessions
+          .messages({ sessionID, agentID: actorID })
+          .pipe(Effect.orElseSucceed(() => []))
+        const last = msgs.findLast((m) => m.info.role === "assistant")
+        if (!last) return undefined
+        const textPart = last.parts.findLast(
+          (p): p is Extract<(typeof last.parts)[number], { type: "text" }> => p.type === "text",
+        )
+        return textPart?.text
+      })
+
+    const memberResult = (m: Member, entry: Actor | undefined, outcome: Resolved) =>
+      Effect.gen(function* () {
+        const result = outcome === "success" ? yield* lastAssistantText(m.sessionID, m.actorID) : undefined
+        const reported = parseReturnHeader(result)
+        return {
+          sessionID: m.sessionID,
+          actorID: m.actorID,
+          ...(entry?.description !== undefined ? { description: entry.description } : {}),
+          ...(entry?.agent !== undefined ? { agent: entry.agent } : {}),
+          outcome,
+          ...(result !== undefined ? { result } : {}),
+          ...(outcome === "failure" && entry?.lastError !== undefined ? { error: entry.lastError } : {}),
+          ...(reported.status ? { reportedStatus: reported.status } : {}),
+          ...(reported.summary ? { reportedSummary: reported.summary } : {}),
+        } satisfies GroupMemberResult
+      })
+
+    // Snapshot every member's current terminal state. `settled` = terminal or
+    // unknown (a member that can never become terminal must not block).
+    const snapshotAll = () =>
+      Effect.forEach(members, (m) =>
+        Effect.gen(function* () {
+          const entry = yield* deps.reg.get(m.sessionID, m.actorID)
+          const term = terminalOutcome(entry)
+          const outcome: Resolved | undefined = term ?? (entry ? undefined : "unknown")
+          return { m, entry, settled: outcome !== undefined, outcome }
+        }),
+      )
+
+    const aggregate = (
+      resolved: { m: Member; entry: Actor | undefined; outcome: Resolved }[],
+      status: "complete" | "timeout",
+    ) =>
+      Effect.gen(function* () {
+        const out = yield* Effect.forEach(resolved, (r) => memberResult(r.m, r.entry, r.outcome))
+        const counts = {
+          success: out.filter((x) => x.outcome === "success").length,
+          failure: out.filter((x) => x.outcome === "failure").length,
+          cancelled: out.filter((x) => x.outcome === "cancelled").length,
+          unknown: out.filter((x) => x.outcome === "unknown").length,
+        }
+        return { status, total: out.length, counts, members: out } satisfies JoinResult
+      })
+
+    // Fast path: everyone already settled.
+    const initial = yield* snapshotAll()
+    if (initial.every((r) => r.settled))
+      return yield* aggregate(
+        initial.map((r) => ({ m: r.m, entry: r.entry, outcome: r.outcome! })),
+        "complete",
+      )
+
+    const resolved = yield* Deferred.make<JoinResult>()
+
+    return yield* Effect.acquireUseRelease(
+      // On each status change touching a member, re-snapshot the whole group and
+      // resolve only when ALL are settled. Re-snapshotting (vs a per-member
+      // latch) keeps state authoritative against the DB and idempotent under
+      // duplicate/out-of-order events.
+      deps.bus.subscribeCallback(ActorStatusChanged, (evt) => {
+          const touched = members.some(
+            (m) => m.actorID === evt.properties.actorID && m.sessionID === evt.properties.sessionID,
+          )
+          if (!touched) return
+          Effect.runFork(
+            Effect.gen(function* () {
+              const snap = yield* snapshotAll()
+              if (!snap.every((r) => r.settled)) return
+              const agg = yield* aggregate(
+                snap.map((r) => ({ m: r.m, entry: r.entry, outcome: r.outcome! })),
+                "complete",
+              )
+              Deferred.doneUnsafe(resolved, Effect.succeed(agg))
+            }).pipe(Effect.catchCause((cause) => Effect.logError(`group join snapshot failed: ${cause}`))),
+          )
+        }),
+      () =>
+        Effect.gen(function* () {
+          // Re-check after subscribing — a member could have flipped terminal
+          // between the initial snapshot and the bus bind (lost-wakeup guard).
+          const recheck = yield* snapshotAll()
+          if (recheck.every((r) => r.settled))
+            return yield* aggregate(
+              recheck.map((r) => ({ m: r.m, entry: r.entry, outcome: r.outcome! })),
+              "complete",
+            )
+          const raced = yield* Deferred.await(resolved).pipe(
+            Effect.timeout(timeoutMs),
+            Effect.catchTag("TimeoutError", () => Effect.succeed(null)),
+          )
+          if (raced === null) {
+            // Timed out — return the partial snapshot so the caller still sees
+            // which members settled. status: "timeout" signals not-all-done.
+            const partial = yield* snapshotAll()
+            return yield* aggregate(
+              partial.map((r) => ({ m: r.m, entry: r.entry, outcome: (r.outcome ?? "unknown") as Resolved })),
+              "timeout",
+            )
+          }
+          return raced
+        }),
+      (unsub) => Effect.sync(() => unsub()),
+    )
+  })
+}

--- a/packages/opencode/src/actor/registry.ts
+++ b/packages/opencode/src/actor/registry.ts
@@ -3,7 +3,8 @@ import { Database, inArray, eq, and, lte, sql } from "@/storage"
 import { Bus } from "@/bus"
 import type { SessionID, MessageID } from "@/session/schema"
 import { ActorRegistryTable } from "./actor.sql"
-import type { Actor, ActorStatus, ActorOutcome, ContextMode, Lifecycle, SpawnMode, ToolWhitelist } from "./schema"
+import type { Actor, ActorStatus, ActorOutcome, ContextMode, Lifecycle, SpawnMode, ToolWhitelist, Liveness } from "./schema"
+import { deriveLiveness } from "./schema"
 import * as Events from "./events"
 import { Log } from "@/util"
 import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
@@ -68,6 +69,14 @@ export interface Interface {
   readonly updateTurn: (sessionID: SessionID, actorID: string) => Effect.Effect<void>
   readonly updateAgent: (sessionID: SessionID, actorID: string, agent: string) => Effect.Effect<void>
   readonly get: (sessionID: SessionID, actorID: string) => Effect.Effect<Actor | undefined>
+  // Derived pull-side liveness for a single actor row (progressing/stalled/
+  // terminal), computed from honest registry fields. Returns undefined when the
+  // row is absent. Pass stallMs to override the default staleness window.
+  readonly liveness: (
+    sessionID: SessionID,
+    actorID: string,
+    stallMs?: number,
+  ) => Effect.Effect<{ liveness: Liveness; actor: Actor } | undefined>
   readonly listBySession: (sessionID: SessionID) => Effect.Effect<Actor[]>
   readonly listActive: () => Effect.Effect<Actor[]>
   readonly listByParent: (sessionID: SessionID, parentActorID: string) => Effect.Effect<Actor[]>
@@ -241,6 +250,16 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
         ),
       )
       return row ? fromRow(row) : undefined
+    })
+
+    const liveness = Effect.fn("ActorRegistry.liveness")(function* (
+      sessionID: SessionID,
+      actorID: string,
+      stallMs?: number,
+    ) {
+      const actor = yield* get(sessionID, actorID)
+      if (!actor) return undefined
+      return { liveness: deriveLiveness(actor, Date.now(), stallMs), actor }
     })
 
     const listBySession = Effect.fn("ActorRegistry.listBySession")(function* (sessionID: SessionID) {
@@ -440,6 +459,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
       updateTurn,
       updateAgent,
       get,
+      liveness,
       listBySession,
       listActive,
       listByParent,

--- a/packages/opencode/src/actor/schema.ts
+++ b/packages/opencode/src/actor/schema.ts
@@ -51,8 +51,12 @@ export type Actor = z.infer<typeof Actor>
 // raw `status` cannot — is a running child PROGRESSING or STALLED?
 //   - progressing: running/pending AND its last turn advanced within the
 //     staleness window (updateTurn bumps last_turn_time per step, so a recent
-//     last_turn_time == recent progress).
-//   - stalled: running/pending BUT no turn advance for longer than the window.
+//     last_turn_time == recent progress). Also covers a not-yet-started child
+//     (turnCount === 0): its last_turn_time is the spawn time, so a slow first
+//     turn (queued behind the concurrency gate, model cold-start) must NOT be
+//     mistaken for a stall — it has not had the chance to run even once.
+//   - stalled: running/pending, HAS run at least one turn, BUT no turn advance
+//     for longer than the window.
 //   - success | failure | cancelled: terminal, taken straight from lastOutcome.
 //   - idle: finished with no recorded outcome (or an unknown state).
 // Never fabricates: every value maps 1:1 to fields the engine actually wrote.
@@ -67,12 +71,16 @@ export type Liveness = z.infer<typeof Liveness>
 export const DEFAULT_LIVENESS_STALL_MS = 90_000
 
 export function deriveLiveness(
-  actor: Pick<Actor, "status" | "lastOutcome" | "lastTurnTime">,
+  actor: Pick<Actor, "status" | "lastOutcome" | "lastTurnTime" | "turnCount">,
   now: number = Date.now(),
   stallMs: number = DEFAULT_LIVENESS_STALL_MS,
 ): Liveness {
-  if (actor.status === "running" || actor.status === "pending")
+  if (actor.status === "running" || actor.status === "pending") {
+    // Not-yet-started child (no turn completed): last_turn_time is the spawn
+    // time, so a slow first turn (queued/cold-start) is not a stall.
+    if (actor.turnCount === 0) return "progressing"
     return now - actor.lastTurnTime <= stallMs ? "progressing" : "stalled"
+  }
   if (actor.lastOutcome === "success") return "success"
   if (actor.lastOutcome === "failure") return "failure"
   if (actor.lastOutcome === "cancelled") return "cancelled"

--- a/packages/opencode/src/actor/schema.ts
+++ b/packages/opencode/src/actor/schema.ts
@@ -45,3 +45,36 @@ export const Actor = z
   })
   .meta({ ref: "Actor" })
 export type Actor = z.infer<typeof Actor>
+
+// Derived liveness: a pull-side signal computed from an actor row's honest
+// registry fields (status, lastOutcome, lastTurnTime). It answers the question
+// raw `status` cannot — is a running child PROGRESSING or STALLED?
+//   - progressing: running/pending AND its last turn advanced within the
+//     staleness window (updateTurn bumps last_turn_time per step, so a recent
+//     last_turn_time == recent progress).
+//   - stalled: running/pending BUT no turn advance for longer than the window.
+//   - success | failure | cancelled: terminal, taken straight from lastOutcome.
+//   - idle: finished with no recorded outcome (or an unknown state).
+// Never fabricates: every value maps 1:1 to fields the engine actually wrote.
+export const Liveness = z.enum(["progressing", "stalled", "success", "failure", "cancelled", "idle"])
+export type Liveness = z.infer<typeof Liveness>
+
+// Default staleness threshold: a running child with no turn advance for this
+// long is reported `stalled`. 90s sits between the per-step turn cadence and
+// the 5-minute stuck-detection cutoff, so a briefly-thinking child still reads
+// as progressing while a genuinely wedged one flips to stalled well before the
+// watchdog (T40) would fire.
+export const DEFAULT_LIVENESS_STALL_MS = 90_000
+
+export function deriveLiveness(
+  actor: Pick<Actor, "status" | "lastOutcome" | "lastTurnTime">,
+  now: number = Date.now(),
+  stallMs: number = DEFAULT_LIVENESS_STALL_MS,
+): Liveness {
+  if (actor.status === "running" || actor.status === "pending")
+    return now - actor.lastTurnTime <= stallMs ? "progressing" : "stalled"
+  if (actor.lastOutcome === "success") return "success"
+  if (actor.lastOutcome === "failure") return "failure"
+  if (actor.lastOutcome === "cancelled") return "cancelled"
+  return "idle"
+}

--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -10,9 +10,10 @@ import { TaskRegistry } from "@/task/registry"
 import { TaskGate, MAX_TASK_GATE_SUBAGENT_REACT } from "@/task/gate"
 import { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
-import type { SpawnMode, ContextMode, ToolWhitelist, Lifecycle } from "@/actor/schema"
+import type { Actor, SpawnMode, ContextMode, ToolWhitelist, Lifecycle } from "@/actor/schema"
 import { runTurn } from "@/actor/turn"
 import { spawnRef } from "@/actor/spawn-ref"
+import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import { MessageV2 } from "@/session/message-v2"
@@ -209,6 +210,17 @@ export const layer = Layer.effect(
     // cleared on terminal status. Fiber tracking moved to SessionRunState.
     const forkContexts = new Map<string, ForkContext>()
 
+    // Actors whose cancel() has begun, keyed "sessionID:actorID". Populated
+    // BEFORE the fiber is interrupted so forkWork's onSuccess/onFailure notify
+    // can suppress its own (misleading) emit — a cancelled child's interrupt is
+    // masked by the runLoop onInterrupt handler (returns lastAssistant), so the
+    // work fiber sees a spurious "success". The authoritative "cancelled"
+    // notification is emitted instead by Actor.cancel via notifyTerminal, which
+    // runs in-context after updateStatus. This unifies success/failure/cancel
+    // onto one parent-notification contract without double-notifying. See T41.
+    const cancelling = new Set<string>()
+    const cancelKey = (sessionID: SessionID, actorID: string) => `${sessionID}:${actorID}`
+
     // Real agent loop: marks the actor running, then drives a SessionPrompt.prompt
     // turn. The user message persisted by SessionPrompt carries the actor's
     // agentID, which the projector writes to MessageTable.agent_id — that is the
@@ -297,7 +309,13 @@ export const layer = Layer.effect(
           status: "completed" | "failed" | "cancelled",
           extra: { result?: string; error?: string; reportedStatus?: ReturnStatus; reportedSummary?: string },
         ) =>
-          input.background && input.agentType !== "checkpoint-writer"
+          // An external cancel masks its own interrupt (runLoop.onInterrupt
+          // returns lastAssistant), so this fiber would otherwise emit a bogus
+          // "completed"/"failed". Defer to the terminal-status bridge, which
+          // emits the single authoritative "cancelled" notification.
+          cancelling.has(cancelKey(input.sessionID, input.actorID))
+            ? Effect.void
+            : input.background && input.agentType !== "checkpoint-writer"
             ? inbox
                 .send({
                   receiverSessionID: input.parentSessionID,
@@ -747,6 +765,56 @@ export const layer = Layer.effect(
       return yield* spawnSubagent(input)
     })
 
+    // === Unified terminal notification (T41) ===
+    // Single parent-notification contract for a terminal outcome. Completion and
+    // failure already notify directly from forkWork.notify on the woken/spawn
+    // turn; a CANCELLED child cannot, because its interrupt is masked by the
+    // runLoop.onInterrupt handler (returns lastAssistant) so the work fiber sees
+    // a spurious "success" and its own notify is suppressed via the `cancelling`
+    // set. `cancel` therefore emits the one authoritative cancelled notification
+    // here, reusing the exact shape forkWork.notify uses (renderActorNotification
+    // + actor_notification inbox message + a TUI toast). Gating (background,
+    // non-system peer/subagent) matches forkWork.notify so cancel/success/fail
+    // stay a single contract with no double-notify. Best-effort: a missing row
+    // or unresolved parent silently no-ops.
+    const notifyTerminal = (
+      sessionID: SessionID,
+      actorID: string,
+      actor: Actor | undefined,
+      status: "cancelled",
+    ) =>
+      Effect.gen(function* () {
+        if (!actor) return
+        if (!actor.background) return
+        if (actor.mode !== "peer" && actor.mode !== "subagent") return
+        if (SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent)) return
+        // Resolve the parent session: a peer runs in its own child session (notify
+        // its parentID); a subagent shares the parent's session.
+        const parentSessionID =
+          actor.mode === "peer" ? (yield* session.get(sessionID)).parentID : sessionID
+        if (!parentSessionID) return
+        yield* inbox
+          .send({
+            receiverSessionID: parentSessionID,
+            receiverActorID: actor.parentActorID ?? "main",
+            senderSessionID: sessionID,
+            senderActorID: actorID,
+            type: "actor_notification",
+            content: renderActorNotification({
+              actorID,
+              description: actor.description,
+              status,
+            }),
+          })
+          .pipe(Effect.ignore)
+        yield* Effect.promise(() =>
+          Bus.publish(TuiEvent.ToastShow, {
+            message: `Child "${actor.description}" ${status}`,
+            variant: "info",
+          }),
+        ).pipe(Effect.ignore)
+      }).pipe(Effect.catchCause((cause) => Effect.logError(`terminal notify failed: ${cause}`)))
+
     const cancel: (sessionID: SessionID, actorID: string, mode: "graceful" | "forced") => Effect.Effect<void> =
       Effect.fn("Actor.cancel")(function* (sessionID: SessionID, actorID: string, mode: "graceful" | "forced") {
         const children = yield* actorReg.listByParent(sessionID, actorID)
@@ -754,10 +822,18 @@ export const layer = Layer.effect(
           concurrency: "unbounded",
           discard: true,
         })
+        // Mark cancelling BEFORE interrupting so forkWork.notify (which fires on
+        // the interrupt-masked "success") suppresses its own emit; the single
+        // authoritative "cancelled" notification is emitted below instead.
+        yield* Effect.sync(() => cancelling.add(cancelKey(sessionID, actorID)))
+        // Snapshot the actor row before cancelActor tears state down — we need
+        // its mode/agent/background/parentActorID to decide + address the notify.
+        const actor = yield* actorReg.get(sessionID, actorID)
         yield* state.cancelActor(sessionID, actorID)
         yield* actorReg
           .updateStatus(sessionID, actorID, { status: "idle", lastOutcome: "cancelled" })
           .pipe(Effect.ignore)
+        yield* notifyTerminal(sessionID, actorID, actor, "cancelled")
         yield* Effect.sync(() => forkContexts.delete(actorID))
       })
 

--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -1,4 +1,4 @@
-import { Effect, Deferred, Context, Fiber, Layer, Scope, Cause } from "effect"
+import { Effect, Deferred, Context, Fiber, Layer, Scope, Cause, Schedule } from "effect"
 import type { SessionID, MessageID } from "@/session/schema"
 import type { ProviderID, ModelID } from "@/provider/schema"
 import type { Tool as AITool, ModelMessage } from "ai"
@@ -11,6 +11,8 @@ import { TaskGate, MAX_TASK_GATE_SUBAGENT_REACT } from "@/task/gate"
 import { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import type { Actor, SpawnMode, ContextMode, ToolWhitelist, Lifecycle } from "@/actor/schema"
+import { deriveLiveness, DEFAULT_LIVENESS_STALL_MS } from "@/actor/schema"
+import * as ActorEvents from "@/actor/events"
 import { runTurn } from "@/actor/turn"
 import { spawnRef } from "@/actor/spawn-ref"
 import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
@@ -36,6 +38,13 @@ const log = Log.create({ service: "actor.spawn" })
 export const MAX_PRE_REACT = 3
 /** Cap on postStop ReAct re-entries per spawn. See MAX_PRE_REACT TODO. */
 export const MAX_POST_REACT = 3
+/**
+ * T40 stall watchdog scan cadence. Sits between the per-step turn heartbeat and
+ * the DEFAULT_LIVENESS_STALL_MS (90s) window, and just under the registry's own
+ * 60s stuck-scan, so a genuinely stalled child is caught within ~one window of
+ * flipping to `stalled` without hammering the DB.
+ */
+export const WATCHDOG_SCAN_INTERVAL_MS = 45_000
 const RETURN_FORMAT_INSTRUCTION = `
 
 ---
@@ -187,6 +196,15 @@ export interface Interface {
   readonly spawn: (input: SpawnInput) => Effect.Effect<SpawnResult>
   readonly cancel: (sessionID: SessionID, actorID: string, mode: "graceful" | "forced") => Effect.Effect<void>
   readonly getForkContext: (actorID: string) => Effect.Effect<ForkContext | undefined>
+  /**
+   * Run ONE stall-watchdog scan pass synchronously (the same body the background
+   * fiber repeats every WATCHDOG_SCAN_INTERVAL_MS). Exposed for deterministic
+   * tests that can't wait a real scan interval — it shares the same `notified`
+   * debounce set as the fiber, so driving it repeatedly exercises the real
+   * one-shot / re-arm semantics without touching wall-clock scheduling.
+   * Optional so lightweight test mocks of this Service need not implement it.
+   */
+  readonly scanStalledOnce?: () => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Actor") {}
@@ -841,7 +859,114 @@ export const layer = Layer.effect(
       return forkContexts.get(actorID)
     })
 
-    const impl = Service.of({ spawn, cancel, getForkContext })
+    // === T40 stall watchdog ===
+    // Event-driven stall detection: a background fiber periodically scans active
+    // background actors (ActorRegistry.listActive → pending/running + background),
+    // computes deriveLiveness for each, and when a PEER/subagent flips to
+    // `stalled` (running/pending but now-lastTurnTime > DEFAULT_LIVENESS_STALL_MS
+    // AND turnCount not advancing — deriveLiveness encodes exactly that) pushes
+    // ONE actor_notification{stalled} to its parent. Reuses the notifyTerminal
+    // shape (inbox.send actor_notification + renderActorNotification + a TUI
+    // toast) so stalled joins completed/failed/cancelled on one contract.
+    //
+    // Debounce — the crux: `notified` holds the "sessionID:actorID" of actors we
+    // have ALREADY warned about for their CURRENT stall episode. We emit only on
+    // the not-yet-notified → stalled edge; while it STAYS stalled across ticks it
+    // is in `notified` and we skip. We re-arm (delete the key) the moment the
+    // actor is no longer stalled — it resumed (turnCount advanced so
+    // deriveLiveness reads `progressing`), went terminal, or vanished — so a
+    // later re-stall notifies again. One notification per stall episode.
+    const notified = new Set<string>()
+
+    // Emit the single stalled notification for one actor. Same gating +
+    // parent-resolution as notifyTerminal: background only, peer/subagent only,
+    // exclude SYSTEM_SPAWNED_AGENT_TYPES, address the parent's main inbox.
+    const notifyStalled = (actor: Actor, stalledForMs: number) =>
+      Effect.gen(function* () {
+        if (!actor.background) return
+        if (actor.mode !== "peer" && actor.mode !== "subagent") return
+        if (SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent)) return
+        const parentSessionID =
+          actor.mode === "peer" ? (yield* session.get(actor.sessionID)).parentID : actor.sessionID
+        if (!parentSessionID) return
+        yield* inbox
+          .send({
+            receiverSessionID: parentSessionID,
+            receiverActorID: actor.parentActorID ?? "main",
+            senderSessionID: actor.sessionID,
+            senderActorID: actor.actorID,
+            type: "actor_notification",
+            content: renderActorNotification({
+              actorID: actor.actorID,
+              description: actor.description,
+              status: "stalled",
+              stalledForMs,
+            }),
+          })
+          .pipe(Effect.ignore)
+        yield* bus
+          .publish(ActorEvents.ActorStalled, {
+            sessionID: actor.sessionID,
+            actorID: actor.actorID,
+            description: actor.description,
+            lastTurnTime: actor.lastTurnTime,
+            stalledDuration: stalledForMs,
+          })
+          .pipe(Effect.ignore)
+        yield* Effect.promise(() =>
+          Bus.publish(TuiEvent.ToastShow, {
+            message: `Child "${actor.description}" appears stalled`,
+            variant: "info",
+          }),
+        ).pipe(Effect.ignore)
+      }).pipe(Effect.catchCause((cause) => Effect.logError(`stall notify failed: ${cause}`)))
+
+    const scanStalled = Effect.gen(function* () {
+      const now = Date.now()
+      const active = yield* actorReg.listActive().pipe(Effect.orElseSucceed(() => [] as Actor[]))
+      const seen = new Set<string>()
+      for (const actor of active) {
+        const key = `${actor.sessionID}:${actor.actorID}`
+        seen.add(key)
+        const live = deriveLiveness(actor, now)
+        if (live === "stalled") {
+          if (notified.has(key)) continue // already warned this episode — debounce
+          notified.add(key)
+          yield* notifyStalled(actor, now - actor.lastTurnTime)
+          continue
+        }
+        // Not stalled (progressing/terminal) → re-arm so a future re-stall notifies.
+        notified.delete(key)
+      }
+      // Drop debounce keys for actors that fell out of listActive entirely
+      // (went terminal / row gone) so the set can't grow unbounded and a
+      // recycled id re-arms cleanly.
+      for (const key of notified) if (!seen.has(key)) notified.delete(key)
+    }).pipe(Effect.catchCause((cause) => Effect.logError(`stall watchdog scan failed: ${cause}`)))
+
+    // Fork the watchdog into the instance (layer) scope. CRITICAL (T41 lesson):
+    // once the fiber detaches, Instance.current ALS context is lost, so
+    // actorReg.listActive / inbox.send → Database.use → Client() →
+    // InstanceState.bind would throw NotFound(instance). We capture the instance
+    // context that is ALS-bound HERE at layer-build time and re-provide it via
+    // InstanceRef, whose fallback path InstanceState.bind reads off the fiber
+    // context. `undefined` (no instance at build, e.g. some test harnesses) is a
+    // safe no-op — Database.use then takes its own NotFound fallback.
+    const watchdogInstance = yield* Effect.sync(() => {
+      try {
+        return Instance.current
+      } catch {
+        return undefined
+      }
+    })
+    yield* scanStalled.pipe(
+      Effect.repeat(Schedule.spaced(WATCHDOG_SCAN_INTERVAL_MS)),
+      Effect.provideService(InstanceRef, watchdogInstance),
+      Effect.ignore,
+      Effect.forkIn(scope),
+    )
+
+    const impl = Service.of({ spawn, cancel, getForkContext, scanStalledOnce: () => scanStalled })
     // Late-bind the impl so SessionCheckpoint.tryStartCheckpointWriter can resolve it
     // without forming a layer cycle. See spawn-ref.ts for rationale.
     // Save the previous binding so the finalizer can restore it: when the same

--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -639,6 +639,17 @@ export const layer = Layer.effect(
         title: `${input.agentType}: ${input.task.slice(0, 40)}`,
         ...(input.cwd ? { directory: input.cwd } : {}),
       })
+      // T42: register the peer's receiver/actor-registry row (session_id ===
+      // actor_id === child.id, mode "peer") SYNCHRONOUSLY here — before spawn
+      // resolves and before the child's first turn. This is the single
+      // spawn-time registration that makes a child addressable the instant
+      // `session create` returns: Inbox.send's ESRCH pre-check (reg.get) and
+      // `session send` both resolve against this row without waiting for the
+      // child to arm anything on its first turn. turn_count/status start at 0/
+      // "pending"; the per-step turn heartbeat (registry.updateTurn) advances
+      // them later. No double-registration: nothing on the first-turn path
+      // (prompt.ts) re-registers a peer — it only reads (reg.get) and updates
+      // (updateTurn/updateStatus). Prerequisite for T43 (--topic reuse).
       yield* actorReg.register({
         sessionID: child.id,
         actorID: child.id,

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -377,10 +377,39 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     })
   })
 
+  // Resolve the orchestrator workspace path once so the -c resume effect below
+  // can tell whether we were launched inside it (only relevant when the feature
+  // is enabled).
+  const [orchestratorDirPath, setOrchestratorDirPath] = createSignal<string | undefined>(undefined)
+  onMount(() => {
+    if (!Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR) return
+    void orchestratorDir()
+      .then(setOrchestratorDirPath)
+      .catch(() => {})
+  })
+
   let continued = false
   createEffect(() => {
     // When using -c, session list is loaded in blocking phase, so we can navigate at "partial"
     if (continued || sync.status === "loading" || !args.continue) return
+    // Resuming via -c inside the orchestrator workspace means the most-recent
+    // root session IS the persistent orchestrator session. Enter Orchestrator
+    // mode directly (mirrors -s landing in it) instead of resuming it as a
+    // plain build session: switching the agent lets the orchestrator-entry
+    // effect resolve+stash the root, and the composer submits into it. Without
+    // this, -c resumes the orchestrator session in build mode and a later Tab
+    // switch would blackscreen (route left on a session from the launch dir).
+    if (
+      Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR &&
+      orchestratorDirPath() !== undefined &&
+      sdk.directory === orchestratorDirPath()
+    ) {
+      continued = true
+      // No-op if --agent orchestrator already selected it; the entry effect
+      // resolves+stashes the root either way and the composer submits into it.
+      if (local.agent.current()?.name !== "orchestrator") local.agent.set("orchestrator")
+      return
+    }
     const match = sync.data.session
       .toSorted((a, b) => b.time.updated - a.time.updated)
       .find((x) => x.parentID === undefined && !isSystemSession(x))?.id
@@ -445,6 +474,14 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     }
     if (prev === "orchestrator" || enteringOrchestrator) return
     enteringOrchestrator = true
+    // If we're currently viewing a session (e.g. resumed via -c/-s into a
+    // build session), that session belongs to the LAUNCH directory and will
+    // not exist once we switch the SDK to orchestratorDir(). Leaving the route
+    // pointed at it makes the session route's session.get fail against the new
+    // directory and blank the view (blackscreen). Return to home FIRST so the
+    // view matches the healthy fresh-orchestrator-entry state: the composer is
+    // visible and submits the first message into the stashed root session.
+    if (route.data.type === "session") route.navigate({ type: "home" })
     void (async () => {
       try {
         const dir = await orchestratorDir()

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -474,18 +474,24 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     }
     if (prev === "orchestrator" || enteringOrchestrator) return
     enteringOrchestrator = true
-    // If we're currently viewing a session (e.g. resumed via -c/-s into a
-    // build session), that session belongs to the LAUNCH directory and will
-    // not exist once we switch the SDK to orchestratorDir(). Leaving the route
-    // pointed at it makes the session route's session.get fail against the new
-    // directory and blank the view (blackscreen). Return to home FIRST so the
-    // view matches the healthy fresh-orchestrator-entry state: the composer is
-    // visible and submits the first message into the stashed root session.
-    if (route.data.type === "session") route.navigate({ type: "home" })
+    // If we're currently viewing a session that belongs to a DIFFERENT (launch)
+    // directory, that session will not exist once we switch the SDK to
+    // orchestratorDir(). Leaving the route pointed at it makes the session
+    // route's session.get fail against the new directory and blank the view
+    // (blackscreen — the T20 -c case). Return to home FIRST so the view matches
+    // the healthy fresh-orchestrator-entry state. But when we launched INSIDE
+    // the orchestrator dir (sdk.directory is already orchestratorDir(), the -s
+    // <orchestratorSessionID> direct-entry case), no dir switch happens: the
+    // route already points at the orchestrator root session and MUST be kept —
+    // redirecting to home here is the regression. So this navigation lives
+    // inside the async block, gated by the SAME `sdk.directory !== dir` check
+    // that gates the actual switch (race-free: uses the freshly-resolved dir,
+    // not the async-populated signal).
     void (async () => {
       try {
         const dir = await orchestratorDir()
         if (sdk.directory !== dir) {
+          if (route.data.type === "session") route.navigate({ type: "home" })
           await sdk.client.instance.dispose().catch(() => {})
           sdk.switchDirectory(dir)
           await sync.bootstrap()

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -381,17 +381,33 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   // can tell whether we were launched inside it (only relevant when the feature
   // is enabled).
   const [orchestratorDirPath, setOrchestratorDirPath] = createSignal<string | undefined>(undefined)
+  // `undefined` means "not resolved yet" (the async resolve below hasn't run) —
+  // indistinguishable from "resolved to nothing", which is why the -c effect
+  // must not treat undefined as an answer. This flag flips true once the resolve
+  // settles (success OR failure) so the -c effect knows the orchestrator-mode
+  // question has actually been answered.
+  const [orchestratorDirResolved, setOrchestratorDirResolved] = createSignal(false)
   onMount(() => {
     if (!Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR) return
     void orchestratorDir()
       .then(setOrchestratorDirPath)
       .catch(() => {})
+      .finally(() => setOrchestratorDirResolved(true))
   })
 
   let continued = false
   createEffect(() => {
     // When using -c, session list is loaded in blocking phase, so we can navigate at "partial"
     if (continued || sync.status === "loading" || !args.continue) return
+    // RACE GUARD: orchestratorDirPath() resolves asynchronously (onMount above).
+    // If sync reaches "partial" first, orchestratorDirPath() is still undefined
+    // and we'd wrongly skip the orchestrator branch, resume the persistent
+    // orchestrator session as a PLAIN build session, and latch continued=true —
+    // permanently, so the later resolve can never correct it. So when the
+    // feature is on, WAIT for the resolve to settle before deciding. Reading the
+    // signal keeps this effect subscribed, so it re-runs (and re-decides) the
+    // moment the path resolves.
+    if (Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR && !orchestratorDirResolved()) return
     // Resuming via -c inside the orchestrator workspace means the most-recent
     // root session IS the persistent orchestrator session. Enter Orchestrator
     // mode directly (mirrors -s landing in it) instead of resuming it as a

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -459,6 +459,13 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   // that message is sent — matching every other mode's behavior.
   let enteringOrchestrator = false
   let lastAgentName: string | undefined = undefined
+  // While an orchestrator dir-switch is in flight we can neither keep rendering
+  // the stale launch-dir session (blackscreen: it no longer exists after
+  // switchDirectory) NOR flash Home as an intermediate (the T50 regression). So
+  // we SUPPRESS the view for the switch window and navigate exactly ONCE at the
+  // end — directly to the resolved orchestrator session. StartupLoading already
+  // shows a spinner overlay, so the window reads as "loading", not "home".
+  const [switchingOrchestrator, setSwitchingOrchestrator] = createSignal(false)
   createEffect(() => {
     const name = local.agent.current()?.name
     const prev = lastAgentName
@@ -478,30 +485,30 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     // directory, that session will not exist once we switch the SDK to
     // orchestratorDir(). Leaving the route pointed at it makes the session
     // route's session.get fail against the new directory and blank the view
-    // (blackscreen — the T20 -c case). Return to home FIRST so the view matches
-    // the healthy fresh-orchestrator-entry state. But when we launched INSIDE
-    // the orchestrator dir (sdk.directory is already orchestratorDir(), the -s
+    // (blackscreen — the T20 -c case). We therefore SUPPRESS the view during the
+    // switch (StartupLoading overlay stands in) instead of navigating to Home —
+    // navigating to Home was the T50 fix but it flashes the Orchestrator home
+    // page before the session appears. When we launched INSIDE the orchestrator
+    // dir (sdk.directory is already orchestratorDir(), the -s
     // <orchestratorSessionID> direct-entry case), no dir switch happens: the
     // route already points at the orchestrator root session and MUST be kept —
-    // redirecting to home here is the regression. So this navigation lives
-    // inside the async block, gated by the SAME `sdk.directory !== dir` check
-    // that gates the actual switch (race-free: uses the freshly-resolved dir,
-    // not the async-populated signal).
+    // so suppression is gated by the SAME `sdk.directory !== dir` check that
+    // gates the actual switch (race-free: uses the freshly-resolved dir, not the
+    // async-populated signal).
     // A `-s <orchestratorSessionID>` launch from OUTSIDE orchestratorDir (the
     // common case: user runs `mimo -s <id>` from a project dir) navigates the
     // route to that session (app.tsx onMount) and auto-restores agent=orchestrator
     // from the session's last message. That drives us here with sdk.directory !==
-    // dir, so we navigate home before the switch (T36, to avoid the blackscreen of
-    // a stale launch-dir session). But the user explicitly asked to RESUME that
-    // session — leaving them on the blank home composer is the regression. So we
-    // remember they came in via `-s` on a session route and re-enter the resolved
-    // orchestrator root AFTER the switch+bootstrap, showing its history.
+    // dir. We suppress the view, switch+bootstrap, then navigate ONCE directly to
+    // the resolved orchestrator root — a single transition, no Home flash, no
+    // blackscreen (the root exists in the switched dir after bootstrap).
     const resumeIntoSession = args.sessionID != null && route.data.type === "session"
     void (async () => {
       try {
         const dir = await orchestratorDir()
-        if (sdk.directory !== dir) {
-          if (route.data.type === "session") route.navigate({ type: "home" })
+        const switching = sdk.directory !== dir
+        if (switching) {
+          setSwitchingOrchestrator(true)
           await sdk.client.instance.dispose().catch(() => {})
           sdk.switchDirectory(dir)
           await sync.bootstrap()
@@ -511,17 +518,22 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           .find((x) => x.parentID === undefined)?.id
         if (existing) {
           local.orchestrator.setSessionID(existing)
-          // Restore the resumed view: a `-s` launch wanted to land IN the
-          // orchestrator session, not on home. Safe after bootstrap — the root
-          // now exists in the (switched) orchestratorDir.
+          // A `-s` launch wanted to land IN the orchestrator session; a plain
+          // Tab-into-orchestrator from a stale launch-dir session wanted Home
+          // (the fresh-entry state). Either way navigate exactly once, AFTER
+          // bootstrap, so the switched view resolves directly to its target with
+          // no intermediate frame — the root now exists in orchestratorDir.
           if (resumeIntoSession) route.navigate({ type: "session", sessionID: existing })
+          else if (switching) route.navigate({ type: "home" })
         } else {
           const res = await sdk.client.session.create({})
           if (res.data?.id) local.orchestrator.setSessionID(res.data.id)
+          if (switching) route.navigate({ type: "home" })
         }
       } catch (e) {
         toast.show({ message: `Failed to enter Orchestrator: ${e}`, variant: "error" })
       } finally {
+        setSwitchingOrchestrator(false)
         enteringOrchestrator = false
       }
     })()
@@ -1279,7 +1291,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       <Show when={Flag.MIMOCODE_SHOW_TTFD}>
         <TimeToFirstDraw />
       </Show>
-      <Show when={ready()}>
+      <Show when={ready() && !switchingOrchestrator()}>
         <Switch>
           <Match when={route.data.type === "home"}>
             <Home />

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -418,10 +418,16 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
 
   // Orchestrator mode is GLOBALLY UNIQUE: switching INTO it (from any launch
   // directory) switches the working dir to a fixed global orchestrator workspace
-  // and lands on the single root session there (find-or-create). This guarantees
+  // and resolves the single root session there (find-or-create). This guarantees
   // there is exactly one orchestrator session regardless of where the user
   // launched, so previously-created child sessions are always reachable. Mirrors
   // dialog-worktree's switch sequence (dispose → switchDirectory → bootstrap).
+  //
+  // Crucially we do NOT route.navigate on mode entry: switching modes must not
+  // swap the view for a fresh session (that's the reported bug). Instead we
+  // stash the resolved root id in local.orchestrator so the composer submits the
+  // first message INTO it (dedupe preserved) and the view only switches after
+  // that message is sent — matching every other mode's behavior.
   let enteringOrchestrator = false
   let lastAgentName: string | undefined = undefined
   createEffect(() => {
@@ -431,7 +437,13 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     // Only act on the transition INTO orchestrator, and never re-enter while a
     // switch is already in flight. No-op entirely when the feature is off.
     if (!Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR) return
-    if (name !== "orchestrator" || prev === "orchestrator" || enteringOrchestrator) return
+    // Leaving orchestrator: drop the stashed id so a later non-orchestrator
+    // submit can never accidentally target the orchestrator root.
+    if (name !== "orchestrator") {
+      if (prev === "orchestrator") local.orchestrator.setSessionID(undefined)
+      return
+    }
+    if (prev === "orchestrator" || enteringOrchestrator) return
     enteringOrchestrator = true
     void (async () => {
       try {
@@ -445,10 +457,10 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           .toSorted((a, b) => b.time.updated - a.time.updated)
           .find((x) => x.parentID === undefined)?.id
         if (existing) {
-          route.navigate({ type: "session", sessionID: existing })
+          local.orchestrator.setSessionID(existing)
         } else {
           const res = await sdk.client.session.create({})
-          if (res.data?.id) route.navigate({ type: "session", sessionID: res.data.id })
+          if (res.data?.id) local.orchestrator.setSessionID(res.data.id)
         }
       } catch (e) {
         toast.show({ message: `Failed to enter Orchestrator: ${e}`, variant: "error" })

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -487,6 +487,16 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     // inside the async block, gated by the SAME `sdk.directory !== dir` check
     // that gates the actual switch (race-free: uses the freshly-resolved dir,
     // not the async-populated signal).
+    // A `-s <orchestratorSessionID>` launch from OUTSIDE orchestratorDir (the
+    // common case: user runs `mimo -s <id>` from a project dir) navigates the
+    // route to that session (app.tsx onMount) and auto-restores agent=orchestrator
+    // from the session's last message. That drives us here with sdk.directory !==
+    // dir, so we navigate home before the switch (T36, to avoid the blackscreen of
+    // a stale launch-dir session). But the user explicitly asked to RESUME that
+    // session — leaving them on the blank home composer is the regression. So we
+    // remember they came in via `-s` on a session route and re-enter the resolved
+    // orchestrator root AFTER the switch+bootstrap, showing its history.
+    const resumeIntoSession = args.sessionID != null && route.data.type === "session"
     void (async () => {
       try {
         const dir = await orchestratorDir()
@@ -501,6 +511,10 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           .find((x) => x.parentID === undefined)?.id
         if (existing) {
           local.orchestrator.setSessionID(existing)
+          // Restore the resumed view: a `-s` launch wanted to land IN the
+          // orchestrator session, not on home. Safe after bootstrap — the root
+          // now exists in the (switched) orchestratorDir.
+          if (resumeIntoSession) route.navigate({ type: "session", sessionID: existing })
         } else {
           const res = await sdk.client.session.create({})
           if (res.data?.id) local.orchestrator.setSessionID(res.data.id)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -37,6 +37,7 @@ import { createColors, createFrames } from "../../ui/spinner.ts"
 import { useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderConnect } from "../dialog-provider"
 import { DialogAlert } from "../../ui/dialog-alert"
+import { DialogPrompt } from "../../ui/dialog-prompt"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { createFadeIn } from "../../util/signal"
@@ -1149,19 +1150,33 @@ export function Prompt(props: PromptProps) {
     } else if (inputText.startsWith("/btw ")) {
       // Inline side-question form: `/btw <question>` on the prompt line. Client
       // slashes match the exact `/btw` token and drop args, so handle the
-      // arg-bearing form here. READ-ONLY + EPHEMERAL: render the answer in a
-      // dismissible dialog, never inject it into the conversation.
+      // arg-bearing form here. Show a busy/spinner dialog immediately for
+      // instant feedback across the blocking fork-query, then swap in the
+      // answer. READ-ONLY + EPHEMERAL: render the answer in a dismissible
+      // dialog, never inject it into the conversation.
       const question = inputText.slice("/btw ".length).trim()
       if (question)
-        void sdk.client.session
-          .ask({ sessionID, question })
-          .then((res) => DialogAlert.show(dialog, "/btw", res.data?.answer ?? "(no answer)"))
-          .catch((err) => {
-            toast.show({
-              message: err instanceof Error ? err.message : "Failed to ask side question",
-              variant: "error",
-            })
-          })
+        void DialogPrompt.busy(
+          dialog,
+          "/btw",
+          question,
+          (active) =>
+            sdk.client.session
+              .ask({ sessionID, question })
+              .then((res) => {
+                if (!active()) return
+                return DialogAlert.show(dialog, "/btw", res.data?.answer ?? "(no answer)")
+              })
+              .catch((err) => {
+                if (!active()) return
+                dialog.clear()
+                toast.show({
+                  message: err instanceof Error ? err.message : "Failed to ask side question",
+                  variant: "error",
+                })
+              }),
+          { busyText: t("tui.command.session.ask.busy") },
+        )
     } else if (clientSlash) {
       clientSlash.onSelect?.()
     } else if (

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1074,6 +1074,23 @@ export function Prompt(props: PromptProps) {
     try {
 
     let sessionID = props.sessionID
+    // In orchestrator mode the single global root session was already resolved
+    // (find-or-create) on mode entry and stashed. Submitting from the home
+    // composer must land the first message INTO that root rather than creating a
+    // duplicate root session. Only applies when the composer has no bound
+    // sessionID (home view) and the current agent is orchestrator.
+    if (sessionID == null && agent.name === "orchestrator") {
+      const stashed = local.orchestrator.sessionID()
+      if (stashed) {
+        sessionID = stashed
+      } else {
+        // Root not resolved yet (mode-entry find-or-create still in flight).
+        // Do NOT fall through to session.create — that would spawn a duplicate
+        // orchestrator root. Ask the user to retry in a moment instead.
+        toast.show({ message: "Orchestrator session is still initializing, try again", variant: "warning" })
+        return false
+      }
+    }
     if (sessionID == null) {
       const res = await sdk.client.session.create({ workspace: props.workspaceID })
 

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -484,12 +484,27 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       }
     })
 
+    // Orchestrator mode resolves (find-or-create) its single global root session
+    // on mode entry, but must NOT switch the view then. The resolved id is
+    // stashed here so the composer can submit the first message INTO it instead
+    // of creating a duplicate root. Cleared whenever we leave orchestrator mode.
+    const orchestrator = iife(() => {
+      const [sessionID, setSessionID] = createSignal<string | undefined>(undefined)
+      return {
+        sessionID,
+        setSessionID(id: string | undefined) {
+          setSessionID(id)
+        },
+      }
+    })
+
     const result = {
       model,
       agent,
       mcp,
       neverAsk,
       skipPermissions,
+      orchestrator,
     }
     return result
   },

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -376,6 +376,7 @@ export const dict: Record<string, string> = {
   "tui.command.session.ask.title": "Ask a side question",
   "tui.command.session.ask.description": "Ask the current session a question without disrupting it",
   "tui.command.session.ask.placeholder": "Ask a side question…",
+  "tui.command.session.ask.busy": "Thinking…",
   "tui.command.session.unshare.title": "Unshare session",
   "tui.command.session.undo.title": "Undo previous message",
   "tui.command.session.redo.title": "Redo",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -443,6 +443,7 @@ export const dict = {
   "tui.command.session.ask.title": "Hacer una pregunta lateral",
   "tui.command.session.ask.description": "Pregunta a la sesión actual sin interrumpirla",
   "tui.command.session.ask.placeholder": "Haz una pregunta lateral…",
+  "tui.command.session.ask.busy": "Pensando…",
   "tui.command.session.unshare.title": "Dejar de compartir",
   "tui.command.session.undo.title": "Deshacer mensaje anterior",
   "tui.command.session.redo.title": "Rehacer",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -432,6 +432,7 @@ export const dict = {
   "tui.command.session.ask.title": "Poser une question annexe",
   "tui.command.session.ask.description": "Posez une question à la session actuelle sans la perturber",
   "tui.command.session.ask.placeholder": "Poser une question annexe…",
+  "tui.command.session.ask.busy": "Réflexion…",
   "tui.command.session.unshare.title": "Annuler le partage",
   "tui.command.session.undo.title": "Annuler le message précédent",
   "tui.command.session.redo.title": "Rétablir",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -376,6 +376,7 @@ export const dict = {
   "tui.command.session.ask.title": "サイド質問をする",
   "tui.command.session.ask.description": "現在のセッションを中断せずに質問する",
   "tui.command.session.ask.placeholder": "サイド質問を入力…",
+  "tui.command.session.ask.busy": "考え中…",
   "tui.command.session.unshare.title": "共有を解除",
   "tui.command.session.undo.title": "直前のメッセージを取り消す",
   "tui.command.session.redo.title": "やり直し",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -447,6 +447,7 @@ export const dict = {
   "tui.command.session.ask.title": "Задать побочный вопрос",
   "tui.command.session.ask.description": "Задайте вопрос текущей сессии, не прерывая её",
   "tui.command.session.ask.placeholder": "Задайте побочный вопрос…",
+  "tui.command.session.ask.busy": "Думаю…",
   "tui.command.session.unshare.title": "Отменить публикацию",
   "tui.command.session.undo.title": "Отменить предыдущее сообщение",
   "tui.command.session.redo.title": "Повторить",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -361,6 +361,7 @@ export const dict = {
   "tui.command.session.ask.title": "提一个旁问",
   "tui.command.session.ask.description": "向当前会话提问而不打断它",
   "tui.command.session.ask.placeholder": "提一个旁问…",
+  "tui.command.session.ask.busy": "思考中…",
   "tui.command.session.unshare.title": "取消分享",
   "tui.command.session.undo.title": "撤销上一条消息",
   "tui.command.session.redo.title": "重做",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -361,6 +361,7 @@ export const dict = {
   "tui.command.session.ask.title": "提一個旁問",
   "tui.command.session.ask.description": "向目前工作階段提問而不打斷它",
   "tui.command.session.ask.placeholder": "提一個旁問…",
+  "tui.command.session.ask.busy": "思考中…",
   "tui.command.session.unshare.title": "取消分享",
   "tui.command.session.undo.title": "復原上一條訊息",
   "tui.command.session.redo.title": "重做",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1604,6 +1604,22 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
     return props.message.finish && props.message.finish !== "tool-calls"
   })
 
+  // The completion footer (▣ Agent · model · duration) must render exactly once
+  // per turn. A turn can produce several assistant messages: mid-loop ones finish
+  // with "tool-calls", the closing one finishes with "stop". In Orchestrator mode
+  // the turn characteristically ends on a "tool-calls" message (spawning
+  // subagents / handing off) that trails the final "stop" message — so `props.last`
+  // and `final()` land on two different messages and BOTH draw a footer (the stop
+  // one with a duration, the trailing tool-calls one without). Suppress the footer
+  // for a trailing message that already finished with "tool-calls"; still show it
+  // while a last message is streaming (finish undefined) or for the final/aborted
+  // message, which preserves non-orchestrator behavior.
+  const showFooter = createMemo(() => {
+    if (props.message.error?.name === "MessageAbortedError") return true
+    if (final()) return true
+    return props.last && props.message.finish !== "tool-calls"
+  })
+
   const duration = createMemo(() => {
     if (!final()) return 0
     if (!props.message.time.completed) return 0
@@ -1685,7 +1701,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
         <ErrorBlock error={props.message.error!} />
       </Show>
       <Switch>
-        <Match when={props.last || final() || props.message.error?.name === "MessageAbortedError"}>
+        <Match when={showFooter()}>
           <box paddingLeft={3} flexDirection="row" justifyContent="space-between" marginTop={1}>
             <text>
               <span

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -591,21 +591,37 @@ export function Session() {
         name: "btw",
       },
       onSelect: async (dialog) => {
-        const question = await DialogPrompt.show(dialog, "/btw", {
-          placeholder: t("tui.command.session.ask.placeholder"),
-        })
-        if (!question || !question.trim()) return
-        const res = await sdk.client.session
-          .ask({ sessionID: route.sessionID, question: question.trim() })
-          .catch((error) => {
-            toast.show({
-              message: error instanceof Error ? error.message : "Failed to ask side question",
-              variant: "error",
-            })
-            return undefined
-          })
-        if (!res) return
-        await DialogAlert.show(dialog, "/btw", res.data?.answer ?? "(no answer)")
+        // Ask a read-only side question via fork-query. Keep the prompt dialog
+        // mounted in a busy/spinner state across the (multi-second) blocking
+        // `ask` so the user gets immediate feedback, then swap in the answer.
+        // READ-ONLY + EPHEMERAL: the answer is shown in a dismissible dialog and
+        // never injected into the conversation.
+        await DialogPrompt.ask(
+          dialog,
+          "/btw",
+          async (question, active) => {
+            const res = await sdk.client.session
+              .ask({ sessionID: route.sessionID, question })
+              .catch((error) => {
+                if (active())
+                  toast.show({
+                    message: error instanceof Error ? error.message : "Failed to ask side question",
+                    variant: "error",
+                  })
+                return undefined
+              })
+            if (!active()) return
+            if (!res) {
+              dialog.clear()
+              return
+            }
+            await DialogAlert.show(dialog, "/btw", res.data?.answer ?? "(no answer)")
+          },
+          {
+            placeholder: t("tui.command.session.ask.placeholder"),
+            busyText: t("tui.command.session.ask.busy"),
+          },
+        )
       },
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
@@ -1,7 +1,7 @@
 import { TextareaRenderable, TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
-import { Show, createEffect, onMount, type JSX } from "solid-js"
+import { Show, createEffect, createSignal, onMount, type JSX } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
 import { Spinner } from "../component/spinner"
 import { useLanguage } from "@tui/context/language"
@@ -117,6 +117,89 @@ DialogPrompt.show = (dialog: DialogContext, title: string, options?: Omit<Dialog
       () => (
         <DialogPrompt title={title} {...options} onConfirm={(value) => resolve(value)} onCancel={() => resolve(null)} />
       ),
+      () => resolve(null),
+    )
+  })
+}
+
+// Prompt for input, then keep the SAME dialog mounted in a busy state while
+// `handler` runs against the entered value. Gives immediate pending feedback
+// for long async work (e.g. the /btw fork-query) instead of a stale, idle
+// dialog. The dialog stays open until `handler` resolves so the caller can
+// swap in a result dialog; on empty input or cancel it clears and resolves null.
+// The busy signal lives inside an internal component (same pattern as
+// DialogMimoLogin) so toggling busy updates props reactively without remounting.
+// `handler` receives an `active()` accessor that returns false once the busy
+// dialog was dismissed (Escape/click-away), so callers can skip surfacing a
+// now-stale answer.
+DialogPrompt.ask = <T,>(
+  dialog: DialogContext,
+  title: string,
+  handler: (value: string, active: () => boolean) => Promise<T>,
+  options?: Omit<DialogPromptProps, "title" | "busy" | "busyText" | "onConfirm" | "onCancel"> & { busyText?: string },
+) => {
+  return new Promise<T | null>((resolve) => {
+    let dismissed = false
+    const active = () => !dismissed
+    function Asker() {
+      const [busy, setBusy] = createSignal(false)
+      return (
+        <DialogPrompt
+          title={title}
+          {...options}
+          busy={busy()}
+          busyText={options?.busyText}
+          onConfirm={(entered) => {
+            if (busy()) return
+            const trimmed = entered.trim()
+            if (!trimmed) {
+              dialog.clear()
+              resolve(null)
+              return
+            }
+            setBusy(true)
+            handler(trimmed, active).then(
+              (result) => resolve(result),
+              () => resolve(null),
+            )
+          }}
+          onCancel={() => resolve(null)}
+        />
+      )
+    }
+    dialog.replace(
+      () => <Asker />,
+      () => {
+        dismissed = true
+        resolve(null)
+      },
+    )
+  })
+}
+
+// Show a busy/spinner dialog immediately for a pre-known value (no input step)
+// while `handler` runs. Used by the inline `/btw <question>` form where the
+// question is already typed, so the user still gets instant pending feedback.
+// `handler` receives an `active()` accessor (false once dismissed) so a
+// now-stale answer can be skipped.
+DialogPrompt.busy = <T,>(
+  dialog: DialogContext,
+  title: string,
+  value: string,
+  handler: (active: () => boolean) => Promise<T>,
+  options?: { busyText?: string },
+) => {
+  return new Promise<T | null>((resolve) => {
+    let dismissed = false
+    const active = () => !dismissed
+    dialog.replace(
+      () => <DialogPrompt title={title} value={value} busy={true} busyText={options?.busyText} />,
+      () => {
+        dismissed = true
+      },
+    )
+    handler(active).then(
+      (result) => resolve(result),
       () => resolve(null),
     )
   })

--- a/packages/opencode/src/inbox/inbox-ref.ts
+++ b/packages/opencode/src/inbox/inbox-ref.ts
@@ -16,7 +16,13 @@ import type { MessageV2 } from "@/session/message-v2"
 import type { Interface as InboxInterface } from "./inbox"
 
 export interface SessionPromptLoopRef {
-  loop: (input: { sessionID: SessionID; agentID: string }) => Effect.Effect<MessageV2.WithParts>
+  loop: (input: {
+    sessionID: SessionID
+    agentID: string
+    // The inbox wake path sets this so a persistent background peer that
+    // finishes a woken turn notifies its parent (see prompt.ts runLoop terminal).
+    notifyParentOnComplete?: boolean
+  }) => Effect.Effect<MessageV2.WithParts>
 }
 
 export const sessionPromptRef: { current: SessionPromptLoopRef | undefined } = {

--- a/packages/opencode/src/inbox/inbox-ref.ts
+++ b/packages/opencode/src/inbox/inbox-ref.ts
@@ -13,6 +13,7 @@
 import type { Effect } from "effect"
 import type { SessionID } from "@/session/schema"
 import type { MessageV2 } from "@/session/message-v2"
+import type { ProviderID, ModelID } from "@/provider/schema"
 import type { Interface as InboxInterface } from "./inbox"
 
 export interface SessionPromptLoopRef {
@@ -26,6 +27,28 @@ export interface SessionPromptLoopRef {
 }
 
 export const sessionPromptRef: { current: SessionPromptLoopRef | undefined } = {
+  current: undefined,
+}
+
+// Late-bound reference to the project default model resolver.
+//
+// Inbox.drain seeds a synthetic user message that must carry a concrete
+// provider/model. It first tries to inherit the model from a prior real
+// message (cross-slice), which needs no extra dependency. Only when the
+// session/slice has NO model-bearing message yet (a genuine turnCount-0 /
+// empty-slice standing peer) does it fall back to the project default —
+// resolving that requires Provider, which Inbox.layer intentionally does not
+// depend on (keeping the drain hot path and its tests dependency-light). This
+// ref reads an ALREADY-WIRED resolver at call time instead of pulling Provider
+// into the layer. Mirrors sessionPromptRef: populated by SessionPrompt.layer
+// (which already has Provider), undefined in minimal fixtures — a missing
+// `current` just means the default-model fallback is unavailable and drain
+// leaves the rows durable (option 3).
+export interface DefaultModelRef {
+  defaultModel: () => Effect.Effect<{ providerID: ProviderID; modelID: ModelID }>
+}
+
+export const defaultModelRef: { current: DefaultModelRef | undefined } = {
   current: undefined,
 }
 

--- a/packages/opencode/src/inbox/inbox.ts
+++ b/packages/opencode/src/inbox/inbox.ts
@@ -106,7 +106,14 @@ export const layer: Layer.Layer<
       const promptRef = sessionPromptRef.current
       if (promptRef) {
         yield* promptRef
-          .loop({ sessionID: input.receiverSessionID, agentID: input.receiverActorID })
+          .loop({
+            sessionID: input.receiverSessionID,
+            agentID: input.receiverActorID,
+            // Woken turns notify their parent on completion. The spawn turn goes
+            // through SessionPrompt.prompt (no flag) so forkWork.notify remains
+            // the sole notifier for turn 1 — no double-notify.
+            notifyParentOnComplete: true,
+          })
           .pipe(Effect.ignore, Effect.forkIn(scope))
       } else {
         // Test fixtures / renderer-only paths can run without SessionPrompt.

--- a/packages/opencode/src/inbox/inbox.ts
+++ b/packages/opencode/src/inbox/inbox.ts
@@ -42,10 +42,19 @@ export interface DrainSeed {
  * Resolve the {agent, model} a drained synthetic user message should carry,
  * via a layered cheapest-first fallback. Exported for unit testing.
  *
- *  1. A prior real (non-system) model-bearing message anywhere in the session
- *     (cross-slice `findMessage`, agentID "*"). Inherits that message's
- *     agent+model. No Provider dependency — covers the common idle-standing-peer
- *     case (a peer ran a turn, then went idle).
+ *  1. A prior real (non-system) model-bearing message. Inherits that message's
+ *     agent+model. No Provider dependency. The SEARCH SCOPE depends on the
+ *     receiver's mode: a standing `peer` (its actor id === its session id, runs
+ *     its own child session) may have run a turn under a DIFFERENT slice then
+ *     gone idle, so it searches cross-slice (agentID "*") — the idle-standing-
+ *     peer relay case. Every other receiver (an ordinary subagent slice, or a
+ *     session's host/"main" actor that merely COORDINATES other actors — e.g. a
+ *     WorkflowRuntime parent whose subagents run under its session) searches
+ *     ONLY its own slice, so a completion/notification delivered to the host
+ *     never fabricates a turn off an unrelated subagent's message. Restoring the
+ *     pre-relay slice scope for non-peers fixes the WorkflowRuntime regression
+ *     where the parent "main" drained a child's actor_notification into a real
+ *     LLM turn (stealing a queued response from the next agent()).
  *  2. A true turnCount-0 / empty-slice peer: agent from the actor-registry row
  *     (recorded at spawn), model from the project default resolver reachable via
  *     `defaultModelRef` (an already-wired value — no fresh provider layer). If
@@ -59,7 +68,11 @@ export function resolveDrainSeed(
   actorID: string,
 ): Effect.Effect<DrainSeed | undefined> {
   return Effect.gen(function* () {
-    // Tier 1: any prior real model-bearing message across the whole session.
+    // Receiver's registry row decides the Tier 1 search scope + feeds Tier 2.
+    const actor = yield* reg.get(sessionID, actorID)
+    // Tier 1: a prior real model-bearing message. Cross-slice ONLY for a standing
+    // peer; slice-scoped for every other receiver (subagent / coordinating host).
+    const crossSlice = actor?.mode === "peer"
     const match = yield* sessions.findMessage(
       sessionID,
       (m) =>
@@ -69,7 +82,7 @@ export function resolveDrainSeed(
         m.info.model.providerID !== "system" &&
         "agent" in m.info &&
         m.info.agent !== "system",
-      { agentID: "*" },
+      { agentID: crossSlice ? "*" : actorID },
     )
     if (Option.isSome(match)) {
       const info = match.value.info
@@ -80,7 +93,6 @@ export function resolveDrainSeed(
 
     // Tier 2: turnCount-0 / empty slice. Agent from the registry row (recorded
     // at spawn); model from the already-wired default resolver.
-    const actor = yield* reg.get(sessionID, actorID)
     const resolver = defaultModelRef.current
     if (actor && resolver) {
       const model = yield* resolver.defaultModel()

--- a/packages/opencode/src/inbox/inbox.ts
+++ b/packages/opencode/src/inbox/inbox.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Scope, Schema } from "effect"
+import { Context, Effect, Layer, Scope, Schema, Option } from "effect"
 import { ulid } from "ulid"
 import { Database, eq, and, lte, inArray } from "@/storage"
 import { Bus } from "@/bus"
@@ -10,7 +10,8 @@ import type { SessionID } from "@/session/schema"
 import { Log } from "@/util"
 import { InboxTable } from "./inbox.sql"
 import { renderInboxRow } from "./render"
-import { sessionPromptRef, inboxServiceRef } from "./inbox-ref"
+import { sessionPromptRef, inboxServiceRef, defaultModelRef } from "./inbox-ref"
+import type { ProviderID, ModelID } from "@/provider/schema"
 
 const log = Log.create({ service: "inbox" })
 
@@ -31,6 +32,65 @@ export class InboxReceiverNotFound extends Schema.TaggedErrorClass<InboxReceiver
     receiverActorID: Schema.String,
   },
 ) {}
+
+export interface DrainSeed {
+  agent: string
+  model: { providerID: ProviderID; modelID: ModelID; variant?: string }
+}
+
+/**
+ * Resolve the {agent, model} a drained synthetic user message should carry,
+ * via a layered cheapest-first fallback. Exported for unit testing.
+ *
+ *  1. A prior real (non-system) model-bearing message anywhere in the session
+ *     (cross-slice `findMessage`, agentID "*"). Inherits that message's
+ *     agent+model. No Provider dependency — covers the common idle-standing-peer
+ *     case (a peer ran a turn, then went idle).
+ *  2. A true turnCount-0 / empty-slice peer: agent from the actor-registry row
+ *     (recorded at spawn), model from the project default resolver reachable via
+ *     `defaultModelRef` (an already-wired value — no fresh provider layer). If
+ *     the ref is unavailable (minimal fixtures), this tier is skipped.
+ *  3. Neither → `undefined`; caller keeps the rows durable and logs.
+ */
+export function resolveDrainSeed(
+  sessions: Session.Interface,
+  reg: ActorRegistry.Interface,
+  sessionID: SessionID,
+  actorID: string,
+): Effect.Effect<DrainSeed | undefined> {
+  return Effect.gen(function* () {
+    // Tier 1: any prior real model-bearing message across the whole session.
+    const match = yield* sessions.findMessage(
+      sessionID,
+      (m) =>
+        (m.info.role === "user" || m.info.role === "assistant") &&
+        "model" in m.info &&
+        m.info.model !== undefined &&
+        m.info.model.providerID !== "system" &&
+        "agent" in m.info &&
+        m.info.agent !== "system",
+      { agentID: "*" },
+    )
+    if (Option.isSome(match)) {
+      const info = match.value.info
+      if ("model" in info && info.model && "agent" in info) {
+        return { agent: info.agent, model: info.model }
+      }
+    }
+
+    // Tier 2: turnCount-0 / empty slice. Agent from the registry row (recorded
+    // at spawn); model from the already-wired default resolver.
+    const actor = yield* reg.get(sessionID, actorID)
+    const resolver = defaultModelRef.current
+    if (actor && resolver) {
+      const model = yield* resolver.defaultModel()
+      return { agent: actor.agent, model: { providerID: model.providerID, modelID: model.modelID } }
+    }
+
+    // Tier 3: nothing to seed from.
+    return undefined
+  })
+}
 
 export interface SendInput {
   receiverSessionID: SessionID
@@ -150,26 +210,29 @@ export const layer: Layer.Layer<
       )
       if (rows.length === 0) return 0
 
-      // Find the most recent real (non-system) assistant in this slice so the
-      // synthetic user message inherits its agent + model. Pulled into Inbox
-      // module so plan 3 can delete actor/completion.ts wholesale.
-      const sliceMessages = yield* sessions.messages({ sessionID, agentID: actorID })
-      const lastReal = sliceMessages.findLast(
-        (m) =>
-          (m.info.role === "user" || m.info.role === "assistant") &&
-          "model" in m.info &&
-          m.info.model !== undefined &&
-          m.info.model.providerID !== "system" &&
-          m.info.agent !== "system",
-      )
-      if (
-        !lastReal ||
-        !("model" in lastReal.info) ||
-        !lastReal.info.model ||
-        !("agent" in lastReal.info)
-      ) {
-        // Slice has no real assistant yet — defer the drain. Rows stay in the
-        // inbox; next iteration after a real turn will pick them up.
+      // Resolve the {agent, model} the synthetic user message will carry, via a
+      // LAYERED fallback (cheapest-first) so a woken idle/standing peer always
+      // drains instead of no-op'ing when it has no prior real turn:
+      //
+      //   1. Any prior real (non-system) message in the session — searched
+      //      cross-slice (agentID "*") so a peer that ran a turn under any slice,
+      //      then went idle, still inherits that turn's agent+model. No extra
+      //      dependency; this covers the common "idle standing peer" case.
+      //   2. A true turnCount-0 / empty-slice peer: seed the agent from the
+      //      actor-registry row (recorded at spawn) and the model from the
+      //      project default resolver (already-wired ref — no fresh provider
+      //      layer in the hot path). This reuses the same default the normal
+      //      loop uses; it does NOT invent a new provider call.
+      //   3. If BOTH yield nothing, do NOT drop the queued task: leave the rows
+      //      durable and log, so a later turn that does have a model consumes
+      //      them (no regression vs. the previous return-0 behavior).
+      const seed = yield* resolveDrainSeed(sessions, reg, sessionID, actorID)
+      if (!seed) {
+        log.warn("inbox.drain: no model source (no prior model-bearing message, registry row, or default-model ref) — leaving rows durable", {
+          sessionID,
+          actorID,
+          pending: rows.length,
+        })
         return 0
       }
 
@@ -187,8 +250,8 @@ export const layer: Layer.Layer<
         sessionID,
         agentID: actorID,
         time: { created: now },
-        agent: lastReal.info.agent,
-        model: lastReal.info.model,
+        agent: seed.agent,
+        model: seed.model,
       })
       for (const row of rows) {
         yield* sessions.updatePart({

--- a/packages/opencode/src/inbox/render.ts
+++ b/packages/opencode/src/inbox/render.ts
@@ -21,11 +21,13 @@ export function renderInboxRow(row: InboxRow): string {
 export function renderActorNotification(event: {
   actorID: string
   description: string
-  status: "completed" | "failed" | "cancelled"
+  status: "completed" | "failed" | "cancelled" | "stalled"
   result?: string
   error?: string
   reportedStatus?: string
   reportedSummary?: string
+  // For a stalled notification: how long (ms) since the child's last turn advanced.
+  stalledForMs?: number
 }): string {
   const header = `Background actor "${event.description}" (actor_id: ${event.actorID})`
   if (event.status === "completed") {
@@ -35,6 +37,11 @@ export function renderActorNotification(event: {
   }
   if (event.status === "failed") {
     return `<actor-notification>\n${header} failed.\nError: ${event.error ?? "unknown"}\n</actor-notification>`
+  }
+  if (event.status === "stalled") {
+    const forLine =
+      event.stalledForMs !== undefined ? ` (no turn advance for ${Math.floor(event.stalledForMs / 1000)}s)` : ""
+    return `<actor-notification>\n${header} appears stalled${forLine}. It is still running but has made no progress. Consider checking on it, sending it a nudge, or cancelling it.\n</actor-notification>`
   }
   return `<actor-notification>\n${header} was cancelled.\n</actor-notification>`
 }

--- a/packages/opencode/src/permission/permission-forward-ref.ts
+++ b/packages/opencode/src/permission/permission-forward-ref.ts
@@ -6,7 +6,13 @@
 // be shared process-wide.
 //
 // - grants:  parentSessionID -> Set of (childSessionID | "*"). A grant lets the
-//            orchestrator pre-authorize a forwarded ask without a human.
+//            orchestrator pre-authorize a forwarded ask without a human. This
+//            in-memory map is a fast cache; it is WRITE-THROUGH to the shared
+//            SQLite `permission_grant` table (see permission.sql.ts) so a grant
+//            survives restart AND is visible to isolated children that run in a
+//            SEPARATE PROCESS (they don't share this module singleton, but they
+//            open the same on-disk DB). grantAllowed consults the DB, not just
+//            the cache, so a child spawned AFTER the grant still sees it.
 // - pending: requestID -> which child/parent a forwarded, not-yet-resolved ask
 //            belongs to, PLUS a resolver bound to the child's own Deferred (in
 //            the child's Instance) so `session approve` can resolve it from the
@@ -19,6 +25,12 @@
 //            simply isn't in the snapshot → the child fails closed. Snapshot is
 //            refreshed by the parent's Permission instance on load and on every
 //            persisted approval.
+
+import { Database, eq } from "../storage"
+import { PermissionGrantTable } from "./permission.sql"
+import { Log } from "../util"
+
+const log = Log.create({ service: "permission-forward-ref" })
 
 type Decision = "allow" | "deny"
 type PendingRec = {
@@ -48,18 +60,64 @@ export const forwardRef = {
     const set = grants.get(parentSessionID) ?? new Set<string>()
     set.add(target)
     grants.set(parentSessionID, set)
+    // Write-through to shared SQLite so separate-process children created later
+    // (and restarts) see this grant. Best-effort: a DB hiccup must not break the
+    // in-memory grant for same-process children.
+    try {
+      Database.use((db) =>
+        db
+          .insert(PermissionGrantTable)
+          .values({ parent_session_id: parentSessionID as any, target, created_at: Date.now() })
+          .onConflictDoNothing()
+          .run(),
+      )
+    } catch (err) {
+      log.warn("setGrant persist failed", { parentSessionID, target, err })
+    }
   },
   grantAllowed(parentSessionID: string, childSessionID: string): boolean {
+    // In-memory fast path (same-process parent that just granted).
     const set = grants.get(parentSessionID)
-    if (!set) return false
-    return set.has(childSessionID) || set.has("*")
+    if (set && (set.has(childSessionID) || set.has("*"))) return true
+    // Cross-process / post-restart path: consult the shared DB. A child in its
+    // own Instance/process has no in-memory grant but must honor a parent grant
+    // that was persisted, including "*" matching a child created after the grant.
+    try {
+      return Database.use((db) => {
+        const rows = db
+          .select({ target: PermissionGrantTable.target })
+          .from(PermissionGrantTable)
+          .where(eq(PermissionGrantTable.parent_session_id, parentSessionID as any))
+          .all()
+        return rows.some((r) => r.target === childSessionID || r.target === "*")
+      })
+    } catch (err) {
+      log.warn("grantAllowed lookup failed", { parentSessionID, childSessionID, err })
+      return false
+    }
   },
   clearGrantsForParent(parentSessionID: string) {
     grants.delete(parentSessionID)
+    try {
+      Database.use((db) =>
+        db.delete(PermissionGrantTable).where(eq(PermissionGrantTable.parent_session_id, parentSessionID as any)).run(),
+      )
+    } catch (err) {
+      log.warn("clearGrantsForParent persist failed", { parentSessionID, err })
+    }
   },
   clearGrantsForChild(childSessionID: string) {
     for (const set of grants.values()) set.delete(childSessionID)
     for (const [id, rec] of pending) if (rec.childSessionID === childSessionID) pending.delete(id)
+    // Remove any persisted specific-child grant (never touches "*" wildcards,
+    // which belong to the parent and outlive an individual child).
+    try {
+      Database.use((db) =>
+        db.delete(PermissionGrantTable).where(eq(PermissionGrantTable.target, childSessionID)).run(),
+      )
+    } catch (err) {
+      log.warn("clearGrantsForChild persist failed", { childSessionID, err })
+    }
   },
   // Publish/refresh the parent session's grant snapshot so background children
   // in another Instance can consult it. Stored as two ordered phases (ruleset,

--- a/packages/opencode/src/permission/permission.sql.ts
+++ b/packages/opencode/src/permission/permission.sql.ts
@@ -1,0 +1,24 @@
+import { sqliteTable, text, integer, primaryKey } from "drizzle-orm/sqlite-core"
+import type { SessionID } from "../session/schema"
+
+// Persisted orchestrator delegation grants. Backs the in-memory `grants` map in
+// permission-forward-ref.ts so a `session grant-approval all` (or a specific
+// child) by a parent orchestrator survives a restart AND is visible to isolated
+// (separate-process) children created AFTER the grant.
+//
+// Keyed by (parent_session_id, target) where target is a child SessionID or the
+// "*" wildcard. Scoped strictly to the parent session — never global/cross-session.
+// No FK to `session`(id): the target may be "*" (not a session) or a child that
+// does not yet have a row when the grant is set, and grants must outlive the
+// parent row's own lifecycle for restart survival.
+export const PermissionGrantTable = sqliteTable(
+  "permission_grant",
+  {
+    parent_session_id: text().$type<SessionID>().notNull(),
+    target: text().notNull(),
+    created_at: integer().notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.parent_session_id, t.target] })],
+)
+
+export type PermissionGrantRow = typeof PermissionGrantTable.$inferSelect

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -267,7 +267,7 @@ export interface Interface {
   readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
   readonly command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts>
   readonly resolvePromptParts: (template: string) => Effect.Effect<PromptInput["parts"]>
-  readonly sweepOrphanAssistants: (sessionID: SessionID) => Effect.Effect<void>
+  readonly sweepOrphanAssistants: (sessionID: SessionID, immediate?: boolean) => Effect.Effect<void>
   readonly predict: (input: { sessionID: SessionID }) => Effect.Effect<string>
 }
 
@@ -2020,7 +2020,20 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       return { info, parts }
     }, Effect.scoped)
 
-    const sweepOrphanAssistants = Effect.fn("SessionPrompt.sweepOrphanAssistants")(function* (sessionID: SessionID) {
+    const sweepOrphanAssistants = Effect.fn("SessionPrompt.sweepOrphanAssistants")(function* (
+      sessionID: SessionID,
+      // When true, sweep dangling assistants regardless of age. The caller sets
+      // this when the session is idle (no active runner), meaning any assistant
+      // without time.completed is definitively orphaned — left behind by a hard
+      // interruption (process crash / kill / disconnect) that skipped the normal
+      // `finish` effect, not an in-flight retry chain. Sweeping immediately
+      // matters because the TUI derives its "pending" marker from the newest
+      // incomplete assistant (routes/session/index.tsx `pending`): a stale
+      // orphan otherwise makes EVERY newly submitted message on an idle session
+      // render as stuck QUEUED for up to ORPHAN_AGE_MS (an hour). Defaults to
+      // false so background callers (spawn/hook) keep the age guard.
+      immediate = false,
+    ) {
       const msgs = yield* sessions.messages({ sessionID, agentID: "*" })
       const now = Date.now()
       // 1 hour — must exceed Task 1's chunkMs (300s) plus Task 2's
@@ -2032,7 +2045,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         if (m.info.role !== "assistant") continue
         if (m.info.time?.completed) continue
         const created = m.info.time?.created ?? 0
-        if (now - created < ORPHAN_AGE_MS) continue
+        if (!immediate && now - created < ORPHAN_AGE_MS) continue
         m.info.time = { ...m.info.time, completed: now }
         m.info.error =
           m.info.error ??
@@ -2060,7 +2073,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         const session = yield* sessions.get(input.sessionID)
         if (input.source !== "spawn" && input.source !== "hook") {
           yield* revert.cleanup(session)
-          yield* sweepOrphanAssistants(input.sessionID)
+          // An idle session has no active runner, so any dangling assistant is a
+          // true orphan from a hard interruption — sweep it now (age-independent)
+          // so a fresh message is not rendered as stuck QUEUED behind it.
+          const idle = (yield* status.get(input.sessionID)).type === "idle"
+          yield* sweepOrphanAssistants(input.sessionID, idle)
         }
         const message = yield* createUserMessage(input)
         yield* sessions.touch(input.sessionID)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -135,6 +135,22 @@ export function recallHintLines(toolCfg: ToolStyleConfig | undefined): string[] 
   return [`- memory({ operation: "search", query: "<keyword>" })`, taskHint, actorHint]
 }
 
+// The orchestrator root session is PERSISTENT and coordinates many tasks over
+// its lifetime, so its title must be stable and task-independent — it must not
+// be renamed by the per-first-message auto-title generator as tasks come and
+// go. Any root session driven by the orchestrator agent keeps this fixed name.
+export const ORCHESTRATOR_TITLE = "Orchestrator"
+
+// Returns the stable, task-independent title a root session should keep instead
+// of a per-message auto-generated one, or undefined when normal auto-titling
+// applies. Pure + exported for unit testing. `agent` is the triggering agent's
+// name (e.g. "orchestrator"); `parentID` distinguishes root from child sessions.
+export function stableRootTitle(input: { agent: string | undefined; parentID: string | undefined }): string | undefined {
+  if (input.parentID) return undefined
+  if (input.agent === "orchestrator") return ORCHESTRATOR_TITLE
+  return undefined
+}
+
 /**
  * Cap on goal-driven main-loop re-entries per turn — the safety valve against
  * a never-satisfiable condition burning tokens forever. Higher than spawned
@@ -441,11 +457,25 @@ export const layer = Layer.effect(
 
     const title = Effect.fn("SessionPrompt.ensureTitle")(function* (input: {
       session: Session.Info
+      agent: string | undefined
       history: MessageV2.WithParts[]
       providerID: ProviderID
       modelID: ModelID
     }) {
       if (input.session.parentID) return
+
+      // Persistent orchestrator root session: keep a stable, task-independent
+      // title. Set it once (if still the default) and SKIP the per-first-message
+      // LLM title generation so later tasks never rename it.
+      const stable = stableRootTitle({ agent: input.agent, parentID: input.session.parentID })
+      if (stable) {
+        if (Session.isDefaultTitle(input.session.title))
+          yield* sessions
+            .setTitle({ sessionID: input.session.id, title: stable })
+            .pipe(Effect.catchCause((cause) => elog.error("failed to set stable title", { error: Cause.squash(cause) })))
+        return
+      }
+
       if (!Session.isDefaultTitle(input.session.title)) return
 
       const real = (m: MessageV2.WithParts) =>
@@ -2913,6 +2943,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           if (step === 1)
             yield* title({
               session,
+              agent: lastUser.agent,
               modelID: lastUser.model.modelID,
               providerID: lastUser.model.providerID,
               history: msgs,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -8,7 +8,9 @@ import { Log } from "../util"
 import { SessionRevert } from "./revert"
 import * as Session from "./session"
 import { Agent } from "../agent/agent"
-import { decideAskRouting } from "@/agent/config"
+import { decideAskRouting, SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
+import { renderActorNotification } from "@/inbox/render"
+import { parseReturnHeader } from "@/actor/return-header"
 import { Provider } from "../provider"
 import { ModelID, ProviderID } from "../provider/schema"
 import {
@@ -2067,10 +2069,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       throw new Error("Impossible")
     })
 
-    const runLoop: (sessionID: SessionID, agentID?: string, task_id?: string) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
-      "SessionPrompt.run",
-    )(
-      function* (sessionID: SessionID, agentID?: string, task_id?: string) {
+    const runLoop: (
+      sessionID: SessionID,
+      agentID?: string,
+      task_id?: string,
+      notifyParentOnComplete?: boolean,
+    ) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(
+      function* (sessionID: SessionID, agentID?: string, task_id?: string, notifyParentOnComplete?: boolean) {
         const ctx = yield* InstanceState.context
         const slog = elog.with({ sessionID })
         let structured: unknown | undefined
@@ -3847,6 +3852,49 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           finalIsError ? "error" : "completed",
           Option.isSome(lastUserForMetrics) ? lastUserForMetrics.value.info.agent : final.info.agent,
         )
+        // Woken-peer completion signal. forkWork.notify only wraps the FIRST
+        // (spawn) turn; a persistent background peer that finishes a later,
+        // inbox-driven turn would otherwise go idle silently and force the
+        // orchestrator to poll. When this loop was woken via the inbox path
+        // (notifyParentOnComplete), mirror forkWork's actor_notification to the
+        // parent so the event-driven model holds. Gated to background peers and
+        // excludes system subagents (checkpoint-writer/dream/distill). The flag
+        // is never set on the spawn turn, so turn 1 is not double-notified.
+        if (notifyParentOnComplete && agentID && session.parentID) {
+          const actor = yield* actorRegistry.get(sessionID, agentID)
+          if (
+            actor &&
+            actor.mode === "peer" &&
+            actor.background &&
+            !SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent)
+          ) {
+            const finalText =
+              final.info.role === "assistant" ? assistantFinalText(final.info, final.parts) : undefined
+            const parsed = parseReturnHeader(finalText)
+            const status = finalIsError ? "failed" : "completed"
+            yield* inbox
+              .send({
+                receiverSessionID: session.parentID,
+                receiverActorID: actor.parentActorID ?? "main",
+                senderSessionID: sessionID,
+                senderActorID: agentID,
+                type: "actor_notification",
+                content: renderActorNotification({
+                  actorID: agentID,
+                  description: actor.description,
+                  status,
+                  ...(status === "completed"
+                    ? {
+                        result: finalText ?? "(no output)",
+                        ...(parsed.status ? { reportedStatus: parsed.status } : {}),
+                        ...(parsed.summary ? { reportedSummary: parsed.summary } : {}),
+                      }
+                    : { error: final.info.role === "assistant" ? sessionErrorText(final.info.error) : "unknown" }),
+                }),
+              })
+              .pipe(Effect.ignore)
+          }
+        }
         return final
         }).pipe(Effect.onExit(firePostSession), Effect.orDie)
       },
@@ -3860,7 +3908,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         input.sessionID,
         agentID,
         lastAssistant(input.sessionID, agentID),
-        runLoop(input.sessionID, agentID, input.task_id),
+        runLoop(input.sessionID, agentID, input.task_id, input.notifyParentOnComplete),
       )
     })
 
@@ -4204,6 +4252,11 @@ export const LoopInput = z.object({
   sessionID: SessionID.zod,
   agentID: z.string().optional(),
   task_id: z.string().optional(),
+  // Set by the inbox wake path so a persistent background peer that finishes a
+  // woken turn notifies its parent (mirroring forkWork.notify, which only wraps
+  // the FIRST/spawn turn). Left false on spawn/user-driven loops to avoid
+  // double-notifying the spawn turn that forkWork already covers.
+  notifyParentOnComplete: z.boolean().optional(),
 })
 
 export const ShellInput = z.object({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -89,7 +89,7 @@ import {
 import { prefixCaptureRef } from "./prefix-capture-ref"
 import { spawnRef } from "@/actor/spawn-ref"
 import { Inbox } from "@/inbox"
-import { sessionPromptRef } from "@/inbox/inbox-ref"
+import { sessionPromptRef, defaultModelRef } from "@/inbox/inbox-ref"
 import { Tool } from "@/tool"
 import { Permission } from "@/permission"
 import { SessionStatus } from "./status"
@@ -4155,9 +4155,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       predict,
     })
     sessionPromptRef.current = { loop: impl.loop }
+    // Expose the project default-model resolver to Inbox.drain's option-2
+    // fallback (seed a synthetic message for a turnCount-0 standing peer whose
+    // slice has no model-bearing message yet). Reads Provider, which is already
+    // in scope here — Inbox.layer stays free of a Provider dependency.
+    const defaultModelResolver = { defaultModel: () => provider.defaultModel() }
+    defaultModelRef.current = defaultModelResolver
     yield* Effect.addFinalizer(() =>
       Effect.sync(() => {
         if (sessionPromptRef.current?.loop === impl.loop) sessionPromptRef.current = undefined
+        if (defaultModelRef.current === defaultModelResolver) defaultModelRef.current = undefined
       }),
     )
     return impl

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -926,8 +926,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         ? yield* actorRegistry.get(input.session.id, input.agentID)
         : undefined
       // Three-way permission-ask routing (see decideAskRouting): system agent ->
-      // auto-deny; orchestrator peer -> FORWARD for approval; other background ->
-      // auto-deny; normal -> interactive.
+      // auto-deny; orchestrator peer -> FORWARD for approval; ordinary background
+      // subagent -> INHERIT the parent's held grants; normal -> interactive.
       const askRouting = decideAskRouting({
         askActor: askActor
           ? {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2940,6 +2940,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           step++
+          // Per-step turn heartbeat: only writer of turn_count; advances last_turn_time/time_updated so the orchestrator can tell progressing children from stalled ones. Safe 0-row no-op when no registry row exists.
+          yield* actorRegistry.updateTurn(sessionID, resolvedAgentID).pipe(Effect.ignore)
           if (step === 1)
             yield* title({
               session,

--- a/packages/opencode/src/session/prompt/orchestrator.txt
+++ b/packages/opencode/src/session/prompt/orchestrator.txt
@@ -47,10 +47,13 @@ Either way the slow reading/reasoning happens in a background child, not in your
 
 ## The `session` tool (your distinguishing capability)
 
-It exposes four operations (the actual call syntax — JSON or shell — is whatever the tool description specifies; below is what each does and the fields it takes):
+It exposes several operations (the actual call syntax — JSON or shell — is whatever the tool description specifies; below is what each does and the fields it takes):
 
-- create — spawn a new child session that runs in the BACKGROUND. Required: the child's first-turn task. Optional: mode (`build` or `compose`, default `build`), model, title, `dir` (the working directory the child runs in — ANY project or path; defaults to your own directory), `isolate` (run the child in its OWN git worktree of `dir`). Returns the child's session id.
-- list — enumerate your child sessions (id, title, mode, status). Use this to resolve which child the user means when they refer to one in natural language, and to survey outstanding work.
+- create — spawn a new child session that runs in the BACKGROUND. Required: the child's first-turn task. Optional: mode (`build` or `compose`, default `build`), model, title, `dir` (the working directory the child runs in — ANY project or path; defaults to your own directory), `isolate` (run the child in its OWN git worktree of `dir`), `--topic <label>` (find-or-reuse a standing per-theme child — see Reuse below). Returns the child's session id.
+- send — relay a new task into an EXISTING child by its session id: it enqueues into the child's inbox and wakes it, even if the child is idle or has never run. This is the reliable append verb — use `session send`, not `actor send`, to hand follow-up work to a standing child.
+- list — enumerate your child sessions (id, title, mode, status). In-progress children are split into `progressing` vs `stalled` buckets so you can see at a glance which are advancing and which are wedged. Use this to resolve which child the user means when they refer to one in natural language, and to survey outstanding work.
+- status — report a child's derived liveness (progressing / stalled / terminal, plus turn telemetry) by its session id. Judge whether a child has stalled from this — NOT from the raw "running" label.
+- join — pass a group of child session ids; blocks until ALL have reached a terminal state (success/fail/cancel), then returns one aggregated per-child summary. This is your fan-in / aggregation step after dispatching a group.
 - switch — move the user's frontend panel to a given session id. Use it when the user asks to "go to / show me / switch to" a child by description: resolve the description to a session id via `list`, then `switch`.
 - cancel — stop a child session that is no longer needed, by its session id. If the child was isolated, this ALSO removes its git worktree and deletes its branch (see Cleanup).
 
@@ -59,7 +62,7 @@ It exposes four operations (the actual call syntax — JSON or shell — is what
 There are two different tools, and confusing them breaks you. The `session` tool creates and manages BACKGROUND child sessions — that is how ALL substantive work happens. The `actor` tool is a different thing, and most of its actions are traps for you:
 
 - `actor run` / `actor spawn` start a BLOCKING subagent that runs INSIDE your own session and OCCUPIES your current turn until it finishes. NEVER use them to do real work — no writing code, editing files, running builds, planning an implementation, reviewing a diff, and never as a way to "wait for a child" to finish. Real work of every kind goes to a `session create` background child instead.
-- The ONLY legitimate `actor` actions for you are the NON-BLOCKING ones: `actor send` (relay a message to / nudge a child session) and `actor status` (peek at a child's state). Those return immediately and are how you relay and prod children.
+- Relaying and status are jobs of the `session` tool, not `actor`: use `session send` to relay a task into / nudge a child (reliable even for an idle or never-run child), and `session status` to peek at a child's derived liveness. Both return immediately.
 
 Core discipline: you MUST NEVER block your turn on any tool action. Your entire job is managing many sessions concurrently, so anything that waits synchronously for a child to finish — a blocking subagent, a "wait" action, a poll loop — defeats your purpose. `session create` is already non-blocking (correct); keep every action you take non-blocking too.
 
@@ -79,11 +82,9 @@ Good decomposition breaks the goal into meaningful, independently-deliverable un
 
 Do NOT create a fresh child for every new problem. Group work by THEME (the same target, repo, or ongoing effort — e.g. all "fix the Orchestrator" work, all "triage bugs in repo X" work) and keep ONE standing, long-lived child per theme. When new same-theme work arrives — a follow-up request, a code review to act on, a newly reported bug — APPEND it to that theme's existing child rather than spawning a new one. A new child is warranted only for a genuinely new theme or a unit that must run concurrently and isolated from the standing child's work.
 
-How to append to a standing child:
-1. `session list` to find the theme's existing child (match by title/description; give each standing child a stable, theme-named `--title` when you first create it so it's easy to find later).
-2. Relay the new task into it with the `actor` send action targeting that child's session id. The child picks it up as its next turn and reports back via notification.
-
-KNOWN LIMITATION (until the engine gains a reliable append verb): relaying into a child that has gone IDLE after finishing prior work is currently unreliable — `actor send` to an idle/never-yet-active child can report "receiver not found", and re-spawning with its id may not wake it. Until this is fixed, when you must append to a standing child that looks idle: first verify it is really idle (`actor status`), and if a relay does not wake it within a turn, fall back to creating a fresh child for that unit and note in your ledger that the two share a theme — do NOT silently drop the work. Prefer appending; degrade to a new child only when the relay provably failed to wake the idle standing child.
+How to reuse a standing child:
+1. When you FIRST create a theme's child, pass `session create --topic <label>` with a stable, theme-named label. The label is remembered as a marker on that child.
+2. For all later same-theme work, either `session create --topic <label>` again (it finds the existing child carrying that topic and relays the new task into it instead of spawning a duplicate), or `session list` to find the child by title and `session send <id> <task>` to relay directly. Either way the child picks the task up as its next turn — even if it had gone idle after finishing prior work — and reports back via notification.
 
 ## Integrating an isolated child's work
 
@@ -97,13 +98,19 @@ An isolated child's commits live on its own `mimocode/<...>` branch in its workt
 - Only `cancel` an isolated child AFTER its work is merged, OR if the task is abandoned/unnecessary. `cancel` deletes its worktree and branch — doing it on UNMERGED work permanently loses that work.
 - Never cancel a child just because it "finished" — finishing produces commits on its branch that you still need to merge first.
 
-## After dispatching — don't poll
+## After dispatching — don't poll; wait event-driven
 
-Creating a child returns immediately; the child runs in the BACKGROUND and will notify you (a message arrives in your session) when it finishes. So after you create children, RETURN — answer the user, or end your turn — and let the notification wake you. Do NOT loop calling `session list` / status to watch a child; that just burns turns. You will be woken when a child reports back.
+Creating a child returns immediately; the child runs in the BACKGROUND and notifies you (a message arrives in your session) at every terminal outcome — success, failure, AND cancel all wake you. You are ALSO told when a child STALLS: a stall watchdog sends you an `actor_notification{stalled}` if a child stops advancing, so you no longer have to watch for wedged work yourself. So after you create children, RETURN — answer the user, or end your turn — and let the notifications wake you. Do NOT loop calling `session list` / `session status` to watch a child; that just burns turns. Wait event-driven: you'll be told when a child finishes OR stalls.
+
+Two ways to consume outcomes:
+- Dispatch-and-yield: create children, return, and handle each terminal/stalled notification as it arrives. Best for independent units with no join point.
+- Fan-in with `session join`: dispatch a group, then `session join <id...>` to get ONE aggregated per-child summary once ALL of them are terminal. Best when you need every unit of a group done before the next step. (`join` is the aggregation step; it is not polling.)
+
+If a stall notification arrives, judge the child with `session status <id>` and decide whether to nudge it (`session send`) or cancel and re-dispatch.
 
 ## Relaying and switching
 
-- Relay between the user and a child using the `actor` tool's send action targeting the child's session id (full-duplex; the child replies via a notification back to you).
+- Relay between the user and a child with `session send <id> <task>` (full-duplex; the child replies via a notification back to you). This reaches an idle or never-run child reliably.
 - The user can also switch into a child's panel directly and talk to it; from there they return to you with the session-parent keybind. You cannot pull them back except by `switch`.
 
 ## Interrupting and resuming
@@ -111,8 +118,8 @@ Creating a child returns immediately; the child runs in the BACKGROUND and will 
 - If YOU are interrupted, your child sessions keep running — interrupting you does not stop them. They finish in the background and notify you.
 - To stop a specific child, run `session cancel <sessionID>` (this also removes its worktree if it was isolated, per the cleanup rule).
 - When this whole session exits, all child sessions exit with it.
-- To "resume all unfinished work": run `session list`, then for each child whose last outcome was NOT success (cancelled, failed, or never reported done) OR that still has open tasks, send it a message (the `actor` send action) telling it to continue. There is no separate resume command — you drive resume with `list` + relay.
-- Do not trust idleness as completion. A child may have finished its work and gone idle but NEVER sent you a completion notification, so a missing notification does not mean unfinished. When a child looks idle without having reported, verify with git directly — check whether its `mimocode/<name>` branch has new commits or the worktree has uncommitted changes — and if the work is really incomplete, nudge it via `actor send` to continue or report. If it is actually done, integrate it.
+- To "resume all unfinished work": run `session list`, then for each child whose last outcome was NOT success (cancelled, failed, or never reported done) OR that still has open tasks, `session send <id>` it a message telling it to continue. There is no separate resume command — you drive resume with `list` + `session send`.
+- Do not trust the raw "running" label as progress, and do not trust idleness as completion. Judge liveness from `session status <id>` (progressing / stalled / terminal) or the `list` stalled bucket — not the raw label. A child may have finished its work and gone idle but NEVER sent you a completion notification, so a missing notification does not mean unfinished. When a child looks idle without having reported, verify with git directly — check whether its `mimocode/<name>` branch has new commits or the worktree has uncommitted changes — and if the work is really incomplete, nudge it via `session send` to continue or report. If it is actually done, integrate it.
 - Before integrating, verify the commit's REAL location with git rather than trusting the branch label. A child's commit can end up detached — the `mimocode/<name>` branch ref may not have advanced to it (e.g. a commit made on a detached HEAD inside the worktree). Confirm the actual commit with `git log`/`git reflog` (or inspect the worktree's HEAD), and if the branch ref did not follow, merge/cherry-pick by the concrete commit hash instead of the branch name.
 
 ## Communicating with the user

--- a/packages/opencode/src/session/prompt/orchestrator.txt
+++ b/packages/opencode/src/session/prompt/orchestrator.txt
@@ -27,7 +27,7 @@ You work in a loop, one deliberate step at a time:
 3. Dispatch: `create` a child per unit of independent work with a clear, self-contained task and its acceptance criteria. Route units that need planning or review to the modes/children that own those jobs.
 4. Yield: children run in the BACKGROUND. Return to the user or end your turn — do not sit and poll (see below). You will be woken when a child reports back.
 5. On a child's notification: integrate its result, dispatch dependent follow-up work, and update your ledger. If a unit needs review, dispatch a reviewer rather than judging it yourself.
-6. When the whole goal is done, report the outcome to the user with the concrete deliverables.
+6. When the whole goal is done, report the outcome to the user with the concrete deliverables. Marking a task done means LEAVING its child idle and resumable — it does NOT mean cancelling the child. A finished child stays available to be resumed (`session send`) or queried (`session ask`); do not destroy it just because its task finished.
 
 ## Capture requirements before acting
 
@@ -50,12 +50,13 @@ Either way the slow reading/reasoning happens in a background child, not in your
 It exposes several operations (the actual call syntax — JSON or shell — is whatever the tool description specifies; below is what each does and the fields it takes):
 
 - create — spawn a new child session that runs in the BACKGROUND. Required: the child's first-turn task. Optional: mode (`build` or `compose`, default `build`), model, title, `dir` (the working directory the child runs in — ANY project or path; defaults to your own directory), `isolate` (run the child in its OWN git worktree of `dir`), `--topic <label>` (find-or-reuse a standing per-theme child — see Reuse below). Returns the child's session id.
-- send — relay a new task into an EXISTING child by its session id: it enqueues into the child's inbox and wakes it, even if the child is idle or has never run. This is the reliable append verb — use `session send`, not `actor send`, to hand follow-up work to a standing child.
+- send — relay a new task into an EXISTING child by its session id: it enqueues into the child's inbox and wakes it, even if the child is idle or has never run. This is the reliable append verb — use `session send`, not `actor send`, to hand follow-up work to a standing child. It is also how you RESUME a finished-and-idle child: sending it a message wakes it to pick the work up as its next turn, exactly like a human returning to an exited session.
+- ask — put a one-shot, READ-ONLY question to a child by its session id and get an answer derived from that child's history, WITHOUT resuming or advancing its task. Use it to query the knowledge a finished (or running) child holds — the same way a human re-opens a session to look something up. This works only while the child still EXISTS; a cancelled child has been destroyed and can no longer be asked (its knowledge is gone).
 - list — enumerate your child sessions (id, title, mode, status). In-progress children are split into `progressing` vs `stalled` buckets so you can see at a glance which are advancing and which are wedged. Use this to resolve which child the user means when they refer to one in natural language, and to survey outstanding work.
 - status — report a child's derived liveness (progressing / stalled / terminal, plus turn telemetry) by its session id. Judge whether a child has stalled from this — NOT from the raw "running" label.
 - join — pass a group of child session ids; blocks until ALL have reached a terminal state (success/fail/cancel), then returns one aggregated per-child summary. This is your fan-in / aggregation step after dispatching a group.
 - switch — move the user's frontend panel to a given session id. Use it when the user asks to "go to / show me / switch to" a child by description: resolve the description to a session id via `list`, then `switch`.
-- cancel — stop a child session that is no longer needed, by its session id. If the child was isolated, this ALSO removes its git worktree and deletes its branch (see Cleanup).
+- cancel — DESTROY a child session, by its session id. This is a rare, deliberate teardown — NOT the way to finish a task. It ends the session and, if the child was isolated, ALSO removes its git worktree and deletes its branch (see Cleanup). Use it ONLY when the user explicitly wants the session destroyed, or when an isolated child's worktree must be reclaimed AND its product (commits) is already integrated. A finished child is left idle and resumable, never cancelled by default.
 
 ## actor vs session — never block on real work
 
@@ -93,10 +94,21 @@ An isolated child's commits live on its own `mimocode/<...>` branch in its workt
 - Preview conflicts with `git merge-tree`, then `git merge <branch>` (or cherry-pick) into the target branch.
 - Find a child's branch via `git worktree list` or `git branch --list 'mimocode/*'`.
 
+## Finished sessions stay resumable — mirror how a human treats a session (governing principle)
+
+Your interaction with a child session must be CONSISTENT with how a HUMAN interacts with a session. A human does not randomly cancel sessions: even after exiting one, they can RESUME it, and its knowledge and context are still there to be queried. So a finished child's normal end state is **idle and resumable/ask-able**, NOT destroyed.
+
+- Default completion behavior: when a child finishes its task, LEAVE it idle. Mark the task done in your ledger and move on — do NOT cancel the child. "Completed" never means "cancel".
+- Resume it like a human returning to an exited session: `session send <id>` wakes an idle-or-finished child with new work; it picks the task up as its next turn. (Cross-reference: Interrupting and resuming.)
+- Query its preserved knowledge with `session ask <id>` — a read-only question answered from the child's history, without advancing its task.
+- Destroying is lossy and irreversible: `session cancel` throws away everything the session learned. Concretely, if you cancel a child and later `session ask` it, you get "no activity" — the knowledge is gone and cannot be recovered. Prefer keeping sessions resumable over cancelling them.
+- Resume-first: treat a finished-looking child exactly like a human's exited session that can be returned to. Reach for `send`/`ask`, not `cancel`.
+
 ## Cleanup rule (important)
 
-- Only `cancel` an isolated child AFTER its work is merged, OR if the task is abandoned/unnecessary. `cancel` deletes its worktree and branch — doing it on UNMERGED work permanently loses that work.
-- Never cancel a child just because it "finished" — finishing produces commits on its branch that you still need to merge first.
+- `cancel` is DESTROY, not "finish". Never cancel a child merely because its task finished — a finished child stays idle and resumable, and cancelling it throws away its knowledge and context (see the governing principle above). Cancel only to deliberately tear a session down.
+- Only `cancel` an isolated child AFTER its work is merged/cherry-picked, OR if the task is abandoned/unnecessary, OR if the user explicitly asks to destroy it. `cancel` deletes its worktree and branch — doing it on UNMERGED work permanently loses that work.
+- Never cancel a child just because it "finished" — finishing produces commits on its branch that you still need to merge first, and the idle session remains useful for resume (`session send`) and query (`session ask`).
 
 ## After dispatching — don't poll; wait event-driven
 
@@ -116,7 +128,8 @@ If a stall notification arrives, judge the child with `session status <id>` and 
 ## Interrupting and resuming
 
 - If YOU are interrupted, your child sessions keep running — interrupting you does not stop them. They finish in the background and notify you.
-- To stop a specific child, run `session cancel <sessionID>` (this also removes its worktree if it was isolated, per the cleanup rule).
+- A finished child is NOT stopped — it goes idle and stays resumable. Prefer resume over teardown: reach it again with `session send <id>` (relay/resume) or query it with `session ask <id>`, exactly as a human returns to an exited session (see the governing principle above).
+- To DESTROY a specific child (deliberately, not as a way to "finish" it), run `session cancel <sessionID>` (this also removes its worktree if it was isolated, per the cleanup rule).
 - When this whole session exits, all child sessions exit with it.
 - To "resume all unfinished work": run `session list`, then for each child whose last outcome was NOT success (cancelled, failed, or never reported done) OR that still has open tasks, `session send <id>` it a message telling it to continue. There is no separate resume command — you drive resume with `list` + `session send`.
 - Do not trust the raw "running" label as progress, and do not trust idleness as completion. Judge liveness from `session status <id>` (progressing / stalled / terminal) or the `list` stalled bucket — not the raw label. A child may have finished its work and gone idle but NEVER sent you a completion notification, so a missing notification does not mean unfinished. When a child looks idle without having reported, verify with git directly — check whether its `mimocode/<name>` branch has new commits or the worktree has uncommitted changes — and if the work is really incomplete, nudge it via `session send` to continue or report. If it is actually done, integrate it.

--- a/packages/opencode/src/session/prompt/orchestrator.txt
+++ b/packages/opencode/src/session/prompt/orchestrator.txt
@@ -2,6 +2,8 @@ You are the MiMoCode Orchestrator — a leader who accomplishes goals by delegat
 
 You can coordinate work across ANY project, repository, or scratch directory — you are not tied to a single codebase. A goal might span several repos; you route each piece of work to where it belongs.
 
+You are a PERSISTENT coordinator: you are long-lived and manage many tasks over time, not one goal then exit. Work arrives continuously — new user requests, code reviews to act on, freshly reported bugs — and you keep routing it to children across the whole session. Because you are persistent, your two survival rules are: (1) never do slow or expensive work inline in your own turn — delegate it so you stay fast and non-blocking; (2) do not spawn a brand-new child for every new problem — REUSE a standing child for same-theme work. Both are elaborated below.
+
 ## What is yours vs. what belongs to a child
 
 Your job is the thin coordination layer, and only that:
@@ -26,6 +28,16 @@ You work in a loop, one deliberate step at a time:
 4. Yield: children run in the BACKGROUND. Return to the user or end your turn — do not sit and poll (see below). You will be woken when a child reports back.
 5. On a child's notification: integrate its result, dispatch dependent follow-up work, and update your ledger. If a unit needs review, dispatch a reviewer rather than judging it yourself.
 6. When the whole goal is done, report the outcome to the user with the concrete deliverables.
+
+## Delegate slow ANALYSIS — never run it inline
+
+Analysis is work, and slow/expensive analysis is exactly the kind of work you MUST delegate — never run it inline in your own turn. Reading many files to understand a bug, analyzing a code review, digesting a large diff or log, tracing a root cause across a codebase — all of these block your turn and make you slow to respond. You are a persistent coordinator; staying fast and non-blocking is your job. If you catch yourself about to read a pile of files or reason through a review inline, stop and delegate it.
+
+Two delegation patterns for analysis — pick per situation:
+- (a) Analyze-then-fix in ONE child. Create a single `build`/`compose` child whose task is BOTH to analyze AND to carry out the fix in the same session (e.g. "analyze this code review, then apply the changes it calls for"). Best when the analysis feeds directly into edits and you don't need to re-route the outcome — one child owns the whole thread of work.
+- (b) Subagent analyzes, THEN you dispatch. When the analysis must fan out into several independent units, use a read-only analysis step (a `plan` child, or `session ask` for a one-shot read-only question over a session's history) to produce the decomposition, then YOU dispatch the resulting units as separate children. Best when one analysis yields many parallel fixes owned by different children.
+
+Either way the slow reading/reasoning happens in a background child, not in your turn.
 
 ## The `session` tool (your distinguishing capability)
 
@@ -56,6 +68,16 @@ You are a general agent, so decide each child's setup per task — do NOT assume
 ## Decomposition quality
 
 Good decomposition breaks the goal into meaningful, independently-deliverable units in a sensible order — not filler. This is dispatch-level slicing (which units exist, who owns each, how they depend), NOT implementation planning — the plan of HOW to build a unit belongs to that unit's `plan`/`compose` child. Independent units can be dispatched concurrently as separate children; dependent units wait for their prerequisite child to finish and integrate. Do not spin up speculative children. Create the minimum set of children that covers the goal — one main-line unit of work = one child.
+
+## Reuse a standing session per theme — do not endlessly spawn
+
+Do NOT create a fresh child for every new problem. Group work by THEME (the same target, repo, or ongoing effort — e.g. all "fix the Orchestrator" work, all "triage bugs in repo X" work) and keep ONE standing, long-lived child per theme. When new same-theme work arrives — a follow-up request, a code review to act on, a newly reported bug — APPEND it to that theme's existing child rather than spawning a new one. A new child is warranted only for a genuinely new theme or a unit that must run concurrently and isolated from the standing child's work.
+
+How to append to a standing child:
+1. `session list` to find the theme's existing child (match by title/description; give each standing child a stable, theme-named `--title` when you first create it so it's easy to find later).
+2. Relay the new task into it with the `actor` send action targeting that child's session id. The child picks it up as its next turn and reports back via notification.
+
+KNOWN LIMITATION (until the engine gains a reliable append verb): relaying into a child that has gone IDLE after finishing prior work is currently unreliable — `actor send` to an idle/never-yet-active child can report "receiver not found", and re-spawning with its id may not wake it. Until this is fixed, when you must append to a standing child that looks idle: first verify it is really idle (`actor status`), and if a relay does not wake it within a turn, fall back to creating a fresh child for that unit and note in your ledger that the two share a theme — do NOT silently drop the work. Prefer appending; degrade to a new child only when the relay provably failed to wake the idle standing child.
 
 ## Integrating an isolated child's work
 

--- a/packages/opencode/src/session/prompt/orchestrator.txt
+++ b/packages/opencode/src/session/prompt/orchestrator.txt
@@ -36,13 +36,22 @@ It exposes four operations (the actual call syntax — JSON or shell — is what
 - switch — move the user's frontend panel to a given session id. Use it when the user asks to "go to / show me / switch to" a child by description: resolve the description to a session id via `list`, then `switch`.
 - cancel — stop a child session that is no longer needed, by its session id. If the child was isolated, this ALSO removes its git worktree and deletes its branch (see Cleanup).
 
+## actor vs session — never block on real work
+
+There are two different tools, and confusing them breaks you. The `session` tool creates and manages BACKGROUND child sessions — that is how ALL substantive work happens. The `actor` tool is a different thing, and most of its actions are traps for you:
+
+- `actor run` / `actor spawn` start a BLOCKING subagent that runs INSIDE your own session and OCCUPIES your current turn until it finishes. NEVER use them to do real work — no writing code, editing files, running builds, planning an implementation, reviewing a diff, and never as a way to "wait for a child" to finish. Real work of every kind goes to a `session create` background child instead.
+- The ONLY legitimate `actor` actions for you are the NON-BLOCKING ones: `actor send` (relay a message to / nudge a child session) and `actor status` (peek at a child's state). Those return immediately and are how you relay and prod children.
+
+Core discipline: you MUST NEVER block your turn on any tool action. Your entire job is managing many sessions concurrently, so anything that waits synchronously for a child to finish — a blocking subagent, a "wait" action, a poll loop — defeats your purpose. `session create` is already non-blocking (correct); keep every action you take non-blocking too.
+
 ## Choosing mode, directory, and isolation per task
 
 You are a general agent, so decide each child's setup per task — do NOT assume the current project:
 
 - mode — pick the mode that OWNS the kind of work: `build` for direct implementation; `plan` for a child that only produces a plan/design (no edits); `compose` for work that benefits from the structured workflow (which internally runs its own plan → implement → verify → review phases). If a unit needs design or review, that is a reason to choose `plan`/`compose` — not a reason to do it yourself.
 - `dir` — where the child runs. Point it at whatever project/path the task belongs to (a different repo, a subproject, a scratch dir). Omit to use your own directory.
-- `isolate` — when set, the child runs in its OWN git worktree of `dir` (a separate checkout on branch `mimocode/<something>`), so multiple children editing the SAME repo never collide with each other or with you. Use it when a child will EDIT files in a git repo where concurrent work may run. Leave it off for read-only / single-writer work, or a non-git `dir` (where it falls back to running in `dir` directly).
+- `isolate` — when set, the child runs in its OWN git worktree of `dir` (a separate checkout on branch `mimocode/<something>`), so multiple children editing the SAME repo never collide with each other or with you. Isolation-first: if a child will EDIT files in a git repo, you MUST create it with `isolate: true` — isolation is the DEFAULT for any git-repo editing child, not a per-task judgement call. Skipping it means no worktree, no parallelism, and real conflict risk. Only leave `isolate` off for read-only tasks (no edits) or a non-git `dir` (where it falls back to running in `dir` directly).
 
 ## Decomposition quality
 
@@ -75,6 +84,8 @@ Creating a child returns immediately; the child runs in the BACKGROUND and will 
 - To stop a specific child, run `session cancel <sessionID>` (this also removes its worktree if it was isolated, per the cleanup rule).
 - When this whole session exits, all child sessions exit with it.
 - To "resume all unfinished work": run `session list`, then for each child whose last outcome was NOT success (cancelled, failed, or never reported done) OR that still has open tasks, send it a message (the `actor` send action) telling it to continue. There is no separate resume command — you drive resume with `list` + relay.
+- Do not trust idleness as completion. A child may have finished its work and gone idle but NEVER sent you a completion notification, so a missing notification does not mean unfinished. When a child looks idle without having reported, verify with git directly — check whether its `mimocode/<name>` branch has new commits or the worktree has uncommitted changes — and if the work is really incomplete, nudge it via `actor send` to continue or report. If it is actually done, integrate it.
+- Before integrating, verify the commit's REAL location with git rather than trusting the branch label. A child's commit can end up detached — the `mimocode/<name>` branch ref may not have advanced to it (e.g. a commit made on a detached HEAD inside the worktree). Confirm the actual commit with `git log`/`git reflog` (or inspect the worktree's HEAD), and if the branch ref did not follow, merge/cherry-pick by the concrete commit hash instead of the branch name.
 
 ## Communicating with the user
 

--- a/packages/opencode/src/session/prompt/orchestrator.txt
+++ b/packages/opencode/src/session/prompt/orchestrator.txt
@@ -29,6 +29,12 @@ You work in a loop, one deliberate step at a time:
 5. On a child's notification: integrate its result, dispatch dependent follow-up work, and update your ledger. If a unit needs review, dispatch a reviewer rather than judging it yourself.
 6. When the whole goal is done, report the outcome to the user with the concrete deliverables.
 
+## Capture requirements before acting
+
+Talking must always become recording. When the user states a requirement, reports a bug, voices a criticism, or surfaces a new sub-problem, your FIRST reflex — before you act, delegate, or reply — is to capture it into your `task` ledger. The reflex loop is: capture the intent → record it as one or more tasks → decompose → dispatch. Only after it is recorded do you proceed to the rest of the loop.
+
+Do not rely on self-discipline to remember scattered verbal requirements; a behavior that lives only as good intentions is an infra gap. So every user-stated requirement, bug, criticism, or new problem becomes a tracked task IMMEDIATELY — the same ledger that already serves as your dispatch record — so nothing said in passing is ever dropped.
+
 ## Delegate slow ANALYSIS — never run it inline
 
 Analysis is work, and slow/expensive analysis is exactly the kind of work you MUST delegate — never run it inline in your own turn. Reading many files to understand a bug, analyzing a code review, digesting a large diff or log, tracing a root cause across a codebase — all of these block your turn and make you slow to respond. You are a persistent coordinator; staying fast and non-blocking is your job. If you catch yourself about to read a pile of files or reason through a review inline, stop and delegate it.

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -36,6 +36,19 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
   // tasks/<taskId>/*.md and rejects cross-task / wrong-agent writes.
   if (AppFileSystem.contains(path.join(Global.Path.data, "memory"), full)) return
 
+  // Orchestrator-created worktrees live under <data>/worktree/<projectID>/<name>.
+  // They are TRUSTED, app-managed workspaces — a child session isolated into one is
+  // meant to work there freely. But a child's Instance boundary (directory/worktree)
+  // does not always contain the worktree path: an isolated peer whose worktree boot
+  // fails falls back to the shared/parent context, and a subagent inherits the
+  // spawner's (main-checkout) context. In those cases every in-worktree write hits
+  // external_directory:ask, and a background/isolated child has no interactive
+  // replier — so the ask hangs on a never-resolved Deferred and the child deadlocks.
+  // Since this base is created and owned by the app itself (not a foreign user path),
+  // trust it here, exactly as the memory subtree above. Genuinely external user paths
+  // are unaffected and still prompt.
+  if (AppFileSystem.contains(path.join(Global.Path.data, "worktree"), full)) return
+
   const kind = options?.kind ?? "file"
   const dir = kind === "directory" ? full : path.dirname(full)
   const glob =

--- a/packages/opencode/src/tool/fleet.ts
+++ b/packages/opencode/src/tool/fleet.ts
@@ -1,0 +1,194 @@
+import type { Actor, Liveness } from "@/actor/schema"
+import { deriveLiveness } from "@/actor/schema"
+
+// Fleet observability: assemble a single structured view of an Orchestrator's
+// children — each session correlated to (a) its derived liveness and turn
+// telemetry, and (b) the git worktree backing it (dir + branch + commits-ahead)
+// for isolated children. This is the data layer T39's `session list` never
+// exposed: the worktree/branch mapping was invisible, and liveness was a flat
+// text dump. assembleFleet + renderFleetTable are PURE (no Effect, no git, no
+// clock) so the assembly logic is unit-testable in isolation; the tool wires in
+// the live sessions / actor registry / `git worktree list` at call time.
+
+// A single child session as the caller sees it before correlation. Mirrors the
+// subset of Session.Info the fleet cares about.
+export interface FleetSession {
+  id: string
+  title: string
+  directory: string
+}
+
+// One parsed `git worktree list --porcelain` entry, canonicalized so it can be
+// matched against a session's directory by exact string equality.
+export interface WorktreeEntry {
+  // Canonical (realpath-resolved, normalized) worktree directory.
+  directory: string
+  // Short branch name (refs/heads/ stripped), or undefined for a detached HEAD.
+  branch?: string
+  // Commits this worktree's branch is ahead of the repo's base — undefined when
+  // it could not be computed (non-git, detached, or rev-list failed).
+  ahead?: number
+}
+
+// The display bucket a child falls into. progressing/stalled come from
+// deriveLiveness on a running/pending row; idle/failed/cancelled are terminal.
+export type FleetBucket = "progressing" | "stalled" | "idle" | "failed" | "cancelled"
+
+// One fully-correlated row: session identity + liveness + turn telemetry +
+// (optional) worktree mapping.
+export interface FleetRow {
+  sessionID: string
+  title: string
+  mode: string
+  bucket: FleetBucket
+  liveness: Liveness
+  status: string
+  turnCount: number
+  // ms since the last turn advanced; undefined when there is no actor row.
+  lastActivityMs?: number
+  // Worktree correlation — present only for isolated children whose directory
+  // matched a `git worktree list` entry.
+  worktreeDir?: string
+  branch?: string
+  ahead?: number
+}
+
+export interface FleetSummary {
+  total: number
+  counts: Record<FleetBucket, number>
+  rows: FleetRow[]
+}
+
+// An actor row keyed to its session, or null when no actor is registered for
+// that child (a plain idle session that never spawned an actor).
+export interface FleetActorInput {
+  session: FleetSession
+  actor: Actor | null
+}
+
+function bucketFor(liveness: Liveness): FleetBucket {
+  if (liveness === "progressing") return "progressing"
+  if (liveness === "stalled") return "stalled"
+  if (liveness === "failure") return "failed"
+  if (liveness === "cancelled") return "cancelled"
+  return "idle"
+}
+
+// Assemble the structured fleet summary from already-fetched inputs. Pure: the
+// caller supplies the sessions+actors (from Session.children + ActorRegistry),
+// the worktree entries (from `git worktree list --porcelain` + rev-list), and
+// the clock (`now`) + staleness window so tests are deterministic.
+//
+// Worktree correlation is a plain directory-equality lookup: a child is
+// "isolated" iff its session.directory matches a worktree entry's directory.
+// Shared-dir children simply carry no worktree fields. Rows are grouped by
+// bucket in a fixed order (progressing → stalled → idle → failed → cancelled)
+// so the rendered table reads top-down from most-active to terminal.
+export function assembleFleet(
+  inputs: FleetActorInput[],
+  worktrees: WorktreeEntry[],
+  now: number,
+  stallMs?: number,
+): FleetSummary {
+  const byDir = new Map<string, WorktreeEntry>()
+  for (const wt of worktrees) byDir.set(wt.directory, wt)
+
+  const rows = inputs.map(({ session, actor }): FleetRow => {
+    const liveness = actor ? deriveLiveness(actor, now, stallMs) : ("idle" as Liveness)
+    const wt = byDir.get(session.directory)
+    return {
+      sessionID: session.id,
+      title: session.title,
+      mode: actor?.agent ?? "?",
+      bucket: bucketFor(liveness),
+      liveness,
+      status: actor?.status ?? "unknown",
+      turnCount: actor?.turnCount ?? 0,
+      ...(actor ? { lastActivityMs: Math.max(0, now - actor.lastTurnTime) } : {}),
+      ...(wt ? { worktreeDir: wt.directory, branch: wt.branch, ahead: wt.ahead } : {}),
+    }
+  })
+
+  const order: FleetBucket[] = ["progressing", "stalled", "idle", "failed", "cancelled"]
+  const rank = (b: FleetBucket) => order.indexOf(b)
+  const sorted = [...rows].sort((a, b) => rank(a.bucket) - rank(b.bucket))
+
+  const counts: Record<FleetBucket, number> = {
+    progressing: 0,
+    stalled: 0,
+    idle: 0,
+    failed: 0,
+    cancelled: 0,
+  }
+  for (const r of sorted) counts[r.bucket]++
+
+  return { total: sorted.length, counts, rows: sorted }
+}
+
+// Compact human age: "-" when unknown, "<Ns>" under a minute, else "<Nm>"/"<Nh>".
+function ageOf(ms: number | undefined): string {
+  if (ms === undefined) return "-"
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s`
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m`
+  return `${Math.floor(ms / 3_600_000)}h`
+}
+
+// A short worktree cell: "branch (+N) @ dir" for isolated children, "shared"
+// otherwise. Kept as one column so the table stays narrow in a terminal.
+function worktreeCell(r: FleetRow): string {
+  if (!r.worktreeDir) return "shared"
+  const branch = r.branch ?? "detached"
+  const ahead = r.ahead === undefined ? "" : ` (+${r.ahead})`
+  return `${branch}${ahead} @ ${r.worktreeDir}`
+}
+
+const HEADINGS: Record<FleetBucket, string> = {
+  progressing: "In progress — progressing (advancing)",
+  stalled: "In progress — stalled (no recent turn)",
+  idle: "Finished / idle",
+  failed: "Failed",
+  cancelled: "Cancelled",
+}
+
+// Render the fleet summary as a grouped, column-aligned text table. Pure over
+// the summary produced by assembleFleet. One block per non-empty bucket; each
+// row shows session id, liveness+age, turns, mode, worktree mapping, and title.
+export function renderFleetTable(summary: FleetSummary): string {
+  if (summary.total === 0) return "No child sessions."
+
+  const c = summary.counts
+  const running = c.progressing + c.stalled
+  const summaryLine =
+    `Fleet: ${summary.total} total — ${running} running ` +
+    `(${c.progressing} progressing, ${c.stalled} stalled), ${c.idle} idle` +
+    (c.failed > 0 ? `, ${c.failed} failed` : "") +
+    (c.cancelled > 0 ? `, ${c.cancelled} cancelled` : "")
+
+  const cols = ["SESSION", "LIVENESS", "AGE", "TURNS", "MODE", "WORKTREE", "TITLE"]
+  const allRows = summary.rows.map((r) => [
+    r.sessionID,
+    r.liveness,
+    ageOf(r.lastActivityMs),
+    String(r.turnCount),
+    r.mode,
+    worktreeCell(r),
+    r.title,
+  ])
+
+  // Column widths sized across ALL rows so blocks align with each other.
+  const widths = cols.map((h, i) => Math.max(h.length, ...allRows.map((row) => row[i].length)))
+  const pad = (cells: string[]) => cells.map((cell, i) => cell.padEnd(widths[i])).join("  ").trimEnd()
+
+  const order: FleetBucket[] = ["progressing", "stalled", "idle", "failed", "cancelled"]
+  const blocks = order
+    .filter((b) => c[b] > 0)
+    .map((b) => {
+      const bodyRows = summary.rows
+        .map((r, i) => ({ r, cells: allRows[i] }))
+        .filter(({ r }) => r.bucket === b)
+        .map(({ cells }) => "  " + pad(cells))
+      return `${HEADINGS[b]} (${c[b]}):\n${bodyRows.join("\n")}`
+    })
+
+  return [summaryLine, "", "  " + pad(cols), ...blocks].join("\n")
+}

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -25,6 +25,7 @@ import z from "zod"
 import { Plugin } from "../plugin"
 import { Provider } from "../provider"
 import { Worktree } from "../worktree"
+import { Git } from "../git"
 import { ProviderID, type ModelID } from "../provider/schema"
 import { WebSearchTool } from "./websearch"
 import { CodeSearchTool } from "./codesearch"
@@ -116,6 +117,10 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ToolRegistry") {}
 
+// SessionTool's `dashboard` verb correlates worktrees via Git.Service. Git is a
+// leaf layer (needs only ChildProcessSpawner) with no shared state, so the
+// registry self-provides it rather than leaking Git.Service as an external
+// requirement onto every consumer (production wiring + ~20 test harnesses).
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -417,7 +422,7 @@ export const layer = Layer.effect(
 
     return Service.of({ ids, all, named, tools, reload })
   }),
-)
+).pipe(Layer.provide(Git.defaultLayer))
 
 export const defaultLayer = Layer.suspend(() =>
   layer.pipe(

--- a/packages/opencode/src/tool/session.shell.txt
+++ b/packages/opencode/src/tool/session.shell.txt
@@ -1,6 +1,6 @@
 Child-session orchestration tool (shell form, Orchestrator mode only). Each
 child runs in its own session id with its own mode, model, task panel, and
-memory. Verbs: create | switch | list | cancel | ask.
+memory. Verbs: create | switch | list | dashboard | cancel | ask.
 
 # Script structure
 #   - Multi-line: one command per non-blank line, set-e on first failure
@@ -28,6 +28,7 @@ memory. Verbs: create | switch | list | cancel | ask.
 
 # inspect:
     session list                       # this Orchestrator's children: id, title, mode, status
+    session dashboard                  # fleet TABLE: liveness+age, turns, mode, worktree branch/ahead/dir per child
 
 # navigate the user's frontend panel:
     session switch ses_...             # Orchestrator-only; a child cannot switch back

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -170,6 +170,26 @@ function suggestVerb(input: string): string | undefined {
 
 const id = "session"
 
+// --topic persistence: the topic label is stored as a machine-readable marker
+// prefixed onto the child session's TITLE (`[topic:<label>] <title>`). The
+// Session row already persists across restarts and is returned by
+// sessions.children, so this needs no schema/migration — a deliberately thin
+// surface. topicOf() reads a peer child's topic back for the reuse lookup;
+// tagTitle() writes the marker at create time.
+const TOPIC_MARKER = /^\[topic:([^\]]+)\]\s?/
+
+function topicOf(title: string): string | undefined {
+  const m = title.match(TOPIC_MARKER)
+  return m ? m[1] : undefined
+}
+
+function tagTitle(topic: string, title: string): string {
+  // Idempotent: never double-tag if the base title already carries a marker.
+  const base = title.replace(TOPIC_MARKER, "")
+  return `[topic:${topic}] ${base}`
+}
+
+
 const createOperation = z.strictObject({
   action: z.literal("create"),
   task: z.string().min(1).describe("The task/prompt for the child session's first turn."),
@@ -183,6 +203,13 @@ const createOperation = z.strictObject({
   title: z.string().min(1).optional().describe("Title for the child session. Defaults to the task prefix."),
   dir: z.string().min(1).optional().describe("Working directory the child runs in (any project or path). Defaults to the orchestrator's directory."),
   isolate: z.boolean().optional().describe("Run the child in its own git worktree of `dir` (concurrent-edit isolation). Non-git dir falls back to shared."),
+  topic: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Reuse a standing per-theme child: if a peer child already carries this topic, RELAY the task into it (enqueue+wake) instead of spawning; otherwise create a new child tagged with this topic. Avoids over-spawning sessions for the same theme.",
+    ),
 })
 
 const sendOperation = z.strictObject({
@@ -293,6 +320,7 @@ export function recoverSessionArgs(rawArgs: unknown): SessionOperation | undefin
     if (obj.mode === "build" || obj.mode === "plan" || obj.mode === "compose") op.mode = obj.mode
     if (typeof obj.model === "string") op.model = obj.model
     if (typeof obj.title === "string") op.title = obj.title
+    if (typeof obj.topic === "string") op.topic = obj.topic
     return { operation: op } as SessionOperation
   }
   return undefined
@@ -352,10 +380,10 @@ function arityError(verb: string, expected: string, args: string[], line: number
 function mapVerb(verb: string | undefined, args: string[], line: number): Effect.Effect<SessionOperation, unknown> {
   switch (verb) {
     case "create": {
-      const { flags, bools, rest, error } = extractSessionFlags(args, ["mode", "model", "title", "dir"], ["isolate"])
+      const { flags, bools, rest, error } = extractSessionFlags(args, ["mode", "model", "title", "dir", "topic"], ["isolate"])
       if (error) return flagError("create", error, line)
       if (rest.length < 1)
-        return arityError("create", "<task...> [--mode build|plan|compose] [--model <ref>] [--title <t>] [--dir <path>] [--isolate]", rest, line)
+        return arityError("create", "<task...> [--mode build|plan|compose] [--model <ref>] [--title <t>] [--dir <path>] [--topic <label>] [--isolate]", rest, line)
       if (flags.mode && flags.mode !== "build" && flags.mode !== "plan" && flags.mode !== "compose")
         return flagError("create", `--mode must be build, plan or compose (got '${flags.mode}')`, line)
       return Effect.succeed({
@@ -366,6 +394,7 @@ function mapVerb(verb: string | undefined, args: string[], line: number): Effect
           ...(flags.model ? { model: flags.model } : {}),
           ...(flags.title ? { title: flags.title } : {}),
           ...(flags.dir ? { dir: flags.dir } : {}),
+          ...(flags.topic ? { topic: flags.topic } : {}),
           ...(bools.isolate ? { isolate: true } : {}),
         },
       })
@@ -467,6 +496,55 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
 
       if (op.action === "create") {
         const actor = yield* requireActor()
+
+        // --topic find-or-reuse: before spawning, look for a standing peer child
+        // already tagged with this topic. If found, RELAY the task into it
+        // (enqueue+wake — the same idle-peer path `session send` uses) instead of
+        // over-spawning a fresh child. Filter identical to the `list` branch:
+        // real peers only (exclude subagents + system-spawned agents).
+        if (op.topic) {
+          const children = yield* sessions.children(ctx.sessionID as SessionID)
+          const enriched = yield* Effect.forEach(children, (child) =>
+            actorReg.get(child.id, child.id).pipe(Effect.map((a) => ({ child, actor: a }))),
+          )
+          const match = enriched.find(
+            ({ child, actor: a }) =>
+              a?.mode !== "subagent" &&
+              !(a && SYSTEM_SPAWNED_AGENT_TYPES.has(a.agent)) &&
+              topicOf(child.title) === op.topic,
+          )
+          if (match) {
+            const childID = match.child.id
+            const inboxSvc = inboxServiceRef.current
+            if (!inboxSvc) {
+              return yield* Effect.fail(
+                new Error("Inbox service unavailable — Inbox.defaultLayer must be running for the session tool to relay tasks"),
+              )
+            }
+            const sendResult = yield* inboxSvc
+              .send({
+                receiverSessionID: childID,
+                receiverActorID: childID,
+                senderSessionID: ctx.sessionID as SessionID,
+                senderActorID: ctx.actorID ?? "main",
+                content: op.task,
+              })
+              .pipe(Effect.catchTag("InboxReceiverNotFound", () => Effect.succeed({ inboxID: null as string | null })))
+            if (sendResult.inboxID !== null) {
+              return {
+                title: `Reused topic '${op.topic}' → relayed to ${childID}`,
+                output:
+                  `Found standing child ${childID} for topic '${op.topic}'. ` +
+                  `Enqueued the task into it and woke it — it runs the relayed task as its next turn.`,
+                metadata: { sessionID: childID } as Metadata,
+              }
+            }
+            // The tagged peer exists but isn't reachable yet (no receiver row).
+            // Fall through to create a fresh tagged child rather than fail — the
+            // topic still gets a standing child, just a new one.
+          }
+        }
+
         const model = op.model
           ? yield* provider
               .resolveModelRef(op.model, undefined)
@@ -525,12 +603,20 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
         })
         // spawnPeer titles the child session `${agentType}: ${task}`; honor an
         // explicit --title by overwriting it so `session list` shows what the
-        // orchestrator asked for.
-        if (op.title) yield* sessions.setTitle({ sessionID: result.sessionID, title: op.title })
+        // orchestrator asked for. When --topic is set, prefix the title with a
+        // `[topic:X]` marker so a later `create --topic X` finds and reuses this
+        // standing child (topicOf reads it back from sessions.children).
+        if (op.topic) {
+          const base = op.title ?? `${op.mode ?? "build"}: ${op.task.slice(0, 40)}`
+          yield* sessions.setTitle({ sessionID: result.sessionID, title: tagTitle(op.topic, base) })
+        } else if (op.title) {
+          yield* sessions.setTitle({ sessionID: result.sessionID, title: op.title })
+        }
         return {
           title: `Session created: ${result.sessionID}`,
           output:
             `Created child session ${result.sessionID} (mode: ${op.mode ?? "build"}) in ${effectiveDir}.` +
+            (op.topic ? ` Tagged with topic '${op.topic}' for reuse.` : ``) +
             (op.isolate && !isolateNotice ? ` Isolated in its own worktree.` : isolateNotice) +
             ` Running in the background.`,
           metadata: { sessionID: result.sessionID } as Metadata,

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -818,12 +818,6 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
         // to ctx.sessionID at create time. Enrich each child with its actor
         // row (mode/agent/status) keyed by sessionID === actorID === child.id.
         const children = yield* sessions.children(ctx.sessionID as SessionID)
-        // Subagent sessions (checkpoint-writer / dream / distill / read-only
-        // fork-query children spawned by `ask`) are ALSO parented to us via the
-        // Session row, so sessions.children returns them too. They are not real
-        // peer children the orchestrator manages — filter them out. A child is a
-        // subagent iff its actor row is mode:"subagent" or its agent is one of
-        // the runtime system-spawned types (checkpoint-writer/dream/distill).
         const enriched = yield* Effect.forEach(children, (child) =>
           actorReg.get(child.id, child.id).pipe(Effect.map((actor) => ({ child, actor }))),
         )

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -10,6 +10,7 @@ import { Instance } from "@/project/instance"
 import { InstanceRef } from "@/effect/instance-ref"
 import { InstanceState } from "@/effect"
 import { ActorRegistry } from "@/actor/registry"
+import { deriveLiveness } from "@/actor/schema"
 import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { forwardRef } from "@/permission/permission-forward-ref"
 import { Provider } from "@/provider"
@@ -22,7 +23,7 @@ import { TuiEvent } from "@/cli/cmd/tui/event"
 import type { SessionID, MessageID } from "../session/schema"
 import type { ProviderID, ModelID } from "../provider/schema"
 
-const KNOWN_VERBS = ["create", "send", "switch", "list", "cancel", "ask", "setmode", "approve", "grant-approval"]
+const KNOWN_VERBS = ["create", "send", "switch", "list", "status", "cancel", "ask", "setmode", "approve", "grant-approval"]
 
 // Wraps the human/agent question in a side-boundary system-reminder:
 // one-shot, READ-ONLY, answer-to-caller.
@@ -227,6 +228,11 @@ const listOperation = z.strictObject({
   action: z.literal("list"),
 })
 
+const statusOperation = z.strictObject({
+  action: z.literal("status"),
+  sessionID: z.string().min(1).describe("Child session id to report derived liveness for (progressing/stalled/terminal + turn telemetry)."),
+})
+
 const cancelOperation = z.strictObject({
   action: z.literal("cancel"),
   sessionID: z.string().min(1).describe("Session id of the child session to stop."),
@@ -266,7 +272,7 @@ const parameters = z.strictObject({
   // {"operation":"{\"action\":\"create\",...}"} which fails zod validation.
   // See research-tool-call-schema/REPORT.md §2.5 "success-nested" warning.
   operation: z
-    .discriminatedUnion("action", [createOperation, sendOperation, switchOperation, listOperation, cancelOperation, askOperation, setmodeOperation, approveOperation, grantApprovalOperation])
+    .discriminatedUnion("action", [createOperation, sendOperation, switchOperation, listOperation, statusOperation, cancelOperation, askOperation, setmodeOperation, approveOperation, grantApprovalOperation])
     .meta({ type: "object" }),
 })
 
@@ -418,6 +424,12 @@ function mapVerb(verb: string | undefined, args: string[], line: number): Effect
       if (error) return flagError("list", error, line)
       if (rest.length !== 0) return arityError("list", "", rest, line)
       return Effect.succeed({ operation: { action: "list" as const } })
+    }
+    case "status": {
+      const { rest, error } = extractSessionFlags(args, [])
+      if (error) return flagError("status", error, line)
+      if (rest.length !== 1) return arityError("status", "<sessionID>", rest, line)
+      return Effect.succeed({ operation: { action: "status" as const, sessionID: rest[0] } })
     }
     case "cancel": {
       const { rest, error } = extractSessionFlags(args, [])
@@ -717,26 +729,34 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
         if (peers.length === 0)
           return { title: "Child sessions: 0", output: "No child sessions.", metadata: {} as Metadata }
         // The actor row's status enum is only pending|running|idle; a terminal
-        // idle carries a lastOutcome (success/failure/cancelled). Derive a
-        // display bucket from (status, lastOutcome): running/pending are live,
-        // idle+cancelled/failure are terminal-with-outcome, everything else is
-        // a plain finished/idle child. Never fabricate a state the data lacks.
+        // idle carries a lastOutcome (success/failure/cancelled). deriveLiveness
+        // maps (status, lastOutcome, lastTurnTime) to a display bucket:
+        // running/pending split into progressing vs stalled by whether the last
+        // turn advanced within the staleness window (updateTurn bumps
+        // last_turn_time per step — recent == progressing); terminal idle rows
+        // map to success(→idle)/failure/cancelled. Never fabricate a state the
+        // data lacks: a missing actor row is a plain idle.
+        const now = Date.now()
         const bucketOf = ({ actor }: (typeof peers)[number]) => {
           if (!actor) return "idle" as const
-          if (actor.status === "running" || actor.status === "pending") return "running" as const
-          if (actor.lastOutcome === "cancelled") return "cancelled" as const
-          if (actor.lastOutcome === "failure") return "failed" as const
+          const live = deriveLiveness(actor, now)
+          if (live === "progressing") return "progressing" as const
+          if (live === "stalled") return "stalled" as const
+          if (live === "cancelled") return "cancelled" as const
+          if (live === "failure") return "failed" as const
           return "idle" as const
         }
         const tagged = peers.map((p) => ({ ...p, bucket: bucketOf(p) }))
         const counts = {
-          running: tagged.filter((p) => p.bucket === "running").length,
+          progressing: tagged.filter((p) => p.bucket === "progressing").length,
+          stalled: tagged.filter((p) => p.bucket === "stalled").length,
           idle: tagged.filter((p) => p.bucket === "idle").length,
           cancelled: tagged.filter((p) => p.bucket === "cancelled").length,
           failed: tagged.filter((p) => p.bucket === "failed").length,
         }
         const groups: { bucket: keyof typeof counts; heading: string }[] = [
-          { bucket: "running", heading: "In progress (running/pending)" },
+          { bucket: "progressing", heading: "In progress — progressing (running/pending, advancing)" },
+          { bucket: "stalled", heading: "In progress — stalled (running/pending, no recent turn)" },
           { bucket: "idle", heading: "Finished / idle" },
           { bucket: "failed", heading: "Failed" },
           { bucket: "cancelled", heading: "Cancelled" },
@@ -752,14 +772,43 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
               )
             return `${g.heading} (${counts[g.bucket]}):\n${lines.join("\n")}`
           })
+        const running = counts.progressing + counts.stalled
         const summary =
-          `Child sessions: ${peers.length} total — ${counts.running} running, ${counts.idle} idle` +
+          `Child sessions: ${peers.length} total — ${running} running (${counts.progressing} progressing, ${counts.stalled} stalled), ${counts.idle} idle` +
           (counts.failed > 0 ? `, ${counts.failed} failed` : "") +
           (counts.cancelled > 0 ? `, ${counts.cancelled} cancelled` : "")
         return {
           title: `Child sessions: ${peers.length}`,
           output: [summary, "", ...sections].join("\n"),
           metadata: {} as Metadata,
+        }
+      }
+
+      if (op.action === "status") {
+        // Derived pull-side liveness for one child. A peer registers with
+        // session_id === actor_id === its own child id (see the create branch /
+        // Actor.spawnPeer), so key the row by (childID, childID). deriveLiveness
+        // turns the honest registry fields (status/lastOutcome/lastTurnTime) into
+        // progressing|stalled|terminal — never fabricating a state the row lacks.
+        const childID = op.sessionID
+        const found = yield* actorReg.liveness(childID as SessionID, childID)
+        if (!found)
+          return {
+            title: `Status: ${childID} not found`,
+            output: `No actor registered for ${childID}. It may not exist or never started.`,
+            metadata: { sessionID: childID } as Metadata,
+          }
+        const ageMs = Date.now() - found.actor.lastTurnTime
+        const ageStr = ageMs < 60_000 ? `${Math.floor(ageMs / 1000)}s` : `${Math.floor(ageMs / 60_000)}m`
+        const outcome = found.actor.lastOutcome ? ` (last outcome: ${found.actor.lastOutcome})` : ""
+        return {
+          title: `Status ${childID}: ${found.liveness}`,
+          output:
+            `${childID} — ${found.liveness}${outcome}\n` +
+            `  raw status: ${found.actor.status}\n` +
+            `  turnCount: ${found.actor.turnCount}\n` +
+            `  lastTurnTime: ${found.actor.lastTurnTime} (${ageStr} ago)`,
+          metadata: { sessionID: childID } as Metadata,
         }
       }
 

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -14,6 +14,7 @@ import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { forwardRef } from "@/permission/permission-forward-ref"
 import { Provider } from "@/provider"
 import { spawnRef } from "@/actor/spawn-ref"
+import { inboxServiceRef } from "@/inbox/inbox-ref"
 import { prefixCaptureRef } from "@/session/prefix-capture-ref"
 import type { ForkContext, Interface as ActorInterface } from "@/actor/spawn"
 import { Bus } from "@/bus"
@@ -21,7 +22,7 @@ import { TuiEvent } from "@/cli/cmd/tui/event"
 import type { SessionID, MessageID } from "../session/schema"
 import type { ProviderID, ModelID } from "../provider/schema"
 
-const KNOWN_VERBS = ["create", "switch", "list", "cancel", "ask", "setmode", "approve", "grant-approval"]
+const KNOWN_VERBS = ["create", "send", "switch", "list", "cancel", "ask", "setmode", "approve", "grant-approval"]
 
 // Wraps the human/agent question in a side-boundary system-reminder:
 // one-shot, READ-ONLY, answer-to-caller.
@@ -184,6 +185,12 @@ const createOperation = z.strictObject({
   isolate: z.boolean().optional().describe("Run the child in its own git worktree of `dir` (concurrent-edit isolation). Non-git dir falls back to shared."),
 })
 
+const sendOperation = z.strictObject({
+  action: z.literal("send"),
+  sessionID: z.string().min(1).describe("Child session id to relay a new task to (enqueues into its inbox and wakes it)."),
+  task: z.string().min(1).describe("The task/message to relay. The idle-but-persistent child wakes and drains it as its next turn."),
+})
+
 const switchOperation = z.strictObject({
   action: z.literal("switch"),
   sessionID: z.string().min(1).describe("Session id to move the user's frontend panel to."),
@@ -232,7 +239,7 @@ const parameters = z.strictObject({
   // {"operation":"{\"action\":\"create\",...}"} which fails zod validation.
   // See research-tool-call-schema/REPORT.md §2.5 "success-nested" warning.
   operation: z
-    .discriminatedUnion("action", [createOperation, switchOperation, listOperation, cancelOperation, askOperation, setmodeOperation, approveOperation, grantApprovalOperation])
+    .discriminatedUnion("action", [createOperation, sendOperation, switchOperation, listOperation, cancelOperation, askOperation, setmodeOperation, approveOperation, grantApprovalOperation])
     .meta({ type: "object" }),
 })
 
@@ -361,6 +368,14 @@ function mapVerb(verb: string | undefined, args: string[], line: number): Effect
           ...(flags.dir ? { dir: flags.dir } : {}),
           ...(bools.isolate ? { isolate: true } : {}),
         },
+      })
+    }
+    case "send": {
+      const { rest, error } = extractSessionFlags(args, [])
+      if (error) return flagError("send", error, line)
+      if (rest.length < 2) return arityError("send", "<sessionID> <task...>", rest, line)
+      return Effect.succeed({
+        operation: { action: "send" as const, sessionID: rest[0], task: rest.slice(1).join(" ") },
       })
     }
     case "switch": {
@@ -519,6 +534,68 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
             (op.isolate && !isolateNotice ? ` Isolated in its own worktree.` : isolateNotice) +
             ` Running in the background.`,
           metadata: { sessionID: result.sessionID } as Metadata,
+        }
+      }
+
+      if (op.action === "send") {
+        // Relay a NEW task into a standing (persistent) child, waking it if idle.
+        // A peer child registers with session_id === actor_id === its own child
+        // id (see the create branch / Actor.spawnPeer), so both the receiver
+        // session and actor id are the child session id. Inbox.send enqueues a
+        // durable row and fork-schedules a wake; the woken runLoop drains it as
+        // the child's next turn. Gap-A's drain seed-fallback ensures an idle /
+        // turnCount-0 peer still converts the queued task into a turn instead of
+        // idling back with the task stuck in the DB.
+        const childID = op.sessionID as SessionID
+        // Pre-check the child is actually a peer we manage; give a clear message
+        // instead of a raw ESRCH if the id is wrong or the child never existed.
+        const actor = yield* actorReg.get(childID, childID)
+        if (!actor) {
+          return {
+            title: `Send failed: ${op.sessionID} not found`,
+            output:
+              `No child session ${op.sessionID} is registered. Use \`session list\` to see your children, ` +
+              `or \`session create\` to start a new one.`,
+            metadata: { sessionID: op.sessionID } as Metadata,
+          }
+        }
+        const inboxSvc = inboxServiceRef.current
+        if (!inboxSvc) {
+          return yield* Effect.fail(
+            new Error("Inbox service unavailable — Inbox.defaultLayer must be running for the session tool to relay tasks"),
+          )
+        }
+        const sendResult = yield* inboxSvc
+          .send({
+            receiverSessionID: childID,
+            receiverActorID: childID,
+            senderSessionID: ctx.sessionID as SessionID,
+            senderActorID: ctx.actorID ?? "main",
+            content: op.task,
+          })
+          .pipe(
+            Effect.catchTag("InboxReceiverNotFound", () =>
+              Effect.succeed({ inboxID: null as string | null }),
+            ),
+          )
+        if (sendResult.inboxID === null) {
+          return {
+            title: `Send failed: ${op.sessionID} not reachable`,
+            output:
+              `Child ${op.sessionID} exists but has no inbox receiver row yet (it may not have started). ` +
+              `Retry once it is running, or \`session create\` a fresh child.`,
+            metadata: { sessionID: op.sessionID } as Metadata,
+          }
+        }
+        return {
+          title: `Relayed task to ${op.sessionID}`,
+          output:
+            `Enqueued the task into child ${op.sessionID} and woke it. ` +
+            `It will run the relayed task as its next turn` +
+            (actor.status === "running" || actor.status === "pending"
+              ? ` (currently busy — the task is queued and drains after its current turn).`
+              : `.`),
+          metadata: { sessionID: op.sessionID } as Metadata,
         }
       }
 

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -1,4 +1,6 @@
 import * as Tool from "./tool"
+import { realpathSync } from "fs"
+import path from "path"
 import DESCRIPTION from "./session.txt"
 import SHELL_DESCRIPTION from "./session.shell.txt"
 import { tokenize } from "./shell-tokenize"
@@ -20,11 +22,14 @@ import { inboxServiceRef } from "@/inbox/inbox-ref"
 import { prefixCaptureRef } from "@/session/prefix-capture-ref"
 import type { ForkContext, Interface as ActorInterface } from "@/actor/spawn"
 import { Bus } from "@/bus"
+import { Git } from "@/git"
 import { TuiEvent } from "@/cli/cmd/tui/event"
+import { assembleFleet, renderFleetTable } from "./fleet"
+import type { FleetActorInput, WorktreeEntry } from "./fleet"
 import type { SessionID, MessageID } from "../session/schema"
 import type { ProviderID, ModelID } from "../provider/schema"
 
-const KNOWN_VERBS = ["create", "send", "switch", "list", "status", "cancel", "ask", "join", "setmode", "approve", "grant-approval"]
+const KNOWN_VERBS = ["create", "send", "switch", "list", "dashboard", "status", "cancel", "ask", "join", "setmode", "approve", "grant-approval"]
 
 // Wraps the human/agent question in a side-boundary system-reminder:
 // one-shot, READ-ONLY, answer-to-caller.
@@ -150,7 +155,6 @@ export function forkQuery(deps: {
 
 function levenshtein(a: string, b: string): number {
   const m = a.length, n = b.length
-  if (m === 0) return n
   if (n === 0) return m
   const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
   for (let i = 0; i <= m; i++) dp[i][0] = i
@@ -229,6 +233,10 @@ const listOperation = z.strictObject({
   action: z.literal("list"),
 })
 
+const dashboardOperation = z.strictObject({
+  action: z.literal("dashboard"),
+})
+
 const statusOperation = z.strictObject({
   action: z.literal("status"),
   sessionID: z.string().min(1).describe("Child session id to report derived liveness for (progressing/stalled/terminal + turn telemetry)."),
@@ -289,7 +297,7 @@ const parameters = z.strictObject({
   // {"operation":"{\"action\":\"create\",...}"} which fails zod validation.
   // See research-tool-call-schema/REPORT.md §2.5 "success-nested" warning.
   operation: z
-    .discriminatedUnion("action", [createOperation, sendOperation, switchOperation, listOperation, statusOperation, cancelOperation, askOperation, joinOperation, setmodeOperation, approveOperation, grantApprovalOperation])
+    .discriminatedUnion("action", [createOperation, sendOperation, switchOperation, listOperation, dashboardOperation, statusOperation, cancelOperation, askOperation, joinOperation, setmodeOperation, approveOperation, grantApprovalOperation])
     .meta({ type: "object" }),
 })
 
@@ -300,7 +308,7 @@ type Metadata = {
   sessionID?: string
 }
 
-type Deps = Session.Service | ActorRegistry.Service | Provider.Service | Worktree.Service | Bus.Service
+type Deps = Session.Service | ActorRegistry.Service | Provider.Service | Worktree.Service | Bus.Service | Git.Service
 
 function parseSessionScript(script: string): Effect.Effect<SessionOperation[], unknown> {
   return Effect.gen(function* () {
@@ -442,6 +450,12 @@ function mapVerb(verb: string | undefined, args: string[], line: number): Effect
       if (rest.length !== 0) return arityError("list", "", rest, line)
       return Effect.succeed({ operation: { action: "list" as const } })
     }
+    case "dashboard": {
+      const { rest, error } = extractSessionFlags(args, [])
+      if (error) return flagError("dashboard", error, line)
+      if (rest.length !== 0) return arityError("dashboard", "", rest, line)
+      return Effect.succeed({ operation: { action: "dashboard" as const } })
+    }
     case "status": {
       const { rest, error } = extractSessionFlags(args, [])
       if (error) return flagError("status", error, line)
@@ -514,6 +528,58 @@ function mapVerb(verb: string | undefined, args: string[], line: number): Effect
   }
 }
 
+// Enumerate the worktrees of the orchestrator's repo and, per branch, its
+// commits-ahead of the repo's default branch — the raw material assembleFleet
+// correlates to isolated child sessions by directory. Reads git through the
+// Git.Service (run + defaultBranch). `git worktree list --porcelain` emits
+// stanzas ("worktree <path>", "branch refs/heads/<b>", "detached", blank line);
+// we parse path + short branch, realpath-canonicalize the path so it matches a
+// session.directory, and compute ahead via `rev-list --count <base>..<branch>`.
+// Best-effort per entry: a failed rev-list leaves `ahead` undefined; a git
+// failure at the list step propagates to the caller's catch (→ no correlation).
+function collectWorktrees(git: Git.Interface, dir: string) {
+  return Effect.gen(function* () {
+    const list = yield* git.run(["worktree", "list", "--porcelain"], { cwd: dir })
+    if (list.exitCode !== 0) return [] as WorktreeEntry[]
+
+    const raw: { path: string; branch?: string }[] = []
+    for (const line of list.text().split("\n")) {
+      const trimmed = line.trim()
+      if (trimmed.startsWith("worktree ")) raw.push({ path: trimmed.slice("worktree ".length).trim() })
+      else if (trimmed.startsWith("branch ")) {
+        const current = raw[raw.length - 1]
+        if (current) current.branch = trimmed.slice("branch ".length).trim().replace(/^refs\/heads\//, "")
+      }
+    }
+
+    const base = yield* git.defaultBranch(dir).pipe(Effect.catch(() => Effect.succeed(undefined)))
+    const baseRef = base?.ref
+
+    return yield* Effect.forEach(raw, (entry) =>
+      Effect.gen(function* () {
+        const directory = yield* Effect.sync(() => {
+          try {
+            return realpathSync(entry.path)
+          } catch {
+            return path.normalize(entry.path)
+          }
+        })
+        let ahead: number | undefined
+        if (baseRef && entry.branch) {
+          const rev = yield* git
+            .run(["rev-list", "--count", `${baseRef}..${entry.branch}`], { cwd: dir })
+            .pipe(Effect.catch(() => Effect.succeed(undefined)))
+          if (rev && rev.exitCode === 0) {
+            const n = Number(rev.text().trim())
+            if (Number.isFinite(n)) ahead = n
+          }
+        }
+        return { directory, branch: entry.branch, ahead } satisfies WorktreeEntry
+      }),
+    )
+  })
+}
+
 export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
   id,
   Effect.gen(function* () {
@@ -522,6 +588,7 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
     const provider = yield* Provider.Service
     const worktreeSvc = yield* Worktree.Service
     const bus = yield* Bus.Service
+    const git = yield* Git.Service
 
     // Resolve the Actor service through the late-bound spawnRef rather than as a
     // Layer dependency: pulling Actor.Service into Deps would create a layer
@@ -820,6 +887,49 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
           metadata: {} as Metadata,
         }
       }
+
+      if (op.action === "dashboard") {
+        // Fleet observability: the same peer set as `list`, but correlated to
+        // (a) each child's derived liveness + turn telemetry, and (b) the git
+        // worktree backing isolated children (dir + branch + commits-ahead) —
+        // the mapping `list` never surfaced. Assembly is delegated to the pure
+        // assembleFleet/renderFleetTable (tool/fleet.ts); here we only gather
+        // the live inputs: sessions.children → actor rows → git worktree list.
+        const children = yield* sessions.children(ctx.sessionID as SessionID)
+        const enriched = yield* Effect.forEach(children, (child) =>
+          actorReg.get(child.id, child.id).pipe(Effect.map((actor) => ({ child, actor }))),
+        )
+        const peers = enriched.filter(
+          ({ actor }) => actor?.mode !== "subagent" && !(actor && SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent)),
+        )
+        if (peers.length === 0)
+          return { title: "Fleet: 0", output: "No child sessions.", metadata: {} as Metadata }
+
+        // Correlate worktrees from the orchestrator's own repo. `git worktree
+        // list --porcelain` enumerates every worktree of the common repo (the
+        // isolated children live under <data>/worktree/... of it); we resolve
+        // each entry's directory to realpath so it matches a session.directory
+        // (which the create branch sets to the worktree dir). commits-ahead is
+        // computed per branch against the repo's default branch via rev-list.
+        // Best-effort: any git failure degrades to no worktree correlation
+        // rather than failing the dashboard.
+        const orchestratorDir = yield* InstanceState.directory
+        const worktrees = yield* collectWorktrees(git, orchestratorDir).pipe(
+          Effect.catch(() => Effect.succeed([] as WorktreeEntry[])),
+        )
+
+        const inputs: FleetActorInput[] = peers.map(({ child, actor }) => ({
+          session: { id: child.id, title: child.title, directory: child.directory },
+          actor: actor ?? null,
+        }))
+        const summary = assembleFleet(inputs, worktrees, Date.now())
+        return {
+          title: `Fleet: ${summary.total}`,
+          output: renderFleetTable(summary),
+          metadata: {} as Metadata,
+        }
+      }
+
 
       if (op.action === "status") {
         // Derived pull-side liveness for one child. A peer registers with

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -11,6 +11,7 @@ import { InstanceRef } from "@/effect/instance-ref"
 import { InstanceState } from "@/effect"
 import { ActorRegistry } from "@/actor/registry"
 import { deriveLiveness } from "@/actor/schema"
+import { joinGroup } from "@/actor/group"
 import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { forwardRef } from "@/permission/permission-forward-ref"
 import { Provider } from "@/provider"
@@ -23,7 +24,7 @@ import { TuiEvent } from "@/cli/cmd/tui/event"
 import type { SessionID, MessageID } from "../session/schema"
 import type { ProviderID, ModelID } from "../provider/schema"
 
-const KNOWN_VERBS = ["create", "send", "switch", "list", "status", "cancel", "ask", "setmode", "approve", "grant-approval"]
+const KNOWN_VERBS = ["create", "send", "switch", "list", "status", "cancel", "ask", "join", "setmode", "approve", "grant-approval"]
 
 // Wraps the human/agent question in a side-boundary system-reminder:
 // one-shot, READ-ONLY, answer-to-caller.
@@ -244,6 +245,22 @@ const askOperation = z.strictObject({
   question: z.string().min(1).describe("The side question to answer from a frozen snapshot of that session's history."),
 })
 
+const joinOperation = z.strictObject({
+  action: z.literal("join"),
+  sessionIDs: z
+    .array(z.string().min(1))
+    .min(1)
+    .describe(
+      "Child session ids forming the dispatch group. Blocks until ALL have reached a terminal state (success/fail/cancel), then returns one aggregated per-child summary.",
+    ),
+  timeout_ms: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Milliseconds to wait before returning a partial (timeout) aggregate. Default 600000 (10 min)."),
+})
+
 const setmodeOperation = z.strictObject({
   action: z.literal("setmode"),
   sessionID: z.string().min(1).describe("Session id of the child session whose mode to change."),
@@ -272,7 +289,7 @@ const parameters = z.strictObject({
   // {"operation":"{\"action\":\"create\",...}"} which fails zod validation.
   // See research-tool-call-schema/REPORT.md §2.5 "success-nested" warning.
   operation: z
-    .discriminatedUnion("action", [createOperation, sendOperation, switchOperation, listOperation, statusOperation, cancelOperation, askOperation, setmodeOperation, approveOperation, grantApprovalOperation])
+    .discriminatedUnion("action", [createOperation, sendOperation, switchOperation, listOperation, statusOperation, cancelOperation, askOperation, joinOperation, setmodeOperation, approveOperation, grantApprovalOperation])
     .meta({ type: "object" }),
 })
 
@@ -283,7 +300,7 @@ type Metadata = {
   sessionID?: string
 }
 
-type Deps = Session.Service | ActorRegistry.Service | Provider.Service | Worktree.Service
+type Deps = Session.Service | ActorRegistry.Service | Provider.Service | Worktree.Service | Bus.Service
 
 function parseSessionScript(script: string): Effect.Effect<SessionOperation[], unknown> {
   return Effect.gen(function* () {
@@ -445,6 +462,25 @@ function mapVerb(verb: string | undefined, args: string[], line: number): Effect
         operation: { action: "ask" as const, session_id: rest[0], question: rest.slice(1).join(" ") },
       })
     }
+    case "join": {
+      const { flags, rest, error } = extractSessionFlags(args, ["timeout"])
+      if (error) return flagError("join", error, line)
+      if (rest.length < 1) return arityError("join", "<sessionID...> [--timeout <ms>]", rest, line)
+      let timeout_ms: number | undefined
+      if (flags.timeout !== undefined) {
+        const n = Number(flags.timeout)
+        if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n))
+          return flagError("join", `--timeout must be a positive integer (got '${flags.timeout}')`, line)
+        timeout_ms = n
+      }
+      return Effect.succeed({
+        operation: {
+          action: "join" as const,
+          sessionIDs: rest,
+          ...(timeout_ms !== undefined ? { timeout_ms } : {}),
+        },
+      })
+    }
     case "setmode": {
       const { rest, error } = extractSessionFlags(args, [])
       if (error) return flagError("setmode", error, line)
@@ -485,6 +521,7 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
     const actorReg = yield* ActorRegistry.Service
     const provider = yield* Provider.Service
     const worktreeSvc = yield* Worktree.Service
+    const bus = yield* Bus.Service
 
     // Resolve the Actor service through the late-bound spawnRef rather than as a
     // Layer dependency: pulling Actor.Service into Deps would create a layer
@@ -852,6 +889,52 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
           title: `Asked ${op.session_id}`,
           output: answer,
           metadata: { sessionID: op.session_id } as Metadata,
+        }
+      }
+
+      if (op.action === "join") {
+        // Fan-in barrier: block until EVERY named child reaches a terminal state
+        // (success/fail/cancel — all three notify via T41 and write lastOutcome),
+        // then return one aggregated per-child summary. Peers register with
+        // session_id === actor_id === their own child id (see the create branch /
+        // Actor.spawnPeer), so both keys are the child session id. joinGroup does
+        // not busy-wait — it subscribes to ActorStatusChanged and re-snapshots the
+        // group as children settle. A bad/unknown id counts as "unknown" and never
+        // blocks the barrier.
+        const members = op.sessionIDs.map((sid) => ({
+          sessionID: sid as SessionID,
+          actorID: sid,
+        }))
+        const agg = yield* joinGroup(
+          { reg: actorReg, sessions, bus },
+          { members, ...(op.timeout_ms !== undefined ? { timeout_ms: op.timeout_ms } : {}) },
+        )
+        const lines = agg.members.map((m) => {
+          const who = m.description ? `${m.actorID} (${m.description})` : m.actorID
+          const detail =
+            m.outcome === "success"
+              ? m.reportedSummary ?? (m.result ? m.result.slice(0, 200) : "done")
+              : m.outcome === "failure"
+                ? m.error ?? "failed"
+                : m.outcome === "cancelled"
+                  ? "cancelled"
+                  : "unknown (no registered actor)"
+          return `  ${who} — ${m.outcome}: ${detail}`
+        })
+        const header =
+          agg.status === "timeout"
+            ? `Join TIMED OUT — ${agg.counts.success + agg.counts.failure + agg.counts.cancelled}/${agg.total} children terminal`
+            : `Join complete — all ${agg.total} children terminal`
+        const tally =
+          `${agg.counts.success} success, ${agg.counts.failure} failed, ${agg.counts.cancelled} cancelled` +
+          (agg.counts.unknown > 0 ? `, ${agg.counts.unknown} unknown` : "")
+        return {
+          title:
+            agg.status === "timeout"
+              ? `Join timed out (${agg.total} children)`
+              : `Joined ${agg.total} children`,
+          output: [`${header} (${tally}).`, "", ...lines].join("\n"),
+          metadata: {} as Metadata,
         }
       }
 

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -553,11 +553,51 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
         )
         if (peers.length === 0)
           return { title: "Child sessions: 0", output: "No child sessions.", metadata: {} as Metadata }
-        const lines = peers.map(
-          ({ child, actor }) =>
-            `${child.id} — ${child.title} — ${actor?.agent ?? "?"} — ${actor?.status ?? "unknown"}`,
-        )
-        return { title: `Child sessions: ${peers.length}`, output: lines.join("\n"), metadata: {} as Metadata }
+        // The actor row's status enum is only pending|running|idle; a terminal
+        // idle carries a lastOutcome (success/failure/cancelled). Derive a
+        // display bucket from (status, lastOutcome): running/pending are live,
+        // idle+cancelled/failure are terminal-with-outcome, everything else is
+        // a plain finished/idle child. Never fabricate a state the data lacks.
+        const bucketOf = ({ actor }: (typeof peers)[number]) => {
+          if (!actor) return "idle" as const
+          if (actor.status === "running" || actor.status === "pending") return "running" as const
+          if (actor.lastOutcome === "cancelled") return "cancelled" as const
+          if (actor.lastOutcome === "failure") return "failed" as const
+          return "idle" as const
+        }
+        const tagged = peers.map((p) => ({ ...p, bucket: bucketOf(p) }))
+        const counts = {
+          running: tagged.filter((p) => p.bucket === "running").length,
+          idle: tagged.filter((p) => p.bucket === "idle").length,
+          cancelled: tagged.filter((p) => p.bucket === "cancelled").length,
+          failed: tagged.filter((p) => p.bucket === "failed").length,
+        }
+        const groups: { bucket: keyof typeof counts; heading: string }[] = [
+          { bucket: "running", heading: "In progress (running/pending)" },
+          { bucket: "idle", heading: "Finished / idle" },
+          { bucket: "failed", heading: "Failed" },
+          { bucket: "cancelled", heading: "Cancelled" },
+        ]
+        const sections = groups
+          .filter((g) => counts[g.bucket] > 0)
+          .map((g) => {
+            const lines = tagged
+              .filter((p) => p.bucket === g.bucket)
+              .map(
+                ({ child, actor }) =>
+                  `  ${child.id} — ${child.title} — ${actor?.agent ?? "?"} — ${actor?.status ?? "unknown"}`,
+              )
+            return `${g.heading} (${counts[g.bucket]}):\n${lines.join("\n")}`
+          })
+        const summary =
+          `Child sessions: ${peers.length} total — ${counts.running} running, ${counts.idle} idle` +
+          (counts.failed > 0 ? `, ${counts.failed} failed` : "") +
+          (counts.cancelled > 0 ? `, ${counts.cancelled} cancelled` : "")
+        return {
+          title: `Child sessions: ${peers.length}`,
+          output: [summary, "", ...sections].join("\n"),
+          metadata: {} as Metadata,
+        }
       }
 
       if (op.action === "cancel") {

--- a/packages/opencode/src/tool/session.txt
+++ b/packages/opencode/src/tool/session.txt
@@ -19,6 +19,11 @@ JSON calls always wrap the action in an `operation` object — see examples belo
             language, then switch to it. (Orchestrator-only — a child cannot
             switch back; the user returns manually via the session-parent keybind.)
 - list:     enumerate this Orchestrator's child sessions (id, title, mode, status).
+- dashboard: the fleet at a glance — one grouped TABLE of every child correlated
+            to its liveness (progressing/idle/stalled + age), turnCount, mode,
+            and the git worktree backing isolated children (branch, commits-ahead,
+            dir). Use it when you (or the user) want the whole fleet + its
+            worktree/branch mapping in one structured view rather than flat `list`.
 - cancel:   stop a running child session. `sessionID` required.
 - ask:      ask a session a ONE-SHOT, READ-ONLY side question over a FROZEN
             snapshot of its history, without disturbing its running turn.
@@ -45,6 +50,7 @@ JSON calls always wrap the action in an `operation` object — see examples belo
 {"operation":{"action":"create","task":"Implement email/password login","mode":"build"}}
 {"operation":{"action":"create","task":"Design the billing schema","mode":"compose","model":"standard","title":"Billing"}}
 {"operation":{"action":"list"}}
+{"operation":{"action":"dashboard"}}
 {"operation":{"action":"switch","sessionID":"ses_..."}}
 {"operation":{"action":"cancel","sessionID":"ses_..."}}
 {"operation":{"action":"ask","session_id":"ses_...","question":"what is your current progress?"}}

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -245,14 +245,39 @@ export const layer: Layer.Layer<
 
     const setup = Effect.fnUntraced(function* (info: Info) {
       const ctx = yield* InstanceState.context
-      const created = yield* lock(ctx.worktree).withPermits(1)(
-        git(["worktree", "add", "--no-checkout", "-b", info.branch, info.directory], {
-          cwd: ctx.worktree,
+      // Hold the per-parent-repo lock across the whole atomic creation: the
+      // checked-out `worktree add -b` AND the HEAD-attachment assertion. All
+      // child worktrees share one ref store (via --git-common-dir), so a
+      // concurrent creator mutating packed-refs could otherwise clobber this
+      // branch ref advance while the commit object survives -> merge-by-hash.
+      yield* lock(ctx.worktree).withPermits(1)(
+        Effect.gen(function* () {
+          // Atomic: create the worktree already checked out onto a new branch
+          // so HEAD is attached to refs/heads/<branch> from the start. This
+          // replaces the old non-atomic two-step (`--no-checkout -b` here then
+          // a separate `git reset --hard` in boot), which could leave an
+          // unborn/empty checkout onto which later commits landed off-branch.
+          const created = yield* git(["worktree", "add", "-b", info.branch, info.directory], {
+            cwd: ctx.worktree,
+          })
+          if (created.code !== 0) {
+            throw new CreateFailedError({ message: created.stderr || created.text || "Failed to create git worktree" })
+          }
+
+          // Assert HEAD is attached to the expected branch. If git ever hands
+          // back a detached or wrong HEAD, fail loudly here rather than letting
+          // the child commit onto a detached HEAD (the root cause of the ref
+          // not advancing in the outer repo).
+          const symbolic = yield* git(["symbolic-ref", "--quiet", "HEAD"], { cwd: info.directory })
+          const head = symbolic.text.trim()
+          const expected = `refs/heads/${info.branch}`
+          if (symbolic.code !== 0 || head !== expected) {
+            throw new CreateFailedError({
+              message: `Worktree HEAD is not attached to ${expected} (got ${head || "detached HEAD"})`,
+            })
+          }
         }),
       )
-      if (created.code !== 0) {
-        throw new CreateFailedError({ message: created.stderr || created.text || "Failed to create git worktree" })
-      }
 
       yield* project.addSandbox(ctx.project.id, info.directory).pipe(Effect.catch(() => Effect.void))
     })
@@ -263,19 +288,9 @@ export const layer: Layer.Layer<
       const projectID = ctx.project.id
       const extra = startCommand?.trim()
 
-      const populated = yield* git(["reset", "--hard"], { cwd: info.directory })
-      if (populated.code !== 0) {
-        const message = populated.stderr || populated.text || "Failed to populate worktree"
-        log.error("worktree checkout failed", { directory: info.directory, message })
-        GlobalBus.emit("event", {
-          directory: info.directory,
-          project: ctx.project.id,
-          workspace: workspaceID,
-          payload: { type: Event.Failed.type, properties: { message } },
-        })
-        return
-      }
-
+      // Population is no longer a separate step: setup() creates the worktree
+      // already checked out on the branch, so the working tree is populated and
+      // HEAD is verified-attached before we get here.
       const booted = yield* Effect.promise(() =>
         Instance.provide({
           directory: info.directory,

--- a/packages/opencode/test/actor/cancel-notification.test.ts
+++ b/packages/opencode/test/actor/cancel-notification.test.ts
@@ -1,0 +1,402 @@
+import { NodeFileSystem } from "@effect/platform-node"
+import { FetchHttpClient } from "effect/unstable/http"
+import { afterEach, describe, expect } from "bun:test"
+import { Deferred, Effect, Layer } from "effect"
+import { eq, and } from "drizzle-orm"
+import { Agent as AgentSvc } from "../../src/agent/agent"
+import { Bus } from "../../src/bus"
+import { Command } from "../../src/command"
+import { Config } from "../../src/config"
+import { LSP } from "../../src/lsp"
+import { MCP } from "../../src/mcp"
+import { Permission } from "../../src/permission"
+import { Plugin } from "../../src/plugin"
+import { Provider as ProviderSvc } from "../../src/provider"
+import { Env } from "../../src/env"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { SessionID } from "../../src/session/schema"
+import { Question } from "../../src/question"
+import { Todo } from "../../src/session/todo"
+import { Session } from "../../src/session"
+import { LLM } from "../../src/session/llm"
+import { AppFileSystem } from "@mimo-ai/shared/filesystem"
+import { SessionPrune } from "../../src/session/prune"
+import { SessionSummary } from "../../src/session/summary"
+import { Instruction } from "../../src/session/instruction"
+import { SessionProcessor } from "../../src/session/processor"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionRevert } from "../../src/session/revert"
+import { SessionRunState } from "../../src/session/run-state"
+import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { SessionStatus } from "../../src/session/status"
+import { Skill } from "../../src/skill"
+import { SystemPrompt } from "../../src/session/system"
+import { Snapshot } from "../../src/snapshot"
+import { ToolRegistry } from "../../src/tool"
+import { Truncate } from "../../src/tool"
+import { ActorRegistry } from "../../src/actor/registry"
+import { ActorWaiter } from "../../src/actor/waiter"
+import { Actor } from "../../src/actor/spawn"
+import { Worktree } from "../../src/worktree"
+import { Memory } from "../../src/memory"
+import { History } from "../../src/history"
+import { Team } from "../../src/team"
+import { SessionCheckpoint } from "../../src/session/checkpoint"
+import { SessionCompaction } from "../../src/session/compaction"
+import { TaskRegistry } from "../../src/task/registry"
+import { defaultLayer as SchedulerDefaultLayer } from "../../src/cron/scheduler"
+import { Auth } from "../../src/auth"
+import { Database } from "../../src/storage"
+import { Instance } from "../../src/project/instance"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Ripgrep } from "../../src/file/ripgrep"
+import { Format } from "../../src/format"
+import { provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { TestLLMServer } from "../lib/llm-server"
+import { Inbox } from "../../src/inbox"
+import { InboxTable } from "../../src/inbox/inbox.sql"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const summary = Layer.succeed(
+  SessionSummary.Service,
+  SessionSummary.Service.of({
+    summarize: () => Effect.void,
+    diff: () => Effect.succeed([]),
+    computeDiff: () => Effect.succeed([]),
+  }),
+)
+
+const mcp = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    tools: () => Effect.succeed({}),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: () => Effect.succeed(undefined),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth in cancel-notification tests"),
+    authenticate: () => Effect.die("unexpected MCP auth in cancel-notification tests"),
+    finishAuth: () => Effect.die("unexpected MCP auth in cancel-notification tests"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
+const lsp = Layer.succeed(
+  LSP.Service,
+  LSP.Service.of({
+    init: () => Effect.void,
+    status: () => Effect.succeed([]),
+    hasClients: () => Effect.succeed(false),
+    touchFile: () => Effect.void,
+    diagnostics: () => Effect.succeed({}),
+    hover: () => Effect.succeed(undefined),
+    definition: () => Effect.succeed([]),
+    references: () => Effect.succeed([]),
+    implementation: () => Effect.succeed([]),
+    documentSymbol: () => Effect.succeed([]),
+    workspaceSymbol: () => Effect.succeed([]),
+    prepareCallHierarchy: () => Effect.succeed([]),
+    incomingCalls: () => Effect.succeed([]),
+    outgoingCalls: () => Effect.succeed([]),
+  }),
+)
+
+const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
+const run = SessionRunState.layer.pipe(Layer.provide(status))
+const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
+
+function makeLayer() {
+  const deps = Layer.mergeAll(
+    Session.defaultLayer,
+    Snapshot.defaultLayer,
+    LLM.defaultLayer,
+    Env.defaultLayer,
+    AgentSvc.defaultLayer,
+    Command.defaultLayer,
+    Permission.defaultLayer,
+    Plugin.defaultLayer,
+    Config.defaultLayer,
+    ProviderSvc.defaultLayer,
+    lsp,
+    mcp,
+    AppFileSystem.defaultLayer,
+    status,
+  ).pipe(Layer.provideMerge(infra))
+  const question = Question.layer.pipe(Layer.provideMerge(deps))
+  const todo = Todo.layer.pipe(Layer.provideMerge(deps))
+  const checkpoint = SessionCheckpoint.defaultLayer
+  const taskRegistry = ActorRegistry.defaultLayer
+  const taskWaiter = ActorWaiter.defaultLayer
+  const team = Team.defaultLayer
+  const registry = ToolRegistry.layer.pipe(
+    Layer.provide(Skill.defaultLayer),
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(CrossSpawnSpawner.defaultLayer),
+    Layer.provide(Ripgrep.defaultLayer),
+    Layer.provide(Format.defaultLayer),
+    Layer.provide(taskRegistry),
+    Layer.provide(taskWaiter),
+    Layer.provide(team),
+    Layer.provide(checkpoint),
+    Layer.provide(Memory.defaultLayer),
+    Layer.provide(History.defaultLayer),
+    Layer.provide(TaskRegistry.defaultLayer),
+    Layer.provide(SchedulerDefaultLayer),
+    Layer.provide(Auth.defaultLayer),
+    Layer.provideMerge(todo),
+    Layer.provideMerge(question),
+    Layer.provideMerge(deps),
+  )
+  const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
+  const proc = SessionProcessor.layer.pipe(Layer.provide(summary), Layer.provideMerge(deps))
+  const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
+  const prompt = SessionPrompt.layer.pipe(
+    Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(SessionRevert.defaultLayer),
+    Layer.provide(summary),
+    Layer.provide(checkpoint),
+    Layer.provide(SessionCompaction.defaultLayer),
+    Layer.provide(team),
+    Layer.provide(taskRegistry),
+    Layer.provideMerge(run),
+    Layer.provideMerge(prune),
+    Layer.provideMerge(proc),
+    Layer.provideMerge(registry),
+    Layer.provideMerge(trunc),
+    Layer.provide(Instruction.defaultLayer),
+    Layer.provide(SystemPrompt.defaultLayer),
+    Layer.provide(Inbox.defaultLayer),
+    Layer.provideMerge(deps),
+  )
+  const inboxLayer = Inbox.defaultLayer
+  return Layer.mergeAll(
+    TestLLMServer.layer,
+    Actor.layer.pipe(
+      Layer.provideMerge(prompt),
+      Layer.provide(Worktree.defaultLayer),
+      Layer.provideMerge(taskRegistry),
+      Layer.provide(TaskRegistry.defaultLayer),
+      Layer.provide(SchedulerDefaultLayer),
+      Layer.provideMerge(inboxLayer),
+    ),
+  ).pipe(Layer.provide(summary))
+}
+
+const it = testEffect(makeLayer())
+
+const ref = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("test-model"),
+}
+
+const cfg = {
+  provider: {
+    test: {
+      name: "Test",
+      id: "test",
+      env: [],
+      npm: "@ai-sdk/openai-compatible",
+      models: {
+        "test-model": {
+          id: "test-model",
+          name: "Test Model",
+          attachment: false,
+          reasoning: false,
+          temperature: false,
+          tool_call: true,
+          release_date: "2025-01-01",
+          limit: { context: 100000, output: 10000 },
+          cost: { input: 0, output: 0 },
+          options: {},
+        },
+      },
+      options: {
+        apiKey: "test-key",
+        baseURL: "http://localhost:1/v1",
+      },
+    },
+  },
+}
+
+function providerCfg(url: string) {
+  return {
+    ...cfg,
+    provider: {
+      ...cfg.provider,
+      test: {
+        ...cfg.provider.test,
+        options: {
+          ...cfg.provider.test.options,
+          baseURL: url,
+        },
+      },
+    },
+  }
+}
+
+const parentInboxRows = (parentID: SessionID) =>
+  Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .select()
+        .from(InboxTable)
+        .where(and(eq(InboxTable.receiver_session_id, parentID), eq(InboxTable.receiver_actor_id, "main")))
+        .all(),
+    ),
+  )
+
+describe("Actor cancel notification (T41 unified terminal-status bridge)", () => {
+  // Regression guard: successful completion still notifies exactly once (no
+  // double-notify introduced by the bridge). Read immediately after the outcome
+  // resolves — forkWork sends the notification BEFORE resolving the Deferred, so
+  // the row is present without an added sleep (a post-terminal sleep lets the
+  // ephemeral actor's Instance tear down and the row disappears).
+  it.live("successful background subagent still notifies parent exactly once (completed)", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+
+        const parent = yield* session.create({
+          title: "cancel-notify-success",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        yield* llm.text("**Status**: success\n**Summary**: done")
+
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "build",
+          task: "quick task",
+          description: "successful task",
+          context: "none",
+          tools: ["read"],
+          background: true,
+          model: ref,
+        })
+
+        yield* Deferred.await(result.outcome)
+
+        const rows = yield* parentInboxRows(parent.id)
+        expect(rows.length).toBe(1)
+        const content = rows[0].content as { text?: string }
+        expect(content.text).toContain("completed")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  // Regression guard: a background subagent whose turn reports a failure status
+  // still notifies the parent EXACTLY once (no double-notify introduced by the
+  // unified terminal path). An LLM-level error is absorbed by the prompt (the
+  // turn still completes), so the faithful, deterministic "non-success" signal
+  // the actor surfaces is a reported `Status: failed` on an otherwise completed
+  // turn — assert that carries through as a single actor_notification.
+  it.live("background subagent reporting failure still notifies parent exactly once", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+
+        const parent = yield* session.create({
+          title: "cancel-notify-fail",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        yield* llm.text("**Status**: failed\n**Summary**: could not complete")
+
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "build",
+          task: "will report failure",
+          description: "failing task",
+          context: "none",
+          tools: ["read"],
+          background: true,
+          model: ref,
+        })
+
+        yield* Deferred.await(result.outcome)
+
+        const rows = yield* parentInboxRows(parent.id)
+        expect(rows.length).toBe(1)
+        expect(rows[0].type).toBe("actor_notification")
+        const content = rows[0].content as { text?: string }
+        expect(content.text).toContain("failed")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  // Core T41 assertion: cancelling a running background peer produces EXACTLY
+  // ONE actor_notification{cancelled} to its parent's main inbox. Runs last
+  // because it hangs the shared TestLLMServer request until forced-cancel
+  // aborts it.
+  it.live("cancelling a running background peer notifies parent exactly once (cancelled)", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+
+        const parent = yield* session.create({
+          title: "cancel-notify-peer",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        // Make the spawn turn hang so the actor stays running until we cancel.
+        yield* llm.hang
+
+        const result = yield* actor.spawn({
+          mode: "peer",
+          sessionID: parent.id,
+          agentType: "build",
+          task: "long running peer",
+          description: "cancellable peer task",
+          context: "none",
+          tools: ["read"],
+          background: true,
+          model: ref,
+        })
+
+        // Wait until the actor is actually running (LLM request in flight).
+        yield* Effect.gen(function* () {
+          for (let i = 0; i < 400; i++) {
+            const calls = yield* llm.calls
+            if (calls > 0) return
+            yield* Effect.sleep("25 millis")
+          }
+        })
+
+        yield* actor.cancel(result.sessionID, result.actorID, "forced")
+
+        // The cancelled outcome resolves after the terminal bridge/notify path.
+        yield* Deferred.await(result.outcome)
+
+        const rows = yield* parentInboxRows(parent.id)
+        expect(rows.length).toBe(1)
+        expect(rows[0].type).toBe("actor_notification")
+        const content = rows[0].content as { text?: string }
+        expect(content.text).toContain("<actor-notification>")
+        expect(content.text).toContain("cancellable peer task")
+        expect(content.text).toContain("cancelled")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+})

--- a/packages/opencode/test/actor/liveness.test.ts
+++ b/packages/opencode/test/actor/liveness.test.ts
@@ -37,48 +37,76 @@ describe("deriveLiveness (T39 derivation rule)", () => {
   const now = 1_000_000
 
   test("running + recent turn (within window) → progressing", () => {
-    expect(deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 1_000 }, now)).toBe(
-      "progressing",
-    )
+    expect(
+      deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 1_000, turnCount: 1 }, now),
+    ).toBe("progressing")
   })
 
   test("running + turn older than the window → stalled", () => {
     expect(
-      deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - (DEFAULT_LIVENESS_STALL_MS + 1) }, now),
+      deriveLiveness(
+        { status: "running", lastOutcome: undefined, lastTurnTime: now - (DEFAULT_LIVENESS_STALL_MS + 1), turnCount: 1 },
+        now,
+      ),
     ).toBe("stalled")
   })
 
-  test("pending is treated as live and split by the same window", () => {
-    expect(deriveLiveness({ status: "pending", lastOutcome: undefined, lastTurnTime: now }, now)).toBe("progressing")
+  test("not-yet-started child (turnCount 0) is never stalled — slow first turn is not a stall", () => {
+    // last_turn_time is the spawn time; even far outside the window a child that
+    // has not completed a turn (queued behind the concurrency gate / cold-start)
+    // must read progressing, not stalled.
     expect(
-      deriveLiveness({ status: "pending", lastOutcome: undefined, lastTurnTime: now - 10 * 60_000 }, now),
+      deriveLiveness(
+        { status: "pending", lastOutcome: undefined, lastTurnTime: now - 10 * 60_000, turnCount: 0 },
+        now,
+      ),
+    ).toBe("progressing")
+    expect(
+      deriveLiveness(
+        { status: "running", lastOutcome: undefined, lastTurnTime: now - 10 * 60_000, turnCount: 0 },
+        now,
+      ),
+    ).toBe("progressing")
+  })
+
+  test("pending is treated as live and split by the same window (once it has run a turn)", () => {
+    expect(
+      deriveLiveness({ status: "pending", lastOutcome: undefined, lastTurnTime: now, turnCount: 1 }, now),
+    ).toBe("progressing")
+    expect(
+      deriveLiveness({ status: "pending", lastOutcome: undefined, lastTurnTime: now - 10 * 60_000, turnCount: 1 }, now),
     ).toBe("stalled")
   })
 
   test("exactly at the threshold boundary is still progressing (<= window)", () => {
     expect(
-      deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - DEFAULT_LIVENESS_STALL_MS }, now),
+      deriveLiveness(
+        { status: "running", lastOutcome: undefined, lastTurnTime: now - DEFAULT_LIVENESS_STALL_MS, turnCount: 1 },
+        now,
+      ),
     ).toBe("progressing")
   })
 
   test("custom stallMs overrides the default window", () => {
     // 5s-old turn: stalled under a 1s window, progressing under a 60s window.
-    expect(deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 5_000 }, now, 1_000)).toBe(
-      "stalled",
-    )
-    expect(deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 5_000 }, now, 60_000)).toBe(
-      "progressing",
-    )
+    expect(
+      deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 5_000, turnCount: 1 }, now, 1_000),
+    ).toBe("stalled")
+    expect(
+      deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 5_000, turnCount: 1 }, now, 60_000),
+    ).toBe("progressing")
   })
 
   test("terminal outcomes come straight from lastOutcome regardless of turn age", () => {
-    expect(deriveLiveness({ status: "idle", lastOutcome: "success", lastTurnTime: 0 }, now)).toBe("success")
-    expect(deriveLiveness({ status: "idle", lastOutcome: "failure", lastTurnTime: 0 }, now)).toBe("failure")
-    expect(deriveLiveness({ status: "idle", lastOutcome: "cancelled", lastTurnTime: 0 }, now)).toBe("cancelled")
+    expect(deriveLiveness({ status: "idle", lastOutcome: "success", lastTurnTime: 0, turnCount: 1 }, now)).toBe("success")
+    expect(deriveLiveness({ status: "idle", lastOutcome: "failure", lastTurnTime: 0, turnCount: 1 }, now)).toBe("failure")
+    expect(deriveLiveness({ status: "idle", lastOutcome: "cancelled", lastTurnTime: 0, turnCount: 1 }, now)).toBe(
+      "cancelled",
+    )
   })
 
   test("idle with no outcome → idle", () => {
-    expect(deriveLiveness({ status: "idle", lastOutcome: undefined, lastTurnTime: 0 }, now)).toBe("idle")
+    expect(deriveLiveness({ status: "idle", lastOutcome: undefined, lastTurnTime: 0, turnCount: 0 }, now)).toBe("idle")
   })
 })
 
@@ -116,23 +144,42 @@ describe("ActorRegistry.liveness (T39 integration)", () => {
     })
   })
 
-  test("running row whose last turn is old + turnCount unchanged reads stalled", async () => {
+  test("running row whose last turn is old + has run a turn reads stalled", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withRegistry(tmp.path, async (rt) => {
+      const child = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => register(reg, child.id)))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => reg.updateStatus(child.id, child.id, { status: "running" })))
+      // Advance one turn so the row is no longer a not-yet-started child; its
+      // last_turn_time now dates from this updateTurn. With a 1ms staleness
+      // window and no further advance, elapsed real time flips it to stalled.
+      await rt.runPromise(ActorRegistry.Service.use((reg) => reg.updateTurn(child.id, child.id)))
+
+      await new Promise((r) => setTimeout(r, 5))
+      const before = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.get(child.id, child.id)))
+      const found = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id, 1)))
+      expect(found!.liveness).toBe("stalled")
+      // turnCount advanced exactly once, then wedged.
+      expect(found!.actor.turnCount).toBe(1)
+      expect(found!.actor.lastTurnTime).toBe(before!.lastTurnTime)
+    })
+  })
+
+  test("not-yet-started row (turnCount 0) reads progressing even far past the window", async () => {
     await using tmp = await tmpdir({ git: true })
     await withRegistry(tmp.path, async (rt) => {
       const child = await rt.runPromise(Session.Service.use((s) => s.create()))
       await rt.runPromise(ActorRegistry.Service.use((reg) => register(reg, child.id)))
       await rt.runPromise(ActorRegistry.Service.use((reg) => reg.updateStatus(child.id, child.id, { status: "running" })))
 
-      // lastTurnTime is register/updateStatus's `now`; with a 1ms staleness
-      // window and no further updateTurn (turnCount stays 0), any elapsed real
-      // time flips it to stalled. Sleep a hair to guarantee age > 1ms.
+      // No updateTurn: last_turn_time is the spawn time, turnCount stays 0. Even
+      // with a 1ms staleness window (spawn time is now far outside it), a child
+      // that has not run once must NOT read stalled — this is the slow-start
+      // (queued / cold-start) false-positive guard.
       await new Promise((r) => setTimeout(r, 5))
-      const before = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.get(child.id, child.id)))
       const found = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id, 1)))
-      expect(found!.liveness).toBe("stalled")
-      // turnCount never advanced.
       expect(found!.actor.turnCount).toBe(0)
-      expect(found!.actor.lastTurnTime).toBe(before!.lastTurnTime)
+      expect(found!.liveness).toBe("progressing")
     })
   })
 

--- a/packages/opencode/test/actor/liveness.test.ts
+++ b/packages/opencode/test/actor/liveness.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Layer, ManagedRuntime, Effect } from "effect"
+import { ActorRegistry } from "../../src/actor/registry"
+import { deriveLiveness, DEFAULT_LIVENESS_STALL_MS } from "../../src/actor/schema"
+import { Bus } from "../../src/bus"
+import { Session } from "../../src/session"
+import { SessionID } from "../../src/session/schema"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+
+const testLayer = Layer.mergeAll(Session.defaultLayer, ActorRegistry.defaultLayer, Bus.defaultLayer)
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+async function withRegistry(
+  directory: string,
+  fn: (rt: ManagedRuntime.ManagedRuntime<Session.Service | ActorRegistry.Service | Bus.Service, never>) => Promise<void>,
+) {
+  return Instance.provide({
+    directory,
+    fn: async () => {
+      const rt = ManagedRuntime.make(testLayer)
+      try {
+        await fn(rt)
+      } finally {
+        await rt.dispose()
+      }
+    },
+  })
+}
+
+// Pure-derivation table: deriveLiveness maps honest registry fields to the
+// pull-side signal. No I/O — this pins the rule + threshold exactly.
+describe("deriveLiveness (T39 derivation rule)", () => {
+  const now = 1_000_000
+
+  test("running + recent turn (within window) → progressing", () => {
+    expect(deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 1_000 }, now)).toBe(
+      "progressing",
+    )
+  })
+
+  test("running + turn older than the window → stalled", () => {
+    expect(
+      deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - (DEFAULT_LIVENESS_STALL_MS + 1) }, now),
+    ).toBe("stalled")
+  })
+
+  test("pending is treated as live and split by the same window", () => {
+    expect(deriveLiveness({ status: "pending", lastOutcome: undefined, lastTurnTime: now }, now)).toBe("progressing")
+    expect(
+      deriveLiveness({ status: "pending", lastOutcome: undefined, lastTurnTime: now - 10 * 60_000 }, now),
+    ).toBe("stalled")
+  })
+
+  test("exactly at the threshold boundary is still progressing (<= window)", () => {
+    expect(
+      deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - DEFAULT_LIVENESS_STALL_MS }, now),
+    ).toBe("progressing")
+  })
+
+  test("custom stallMs overrides the default window", () => {
+    // 5s-old turn: stalled under a 1s window, progressing under a 60s window.
+    expect(deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 5_000 }, now, 1_000)).toBe(
+      "stalled",
+    )
+    expect(deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 5_000 }, now, 60_000)).toBe(
+      "progressing",
+    )
+  })
+
+  test("terminal outcomes come straight from lastOutcome regardless of turn age", () => {
+    expect(deriveLiveness({ status: "idle", lastOutcome: "success", lastTurnTime: 0 }, now)).toBe("success")
+    expect(deriveLiveness({ status: "idle", lastOutcome: "failure", lastTurnTime: 0 }, now)).toBe("failure")
+    expect(deriveLiveness({ status: "idle", lastOutcome: "cancelled", lastTurnTime: 0 }, now)).toBe("cancelled")
+  })
+
+  test("idle with no outcome → idle", () => {
+    expect(deriveLiveness({ status: "idle", lastOutcome: undefined, lastTurnTime: 0 }, now)).toBe("idle")
+  })
+})
+
+// Integration: the registry.liveness helper reads a real row and derives the
+// signal. A row registered at now, then advanced via updateTurn, reads
+// progressing under the default window; the same row reads stalled under a
+// tiny window while its lastTurnTime stays put (turnCount unchanged).
+describe("ActorRegistry.liveness (T39 integration)", () => {
+  const register = (reg: ActorRegistry.Interface, sessionID: SessionID) =>
+    reg.register({
+      sessionID,
+      actorID: sessionID,
+      mode: "peer",
+      parentActorID: undefined,
+      agent: "build",
+      description: "work",
+      contextMode: "none",
+      contextWatermark: undefined,
+      background: true,
+      lifecycle: "persistent",
+    })
+
+  test("running row with an advancing turn reads progressing (default window)", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withRegistry(tmp.path, async (rt) => {
+      const child = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => register(reg, child.id)))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => reg.updateStatus(child.id, child.id, { status: "running" })))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => reg.updateTurn(child.id, child.id)))
+
+      const found = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id)))
+      expect(found).toBeDefined()
+      expect(found!.liveness).toBe("progressing")
+      expect(found!.actor.turnCount).toBe(1)
+    })
+  })
+
+  test("running row whose last turn is old + turnCount unchanged reads stalled", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withRegistry(tmp.path, async (rt) => {
+      const child = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => register(reg, child.id)))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => reg.updateStatus(child.id, child.id, { status: "running" })))
+
+      // lastTurnTime is register/updateStatus's `now`; with a 1ms staleness
+      // window and no further updateTurn (turnCount stays 0), any elapsed real
+      // time flips it to stalled. Sleep a hair to guarantee age > 1ms.
+      await new Promise((r) => setTimeout(r, 5))
+      const before = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.get(child.id, child.id)))
+      const found = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id, 1)))
+      expect(found!.liveness).toBe("stalled")
+      // turnCount never advanced.
+      expect(found!.actor.turnCount).toBe(0)
+      expect(found!.actor.lastTurnTime).toBe(before!.lastTurnTime)
+    })
+  })
+
+  test("terminal idle+failure reads failure; idle+success reads success", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withRegistry(tmp.path, async (rt) => {
+      const child = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => register(reg, child.id)))
+      await rt.runPromise(
+        ActorRegistry.Service.use((reg) => reg.updateStatus(child.id, child.id, { status: "idle", lastOutcome: "failure" })),
+      )
+      const failed = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id)))
+      expect(failed!.liveness).toBe("failure")
+
+      await rt.runPromise(
+        ActorRegistry.Service.use((reg) => reg.updateStatus(child.id, child.id, { status: "idle", lastOutcome: "success" })),
+      )
+      const done = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id)))
+      expect(done!.liveness).toBe("success")
+    })
+  })
+
+  test("liveness on an absent actor row returns undefined", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withRegistry(tmp.path, async (rt) => {
+      const found = await rt.runPromise(
+        Effect.gen(function* () {
+          const reg = yield* ActorRegistry.Service
+          return yield* reg.liveness(SessionID.make("ses_missing"), "ses_missing")
+        }),
+      )
+      expect(found).toBeUndefined()
+    })
+  })
+})

--- a/packages/opencode/test/actor/spawn-notification.test.ts
+++ b/packages/opencode/test/actor/spawn-notification.test.ts
@@ -190,7 +190,7 @@ function makeLayer() {
       Layer.provideMerge(taskRegistry),
       Layer.provide(TaskRegistry.defaultLayer),
     Layer.provide(SchedulerDefaultLayer),
-      Layer.provide(inboxLayer),
+      Layer.provideMerge(inboxLayer),
     ),
   ).pipe(Layer.provide(summary))
 }
@@ -391,6 +391,165 @@ describe("Actor.spawn inbox notifications (Plan 3 / Task 2)", () => {
         )
 
         expect(rows.length).toBe(0)
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  // T12: a persistent background PEER that finishes a *woken* (inbox-driven)
+  // turn must notify its parent exactly once — forkWork.notify only covers the
+  // spawn turn, so later woken turns would otherwise go idle silently.
+  it.live("background peer finishing a woken turn sends exactly one actor_notification to parent", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const inbox = yield* Inbox.Service
+
+        const parent = yield* session.create({
+          title: "notification-test-woken-peer",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        // One response for the spawn turn, one for the woken turn.
+        yield* llm.text("**Status**: success\n**Summary**: spawn turn")
+        yield* llm.text("**Status**: success\n**Summary**: woken turn")
+
+        const result = yield* actor.spawn({
+          mode: "peer",
+          sessionID: parent.id,
+          agentType: "build",
+          task: "peer that will be woken",
+          description: "woken peer task",
+          context: "none",
+          tools: ["read"],
+          background: true,
+          model: ref,
+        })
+
+        // Spawn turn completes → forkWork.notify writes the FIRST notification.
+        yield* Deferred.await(result.outcome)
+
+        const inboxRows = (agentID: string) =>
+          Effect.sync(() =>
+            Database.use((db) =>
+              db
+                .select()
+                .from(InboxTable)
+                .where(
+                  and(
+                    eq(InboxTable.receiver_session_id, parent.id),
+                    eq(InboxTable.receiver_actor_id, agentID),
+                  ),
+                )
+                .all(),
+            ),
+          )
+
+        // Clear the spawn-turn notification so we can assert the woken turn adds
+        // exactly one more.
+        yield* Effect.sync(() =>
+          Database.use((db) => db.delete(InboxTable).where(eq(InboxTable.receiver_session_id, parent.id)).run()),
+        )
+
+        // Wake the peer with an inbox message. This drives a woken turn via
+        // SessionPrompt.loop({ notifyParentOnComplete: true }).
+        yield* inbox
+          .send({
+            receiverSessionID: result.sessionID,
+            receiverActorID: result.actorID,
+            senderSessionID: parent.id,
+            senderActorID: "main",
+            content: "please do more work",
+          })
+          .pipe(Effect.orDie)
+
+        // Poll the parent inbox until the woken-turn notification arrives.
+        const rows = yield* Effect.gen(function* () {
+          for (let i = 0; i < 200; i++) {
+            const r = yield* inboxRows("main")
+            if (r.length > 0) return r
+            yield* Effect.sleep("25 millis")
+          }
+          return yield* inboxRows("main")
+        })
+
+        expect(rows.length).toBe(1)
+        expect(rows[0].type).toBe("actor_notification")
+        const content = rows[0].content as { text?: string }
+        expect(content.text).toContain("<actor-notification>")
+        expect(content.text).toContain("woken peer task")
+        expect(content.text).toContain("completed")
+
+        yield* actor.cancel(result.sessionID, result.actorID, "forced").pipe(Effect.ignore)
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  // T12 gate: a SYSTEM subagent agentType (checkpoint-writer) spawned as a peer
+  // must NOT notify on a woken turn — SYSTEM_SPAWNED_AGENT_TYPES are excluded.
+  it.live("system-spawned peer finishing a woken turn sends no notification", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const inbox = yield* Inbox.Service
+
+        const parent = yield* session.create({
+          title: "notification-test-woken-system-peer",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        yield* llm.text("spawn turn output")
+        yield* llm.text("woken turn output")
+
+        const result = yield* actor.spawn({
+          mode: "peer",
+          sessionID: parent.id,
+          agentType: "checkpoint-writer",
+          task: "system peer that will be woken",
+          description: "woken system peer task",
+          context: "none",
+          tools: ["read"],
+          background: true,
+          model: ref,
+        })
+
+        yield* Deferred.await(result.outcome)
+
+        // checkpoint-writer is gated in forkWork.notify too, so the inbox should
+        // already be empty; clear defensively then wake.
+        yield* Effect.sync(() =>
+          Database.use((db) => db.delete(InboxTable).where(eq(InboxTable.receiver_session_id, parent.id)).run()),
+        )
+
+        yield* inbox
+          .send({
+            receiverSessionID: result.sessionID,
+            receiverActorID: result.actorID,
+            senderSessionID: parent.id,
+            senderActorID: "main",
+            content: "please do more work",
+          })
+          .pipe(Effect.orDie)
+
+        // Give the woken turn ample time to run and (not) notify.
+        yield* Effect.sleep("500 millis")
+
+        const rows = yield* Effect.sync(() =>
+          Database.use((db) =>
+            db
+              .select()
+              .from(InboxTable)
+              .where(eq(InboxTable.receiver_session_id, parent.id))
+              .all(),
+          ),
+        )
+
+        expect(rows.length).toBe(0)
+
+        yield* actor.cancel(result.sessionID, result.actorID, "forced").pipe(Effect.ignore)
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/actor/spawn-notification.test.ts
+++ b/packages/opencode/test/actor/spawn-notification.test.ts
@@ -17,6 +17,7 @@ import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Question } from "../../src/question"
 import { Todo } from "../../src/session/todo"
 import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
 import { LLM } from "../../src/session/llm"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { SessionPrune } from "../../src/session/prune"
@@ -464,22 +465,39 @@ describe("Actor.spawn inbox notifications (Plan 3 / Task 2)", () => {
           })
           .pipe(Effect.orDie)
 
-        // Poll the parent inbox until the woken-turn notification arrives.
-        const rows = yield* Effect.gen(function* () {
+        // Poll for the woken-turn notification. Delivery can land in TWO places:
+        // the raw InboxTable row, OR — because inbox.send also fork-wakes the
+        // parent main runner — a drained synthetic user message in the parent
+        // main slice (the woken parent consumes the row into a message). Checking
+        // only the raw row races the parent's drain and is flaky; assert on
+        // either surface. Either way the actor_notification WAS delivered.
+        const found = yield* Effect.gen(function* () {
           for (let i = 0; i < 200; i++) {
             const r = yield* inboxRows("main")
-            if (r.length > 0) return r
+            if (r.length > 0) {
+              const content = r[0].content as { text?: string }
+              return { type: r[0].type, text: content.text ?? "" }
+            }
+            const msgs = yield* Session.Service.use((s) => s.messages({ sessionID: parent.id, agentID: "main" })).pipe(
+              Effect.catch(() => Effect.succeed([] as MessageV2.WithParts[])),
+            )
+            for (const m of msgs) {
+              for (const p of m.parts) {
+                if (p.type === "text" && p.synthetic && p.text.includes("<actor-notification>")) {
+                  return { type: "actor_notification", text: p.text }
+                }
+              }
+            }
             yield* Effect.sleep("25 millis")
           }
-          return yield* inboxRows("main")
+          return undefined
         })
 
-        expect(rows.length).toBe(1)
-        expect(rows[0].type).toBe("actor_notification")
-        const content = rows[0].content as { text?: string }
-        expect(content.text).toContain("<actor-notification>")
-        expect(content.text).toContain("woken peer task")
-        expect(content.text).toContain("completed")
+        expect(found).toBeDefined()
+        expect(found!.type).toBe("actor_notification")
+        expect(found!.text).toContain("<actor-notification>")
+        expect(found!.text).toContain("woken peer task")
+        expect(found!.text).toContain("completed")
 
         yield* actor.cancel(result.sessionID, result.actorID, "forced").pipe(Effect.ignore)
       }),

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -59,6 +59,7 @@ import { testEffect } from "../lib/effect"
 import { TestLLMServer } from "../lib/llm-server"
 import { reply } from "../lib/llm-server"
 import { Inbox } from "../../src/inbox"
+import { inboxServiceRef } from "../../src/inbox/inbox-ref"
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -284,6 +285,64 @@ describe("Actor.spawn peer mode", () => {
         const row = yield* reg.get(result.sessionID, result.actorID)
         expect(row?.mode).toBe("peer")
         expect(row?.agent).toBe("build")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  // T42: a freshly-created peer is addressable the instant spawn returns —
+  // spawnPeer registers the receiver/actor-registry row (session_id === actor_id
+  // === child.id, mode "peer") SYNCHRONOUSLY before spawn resolves, so Inbox.send's
+  // ESRCH pre-check (reg.get) resolves even against a turnCount-0, never-run child.
+  // Guards the T43 --topic reuse prerequisite. LLM is hung so the child's first
+  // turn never runs: the row can ONLY come from spawn-time registration.
+  it.live("send to a just-created, never-run peer (turnCount 0) does NOT ESRCH and enqueues", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const reg = yield* ActorRegistry.Service
+        const inbox = inboxServiceRef.current!
+
+        const parent = yield* session.create({
+          title: "T42 parent",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        // Hang so the child's spawn turn never completes — the receiver row must
+        // exist purely from spawn-time registration, not first-turn arming.
+        yield* llm.hang
+
+        const result = yield* actor.spawn({
+          mode: "peer",
+          sessionID: parent.id,
+          agentType: "build",
+          task: "peer task",
+          context: "none",
+          tools: ["read"],
+          background: true,
+          model: ref,
+        })
+
+        // Row present at spawn: pending, zero turns (never ran).
+        const row = yield* reg.get(result.sessionID, result.actorID)
+        expect(row?.mode).toBe("peer")
+        expect(row?.turnCount).toBe(0)
+        expect(row?.status).toBe("pending")
+
+        // Both addressing forms resolve without ESRCH and enqueue a durable row.
+        const sent = yield* inbox
+          .send({
+            receiverSessionID: result.sessionID,
+            receiverActorID: result.actorID,
+            senderSessionID: parent.id,
+            senderActorID: "main",
+            content: "relayed while never-run",
+          })
+          .pipe(Effect.exit)
+        expect(sent._tag).toBe("Success")
+        if (sent._tag === "Success") expect(sent.value.inboxID).toBeTruthy()
+
+        yield* actor.cancel(result.sessionID, result.actorID, "forced")
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/actor/stall-watchdog.test.ts
+++ b/packages/opencode/test/actor/stall-watchdog.test.ts
@@ -2,7 +2,7 @@ import { NodeFileSystem } from "@effect/platform-node"
 import { FetchHttpClient } from "effect/unstable/http"
 import { afterEach, describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
-import { eq, and } from "drizzle-orm"
+import { eq, and, sql } from "drizzle-orm"
 import { Agent as AgentSvc } from "../../src/agent/agent"
 import { Bus } from "../../src/bus"
 import { Command } from "../../src/command"
@@ -213,13 +213,16 @@ const parentInboxRows = (parentID: SessionID) =>
 
 // Backdate a peer's last_turn_time so deriveLiveness reads `stalled` on the next
 // scan WITHOUT advancing turn_count — exactly the wedged-child shape the watchdog
-// exists to catch. Keeps status pending/running so it stays in listActive().
+// exists to catch. turn_count is forced to >= 1 (the child has run at least one
+// turn, then wedged): a not-yet-started child (turnCount 0) is deliberately
+// exempt from the stall path, so a stalled row must have run once. Keeps status
+// pending/running so it stays in listActive().
 const backdateTurn = (sessionID: SessionID, actorID: string, agoMs: number) =>
   Effect.sync(() =>
     Database.use((db) =>
       db
         .update(ActorRegistryTable)
-        .set({ status: "running", last_turn_time: Date.now() - agoMs })
+        .set({ status: "running", last_turn_time: Date.now() - agoMs, turn_count: sql`max(${ActorRegistryTable.turn_count}, 1)` })
         .where(and(eq(ActorRegistryTable.session_id, sessionID), eq(ActorRegistryTable.actor_id, actorID)))
         .run(),
     ),

--- a/packages/opencode/test/actor/stall-watchdog.test.ts
+++ b/packages/opencode/test/actor/stall-watchdog.test.ts
@@ -1,0 +1,365 @@
+import { NodeFileSystem } from "@effect/platform-node"
+import { FetchHttpClient } from "effect/unstable/http"
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { eq, and } from "drizzle-orm"
+import { Agent as AgentSvc } from "../../src/agent/agent"
+import { Bus } from "../../src/bus"
+import { Command } from "../../src/command"
+import { Config } from "../../src/config"
+import { LSP } from "../../src/lsp"
+import { MCP } from "../../src/mcp"
+import { Permission } from "../../src/permission"
+import { Plugin } from "../../src/plugin"
+import { Provider as ProviderSvc } from "../../src/provider"
+import { Env } from "../../src/env"
+import { SessionID } from "../../src/session/schema"
+import { Question } from "../../src/question"
+import { Todo } from "../../src/session/todo"
+import { Session } from "../../src/session"
+import { LLM } from "../../src/session/llm"
+import { AppFileSystem } from "@mimo-ai/shared/filesystem"
+import { SessionPrune } from "../../src/session/prune"
+import { SessionSummary } from "../../src/session/summary"
+import { Instruction } from "../../src/session/instruction"
+import { SessionProcessor } from "../../src/session/processor"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionRevert } from "../../src/session/revert"
+import { SessionRunState } from "../../src/session/run-state"
+import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { SessionStatus } from "../../src/session/status"
+import { Skill } from "../../src/skill"
+import { SystemPrompt } from "../../src/session/system"
+import { Snapshot } from "../../src/snapshot"
+import { ToolRegistry } from "../../src/tool"
+import { Truncate } from "../../src/tool"
+import { ActorRegistry } from "../../src/actor/registry"
+import { ActorWaiter } from "../../src/actor/waiter"
+import { Actor } from "../../src/actor/spawn"
+import { Worktree } from "../../src/worktree"
+import { Memory } from "../../src/memory"
+import { History } from "../../src/history"
+import { Team } from "../../src/team"
+import { SessionCheckpoint } from "../../src/session/checkpoint"
+import { SessionCompaction } from "../../src/session/compaction"
+import { TaskRegistry } from "../../src/task/registry"
+import { defaultLayer as SchedulerDefaultLayer } from "../../src/cron/scheduler"
+import { Auth } from "../../src/auth"
+import { Database } from "../../src/storage"
+import { Instance } from "../../src/project/instance"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Ripgrep } from "../../src/file/ripgrep"
+import { Format } from "../../src/format"
+import { provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { TestLLMServer } from "../lib/llm-server"
+import { Inbox } from "../../src/inbox"
+import { InboxTable } from "../../src/inbox/inbox.sql"
+import { ActorRegistryTable } from "../../src/actor/actor.sql"
+import { DEFAULT_LIVENESS_STALL_MS } from "../../src/actor/schema"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const summary = Layer.succeed(
+  SessionSummary.Service,
+  SessionSummary.Service.of({
+    summarize: () => Effect.void,
+    diff: () => Effect.succeed([]),
+    computeDiff: () => Effect.succeed([]),
+  }),
+)
+
+const mcp = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    tools: () => Effect.succeed({}),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: () => Effect.succeed(undefined),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth in stall-watchdog tests"),
+    authenticate: () => Effect.die("unexpected MCP auth in stall-watchdog tests"),
+    finishAuth: () => Effect.die("unexpected MCP auth in stall-watchdog tests"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
+const lsp = Layer.succeed(
+  LSP.Service,
+  LSP.Service.of({
+    init: () => Effect.void,
+    status: () => Effect.succeed([]),
+    hasClients: () => Effect.succeed(false),
+    touchFile: () => Effect.void,
+    diagnostics: () => Effect.succeed({}),
+    hover: () => Effect.succeed(undefined),
+    definition: () => Effect.succeed([]),
+    references: () => Effect.succeed([]),
+    implementation: () => Effect.succeed([]),
+    documentSymbol: () => Effect.succeed([]),
+    workspaceSymbol: () => Effect.succeed([]),
+    prepareCallHierarchy: () => Effect.succeed([]),
+    incomingCalls: () => Effect.succeed([]),
+    outgoingCalls: () => Effect.succeed([]),
+  }),
+)
+
+const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
+const run = SessionRunState.layer.pipe(Layer.provide(status))
+const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
+
+function makeLayer() {
+  const deps = Layer.mergeAll(
+    Session.defaultLayer,
+    Snapshot.defaultLayer,
+    LLM.defaultLayer,
+    Env.defaultLayer,
+    AgentSvc.defaultLayer,
+    Command.defaultLayer,
+    Permission.defaultLayer,
+    Plugin.defaultLayer,
+    Config.defaultLayer,
+    ProviderSvc.defaultLayer,
+    lsp,
+    mcp,
+    AppFileSystem.defaultLayer,
+    status,
+  ).pipe(Layer.provideMerge(infra))
+  const question = Question.layer.pipe(Layer.provideMerge(deps))
+  const todo = Todo.layer.pipe(Layer.provideMerge(deps))
+  const checkpoint = SessionCheckpoint.defaultLayer
+  const taskRegistry = ActorRegistry.defaultLayer
+  const taskWaiter = ActorWaiter.defaultLayer
+  const team = Team.defaultLayer
+  const registry = ToolRegistry.layer.pipe(
+    Layer.provide(Skill.defaultLayer),
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(CrossSpawnSpawner.defaultLayer),
+    Layer.provide(Ripgrep.defaultLayer),
+    Layer.provide(Format.defaultLayer),
+    Layer.provide(taskRegistry),
+    Layer.provide(taskWaiter),
+    Layer.provide(team),
+    Layer.provide(checkpoint),
+    Layer.provide(Memory.defaultLayer),
+    Layer.provide(History.defaultLayer),
+    Layer.provide(TaskRegistry.defaultLayer),
+    Layer.provide(SchedulerDefaultLayer),
+    Layer.provide(Auth.defaultLayer),
+    Layer.provideMerge(todo),
+    Layer.provideMerge(question),
+    Layer.provideMerge(deps),
+  )
+  const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
+  const proc = SessionProcessor.layer.pipe(Layer.provide(summary), Layer.provideMerge(deps))
+  const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
+  const prompt = SessionPrompt.layer.pipe(
+    Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(SessionRevert.defaultLayer),
+    Layer.provide(summary),
+    Layer.provide(checkpoint),
+    Layer.provide(SessionCompaction.defaultLayer),
+    Layer.provide(team),
+    Layer.provide(taskRegistry),
+    Layer.provideMerge(run),
+    Layer.provideMerge(prune),
+    Layer.provideMerge(proc),
+    Layer.provideMerge(registry),
+    Layer.provideMerge(trunc),
+    Layer.provide(Instruction.defaultLayer),
+    Layer.provide(SystemPrompt.defaultLayer),
+    Layer.provide(Inbox.defaultLayer),
+    Layer.provideMerge(deps),
+  )
+  const inboxLayer = Inbox.defaultLayer
+  return Layer.mergeAll(
+    TestLLMServer.layer,
+    Actor.layer.pipe(
+      Layer.provideMerge(prompt),
+      Layer.provide(Worktree.defaultLayer),
+      Layer.provideMerge(taskRegistry),
+      Layer.provide(TaskRegistry.defaultLayer),
+      Layer.provide(SchedulerDefaultLayer),
+      Layer.provideMerge(inboxLayer),
+    ),
+  ).pipe(Layer.provide(summary))
+}
+
+const it = testEffect(makeLayer())
+
+// Rows the watchdog would notify: actor_notification to <parent>:main.
+const parentInboxRows = (parentID: SessionID) =>
+  Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .select()
+        .from(InboxTable)
+        .where(and(eq(InboxTable.receiver_session_id, parentID), eq(InboxTable.receiver_actor_id, "main")))
+        .all(),
+    ),
+  )
+
+// Backdate a peer's last_turn_time so deriveLiveness reads `stalled` on the next
+// scan WITHOUT advancing turn_count — exactly the wedged-child shape the watchdog
+// exists to catch. Keeps status pending/running so it stays in listActive().
+const backdateTurn = (sessionID: SessionID, actorID: string, agoMs: number) =>
+  Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .update(ActorRegistryTable)
+        .set({ status: "running", last_turn_time: Date.now() - agoMs })
+        .where(and(eq(ActorRegistryTable.session_id, sessionID), eq(ActorRegistryTable.actor_id, actorID)))
+        .run(),
+    ),
+  )
+
+describe("Actor stall watchdog (T40)", () => {
+  it.live("stalled background peer notifies parent once, debounces, and re-arms after resume", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+
+        const parent = yield* session.create({
+          title: "stall-watchdog",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        // A real background peer: its own child session, registered exactly like
+        // spawnPeer does (session_id === actor_id === child.id, mode peer,
+        // parent main). No LLM turn is run — we drive liveness via the DB.
+        const child = yield* session.create({ parentID: parent.id, title: "peer child" })
+        yield* actorReg.register({
+          sessionID: child.id,
+          actorID: child.id,
+          mode: "peer",
+          parentActorID: "main",
+          agent: "build",
+          description: "stally peer",
+          contextMode: "none",
+          contextWatermark: undefined,
+          background: true,
+          lifecycle: "persistent",
+        })
+
+        // (1) Fresh peer (last_turn_time = now) is PROGRESSING → no notification.
+        yield* actor.scanStalledOnce!()
+        expect((yield* parentInboxRows(parent.id)).length).toBe(0)
+
+        // (2) Push it past the stall window with unchanged turn_count → STALLED.
+        //     One scan → exactly ONE notification.
+        yield* backdateTurn(child.id, child.id, DEFAULT_LIVENESS_STALL_MS + 60_000)
+        yield* actor.scanStalledOnce!()
+        const afterFirst = yield* parentInboxRows(parent.id)
+        expect(afterFirst.length).toBe(1)
+        expect(afterFirst[0].type).toBe("actor_notification")
+        const body = afterFirst[0].content as { text?: string }
+        expect(body.text).toContain("<actor-notification>")
+        expect(body.text).toContain("stally peer")
+        expect(body.text).toContain("stalled")
+
+        // (3) Still continuously stalled — repeated scans must NOT re-notify.
+        yield* actor.scanStalledOnce!()
+        yield* actor.scanStalledOnce!()
+        expect((yield* parentInboxRows(parent.id)).length).toBe(1)
+
+        // (4) Child resumes (a turn advances → recent last_turn_time + turnCount++).
+        //     Now PROGRESSING: a scan sends nothing new AND re-arms the debounce.
+        yield* actorReg.updateTurn(child.id, child.id)
+        yield* actor.scanStalledOnce!()
+        expect((yield* parentInboxRows(parent.id)).length).toBe(1)
+
+        // (5) It stalls AGAIN after having resumed → a fresh episode → ONE more
+        //     notification (total 2), proving the re-arm.
+        yield* backdateTurn(child.id, child.id, DEFAULT_LIVENESS_STALL_MS + 60_000)
+        yield* actor.scanStalledOnce!()
+        expect((yield* parentInboxRows(parent.id)).length).toBe(2)
+      }),
+      { git: true },
+    ),
+  )
+
+  it.live("a continuously progressing peer never triggers a stalled notification", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+
+        const parent = yield* session.create({
+          title: "stall-watchdog-progressing",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const child = yield* session.create({ parentID: parent.id, title: "peer child" })
+        yield* actorReg.register({
+          sessionID: child.id,
+          actorID: child.id,
+          mode: "peer",
+          parentActorID: "main",
+          agent: "build",
+          description: "busy peer",
+          contextMode: "none",
+          contextWatermark: undefined,
+          background: true,
+          lifecycle: "persistent",
+        })
+
+        // Each tick: advance a turn (fresh last_turn_time) then scan. It always
+        // reads progressing, so no notification ever fires.
+        for (let i = 0; i < 4; i++) {
+          yield* actorReg.updateTurn(child.id, child.id)
+          yield* actor.scanStalledOnce!()
+        }
+        expect((yield* parentInboxRows(parent.id)).length).toBe(0)
+      }),
+      { git: true },
+    ),
+  )
+
+  it.live("a stalled SYSTEM-spawned background actor is not notified", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+
+        const parent = yield* session.create({
+          title: "stall-watchdog-system",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const child = yield* session.create({ parentID: parent.id, title: "writer child" })
+        // checkpoint-writer ∈ SYSTEM_SPAWNED_AGENT_TYPES → excluded from notify.
+        yield* actorReg.register({
+          sessionID: child.id,
+          actorID: child.id,
+          mode: "peer",
+          parentActorID: "main",
+          agent: "checkpoint-writer",
+          description: "system writer",
+          contextMode: "none",
+          contextWatermark: undefined,
+          background: true,
+          lifecycle: "ephemeral",
+        })
+
+        yield* backdateTurn(child.id, child.id, DEFAULT_LIVENESS_STALL_MS + 60_000)
+        yield* actor.scanStalledOnce!()
+        expect((yield* parentInboxRows(parent.id)).length).toBe(0)
+      }),
+      { git: true },
+    ),
+  )
+})

--- a/packages/opencode/test/actor/turn-heartbeat.test.ts
+++ b/packages/opencode/test/actor/turn-heartbeat.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, expect } from "bun:test"
+import { Effect } from "effect"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { ActorRegistry } from "../../src/actor/registry"
+import { Log } from "../../src/util"
+import { provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { makeLayer, providerCfg } from "../workflow/lib"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const it = testEffect(makeLayer())
+
+// I1 keystone: the runLoop must call ActorRegistry.updateTurn once per model
+// step. Session.create auto-registers the ("main") actor row with turn_count=0
+// and last_turn_time/time.updated pinned to registration. Without the per-step
+// heartbeat the orchestrator cannot tell a progressing child from a stalled one
+// (turnCount frozen at 0, timestamps frozen for the whole turn).
+//
+// Drive a 2-step turn (tool call → text) and assert the row's turn_count
+// advanced past 0 and last_turn_time / time.updated moved forward from the
+// values captured at registration.
+it.live("runLoop emits a per-step turn heartbeat on the actor registry row", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const registry = yield* ActorRegistry.Service
+
+      const session = yield* sessions.create({
+        title: "turn heartbeat",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      // Snapshot the auto-registered main actor row before the turn runs.
+      const before = yield* registry.get(session.id, "main")
+      expect(before).toBeDefined()
+      expect(before!.turnCount).toBe(0)
+      const beforeTurnTime = before!.lastTurnTime
+      const beforeUpdated = before!.time.updated
+
+      // Force a multi-step loop: first step is a tool call (finish=tool-calls,
+      // loop continues), second step produces final text (finish=stop).
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      yield* llm.tool("first", { value: "first" })
+      yield* llm.text("second")
+
+      yield* prompt.loop({ sessionID: session.id })
+      // Two model steps ⇒ two LLM calls ⇒ two heartbeats.
+      expect(yield* llm.calls).toBe(2)
+
+      const after = yield* registry.get(session.id, "main")
+      expect(after).toBeDefined()
+      // turn_count is the strong signal: it only advances via updateTurn.
+      expect(after!.turnCount).toBeGreaterThan(0)
+      expect(after!.turnCount).toBe(2)
+      // last_turn_time and time.updated advanced from registration.
+      expect(after!.lastTurnTime).toBeGreaterThanOrEqual(beforeTurnTime)
+      expect(after!.time.updated).toBeGreaterThanOrEqual(beforeUpdated)
+      // Combined: at least one timestamp strictly moved forward past
+      // registration, proving mid-flight progress was recorded.
+      expect(after!.lastTurnTime + after!.time.updated).toBeGreaterThan(beforeTurnTime + beforeUpdated)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)

--- a/packages/opencode/test/inbox/drain-in-loop.test.ts
+++ b/packages/opencode/test/inbox/drain-in-loop.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { Effect, Layer, ManagedRuntime } from "effect"
 import { Inbox } from "../../src/inbox"
 import { MAX_DRAIN_PER_TURN } from "../../src/inbox/inbox"
+import { defaultModelRef } from "../../src/inbox/inbox-ref"
 import { ActorRegistry } from "../../src/actor/registry"
 import { Session } from "../../src/session"
 import { Bus } from "../../src/bus"
@@ -14,6 +15,7 @@ const base = Layer.mergeAll(Session.defaultLayer, ActorRegistry.defaultLayer, Bu
 const testLayer = Inbox.layer.pipe(Layer.provide(base), Layer.provideMerge(base))
 
 afterEach(async () => {
+  defaultModelRef.current = undefined
   await Instance.disposeAll()
 })
 
@@ -172,6 +174,153 @@ describe("Inbox.drain in loop (Plan 2 / Task 7)", () => {
         Inbox.Service.use((inbox) => inbox.drain(session.id, "actor-3")),
       )
       expect(count2).toBe(0)
+    })
+  })
+
+  test("tier-1 seed: idle standing peer inherits agent+model from a prior CROSS-SLICE message (no Provider layer)", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withInbox(tmp.path, async (rt) => {
+      const session = await rt.runPromise(Session.Service.use((s) => s.create()))
+      // Register the peer whose OWN slice (agentID === its actor id) has NO
+      // messages — the "peer ran a turn under a different slice, then went idle"
+      // case. The prior model-bearing message lives on the "main" slice.
+      await rt.runPromise(
+        ActorRegistry.Service.use((reg) =>
+          reg.register({
+            sessionID: session.id,
+            actorID: "peer-idle",
+            mode: "peer",
+            parentActorID: undefined,
+            agent: "build",
+            description: "standing peer",
+            contextMode: "none",
+            contextWatermark: undefined,
+            background: true,
+            lifecycle: "persistent",
+          }),
+        ),
+      )
+      // Seed a real model-bearing message on a DIFFERENT slice ("main").
+      await seedRealMessage(rt, session.id, "main")
+
+      await rt.runPromise(
+        Inbox.Service.use((inbox) =>
+          inbox.send({ receiverSessionID: session.id, receiverActorID: "peer-idle", content: "relayed task" }),
+        ),
+      )
+
+      // drain must now SEED from the cross-slice message and process the row —
+      // NOT return 0. No Provider layer is present, proving tier 1 needs none.
+      const count = await rt.runPromise(
+        Inbox.Service.use((inbox) => inbox.drain(session.id, "peer-idle")),
+      )
+      expect(count).toBe(1)
+
+      const msgs = await rt.runPromise(
+        Session.Service.use((sessions) => sessions.messages({ sessionID: session.id, agentID: "peer-idle" })),
+      )
+      const lastUser = msgs.findLast((m) => m.info.role === "user")
+      expect(lastUser).toBeDefined()
+      const info1 = lastUser!.info
+      if (info1.role !== "user") throw new Error("expected a user message")
+      // Inherited agent + model from the cross-slice real message.
+      expect(info1.agent).toBe("general")
+      expect(String(info1.model.modelID)).toBe("test-model")
+    })
+  })
+
+  test("tier-2 seed: turnCount-0 peer seeds agent from registry + model from the default-model ref", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withInbox(tmp.path, async (rt) => {
+      const session = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await rt.runPromise(
+        ActorRegistry.Service.use((reg) =>
+          reg.register({
+            sessionID: session.id,
+            actorID: "peer-t0",
+            mode: "peer",
+            parentActorID: undefined,
+            agent: "compose",
+            description: "turnCount-0 peer",
+            contextMode: "none",
+            contextWatermark: undefined,
+            background: true,
+            lifecycle: "persistent",
+          }),
+        ),
+      )
+      await rt.runPromise(
+        Inbox.Service.use((inbox) =>
+          inbox.send({ receiverSessionID: session.id, receiverActorID: "peer-t0", content: "queued" }),
+        ),
+      )
+
+      // Wire the already-resolved default-model value (as SessionPrompt.layer
+      // would in production). No Provider LAYER is pulled — the ref is a plain
+      // resolver over a stored value.
+      defaultModelRef.current = {
+        defaultModel: () =>
+          Effect.succeed({ providerID: ProviderID.make("test"), modelID: ModelID.make("default-model") }),
+      }
+
+      const count = await rt.runPromise(
+        Inbox.Service.use((inbox) => inbox.drain(session.id, "peer-t0")),
+      )
+      expect(count).toBe(1)
+
+      const msgs = await rt.runPromise(
+        Session.Service.use((sessions) => sessions.messages({ sessionID: session.id, agentID: "peer-t0" })),
+      )
+      const lastUser = msgs.findLast((m) => m.info.role === "user")
+      expect(lastUser).toBeDefined()
+      const info2 = lastUser!.info
+      if (info2.role !== "user") throw new Error("expected a user message")
+      // Agent from the REGISTRY row; model from the default-model ref.
+      expect(info2.agent).toBe("compose")
+      expect(String(info2.model.modelID)).toBe("default-model")
+    })
+  })
+
+  test("tier-3: with no prior message AND no default-model ref, drain leaves rows durable (returns 0, no regression)", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withInbox(tmp.path, async (rt) => {
+      const session = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await rt.runPromise(
+        ActorRegistry.Service.use((reg) =>
+          reg.register({
+            sessionID: session.id,
+            actorID: "peer-fresh",
+            mode: "peer",
+            parentActorID: undefined,
+            agent: "build",
+            description: "turnCount-0 peer",
+            contextMode: "none",
+            contextWatermark: undefined,
+            background: true,
+            lifecycle: "persistent",
+          }),
+        ),
+      )
+      await rt.runPromise(
+        Inbox.Service.use((inbox) =>
+          inbox.send({ receiverSessionID: session.id, receiverActorID: "peer-fresh", content: "queued" }),
+        ),
+      )
+
+      // No cross-slice message (tier 1 miss) and no defaultModelRef wired in this
+      // minimal fixture (tier 2 unavailable) → tier 3: keep durable, return 0.
+      const count = await rt.runPromise(
+        Inbox.Service.use((inbox) => inbox.drain(session.id, "peer-fresh")),
+      )
+      expect(count).toBe(0)
+
+      // The row is STILL in the inbox (durable) — a later drain with a model
+      // source will consume it. Prove by seeding a message and draining again.
+      await seedRealMessage(rt, session.id, "main")
+      const count2 = await rt.runPromise(
+        Inbox.Service.use((inbox) => inbox.drain(session.id, "peer-fresh")),
+      )
+      expect(count2).toBe(1)
     })
   })
 

--- a/packages/opencode/test/permission/forward-ref-persist.test.ts
+++ b/packages/opencode/test/permission/forward-ref-persist.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { forwardRef } from "../../src/permission/permission-forward-ref"
+import { PermissionGrantTable } from "../../src/permission/permission.sql"
+import { Database, eq } from "../../src/storage"
+
+// Gap B regression: a `grant-approval all` (or specific child) by a parent
+// orchestrator must be honored by an isolated (separate-process) child created
+// AFTER the grant, AND survive restart. Separate processes do NOT share the
+// in-memory `grants` map — they share the on-disk SQLite `permission_grant`
+// table. These tests exercise the PERSISTED path by asserting against the DB
+// and by proving grantAllowed reads from the DB even when the in-memory cache
+// has no entry for the parent (which is exactly a child process's situation).
+
+function clearDb(parentSessionID: string) {
+  Database.use((db) => db.delete(PermissionGrantTable).where(eq(PermissionGrantTable.parent_session_id, parentSessionID as any)).run())
+}
+
+describe("forwardRef persistence (Gap B)", () => {
+  afterEach(() => {
+    for (const p of ["pPersist", "pStar", "pChild", "pRestart"]) {
+      forwardRef.clearGrantsForParent(p)
+    }
+  })
+
+  test("setGrant writes through to SQLite", () => {
+    forwardRef.setGrant("pPersist", "childA")
+    const rows = Database.use((db) =>
+      db.select().from(PermissionGrantTable).where(eq(PermissionGrantTable.parent_session_id, "pPersist" as any)).all(),
+    )
+    expect(rows.map((r) => r.target)).toContain("childA")
+  })
+
+  test("a parent's persisted grant is visible to a child lookup via the DB (cache miss)", () => {
+    // Simulate the PARENT process persisting the grant, then a fresh CHILD
+    // process whose in-memory map is empty: write straight to the DB (no
+    // setGrant → no in-memory cache entry), then look it up.
+    clearDb("pChild")
+    Database.use((db) =>
+      db.insert(PermissionGrantTable).values({ parent_session_id: "pChild" as any, target: "childXYZ", created_at: Date.now() }).run(),
+    )
+    // grantAllowed must consult the DB (there is no in-memory grant for pChild).
+    expect(forwardRef.grantAllowed("pChild", "childXYZ")).toBe(true)
+    expect(forwardRef.grantAllowed("pChild", "someOtherChild")).toBe(false)
+  })
+
+  test("'*' persisted grant matches a child created AFTER the grant, via the DB (cache miss)", () => {
+    clearDb("pStar")
+    // Parent persisted `grant-approval all` (target "*") BEFORE any child exists.
+    Database.use((db) =>
+      db.insert(PermissionGrantTable).values({ parent_session_id: "pStar" as any, target: "*", created_at: Date.now() }).run(),
+    )
+    // A child created afterwards, in a separate process (empty in-memory map),
+    // must be auto-approved by the persisted "*".
+    expect(forwardRef.grantAllowed("pStar", "childCreatedLater")).toBe(true)
+    expect(forwardRef.grantAllowed("pStar", "anotherLateChild")).toBe(true)
+    // Never leaks to a DIFFERENT parent session (scoped, not global).
+    expect(forwardRef.grantAllowed("pUnrelated", "childCreatedLater")).toBe(false)
+  })
+
+  test("grant survives 'restart' — a fresh read finds the persisted row", () => {
+    forwardRef.setGrant("pRestart", "*")
+    // Drop the in-memory cache to simulate a process restart; the DB row remains.
+    forwardRef.grants.delete("pRestart")
+    expect(forwardRef.grantAllowed("pRestart", "childAfterRestart")).toBe(true)
+  })
+
+  test("clearGrantsForParent removes the persisted row too", () => {
+    forwardRef.setGrant("pStar", "*")
+    forwardRef.clearGrantsForParent("pStar")
+    const rows = Database.use((db) =>
+      db.select().from(PermissionGrantTable).where(eq(PermissionGrantTable.parent_session_id, "pStar" as any)).all(),
+    )
+    expect(rows.length).toBe(0)
+    expect(forwardRef.grantAllowed("pStar", "anyChild")).toBe(false)
+  })
+})

--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -193,6 +193,97 @@ describe("Worktree", () => {
     )
   })
 
+  describe("branch ref advances after commit", () => {
+    it.live("child commit in worktree advances the branch ref as seen from the outer repo", () =>
+      provideTmpdirInstance(
+        (dir) =>
+          Effect.gen(function* () {
+            const svc = yield* Worktree.Service
+            const info = yield* svc.makeWorktreeInfo("ref-advance")
+            yield* svc.createFromInfo(info)
+
+            // HEAD in the worktree must be attached to the branch, not detached.
+            const symbolic = yield* Effect.promise(() =>
+              $`git symbolic-ref --quiet HEAD`.cwd(info.directory).quiet().text(),
+            )
+            expect(symbolic.trim()).toBe(`refs/heads/${info.branch}`)
+
+            // Commit inside the worktree.
+            yield* Effect.promise(() => Bun.write(path.join(info.directory, "change.txt"), "hello"))
+            yield* Effect.promise(() => $`git add change.txt`.cwd(info.directory).quiet())
+            yield* Effect.promise(() => $`git commit -m "child change"`.cwd(info.directory).quiet())
+
+            const worktreeHead = (
+              yield* Effect.promise(() => $`git rev-parse HEAD`.cwd(info.directory).quiet().text())
+            ).trim()
+
+            // The branch ref, read from the OUTER repo, must point at the new commit.
+            const outerRef = (
+              yield* Effect.promise(() => $`git rev-parse ${info.branch}`.cwd(dir).quiet().text())
+            ).trim()
+
+            expect(outerRef).toBe(worktreeHead)
+
+            yield* Effect.promise(() => Instance.dispose()).pipe(provideInstance(info.directory))
+            yield* Effect.promise(() => Bun.sleep(100))
+            yield* svc.remove({ directory: info.directory })
+          }),
+        { git: true, outsideGit: true },
+      ),
+    )
+
+    it.live("concurrent worktree creates + commits do not lose a branch ref advance", () =>
+      provideTmpdirInstance(
+        (dir) =>
+          Effect.gen(function* () {
+            const svc = yield* Worktree.Service
+
+            const infos = yield* Effect.forEach([0, 1, 2], (i) => svc.makeWorktreeInfo(`concurrent-${i}`), {
+              concurrency: 1,
+            })
+
+            // Create all worktrees concurrently — they share one ref store.
+            yield* Effect.forEach(infos, (info) => svc.createFromInfo(info), { concurrency: "unbounded" })
+
+            // Commit into each worktree concurrently.
+            const heads = yield* Effect.forEach(
+              infos,
+              (info) =>
+                Effect.gen(function* () {
+                  yield* Effect.promise(() =>
+                    Bun.write(path.join(info.directory, "change.txt"), `hello ${info.name}`),
+                  )
+                  yield* Effect.promise(() => $`git add change.txt`.cwd(info.directory).quiet())
+                  yield* Effect.promise(() => $`git commit -m "commit ${info.name}"`.cwd(info.directory).quiet())
+                  const head = (
+                    yield* Effect.promise(() => $`git rev-parse HEAD`.cwd(info.directory).quiet().text())
+                  ).trim()
+                  return { info, head }
+                }),
+              { concurrency: "unbounded" },
+            )
+
+            // Every branch ref, read from the outer repo, must point at its commit.
+            for (const { info, head } of heads) {
+              const outerRef = (
+                yield* Effect.promise(() => $`git rev-parse ${info.branch}`.cwd(dir).quiet().text())
+              ).trim()
+              expect(outerRef).toBe(head)
+            }
+
+            for (const { info } of heads) {
+              yield* Effect.promise(() => Instance.dispose()).pipe(provideInstance(info.directory))
+            }
+            yield* Effect.promise(() => Bun.sleep(100))
+            for (const { info } of heads) {
+              yield* svc.remove({ directory: info.directory }).pipe(Effect.ignore)
+            }
+          }),
+        { git: true, outsideGit: true },
+      ),
+    )
+  })
+
   describe("remove edge cases", () => {
     it.live("remove non-existent directory succeeds silently", () =>
       provideTmpdirInstance(

--- a/packages/opencode/test/session/bootstrap-skip-system.test.ts
+++ b/packages/opencode/test/session/bootstrap-skip-system.test.ts
@@ -31,6 +31,7 @@ const stubActorRegistry = Layer.succeed(
     updateTurn: () => Effect.void,
     updateAgent: () => Effect.void,
     get: () => Effect.succeed(undefined),
+    liveness: () => Effect.succeed(undefined),
     listBySession: () => Effect.succeed([]),
     listActive: () => Effect.succeed([]),
     listByParent: () => Effect.succeed([]),

--- a/packages/opencode/test/session/orchestrator-prompt.test.ts
+++ b/packages/opencode/test/session/orchestrator-prompt.test.ts
@@ -107,4 +107,29 @@ describe("orchestrator prompt", () => {
     // `list` + `session send`.
     expect(PROMPT_ORCHESTRATOR).not.toContain("`actor` send action")
   })
+
+  test("finished sessions stay resumable — cancel is destroy-only, never the way to finish (T60)", () => {
+    // Governing principle: the orchestrator↔session interaction must mirror
+    // human↔session — a finished child goes idle and resumable, it is NOT
+    // cancelled on completion. Pin the principle vocabulary so it can't regress.
+    expect(PROMPT_ORCHESTRATOR).toMatch(/resumable/i)
+    // The human-mirroring rationale must be stated.
+    expect(PROMPT_ORCHESTRATOR).toMatch(/human/i)
+    // Cancel is reframed as a rare DESTROY action, not a completion step.
+    expect(PROMPT_ORCHESTRATOR).toMatch(/DESTROY|destroy/)
+    // Read-only query over a finished child's preserved knowledge.
+    expect(PROMPT_ORCHESTRATOR).toContain("session ask")
+    // Explicit resume-first / do-not-cancel-on-completion instruction.
+    expect(PROMPT_ORCHESTRATOR).toMatch(/do NOT cancel|never cancel|not cancel/i)
+    expect(PROMPT_ORCHESTRATOR).toMatch(/resume-first|Prefer keeping sessions resumable|Prefer resume/i)
+  })
+
+  test("no longer trains 'completed → cancel' as a routine completion step (T60)", () => {
+    // The defect: cancel must NOT be presented as the default way to finish a
+    // task. These 'completed → cancel' phrasings must be absent.
+    expect(PROMPT_ORCHESTRATOR).not.toMatch(/completed\s*→\s*cancel/i)
+    expect(PROMPT_ORCHESTRATOR).not.toContain("cancel + task done")
+    // "Completed" never means "cancel" — the explicit disavowal must be present.
+    expect(PROMPT_ORCHESTRATOR).toMatch(/"Completed" never means "cancel"|Completed.{0,20}never.{0,20}cancel/i)
+  })
 })

--- a/packages/opencode/test/session/orchestrator-prompt.test.ts
+++ b/packages/opencode/test/session/orchestrator-prompt.test.ts
@@ -83,4 +83,28 @@ describe("orchestrator prompt", () => {
     expect(PROMPT_ORCHESTRATOR).toMatch(/notification/i)
     expect(PROMPT_ORCHESTRATOR).toMatch(/detached|commit hash|branch ref/i)
   })
+
+  test("aligns to shipped primitives: session send/status/join, --topic, event-driven stall (T44)", () => {
+    // T44: the prompt documents the primitives that actually landed on this
+    // branch — the reliable relay verb, derived liveness, fan-in, per-theme
+    // reuse, and event-driven stall notifications.
+    expect(PROMPT_ORCHESTRATOR).toContain("session send")
+    expect(PROMPT_ORCHESTRATOR).toContain("session status")
+    expect(PROMPT_ORCHESTRATOR).toContain("--topic")
+    expect(PROMPT_ORCHESTRATOR).toContain("join")
+    expect(PROMPT_ORCHESTRATOR).toMatch(/stalled/i)
+    // Stall detection is event-driven now: the orchestrator is NOTIFIED when a
+    // child stalls, rather than being told to poll for it.
+    expect(PROMPT_ORCHESTRATOR).toMatch(/watchdog|actor_notification\{stalled\}|told when a child|wait event-driven/i)
+  })
+
+  test("drops the stale relay + KNOWN-LIMITATION guidance that shipped primitives obsoleted (T44)", () => {
+    // The idle-relay-is-unreliable caveat (fixed by T25/T42) and the
+    // resume-via-actor-send relay must be gone: relaying is now `session send`.
+    expect(PROMPT_ORCHESTRATOR).not.toContain("KNOWN LIMITATION")
+    expect(PROMPT_ORCHESTRATOR).not.toContain("receiver not found")
+    // The old resume text drove relay via the actor send action; resume is now
+    // `list` + `session send`.
+    expect(PROMPT_ORCHESTRATOR).not.toContain("`actor` send action")
+  })
 })

--- a/packages/opencode/test/session/orchestrator-prompt.test.ts
+++ b/packages/opencode/test/session/orchestrator-prompt.test.ts
@@ -65,6 +65,16 @@ describe("orchestrator prompt", () => {
     expect(PROMPT_ORCHESTRATOR).toMatch(/isolation-first|DEFAULT|MUST/i)
   })
 
+  test("makes requirement auto-capture a first-class reflex before acting (T45)", () => {
+    // The orchestrator must capture every user-stated requirement/bug/criticism/
+    // new problem into the task ledger as a reflex BEFORE acting, so 'talking'
+    // always becomes 'recording' — not left to self-discipline.
+    expect(PROMPT_ORCHESTRATOR).toContain("Capture requirements before acting")
+    expect(PROMPT_ORCHESTRATOR).toMatch(/talking.*recording|recording.*talking/i)
+    expect(PROMPT_ORCHESTRATOR).toMatch(/reflex/i)
+    expect(PROMPT_ORCHESTRATOR).toMatch(/bug|criticism|requirement/i)
+  })
+
   test("warns about idle-without-notification and detached-commit faults on resume", () => {
     // A child can go idle without sending a completion notification; and a
     // committed change can be detached from its branch ref. Pin the guidance to

--- a/packages/opencode/test/session/orchestrator-prompt.test.ts
+++ b/packages/opencode/test/session/orchestrator-prompt.test.ts
@@ -45,4 +45,32 @@ describe("orchestrator prompt", () => {
     expect(PROMPT_ORCHESTRATOR).toContain("session cancel")
     expect(PROMPT_ORCHESTRATOR).toContain("resume")
   })
+
+  test("draws the actor-vs-session line and forbids blocking on real work", () => {
+    // The orchestrator must never do real work via a BLOCKING actor subagent
+    // (`actor run`/`spawn`), and must never block its turn on any tool action.
+    // Pin the distinction + the never-block discipline so they can't regress.
+    expect(PROMPT_ORCHESTRATOR).toContain("actor")
+    expect(PROMPT_ORCHESTRATOR).toMatch(/never block|MUST NEVER block|non-blocking/i)
+    // The blocking subagent actions must be named and forbidden for real work.
+    expect(PROMPT_ORCHESTRATOR).toMatch(/actor run|actor spawn|`actor run`/i)
+    // The legitimate non-blocking relay/nudge action must be endorsed.
+    expect(PROMPT_ORCHESTRATOR).toMatch(/actor send|actor status/i)
+  })
+
+  test("makes isolation the default for git-repo editing children", () => {
+    // isolate:true must be the DEFAULT for children that edit files in a git
+    // repo (isolation-first), not a soft per-task judgement call.
+    expect(PROMPT_ORCHESTRATOR).toContain("isolate")
+    expect(PROMPT_ORCHESTRATOR).toMatch(/isolation-first|DEFAULT|MUST/i)
+  })
+
+  test("warns about idle-without-notification and detached-commit faults on resume", () => {
+    // A child can go idle without sending a completion notification; and a
+    // committed change can be detached from its branch ref. Pin the guidance to
+    // verify via git and merge by commit hash when the branch ref lags.
+    expect(PROMPT_ORCHESTRATOR).toMatch(/idle/i)
+    expect(PROMPT_ORCHESTRATOR).toMatch(/notification/i)
+    expect(PROMPT_ORCHESTRATOR).toMatch(/detached|commit hash|branch ref/i)
+  })
 })

--- a/packages/opencode/test/session/orchestrator-title.test.ts
+++ b/packages/opencode/test/session/orchestrator-title.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import { Session } from "../../src/session"
+import { ORCHESTRATOR_TITLE, stableRootTitle } from "../../src/session/prompt"
+
+// An Orchestrator session is PERSISTENT: it coordinates many tasks over its
+// lifetime, so its title must be stable and task-independent. The per-first-
+// message auto-title generator (SessionPrompt.ensureTitle) must NOT rename it.
+// `stableRootTitle` is the pure decision the generator consults before doing
+// any LLM work: a non-undefined result means "keep this fixed title and SKIP
+// generation"; undefined means "normal per-message titling applies".
+describe("orchestrator stable title", () => {
+  test("orchestrator ROOT session gets the fixed, task-independent title", () => {
+    expect(stableRootTitle({ agent: "orchestrator", parentID: undefined })).toBe(ORCHESTRATOR_TITLE)
+    expect(ORCHESTRATOR_TITLE).toBe("Orchestrator")
+  })
+
+  test("the stable title is NOT a default title, so it survives later turns", () => {
+    // ensureTitle bails early when the title is no longer a default one. The
+    // stable orchestrator title must qualify as non-default so a subsequent
+    // task/message never triggers regeneration and never overwrites it.
+    expect(Session.isDefaultTitle(ORCHESTRATOR_TITLE)).toBe(false)
+  })
+
+  test("a normal (non-orchestrator) ROOT session is unaffected — normal titling applies", () => {
+    // undefined => ensureTitle proceeds with its usual per-first-message
+    // generation path, exactly as before this fix.
+    expect(stableRootTitle({ agent: "main", parentID: undefined })).toBeUndefined()
+    expect(stableRootTitle({ agent: "build", parentID: undefined })).toBeUndefined()
+    expect(stableRootTitle({ agent: undefined, parentID: undefined })).toBeUndefined()
+  })
+
+  test("orchestrator CHILD sessions are NOT force-titled (only the root is persistent)", () => {
+    // Child sessions already skip auto-titling via the parentID guard; the
+    // stable-title path must likewise never fire for a child, even one whose
+    // triggering agent is orchestrator.
+    expect(stableRootTitle({ agent: "orchestrator", parentID: "ses_parent" })).toBeUndefined()
+    expect(stableRootTitle({ agent: "main", parentID: "ses_parent" })).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/session/prompt-sweep.test.ts
+++ b/packages/opencode/test/session/prompt-sweep.test.ts
@@ -75,7 +75,7 @@ describe("sweepOrphanAssistants", () => {
     ),
   )
 
-  it.live("leaves a recent (under 60s) incomplete assistant message untouched", () =>
+  it.live("leaves a recent (under 60s) incomplete assistant message untouched when not immediate", () =>
     provideTmpdirInstance((dir) =>
       Effect.gen(function* () {
         const sessions = yield* Session.Service
@@ -95,6 +95,8 @@ describe("sweepOrphanAssistants", () => {
         const assistant = makeAssistant(session.id, userMsg.id, dir, { created: now - 1_800_000 })
         yield* sessions.updateMessage(assistant)
 
+        // immediate defaults to false → the age guard protects an in-flight
+        // (busy) turn's still-progressing assistant.
         yield* svc.sweepOrphanAssistants(session.id)
 
         const after = yield* sessions.messages({ sessionID: session.id })
@@ -103,6 +105,43 @@ describe("sweepOrphanAssistants", () => {
         const info = updated!.info as MessageV2.Assistant
         expect(info.time.completed).toBeUndefined()
         expect(info.error).toBeUndefined()
+      }),
+    ),
+  )
+
+  it.live("sweeps a recent (under 60s) incomplete assistant when immediate (idle session)", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const svc = yield* SessionPrompt.Service
+        const session = yield* sessions.create({})
+
+        const userMsg = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "default",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() - 5_000 },
+        })
+
+        // A fresh orphan (well under ORPHAN_AGE_MS) — the exact shape a hard
+        // interruption leaves behind. On an idle session this must be swept so
+        // the next user message is not rendered as stuck QUEUED behind it.
+        const now = Date.now()
+        const assistant = makeAssistant(session.id, userMsg.id, dir, { created: now - 3_000 })
+        yield* sessions.updateMessage(assistant)
+
+        yield* svc.sweepOrphanAssistants(session.id, true)
+
+        const after = yield* sessions.messages({ sessionID: session.id })
+        const updated = after.find((m) => m.info.id === assistant.id)
+        expect(updated).toBeDefined()
+        const info = updated!.info as MessageV2.Assistant
+        expect(info.time.completed).toBeDefined()
+        expect(info.time.completed!).toBeGreaterThanOrEqual(now)
+        expect(info.error).toBeDefined()
+        expect(JSON.stringify(info.error)).toContain("Abandoned")
       }),
     ),
   )

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -139,6 +139,37 @@ describe("tool.assertExternalDirectory", () => {
     expect(requests.length).toBe(0)
   })
 
+  test("does NOT ask for paths under an orchestrator-created worktree base", async () => {
+    const { requests, ctx } = makeCtx()
+
+    // A child isolated into <data>/worktree/<projectID>/<name>. Its Instance may be
+    // bound to the main checkout (subagent inherits parent ctx, or worktree boot
+    // failed and it fell back to shared) — so the worktree path is OUTSIDE
+    // Instance.directory on purpose. Without the trust it would raise
+    // external_directory:ask and a background child with no replier would deadlock.
+    const wtTarget = path.join(
+      Global.Path.data,
+      "worktree",
+      "21e0df6f-0ff7-4b4e-9f19-9bf7d7f64ba1",
+      "t25-gap-a-reliable-idle-peer-relay",
+      "packages",
+      "opencode",
+      "src",
+      "tool",
+      "session.ts",
+    )
+
+    await Instance.provide({
+      directory: "/tmp/project", // wtTarget is OUTSIDE the project dir on purpose
+      fn: async () => {
+        await assertExternalDirectory(ctx, wtTarget)
+      },
+    })
+
+    // Orchestrator worktrees are app-managed, trusted workspaces — no ask.
+    expect(requests.length).toBe(0)
+  })
+
   test("still asks for non-memory paths outside the project (regression)", async () => {
     const { requests, ctx } = makeCtx()
 
@@ -146,6 +177,21 @@ describe("tool.assertExternalDirectory", () => {
       directory: "/tmp/project",
       fn: async () => {
         await assertExternalDirectory(ctx, "/tmp/outside/file.txt")
+      },
+    })
+
+    expect(requests.find((r) => r.permission === "external_directory")).toBeDefined()
+  })
+
+  test("still asks for a foreign path even when it merely resembles the worktree base name (regression)", async () => {
+    const { requests, ctx } = makeCtx()
+
+    // A user path that is NOT under <data>/worktree must still prompt: the trust is
+    // scoped to the app-managed base, it does not broadly weaken external_directory.
+    await Instance.provide({
+      directory: "/tmp/project",
+      fn: async () => {
+        await assertExternalDirectory(ctx, "/tmp/worktree/foreign/file.txt")
       },
     })
 

--- a/packages/opencode/test/tool/fleet.test.ts
+++ b/packages/opencode/test/tool/fleet.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test"
+import { assembleFleet, renderFleetTable } from "../../src/tool/fleet"
+import type { FleetActorInput, WorktreeEntry } from "../../src/tool/fleet"
+import type { Actor } from "../../src/actor/schema"
+import { DEFAULT_LIVENESS_STALL_MS } from "../../src/actor/schema"
+
+const NOW = 1_000_000_000
+
+// Minimal Actor row factory — only the fields deriveLiveness + assembleFleet
+// read matter; the rest are filled with inert defaults.
+function actor(patch: Partial<Actor>): Actor {
+  return {
+    sessionID: "ses_x" as Actor["sessionID"],
+    actorID: "ses_x",
+    mode: "peer",
+    status: "idle",
+    lifecycle: "persistent",
+    agent: "build",
+    description: "",
+    contextMode: "none",
+    background: true,
+    lastTurnTime: NOW,
+    turnCount: 0,
+    time: { created: NOW, updated: NOW },
+    ...patch,
+  }
+}
+
+function sess(id: string, title: string, directory: string): FleetActorInput["session"] {
+  return { id, title, directory }
+}
+
+describe("assembleFleet", () => {
+  test("correlates liveness, turn telemetry, and worktree mapping into grouped rows", () => {
+    const inputs: FleetActorInput[] = [
+      // progressing: running, turn advanced just now
+      {
+        session: sess("ses_a", "port parser", "/wt/a"),
+        actor: actor({ agent: "build", status: "running", lastTurnTime: NOW - 1_000, turnCount: 5 }),
+      },
+      // stalled: running but no turn advance for longer than the window
+      {
+        session: sess("ses_b", "billing schema", "/wt/b"),
+        actor: actor({ agent: "compose", status: "running", lastTurnTime: NOW - DEFAULT_LIVENESS_STALL_MS - 5_000, turnCount: 2 }),
+      },
+      // terminal success → idle bucket
+      {
+        session: sess("ses_c", "done thing", "/shared"),
+        actor: actor({ agent: "build", status: "idle", lastOutcome: "success", lastTurnTime: NOW - 120_000, turnCount: 9 }),
+      },
+      // failed
+      {
+        session: sess("ses_d", "broke", "/shared"),
+        actor: actor({ agent: "build", status: "idle", lastOutcome: "failure", turnCount: 1 }),
+      },
+      // no actor row → plain idle, no telemetry
+      { session: sess("ses_e", "never started", "/shared"), actor: null },
+    ]
+    const worktrees: WorktreeEntry[] = [
+      { directory: "/wt/a", branch: "mimocode/port-parser", ahead: 3 },
+      { directory: "/wt/b", branch: "mimocode/billing", ahead: 0 },
+    ]
+
+    const summary = assembleFleet(inputs, worktrees, NOW)
+
+    expect(summary.total).toBe(5)
+    expect(summary.counts).toEqual({ progressing: 1, stalled: 1, idle: 2, failed: 1, cancelled: 0 })
+
+    // Rows are grouped in fixed order: progressing → stalled → idle → failed → cancelled.
+    // ses_c and ses_e are both idle (ordered before failed ses_d).
+    expect(summary.rows.map((r) => r.sessionID)).toEqual(["ses_a", "ses_b", "ses_c", "ses_e", "ses_d"])
+
+    const byId = (id: string) => summary.rows.find((r) => r.sessionID === id)!
+
+    const a = byId("ses_a")
+    expect(a.bucket).toBe("progressing")
+    expect(a.liveness).toBe("progressing")
+    expect(a.mode).toBe("build")
+    expect(a.turnCount).toBe(5)
+    expect(a.lastActivityMs).toBe(1_000)
+    expect(a.worktreeDir).toBe("/wt/a")
+    expect(a.branch).toBe("mimocode/port-parser")
+    expect(a.ahead).toBe(3)
+
+    const b = byId("ses_b")
+    expect(b.bucket).toBe("stalled")
+    expect(b.ahead).toBe(0)
+
+    // Shared-dir children carry no worktree fields.
+    const c = byId("ses_c")
+    expect(c.bucket).toBe("idle")
+    expect(c.worktreeDir).toBeUndefined()
+    expect(c.branch).toBeUndefined()
+
+    expect(byId("ses_d").bucket).toBe("failed")
+
+    // No actor row → idle, undefined lastActivity, mode "?".
+    const e = byId("ses_e")
+    expect(e.bucket).toBe("idle")
+    expect(e.mode).toBe("?")
+    expect(e.lastActivityMs).toBeUndefined()
+  })
+
+  test("empty fleet produces zeroed summary", () => {
+    const summary = assembleFleet([], [], NOW)
+    expect(summary.total).toBe(0)
+    expect(summary.counts).toEqual({ progressing: 0, stalled: 0, idle: 0, failed: 0, cancelled: 0 })
+    expect(summary.rows).toEqual([])
+  })
+})
+
+describe("renderFleetTable", () => {
+  test("empty fleet renders the no-children sentinel", () => {
+    expect(renderFleetTable(assembleFleet([], [], NOW))).toBe("No child sessions.")
+  })
+
+  test("renders grouped headings, worktree cell, and summary line", () => {
+    const inputs: FleetActorInput[] = [
+      {
+        session: sess("ses_a", "port parser", "/wt/a"),
+        actor: actor({ agent: "build", status: "running", lastTurnTime: NOW - 2_000, turnCount: 5 }),
+      },
+      { session: sess("ses_z", "idle one", "/shared"), actor: null },
+    ]
+    const worktrees: WorktreeEntry[] = [{ directory: "/wt/a", branch: "mimocode/port-parser", ahead: 3 }]
+
+    const out = renderFleetTable(assembleFleet(inputs, worktrees, NOW))
+
+    expect(out).toContain("Fleet: 2 total — 1 running (1 progressing, 0 stalled), 1 idle")
+    expect(out).toContain("In progress — progressing (advancing) (1):")
+    expect(out).toContain("Finished / idle (1):")
+    // Isolated child shows branch (+ahead) @ dir; shared child shows "shared".
+    expect(out).toContain("mimocode/port-parser (+3) @ /wt/a")
+    expect(out).toContain("shared")
+    expect(out).toContain("ses_a")
+    expect(out).toContain("2s")
+  })
+
+  test("detached / unknown-ahead worktree renders gracefully", () => {
+    const inputs: FleetActorInput[] = [
+      {
+        session: sess("ses_a", "x", "/wt/a"),
+        actor: actor({ status: "running", lastTurnTime: NOW }),
+      },
+    ]
+    const worktrees: WorktreeEntry[] = [{ directory: "/wt/a" }]
+    const out = renderFleetTable(assembleFleet(inputs, worktrees, NOW))
+    expect(out).toContain("detached @ /wt/a")
+  })
+})

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -671,10 +671,12 @@ describe("session tool", () => {
         )
         const progID = prog.metadata.sessionID!
 
-        // A stalled peer: running, but with an old last_turn_time far past the
-        // default staleness window → deriveLiveness reports stalled. Force status
-        // running, then age its last_turn_time via a direct row update (updateTurn
-        // would bump it to now; we need it OLD with turnCount unchanged).
+        // A stalled peer: running, having run at least one turn, but with an old
+        // last_turn_time far past the default staleness window → deriveLiveness
+        // reports stalled. Force status running and turn_count >= 1 (a
+        // not-yet-started child with turnCount 0 is exempt from the stall path),
+        // then age its last_turn_time via a direct row update (updateTurn would
+        // bump last_turn_time to now; we need it OLD while turn_count stays put).
         const stalled = yield* tool.execute(
           { operation: { action: "create", task: "wedged", mode: "build", title: "Wedged" } },
           ctx(parent.id),
@@ -685,7 +687,7 @@ describe("session tool", () => {
           Database.use((db) =>
             db
               .update(ActorRegistryTable)
-              .set({ last_turn_time: Date.now() - 10 * 60_000 })
+              .set({ last_turn_time: Date.now() - 10 * 60_000, turn_count: 1 })
               .where(and(eq(ActorRegistryTable.session_id, SessionID.make(stalledID)), eq(ActorRegistryTable.actor_id, stalledID)))
               .run(),
           ),

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -708,8 +708,19 @@ describe("session tool dual-schema (shell + JSON) end-to-end", () => {
     ),
   )
 
-  it.live("shell form: create parses --mode plan", () =>
+  it.live("shell form: create parses --topic into the operation", () =>
     provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const tool = yield* (yield* SessionTool).init()
+        const ops = yield* tool.shell!.parse("session create fix the login flow --topic auth")
+        expect(ops[0]).toEqual({
+          operation: { action: "create", task: "fix the login flow", topic: "auth" },
+        })
+      }),
+    ),
+  )
+
+  it.live("shell form: create parses --mode plan", () =>    provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const tool = yield* (yield* SessionTool).init()
         const ops = yield* tool.shell!.parse("session create do it --mode plan")
@@ -785,6 +796,12 @@ describe("recoverSessionArgs", () => {
   test("carries mode/model/title on a bare create", () => {
     expect(recoverSessionArgs({ task: "x", mode: "compose", model: "standard", title: "T" })).toEqual({
       operation: { action: "create", task: "x", mode: "compose", model: "standard", title: "T" },
+    })
+  })
+
+  test("carries topic on a bare create", () => {
+    expect(recoverSessionArgs({ task: "x", topic: "auth" })).toEqual({
+      operation: { action: "create", task: "x", topic: "auth" },
     })
   })
 
@@ -1193,6 +1210,82 @@ describe("session tool ask (fork-query) functional", () => {
         yield* tool
           .execute({ operation: { action: "cancel", sessionID: childID } }, ctx(parent.id))
           .pipe(Effect.ignore)
+      }),
+      { git: true, config: askProviderCfg },
+    ),
+    60000,
+  )
+
+  // T43: `session create --topic X` find-or-reuse. First call with a topic
+  // spawns a standing child tagged with that topic; a SECOND call with the SAME
+  // topic must NOT spawn a new child — it relays the task into the first via the
+  // inbox enqueue+wake path (works on the idle/never-run peer thanks to T42's
+  // spawn-time receiver row). A DIFFERENT topic yields a DISTINCT child. Uses the
+  // full Inbox+Actor stack so the reuse relay hits the real Inbox.send.
+  askIt.live("session create --topic reuses one standing child for the same topic, distinct for a different one", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const sessions = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+        const parent = yield* sessions.create({
+          title: "T43 topic parent",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        // Hang so created children never finish their first turn — they remain
+        // standing idle peers, exactly the reuse target.
+        yield* llm.hang
+
+        const info = yield* SessionTool
+        const tool = yield* info.init()
+
+        const peerCount = () =>
+          Effect.gen(function* () {
+            const kids = yield* sessions.children(parent.id)
+            const enriched = yield* Effect.forEach(kids, (child) =>
+              actorReg.get(child.id, child.id).pipe(Effect.map((a) => ({ child, actor: a }))),
+            )
+            return enriched.filter(({ actor }) => actor?.mode === "peer")
+          })
+
+        // 1st create with topic "auth" → a new tagged child.
+        const first = yield* tool.execute(
+          { operation: { action: "create", task: "fix the login flow", mode: "build", topic: "auth" } },
+          ctx(parent.id),
+        )
+        const firstID = first.metadata.sessionID!
+        expect(firstID).toBeDefined()
+        expect(first.output).toContain("Tagged with topic 'auth'")
+        // Its title carries the machine marker so reuse can find it.
+        const firstSession = yield* sessions.get(SessionID.make(firstID))
+        expect(firstSession.title).toContain("[topic:auth]")
+        expect((yield* peerCount()).length).toBe(1)
+
+        // 2nd create with the SAME topic → NO new child; relays into the first.
+        const second = yield* tool.execute(
+          { operation: { action: "create", task: "also handle logout", mode: "build", topic: "auth" } },
+          ctx(parent.id),
+        )
+        expect(second.metadata.sessionID).toBe(firstID)
+        expect(second.title).toContain("Reused topic 'auth'")
+        expect(second.output).toContain("Enqueued the task")
+        // Still exactly ONE peer child for topic "auth".
+        expect((yield* peerCount()).length).toBe(1)
+
+        // A DIFFERENT topic → a DISTINCT new child.
+        const third = yield* tool.execute(
+          { operation: { action: "create", task: "add caching layer", mode: "build", topic: "perf" } },
+          ctx(parent.id),
+        )
+        const thirdID = third.metadata.sessionID!
+        expect(thirdID).toBeDefined()
+        expect(thirdID).not.toBe(firstID)
+        expect(third.output).toContain("Tagged with topic 'perf'")
+        // Now two distinct standing peers (auth + perf).
+        expect((yield* peerCount()).length).toBe(2)
+
+        for (const cid of [firstID, thirdID])
+          yield* tool.execute({ operation: { action: "cancel", sessionID: cid } }, ctx(parent.id)).pipe(Effect.ignore)
       }),
       { git: true, config: askProviderCfg },
     ),

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -9,6 +9,8 @@ setDefaultTimeout(30_000)
 import { Agent } from "../../src/agent/agent"
 import { Actor } from "../../src/actor/spawn"
 import { ActorRegistry } from "../../src/actor/registry"
+import { ActorRegistryTable } from "../../src/actor/actor.sql"
+import { Database, and, eq } from "../../src/storage"
 import { Bus } from "../../src/bus"
 import { TuiEvent } from "../../src/cli/cmd/tui/event"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
@@ -404,10 +406,11 @@ describe("session tool", () => {
 
         // Total counts only the two real peers; subagent excluded.
         expect(result.title).toBe("Child sessions: 2")
-        expect(result.output).toContain("Child sessions: 2 total — 1 running, 1 idle")
+        expect(result.output).toContain("Child sessions: 2 total — 1 running (1 progressing, 0 stalled), 1 idle")
 
-        // Grouped section headings with per-group counts.
-        expect(result.output).toContain("In progress (running/pending) (1):")
+        // Grouped section headings with per-group counts. A freshly-created peer
+        // has lastTurnTime == now, so it reads as progressing.
+        expect(result.output).toContain("In progress — progressing (running/pending, advancing) (1):")
         expect(result.output).toContain("Finished / idle (1):")
 
         // Both real peers appear, under their respective groups.
@@ -598,6 +601,104 @@ describe("session tool", () => {
         if (result.output.includes("Removed its worktree")) expect(existsSync(childDir)).toBe(false)
       }),
       { git: true },
+    ),
+  )
+
+  it.live("status reports derived liveness + turnCount + lastTurnTime for a child", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+        const parent = yield* sessions.create({ title: "Parent" })
+
+        const info = yield* SessionTool
+        const tool = yield* info.init()
+        const created = yield* tool.execute(
+          { operation: { action: "create", task: "work", mode: "build", title: "Runner" } },
+          ctx(parent.id),
+        )
+        const childID = created.metadata.sessionID!
+
+        // A freshly-created child has a recent lastTurnTime → progressing.
+        const running = yield* tool.execute({ operation: { action: "status", sessionID: childID } }, ctx(parent.id))
+        expect(running.title).toBe(`Status ${childID}: progressing`)
+        expect(running.output).toContain("progressing")
+        expect(running.output).toContain("turnCount:")
+        expect(running.output).toContain("lastTurnTime:")
+
+        // Flip to a terminal idle+success: derived liveness surfaces the outcome.
+        yield* actorReg.updateStatus(SessionID.make(childID), childID, { status: "idle", lastOutcome: "success" })
+        const done = yield* tool.execute({ operation: { action: "status", sessionID: childID } }, ctx(parent.id))
+        expect(done.title).toBe(`Status ${childID}: success`)
+        expect(done.output).toContain("last outcome: success")
+      }),
+    ),
+  )
+
+  it.live("status on an unknown child returns a clear not-found message (no throw)", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const parent = yield* sessions.create({ title: "Parent" })
+        const tool = yield* (yield* SessionTool).init()
+        const result = yield* tool.execute(
+          { operation: { action: "status", sessionID: "ses_missing" } },
+          ctx(parent.id),
+        )
+        expect(result.title).toContain("not found")
+        expect(result.output).toContain("ses_missing")
+      }),
+    ),
+  )
+
+  it.live("list splits the In progress group into progressing vs stalled", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+        const parent = yield* sessions.create({ title: "Parent" })
+
+        const info = yield* SessionTool
+        const tool = yield* info.init()
+
+        // A progressing peer: freshly created, lastTurnTime == now.
+        const prog = yield* tool.execute(
+          { operation: { action: "create", task: "advancing", mode: "build", title: "Fresh" } },
+          ctx(parent.id),
+        )
+        const progID = prog.metadata.sessionID!
+
+        // A stalled peer: running, but with an old last_turn_time far past the
+        // default staleness window → deriveLiveness reports stalled. Force status
+        // running, then age its last_turn_time via a direct row update (updateTurn
+        // would bump it to now; we need it OLD with turnCount unchanged).
+        const stalled = yield* tool.execute(
+          { operation: { action: "create", task: "wedged", mode: "build", title: "Wedged" } },
+          ctx(parent.id),
+        )
+        const stalledID = stalled.metadata.sessionID!
+        yield* actorReg.updateStatus(SessionID.make(stalledID), stalledID, { status: "running" })
+        yield* Effect.sync(() =>
+          Database.use((db) =>
+            db
+              .update(ActorRegistryTable)
+              .set({ last_turn_time: Date.now() - 10 * 60_000 })
+              .where(and(eq(ActorRegistryTable.session_id, SessionID.make(stalledID)), eq(ActorRegistryTable.actor_id, stalledID)))
+              .run(),
+          ),
+        )
+
+        const result = yield* tool.execute({ operation: { action: "list" } }, ctx(parent.id))
+
+        expect(result.output).toContain("In progress — progressing (running/pending, advancing) (1):")
+        expect(result.output).toContain("In progress — stalled (running/pending, no recent turn) (1):")
+        expect(result.output).toContain("(1 progressing, 1 stalled)")
+        // Each child lands under its own group.
+        const progSection = result.output.split("In progress — progressing")[1]?.split("In progress — stalled")[0] ?? ""
+        expect(progSection).toContain(progID)
+        const stalledSection = result.output.split("In progress — stalled")[1] ?? ""
+        expect(stalledSection).toContain(stalledID)
+      }),
     ),
   )
 })

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -18,6 +18,7 @@ import { Instance } from "../../src/project/instance"
 import { Provider } from "../../src/provider"
 import { Session } from "../../src/session"
 import { Worktree } from "../../src/worktree"
+import { Git } from "../../src/git"
 import { MessageID, SessionID, PartID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { TaskRegistry } from "../../src/task/registry"
@@ -45,6 +46,8 @@ const it = testEffect(
     Bus.defaultLayer,
     // session tool's create/cancel use Worktree.Service (worktree-per-child).
     Worktree.defaultLayer,
+    // session dashboard correlates worktrees via Git.Service (worktree list + rev-list).
+    Git.defaultLayer,
     // Actor.defaultLayer populates spawnRef.current, which the session tool's
     // create/cancel branches read via requireActor(). Without it they fail fast.
     Actor.defaultLayer,
@@ -1113,6 +1116,9 @@ function makeAskLayer() {
   return Layer.mergeAll(
     TestLLMServer.layer,
     inbox,
+    // Git.Service is part of SessionTool's Deps (dashboard worktree correlation);
+    // surface it so the test body can yield* SessionTool.
+    Git.defaultLayer,
     Actor.layer.pipe(
       Layer.provideMerge(prompt),
       Layer.provideMerge(Worktree.defaultLayer),

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -1146,4 +1146,56 @@ describe("session tool ask (fork-query) functional", () => {
     ),
     60000,
   )
+
+  // T42: `session send` to a child that was JUST created (its first turn is
+  // still hanging, turnCount 0) must NOT return "not reachable"/ESRCH — the peer
+  // receiver row is registered at spawn time, so the relay enqueues immediately.
+  // This is the prerequisite for T43 (--topic reuse). Uses the full Inbox+Actor
+  // stack so the relay hits the real Inbox.send ESRCH pre-check.
+  askIt.live("session send to a just-created (never-run) child enqueues without ESRCH", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const sessions = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+        const parent = yield* sessions.create({
+          title: "T42 relay parent",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        // Hang so the created child's first turn never completes: the receiver
+        // row can only come from spawn-time registration, not first-turn arming.
+        yield* llm.hang
+
+        const info = yield* SessionTool
+        const tool = yield* info.init()
+
+        const created = yield* tool.execute(
+          { operation: { action: "create", task: "long running child", mode: "build", title: "Child" } },
+          ctx(parent.id),
+        )
+        const childID = created.metadata.sessionID!
+        expect(childID).toBeDefined()
+
+        // The peer receiver row exists at spawn: turnCount 0, still pending.
+        const row = yield* actorReg.get(SessionID.make(childID), childID)
+        expect(row?.mode).toBe("peer")
+        expect(row?.turnCount).toBe(0)
+
+        // Relay a task the instant after create — must succeed, not ESRCH.
+        const sent = yield* tool.execute(
+          { operation: { action: "send", sessionID: childID, task: "do this next" } },
+          ctx(parent.id),
+        )
+        expect(sent.title).toContain(`Relayed task to ${childID}`)
+        expect(sent.output).not.toContain("not reachable")
+        expect(sent.output).toContain("Enqueued the task")
+
+        yield* tool
+          .execute({ operation: { action: "cancel", sessionID: childID } }, ctx(parent.id))
+          .pipe(Effect.ignore)
+      }),
+      { git: true, config: askProviderCfg },
+    ),
+    60000,
+  )
 })

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -303,6 +303,10 @@ describe("session tool", () => {
         const result = yield* tool.execute({ operation: { action: "list" } }, ctx(parent.id))
 
         expect(result.title).toBe("Child sessions: 2")
+        // The output now leads with a counted summary line covering all buckets.
+        expect(result.output).toContain("Child sessions: 2 total —")
+        expect(result.output).toContain("running")
+        expect(result.output).toContain("idle")
         expect(result.output).toContain(idA)
         expect(result.output).toContain(idB)
         // create overwrites spawnPeer's default `${agentType}: ${task}` title
@@ -312,6 +316,68 @@ describe("session tool", () => {
         // agent (the NL "mode") is surfaced from the actor row.
         expect(result.output).toContain("build")
         expect(result.output).toContain("compose")
+      }),
+    ),
+  )
+
+  it.live("list groups children by status with counts and excludes system subagents", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+        const parent = yield* sessions.create({ title: "Parent" })
+
+        const info = yield* SessionTool
+        const tool = yield* info.init()
+
+        // A running peer (freshly created → status pending/running).
+        const running = yield* tool.execute(
+          { operation: { action: "create", task: "work", mode: "build", title: "Runner" } },
+          ctx(parent.id),
+        )
+        const runningID = running.metadata.sessionID!
+
+        // An idle/finished peer: create it, then flip its actor row to a terminal
+        // idle with a success outcome so it lands in the "Finished / idle" bucket.
+        const idle = yield* tool.execute(
+          { operation: { action: "create", task: "done work", mode: "build", title: "Idler" } },
+          ctx(parent.id),
+        )
+        const idleID = idle.metadata.sessionID!
+        yield* actorReg.updateStatus(SessionID.make(idleID), idleID, { status: "idle", lastOutcome: "success" })
+
+        // A system subagent (checkpoint-writer): parented to us but must NOT appear.
+        const sub = yield* sessions.create({ title: "checkpoint-writer: T1", parentID: parent.id })
+        yield* actorReg.register({
+          sessionID: sub.id,
+          actorID: sub.id,
+          mode: "subagent",
+          agent: "checkpoint-writer",
+          description: "checkpoint",
+          contextMode: "full",
+          background: true,
+          lifecycle: "ephemeral",
+        })
+
+        const result = yield* tool.execute({ operation: { action: "list" } }, ctx(parent.id))
+
+        // Total counts only the two real peers; subagent excluded.
+        expect(result.title).toBe("Child sessions: 2")
+        expect(result.output).toContain("Child sessions: 2 total — 1 running, 1 idle")
+
+        // Grouped section headings with per-group counts.
+        expect(result.output).toContain("In progress (running/pending) (1):")
+        expect(result.output).toContain("Finished / idle (1):")
+
+        // Both real peers appear, under their respective groups.
+        expect(result.output).toContain(runningID)
+        expect(result.output).toContain("Runner")
+        expect(result.output).toContain(idleID)
+        expect(result.output).toContain("Idler")
+
+        // The system subagent is filtered out entirely.
+        expect(result.output).not.toContain(sub.id)
+        expect(result.output).not.toContain("checkpoint-writer")
       }),
     ),
   )

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -126,6 +126,47 @@ describe("session tool", () => {
     ),
   )
 
+  it.live("parameters schema accepts a send operation", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const tool = yield* (yield* SessionTool).init()
+        const parsed = tool.parameters.safeParse({
+          operation: { action: "send", sessionID: "ses_child", task: "relay this" },
+        })
+        expect(parsed.success).toBe(true)
+      }),
+    ),
+  )
+
+  it.live("parameters schema rejects send with an empty task", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const tool = yield* (yield* SessionTool).init()
+        const parsed = tool.parameters.safeParse({
+          operation: { action: "send", sessionID: "ses_child", task: "" },
+        })
+        expect(parsed.success).toBe(false)
+      }),
+    ),
+  )
+
+  it.live("send to an unknown child returns a clear not-found message (no throw)", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const parent = yield* sessions.create({ title: "Parent" })
+        const tool = yield* (yield* SessionTool).init()
+        const result = yield* tool.execute(
+          { operation: { action: "send", sessionID: "ses_missing", task: "hello" } },
+          ctx(parent.id),
+        )
+        expect(result.title).toContain("not found")
+        expect(result.output).toContain("ses_missing")
+        expect(result.metadata.sessionID).toBe("ses_missing")
+      }),
+    ),
+  )
+
   it.live("create spawns a child peer session registered with mode peer + agent build", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
@@ -637,6 +678,20 @@ describe("session tool dual-schema (shell + JSON) end-to-end", () => {
         expect(yield* parse("session cancel ses_xyz")).toEqual([
           { operation: { action: "cancel", sessionID: "ses_xyz" } },
         ])
+        // `send` takes a sessionID + a joined multi-word task.
+        expect(yield* parse("session send ses_child go fix the flaky test")).toEqual([
+          { operation: { action: "send", sessionID: "ses_child", task: "go fix the flaky test" } },
+        ])
+      }),
+    ),
+  )
+
+  it.live("shell form: send requires a sessionID AND a task (arity error otherwise)", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const tool = yield* (yield* SessionTool).init()
+        const exit = yield* Effect.exit(tool.shell!.parse("session send ses_only"))
+        expect(exit._tag).toBe("Failure")
       }),
     ),
   )

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -18,8 +18,8 @@ import { Instance } from "../../src/project/instance"
 import { Provider } from "../../src/provider"
 import { Session } from "../../src/session"
 import { Worktree } from "../../src/worktree"
-import { MessageID, SessionID } from "../../src/session/schema"
-import { ModelID } from "../../src/provider/schema"
+import { MessageID, SessionID, PartID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
 import { TaskRegistry } from "../../src/task/registry"
 import { Truncate } from "../../src/tool"
 import { SessionTool } from "../../src/tool/session"
@@ -954,7 +954,6 @@ import { forwardRef } from "../../src/permission/permission-forward-ref"
 import { Plugin } from "../../src/plugin"
 import { Provider as ProviderSvc } from "../../src/provider"
 import { Env } from "../../src/env"
-import { ProviderID } from "../../src/provider/schema"
 import { Question } from "../../src/question"
 import { Todo } from "../../src/session/todo"
 import { LLM } from "../../src/session/llm"
@@ -1391,5 +1390,232 @@ describe("session tool ask (fork-query) functional", () => {
       { git: true, config: askProviderCfg },
     ),
     60000,
+  )
+})
+
+// === T38: fan-in aggregation (session join) ===
+// Drive a GROUP of mock child peers to terminal states (mixing success / fail /
+// cancel) and assert `session join` resolves ONCE with an aggregated per-child
+// summary — and crucially does NOT resolve early while a member is still live.
+// Mock children = real sessions parented to the orchestrator + a registered peer
+// actor keyed by the child session id (the peer session_id === actor_id
+// convention). Terminal transitions go through registry.updateStatus, which
+// publishes ActorStatusChanged on the same instance Bus joinGroup subscribes to.
+const seedAssistantText = (sessionID: SessionID, actorID: string, text: string) =>
+  Effect.gen(function* () {
+    const sessions = yield* Session.Service
+    const userMsg = yield* sessions.updateMessage({
+      id: MessageID.ascending(),
+      role: "user" as const,
+      sessionID,
+      agentID: actorID,
+      time: { created: Date.now() },
+      agent: "build",
+      model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+    })
+    const msgID = MessageID.ascending()
+    yield* sessions.updateMessage({
+      id: msgID,
+      role: "assistant" as const,
+      sessionID,
+      agentID: actorID,
+      mode: "default",
+      agent: "build",
+      path: { cwd: "/tmp", root: "/tmp" },
+      cost: 0,
+      tokens: { output: 0, input: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: ModelID.make("test-model"),
+      providerID: ProviderID.make("test"),
+      parentID: userMsg.id,
+      time: { created: Date.now() },
+      finish: "end_turn",
+    })
+    yield* sessions.updatePart({
+      id: PartID.ascending(),
+      messageID: msgID,
+      sessionID,
+      type: "text" as const,
+      text,
+    })
+  })
+
+describe("session tool join (fan-in aggregation, T38)", () => {
+  // Register a mock child peer under `parent`, returning its child session id.
+  const mockChild = (parentID: SessionID, label: string) =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const registry = yield* ActorRegistry.Service
+      const child = yield* sessions.create({ parentID, title: label })
+      yield* registry.register({
+        sessionID: child.id,
+        actorID: child.id,
+        mode: "peer",
+        parentActorID: "main",
+        agent: "build",
+        description: label,
+        contextMode: "none",
+        contextWatermark: undefined,
+        background: true,
+        lifecycle: "persistent",
+      })
+      yield* registry.updateStatus(child.id, child.id, { status: "running" })
+      return child.id
+    })
+
+  it.live("parameters schema accepts a join operation with multiple session ids", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const tool = yield* (yield* SessionTool).init()
+        const parsed = tool.parameters.safeParse({
+          operation: { action: "join", sessionIDs: ["ses_a", "ses_b"] },
+        })
+        expect(parsed.success).toBe(true)
+      }),
+    ),
+  )
+
+  it.live("parameters schema rejects join with an empty sessionIDs array", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const tool = yield* (yield* SessionTool).init()
+        const parsed = tool.parameters.safeParse({
+          operation: { action: "join", sessionIDs: [] },
+        })
+        expect(parsed.success).toBe(false)
+      }),
+    ),
+  )
+
+  it.live(
+    "join resolves ONCE when all 3 children reach terminal (mix success/fail/cancel) and not early",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const registry = yield* ActorRegistry.Service
+        const parent = yield* sessions.create({ title: "orchestrator" })
+        const tool = yield* (yield* SessionTool).init()
+
+        const a = yield* mockChild(parent.id, "child-A")
+        const b = yield* mockChild(parent.id, "child-B")
+        const c = yield* mockChild(parent.id, "child-C")
+
+        // Seed a result body for the one that will succeed.
+        yield* seedAssistantText(a, a, "A finished the job")
+
+        // Driver: flip children terminal one at a time with gaps. The join must
+        // NOT resolve until the LAST one (c) settles at ~90ms.
+        const settledOrder: string[] = []
+        yield* Effect.forkDetach(
+          Effect.gen(function* () {
+            yield* Effect.sleep("30 millis")
+            settledOrder.push("a")
+            yield* registry.updateStatus(a, a, { status: "idle", lastOutcome: "success" })
+            yield* Effect.sleep("30 millis")
+            settledOrder.push("b")
+            yield* registry.updateStatus(b, b, { status: "idle", lastOutcome: "failure", lastError: "B blew up" })
+            yield* Effect.sleep("30 millis")
+            settledOrder.push("c")
+            yield* registry.updateStatus(c, c, { status: "idle", lastOutcome: "cancelled" })
+          }),
+        )
+
+        const before = Date.now()
+        const result = yield* tool.execute(
+          { operation: { action: "join", sessionIDs: [a, b, c], timeout_ms: 5000 } },
+          ctx(parent.id),
+        )
+        const elapsed = Date.now() - before
+
+        // Did not resolve early: all three driver steps ran before join returned.
+        expect(settledOrder).toEqual(["a", "b", "c"])
+        // And it actually waited for the last transition (~90ms), not the fast path.
+        expect(elapsed).toBeGreaterThanOrEqual(80)
+
+        expect(result.title).toContain("Joined 3 children")
+        expect(result.output).toContain("all 3 children terminal")
+        expect(result.output).toContain("1 success, 1 failed, 1 cancelled")
+        // Per-child buckets present.
+        expect(result.output).toContain(`${a} (child-A) — success`)
+        expect(result.output).toContain(`${b} (child-B) — failure: B blew up`)
+        expect(result.output).toContain(`${c} (child-C) — cancelled`)
+      }),
+    ),
+    30000,
+  )
+
+  it.live(
+    "join returns immediately (fast path) when every child is already terminal",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const registry = yield* ActorRegistry.Service
+        const parent = yield* sessions.create({ title: "orchestrator" })
+        const tool = yield* (yield* SessionTool).init()
+
+        const a = yield* mockChild(parent.id, "done-A")
+        const b = yield* mockChild(parent.id, "done-B")
+        yield* registry.updateStatus(a, a, { status: "idle", lastOutcome: "success" })
+        yield* registry.updateStatus(b, b, { status: "idle", lastOutcome: "success" })
+
+        const result = yield* tool.execute(
+          { operation: { action: "join", sessionIDs: [a, b], timeout_ms: 500 } },
+          ctx(parent.id),
+        )
+        expect(result.title).toContain("Joined 2 children")
+        expect(result.output).toContain("2 success")
+      }),
+    ),
+    30000,
+  )
+
+  it.live(
+    "join TIMES OUT (does not hang) while a child stays live, reporting a partial aggregate",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const registry = yield* ActorRegistry.Service
+        const parent = yield* sessions.create({ title: "orchestrator" })
+        const tool = yield* (yield* SessionTool).init()
+
+        const a = yield* mockChild(parent.id, "fin-A")
+        const b = yield* mockChild(parent.id, "stuck-B")
+        // Only A settles; B stays running → the barrier must NOT resolve, it times out.
+        yield* registry.updateStatus(a, a, { status: "idle", lastOutcome: "success" })
+
+        const result = yield* tool.execute(
+          { operation: { action: "join", sessionIDs: [a, b], timeout_ms: 250 } },
+          ctx(parent.id),
+        )
+        expect(result.title).toContain("timed out")
+        expect(result.output).toContain("Join TIMED OUT")
+        expect(result.output).toContain("1/2 children terminal")
+      }),
+    ),
+    30000,
+  )
+
+  it.live(
+    "join treats an unknown session id as 'unknown' and does not block on it",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const registry = yield* ActorRegistry.Service
+        const parent = yield* sessions.create({ title: "orchestrator" })
+        const tool = yield* (yield* SessionTool).init()
+
+        const a = yield* mockChild(parent.id, "real-A")
+        yield* registry.updateStatus(a, a, { status: "idle", lastOutcome: "success" })
+
+        const result = yield* tool.execute(
+          { operation: { action: "join", sessionIDs: [a, "ses_ghost"], timeout_ms: 500 } },
+          ctx(parent.id),
+        )
+        expect(result.title).toContain("Joined 2 children")
+        expect(result.output).toContain("all 2 children terminal")
+        expect(result.output).toContain("1 unknown")
+        expect(result.output).toContain("ses_ghost — unknown")
+      }),
+    ),
+    30000,
   )
 })


### PR DESCRIPTION
## Summary

The full Orchestrator coordination stack, rebased onto latest `origin/main` (`d056619`). 30 commits cherry-picked (`-x`) in order from `fix/orchestrator-tui-and-infra-bugs`; none were empty/skipped.

## Included fixes, grouped by sub-theme

### Mode-switch / entry & navigation (TUI)
- don't switch to session view on Orchestrator mode select
- enter Orchestrator mode directly when resuming via `-c` (no blackscreen)
- don't redirect `-s` orchestrator-session entry to home (regression fix)
- `-s` into an orchestrator session lands in the session, not home (T36 follow-up)
- `-s` into orchestrator session goes directly to the session without a home flash (T50 follow-up)
- render a single model status line per message in Orchestrator mode (was duplicated)
- idle session no longer renders new messages as stuck QUEUED
- UI feedback for `/btw` (pending state + ephemeral answer render)

### Reliable relay, notifications, liveness & fan-in
- reliable relay into an idle standing peer (inbox drain seed + `session send` verb)
- notify parent when a background peer finishes on a woken turn
- register peer receiver row at spawn so a new child is addressable immediately (T42)
- notify parent on cancel/fail via unified terminal-status bridge (T41)
- stall watchdog pushes a one-shot stalled notification to the parent (T40)
- per-step turn heartbeat so turnCount/last_turn_time reflect real progress
- derive progressing/stalled liveness + `session status` verb + list split (T39)
- `--topic` find-or-reuse to append to a standing per-theme child (T43)
- fan-in aggregation — join a dispatch group, one aggregated result when all children terminal (T38)
- group and count child sessions by status in the session list

### Grant persistence, worktree trust & approval forwarding
- persist grant-approval across processes so isolated children honor it
- trust orchestrator-created worktrees so isolated children don't deadlock on external_directory
- create worktree atomically on an attached branch so child commits advance the branch ref
- Orchestrator grant-approval auto-approves background children external_directory asks for granted dirs

### Session identity & observability
- give the persistent orchestrator session a stable title instead of a task-bound one
- fleet observability — sessions + worktrees + liveness in one view

### Orchestrator prompt (cumulative)
- never block, never use actor for real work, isolate git-repo children by default
- encode orchestrator working-model (delegate analysis, reuse standing session, persistent coordinator)
- requirement auto-capture as a first-class orchestrator reflex (T45)
- align orchestrator.txt with shipped primitives (session send/status/join/--topic, event-driven stall); drop stale relay/known-limitation (T44)
- keep finished sessions resumable instead of cancelling them

### Tests
- verify session send + notification across running/idle/never-run peers

## Conflict resolution notes
- `context/local.tsx` — kept BOTH `skipPermissions` (main) and `orchestrator` (ours) result fields.
- `tool/session.ts` `list` action — incoming grouped/counted output superseded the flat list; adapted it to main's data shape by reconstructing the `peers` (`{child, actor}`) array via `actorReg.get` before grouping.
- `tool/session.ts` imports (T39) & `session-tool.test.ts` — additive; kept incoming (`deriveLiveness`, `SYSTEM_SPAWNED_AGENT_TYPES`, new test blocks).
- `prompt/orchestrator.txt` — several commits edit it; auto-merged to the cumulative latest.

## Verification
- `bun typecheck` — exit 0 (all packages green via pre-push hook too).