### PR TITLE
fix(session): stream transcript imports and skip oversized files

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -62,8 +62,11 @@ export const SessionImportClaudeCommand = cmd({
     const stats = await ClaudeImport.run({ force: args.force })
     UI.println(
       `Claude import: scanned ${stats.scanned}, imported ${stats.imported}, resynced ${stats.resynced}, skipped ${stats.skipped}` +
+        (stats.oversized ? `, oversized ${stats.oversized}` : "") +
         (stats.errors.length ? `, errors ${stats.errors.length}` : ""),
     )
+    if (stats.oversized)
+      UI.println(`${stats.oversized} transcript(s) exceeded the import size limit; set MIMOCODE_IMPORT_MAX_FILE_BYTES to raise it (0 disables).`)
     for (const err of stats.errors) UI.error(err)
   },
 })

--- a/packages/opencode/src/session/claude-import.ts
+++ b/packages/opencode/src/session/claude-import.ts
@@ -1,6 +1,5 @@
 import path from "path"
 import { existsSync } from "fs"
-import { readFile } from "fs/promises"
 import { Slug } from "@mimo-ai/shared/util/slug"
 import { Glob } from "@mimo-ai/shared/util/glob"
 import { Global } from "../global"
@@ -14,6 +13,7 @@ import { SessionTable, MessageTable, PartTable } from "./session.sql"
 import { ExternalImportTable } from "./external-import.sql"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
+import { Jsonl } from "./jsonl"
 
 const log = Log.create({ service: "claude-import" })
 
