### PR TITLE
fix(tui): hide Orchestrator from home tips when experiment disabled

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -2,6 +2,7 @@ import { createMemo, createSignal, For, onCleanup } from "solid-js"
 import { DEFAULT_THEMES, useTheme } from "@tui/context/theme"
 import { useLanguage } from "@tui/context/language"
 import { useLocal } from "@tui/context/local"
+import { Flag } from "@/flag/flag"
 
 const themeCount = Object.keys(DEFAULT_THEMES).length
 const TIP_ROTATION_MS = 10_000
@@ -16,6 +17,7 @@ const PRIORITY_WEIGHTS: Record<string, number> = {
   "tui.tips.login": 40,
   "tui.tips.theme_mode": 40,
   "tui.tips.tab_agent": 40,
+  "tui.tips.tab_agent_orchestrator": 40,
   "tui.tips.doc": 30,
   "tui.tips.models": 30,
   "tui.tips.connect": 30,
@@ -29,7 +31,6 @@ const TIP_KEYS = [
   "tui.tips.doc",
   "tui.tips.attach_file",
   "tui.tips.shell_prefix",
-  "tui.tips.tab_agent",
   "tui.tips.undo",
   "tui.tips.redo",
   "tui.tips.share",
@@ -128,6 +129,16 @@ const TIP_KEYS = [
   "tui.tips.rename",
 ] as const
 
+// Build the tip key pool. The Tab-cycle tip mentions the Orchestrator agent
+// only when the experiment is enabled; otherwise use the variant without it so
+// we never point users at an agent that isn't reachable. The platform-specific
+// suspend tip is always appended last.
+export function buildTipKeys(orchestratorEnabled: boolean, platform: NodeJS.Platform): readonly string[] {
+  const tabAgentKey = orchestratorEnabled ? "tui.tips.tab_agent_orchestrator" : "tui.tips.tab_agent"
+  const suspendKey = platform === "win32" ? "tui.tips.suspend.win" : "tui.tips.suspend.unix"
+  return [...TIP_KEYS, tabAgentKey, suspendKey]
+}
+
 type TipPart = { text: string; highlight: boolean }
 
 function parse(tip: string): TipPart[] {
@@ -169,8 +180,7 @@ export function Tips() {
   const theme = useTheme().theme
   const lang = useLanguage()
   const local = useLocal()
-  const platformSuspendKey = process.platform === "win32" ? "tui.tips.suspend.win" : "tui.tips.suspend.unix"
-  const allKeys = [...TIP_KEYS, platformSuspendKey] as readonly string[]
+  const allKeys = buildTipKeys(Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR, process.platform)
   const [key, setKey] = createSignal(pickWeighted(allKeys))
   const interval = setInterval(() => setKey(pickWeighted(allKeys)), TIP_ROTATION_MS)
   onCleanup(() => clearInterval(interval))

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -46,6 +46,8 @@ export const dict: Record<string, string> = {
   "tui.tips.shell_prefix":
     "Start a message with {highlight}!{/highlight} to run shell commands directly (e.g., {highlight}!ls -la{/highlight})",
   "tui.tips.tab_agent":
+    "Press {highlight}Tab{/highlight} or {highlight}Shift+Tab{/highlight} to cycle between Build, Plan, and Compose agents",
+  "tui.tips.tab_agent_orchestrator":
     "Press {highlight}Tab{/highlight} or {highlight}Shift+Tab{/highlight} to cycle between Build, Plan, Compose, and Orchestrator agents",
   "tui.tips.theme_mode":
     "Run {highlight}/dark{/highlight} for dark mode or {highlight}/light{/highlight} for light mode",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -51,6 +51,8 @@ export const dict = {
   "tui.tips.shell_prefix":
     "Empieza un mensaje con {highlight}!{/highlight} para ejecutar comandos del shell directamente (p. ej., {highlight}!ls -la{/highlight})",
   "tui.tips.tab_agent":
+    "Pulsa {highlight}Tab{/highlight} o {highlight}Shift+Tab{/highlight} para alternar entre los agentes Build, Plan y Compose",
+  "tui.tips.tab_agent_orchestrator":
     "Pulsa {highlight}Tab{/highlight} o {highlight}Shift+Tab{/highlight} para alternar entre los agentes Build, Plan, Compose y Orchestrator",
   "tui.tips.theme_mode":
     "Ejecuta {highlight}/dark{/highlight} para el modo oscuro o {highlight}/light{/highlight} para el modo claro",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -51,6 +51,8 @@ export const dict = {
   "tui.tips.shell_prefix":
     "Commencez un message par {highlight}!{/highlight} pour exécuter directement des commandes shell (ex. {highlight}!ls -la{/highlight})",
   "tui.tips.tab_agent":
+    "Appuyez sur {highlight}Tab{/highlight} ou {highlight}Shift+Tab{/highlight} pour basculer entre les agents Build, Plan et Compose",
+  "tui.tips.tab_agent_orchestrator":
     "Appuyez sur {highlight}Tab{/highlight} ou {highlight}Shift+Tab{/highlight} pour basculer entre les agents Build, Plan, Compose et Orchestrator",
   "tui.tips.theme_mode":
     "Exécutez {highlight}/dark{/highlight} pour le mode sombre ou {highlight}/light{/highlight} pour le mode clair",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -50,6 +50,8 @@ export const dict = {
   "tui.tips.shell_prefix":
     "メッセージを {highlight}!{/highlight} で始めるとシェルコマンドを直接実行できます（例：{highlight}!ls -la{/highlight}）",
   "tui.tips.tab_agent":
+    "{highlight}Tab{/highlight} または {highlight}Shift+Tab{/highlight} で Build / Plan / Compose エージェントを切り替えます",
+  "tui.tips.tab_agent_orchestrator":
     "{highlight}Tab{/highlight} または {highlight}Shift+Tab{/highlight} で Build / Plan / Compose / Orchestrator エージェントを切り替えます",
   "tui.tips.theme_mode":
     "{highlight}/dark{/highlight} でダークモード、{highlight}/light{/highlight} でライトモードに切り替えます",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -51,6 +51,8 @@ export const dict = {
   "tui.tips.shell_prefix":
     "Начните сообщение с {highlight}!{/highlight}, чтобы выполнить shell-команду напрямую (например, {highlight}!ls -la{/highlight})",
   "tui.tips.tab_agent":
+    "Нажмите {highlight}Tab{/highlight} или {highlight}Shift+Tab{/highlight}, чтобы переключаться между агентами Build, Plan и Compose",
+  "tui.tips.tab_agent_orchestrator":
     "Нажмите {highlight}Tab{/highlight} или {highlight}Shift+Tab{/highlight}, чтобы переключаться между агентами Build, Plan, Compose и Orchestrator",
   "tui.tips.theme_mode":
     "Выполните {highlight}/dark{/highlight} для тёмного режима или {highlight}/light{/highlight} для светлого",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -49,6 +49,8 @@ export const dict = {
   "tui.tips.attach_file": "输入 {highlight}@{/highlight} 后接文件名以模糊搜索并附加文件",
   "tui.tips.shell_prefix": "以 {highlight}!{/highlight} 开头可直接运行 shell 命令（例如 {highlight}!ls -la{/highlight}）",
   "tui.tips.tab_agent":
+    "按 {highlight}Tab{/highlight} 或 {highlight}Shift+Tab{/highlight} 在 Build / Plan / Compose 智能体之间切换",
+  "tui.tips.tab_agent_orchestrator":
     "按 {highlight}Tab{/highlight} 或 {highlight}Shift+Tab{/highlight} 在 Build / Plan / Compose / Orchestrator 智能体之间切换",
   "tui.tips.theme_mode":
     "运行 {highlight}/dark{/highlight} 切换到深色模式，{highlight}/light{/highlight} 切换到浅色模式",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -49,6 +49,8 @@ export const dict = {
   "tui.tips.attach_file": "輸入 {highlight}@{/highlight} 後接檔案名稱以模糊搜尋並附加檔案",
   "tui.tips.shell_prefix": "以 {highlight}!{/highlight} 開頭可直接執行 shell 指令（例如 {highlight}!ls -la{/highlight}）",
   "tui.tips.tab_agent":
+    "按 {highlight}Tab{/highlight} 或 {highlight}Shift+Tab{/highlight} 在 Build / Plan / Compose 智慧代理之間切換",
+  "tui.tips.tab_agent_orchestrator":
     "按 {highlight}Tab{/highlight} 或 {highlight}Shift+Tab{/highlight} 在 Build / Plan / Compose / Orchestrator 智慧代理之間切換",
   "tui.tips.theme_mode":
     "執行 {highlight}/dark{/highlight} 切換深色模式，{highlight}/light{/highlight} 切換淺色模式",

--- a/packages/opencode/test/cli/cmd/tui/tips-view.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/tips-view.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { buildTipKeys } from "../../../../src/cli/cmd/tui/feature-plugins/home/tips-view"
+
+// buildTipKeys assembles the weighted tip pool. The Tab-cycle tip must only
+// mention the Orchestrator agent when the experiment flag is on; otherwise the
+// Orchestrator-free variant is used so we never point users at an unreachable
+// agent.
+describe("buildTipKeys", () => {
+  test("omits the Orchestrator tab tip when the flag is off", () => {
+    const keys = buildTipKeys(false, "linux")
+    expect(keys).toContain("tui.tips.tab_agent")
+    expect(keys).not.toContain("tui.tips.tab_agent_orchestrator")
+  })
+
+  test("uses the Orchestrator tab tip when the flag is on", () => {
+    const keys = buildTipKeys(true, "linux")
+    expect(keys).toContain("tui.tips.tab_agent_orchestrator")
+    expect(keys).not.toContain("tui.tips.tab_agent")
+  })
+
+  test("includes exactly one tab-agent variant regardless of flag", () => {
+    for (const enabled of [true, false]) {
+      const tabKeys = buildTipKeys(enabled, "linux").filter((k) => k.startsWith("tui.tips.tab_agent"))
+      expect(tabKeys).toHaveLength(1)
+    }
+  })
+
+  test("appends the platform-specific suspend tip", () => {
+    expect(buildTipKeys(false, "win32")).toContain("tui.tips.suspend.win")
+    expect(buildTipKeys(false, "darwin")).toContain("tui.tips.suspend.unix")
+    expect(buildTipKeys(false, "linux")).toContain("tui.tips.suspend.unix")
+  })
+})


### PR DESCRIPTION
## Summary
When the Orchestrator experiment (`Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR`) is **off**, the home-screen tips could still surface the `tui.tips.tab_agent` tip — 'cycle between Build, Plan, Compose, and Orchestrator agents' — pointing users at an agent that isn't reachable via Tab. The tip was selected from the full pool unconditionally.

## Fix
- Split the Tab-cycle tip into two i18n keys:
  - `tui.tips.tab_agent` — Build, Plan, Compose (no Orchestrator), used when the flag is **off**.
  - `tui.tips.tab_agent_orchestrator` — Build, Plan, Compose, Orchestrator, used when the flag is **on**.
- Added a pure, exported `buildTipKeys(orchestratorEnabled, platform)` that assembles the tip-key pool, choosing the correct tab-agent variant and appending the platform-specific suspend tip. `Tips()` now reads `Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR` and calls it.
- Updated all 7 locale files that carried the tip (en, zh, zht, es, fr, ru, ja). Other locales inherit via en fallback.

## Test
- New `test/cli/cmd/tui/tips-view.test.ts`: asserts the Orchestrator key is absent when the flag is off and present when on, exactly one tab-agent variant is included, and the correct suspend tip is appended per platform.

## Verification
- `bun typecheck` → exit 0
- `bun test test/cli/cmd/tui/ test/config/tui.test.ts` → 65 pass, 4 skip, 0 fail