### PR TITLE
feat(tui): render Orchestrator actor-notifications as a structured card

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -70,6 +70,7 @@ import { WorkflowTree } from "@tui/component/workflow-tree"
 import { SubagentFooter } from "./subagent-footer.tsx"
 import { DialogSubagent } from "./dialog-subagent.tsx"
 import { Flag } from "@/flag/flag"
+import { parseActorNotification } from "@/inbox/render"
 import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
 import parsers from "../../../../../../parsers-config.ts"
 import * as Clipboard from "../../util/clipboard"
@@ -1440,6 +1441,18 @@ function UserMessage(props: {
     })[0]
   })
   const files = createMemo(() => props.parts.flatMap((x) => (x.type === "file" ? [x] : [])))
+  // Orchestrator actor-notifications arrive as a synthetic user text part whose
+  // text is the pre-rendered <actor-notification> wrapper (inbox/render.ts).
+  // Detect + parse it into a compact status card instead of showing raw XML.
+  // Gated on the orchestrator flag so non-orchestrator sessions are untouched.
+  const actorNotification = createMemo(() => {
+    if (!Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR) return undefined
+    return props.parts.flatMap((x) => {
+      if (x.type !== "text" || !x.synthetic) return []
+      const parsed = parseActorNotification(x.text)
+      return parsed ? [parsed] : []
+    })[0]
+  })
   const { theme } = useTheme()
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
@@ -1478,7 +1491,35 @@ function UserMessage(props: {
           )
         }}
       </Show>
-      <Show when={text()}>
+      <Show when={actorNotification()}>
+        {(note) => {
+          // Map each status to an icon + theme color. Mirrors the cronFire
+          // badge styling so orchestrator notifications read as first-class
+          // structured rows rather than raw <actor-notification> XML.
+          const style = createMemo(() => {
+            const s = note().status
+            if (s === "completed") return { icon: "✓", fg: theme.success, label: "completed" }
+            if (s === "failed") return { icon: "✗", fg: theme.error, label: "failed" }
+            if (s === "stalled") return { icon: "⏳", fg: theme.warning, label: "stalled" }
+            return { icon: "⊜", fg: theme.textMuted, label: "cancelled" }
+          })
+          return (
+            <box id={props.message.id} marginTop={props.index === 0 ? 0 : 1} paddingLeft={2} flexDirection="row" gap={1}>
+              <text fg={theme.textMuted}>
+                <span style={{ bg: theme.backgroundElement, fg: style().fg, bold: true }}>
+                  {" "}
+                  {style().icon} actor {style().label}{" "}
+                </span>
+                <span style={{ fg: theme.text }}> {note().description}</span>
+                <Show when={note().summary}>
+                  <span style={{ fg: theme.textMuted }}> — {note().summary}</span>
+                </Show>
+              </text>
+            </box>
+          )
+        }}
+      </Show>
+      <Show when={text() && !actorNotification()}>
         <box
           id={props.message.id}
           border={["left"]}

--- a/packages/opencode/src/inbox/render.ts
+++ b/packages/opencode/src/inbox/render.ts
@@ -40,6 +40,9 @@ export function renderActorNotification(event: {
 }
 
 export type ParsedActorNotification = {
+  // "stalled" is reserved for a future watchdog-emitted notification;
+  // renderActorNotification never produces it today (only completed/failed/
+  // cancelled). The parse + card styling exist ahead of that producer.
   status: "completed" | "failed" | "cancelled" | "stalled"
   description: string
   summary?: string
@@ -58,7 +61,13 @@ export function parseActorNotification(text: string): ParsedActorNotification | 
   const status: ParsedActorNotification["status"] =
     verb === "completed" ? "completed" : verb === "failed" ? "failed" : verb === "stalled" ? "stalled" : "cancelled"
   // Prefer the most human-relevant one-liner: Summary > Result > Error.
-  const line = (label: string) => text.match(new RegExp(`^${label}:\\s*(.+)$`, "m"))?.[1]?.trim()
-  const summary = line("Summary") ?? line("Result") ?? line("Error")
+  // renderActorNotification always emits the Summary line before the Result
+  // line, so restrict the Summary match to the region before the first
+  // "Result:" line — otherwise a `Summary:`-prefixed line inside the Result
+  // body would be mistaken for the notification's own summary.
+  const resultIdx = text.search(/^Result:/m)
+  const beforeResult = resultIdx === -1 ? text : text.slice(0, resultIdx)
+  const line = (label: string, scope: string) => scope.match(new RegExp(`^${label}:\\s*(.+)$`, "m"))?.[1]?.trim()
+  const summary = line("Summary", beforeResult) ?? line("Result", text) ?? line("Error", text)
   return summary ? { status, description, summary } : { status, description }
 }

--- a/packages/opencode/src/inbox/render.ts
+++ b/packages/opencode/src/inbox/render.ts
@@ -38,3 +38,27 @@ export function renderActorNotification(event: {
   }
   return `<actor-notification>\n${header} was cancelled.\n</actor-notification>`
 }
+
+export type ParsedActorNotification = {
+  status: "completed" | "failed" | "cancelled" | "stalled"
+  description: string
+  summary?: string
+}
+
+// Inverse of renderActorNotification: recover the structured fields from the
+// pre-rendered <actor-notification> text so the TUI can show a card instead of
+// the raw wrapper. Pure + exported so it's unit-testable without the renderer.
+// Returns null for any text that isn't an actor notification.
+export function parseActorNotification(text: string): ParsedActorNotification | null {
+  if (!text.trimStart().startsWith("<actor-notification>")) return null
+  const header = text.match(/Background actor "(.*?)" \(actor_id: [^)]*\)\s+(completed|failed|was cancelled|stalled)\b/)
+  if (!header) return null
+  const description = header[1]
+  const verb = header[2]
+  const status: ParsedActorNotification["status"] =
+    verb === "completed" ? "completed" : verb === "failed" ? "failed" : verb === "stalled" ? "stalled" : "cancelled"
+  // Prefer the most human-relevant one-liner: Summary > Result > Error.
+  const line = (label: string) => text.match(new RegExp(`^${label}:\\s*(.+)$`, "m"))?.[1]?.trim()
+  const summary = line("Summary") ?? line("Result") ?? line("Error")
+  return summary ? { status, description, summary } : { status, description }
+}

