### PR TITLE
feat: migrate theme schema URLs to mimo.xiaomi.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ tsconfig.tsbuildinfo
 .claude/
 *.pid
 .mimo-worktrees
-.mimocode/
 
 # experiment run artifacts (regenerated per run, not source)
 experiment/*.log

--- a/.mimocode/.gitignore
+++ b/.mimocode/.gitignore
@@ -2,6 +2,7 @@ node_modules
 plans
 package.json
 bun.lock
+.gitignore
 package-lock.json
 references/
 .cron-lock

--- a/.mimocode/.gitignore
+++ b/.mimocode/.gitignore
@@ -2,6 +2,7 @@ node_modules
 plans
 package.json
 bun.lock
-.gitignore
 package-lock.json
 references/
+.cron-lock
+scheduled_tasks.json

--- a/.mimocode/plugins/smoke-theme.json
+++ b/.mimocode/plugins/smoke-theme.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "nord0": "#2E3440",
     "nord1": "#3B4252",

--- a/.mimocode/themes/mytheme.json
+++ b/.mimocode/themes/mytheme.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "nord0": "#2E3440",
     "nord1": "#3B4252",

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -43,6 +43,7 @@ import { Global } from "@/global"
 import { Filesystem } from "@/util"
 import { useTuiConfig } from "./tui-config"
 import { isRecord } from "@/util/record"
+import { applyEdits, modify } from "jsonc-parser"
 import type { TuiThemeCurrent } from "@mimo-ai/plugin/tui"
 
 type Theme = TuiThemeCurrent & {
@@ -534,6 +535,8 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   },
 })
 
+const THEME_SCHEMA_URL = "https://mimo.xiaomi.com/mimocode/theme.json"
+
 async function getCustomThemes() {
   const directories = [
     Global.Path.config,
@@ -554,7 +557,18 @@ async function getCustomThemes() {
       symlink: true,
     })) {
       const name = path.basename(item, ".json")
-      result[name] = await Filesystem.readJson(item)
+      const text = await Filesystem.readText(item).catch(() => "")
+      if (!text) continue
+      const data = JSON.parse(text) as ThemeJson
+      if (!data.$schema || data.$schema === "https://opencode.ai/theme.json") {
+        data.$schema = THEME_SCHEMA_URL
+        const edits = modify(text, ["$schema"], THEME_SCHEMA_URL, {
+          formattingOptions: { insertSpaces: true, tabSize: 2 },
+          isArrayInsertion: false,
+        })
+        if (edits.length) await Filesystem.write(item, applyEdits(text, edits)).catch(() => {})
+      }
+      result[name] = data
     }
   }
   return result

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -559,7 +559,8 @@ async function getCustomThemes() {
       const name = path.basename(item, ".json")
       const text = await Filesystem.readText(item).catch(() => "")
       if (!text) continue
-      const data = JSON.parse(text) as ThemeJson
+      let data: ThemeJson
+      try { data = JSON.parse(text) } catch { continue }
       if (!data.$schema || data.$schema === "https://opencode.ai/theme.json") {
         data.$schema = THEME_SCHEMA_URL
         const edits = modify(text, ["$schema"], THEME_SCHEMA_URL, {

--- a/packages/opencode/src/cli/cmd/tui/context/theme/aura.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/aura.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkBg": "#0f0f0f",
     "darkBgPanel": "#15141b",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/ayu.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/ayu.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkBg": "#0B0E14",
     "darkBgAlt": "#0D1017",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/carbonfox.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/carbonfox.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "bg0": "#0d0d0d",
     "bg1": "#161616",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-frappe.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-frappe.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "frappeRosewater": "#f2d5cf",
     "frappeFlamingo": "#eebebe",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-macchiato.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-macchiato.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "macRosewater": "#f4dbd6",
     "macFlamingo": "#f0c6c6",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "lightRosewater": "#dc8a78",
     "lightFlamingo": "#dd7878",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/cobalt2.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/cobalt2.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "background": "#193549",
     "backgroundAlt": "#122738",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/cursor.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/cursor.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkBg": "#181818",
     "darkPanel": "#141414",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/dracula.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/dracula.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "background": "#282a36",
     "currentLine": "#44475a",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/everforest.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/everforest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkStep1": "#2d353b",
     "darkStep2": "#333c43",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/flexoki.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/flexoki.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "black": "#100F0F",
     "base950": "#1C1B1A",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/github.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/github.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkBg": "#0d1117",
     "darkBgAlt": "#010409",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/gruvbox.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/gruvbox.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkBg0": "#282828",
     "darkBg1": "#3c3836",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/kanagawa.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/kanagawa.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "sumiInk0": "#1F1F28",
     "sumiInk1": "#2A2A37",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/lucent-orng.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/lucent-orng.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkStep6": "#3c3c3c",
     "darkStep11": "#808080",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/material.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/material.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkBg": "#263238",
     "darkBgAlt": "#1e272c",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/matrix.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/matrix.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "matrixInk0": "#0a0e0a",
     "matrixInk1": "#0e130d",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/mercury.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/mercury.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "purple-800": "#3442a6",
     "purple-700": "#465bd1",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/mimocode.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/mimocode.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkStep1": "#0a0a0a",
     "darkStep2": "#141414",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/monokai.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/monokai.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "background": "#272822",
     "backgroundAlt": "#1e1f1c",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/nightowl.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/nightowl.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "nightOwlBg": "#011627",
     "nightOwlFg": "#d6deeb",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/nord.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/nord.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "nord0": "#2E3440",
     "nord1": "#3B4252",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/one-dark.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/one-dark.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkBg": "#282c34",
     "darkBgAlt": "#21252b",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/orng.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/orng.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkStep1": "#0a0a0a",
     "darkStep2": "#141414",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/osaka-jade.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/osaka-jade.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkBg0": "#111c18",
     "darkBg1": "#1a2520",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/palenight.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/palenight.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "background": "#292d3e",
     "backgroundAlt": "#1e2132",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/rosepine.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/rosepine.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "base": "#191724",
     "surface": "#1f1d2e",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/solarized.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/solarized.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "base03": "#002b36",
     "base02": "#073642",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/synthwave84.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/synthwave84.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "background": "#262335",
     "backgroundAlt": "#1e1a29",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/tokyonight.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/tokyonight.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "darkStep1": "#1a1b26",
     "darkStep2": "#1e2030",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/vercel.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/vercel.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "background100": "#0A0A0A",
     "background200": "#000000",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/vesper.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/vesper.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "vesperBg": "#101010",
     "vesperFg": "#FFF",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/zenburn.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/zenburn.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/theme.json",
+  "$schema": "https://mimo.xiaomi.com/mimocode/theme.json",
   "defs": {
     "bg": "#3f3f3f",
     "bgAlt": "#4f4f4f",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -640,7 +640,7 @@ export const layer = Layer.effect(
         yield* fs
           .writeFileString(
             gitignore,
-            ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore", ".cron-lock"].join("\n"),
+            ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore", ".cron-lock", "scheduled_tasks.json"].join("\n"),
           )
           .pipe(
             Effect.catchIf(


### PR DESCRIPTION
## Summary

Follow-up to #1511 — migrates all theme file `$schema` URLs from `opencode.ai` to `mimo.xiaomi.com`, adds auto-migration for user custom theme files, and fixes `.mimocode/` tracking in the dev repo.

#1511 的 follow-up：迁移 theme `$schema` URL、添加自定义 theme 自动迁移、修复开发仓库对 `.mimocode/` 的追踪。

## Changes

### Theme schema URL migration

- **33 built-in theme JSON files**: `$schema` updated from `https://opencode.ai/theme.json` to `https://mimo.xiaomi.com/mimocode/theme.json`
- **`.mimocode/plugins/smoke-theme.json`** and **`.mimocode/themes/mytheme.json`**: same URL update
- **`theme.tsx`**: `getCustomThemes()` now auto-migrates custom theme files (in `~/.config/mimocode/themes/` or `.mimocode/themes/`) that have the old URL or no `$schema`, using `jsonc-parser` to preserve formatting

### `.mimocode/` gitignore cleanup

- **Root `.gitignore`**: removed `.mimocode/` rule — the directory is now tracked normally, preventing silent drift (like the `smoke-theme.json` URL missed in this PR, and the `.cron-lock` incident before)
- **`.mimocode/.gitignore`**: removed self-ignore (`.gitignore` entry), added `.cron-lock` and `scheduled_tasks.json`
- **`config.ts` `ensureGitignore`**: added `scheduled_tasks.json` to the auto-generated list so new users get it automatically

## User Impact

- **Built-in themes**: Transparent — editors resolving `$schema` now validate against `mimo.xiaomi.com`
- **Custom themes**: Auto-migrated on first TUI launch. Users see their theme file `$schema` updated silently. No functionality change.
- **New `.mimocode/` setups**: `scheduled_tasks.json` is now auto-ignored (previously could appear as untracked)
- **No breaking changes**

## Verification

- [x] `bun typecheck` passes
- [x] Turbo CI typecheck passes (all 12 packages)
- [x] `git status` clean after removing root `.mimocode/` ignore rule