### PR TITLE
fix: save/restore scroll position when switching between agent views

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -205,7 +205,7 @@ export function Session() {
     if (evt.type !== "scroll") return
     setScrolling(true)
     if (scrollHideTimer) clearTimeout(scrollHideTimer)
-    scrollHideTimer = setTimeout(() => setScrolling(false), 1000)
+    scrollHideTimer = setTimeout(() => setScrolling(false), 2500)
   }
   onCleanup(() => {
     if (scrollHideTimer) clearTimeout(scrollHideTimer)
@@ -1151,7 +1151,7 @@ export function Session() {
   })
 
   // snap to bottom when session changes
-  createEffect(on(() => route.sessionID, toBottom))
+  createEffect(on(() => route.sessionID, () => { scrollByAgent.clear(); toBottom() }))
 
   // save/restore scroll position when switching between agent views
   createEffect(
@@ -1159,18 +1159,23 @@ export function Session() {
       () => currentAgentID(),
       (agentID, prevAgentID) => {
         if (prevAgentID && scroll && !scroll.isDestroyed) {
-          scrollByAgent.set(prevAgentID, scroll.scrollTop)
+          if (scroll.scrollTop >= scroll.scrollHeight - 1) scrollByAgent.delete(prevAgentID)
+          else scrollByAgent.set(prevAgentID, scroll.scrollTop)
         }
         const saved = scrollByAgent.get(agentID)
         if (saved !== undefined) {
-          setTimeout(() => {
+          let tries = 0
+          const restore = () => {
             if (!scroll || scroll.isDestroyed) return
             scroll.scrollTo(Math.min(saved, scroll.scrollHeight))
-          }, 50)
+            if (++tries < 5 && scroll.scrollTop < saved - 1) setTimeout(restore, 60)
+          }
+          setTimeout(restore, 50)
           return
         }
         toBottom()
       },
+      { defer: true },
     ),
   )
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -281,6 +281,7 @@ export function Session() {
 
   let seeded = false
   let scroll: ScrollBoxRenderable
+  const scrollByAgent = new Map<string, number>()
   let prompt: PromptRef | undefined
   const bind = (r: PromptRef | undefined) => {
     prompt = r
@@ -1151,6 +1152,27 @@ export function Session() {
 
   // snap to bottom when session changes
   createEffect(on(() => route.sessionID, toBottom))
+
+  // save/restore scroll position when switching between agent views
+  createEffect(
+    on(
+      () => currentAgentID(),
+      (agentID, prevAgentID) => {
+        if (prevAgentID && scroll && !scroll.isDestroyed) {
+          scrollByAgent.set(prevAgentID, scroll.scrollTop)
+        }
+        const saved = scrollByAgent.get(agentID)
+        if (saved !== undefined) {
+          setTimeout(() => {
+            if (!scroll || scroll.isDestroyed) return
+            scroll.scrollTo(Math.min(saved, scroll.scrollHeight))
+          }, 50)
+          return
+        }
+        toBottom()
+      },
+    ),
+  )
 
   return (
     <context.Provider

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -343,10 +343,13 @@ export function Session() {
   })
 
   // Helper: Find next visible message boundary in direction
+  // Note: scroll.y is the scrollbox's layout Y, and child.y from getChildren()
+  // is in the same absolute coordinate space (includes scroll offset), so
+  // child.y - scroll.y gives a child's position relative to the viewport top.
   const findNextVisibleMessage = (direction: "next" | "prev"): string | null => {
     const children = scroll.getChildren()
     const messagesList = messages()
-    const scrollTop = scroll.y
+    const viewportTop = scroll.y
 
     // Get visible messages sorted by position, filtering for valid non-synthetic, non-ignored content
     // (a synthetic cron-origin text part is also visible — see the clock-row branch in UserMessage)
@@ -375,10 +378,10 @@ export function Session() {
 
     if (direction === "next") {
       // Find first message below current position
-      return visibleMessages.find((c) => c.y > scrollTop + 10)?.id ?? null
+      return visibleMessages.find((c) => c.y > viewportTop + 10)?.id ?? null
     }
     // Find last message above current position
-    return [...visibleMessages].reverse().find((c) => c.y < scrollTop - 10)?.id ?? null
+    return [...visibleMessages].reverse().find((c) => c.y < viewportTop - 10)?.id ?? null
   }
 
   // Helper: Scroll to message in direction or fallback to page scroll


### PR DESCRIPTION
## Summary

- Save and restore scroll position per agent view (main / subagent) when navigating between them
- If the user was at the bottom when leaving a view, next visit goes to bottom (follows new content)
- If the user was scrolled up (reading history), position is preserved on return
- Retry restoration (5 tries, 60ms) for long conversations where layout may take >50ms
- Increase scrollbar auto-hide timeout from 1s to 2.5s
- Clarify `scroll.y` vs `scroll.scrollTop` semantics with rename and comment

## Supersedes #1510

#1510 addressed the same issue by always snapping to bottom on agentID change. That approach loses the user's reading position when they were scrolled up. This PR replaces it with a smarter save/restore mechanism that:
- Preserves position for users reading history mid-conversation
- Still goes to bottom when the user was already following along (the common case)

## Details

When navigating between main conversation and subagent views, the scroll position was unpredictable — the shared scrollbox preserved its raw `scrollTop` value across content switches, causing the position in the new view to be arbitrary.

This fix uses a per-agent position map:
- On leave: if at bottom (`scrollTop >= scrollHeight - 1`), delete any saved position → next visit defaults to `toBottom()`
- On leave: if scrolled up, save `scrollTop` → next visit restores exact position
- On enter: restore saved position (clamped to current `scrollHeight`) with retry, or `toBottom()` if none saved
- Map cleared on session change to prevent cross-session leaks
- Effect uses `{ defer: true }` to only fire on agent switches, not initial render

Additionally renamed the misleading `const scrollTop = scroll.y` to `viewportTop` — `scroll.y` is the scrollbox's layout position (not scroll offset), which works as a viewport anchor because `child.y` from `getChildren()` is in the same absolute coordinate space.

Fixes #1433