@@ -50,19 +50,11 @@ function stringifyToolContent(content: unknown): string {
 
 type Built = { info: MessageV2.Info; parts: { part: MessageV2.Part; time: number }[] }
 
-function parse(text: string, sessionId: SessionID) {
-  const entries = text
-    .split("\n")
-    .map((l) => l.trim())
-    .filter(Boolean)
-    .flatMap((line) => {
-      try {
-        return [JSON.parse(line)]
-      } catch {
-        return []
-      }
-    })
-  if (entries.length === 0) return undefined
+export async function parse(input: string | AsyncIterable<string>, sessionId: SessionID) {
+  // String input is kept for tests and small payloads; the import path streams
+  // lines so a multi-GB transcript never exists as one JS string (issue #1671).
+  const lines = typeof input === "string" ? input.split("\n") : input
+  let sawEntry = false
 
   let cwd: string | undefined
   let version: string | undefined
@@ -81,7 +73,16 @@ function parse(text: string, sessionId: SessionID) {
     current = null
   }
 
-  for (const entry of entries) {
+  for await (const raw of lines) {
+    const line = raw.trim()
+    if (!line) continue
+    let entry: any
+    try {
+      entry = JSON.parse(line)
+    } catch {
+      continue
+    }
+    sawEntry = true
     if (entry.type !== "user" && entry.type !== "assistant") continue
     const t = entry.timestamp ? Date.parse(entry.timestamp) : Date.now()
     if (!cwd && entry.cwd) cwd = entry.cwd
@@ -213,6 +214,7 @@ function parse(text: string, sessionId: SessionID) {
   }
   flushAssistant()
 
+  if (!sawEntry) return undefined
   return {
     cwd: cwd ?? "",
     version,
@@ -231,9 +233,10 @@ function resolveProject(cwd: string): { id: ProjectID; worktree: string; vcs: st
 
 export async function run(opts?: { force?: boolean }) {
   const root = path.join(Global.Path.home, ".claude", "projects")
-  const stats = { scanned: 0, imported: 0, resynced: 0, skipped: 0, errors: [] as string[] }
+  const stats = { scanned: 0, imported: 0, resynced: 0, skipped: 0, oversized: 0, errors: [] as string[] }
   if (!existsSync(root)) return stats
 
+  const maxBytes = Jsonl.maxImportFileBytes()
   const files = await Glob.scan("*/*.jsonl", { cwd: root, absolute: true })
   for (const file of files) {
     stats.scanned++
@@ -242,6 +245,11 @@ export async function run(opts?: { force?: boolean }) {
       const st = Filesystem.stat(file)
       if (!st) {
         stats.skipped++
+        continue
+      }
+      if (maxBytes > 0 && st.size > maxBytes) {
+        stats.oversized++
+        log.warn("skipping transcript over the import size limit", { file, size: st.size, limit: maxBytes })
         continue
       }
       const mtime = Math.floor(Number(st.mtimeMs))
@@ -272,7 +280,7 @@ export async function run(opts?: { force?: boolean }) {
       }
 
       const sessionId = existing ? existing.session_id : SessionID.descending()
-      const parsed = parse(await readFile(file, "utf-8"), sessionId)
+      const parsed = await parse(Jsonl.lines(file), sessionId)
       if (!parsed || parsed.messages.length === 0) {
         stats.skipped++
         continue
@@ -373,7 +381,7 @@ export async function run(opts?: { force?: boolean }) {
     }
   }
 
-  if (stats.imported + stats.resynced > 0 || stats.errors.length > 0)
+  if (stats.imported + stats.resynced + stats.oversized > 0 || stats.errors.length > 0)
     log.info("claude import", { ...stats, errors: stats.errors.length })
   return stats
 }

--- a/packages/opencode/src/session/codex-import.ts
+++ b/packages/opencode/src/session/codex-import.ts
@@ -1,6 +1,5 @@
 import path from "path"
 import { existsSync } from "fs"
-import { readFile } from "fs/promises"
 import { Slug } from "@mimo-ai/shared/util/slug"
 import { Glob } from "@mimo-ai/shared/util/glob"
 import { Global } from "../global"
@@ -14,6 +13,7 @@ import { SessionTable, MessageTable, PartTable } from "./session.sql"
 import { ExternalImportTable } from "./external-import.sql"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
+import { Jsonl } from "./jsonl"
 
 const log = Log.create({ service: "codex-import" })
 
@@ -43,19 +43,10 @@ function parseArguments(raw: unknown): Record<string, unknown> {
   return {}
 }
 
-export function parse(text: string, sessionId: SessionID) {
-  const entries = text
-    .split("\n")
-    .map((l) => l.trim())
-    .filter(Boolean)
-    .flatMap((line) => {
-      try {
-        return [JSON.parse(line)]
-      } catch {
-        return []
-      }
-    })
-  if (entries.length === 0) return undefined
+export async function parse(input: string | AsyncIterable<string>, sessionId: SessionID) {
+  // String input is kept for tests and small payloads; the import path streams
+  // lines so a multi-GB rollout never exists as one JS string (issue #1671).
+  const lines = typeof input === "string" ? input.split("\n") : input
 
   let cwd: string | undefined
   let version: string | undefined
@@ -116,7 +107,15 @@ export function parse(text: string, sessionId: SessionID) {
     return current
   }
 
-  for (const entry of entries) {
+  for await (const raw of lines) {
+    const line = raw.trim()
+    if (!line) continue
+    let entry: any
+    try {
+      entry = JSON.parse(line)
+    } catch {
+      continue
+    }
     const type = entry.type as string
     const payload = entry.payload as Record<string, unknown> | undefined
     const ts = parseTimestamp(entry.timestamp as string)
@@ -263,14 +262,16 @@ export type ImportStats = {
   imported: number
   resynced: number
   skipped: number
+  oversized: number
   errors: string[]
 }
 
 export async function run(opts?: { force?: boolean }): Promise<ImportStats> {
   const root = path.join(Global.Path.home, ".codex", "sessions")
-  const stats: ImportStats = { scanned: 0, imported: 0, resynced: 0, skipped: 0, errors: [] }
+  const stats: ImportStats = { scanned: 0, imported: 0, resynced: 0, skipped: 0, oversized: 0, errors: [] }
   if (!existsSync(root)) return stats
 
+  const maxBytes = Jsonl.maxImportFileBytes()
   const files = await Glob.scan("**/*.jsonl", { cwd: root, absolute: true })
   for (const file of files) {
     stats.scanned++
@@ -279,6 +280,11 @@ export async function run(opts?: { force?: boolean }): Promise<ImportStats> {
       const st = Filesystem.stat(file)
       if (!st) {
         stats.skipped++
+        continue
+      }
+      if (maxBytes > 0 && st.size > maxBytes) {
+        stats.oversized++
+        log.warn("skipping rollout over the import size limit", { file, size: st.size, limit: maxBytes })
         continue
       }
       const mtime = Math.floor(Number(st.mtimeMs))
@@ -313,7 +319,7 @@ export async function run(opts?: { force?: boolean }): Promise<ImportStats> {
       }
 
       const sessionId = existing ? existing.session_id : SessionID.descending()
-      const parsed = parse(await readFile(file, "utf-8"), sessionId)
+      const parsed = await parse(Jsonl.lines(file), sessionId)
       if (!parsed || parsed.messages.length === 0) {
         stats.skipped++
         continue
@@ -408,7 +414,7 @@ export async function run(opts?: { force?: boolean }): Promise<ImportStats> {
     }
   }
 
-  if (stats.imported + stats.resynced > 0 || stats.errors.length > 0)
+  if (stats.imported + stats.resynced + stats.oversized > 0 || stats.errors.length > 0)
     log.info("codex import", { ...stats, errors: stats.errors.length })
   return stats
 }

--- a/packages/opencode/src/session/external-import.ts
+++ b/packages/opencode/src/session/external-import.ts
@@ -20,6 +20,9 @@ export type ImportStats = {
   imported: number
   resynced: number
   skipped: number
+  // Files skipped for exceeding the import size budget (see Jsonl.maxImportFileBytes).
+  // Optional: the opencode source reads a SQLite DB and never reports it.
+  oversized?: number
   errors: string[]
 }
 

--- a/packages/opencode/src/session/jsonl.ts
+++ b/packages/opencode/src/session/jsonl.ts
@@ -1,0 +1,51 @@
+import { createReadStream } from "fs"
+
+// Multi-GB external transcripts (~/.claude/projects, ~/.codex/sessions) cannot be
+// read with readFile + split("\n"): a single oversized file exceeds the JS string
+// length limit and aborts the process natively, which no try/catch can recover
+// (issue #1671). Importers stream lines instead and skip files over a size budget.
+
+/**
+ * Stream a file's lines without materializing the whole file in memory.
+ * Lines are yielded verbatim (no trimming); a trailing newline does not
+ * produce a final empty line, matching String.split("\n") on "a\nb" vs "a\nb\n"
+ * only in that the phantom last "" is dropped — callers already filter blank lines.
+ */
+export async function* lines(file: string): AsyncGenerator<string> {
+  // The utf8 encoding makes the stream decode statefully, so multi-byte
+  // characters are never split across chunk boundaries.
+  const stream = createReadStream(file, { encoding: "utf8" })
+  try {
+    let buffer = ""
+    for await (const chunk of stream) {
+      buffer += chunk
+      let newline = buffer.indexOf("\n")
+      while (newline !== -1) {
+        yield buffer.slice(0, newline)
+        buffer = buffer.slice(newline + 1)
+        newline = buffer.indexOf("\n")
+      }
+    }
+    if (buffer) yield buffer
+  } finally {
+    stream.destroy()
+  }
+}
+
+export const DEFAULT_MAX_IMPORT_FILE_BYTES = 512 * 1024 * 1024
+
+/**
+ * Per-file size budget for external session imports, in bytes.
+ * Override with MIMOCODE_IMPORT_MAX_FILE_BYTES; 0 disables the guard.
+ * The parsed messages of one transcript are still held in memory for a single
+ * DB transaction, so the guard is what keeps a pathological file from
+ * exhausting memory even with streaming reads.
+ */
+export function maxImportFileBytes(value: string | undefined = process.env["MIMOCODE_IMPORT_MAX_FILE_BYTES"]): number {
+  if (value === undefined || value.trim() === "") return DEFAULT_MAX_IMPORT_FILE_BYTES
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_MAX_IMPORT_FILE_BYTES
+  return Math.floor(parsed)
+}
+
+export * as Jsonl from "./jsonl"

--- a/packages/opencode/test/session/claude-import.test.ts
+++ b/packages/opencode/test/session/claude-import.test.ts
@@ -1,0 +1,131 @@
+import { test, expect, describe } from "bun:test"
+import { parse } from "../../src/session/claude-import"
+import { SessionID } from "../../src/session/schema"
+import { MessageV2 } from "../../src/session/message-v2"
+
+const SID = SessionID.descending()
+
+function userEntry(content: unknown, ts?: string, extra?: Record<string, unknown>) {
+  return JSON.stringify({
+    type: "user",
+    cwd: "/Users/test/project",
+    version: "1.0.0",
+    timestamp: ts ?? "2026-06-01T10:00:00.000Z",
+    message: { role: "user", content },
+    ...extra,
+  })
+}
+
+function assistantEntry(content: unknown[], ts?: string, model?: string, usage?: Record<string, unknown>) {
+  return JSON.stringify({
+    type: "assistant",
+    timestamp: ts ?? "2026-06-01T10:00:05.000Z",
+    message: { role: "assistant", model: model ?? "claude-sonnet-4", usage, content },
+  })
+}
+
+function toolPart(parsed: NonNullable<Awaited<ReturnType<typeof parse>>>) {
+  const parts = parsed.messages.flatMap((m) => m.parts.map((p) => p.part))
+  return parts.find((p): p is MessageV2.ToolPart => p.type === "tool")
+}
+
+describe("claude-import parse", () => {
+  test("parses a standard user/assistant conversation", async () => {
+    const text = [
+      userEntry("hello claude"),
+      assistantEntry([{ type: "text", text: "hello human" }]),
+    ].join("\n")
+    const parsed = await parse(text, SID)
+    expect(parsed).toBeDefined()
+    expect(parsed!.cwd).toBe("/Users/test/project")
+    expect(parsed!.version).toBe("1.0.0")
+    expect(parsed!.title).toBe("hello claude")
+    expect(parsed!.messages.length).toBe(2)
+    expect(parsed!.messages[0].info.role).toBe("user")
+    expect(parsed!.messages[1].info.role).toBe("assistant")
+    expect(parsed!.timeCreated).toBe(Date.parse("2026-06-01T10:00:00.000Z"))
+    expect(parsed!.timeUpdated).toBe(Date.parse("2026-06-01T10:00:05.000Z"))
+  })
+
+  test("patches tool_use with its tool_result", async () => {
+    const text = [
+      userEntry("run a tool"),
+      assistantEntry([{ type: "tool_use", id: "call_1", name: "bash", input: { command: "ls" } }]),
+      userEntry([{ type: "tool_result", tool_use_id: "call_1", content: "file.txt" }], "2026-06-01T10:00:10.000Z"),
+    ].join("\n")
+    const parsed = await parse(text, SID)
+    const tool = toolPart(parsed!)
+    expect(tool).toBeDefined()
+    expect(tool!.tool).toBe("bash")
+    expect(tool!.state.status).toBe("completed")
+    expect((tool!.state as Extract<MessageV2.ToolPart["state"], { status: "completed" }>).output).toBe("file.txt")
+  })
+
+  test("marks errored tool_result as error state", async () => {
+    const text = [
+      userEntry("run a tool"),
+      assistantEntry([{ type: "tool_use", id: "call_1", name: "bash", input: {} }]),
+      userEntry([{ type: "tool_result", tool_use_id: "call_1", content: "boom", is_error: true }], "2026-06-01T10:00:10.000Z"),
+    ].join("\n")
+    const parsed = await parse(text, SID)
+    const tool = toolPart(parsed!)
+    expect(tool!.state.status).toBe("error")
+  })
+
+  test("skips malformed lines and parses valid ones", async () => {
+    const text = ["not json at all", userEntry("still works"), "{broken", assistantEntry([{ type: "text", text: "ok" }])].join("\n")
+    const parsed = await parse(text, SID)
+    expect(parsed).toBeDefined()
+    expect(parsed!.messages.length).toBe(2)
+  })
+
+  test("returns undefined when no line parses as JSON", async () => {
+    expect(await parse("garbage\nmore garbage", SID)).toBeUndefined()
+    expect(await parse("", SID)).toBeUndefined()
+  })
+
+  test("synthesizes a user message when the transcript starts with an assistant turn", async () => {
+    const text = [assistantEntry([{ type: "text", text: "resumed reply" }])].join("\n")
+    const parsed = await parse(text, SID)
+    expect(parsed!.messages.length).toBe(2)
+    expect(parsed!.messages[0].info.role).toBe("user")
+    expect(parsed!.messages[1].info.role).toBe("assistant")
+  })
+
+  test("captures thinking blocks as reasoning parts", async () => {
+    const text = [userEntry("think"), assistantEntry([{ type: "thinking", thinking: "hmm" }, { type: "text", text: "done" }])].join("\n")
+    const parsed = await parse(text, SID)
+    const parts = parsed!.messages[1].parts.map((p) => p.part.type)
+    expect(parts).toEqual(["reasoning", "text"])
+  })
+
+  test("an async iterable of lines produces the same result as the equivalent string", async () => {
+    const lines = [
+      userEntry("hello claude"),
+      assistantEntry([{ type: "tool_use", id: "call_1", name: "bash", input: { command: "ls" } }]),
+      userEntry([{ type: "tool_result", tool_use_id: "call_1", content: "file.txt" }], "2026-06-01T10:00:10.000Z"),
+      assistantEntry([{ type: "text", text: "all done" }], "2026-06-01T10:00:15.000Z"),
+    ]
+    async function* streamed() {
+      for (const line of lines) yield line
+    }
+    const fromString = await parse(lines.join("\n"), SID)
+    const fromStream = await parse(streamed(), SID)
+    expect(fromStream).toBeDefined()
+    // Message/part IDs are freshly generated per parse; compare shape, roles, text and tool states.
+    const shape = (p: NonNullable<typeof fromString>) => ({
+      cwd: p.cwd,
+      title: p.title,
+      timeCreated: p.timeCreated,
+      timeUpdated: p.timeUpdated,
+      messages: p.messages.map((m) => ({
+        role: m.info.role,
+        parts: m.parts.map((x) => {
+          const part = x.part as MessageV2.Part & { text?: string; state?: { status: string; output?: string } }
+          return { type: part.type, text: part.text, status: part.state?.status, output: part.state?.output }
+        }),
+      })),
+    })
+    expect(shape(fromStream!)).toEqual(shape(fromString!))
+  })
+})

--- a/packages/opencode/test/session/codex-import.test.ts
+++ b/packages/opencode/test/session/codex-import.test.ts
@@ -87,14 +87,14 @@ function eventMsg(subtype: string, ts?: string) {
 
 // [TP-R1-01] Standard Codex rollout jsonl parsed correctly
 describe("codex-import parse", () => {
-  test("parses standard conversation with user/assistant messages", () => {
+  test("parses standard conversation with user/assistant messages", async () => {
     const text = [
       sessionMeta(),
       userMessage("Hello, help me with this"),
       assistantMessage("Sure, I can help!"),
     ].join("\n")
 
-    const result = parse(text, SID)
+    const result = await parse(text, SID)
     expect(result).toBeDefined()
     expect(result!.cwd).toBe("/Users/test/project")
     expect(result!.title).toBe("Hello, help me with this")
@@ -112,7 +112,7 @@ describe("codex-import parse", () => {
   })
 
   // [TP-R1-02] Tool use: function_call / function_call_output restored correctly
-  test("restores function_call and function_call_output as ToolPart", () => {
+  test("restores function_call and function_call_output as ToolPart", async () => {
     const text = [
       sessionMeta(),
       userMessage("List files"),
@@ -121,7 +121,7 @@ describe("codex-import parse", () => {
       functionCallOutput("call_abc", "file1.txt\nfile2.txt"),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     expect(result.messages).toHaveLength(2)
 
     const assistant = result.messages[1]
@@ -141,7 +141,7 @@ describe("codex-import parse", () => {
   })
 
   // [TP-R1-02] custom_tool_call (e.g. apply_patch) also restored
-  test("restores custom_tool_call as ToolPart", () => {
+  test("restores custom_tool_call as ToolPart", async () => {
     const text = [
       sessionMeta(),
       userMessage("Apply fix"),
@@ -150,7 +150,7 @@ describe("codex-import parse", () => {
       customToolCallOutput("call_xyz", '{"output":"Success"}'),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     const assistant = result.messages[1]
     const toolParts = assistant.parts.filter((p) => p.part.type === "tool")
     expect(toolParts).toHaveLength(1)
@@ -161,7 +161,7 @@ describe("codex-import parse", () => {
   })
 
   // [TP-R1-03] Reasoning blocks restored
-  test("restores reasoning blocks as reasoning parts", () => {
+  test("restores reasoning blocks as reasoning parts", async () => {
     const text = [
       sessionMeta(),
       userMessage("Think about this"),
@@ -169,7 +169,7 @@ describe("codex-import parse", () => {
       reasoning("I thought about it carefully"),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     const assistant = result.messages[1]
     const reasoningParts = assistant.parts.filter((p) => p.part.type === "reasoning")
     expect(reasoningParts).toHaveLength(1)
@@ -179,17 +179,17 @@ describe("codex-import parse", () => {
   })
 
   // [TP-R1-05] Empty file returns undefined
-  test("returns undefined for empty file", () => {
-    expect(parse("", SID)).toBeUndefined()
+  test("returns undefined for empty file", async () => {
+    expect(await parse("", SID)).toBeUndefined()
   })
 
   // [TP-R1-05] All lines parse failure returns undefined
-  test("returns undefined when all lines fail to parse", () => {
-    expect(parse("not json\nalso not json\n", SID)).toBeUndefined()
+  test("returns undefined when all lines fail to parse", async () => {
+    expect(await parse("not json\nalso not json\n", SID)).toBeUndefined()
   })
 
   // [TP-R1-06] Mixed valid/invalid lines: bad lines skipped, good lines parsed
-  test("skips malformed lines and parses valid ones", () => {
+  test("skips malformed lines and parses valid ones", async () => {
     const text = [
       sessionMeta(),
       "GARBAGE LINE",
@@ -198,35 +198,35 @@ describe("codex-import parse", () => {
       assistantMessage("Hi there"),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     expect(result.messages).toHaveLength(2)
     expect(result.title).toBe("Hello")
   })
 
   // [TP-R1-08] Missing cwd in session_meta
-  test("handles missing cwd gracefully", () => {
+  test("handles missing cwd gracefully", async () => {
     const text = [
       sessionMeta({ cwd: undefined }),
       userMessage("Hello"),
       assistantMessage("Hi"),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     expect(result.cwd).toBe("")
   })
 
   // [TP-R1-09] Only session_meta with no messages → undefined
-  test("returns undefined when only session_meta and no messages", () => {
+  test("returns undefined when only session_meta and no messages", async () => {
     const text = [
       sessionMeta(),
       eventMsg("task_started"),
       eventMsg("task_complete"),
     ].join("\n")
 
-    expect(parse(text, SID)).toBeUndefined()
+    expect(await parse(text, SID)).toBeUndefined()
   })
 
-  test("event_msg lines are ignored (no messages created from them)", () => {
+  test("event_msg lines are ignored (no messages created from them)", async () => {
     const text = [
       sessionMeta(),
       eventMsg("task_started"),
@@ -237,11 +237,11 @@ describe("codex-import parse", () => {
       eventMsg("task_complete"),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     expect(result.messages).toHaveLength(2)
   })
 
-  test("developer role messages treated as user", () => {
+  test("developer role messages treated as user", async () => {
     const text = [
       sessionMeta(),
       line("response_item", {
@@ -252,12 +252,12 @@ describe("codex-import parse", () => {
       assistantMessage("Understood"),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     expect(result.messages).toHaveLength(2)
     expect(result.messages[0].info.role).toBe("user")
   })
 
-  test("timestamps are correctly extracted", () => {
+  test("timestamps are correctly extracted", async () => {
     const t1 = "2026-06-01T09:00:00.000Z"
     const t2 = "2026-06-01T10:00:00.000Z"
     const t3 = "2026-06-01T11:00:00.000Z"
@@ -267,26 +267,26 @@ describe("codex-import parse", () => {
       assistantMessage("Hi", t3),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     expect(result.timeCreated).toBe(Date.parse(t1))
     expect(result.timeUpdated).toBe(Date.parse(t3))
   })
 
   // [TP-R1-04] Verify multiple files would create separate sessions (parse only)
-  test("sessionUuid is extracted from session_meta", () => {
+  test("sessionUuid is extracted from session_meta", async () => {
     const text = [
       sessionMeta({ id: "custom-uuid-123" }),
       userMessage("Hi"),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     expect(result.sessionUuid).toBe("custom-uuid-123")
   })
 
   // [TP-R1-03] Reasoning emitted BEFORE the first assistant text must not be dropped.
   // Codex routinely writes a reasoning item ahead of the assistant message; an
   // earlier version dropped it because no assistant message was open yet.
-  test("restores reasoning that precedes the first assistant message", () => {
+  test("restores reasoning that precedes the first assistant message", async () => {
     const text = [
       sessionMeta(),
       userMessage("Think first"),
@@ -294,7 +294,7 @@ describe("codex-import parse", () => {
       assistantMessage("Done thinking"),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     const assistant = result.messages.find((m) => m.info.role === "assistant")!
     const reasoningParts = assistant.parts.filter((p) => p.part.type === "reasoning")
     expect(reasoningParts).toHaveLength(1)
@@ -307,7 +307,7 @@ describe("codex-import parse", () => {
 
   // [TP-R1-02] A tool call emitted before any assistant text must still be captured,
   // along with its later output (which would otherwise be orphaned).
-  test("restores function_call that precedes the first assistant message", () => {
+  test("restores function_call that precedes the first assistant message", async () => {
     const text = [
       sessionMeta(),
       userMessage("Run it"),
@@ -316,7 +316,7 @@ describe("codex-import parse", () => {
       assistantMessage("Here is the result"),
     ].join("\n")
 
-    const result = parse(text, SID)!
+    const result = (await parse(text, SID))!
     const assistant = result.messages.find((m) => m.info.role === "assistant")!
     const toolParts = assistant.parts.filter((p) => p.part.type === "tool")
     expect(toolParts).toHaveLength(1)

--- a/packages/opencode/test/session/jsonl.test.ts
+++ b/packages/opencode/test/session/jsonl.test.ts
@@ -1,0 +1,83 @@
+import { test, expect, describe } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { Jsonl } from "../../src/session/jsonl"
+
+async function tmpfile(content: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "mimocode-jsonl-test-"))
+  const file = path.join(dir, "data.jsonl")
+  await fs.writeFile(file, content)
+  return {
+    file,
+    async [Symbol.asyncDispose]() {
+      await fs.rm(dir, { recursive: true, force: true })
+    },
+  }
+}
+
+async function collect(file: string) {
+  const out: string[] = []
+  for await (const line of Jsonl.lines(file)) out.push(line)
+  return out
+}
+
+describe("Jsonl.lines", () => {
+  test("yields the same lines as String.split", async () => {
+    const content = ["{}", '{"a":1}', "", "last"].join("\n")
+    await using tmp = await tmpfile(content)
+    expect(await collect(tmp.file)).toEqual(content.split("\n"))
+  })
+
+  test("handles a trailing newline without emitting a phantom line", async () => {
+    await using tmp = await tmpfile('{"a":1}\n{"b":2}\n')
+    expect(await collect(tmp.file)).toEqual(['{"a":1}', '{"b":2}'])
+  })
+
+  test("yields lines longer than the stream chunk size intact", async () => {
+    // fs.ReadStream default highWaterMark is 64KB; make one line span multiple chunks.
+    const long = '{"text":"' + "x".repeat(256 * 1024) + '"}'
+    await using tmp = await tmpfile(`${long}\n{"tail":true}\n`)
+    const lines = await collect(tmp.file)
+    expect(lines).toEqual([long, '{"tail":true}'])
+    expect(JSON.parse(lines[0]).text.length).toBe(256 * 1024)
+  })
+
+  test("preserves CRLF carriage returns for the caller to trim", async () => {
+    await using tmp = await tmpfile('{"a":1}\r\n{"b":2}\r\n')
+    expect(await collect(tmp.file)).toEqual(['{"a":1}\r', '{"b":2}\r'])
+  })
+
+  test("does not split multi-byte UTF-8 characters across chunks", async () => {
+    // 3-byte CJK chars at a size that guarantees chunk boundaries land mid-character.
+    const cjk = "汉".repeat(64 * 1024)
+    await using tmp = await tmpfile(`${cjk}\n`)
+    expect(await collect(tmp.file)).toEqual([cjk])
+  })
+
+  test("empty file yields nothing", async () => {
+    await using tmp = await tmpfile("")
+    expect(await collect(tmp.file)).toEqual([])
+  })
+})
+
+describe("Jsonl.maxImportFileBytes", () => {
+  test("defaults to 512MB when unset or blank", () => {
+    expect(Jsonl.maxImportFileBytes(undefined)).toBe(Jsonl.DEFAULT_MAX_IMPORT_FILE_BYTES)
+    expect(Jsonl.maxImportFileBytes("")).toBe(Jsonl.DEFAULT_MAX_IMPORT_FILE_BYTES)
+    expect(Jsonl.maxImportFileBytes("  ")).toBe(Jsonl.DEFAULT_MAX_IMPORT_FILE_BYTES)
+  })
+
+  test("accepts a numeric override in bytes", () => {
+    expect(Jsonl.maxImportFileBytes("1048576")).toBe(1048576)
+  })
+
+  test("0 disables the guard", () => {
+    expect(Jsonl.maxImportFileBytes("0")).toBe(0)
+  })
+
+  test("falls back to the default on garbage or negative values", () => {
+    expect(Jsonl.maxImportFileBytes("not-a-number")).toBe(Jsonl.DEFAULT_MAX_IMPORT_FILE_BYTES)
+    expect(Jsonl.maxImportFileBytes("-5")).toBe(Jsonl.DEFAULT_MAX_IMPORT_FILE_BYTES)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #1671

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Claude/Codex session importers read each `.jsonl` with `readFile` + `split("\n")`. A multi-GB transcript exceeds the JS string length limit and the process aborts natively — the `try/catch` around `ClaudeImport.run()` never sees it, so with the import in the startup path (until #1075 lands) the app is bricked by one oversized file.

Two changes, matching suggestions 1 and 3 from the issue:

1. **Stream, don't slurp** — `parse()` now consumes an (async) iterable of lines; the import path feeds it a line generator over `createReadStream` (new `session/jsonl.ts`). The file never exists as one string. `parse()` still accepts a plain string, so existing unit tests only gained an `await`.
2. **Size budget** — files over `MIMOCODE_IMPORT_MAX_FILE_BYTES` (default 512 MB, `0` disables) are skipped up front with a warn log, an `oversized` stat, and a CLI hint. This is needed even with streaming because one transcript's parsed messages are still held in memory for the single DB transaction — measured ~3.4 GB peak RSS for a 600 MB file — so an unbounded file would still exhaust memory, just later.

`codex-import.ts` gets the same treatment (identical `readFile`+`split` pattern on `~/.codex/sessions`). Deliberately **not** touching the startup call in `index.ts` — that's #1075's scope and this PR does not conflict with it.

### How did you verify your code works?

Repro + before/after on macOS (32 GB RAM), 2.5 GB synthetic transcript in `~/.claude/projects/`:

| | `mimo --help` | peak RSS |
|---|---|---|
| main | exit 133 (SIGTRAP), no output, dies after `applying migrations` | 3.0 GB |
| this PR | exit 0, full help, transcript skipped as oversized | 548 MB |

- `session import-claude` prints `scanned 1, imported 0, resynced 0, skipped 0, oversized 1` plus the env-var hint.
- Real small session imports correctly end-to-end: verified session/message/part/external_import rows in SQLite, including `tool_result` back-patching onto the earlier `tool_use` part.
- 600 MB file with `MIMOCODE_IMPORT_MAX_FILE_BYTES=0`: streams through and imports fine (exit 0, 601 parts).
- `bun test test/session/jsonl.test.ts test/session/claude-import.test.ts test/session/codex-import.test.ts`: 33 pass. New tests cover chunk-boundary line splitting, CRLF, multi-byte UTF-8 across chunks, and string-vs-stream parse equivalence.
- `bun typecheck` clean; oxlint: no new warnings (the touched files actually dropped from 30 to 28).

### Screenshots / recordings

n/a (CLI)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
