### PR TITLE
fix: scroll position not saved on first subagent navigation

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1161,7 +1161,8 @@ export function Session() {
     on(
       () => currentAgentID(),
       (agentID, prevAgentID) => {
-        if (prevAgentID && scroll && !scroll.isDestroyed) {
+        if (!prevAgentID) return
+        if (scroll && !scroll.isDestroyed) {
           if (scroll.scrollTop >= scroll.scrollHeight - 1) scrollByAgent.delete(prevAgentID)
           else scrollByAgent.set(prevAgentID, scroll.scrollTop)
         }
@@ -1178,7 +1179,6 @@ export function Session() {
         }
         toBottom()
       },
-      { defer: true },
     ),
   )
 


### PR DESCRIPTION
## Summary

Fixes a bug in #1685 where scroll position was not preserved on the **first** subagent enter/exit cycle.

## Root Cause

SolidJS `on()` with `{ defer: true }` passes `undefined` as `prevValue` on the first trigger (not the initial value). This meant the first time a user navigated into a subagent, `prevAgentID` was `undefined`, the save was skipped, and exiting fell through to `toBottom()`.

Second and subsequent navigations worked correctly because `prevAgentID` was properly set from then on.

## Fix

Remove `{ defer: true }` and add an early return on `!prevAgentID` (which only occurs on initial mount). The session-change effect already handles the initial `toBottom()`, so no duplicate operation occurs.