### PR TITLE
feat(workflow): meta.permissions, engine agent retry, and caller-guidance fixes

### DIFF
--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -5,6 +5,7 @@ import { Effect } from "effect"
 import * as Stream from "effect/Stream"
 import { Ripgrep } from "../file/ripgrep"
 import { Skill } from "../skill"
+import { BuiltinWorkflow } from "../workflow/builtin"
 import * as Tool from "./tool"
 import DESCRIPTION from "./skill.txt"
 
@@ -25,6 +26,16 @@ export const SkillTool = Tool.define(
         Effect.gen(function* () {
           const info = yield* skill.get(params.name)
           if (!info) {
+            // A common miss: the name is a built-in WORKFLOW, not a skill (e.g.
+            // the user said "run the naming workflow"). Redirect instead of
+            // dead-ending, so the model calls the workflow tool rather than
+            // giving up and improvising.
+            if (BuiltinWorkflow.get(params.name)) {
+              throw new Error(
+                `"${params.name}" is a built-in WORKFLOW, not a skill. Run it with the workflow tool: ` +
+                  `workflow({ operation: "run", name: "${params.name}", args: { ... } }). Do NOT use the skill tool for it.`,
+              )
+            }
             const all = yield* skill.all()
             const available = all.map((item) => item.name).join(", ")
             throw new Error(`Skill "${params.name}" not found. Available skills: ${available || "none"}`)

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -38,7 +38,12 @@ const runSchema = z.strictObject({
     .describe(
       "(optional) Inline JS workflow script; must begin with `export const meta = {...}`. Provide EITHER name OR script, not both.",
     ),
-  args: z.any().optional().describe("(optional) JSON value exposed to the script as `args`."),
+  args: z
+    .any()
+    .optional()
+    .describe(
+      "(optional) Input value exposed to the script as the global `args`, verbatim. Pass objects/arrays as ACTUAL JSON values — NOT as a JSON string. e.g. args: { theme: \"...\", signals: { trademark: \"required\" } }, never args: \"{ \\\"theme\\\": ... }\".",
+    ),
   workspace: z
     .string()
     .optional()

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -7,6 +7,7 @@ import { ConfigCompose } from "../config"
 import { InstanceState } from "@/effect"
 import { workflowRef } from "@/workflow/runtime-ref"
 import { BuiltinWorkflow } from "@/workflow/builtin"
+import { ActorRegistry } from "@/actor/registry"
 import type { SessionID } from "../session/schema"
 
 const id = "workflow"
@@ -107,10 +108,11 @@ function capTranscript(t: readonly TranscriptEntry[]): TranscriptEntry[] {
   ]
 }
 
-export const WorkflowTool = Tool.define<typeof parameters, Metadata, Config.Service>(
+export const WorkflowTool = Tool.define<typeof parameters, Metadata, Config.Service | ActorRegistry.Service>(
   id,
   Effect.gen(function* () {
     const config = yield* Config.Service
+    const actorRegistry = yield* ActorRegistry.Service
 
     // Resolve the WorkflowRuntime through the late-bound workflowRef rather than as
     // a Layer dependency: pulling WorkflowRuntime.Service in here would push that
@@ -178,6 +180,18 @@ export const WorkflowTool = Tool.define<typeof parameters, Metadata, Config.Serv
             ),
           )
         }
+        // Is a human attached to answer the workflow's up-front manifest
+        // permission ask? A workflow launched from an interactive session actor
+        // (foreground turn, no registered background actor) can prompt the human;
+        // one launched from a BACKGROUND subagent/system actor cannot, so the
+        // engine must ask non-interactively (fail closed) or it would hang forever
+        // on a reply no one can give. Mirrors decideAskRouting's `!askActor.background`:
+        // resolve the launching actor and treat a background actor as non-interactive.
+        // Absent actorID (the main foreground turn) => no background actor => interactive.
+        const askActor = ctx.actorID
+          ? yield* actorRegistry.get(ctx.sessionID as SessionID, ctx.actorID).pipe(Effect.orElseSucceed(() => undefined))
+          : undefined
+        const interactive = !askActor?.background
         const started = yield* runtime.start({
           script,
           sessionID: ctx.sessionID as SessionID,
@@ -186,6 +200,7 @@ export const WorkflowTool = Tool.define<typeof parameters, Metadata, Config.Serv
           workspace: input.workspace,
           maxConcurrentAgents: cfg.workflow?.maxConcurrentAgents,
           scriptDeadlineMs: cfg.workflow?.scriptDeadlineMs,
+          interactive,
           // Only the async (background) path relies on the inbox notification; the
           // sync path below returns the result inline, so suppress the duplicate.
           notifyOnTerminal: input.async === true,

--- a/packages/opencode/src/workflow/meta.ts
+++ b/packages/opencode/src/workflow/meta.ts
@@ -23,6 +23,13 @@ export type WorkflowMeta = {
   whenToUse?: string
   phases?: { title: string; detail?: string }[]
   model?: string
+  // Optional permission manifest: tools/commands the workflow's agents need.
+  // The runtime requests these ONCE at run start in the (interactive) foreground
+  // context, so approval lands in the session ruleset and the workflow's
+  // background subagents inherit it — instead of each subagent hitting an
+  // unanswerable permission prompt that fails closed. Backward-compatible:
+  // absent => today's behavior (no up-front request).
+  permissions?: { permission: string; patterns?: string[]; always?: string[]; reason?: string }[]
 }
 
 export type ParseResult =
@@ -53,6 +60,20 @@ export function parseMeta(script: string): ParseResult {
   if (typeof m.name !== "string" || !m.name) return { ok: false, error: "meta.name (non-empty string) is required" }
   if (typeof m.description !== "string" || !m.description)
     return { ok: false, error: "meta.description (non-empty string) is required" }
+  if (m.permissions !== undefined) {
+    if (!Array.isArray(m.permissions)) return { ok: false, error: "meta.permissions must be an array" }
+    for (const p of m.permissions) {
+      if (typeof p !== "object" || p === null || Array.isArray(p))
+        return { ok: false, error: "each meta.permissions entry must be an object" }
+      const entry = p as Record<string, unknown>
+      if (typeof entry.permission !== "string" || !entry.permission)
+        return { ok: false, error: "each meta.permissions entry needs a non-empty `permission` string" }
+      for (const key of ["patterns", "always"] as const) {
+        if (entry[key] !== undefined && (!Array.isArray(entry[key]) || (entry[key] as unknown[]).some((x) => typeof x !== "string")))
+          return { ok: false, error: `meta.permissions[].${key} must be an array of strings` }
+      }
+    }
+  }
   const endIndex = close + 1 + (script[close + 1] === ";" ? 1 : 0)
   const matched = script.slice(start.index, endIndex)
   const body = script.slice(0, start.index) + matched.replace(/[^\n]/g, " ") + script.slice(endIndex)

--- a/packages/opencode/src/workflow/meta.ts
+++ b/packages/opencode/src/workflow/meta.ts
@@ -72,6 +72,8 @@ export function parseMeta(script: string): ParseResult {
         if (entry[key] !== undefined && (!Array.isArray(entry[key]) || (entry[key] as unknown[]).some((x) => typeof x !== "string")))
           return { ok: false, error: `meta.permissions[].${key} must be an array of strings` }
       }
+      if (entry.reason !== undefined && typeof entry.reason !== "string")
+        return { ok: false, error: "meta.permissions[].reason must be a string" }
     }
   }
   const endIndex = close + 1 + (script[close + 1] === ";" ? 1 : 0)

--- a/packages/opencode/src/workflow/runtime.ts
+++ b/packages/opencode/src/workflow/runtime.ts
@@ -9,6 +9,7 @@ import { Bus } from "@/bus"
 import { Inbox } from "@/inbox"
 import { Worktree } from "@/worktree"
 import { Provider } from "@/provider"
+import { Permission } from "@/permission"
 import { InstanceRef } from "@/effect/instance-ref"
 import { Instance } from "@/project/instance"
 import { Identifier } from "@/id/id"
@@ -223,6 +224,11 @@ interface AgentOpts {
   phase?: string
   /** Per-call override of the run's agentTimeoutMs (ms). */
   timeoutMs?: number
+  /** Opt-in bounded retry of a TRANSIENT failure (spawn-reject / timeout /
+   *  actor-error). Omitted → one attempt (today's behavior). `attempts` is the
+   *  TOTAL attempts including the first (min 1). Terminal reasons (over-cap,
+   *  no-deliverable) are never retried. */
+  retry?: { attempts?: number; baseMs?: number; maxMs?: number }
 }
 
 export interface Interface {
@@ -291,6 +297,10 @@ export const layer = Layer.effect(
     const inbox = yield* Inbox.Service
     const worktree = yield* Worktree.Service
     const provider = yield* Provider.Service
+    // Layer-scoped so its requirement is discharged here (like Config below) and
+    // does not leak into start/resume's effect signatures. Used by launch() to
+    // request a workflow's declared meta.permissions up front.
+    const permissionService = yield* Permission.Service
     // Resolve the Config service handle at layer scope (a legitimate layer dep,
     // satisfied by Config.defaultLayer) so the requirement is discharged here and
     // does NOT leak into start/resume's effect signatures. Only config.get() runs
@@ -623,6 +633,14 @@ export const layer = Layer.effect(
       // null. Pure observability — counters and the agent() return value are
       // unaffected. Wrapped in try/catch so a bus problem can never break a run.
       type FailReason = "over-cap" | "spawn-reject" | "timeout" | "actor-error" | "no-deliverable"
+      // Transient reasons worth re-attempting. Terminal reasons (over-cap =
+      // lifecycle exhausted; no-deliverable = the agent ran fine but produced
+      // nothing, which a re-run won't fix) are NOT retried.
+      const RETRYABLE_REASONS: ReadonlySet<FailReason> = new Set(["spawn-reject", "timeout", "actor-error"])
+      const backoffMs = (attempt: number, baseMs: number, maxMs: number) => {
+        const capped = Math.min(maxMs, baseMs * Math.pow(2, attempt))
+        return Math.floor(Math.random() * capped) // full jitter in [0, capped]
+      }
       const publishAgentFailed = (
         o: AgentOpts,
         reason: FailReason,
@@ -650,6 +668,42 @@ export const layer = Layer.effect(
 
       yield* bus.publish(WorkflowStarted, { sessionID: input.sessionID, runID, name })
 
+      // Up-front permission manifest: the workflow's agents run as background
+      // actors that cannot answer a permission prompt (their asks fail closed).
+      // So here — in the foreground launch context, where a human CAN answer —
+      // request each declared permission ONCE. On "always" the grant lands in the
+      // session ruleset (Permission.reply), and every background subagent sharing
+      // this sessionID inherits it (an allow rule short-circuits before their
+      // non-interactive auto-deny). Denial/rejection does NOT abort the run: the
+      // affected check just falls back or fails closed, per the workflow's own
+      // logic. Best-effort + never-throw so a manifest hiccup can't break launch.
+      const declaredPermissions = parsed.ok ? parsed.meta.permissions : undefined
+      if (declaredPermissions && declaredPermissions.length) {
+        for (const decl of declaredPermissions) {
+          const patterns = decl.patterns && decl.patterns.length ? decl.patterns : decl.always ?? ["*"]
+          yield* permissionService
+            .ask({
+              sessionID: input.sessionID,
+              permission: decl.permission,
+              patterns,
+              always: decl.always ?? patterns,
+              metadata: { workflow: name, ...(decl.reason ? { reason: decl.reason } : {}) },
+              ruleset: [],
+            })
+            .pipe(
+              Effect.catchCause((cause) =>
+                Effect.sync(() => {
+                  log.info("workflow permission not granted up-front", {
+                    runID,
+                    permission: decl.permission,
+                    cause: String(cause),
+                  })
+                }),
+              ),
+            )
+        }
+      }
+
       // Observability-only spawn description from label/phase: "[Phase] label",
       // or just one of them, or undefined (then spawn falls back to agentType —
       // see spawn.ts `input.description ?? input.agentType`). label/phase NEVER
@@ -665,6 +719,11 @@ export const layer = Layer.effect(
       // subagents don't cross-contaminate. context:"none" keeps each worker free
       // of parent history (parallel fan-out is the use case). NEVER throw to the
       // guest for spawn/turn failures — resolve to null so the script continues.
+      // TEST SEAM: MIMOCODE_TEST_SPAWN_FAIL_ONCE=<n> makes the next <n> shared
+      // spawn attempts throw a synthetic spawn-reject (retryable), so a test can
+      // drive the engine retry path deterministically without depending on LLM /
+      // actor failure modes. No-op unless the env var is set. Run-scoped counter.
+      let testSpawnFailsLeft = Number(process.env.MIMOCODE_TEST_SPAWN_FAIL_ONCE ?? 0) || 0
       const spawnShared = async (
         actor: NonNullable<typeof spawnRef.current>,
         prompt: string,
@@ -691,6 +750,10 @@ export const layer = Layer.effect(
         const value = await bridge
           .promise(
             Effect.gen(function* () {
+              if (testSpawnFailsLeft > 0) {
+                testSpawnFailsLeft--
+                return yield* Effect.fail(new Error("test-forced spawn-reject"))
+              }
               const spawned = yield* actor.spawn({
                 mode: "subagent",
                 sessionID: input.sessionID,
@@ -756,7 +819,7 @@ export const layer = Layer.effect(
           publishAgentFailed(o, reason, { actorID, errorMessage })
         }
         scheduleFlush(entry)
-        return value
+        return { value, reason: value !== null ? null : reason }
       }
 
       // Isolated spawn: fresh worktree, file tools rebound to it via Instance.provide.
@@ -786,7 +849,7 @@ export const layer = Layer.effect(
           })
         if (!info) {
           publishAgentFailed(o, "spawn-reject", { errorMessage })
-          return null
+          return { value: null, reason: "spawn-reject" as FailReason }
         }
         // Register the worktree for cleanup the moment it exists on disk — BEFORE
         // the spawn attempt. If spawn rejects or the agent fails, cancel-cleanup
@@ -818,6 +881,10 @@ export const layer = Layer.effect(
             wtBridge
               .promise(
                 Effect.gen(function* () {
+                  if (testSpawnFailsLeft > 0) {
+                    testSpawnFailsLeft--
+                    return yield* Effect.fail(new Error("test-forced spawn-reject"))
+                  }
                   const s = yield* actor.spawn({
                     mode: "subagent",
                     sessionID: input.sessionID,
@@ -903,13 +970,14 @@ export const layer = Layer.effect(
         if (!keep) {
           await bridge.promise(worktree.remove({ directory: info.directory })).catch(() => undefined)
           entry.worktrees.delete(info.directory)
-          return succeeded ? value : null
+          return succeeded ? { value, reason: null } : { value: null, reason }
         }
         // keep: the worktree stays on disk and tracked until an integrate step or
         // cancel reclaims it; surface its branch so the script can act on it.
         const wt = { branch: info.branch, directory: info.directory, changed: true }
-        if (value && typeof value === "object" && !Array.isArray(value)) return { ...(value as object), _worktree: wt }
-        return { _worktree: wt, result: value }
+        if (value && typeof value === "object" && !Array.isArray(value))
+          return { value: { ...(value as object), _worktree: wt }, reason: null }
+        return { value: { _worktree: wt, result: value }, reason: null }
       }
 
       // Per-call start times (host wall-clock) for the observability nodes' durationMs.
@@ -967,20 +1035,38 @@ export const layer = Layer.effect(
             // happens AFTER the slot is released, so file IO never holds a slot.
             const result = await sem.run(async () =>
               globalSemLocal.run(async () => {
-                if (entry.agentCount >= lifecycleCap) {
-                  warnCapOnce()
-                  publishAgentFailed(o, "over-cap")
-                  return null
+                // NOTE: spawnShared counts running/succeeded/failed per ATTEMPT
+                // (each attempt is a real spawn). A call that succeeds on retry N
+                // therefore shows N-1 failed + 1 succeeded — intended: the live
+                // view reflects actual spawns, while the guest sees a single result.
+                const maxAttempts = Math.max(1, o.retry?.attempts ?? 1)
+                const baseMs = o.retry?.baseMs ?? 400
+                const maxMs = o.retry?.maxMs ?? 4000
+                let last: { value: unknown; reason: FailReason | null } = { value: null, reason: "actor-error" }
+                for (let attempt = 0; attempt < maxAttempts; attempt++) {
+                  if (entry.agentCount >= lifecycleCap) {
+                    warnCapOnce()
+                    publishAgentFailed(o, "over-cap")
+                    last = { value: null, reason: "over-cap" }
+                    break
+                  }
+                  entry.agentCount++
+                  const actor = spawnRef.current
+                  if (!actor) throw new Error("Actor service unavailable")
+                  // Resolve the guest's model ref host-side AFTER the journal key was
+                  // computed above (the key hashes the raw `o.model` ref, NOT the
+                  // resolved struct, so resume keys stay stable across config changes).
+                  // Never-throws: an unknown group falls back to input.model.
+                  const resolvedModel = await bridge.promise(resolveAgentModel(o.model, input.model, entry.warnedModelRefs))
+                  last = await spawnShared(actor, promptStr, o, resolvedModel, setActorID)
+                  if (last.value !== null) break // success
+                  if (!last.reason || !RETRYABLE_REASONS.has(last.reason)) break // terminal
+                  if (attempt + 1 < maxAttempts) {
+                    log.info("workflow agent retry", { runID, reason: last.reason, next: attempt + 2, of: maxAttempts })
+                    await new Promise((r) => setTimeout(r, backoffMs(attempt, baseMs, maxMs)))
+                  }
                 }
-                entry.agentCount++
-                const actor = spawnRef.current
-                if (!actor) throw new Error("Actor service unavailable")
-                // Resolve the guest's model ref host-side AFTER the journal key was
-                // computed above (the key hashes the raw `o.model` ref, NOT the
-                // resolved struct, so resume keys stay stable across config changes).
-                // Never-throws: an unknown group falls back to input.model.
-                const resolvedModel = await bridge.promise(resolveAgentModel(o.model, input.model, entry.warnedModelRefs))
-                return spawnShared(actor, promptStr, o, resolvedModel, setActorID)
+                return last.value
               }),
             )
             markAgentNode(result === null ? "failed" : "succeeded", result)
@@ -1001,21 +1087,36 @@ export const layer = Layer.effect(
         }
         return sem.run(async () =>
           globalSemLocal.run(async () => {
-            if (entry.agentCount >= lifecycleCap) {
-              warnCapOnce()
-              publishAgentFailed(o, "over-cap")
-              markAgentNode("failed")
-              return null
+            // Same bounded-retry contract as the shared path; each attempt makes a
+            // fresh worktree (spawnIsolated does this internally + tracks it for
+            // reclaim). markAgentNode flips once, on the final disposition.
+            const maxAttempts = Math.max(1, o.retry?.attempts ?? 1)
+            const baseMs = o.retry?.baseMs ?? 400
+            const maxMs = o.retry?.maxMs ?? 4000
+            let last: { value: unknown; reason: FailReason | null } = { value: null, reason: "actor-error" }
+            for (let attempt = 0; attempt < maxAttempts; attempt++) {
+              if (entry.agentCount >= lifecycleCap) {
+                warnCapOnce()
+                publishAgentFailed(o, "over-cap")
+                last = { value: null, reason: "over-cap" }
+                break
+              }
+              entry.agentCount++
+              const actor = spawnRef.current
+              if (!actor) throw new Error("Actor service unavailable")
+              // Resolve the guest's model ref host-side (isolated agents aren't
+              // journaled, so there's no key to keep stable here). Never-throws.
+              const resolvedModel = await bridge.promise(resolveAgentModel(o.model, input.model, entry.warnedModelRefs))
+              last = await spawnIsolated(actor, promptStr, o, resolvedModel, setActorID)
+              if (last.value !== null) break // success
+              if (!last.reason || !RETRYABLE_REASONS.has(last.reason)) break // terminal
+              if (attempt + 1 < maxAttempts) {
+                log.info("workflow isolated agent retry", { runID, reason: last.reason, next: attempt + 2, of: maxAttempts })
+                await new Promise((r) => setTimeout(r, backoffMs(attempt, baseMs, maxMs)))
+              }
             }
-            entry.agentCount++
-            const actor = spawnRef.current
-            if (!actor) throw new Error("Actor service unavailable")
-            // Resolve the guest's model ref host-side (isolated agents aren't
-            // journaled, so there's no key to keep stable here). Never-throws.
-            const resolvedModel = await bridge.promise(resolveAgentModel(o.model, input.model, entry.warnedModelRefs))
-            const value = await spawnIsolated(actor, promptStr, o, resolvedModel, setActorID)
-            markAgentNode(value === null ? "failed" : "succeeded", value)
-            return value
+            markAgentNode(last.value === null ? "failed" : "succeeded", last.value)
+            return last.value
           }),
         )
       }
@@ -1442,6 +1543,7 @@ export const defaultLayer = layer.pipe(
   Layer.provide(Worktree.defaultLayer),
   Layer.provide(Provider.defaultLayer),
   Layer.provide(Config.defaultLayer),
+  Layer.provide(Permission.defaultLayer),
 )
 
 export * as WorkflowRuntime from "./runtime"

--- a/packages/opencode/src/workflow/runtime.ts
+++ b/packages/opencode/src/workflow/runtime.ts
@@ -207,6 +207,17 @@ interface StartInput {
    * result as its own tool output, so a parent inbox notification would surface a
    * DUPLICATE completion (and duplicate error text) on the next turn. */
   notifyOnTerminal?: boolean
+  /** Is a HUMAN attached to this launch who can answer a permission prompt? The
+   * up-front manifest permission ask uses this to decide `interactive`: a
+   * FOREGROUND launch (a real interactive session actor) prompts the human as
+   * before; a BACKGROUND/NON-INTERACTIVE launcher (a background subagent, a
+   * system actor) — or any NESTED workflow() sub-run (which has no launcher at
+   * all) — asks with `interactive: false` so the permission layer fails CLOSED
+   * (immediate DeniedError) instead of hanging forever on a reply that never
+   * comes. The workflow tool sets this from the launching actor's background
+   * flag; launch() forces it false for nested runs (depth > 0). Defaults to
+   * false (fail-closed) when the launcher can't be determined. */
+  interactive?: boolean
 }
 
 /** Options the guest may pass to `agent(prompt, opts?)`. */
@@ -670,13 +681,26 @@ export const layer = Layer.effect(
 
       // Up-front permission manifest: the workflow's agents run as background
       // actors that cannot answer a permission prompt (their asks fail closed).
-      // So here — in the foreground launch context, where a human CAN answer —
-      // request each declared permission ONCE. On "always" the grant lands in the
-      // session ruleset (Permission.reply), and every background subagent sharing
-      // this sessionID inherits it (an allow rule short-circuits before their
-      // non-interactive auto-deny). Denial/rejection does NOT abort the run: the
-      // affected check just falls back or fails closed, per the workflow's own
-      // logic. Best-effort + never-throw so a manifest hiccup can't break launch.
+      // So here — in the LAUNCH context — request each declared permission ONCE.
+      // On "always" the grant lands in the session ruleset (Permission.reply),
+      // and every background subagent sharing this sessionID inherits it (an allow
+      // rule short-circuits before their non-interactive auto-deny).
+      //
+      // CRITICAL — this ask must NOT hang. It is interactive (blocks for a human
+      // reply) ONLY when a human is actually attached to this launch. A FOREGROUND
+      // launch (interactive session actor) prompts as before. But a BACKGROUND /
+      // NON-INTERACTIVE launcher — a background subagent, a system actor — or any
+      // NESTED workflow() sub-run (depth > 0, spawned by a parent fiber with NO
+      // launcher at all) has no human to answer, so we force interactive:false.
+      // The permission layer then fails CLOSED (immediate DeniedError, no Deferred,
+      // provably cannot hang) exactly as subagent asks do. Effect.catchCause only
+      // rescues failure/denial — it does NOT rescue an indefinite block, so the
+      // interactive flag (not the catch) is what prevents the hang.
+      //
+      // Denial/rejection does NOT abort the run: the affected check just falls back
+      // or fails closed, per the workflow's own logic. Best-effort + never-throw so
+      // a manifest hiccup can't break launch.
+      const askInteractive = depth > 0 ? false : input.interactive === true
       const declaredPermissions = parsed.ok ? parsed.meta.permissions : undefined
       if (declaredPermissions && declaredPermissions.length) {
         for (const decl of declaredPermissions) {
@@ -687,6 +711,7 @@ export const layer = Layer.effect(
               permission: decl.permission,
               patterns,
               always: decl.always ?? patterns,
+              interactive: askInteractive,
               metadata: { workflow: name, ...(decl.reason ? { reason: decl.reason } : {}) },
               ruleset: [],
             })

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -1,5 +1,5 @@
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
-import { Effect, Layer } from "effect"
+import { Cause, Effect, Layer } from "effect"
 import { afterEach, describe, expect } from "bun:test"
 import path from "path"
 import { pathToFileURL } from "url"
@@ -92,6 +92,30 @@ Use this skill.
           expect(result.output).toContain(`<skill_content name="tool-skill">`)
           expect(result.output).toContain(`Base directory for this skill: ${pathToFileURL(skill).href}`)
           expect(result.output).toContain(`<file>${file}</file>`)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("a built-in workflow name redirects to the workflow tool, not a dead-end error", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const registry = yield* ToolRegistry.Service
+          const agent = { name: "build", mode: "primary" as const, permission: [], options: {} }
+          const tool = (yield* registry.tools({
+            providerID: "opencode" as any,
+            modelID: "gpt-5" as any,
+            agent,
+          })).find((tool) => tool.id === SkillTool.id)
+          if (!tool) throw new Error("Skill tool not found")
+          const ctx: Tool.Context = { ...baseCtx, ask: () => Effect.void }
+          const exit = yield* Effect.exit(tool.execute({ name: "fact-check" }, ctx))
+          expect(exit._tag).toBe("Failure")
+          const msg = exit._tag === "Failure" ? Cause.pretty(exit.cause) : ""
+          expect(msg).toContain("built-in WORKFLOW")
+          expect(msg).toContain("workflow tool")
+          expect(msg).toContain('name: "fact-check"')
         }),
       { git: true },
     ),

--- a/packages/opencode/test/workflow/manifest-permission.test.ts
+++ b/packages/opencode/test/workflow/manifest-permission.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, afterEach } from "bun:test"
+import { Effect } from "effect"
+import { Session } from "../../src/session"
+import { Instance } from "../../src/project/instance"
+import { provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { WorkflowRuntime } from "../../src/workflow/runtime"
+import { Permission } from "../../src/permission"
+import { Bus } from "../../src/bus"
+import { makeLayer, ref, providerCfg } from "./lib"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const it = testEffect(makeLayer())
+
+// A workflow whose meta declares a permission the SESSION does NOT already allow.
+// The up-front manifest ask therefore genuinely needs a decision. The body does
+// no agent() call so the run's only permission interaction is the up-front ask.
+const scriptWithManifest = [
+  `export const meta = {`,
+  `  name: "t",`,
+  `  description: "d",`,
+  `  permissions: [{ permission: "bash", patterns: ["rm *"], always: ["rm *"], reason: "cleanup" }],`,
+  `}`,
+  `return "body-ran"`,
+].join("\n")
+
+describe("WorkflowRuntime up-front manifest permission ask", () => {
+  // THE REGRESSION: a workflow launched NON-INTERACTIVELY (background/nested — no
+  // human attached) must NOT hang on the up-front manifest ask. With interactive
+  // omitted (defaults fail-closed) and no session allow-rule, the ask would block
+  // forever if it were interactive; instead the permission layer returns DeniedError
+  // immediately, catchCause swallows it, and the run completes. A bounded wait
+  // proves no hang (a hang would make wait() time out and the run stay "running").
+  it.live("non-interactive launch does NOT hang — fails closed and completes", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const runtime = yield* WorkflowRuntime.Service
+        const session = yield* Session.Service
+        const bus = yield* Bus.Service
+        const asked: string[] = []
+        yield* bus.subscribeCallback(Permission.Event.Asked, (e) => asked.push(e.properties.permission))
+        // NO allow rule -> the manifest ask needs a human decision.
+        const parent = yield* session.create({ title: "wf noninteractive" })
+        // interactive omitted => StartInput default (fail-closed / interactive:false).
+        const { runID } = yield* runtime.start({
+          script: scriptWithManifest,
+          sessionID: parent.id,
+          parentActorID: "main",
+          model: ref,
+        })
+        const outcome = yield* runtime.wait({ runID, timeoutMs: 5_000 })
+        expect(outcome.status).toBe("completed")
+        expect((outcome as { result: string }).result).toBe("body-ran")
+        yield* Effect.sleep("50 millis") // bus is async
+        // Fail-closed path creates NO Deferred and publishes NO Asked event.
+        expect(asked).toEqual([])
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  // The complement: a FOREGROUND launch (interactive:true, a human is attached)
+  // still PROMPTS as before. We prove the ask fires by observing the Asked event
+  // and answering it ("always") so the test itself doesn't block — demonstrating
+  // the interactive path is preserved, not silently forced closed.
+  it.live("interactive launch still prompts the human (Asked event fires)", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const runtime = yield* WorkflowRuntime.Service
+        const session = yield* Session.Service
+        const permission = yield* Permission.Service
+        const bus = yield* Bus.Service
+        const asked: string[] = []
+        // Answer each ask immediately so the interactive ask resolves instead of
+        // blocking the test — the point is that an ask HAPPENS at all.
+        yield* bus.subscribeCallback(Permission.Event.Asked, (e) => {
+          asked.push(e.properties.permission)
+          Effect.runFork(permission.reply({ requestID: e.properties.id, reply: "always" }).pipe(Effect.ignore))
+        })
+        const parent = yield* session.create({ title: "wf interactive" })
+        const { runID } = yield* runtime.start({
+          script: scriptWithManifest,
+          sessionID: parent.id,
+          parentActorID: "main",
+          model: ref,
+          interactive: true,
+        })
+        const outcome = yield* runtime.wait({ runID, timeoutMs: 5_000 })
+        expect(outcome.status).toBe("completed")
+        expect((outcome as { result: string }).result).toBe("body-ran")
+        yield* Effect.sleep("50 millis")
+        expect(asked).toContain("bash")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+})

--- a/packages/opencode/test/workflow/meta.test.ts
+++ b/packages/opencode/test/workflow/meta.test.ts
@@ -139,4 +139,46 @@ describe("workflow meta parser", () => {
       expect(result.meta.description).toBe("d")
     }
   })
+
+  test("parses a valid permissions manifest", () => {
+    const script = [
+      `export const meta = { name: "x", description: "d", permissions: [{ permission: "bash", patterns: ["rm *"], always: ["rm *"], reason: "cleanup" }] }`,
+      `return 1`,
+    ].join("\n")
+    const result = parseMeta(script)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.meta.permissions).toEqual([
+        { permission: "bash", patterns: ["rm *"], always: ["rm *"], reason: "cleanup" },
+      ])
+    }
+  })
+
+  test("rejects permissions that is not an array", () => {
+    const result = parseMeta(`export const meta = { name: "x", description: "d", permissions: "nope" }\nreturn 1`)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain("meta.permissions must be an array")
+  })
+
+  test("rejects a permissions entry missing a permission string", () => {
+    const result = parseMeta(`export const meta = { name: "x", description: "d", permissions: [{ reason: "x" }] }\nreturn 1`)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain("non-empty `permission` string")
+  })
+
+  test("rejects patterns that is not an array of strings", () => {
+    const result = parseMeta(
+      `export const meta = { name: "x", description: "d", permissions: [{ permission: "bash", patterns: [1] }] }\nreturn 1`,
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain("meta.permissions[].patterns must be an array of strings")
+  })
+
+  test("rejects a non-string reason", () => {
+    const result = parseMeta(
+      `export const meta = { name: "x", description: "d", permissions: [{ permission: "bash", reason: 5 }] }\nreturn 1`,
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain("meta.permissions[].reason must be a string")
+  })
 })

--- a/packages/opencode/test/workflow/retry.test.ts
+++ b/packages/opencode/test/workflow/retry.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, afterEach } from "bun:test"
+import { $ } from "bun"
+import { Effect } from "effect"
+import { Session } from "../../src/session"
+import { Instance } from "../../src/project/instance"
+import { provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { WorkflowRuntime } from "../../src/workflow/runtime"
+import { WorkflowAgentFailed } from "../../src/workflow/events"
+import { Worktree } from "../../src/worktree"
+import { Bus } from "../../src/bus"
+import { makeLayer, ref, providerCfg } from "./lib"
+
+afterEach(async () => {
+  delete process.env.MIMOCODE_TEST_SPAWN_FAIL_ONCE
+  await Instance.disposeAll()
+})
+
+const it = testEffect(makeLayer())
+
+// The reliable signal that the ENGINE retried is a WorkflowAgentFailed event:
+// the engine publishes exactly one per FAILED spawn attempt. A transient failure
+// that then succeeds on the engine's retry emits exactly one failed event and a
+// completed run. The MIMOCODE_TEST_SPAWN_FAIL_ONCE seam forces the first N shared
+// spawn attempts to throw a spawn-reject (retryable) deterministically, without
+// depending on LLM/actor failure modes (HTTP errors become terminal
+// no-deliverable, stream errors are retried inside the model layer, hangs don't
+// release for a retry — none of which cleanly drive the engine retry path).
+describe("WorkflowRuntime agent() retry", () => {
+  it.live("retries a spawn-reject and succeeds on the second attempt", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        process.env.MIMOCODE_TEST_SPAWN_FAIL_ONCE = "1" // first spawn attempt throws
+        const runtime = yield* WorkflowRuntime.Service
+        const session = yield* Session.Service
+        const bus = yield* Bus.Service
+        const failed: string[] = []
+        yield* bus.subscribeCallback(WorkflowAgentFailed, (e) => failed.push(e.properties.reason))
+        const parent = yield* session.create({
+          title: "wf retry",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* llm.text("ok") // consumed by the successful retry (attempt 2)
+        const script = [
+          `export const meta = { name: "t", description: "d" }`,
+          `return await agent("go", { retry: { attempts: 2, baseMs: 1, maxMs: 2 } })`,
+        ].join("\n")
+        const { runID } = yield* runtime.start({ script, sessionID: parent.id, parentActorID: "main", model: ref })
+        const outcome = yield* runtime.wait({ runID })
+        expect(outcome.status).toBe("completed")
+        expect((outcome as { result: string }).result).toBe("ok")
+        yield* Effect.sleep("100 millis") // bus is async
+        expect(failed).toEqual(["spawn-reject"]) // exactly one attempt failed, retry succeeded
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  it.live("no retry option => a spawn-reject is not retried (one failed attempt, run returns null)", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        process.env.MIMOCODE_TEST_SPAWN_FAIL_ONCE = "1"
+        const runtime = yield* WorkflowRuntime.Service
+        const session = yield* Session.Service
+        const bus = yield* Bus.Service
+        const failed: string[] = []
+        yield* bus.subscribeCallback(WorkflowAgentFailed, (e) => failed.push(e.properties.reason))
+        const parent = yield* session.create({
+          title: "wf no-retry",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* llm.text("ok") // queued but never consumed — no retry
+        const script = [
+          `export const meta = { name: "t", description: "d" }`,
+          `return await agent("go")`, // no retry opt
+        ].join("\n")
+        const { runID } = yield* runtime.start({ script, sessionID: parent.id, parentActorID: "main", model: ref })
+        const outcome = yield* runtime.wait({ runID })
+        expect(outcome.status).toBe("completed")
+        const v = (outcome as { result: unknown }).result
+        expect(v === null || v === undefined).toBe(true) // agent() returned null
+        yield* Effect.sleep("100 millis")
+        expect(failed).toEqual(["spawn-reject"]) // exactly one attempt, no retry
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  it.live("retry exhausted => still null; every attempt emits a failed event", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        process.env.MIMOCODE_TEST_SPAWN_FAIL_ONCE = "5" // more than attempts -> all fail
+        const runtime = yield* WorkflowRuntime.Service
+        const session = yield* Session.Service
+        const bus = yield* Bus.Service
+        const failed: string[] = []
+        yield* bus.subscribeCallback(WorkflowAgentFailed, (e) => failed.push(e.properties.reason))
+        const parent = yield* session.create({
+          title: "wf exhausted",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const script = [
+          `export const meta = { name: "t", description: "d" }`,
+          `return await agent("go", { retry: { attempts: 3, baseMs: 1, maxMs: 2 } })`,
+        ].join("\n")
+        const { runID } = yield* runtime.start({ script, sessionID: parent.id, parentActorID: "main", model: ref })
+        const outcome = yield* runtime.wait({ runID })
+        expect(outcome.status).toBe("completed")
+        const v = (outcome as { result: unknown }).result
+        expect(v === null || v === undefined).toBe(true)
+        yield* Effect.sleep("100 millis")
+        // 3 attempts, all spawn-reject -> 3 failed events.
+        expect(failed).toEqual(["spawn-reject", "spawn-reject", "spawn-reject"])
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  it.live(
+    "isolated (worktree) agent retries a spawn-reject and succeeds",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ dir, llm }) {
+          process.env.MIMOCODE_TEST_SPAWN_FAIL_ONCE = "1"
+          const runtime = yield* WorkflowRuntime.Service
+          const session = yield* Session.Service
+          const bus = yield* Bus.Service
+          const failed: string[] = []
+          yield* bus.subscribeCallback(WorkflowAgentFailed, (e) => failed.push(e.properties.reason))
+          const parent = yield* session.create({
+            title: "wf retry isolated",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          yield* llm.text("done") // consumed by the successful retry
+          yield* Effect.promise(() => $`git add -A && git commit -q -m wf-config`.cwd(dir).quiet().nothrow())
+          const script = [
+            `export const meta = { name: "t", description: "d" }`,
+            `return await agent("go", { isolation: "worktree", retry: { attempts: 2, baseMs: 1, maxMs: 2 } })`,
+          ].join("\n")
+          const { runID } = yield* runtime.start({ script, sessionID: parent.id, parentActorID: "main", model: ref })
+          const outcome = yield* runtime.wait({ runID })
+          expect(outcome.status).toBe("completed")
+          expect((outcome as { result: unknown }).result).not.toBeNull()
+          yield* Effect.sleep("100 millis")
+          expect(failed).toEqual(["spawn-reject"]) // one failed attempt, retry succeeded
+          const result = (outcome as { result: { _worktree?: { directory?: string } } }).result
+          const wtDir = result?._worktree?.directory
+          if (wtDir) yield* (yield* Worktree.Service).remove({ directory: wtDir }).pipe(Effect.ignore)
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30_000,
+  )
+})


### PR DESCRIPTION
## Summary

Framework-level improvements to the workflow engine and the tools that drive it, extracted from building a workflow. No built-in workflow is added here — these apply to **every** workflow.

- **`meta.permissions` manifest** — a workflow can declare the tools it needs (e.g. `{permission:"bash", always:["whois *"]}`). The runtime requests them **once at run start in the foreground context** (where a human can answer), so the grant lands in the session ruleset and the workflow's **background** subagents inherit it. Background actors' own permission asks fail closed, so this is the only way they can obtain a tool like `whois`. Backward-compatible: no `permissions` ⇒ unchanged behavior.

- **Engine-level `agent()` retry** — opt-in bounded backoff retry of a **transient** spawn failure (`spawn-reject` / `timeout` / `actor-error`) via `agent(prompt, { retry: { attempts, baseMs, maxMs } })`. Terminal reasons (`over-cap`, `no-deliverable`) never retry. Retry holds one concurrency slot across attempts and re-checks the lifecycle cap; `agent()` keeps its never-throw→null contract. `spawnShared`/`spawnIsolated` now return `{value, reason}` so the loop can branch. A `MIMOCODE_TEST_SPAWN_FAIL_ONCE` seam drives the path deterministically in tests.

- **`skill` → `workflow` redirect** — calling `skill({name})` with a built-in **workflow** name previously dead-ended ("Available skills: …"); now it throws a recovery hint pointing at the workflow tool.

- **`workflow` args description** — `args` was `z.any()` with no shape hint, so callers passed a JSON *string* instead of an object. The description now states (like Claude Code) that `args` is exposed verbatim and must be a real JSON value, with a good/bad example.

## Testing

- `bun typecheck` clean.
- New `test/workflow/retry.test.ts` (recover / no-retry / exhaustion / isolated) + updated `test/tool/skill.test.ts` (workflow-name redirect).
- Full workflow suite: **186 pass / 0 fail**.