### PR TITLE
fix(tui): fix slash autocomplete mid-message bugs and add skill i18n

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -21,7 +21,7 @@ import { Flag } from "@/flag/flag"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
 import { detectTrigger } from "./autocomplete-detect"
-import { charAfterCursor } from "./offset"
+import { charAfterCursor, widthToStringIndex, stringIndexToWidth } from "./offset"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -530,12 +530,19 @@ export function Autocomplete(props: {
   function clearTriggerRange() {
     if (store.visible !== "/") return
     const input = props.input()
-    const currentCursorOffset = input.cursorOffset
+    const text = input.plainText
+    // Find end of the slash token (next whitespace or end of text)
+    const startIdx = widthToStringIndex(text, store.index)
+    let endIdx = startIdx
+    while (endIdx < text.length && !/\s/.test(text[endIdx]!)) endIdx++
+    const endWidth = stringIndexToWidth(text, endIdx)
+
     input.cursorOffset = store.index
     const startCursor = input.logicalCursor
-    input.cursorOffset = currentCursorOffset
+    input.cursorOffset = endWidth
     const endCursor = input.logicalCursor
     input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
+    input.cursorOffset = store.index
     props.setPrompt((draft) => {
       draft.input = input.plainText
     })

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -377,6 +377,7 @@ export function Autocomplete(props: {
       if (serverCommand.source === "skill" && !isCompose && serverCommand.name.startsWith("compose:")) continue
       const label = serverCommand.source === "mcp" ? ":mcp" : ""
       const desc = serverCommand.source === "skill"
+        // Command schema lacks `bundled`; pass true to attempt i18n lookup — falls back to raw description for non-bundled skills
         ? skillDescription(lang.t, serverCommand.name, serverCommand.description, true)
         : slashCommandDescription(lang.t, serverCommand.name, serverCommand.description)
       results.push({

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -21,7 +21,7 @@ import { Flag } from "@/flag/flag"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
 import { detectTrigger } from "./autocomplete-detect"
-import { charAfterCursor, widthToStringIndex, stringIndexToWidth } from "./offset"
+import { charAfterCursor, tokenEndWidth } from "./offset"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -535,12 +535,7 @@ export function Autocomplete(props: {
   function clearTriggerRange() {
     if (store.visible !== "/") return
     const input = props.input()
-    const text = input.plainText
-    // Find end of the slash token (next whitespace or end of text)
-    const startIdx = widthToStringIndex(text, store.index)
-    let endIdx = startIdx
-    while (endIdx < text.length && !/\s/.test(text[endIdx]!)) endIdx++
-    const endWidth = stringIndexToWidth(text, endIdx)
+    const endWidth = tokenEndWidth(input.plainText, store.index)
 
     input.cursorOffset = store.index
     const startCursor = input.logicalCursor

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -488,21 +488,7 @@ export function Autocomplete(props: {
   function select() {
     const selected = options()[store.selected]
     if (!selected) return
-    // Clear the trigger range so onSelect works on a clean slate.
-    // Server command onSelect re-inserts at the same position; client-side
-    // slashes just fire their action with the trigger text removed.
-    if (store.visible === "/") {
-      const input = props.input()
-      const currentCursorOffset = input.cursorOffset
-      input.cursorOffset = store.index
-      const startCursor = input.logicalCursor
-      input.cursorOffset = currentCursorOffset
-      const endCursor = input.logicalCursor
-      input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
-      props.setPrompt((draft) => {
-        draft.input = input.plainText
-      })
-    }
+    clearTriggerRange()
     hide()
     selected.onSelect?.()
   }
@@ -539,6 +525,20 @@ export function Autocomplete(props: {
   function hide() {
     command.keybinds(true)
     setStore("visible", false)
+  }
+
+  function clearTriggerRange() {
+    if (store.visible !== "/") return
+    const input = props.input()
+    const currentCursorOffset = input.cursorOffset
+    input.cursorOffset = store.index
+    const startCursor = input.logicalCursor
+    input.cursorOffset = currentCursorOffset
+    const endCursor = input.logicalCursor
+    input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
+    props.setPrompt((draft) => {
+      draft.input = input.plainText
+    })
   }
 
   onMount(() => {
@@ -588,6 +588,7 @@ export function Autocomplete(props: {
             return
           }
           if (name === "escape") {
+            clearTriggerRange()
             hide()
             e.preventDefault()
             return

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -14,6 +14,7 @@ import { SplitBorder } from "@tui/component/border"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useLanguage } from "@tui/context/language"
 import { slashCommandDescription } from "@tui/i18n/slash-command"
+import { skillDescription } from "@tui/i18n/skill"
 import { useTerminalDimensions } from "@opentui/solid"
 import { Locale } from "@/util"
 import { Flag } from "@/flag/flag"
@@ -375,9 +376,12 @@ export function Autocomplete(props: {
       if (serverCommand.source === "skill" && Flag.MIMOCODE_DISABLE_SLASH_SKILLS) continue
       if (serverCommand.source === "skill" && !isCompose && serverCommand.name.startsWith("compose:")) continue
       const label = serverCommand.source === "mcp" ? ":mcp" : ""
+      const desc = serverCommand.source === "skill"
+        ? skillDescription(lang.t, serverCommand.name, serverCommand.description, true)
+        : slashCommandDescription(lang.t, serverCommand.name, serverCommand.description)
       results.push({
         display: "/" + serverCommand.name + label,
-        description: slashCommandDescription(lang.t, serverCommand.name, serverCommand.description),
+        description: desc,
         onSelect: () => {
           const input = props.input()
           const needsSpace = charAfterCursor(props.value, input.cursorOffset) !== " "
@@ -511,14 +515,15 @@ export function Autocomplete(props: {
   }
 
   function hide() {
-    const text = props.input().plainText
-    if (store.visible === "/" && !text.endsWith(" ") && text.startsWith("/")) {
-      const cursor = props.input().logicalCursor
-      props.input().deleteRange(0, 0, cursor.row, cursor.col)
-      // Sync the prompt store immediately since onContentChange is async
-      props.setPrompt((draft) => {
-        draft.input = props.input().plainText
-      })
+    if (store.visible === "/" && store.index === 0) {
+      const text = props.input().plainText
+      if (!text.endsWith(" ") && text.startsWith("/")) {
+        const cursor = props.input().logicalCursor
+        props.input().deleteRange(0, 0, cursor.row, cursor.col)
+        props.setPrompt((draft) => {
+          draft.input = props.input().plainText
+        })
+      }
     }
     command.keybinds(true)
     setStore("visible", false)
@@ -536,8 +541,8 @@ export function Autocomplete(props: {
             props.input().cursorOffset <= store.index ||
             // There is a space between the trigger and the cursor
             props.input().getTextRange(store.index, props.input().cursorOffset).match(/\s/) ||
-            // "/<command>" is not the sole content
-            (store.visible === "/" && value.match(/^\S+\s+\S+\s*$/))
+            // Position-0 slash: dismiss when input has command + args (e.g. "/init foo")
+            (store.visible === "/" && store.index === 0 && value.match(/^\S+\s+\S+\s*$/))
           ) {
             hide()
           }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -368,10 +368,13 @@ export function Autocomplete(props: {
       )
   })
 
-  const [skillMap] = createResource(async () => {
-    const result = await sdk.client.app.skills()
-    return new Map((result.data ?? []).map((s) => [s.name, s]))
-  })
+  const [skillMap] = createResource(
+    () => store.visible === "/" || undefined,
+    async () => {
+      const result = await sdk.client.app.skills()
+      return new Map((result.data ?? []).map((s) => [s.name, s]))
+    },
+  )
 
   const commands = createMemo((): AutocompleteOption[] => {
     const results: AutocompleteOption[] = [...command.slashes()]

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -481,6 +481,21 @@ export function Autocomplete(props: {
   function select() {
     const selected = options()[store.selected]
     if (!selected) return
+    // Clear the trigger range so onSelect works on a clean slate.
+    // Server command onSelect re-inserts at the same position; client-side
+    // slashes just fire their action with the trigger text removed.
+    if (store.visible === "/") {
+      const input = props.input()
+      const currentCursorOffset = input.cursorOffset
+      input.cursorOffset = store.index
+      const startCursor = input.logicalCursor
+      input.cursorOffset = currentCursorOffset
+      const endCursor = input.logicalCursor
+      input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
+      props.setPrompt((draft) => {
+        draft.input = input.plainText
+      })
+    }
     hide()
     selected.onSelect?.()
   }
@@ -515,16 +530,6 @@ export function Autocomplete(props: {
   }
 
   function hide() {
-    if (store.visible === "/" && store.index === 0) {
-      const text = props.input().plainText
-      if (!text.endsWith(" ") && text.startsWith("/")) {
-        const cursor = props.input().logicalCursor
-        props.input().deleteRange(0, 0, cursor.row, cursor.col)
-        props.setPrompt((draft) => {
-          draft.input = props.input().plainText
-        })
-      }
-    }
     command.keybinds(true)
     setStore("visible", false)
   }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -368,17 +368,23 @@ export function Autocomplete(props: {
       )
   })
 
+  const [skillMap] = createResource(async () => {
+    const result = await sdk.client.app.skills()
+    return new Map((result.data ?? []).map((s) => [s.name, s]))
+  })
+
   const commands = createMemo((): AutocompleteOption[] => {
     const results: AutocompleteOption[] = [...command.slashes()]
 
     const isCompose = local.agent.current()?.name === "compose"
+    const skills = skillMap()
     for (const serverCommand of sync.data.command) {
       if (serverCommand.source === "skill" && Flag.MIMOCODE_DISABLE_SLASH_SKILLS) continue
       if (serverCommand.source === "skill" && !isCompose && serverCommand.name.startsWith("compose:")) continue
       const label = serverCommand.source === "mcp" ? ":mcp" : ""
-      const desc = serverCommand.source === "skill"
-        // Command schema lacks `bundled`; pass true to attempt i18n lookup — falls back to raw description for non-bundled skills
-        ? skillDescription(lang.t, serverCommand.name, serverCommand.description, true)
+      const info = serverCommand.source === "skill" ? skills?.get(serverCommand.name) : undefined
+      const desc = info
+        ? skillDescription(lang.t, info.name, info.description, info.bundled)
         : slashCommandDescription(lang.t, serverCommand.name, serverCommand.description)
       results.push({
         display: "/" + serverCommand.name + label,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -397,6 +397,8 @@ export function Autocomplete(props: {
           const needsSpace = charAfterCursor(props.value, input.cursorOffset) !== " "
           const append = "/" + serverCommand.name + (needsSpace ? " " : "")
 
+          // clearTriggerRange() already deleted the token and set cursor to store.index,
+          // so start === end here (no-op delete). Kept for robustness if called from other paths.
           const currentCursorOffset = input.cursorOffset
           input.cursorOffset = store.index
           const startCursor = input.logicalCursor
@@ -562,9 +564,7 @@ export function Autocomplete(props: {
             // Typed text before the trigger
             props.input().cursorOffset <= store.index ||
             // There is a space between the trigger and the cursor
-            props.input().getTextRange(store.index, props.input().cursorOffset).match(/\s/) ||
-            // Position-0 slash: dismiss when input has command + args (e.g. "/init foo")
-            (store.visible === "/" && store.index === 0 && value.match(/^\S+\s+\S+\s*$/))
+            props.input().getTextRange(store.index, props.input().cursorOffset).match(/\s/)
           ) {
             hide()
           }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/offset.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/offset.ts
@@ -43,3 +43,12 @@ export function stringIndexToWidth(text: string, stringIndex: number): number {
 export function charAfterCursor(text: string, cursorWidth: number): string | undefined {
   return text.at(widthToStringIndex(text, cursorWidth))
 }
+
+// Find the display-width position of the end of the token starting at `startWidth`.
+// A token ends at the next whitespace character or end of text.
+export function tokenEndWidth(text: string, startWidth: number): number {
+  const startIdx = widthToStringIndex(text, startWidth)
+  let endIdx = startIdx
+  while (endIdx < text.length && !/\s/.test(text[endIdx]!)) endIdx++
+  return stringIndexToWidth(text, endIdx)
+}

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -210,6 +210,7 @@ export const dict: Record<string, string> = {
   "tui.skill.html-to-video-pipeline.description": "Short-video magic — make short videos with HTML",
   "tui.skill.arxiv.description": "Search, cite, download, and track arXiv papers",
   "tui.skill.skill-creator.description": "Create, review, and improve agent skills",
+  "tui.skill.drive-mimo.description": "Programmatically drive another MiMoCode process — headless JSON events or interactive TUI via tmux",
   "tui.skill.research-paper-writing.description": "Draft, polish, and reviewer-style critique for academic papers",
   "tui.skill.design-blueprint.description":
     "Produce a design blueprint (DESIGN.md + Decision Trace) before mocking up any visual",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -286,6 +286,7 @@ export const dict = {
   "tui.skill.html-to-video-pipeline.description": "El arma definitiva para vídeos cortos — crea vídeos cortos con HTML",
   "tui.skill.arxiv.description": "Busca, cita, descarga y sigue artículos de arXiv",
   "tui.skill.skill-creator.description": "Crea, revisa y mejora skills de agente",
+  "tui.skill.drive-mimo.description": "Controla programáticamente otro proceso MiMoCode — eventos JSON headless o TUI interactiva vía tmux",
   "tui.skill.research-paper-writing.description": "Redacta, pule y critica artículos académicos con perspectiva de revisor",
   "tui.skill.design-blueprint.description":
     "Producir un plano de diseño (DESIGN.md + Decision Trace) antes de crear cualquier mockup",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -274,6 +274,7 @@ export const dict = {
   "tui.skill.html-to-video-pipeline.description": "L'arme ultime pour vidéos courtes — créez des vidéos courtes avec du HTML",
   "tui.skill.arxiv.description": "Rechercher, citer, télécharger et suivre des articles arXiv",
   "tui.skill.skill-creator.description": "Créer, réviser et améliorer des skills d'agent",
+  "tui.skill.drive-mimo.description": "Piloter un autre processus MiMoCode — événements JSON headless ou TUI interactive via tmux",
   "tui.skill.research-paper-writing.description": "Rédiger, polir et critiquer des articles académiques avec l'œil d'un relecteur",
   "tui.skill.design-blueprint.description":
     "Produire un plan de design (DESIGN.md + Decision Trace) avant tout mockup",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -223,6 +223,7 @@ export const dict = {
   "tui.skill.html-to-video-pipeline.description": "ショート動画の神ツール - HTML でショート動画を制作",
   "tui.skill.arxiv.description": "arXiv 論文の検索・引用・ダウンロード・追跡",
   "tui.skill.skill-creator.description": "エージェントスキルの作成・レビュー・改善",
+  "tui.skill.drive-mimo.description": "別の MiMoCode プロセスをプログラムで操作——ヘッドレス JSON イベントまたは tmux 経由のインタラクティブ TUI",
   "tui.skill.research-paper-writing.description": "学術論文の執筆・推敲・査読者視点の批評",
   "tui.skill.design-blueprint.description": "モックアップ着手前に設計仕様（DESIGN.md + Decision Trace）を作成",
   "tui.skill.super-research.description": "自律型研究——実験ループ、調査、量的分析、ベンチマーク、根本原因調査、アブレーション、論文再現、論文執筆",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -289,6 +289,7 @@ export const dict = {
   "tui.skill.html-to-video-pipeline.description": "Магический инструмент для коротких видео — создавайте короткие видео с помощью HTML",
   "tui.skill.arxiv.description": "Поиск, цитирование, загрузка и отслеживание статей arXiv",
   "tui.skill.skill-creator.description": "Создание, проверка и улучшение skills агента",
+  "tui.skill.drive-mimo.description": "Программное управление другим процессом MiMoCode — headless JSON-события или интерактивный TUI через tmux",
   "tui.skill.research-paper-writing.description": "Написание, полировка и рецензирование научных статей",
   "tui.skill.design-blueprint.description":
     "Создать проектную спецификацию (DESIGN.md + Decision Trace) до макетов",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -199,6 +199,7 @@ export const dict = {
   "tui.skill.html-to-video-pipeline.description": "短视频神器 - 利用 HTML 制作短视频",
   "tui.skill.arxiv.description": "搜索、引用、下载与追踪 arXiv 论文",
   "tui.skill.skill-creator.description": "创建、审查与改进 Agent 技能",
+  "tui.skill.drive-mimo.description": "以编程方式驱动另一个 MiMoCode 进程——无头 JSON 事件或通过 tmux 交互",
   "tui.skill.research-paper-writing.description": "撰写、润色学术论文，并以审稿人视角提前把关",
   "tui.skill.design-blueprint.description": "先出设计蓝图（DESIGN.md + 决策轨迹）再动手做视觉",
   "tui.skill.super-research.description": "自主研究——实验循环、主题调研、量化分析、对比评测、根因排查、消融实验、复现论文、写论文",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -199,6 +199,7 @@ export const dict = {
   "tui.skill.html-to-video-pipeline.description": "短影片神器 - 利用 HTML 製作短影片",
   "tui.skill.arxiv.description": "搜尋、引用、下載與追蹤 arXiv 論文",
   "tui.skill.skill-creator.description": "建立、審查與改進 Agent 技能",
+  "tui.skill.drive-mimo.description": "以程式化方式驅動另一個 MiMoCode 程序——無頭 JSON 事件或透過 tmux 互動",
   "tui.skill.research-paper-writing.description": "撰寫、潤色學術論文，並以審稿人視角提前把關",
   "tui.skill.design-blueprint.description": "先出設計藍圖（DESIGN.md + 決策軌跡）再動手做視覺",
   "tui.skill.super-research.description": "自主研究——實驗迴圈、主題調研、量化分析、對比評測、根因排查、消融實驗、複現論文、寫論文",

--- a/packages/opencode/test/cli/cmd/tui/autocomplete-detect.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/autocomplete-detect.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { detectTrigger } from "../../../../src/cli/cmd/tui/component/prompt/autocomplete-detect"
+import { tokenEndWidth } from "../../../../src/cli/cmd/tui/component/prompt/offset"
 
 // cursorWidth is the editor's display-width cursor offset (CJK = 2 columns).
 // detectTrigger inspects the plainText and returns the trigger kind plus the
@@ -51,5 +52,75 @@ describe("detectTrigger", () => {
   test("does not trigger when char before @ is non-whitespace", () => {
     // "a@fo" — '@' is glued to 'a', not a fresh mention
     expect(detectTrigger("a@fo", 4)).toBeUndefined()
+  })
+
+  // Mid-message "/" skill trigger tests
+  test("detects mid-message / with at least one char typed", () => {
+    // "hello /ef" — / preceded by space, "ef" after it, cursor at end (width 9)
+    expect(detectTrigger("hello /ef", 9)).toEqual({ kind: "/", index: 6 })
+  })
+
+  test("does not trigger lone / mid-message (needs at least one char)", () => {
+    // "hello /" — just the slash, no chars after → should NOT open
+    expect(detectTrigger("hello /", 7)).toBeUndefined()
+  })
+
+  test("does not trigger / mid-message when preceded by non-whitespace", () => {
+    // "https://x.com/api" — slashes not preceded by whitespace
+    expect(detectTrigger("https://x.com/api", 17)).toBeUndefined()
+  })
+
+  test("detects mid-message / with CJK before trigger", () => {
+    // "你好 /ef" — 你好(4) + space(1) + /ef(3) = cursor width 8, / at width 5
+    expect(detectTrigger("你好 /ef", 8)).toEqual({ kind: "/", index: 5 })
+  })
+
+  test("position-0 / with whitespace returns undefined (not single-command)", () => {
+    // "/init foo" with cursor at end — has whitespace before cursor, first check fails
+    // mid-message check: last / is at 0, before is undefined (idx===0), between="/init foo" has space → no
+    expect(detectTrigger("/init foo", 9)).toBeUndefined()
+  })
+
+  test("position-0 / without whitespace is detected as position-0 trigger", () => {
+    // "/models1234" cursor in middle (width 8) — no whitespace before cursor
+    expect(detectTrigger("/models1234", 8)).toEqual({ kind: "/", index: 0 })
+  })
+
+  test("prefers later trigger when multiple exist", () => {
+    // "hello /effect /fro" — should detect the LAST / (at position 14)
+    expect(detectTrigger("hello /effect /fro", 18)).toEqual({ kind: "/", index: 14 })
+  })
+})
+
+describe("tokenEndWidth", () => {
+  test("finds end at whitespace boundary", () => {
+    // "/models 1234" — token starts at 0, ends at space (width 7)
+    expect(tokenEndWidth("/models 1234", 0)).toBe(7)
+  })
+
+  test("finds end at end of text when no trailing space", () => {
+    // "hello /effect" — token starts at 6, ends at 13 (end of text)
+    expect(tokenEndWidth("hello /effect", 6)).toBe(13)
+  })
+
+  test("handles mid-text token with content after space", () => {
+    // "hello /effect world" — token at 6, ends at space before "world" (width 13)
+    expect(tokenEndWidth("hello /effect world", 6)).toBe(13)
+  })
+
+  test("handles CJK in token", () => {
+    // "你好 /技能 end" — / at width 5 (string index 3), token is "/技能" (width 5+1+2+2=5 from start)
+    // / width 1, 技 width 2, 能 width 2 → token end at width 5+1+2+2 = 10
+    expect(tokenEndWidth("你好 /技能 end", 5)).toBe(10)
+  })
+
+  test("handles token starting at position 0", () => {
+    // "/init" — whole text is the token
+    expect(tokenEndWidth("/init", 0)).toBe(5)
+  })
+
+  test("handles second token after first", () => {
+    // "/effect /frontend" — second token starts at 8
+    expect(tokenEndWidth("/effect /frontend", 8)).toBe(17)
   })
 })


### PR DESCRIPTION
## Summary

Fixes critical bugs in the mid-message `/skill-name` autocomplete introduced by #1654, adds proper i18n for skill descriptions, and fixes a flickering bug in the dismiss logic.

## Issues fixed

1. **Input clearing**: `hide()` deleted from `(0,0)` to cursor on dismiss — designed for position-0 single-command, but fires on mid-message triggers and clears the entire input.
2. **Premature dismiss + flickering**: Line 540's regex `/^\S+\s+\S+\s*$/` matches any 2-word input. For mid-message this caused instant dismiss; for position-0 it caused open/close flickering when editing a command name before a space (e.g. editing `/models 1234`).
3. **No i18n**: Skills in `/` popup showed raw English descriptions while `/skills` dialog had proper i18n.

## Changes

### Autocomplete text handling (redesigned)

Three distinct paths with clear text behavior:

| Path | Trigger | Text behavior |
|------|---------|--------------|
| **Escape** (active dismiss) | User presses Escape | `clearTriggerRange()` removes the slash token |
| **select()** (selection) | User picks an item | `clearTriggerRange()` removes token, then `onSelect()` inserts/acts |
| **Passive dismiss** | Space typed, cursor moved before trigger | `hide()` only — no text manipulation |

- `hide()` is pure — only closes popup and re-enables keybinds
- `clearTriggerRange()` deletes the slash **token** (from `store.index` to next whitespace), not to cursor position — handles cursor-drift edge case correctly

### Dismiss conditions (simplified)

Removed the problematic regex entirely. Only two conditions remain:
1. Cursor moved before trigger position → dismiss
2. Space between trigger and cursor → dismiss

These two checks are sufficient for all cases. The space check handles "user started typing arguments" and `detectTrigger` won't reopen because it rejects triggers with whitespace before cursor.

### Skill i18n

- Fetches real skill list via `sdk.client.app.skills()` to get proper `bundled` field
- Refetches each time `/` popup opens (lightweight local IPC, <5ms)
- Uses `skillDescription()` with real bundled info (matching `/skills` dialog)
- Falls back to `slashCommandDescription()` while loading
- Added `drive-mimo` i18n across all 7 locales

## Known limitations

- Cursor movement (arrow keys, mouse click) without text change does not trigger dismiss — popup can stay open after cursor drifts away. `clearTriggerRange` token-based deletion ensures correct behavior on Escape/select regardless.
- `createResource` for skills refetches on each popup open but doesn't stream updates mid-popup.

cc @fanhuanjie