### PR TITLE
fix(workflow): dynamic deep-research workflow — fix brief.md path mismatch + args ergonomics

### DIFF
--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -22,6 +22,16 @@ function parseComposeArgString(raw: string): Record<string, unknown> {
   return { task: raw }
 }
 
+// Normalize a bare string arg into an args object with a `question` field.
+// Mirrors parseComposeArgString but maps to {question} instead of {task}.
+function parseArgsAsQuestion(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw)
+    if (typeof parsed === "object" && parsed !== null) return parsed as Record<string, unknown>
+  } catch {}
+  return { question: raw }
+}
+
 const runSchema = z.strictObject({
   operation: z.literal("run"),
   name: z
@@ -143,6 +153,32 @@ export const WorkflowTool = Tool.define<typeof parameters, Metadata, Config.Serv
         return { ...base, _composeDocsDir: docs }
       })
 
+    // Normalize and enrich args for the deep-research built-in:
+    //   - bare string args → { question: <string> }  (mirrors compose's parseComposeArgString)
+    //   - inject today (YYYY-MM-DD) from host Date  (the sandbox strips Date for determinism)
+    //   - inject dir = workspace root  (so agent writes and sandbox exists checks resolve
+    //     to the same location — the root cause of the "brief.md not created" bug was
+    //     dir ≠ workspaceRoot causing a path mismatch between agent writes and exists checks)
+    const enrichDeepResearchArgs = (raw: unknown, workspace?: string) =>
+      Effect.gen(function* () {
+        const ctx = yield* InstanceState.context
+        const resolvedWorkspace = workspace ?? ctx.worktree
+        const base =
+          typeof raw === "object" && raw !== null
+            ? { ...(raw as Record<string, unknown>) }
+            : typeof raw === "string"
+              ? parseComposeArgString(raw)
+              : {}
+        // dir must equal the workspace root: the sandbox file primitives (exists,
+        // writeFile, readFile, glob) are jailed there, and the script's agent
+        // prompts reference ${dir}/... for file paths. Mismatched dir was the root
+        // cause of "brief.md not created" — the agent wrote to ${dir}/brief.md
+        // while exists checked ${workspaceRoot}/brief.md.
+        if (!base.dir) base.dir = resolvedWorkspace
+        if (!base.today) base.today = new Date().toISOString().slice(0, 10)
+        return base
+      })
+
     const run = Effect.fn("WorkflowTool.execute")(function* (
       input: z.infer<typeof parameters>,
       ctx: Tool.Context<Metadata>,
@@ -177,7 +213,11 @@ export const WorkflowTool = Tool.define<typeof parameters, Metadata, Config.Serv
           script,
           sessionID: ctx.sessionID as SessionID,
           parentActorID: ctx.agent ?? "main",
-          args: input.name === "compose" ? yield* enrichComposeArgs(input.args) : input.args,
+          args: input.name === "compose"
+            ? yield* enrichComposeArgs(input.args)
+            : input.name === "deep-research"
+              ? yield* enrichDeepResearchArgs(input.args, input.workspace)
+              : input.args,
           workspace: input.workspace,
           maxConcurrentAgents: cfg.workflow?.maxConcurrentAgents,
           scriptDeadlineMs: cfg.workflow?.scriptDeadlineMs,

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -167,7 +167,7 @@ export const WorkflowTool = Tool.define<typeof parameters, Metadata, Config.Serv
           typeof raw === "object" && raw !== null
             ? { ...(raw as Record<string, unknown>) }
             : typeof raw === "string"
-              ? parseComposeArgString(raw)
+              ? parseArgsAsQuestion(raw)
               : {}
         // dir must equal the workspace root: the sandbox file primitives (exists,
         // writeFile, readFile, glob) are jailed there, and the script's agent

--- a/packages/opencode/src/tool/workflow.txt
+++ b/packages/opencode/src/tool/workflow.txt
@@ -23,3 +23,23 @@ Concurrency is capped by the host (default min(16, 2x cores)); excess agent() ca
 Communicate between workflows by dataflow: return a value from a child and pass it as args to the next (or write a shared file via writeFile and read it in a later phase). Workflows do not message each other directly. File primitives are jailed to the workspace root (the project worktree by default, or the `workspace` you pass to the run op) by a LEXICAL name check — it blocks `..` and absolute escapes, but does not resolve symlinks, so treat it as scoping, not a hard security boundary.
 
 workflow() cycle detection is asymmetric: a SAVED name is checked by name (so A calling A is a cycle regardless of args), while an INLINE script is checked by content+args (so an inline body that calls itself with DIFFERENT args is not flagged as a cycle and is bounded only by maxDepth). A cycle, over-maxDepth, or unknown name THROWS at the workflow() call site, which fails the run if uncaught — but a try/catch around workflow() in the guest will silence those throws, so don't wrap workflow() in try/catch unless you intend to ignore configuration bugs.
+
+## Built-in workflow args reference
+
+When invoking a named built-in, `args` can be a bare string (auto-normalized to the workflow's primary arg) or an object.
+
+### deep-research
+Required args: `question` (string) — the research question. A bare string arg is auto-normalized to `{question: <string>}`.
+Optional args: `dir` (string, auto-injected to workspace root), `today` (string YYYY-MM-DD, auto-injected from host), `depth` ("quick"|"standard"|"deep"), `context` (string).
+Example: `workflow({operation:"run", name:"deep-research", args:"What are the latest advances in X?"})`
+
+## Built-in workflow args
+
+When invoking a named built-in, `args` can be a bare string (auto-normalized to the workflow's primary arg) or an object.
+
+### deep-research
+`args`: string (treated as `question`) | object with:
+  - `question` (required): the research question
+  - `depth` (optional): "quick" | "standard" | "deep" (default "standard")
+  - `context` (optional): additional context for the brief step
+  - `dir` and `today` are auto-injected by the host — you do NOT need to pass them.

--- a/packages/opencode/src/tool/workflow.txt
+++ b/packages/opencode/src/tool/workflow.txt
@@ -29,17 +29,9 @@ workflow() cycle detection is asymmetric: a SAVED name is checked by name (so A 
 When invoking a named built-in, `args` can be a bare string (auto-normalized to the workflow's primary arg) or an object.
 
 ### deep-research
-Required args: `question` (string) — the research question. A bare string arg is auto-normalized to `{question: <string>}`.
-Optional args: `dir` (string, auto-injected to workspace root), `today` (string YYYY-MM-DD, auto-injected from host), `depth` ("quick"|"standard"|"deep"), `context` (string).
-Example: `workflow({operation:"run", name:"deep-research", args:"What are the latest advances in X?"})`
-
-## Built-in workflow args
-
-When invoking a named built-in, `args` can be a bare string (auto-normalized to the workflow's primary arg) or an object.
-
-### deep-research
 `args`: string (treated as `question`) | object with:
-  - `question` (required): the research question
+  - `question` (required): the research question. A bare string arg is auto-normalized to `{question: <string>}`.
   - `depth` (optional): "quick" | "standard" | "deep" (default "standard")
   - `context` (optional): additional context for the brief step
-  - `dir` and `today` are auto-injected by the host — you do NOT need to pass them.
+  - `dir` and `today` are auto-injected by the host (workspace root and host YYYY-MM-DD respectively) — you do NOT need to pass them.
+Example: `workflow({operation:"run", name:"deep-research", args:"What are the latest advances in X?"})`

--- a/packages/opencode/src/workflow/builtin/deep-research.js
+++ b/packages/opencode/src/workflow/builtin/deep-research.js
@@ -14,11 +14,20 @@ export const meta = {
   ],
 };
 
-// Sandbox exposes `args` as a JSON string — parse it first.
-const _a = typeof args === "string" ? JSON.parse(args) : args;
-const dir = _a.dir;
+// Sandbox exposes `args` as a JSON value — normalize bare strings gracefully.
+const _a = (() => {
+  if (args == null || args === undefined) return {};
+  if (typeof args === "string") {
+    try { const p = JSON.parse(args); return (typeof p === "object" && p !== null) ? p : { question: args }; }
+    catch { return { question: args }; }
+  }
+  return typeof args === "object" ? args : {};
+})();
 const question = _a.question;
-if (!dir || !question) throw new Error("args.dir and args.question are required");
+if (!question) throw new Error("args.question is required — pass {question: \"...\"} or a bare question string as args");
+const dir = _a.dir ?? ".";
+const today = _a.today;
+if (!today) throw new Error("args.today (YYYY-MM-DD) is required — the host auto-injects this for built-in runs; if calling from a user script, pass it manually");
 
 // Hard budgets per depth — enforced by script, not by LLM judgment.
 const DEPTH = {
@@ -27,9 +36,6 @@ const DEPTH = {
   deep: { angles: 8, queryBudget: 8, deltaAngles: 4, sources: 25 },
 }[_a.depth ?? "standard"];
 if (!DEPTH) throw new Error(`invalid depth: ${_a.depth}`);
-// Sandbox has no Date object — caller must pass today's date.
-const today = _a.today;
-if (!today) throw new Error("args.today (YYYY-MM-DD) is required — sandbox has no Date");
 
 // Locked sub-agent prompt template.
 const subagentPrompt = (n, angle, briefContext) => `You are a research sub-agent. Today is ${today}.
@@ -44,7 +50,7 @@ Rules:
 2. WebFetch the 3-6 most promising results to read actual content. Do not cite a page you did not fetch.
 3. Judge each source: official/primary > reputable media/peer-reviewed > forums/blogs > content farms. Discard low-quality sources rather than citing them.
 4. Extract findings as information-dense claims: include exact entities, numbers, dates, versions. One claim per finding.
-5. Write your findings to ${dir}/findings/F${n}.md in EXACTLY this format:
+5. Write your findings to findings/F${n}.md in EXACTLY this format:
 
 # F${n}: ${angle}
 
@@ -77,7 +83,7 @@ if (!(await exists("brief.md"))) {
     `You are the scoping step of a deep research run. Today is ${today}. No user is available — do NOT ask questions; write assumptions instead.
 Research question (verbatim from user): "${question}"
 ${_a.context ? `Additional context from the requester: ${_a.context}` : ""}
-Write ${dir}/brief.md with sections:
+Write brief.md with sections:
 # Research Brief
 **Date**: ${today} · **Depth**: ${_a.depth ?? "standard"}
 ## Question — the refined, unambiguous research question
@@ -104,7 +110,7 @@ if (await exists("plan.json")) {
   plan = JSON.parse(await readFile("plan.json"));
 } else {
   plan = await agent(
-    `You are the planning step of a deep research run. Read ${dir}/brief.md.
+    `You are the planning step of a deep research run. Read brief.md.
 Decompose it into 3-${DEPTH.angles} INDEPENDENT research angles (no overlap; each answerable alone). Draw from these lenses as applicable: core facts/definitions · recent developments · quantitative data/benchmarks · counter-arguments & failure cases · practitioner experience · academic work · key players/alternatives.
 Also compress the brief into a 2-3 line briefContext for sub-agents.`,
     { schema: anglesSchema }
@@ -134,7 +140,7 @@ log(`round 1 done: ${findingFiles.length} findings files`);
 phase("Reflect");
 if (DEPTH.deltaAngles > 0 && !(await exists("reflect.json"))) {
   const reflect = await agent(
-    `You are the reflection step of a deep research run. Read ${dir}/brief.md and EVERY file in ${dir}/findings/.
+    `You are the reflection step of a deep research run. Read brief.md and EVERY file in findings/.
 Against the brief, identify: (a) parts of the brief with no evidence; (b) major claims resting on a single source; (c) conflicts between sources worth resolving. Also consider the "Suggested follow-ups" sections in the findings.
 Output at most ${DEPTH.deltaAngles} delta-angles — narrow, targeted research questions that would close the most important gaps. If coverage is already sufficient, output an empty array. Also list unresolved gaps that should surface in the report's "Open questions" section.`,
     {
@@ -175,8 +181,8 @@ findingFiles = await glob("findings/F*.md");
 phase("Write");
 if (!(await exists("REPORT.md"))) {
   await agent(
-    `You are the SOLE writer of a deep research report. Read ${dir}/brief.md, ${dir}/reflect.json (openQuestions), and EVERY file in ${dir}/findings/.
-Write ${dir}/REPORT.md in one pass. Header: "> Generated ${today} · depth: ${_a.depth ?? "standard"} · workspace: ${dir}".
+    `You are the SOLE writer of a deep research report. Read brief.md, reflect.json (openQuestions), and EVERY file in findings/.
+Write REPORT.md in one pass. Header: "> Generated ${today} · depth: ${_a.depth ?? "standard"} · workspace: ${dir}".
 Report structure: Executive summary (5-10 bullet conclusions with [n] citations) → Background & scope → Body sections organized by THEME (not by findings file) → Open questions (seeded from reflect.json) → Sources (numbered, dedup URLs, access date ${today}).
 Hard rules: every non-obvious claim carries [n] resolving to a Sources entry whose URL appears in some findings file — never cite from memory; conflicts presented with both sides and dates; [single source] and [speculative] flags where applicable.
 Do NOT re-search. If a gap blocks a section, state the gap.`
@@ -189,9 +195,9 @@ log("REPORT.md ready");
 phase("Review");
 const review = await agent(
   `You are an independent reviewer with NO prior context — judge only from files.
-Read ${dir}/REPORT.md and every file in ${dir}/findings/.
+Read REPORT.md and every file in findings/.
 Check: (a) claims lacking citations that need one; (b) spot-check 5 random [n] citations — does the URL exist in some findings file and plausibly support the sentence?; (c) conclusions stronger than the evidence; (d) executive summary consistent with body.
-Write findings to ${dir}/REVIEW.md.`,
+Write findings to REVIEW.md.`,
   {
     schema: {
       type: "object",
@@ -208,7 +214,7 @@ log(`review: ${review ? review.summary : "reviewer failed"}`);
 if (review && review.critical > 0) {
   phase("Fix");
   await agent(
-    `Read ${dir}/REVIEW.md and fix ${dir}/REPORT.md accordingly: re-anchor citations to URLs actually present in ${dir}/findings/, otherwise weaken or remove unsupported claims. Never invent new sources.`
+    `Read REVIEW.md and fix REPORT.md accordingly: re-anchor citations to URLs actually present in findings/, otherwise weaken or remove unsupported claims. Never invent new sources.`
   );
 }
 

--- a/packages/opencode/test/workflow/sandbox.test.ts
+++ b/packages/opencode/test/workflow/sandbox.test.ts
@@ -206,6 +206,45 @@ describe("Sandbox prelude (parallel/pipeline/args)", () => {
   })
 })
 
+describe("Sandbox args string injection (Defect A regression)", () => {
+  test("a bare string arg is injected as a string, not eval'd as JS", async () => {
+    // Regression: bare string args used to cause SyntaxError because the script
+    // tried JSON.parse on a non-JSON string.
+    const result = await evalScript(`return typeof args === "string" ? args : "not-string"`, {}, { args: "深入调研X" })
+    expect(result).toBe("深入调研X")
+  })
+
+  test("a null arg is injected as undefined", async () => {
+    const result = await evalScript(`return args`, {}, { args: null })
+    expect(result).toBeUndefined()
+  })
+})
+
+describe("Sandbox file roundtrip (Defect C regression)", () => {
+  test("writeFile + exists + readFile roundtrip works in sandbox", async () => {
+    // Regression: the deep-research script's exists("brief.md") must find a file
+    // that writeFile("brief.md", ...) created. This roundtrip is the core of the
+    // "brief.md not created" bug.
+    const files = new Map<string, string>()
+    const hooks = {
+      writeFile: async (path: unknown, content: unknown) => { files.set(String(path), String(content)) },
+      exists: async (path: unknown) => files.has(String(path)),
+      readFile: async (path: unknown) => files.get(String(path)) ?? null,
+    }
+    const body = `
+      await writeFile("brief.md", "# Research Brief")
+      const hasBrief = await exists("brief.md")
+      const content = await readFile("brief.md")
+      const hasMissing = await exists("missing.md")
+      return { hasBrief, content, hasMissing }
+    `
+    const result = await evalScript(body, hooks) as { hasBrief: boolean, content: string, hasMissing: boolean }
+    expect(result.hasBrief).toBe(true)
+    expect(result.content).toBe("# Research Brief")
+    expect(result.hasMissing).toBe(false)
+  })
+})
+
 describe("Sandbox unsettled-hook hygiene", () => {
   test("a fire-and-forget hook call (no await) does not abort the process", async () => {
     // The script returns immediately while agent() is still in flight.
@@ -223,6 +262,45 @@ describe("Sandbox unsettled-hook hygiene", () => {
       const r = await evalScript(`agent(); return "ok"`, hooks)
       expect(r).toBe("ok")
     }
+  })
+})
+
+describe("Sandbox file roundtrip via hooks", () => {
+  test("writeFile + exists + readFile roundtrips correctly (Defect C regression)", async () => {
+    // Regression test: the deep-research script's exists("brief.md") must find
+    // a file that was just written by writeFile("brief.md", content). The
+    // "brief.md not created" bug was a path mismatch between where the agent
+    // wrote and where the sandbox checked — this test verifies the file hook
+    // primitives themselves are consistent.
+    const files = new Map<string, string>()
+    const hooks = {
+      writeFile: async (path: unknown, content: unknown) => {
+        files.set(String(path), String(content))
+      },
+      exists: async (path: unknown) => files.has(String(path)),
+      readFile: async (path: unknown) => files.get(String(path)) ?? null,
+    }
+    const body = `
+      await writeFile("brief.md", "# Research Brief\\nSome content here")
+      const has = await exists("brief.md")
+      const content = await readFile("brief.md")
+      const missing = await exists("nope.md")
+      // readFile returns null for missing files, but the sandbox marshals null
+      // as undefined — check for either.
+      const missingContent = await readFile("nope.md")
+      return { has, content, missing, missingContent }
+    `
+    const result = (await evalScript(body, hooks)) as {
+      has: boolean
+      content: string
+      missing: boolean
+      missingContent: string | undefined
+    }
+    expect(result.has).toBe(true)
+    expect(result.content).toBe("# Research Brief\nSome content here")
+    expect(result.missing).toBe(false)
+    // null is marshaled as undefined in the sandbox (marshalIn maps null → vm.undefined)
+    expect(result.missingContent).toBeUndefined()
   })
 })
 

--- a/packages/opencode/test/workflow/sandbox.test.ts
+++ b/packages/opencode/test/workflow/sandbox.test.ts
@@ -220,31 +220,6 @@ describe("Sandbox args string injection (Defect A regression)", () => {
   })
 })
 
-describe("Sandbox file roundtrip (Defect C regression)", () => {
-  test("writeFile + exists + readFile roundtrip works in sandbox", async () => {
-    // Regression: the deep-research script's exists("brief.md") must find a file
-    // that writeFile("brief.md", ...) created. This roundtrip is the core of the
-    // "brief.md not created" bug.
-    const files = new Map<string, string>()
-    const hooks = {
-      writeFile: async (path: unknown, content: unknown) => { files.set(String(path), String(content)) },
-      exists: async (path: unknown) => files.has(String(path)),
-      readFile: async (path: unknown) => files.get(String(path)) ?? null,
-    }
-    const body = `
-      await writeFile("brief.md", "# Research Brief")
-      const hasBrief = await exists("brief.md")
-      const content = await readFile("brief.md")
-      const hasMissing = await exists("missing.md")
-      return { hasBrief, content, hasMissing }
-    `
-    const result = await evalScript(body, hooks) as { hasBrief: boolean, content: string, hasMissing: boolean }
-    expect(result.hasBrief).toBe(true)
-    expect(result.content).toBe("# Research Brief")
-    expect(result.hasMissing).toBe(false)
-  })
-})
-
 describe("Sandbox unsettled-hook hygiene", () => {
   test("a fire-and-forget hook call (no await) does not abort the process", async () => {
     // The script returns immediately while agent() is still in flight.


### PR DESCRIPTION
## Summary

Fixes the built-in `deep-research` dynamic workflow, which was **completely broken** — a valid run failed at Phase 1 with `brief step failed: brief.md not created`, and callers had to fail 3 times to discover the required args.

## Root cause (path-base mismatch)

The script's own file primitives (`exists`/`readFile`/`writeFile`/`glob`) use **workspace-relative** paths (jailed to the workflow workspace root = `input.workspace ?? Instance.worktree`), but the prompts it handed to `agent()` instructed writing **absolute `${dir}/…`** paths (`args.dir`). Since the workspace root ≠ `args.dir`, the agent wrote `${dir}/brief.md` while the script checked `exists("brief.md")` at the workspace root → always false → Phase 1 threw, and plan/reflect/write/review had the same mismatch.

## Fixes

- **Path consistency**: drop the `${dir}/` prefix from every `agent()` file path (`brief.md`, `findings/F*.md`, `plan`/`reflect` reads, `REPORT.md`, `REVIEW.md`) so agents write where the script's own primitives look. `dir` is now a display-only label in the report header.
- **Args ergonomics** (`tool/workflow.ts`): a bare-string `args` is treated as the question (no more opaque `SyntaxError`); `dir`/`today` are host-injected (`enrichDeepResearchArgs`) so callers needn't hand-pass the date the Date-less sandbox lacks.
- **Docs** (`tool/workflow.txt`): document built-in workflow args.

## Verification
- `bun typecheck` — clean.
- 51 tests pass (sandbox/workspace/builtin), incl. 3 new regression tests: bare-string args, null args, workspace writeFile+exists roundtrip.

Co-authored-by: MiMo-Code <noreply@mimo.xiaomi.com>