--- a/packages/opencode/test/inbox/parse-actor-notification.test.ts
+++ b/packages/opencode/test/inbox/parse-actor-notification.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { parseActorNotification, renderActorNotification } from "../../src/inbox/render"
+
+describe("parseActorNotification", () => {
+  test("parses a completed notification with reported status + summary", () => {
+    const text = renderActorNotification({
+      actorID: "explore-1",
+      description: "Find error recovery",
+      status: "completed",
+      reportedStatus: "success",
+      reportedSummary: "Located 3 recovery sites",
+      result: "full body here",
+    })
+    expect(parseActorNotification(text)).toEqual({
+      status: "completed",
+      description: "Find error recovery",
+      summary: "Located 3 recovery sites",
+    })
+  })
+
+  test("completed without a summary falls back to the Result line", () => {
+    const text = renderActorNotification({
+      actorID: "explore-2",
+      description: "Scan repo",
+      status: "completed",
+      reportedStatus: "success",
+      result: "42 files scanned",
+    })
+    expect(parseActorNotification(text)).toEqual({
+      status: "completed",
+      description: "Scan repo",
+      summary: "42 files scanned",
+    })
+  })
+
+  test("parses a failed notification with the Error line as summary", () => {
+    const text = renderActorNotification({
+      actorID: "general-9",
+      description: "Type checker review",
+      status: "failed",
+      error: "process exited 1",
+    })
+    expect(parseActorNotification(text)).toEqual({
+      status: "failed",
+      description: "Type checker review",
+      summary: "process exited 1",
+    })
+  })
+
+  test("parses a cancelled notification (no summary)", () => {
+    const text = renderActorNotification({
+      actorID: "peer-3",
+      description: "Long running search",
+      status: "cancelled",
+    })
+    expect(parseActorNotification(text)).toEqual({
+      status: "cancelled",
+      description: "Long running search",
+    })
+  })
+
+  test("parses a stalled notification (watchdog variant)", () => {
+    const text =
+      '<actor-notification>\nBackground actor "Wedged agent" (actor_id: general-7) stalled.\nSummary: no output for 10m\n</actor-notification>'
+    expect(parseActorNotification(text)).toEqual({
+      status: "stalled",
+      description: "Wedged agent",
+      summary: "no output for 10m",
+    })
+  })
+
+  test("returns null for non-notification text", () => {
+    expect(parseActorNotification("just a normal user message")).toBeNull()
+    expect(parseActorNotification("<inbox from=\"x:y\">hello</inbox>")).toBeNull()
+    expect(parseActorNotification("")).toBeNull()
+  })
+
+  test("returns null when the wrapper is present but the header is malformed", () => {
+    expect(parseActorNotification("<actor-notification>\ngarbage\n</actor-notification>")).toBeNull()
+  })
+})

--- a/packages/opencode/test/inbox/parse-actor-notification.test.ts
+++ b/packages/opencode/test/inbox/parse-actor-notification.test.ts
@@ -33,6 +33,21 @@ describe("parseActorNotification", () => {
     })
   })
 
+  test("completed without a summary does not mistake an embedded Summary: line in the Result body", () => {
+    const text = renderActorNotification({
+      actorID: "explore-3",
+      description: "Draft report",
+      status: "completed",
+      reportedStatus: "success",
+      result: "Here is the outline:\nSummary: this is inside the result body\nmore text",
+    })
+    expect(parseActorNotification(text)).toEqual({
+      status: "completed",
+      description: "Draft report",
+      summary: "Here is the outline:",
+    })
+  })
+
   test("parses a failed notification with the Error line as summary", () => {
     const text = renderActorNotification({
       actorID: "general-9",


### PR DESCRIPTION
## Summary
- Render Orchestrator `<actor-notification>` inbox messages as a compact, structured status card in the TUI instead of raw XML text.
- Mirrors the existing `cronFire` badge pattern in `UserMessage` (`routes/session/index.tsx`): a `createMemo` detects the synthetic notification text part and a `<Show>` renders an icon + colored status + description + one-line summary.
- Only changes the human render — the underlying text part is untouched, so the model still sees the full notification.

## Implementation
- `parseActorNotification(text)` (pure, exported) in `packages/opencode/src/inbox/render.ts` — inverse of `renderActorNotification`; recovers `{ status, description, summary? }` or returns `null` for non-notifications.
- `actorNotification` memo + `<Show>` card in `routes/session/index.tsx`, gated on `Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR`.
- Status → icon/color: completed `✓` green, failed `✗` red, cancelled `⊜` muted, stalled `⏳` warning.

## Tests
- `test/inbox/parse-actor-notification.test.ts` — asserts completed/failed/cancelled/stalled shapes parse correctly and non-notification text returns `null`.
- `bun typecheck` exits 0; 24 inbox/render tests pass (no regression).