### PR TITLE
fix(permission): background subagents inherit parent grants instead of re-prompting/failing closed

### DIFF
--- a/packages/opencode/src/agent/config.ts
+++ b/packages/opencode/src/agent/config.ts
@@ -8,7 +8,10 @@ export const SYSTEM_SPAWNED_AGENT_TYPES: ReadonlySet<string> = new Set(["checkpo
  *  - system agent -> non-interactive (auto-deny, no human to answer)
  *  - orchestrator peer (background + mode:peer + has a parent) -> forward the ask
  *    for approval (interactive, with the parent session as approval route)
- *  - other background (e.g. compose subagents) -> non-interactive (auto-deny)
+ *  - other background WITH a parent (e.g. actor run/spawn subagents) ->
+ *    non-interactive but INHERIT: reuse the parent session's already-held grants
+ *    (auto-allow granted paths, fail-closed on ungranted ones — never hang)
+ *  - background without a parent -> non-interactive (auto-deny)
  *  - normal foreground -> interactive
  *  Pure function so the gate is unit-testable without a full prompt turn.
  */
@@ -19,7 +22,7 @@ export function decideAskRouting(input: {
   // When false, orchestrator-peer forwarding is disabled (feature flag off) and
   // a peer falls back to the background auto-deny path.
   orchestratorEnabled?: boolean
-}): { interactive: boolean; forward?: { parentSessionID: string } } {
+}): { interactive: boolean; forward?: { parentSessionID: string }; inherit?: { parentSessionID: string } } {
   const isSystemAgent = input.askActor
     ? SYSTEM_SPAWNED_AGENT_TYPES.has(input.askActor.agent)
     : SYSTEM_SPAWNED_AGENT_TYPES.has(input.agentName)
@@ -31,6 +34,13 @@ export function decideAskRouting(input: {
     !!(input.askActor?.parentActorID || input.sessionParentID)
   if (isOrchestratorPeer && input.sessionParentID) {
     return { interactive: true, forward: { parentSessionID: input.sessionParentID } }
+  }
+  // Ordinary background subagent that has a parent session: don't fail closed
+  // outright — let it inherit the permissions the parent already holds a grant
+  // for. Still non-interactive (no human attached); the ask consults the parent
+  // snapshot and auto-allows only genuinely-granted paths, else fails closed.
+  if (input.askActor?.background && input.sessionParentID) {
+    return { interactive: false, inherit: { parentSessionID: input.sessionParentID } }
   }
   return { interactive: !input.askActor?.background }
 }

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -138,6 +138,14 @@ export const AskInput = Schema.Struct({
   // waits (bounded) for a human/orchestrator reply. Internal to the ask call —
   // NOT persisted on the Request schema.
   forward: Schema.optional(Schema.Struct({ parentSessionID: Schema.String })),
+  // Parent-grant inheritance for ordinary (non-peer) background subagents. When
+  // present, an ask that would block is NOT auto-denied outright: it is first
+  // checked against the PARENT session's approved ruleset (published process-
+  // wide via forwardRef.parentGrants). If the parent already holds a matching
+  // grant for every pattern, the child is auto-allowed with no human round-trip;
+  // otherwise it fails closed (DeniedError) — never hangs, never blocks on a
+  // human. Distinct from `forward` (orchestrator-peer human/delegation routing).
+  inherit: Schema.optional(Schema.Struct({ parentSessionID: Schema.String })),
 })
   .annotate({ identifier: "PermissionAskInput" })
   .pipe(withStatics((s) => ({ zod: zod(s) })))
@@ -222,6 +230,12 @@ export const layer = Layer.effect(
       const { ruleset, ...request } = input
       let needsAsk = false
 
+      // Publish this session's effective grant snapshot (ruleset + persisted
+      // approvals) so background children in another Instance can inherit it.
+      // Merge order matches the child-side check: config/session ruleset first,
+      // then session-accumulated approvals.
+      forwardRef.setParentGrants(request.sessionID, [...ruleset, ...approved])
+
       const forced = FORCED_ASK.has(request.permission)
 
       for (const pattern of request.patterns) {
@@ -254,6 +268,31 @@ export const layer = Layer.effect(
       if (needsAsk && s.skipAll && !forced) {
         log.info("skip-all active, auto-allowing", { permission: request.permission, patterns: request.patterns })
         return
+      }
+
+      // Parent-grant inheritance: an ordinary background subagent reuses the
+      // permissions its parent already holds. Consult the parent session's
+      // published grant snapshot; auto-allow ONLY when the parent already grants
+      // every requested pattern (same evaluate() the parent would run). Ordered
+      // AFTER the deny loop (explicit deny still wins) and forced-ask still falls
+      // through to the fail-closed/human path below. A path the parent doesn't
+      // hold isn't matched → we do NOT return here → it fails closed at the
+      // non-interactive gate. No human wait, no hang.
+      if (needsAsk && input.inherit && !forced) {
+        const parentRuleset = forwardRef.getParentGrants(input.inherit.parentSessionID)
+        if (parentRuleset) {
+          const allAllowed = request.patterns.every(
+            (pattern) => evaluate(request.permission, pattern, parentRuleset).action === "allow",
+          )
+          if (allAllowed) {
+            log.info("inheriting parent grant, auto-allowing", {
+              permission: request.permission,
+              patterns: request.patterns,
+              parentSessionID: input.inherit.parentSessionID,
+            })
+            return
+          }
+        }
       }
 
       // Non-interactive caller (system-spawned background agent): no human is
@@ -453,6 +492,17 @@ export const layer = Layer.effect(
           action: "allow",
         })
       }
+      // Refresh the parent snapshot so a background child inherits this
+      // just-approved grant on its next ask (the parent's `ruleset` isn't known
+      // here, so publish approvals alone — ask() re-publishes with ruleset).
+      forwardRef.setParentGrants(existing.info.sessionID, [
+        ...(forwardRef.getParentGrants(existing.info.sessionID) ?? []),
+        ...existing.info.always.map((pattern) => ({
+          permission: existing.info.permission,
+          pattern,
+          action: "allow" as const,
+        })),
+      ])
 
       for (const [id, item] of pending.entries()) {
         if (item.info.sessionID !== existing.info.sessionID) continue

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -230,11 +230,12 @@ export const layer = Layer.effect(
       const { ruleset, ...request } = input
       let needsAsk = false
 
-      // Publish this session's effective grant snapshot (ruleset + persisted
-      // approvals) so background children in another Instance can inherit it.
-      // Merge order matches the child-side check: config/session ruleset first,
-      // then session-accumulated approvals.
-      forwardRef.setParentGrants(request.sessionID, [...ruleset, ...approved])
+      // Publish this session's effective grant snapshot so background children
+      // in another Instance can inherit it. Kept as two ordered phases (ruleset,
+      // then session-accumulated approvals) — NOT flattened — so the child can
+      // mirror the two-phase evaluation below: a ruleset deny wins outright, and
+      // only a non-denying ruleset lets an approved allow upgrade an ask.
+      forwardRef.setParentGrants(request.sessionID, { ruleset, approved })
 
       const forced = FORCED_ASK.has(request.permission)
 
@@ -279,11 +280,21 @@ export const layer = Layer.effect(
       // hold isn't matched → we do NOT return here → it fails closed at the
       // non-interactive gate. No human wait, no hang.
       if (needsAsk && input.inherit && !forced) {
-        const parentRuleset = forwardRef.getParentGrants(input.inherit.parentSessionID)
-        if (parentRuleset) {
-          const allAllowed = request.patterns.every(
-            (pattern) => evaluate(request.permission, pattern, parentRuleset).action === "allow",
-          )
+        const parentSnapshot = forwardRef.getParentGrants(input.inherit.parentSessionID)
+        if (parentSnapshot) {
+          // Mirror the parent's own two-phase evaluation (see the deny loop
+          // above). A parent ruleset deny must win outright — an approved allow
+          // must NOT be able to out-rank it — so evaluate the ruleset ALONE for
+          // deny first, and only for a non-denying ruleset let approvals upgrade
+          // to allow. Never flatten ruleset+approved into one findLast pass:
+          // that would let a trailing approved allow beat a ruleset deny and let
+          // the child escape a permission the parent itself would refuse.
+          const allAllowed = request.patterns.every((pattern) => {
+            if (evaluate(request.permission, pattern, parentSnapshot.ruleset).action === "deny") return false
+            return (
+              evaluate(request.permission, pattern, parentSnapshot.ruleset, parentSnapshot.approved).action === "allow"
+            )
+          })
           if (allAllowed) {
             log.info("inheriting parent grant, auto-allowing", {
               permission: request.permission,
@@ -493,16 +504,15 @@ export const layer = Layer.effect(
         })
       }
       // Refresh the parent snapshot so a background child inherits this
-      // just-approved grant on its next ask (the parent's `ruleset` isn't known
-      // here, so publish approvals alone — ask() re-publishes with ruleset).
-      forwardRef.setParentGrants(existing.info.sessionID, [
-        ...(forwardRef.getParentGrants(existing.info.sessionID) ?? []),
-        ...existing.info.always.map((pattern) => ({
-          permission: existing.info.permission,
-          pattern,
-          action: "allow" as const,
-        })),
-      ])
+      // just-approved grant on its next ask. The parent's `ruleset` isn't known
+      // here, so preserve whatever ruleset phase ask() last published and update
+      // only the approved phase (the live `approved` array already holds the
+      // just-pushed patterns). Keeping the phases separate preserves deny
+      // precedence for the child (a ruleset deny still can't be out-ranked).
+      forwardRef.setParentGrants(existing.info.sessionID, {
+        ruleset: forwardRef.getParentGrants(existing.info.sessionID)?.ruleset ?? [],
+        approved,
+      })
 
       for (const [id, item] of pending.entries()) {
         if (item.info.sessionID !== existing.info.sessionID) continue

--- a/packages/opencode/src/permission/permission-forward-ref.ts
+++ b/packages/opencode/src/permission/permission-forward-ref.ts
@@ -11,6 +11,14 @@
 //            belongs to, PLUS a resolver bound to the child's own Deferred (in
 //            the child's Instance) so `session approve` can resolve it from the
 //            orchestrator's Instance and the orchestrator can drop its copy.
+// - parentGrants: parentSessionID -> the parent session's current approved
+//            ruleset snapshot. Lets an ordinary background subagent (in a
+//            different Instance/directory than its parent) reuse the exact
+//            directories/permissions the parent already holds a grant for,
+//            WITHOUT a human round-trip and WITHOUT blocking. An ungranted path
+//            simply isn't in the snapshot → the child fails closed. Snapshot is
+//            refreshed by the parent's Permission instance on load and on every
+//            persisted approval.
 
 type Decision = "allow" | "deny"
 type PendingRec = {
@@ -19,12 +27,16 @@ type PendingRec = {
   resolve: (decision: Decision) => void
 }
 
+type Rule = { permission: string; pattern: string; action: "allow" | "ask" | "deny" }
+
 const grants = new Map<string, Set<string>>()
 const pending = new Map<string, PendingRec>()
+const parentGrants = new Map<string, Rule[]>()
 
 export const forwardRef = {
   grants,
   pending,
+  parentGrants,
   setGrant(parentSessionID: string, target: string) {
     const set = grants.get(parentSessionID) ?? new Set<string>()
     set.add(target)
@@ -41,6 +53,18 @@ export const forwardRef = {
   clearGrantsForChild(childSessionID: string) {
     for (const set of grants.values()) set.delete(childSessionID)
     for (const [id, rec] of pending) if (rec.childSessionID === childSessionID) pending.delete(id)
+  },
+  // Publish/refresh the parent session's approved ruleset so background children
+  // in another Instance can consult it. Snapshot is a shallow copy so later
+  // mutation of the parent's live array can't retroactively widen a child grant.
+  setParentGrants(parentSessionID: string, ruleset: Rule[]) {
+    parentGrants.set(parentSessionID, [...ruleset])
+  },
+  getParentGrants(parentSessionID: string): Rule[] | undefined {
+    return parentGrants.get(parentSessionID)
+  },
+  clearParentGrants(parentSessionID: string) {
+    parentGrants.delete(parentSessionID)
   },
   addPending(requestID: string, rec: PendingRec) {
     pending.set(requestID, rec)

--- a/packages/opencode/src/permission/permission-forward-ref.ts
+++ b/packages/opencode/src/permission/permission-forward-ref.ts
@@ -29,9 +29,16 @@ type PendingRec = {
 
 type Rule = { permission: string; pattern: string; action: "allow" | "ask" | "deny" }
 
+// The parent's grant snapshot is kept as TWO ordered phases, never flattened.
+// The child mirrors the parent's own two-phase evaluation: a `ruleset` deny must
+// win outright, and only a non-denying ruleset lets an `approved` allow upgrade
+// an ask. Flattening into one array would let `findLast` pick a trailing
+// approved allow over a ruleset deny — inverting deny precedence.
+type ParentGrantSnapshot = { ruleset: Rule[]; approved: Rule[] }
+
 const grants = new Map<string, Set<string>>()
 const pending = new Map<string, PendingRec>()
-const parentGrants = new Map<string, Rule[]>()
+const parentGrants = new Map<string, ParentGrantSnapshot>()
 
 export const forwardRef = {
   grants,
@@ -54,13 +61,16 @@ export const forwardRef = {
     for (const set of grants.values()) set.delete(childSessionID)
     for (const [id, rec] of pending) if (rec.childSessionID === childSessionID) pending.delete(id)
   },
-  // Publish/refresh the parent session's approved ruleset so background children
-  // in another Instance can consult it. Snapshot is a shallow copy so later
-  // mutation of the parent's live array can't retroactively widen a child grant.
-  setParentGrants(parentSessionID: string, ruleset: Rule[]) {
-    parentGrants.set(parentSessionID, [...ruleset])
+  // Publish/refresh the parent session's grant snapshot so background children
+  // in another Instance can consult it. Stored as two ordered phases (ruleset,
+  // approved) — NEVER flattened — so the child can mirror the parent's two-phase
+  // evaluation (ruleset deny wins outright; only then may an approved allow
+  // upgrade). Each phase is shallow-copied so later mutation of the parent's live
+  // arrays can't retroactively widen a child grant.
+  setParentGrants(parentSessionID: string, snapshot: ParentGrantSnapshot) {
+    parentGrants.set(parentSessionID, { ruleset: [...snapshot.ruleset], approved: [...snapshot.approved] })
   },
-  getParentGrants(parentSessionID: string): Rule[] | undefined {
+  getParentGrants(parentSessionID: string): ParentGrantSnapshot | undefined {
     return parentGrants.get(parentSessionID)
   },
   clearParentGrants(parentSessionID: string) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -859,6 +859,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
       const askInteractive = askRouting.interactive
       const askForward = askRouting.forward
+      const askInherit = askRouting.inherit
       const rejectionFor = (toolID: string) => ({
         title: "Tool not permitted",
         output: `The "${toolID}" tool is not in this actor's whitelist. Allowed tools: ${
@@ -900,9 +901,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 tool: { messageID: input.processor.message.id, callID: options.toolCallId },
                 ruleset: Agent.runtimePermission(input.agent, input.session.permission),
                 // System-spawned + non-peer background agents have no human to answer
-                // → fail clean, don't hang. Orchestrator peers FORWARD for approval.
+                // → fail clean, don't hang. Orchestrator peers FORWARD for approval;
+                // ordinary background subagents INHERIT the parent's held grants.
                 interactive: askInteractive,
                 ...(askForward ? { forward: askForward } : {}),
+                ...(askInherit ? { inherit: askInherit } : {}),
               },
               options.abortSignal,
             )

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -27,6 +27,7 @@ import { SessionID, MessageID, PartID } from "./schema"
 
 import type { Provider } from "@/provider"
 import { Permission } from "@/permission"
+import { forwardRef } from "@/permission/permission-forward-ref"
 import { Global } from "@/global"
 import { ActorRegistry } from "@/actor/registry"
 import { Effect, Layer, Option, Context } from "effect"
@@ -543,6 +544,12 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
         yield* Effect.sync(() => {
           SyncEvent.run(Event.Deleted, { sessionID, info: session }, { publish: hasInstance })
           SyncEvent.remove(sessionID)
+          // Drop this session's published parent-grant snapshot. ask() populates
+          // it process-wide on every call (before the needsAsk short-circuit), so
+          // without this the map grows one entry per session for the life of the
+          // process. Cleared here — the removal point — since a deleted session
+          // can no longer have background children that need to inherit from it.
+          forwardRef.clearParentGrants(sessionID)
         })
       } catch (e) {
         log.error(e)

--- a/packages/opencode/test/agent/ask-routing.test.ts
+++ b/packages/opencode/test/agent/ask-routing.test.ts
@@ -28,7 +28,7 @@ describe("decideAskRouting", () => {
     expect(r.forward).toEqual({ parentSessionID: "ses_orchestrator" })
   })
 
-  test("compose subagent (background + mode:subagent) -> non-interactive, no forward", () => {
+  test("background subagent WITH parent (mode:subagent) -> non-interactive + inherit", () => {
     const r = decideAskRouting({
       askActor: { agent: "general", background: true, mode: "subagent" },
       sessionParentID: "ses_parent",
@@ -36,6 +36,18 @@ describe("decideAskRouting", () => {
     })
     expect(r.interactive).toBe(false)
     expect(r.forward).toBeUndefined()
+    expect(r.inherit).toEqual({ parentSessionID: "ses_parent" })
+  })
+
+  test("background subagent WITHOUT parent -> non-interactive, no inherit (auto-deny)", () => {
+    const r = decideAskRouting({
+      askActor: { agent: "general", background: true, mode: "subagent" },
+      sessionParentID: undefined,
+      agentName: "general",
+    })
+    expect(r.interactive).toBe(false)
+    expect(r.forward).toBeUndefined()
+    expect(r.inherit).toBeUndefined()
   })
 
   test("normal foreground (no actor, not system) -> interactive, no forward", () => {

--- a/packages/opencode/test/permission/inherit.test.ts
+++ b/packages/opencode/test/permission/inherit.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Bus } from "../../src/bus"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Permission } from "../../src/permission"
+import { forwardRef } from "../../src/permission/permission-forward-ref"
+import { Instance } from "../../src/project/instance"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { Log } from "../../src/util"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+beforeEach(() => {
+  forwardRef.parentGrants.clear()
+})
+
+const bus = Bus.layer
+const env = Layer.mergeAll(Permission.layer.pipe(Layer.provide(bus)), bus, CrossSpawnSpawner.defaultLayer)
+const it = testEffect(env)
+
+// A background subagent's ask that would otherwise fail closed (interactive:false).
+function childAsk(patterns: string[], extra?: Partial<Parameters<Permission.Interface["ask"]>[0]>) {
+  return {
+    permission: "edit" as never,
+    patterns,
+    always: ["*"],
+    metadata: {},
+    sessionID: "ses_child" as never,
+    ruleset: [],
+    tool: { messageID: "msg_test" as never, callID: "call_test" },
+    interactive: false as boolean,
+    inherit: { parentSessionID: "ses_parent" },
+    ...extra,
+  }
+}
+
+describe("Permission.ask parent-grant inheritance", () => {
+  it.live(
+    "ordinary background subagent auto-allowed for a dir the parent granted",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        // Parent already holds an "always"-approved grant for /granted/dir.
+        forwardRef.setParentGrants("ses_parent", [
+          { permission: "edit", pattern: "/granted/dir/*", action: "allow" },
+        ])
+        let asked = 0
+        const unsub = Bus.subscribe(Permission.Event.Asked, () => {
+          asked += 1
+        })
+        const result = yield* perm.ask(childAsk(["/granted/dir/file.ts"])).pipe(Effect.exit)
+        unsub()
+        // Auto-allowed: succeeds, no human ask published, nothing left pending.
+        expect(result._tag).toBe("Success")
+        expect(asked).toBe(0)
+        expect((yield* perm.list()).length).toBe(0)
+      }),
+    ),
+  )
+
+  it.live(
+    "ordinary background subagent still fails closed for an ungranted dir",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        forwardRef.setParentGrants("ses_parent", [
+          { permission: "edit", pattern: "/granted/dir/*", action: "allow" },
+        ])
+        let asked = 0
+        const unsub = Bus.subscribe(Permission.Event.Asked, () => {
+          asked += 1
+        })
+        const result = yield* perm.ask(childAsk(["/foreign/dir/file.ts"])).pipe(Effect.exit)
+        unsub()
+        // Not granted by the parent → fail closed (deny), no hang, no ask event.
+        expect(result._tag).toBe("Failure")
+        expect(asked).toBe(0)
+        expect((yield* perm.list()).length).toBe(0)
+      }),
+    ),
+  )
+
+  it.live(
+    "no parent snapshot at all -> fails closed (never hangs)",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        const result = yield* perm.ask(childAsk(["/granted/dir/file.ts"])).pipe(Effect.exit)
+        expect(result._tag).toBe("Failure")
+        expect((yield* perm.list()).length).toBe(0)
+      }),
+    ),
+  )
+
+  it.live(
+    "inherit does NOT override an explicit parent deny",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        forwardRef.setParentGrants("ses_parent", [
+          { permission: "edit", pattern: "/granted/*", action: "allow" },
+          { permission: "edit", pattern: "/granted/secret/*", action: "deny" },
+        ])
+        const result = yield* perm.ask(childAsk(["/granted/secret/x.ts"])).pipe(Effect.exit)
+        // Parent's own deny wins over its broader allow → child fails closed.
+        expect(result._tag).toBe("Failure")
+      }),
+    ),
+  )
+})

--- a/packages/opencode/test/permission/inherit.test.ts
+++ b/packages/opencode/test/permission/inherit.test.ts
@@ -46,9 +46,10 @@ describe("Permission.ask parent-grant inheritance", () => {
       Effect.gen(function* () {
         const perm = yield* Permission.Service
         // Parent already holds an "always"-approved grant for /granted/dir.
-        forwardRef.setParentGrants("ses_parent", [
-          { permission: "edit", pattern: "/granted/dir/*", action: "allow" },
-        ])
+        forwardRef.setParentGrants("ses_parent", {
+          ruleset: [],
+          approved: [{ permission: "edit", pattern: "/granted/dir/*", action: "allow" }],
+        })
         let asked = 0
         const unsub = Bus.subscribe(Permission.Event.Asked, () => {
           asked += 1
@@ -68,9 +69,10 @@ describe("Permission.ask parent-grant inheritance", () => {
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const perm = yield* Permission.Service
-        forwardRef.setParentGrants("ses_parent", [
-          { permission: "edit", pattern: "/granted/dir/*", action: "allow" },
-        ])
+        forwardRef.setParentGrants("ses_parent", {
+          ruleset: [],
+          approved: [{ permission: "edit", pattern: "/granted/dir/*", action: "allow" }],
+        })
         let asked = 0
         const unsub = Bus.subscribe(Permission.Event.Asked, () => {
           asked += 1
@@ -102,13 +104,38 @@ describe("Permission.ask parent-grant inheritance", () => {
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const perm = yield* Permission.Service
-        forwardRef.setParentGrants("ses_parent", [
-          { permission: "edit", pattern: "/granted/*", action: "allow" },
-          { permission: "edit", pattern: "/granted/secret/*", action: "deny" },
-        ])
+        forwardRef.setParentGrants("ses_parent", {
+          ruleset: [
+            { permission: "edit", pattern: "/granted/*", action: "allow" },
+            { permission: "edit", pattern: "/granted/secret/*", action: "deny" },
+          ],
+          approved: [],
+        })
         const result = yield* perm.ask(childAsk(["/granted/secret/x.ts"])).pipe(Effect.exit)
         // Parent's own deny wins over its broader allow → child fails closed.
         expect(result._tag).toBe("Failure")
+      }),
+    ),
+  )
+
+  it.live(
+    "inherit does NOT let an approved allow escape a ruleset deny (deny-precedence)",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        // The core regression: the parent's config ruleset DENIES edit **, but a
+        // separately-approved (persisted "always") allow exists for /x. The
+        // parent itself evaluates the ruleset ALONE first, so /x is denied for
+        // the parent. The child must inherit that same denial — the approved
+        // allow must NOT be able to out-rank the ruleset deny (which a flattened
+        // [...ruleset, ...approved] + findLast snapshot would wrongly permit).
+        forwardRef.setParentGrants("ses_parent", {
+          ruleset: [{ permission: "edit", pattern: "**", action: "deny" }],
+          approved: [{ permission: "edit", pattern: "/x/*", action: "allow" }],
+        })
+        const result = yield* perm.ask(childAsk(["/x/file.ts"])).pipe(Effect.exit)
+        expect(result._tag).toBe("Failure")
+        expect((yield* perm.list()).length).toBe(0)
       }),
     ),
   )


### PR DESCRIPTION
## Summary
Ordinary background subagents (spawned via `actor run`/`spawn`) previously **failed closed** on every permission ask that wasn't already in their own instance's ruleset — even when the main/parent agent had already granted that directory. They neither forwarded the ask (only orchestrator peers do) nor inherited the parent's grants, so users saw repeated re-prompts / hard denials.

## Root cause
- `src/agent/config.ts` `decideAskRouting` returned `{ interactive: false }` with **no `forward`/`inherit`** for any non-system, non-peer background subagent.
- `src/permission/index.ts` hard-denies when `needsAsk && interactive === false`, **before** any grant short-circuit.
- The grant short-circuit (`forwardRef.grantAllowed`) lives inside `if (input.forward)` → unreachable for ordinary subagents.
- `approved` rules are cached **per-directory** (`instance-state.ts`), so a peer/isolated-worktree child (different directory → different project row) never sees the parent session's in-memory approvals.

## Fix (approach: seed + consult, cross-instance)
- Add `forwardRef.parentGrants` (process-global, keyed by session id) — mirrors the existing `forwardRef` cross-Instance pattern. The parent's Permission instance publishes its effective grant snapshot (`ruleset + approved`) on every `ask` and after every persisted approval.
- Add an `inherit: { parentSessionID }` mode to `Permission.ask`: when an ask would block, consult the parent's snapshot; **auto-allow only when the parent already grants every requested pattern** (same `evaluate()` the parent runs, so explicit parent `deny` still wins). Otherwise it **fails closed** — no human wait, no hang.
- `decideAskRouting` now routes any background subagent **with a `sessionParentID`** to `{ interactive: false, inherit }`; background without a parent still auto-denies; system agents and orchestrator peers are unchanged.

## Safety preserved
- Only paths the parent genuinely holds a grant for are auto-approved.
- An ungranted foreign path, a missing parent snapshot, or a parent `deny` all → fail-closed (`DeniedError`), never an indefinite block.
- Forced-ask permissions (`bash_delete`) still fall through to the human/fail-closed path.

## Tests
- `test/permission/inherit.test.ts` (new): granted dir → auto-allowed; ungranted dir → fails closed; no snapshot → fails closed; parent `deny` not overridden.
- `test/agent/ask-routing.test.ts`: updated for the new `inherit` directive.
- `bun typecheck` exit 0; `test/agent/ask-routing.test.ts` + `test/permission/` → 127 pass / 0 fail.

---

## Follow-up fix (deny-precedence correctness + snapshot leak)

Blocking correctness bug found in the inheritance path above, plus the slow leak it introduced.

### Deny-precedence inversion (blocking, fixed)
The parent's own `ask()` (`permission/index.ts`) deliberately evaluates its **ruleset alone** for `deny` first, so a config `deny` cannot be out-ranked by a persisted `approved` allow ("edit approved always in build mode must not beat a `deny`"). The inheritance path violated this: it published a **flattened** `[...ruleset, ...approved]` snapshot, and the child ran a single `findLast` `evaluate()` with `approved` last — so an approved `allow` beat a ruleset `deny`.

Concrete escape: parent `deny edit **` (ruleset) + `allow edit /x` (approved). The parent denies `/x`; the child inherited the flat snapshot → `findLast` → `allow` → **child escaped the parent's deny**, violating the safety invariant.

Fix: publish the snapshot as **two ordered phases** (`{ ruleset, approved }`, never flattened) and have the child **mirror the parent's two-phase evaluation** — a `ruleset` deny wins outright, and only a non-denying ruleset lets an `approved` allow upgrade the ask.

### parentGrants leak (fixed)
`ask()` calls `setParentGrants` process-wide on every call (before the `needsAsk` short-circuit), but `clearParentGrants` was defined and never called → one map entry leaked per session for the process lifetime. Wired `clearParentGrants` into `Session.remove` (the point a session — and any child's need to inherit from it — is gone).

### Tests
- `test/permission/inherit.test.ts`: added a deny-precedence regression — parent `ruleset: [deny edit **]` + `approved: [allow edit /x/*]`, child asking `/x/file.ts` must **fail closed**. Existing inherit tests migrated to the two-phase snapshot shape.
- `bun typecheck` → exit 0. `test/permission/` → 120 pass / 0 fail; `test/tool/session-tool.test.ts` → 31 pass / 0 fail.
