### PR TITLE
fix(session): session ask answers from a child's persisted history

### DIFF
--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -54,12 +54,27 @@ export function forkQuery(deps: {
   actor: ActorInterface
 }, targetSessionID: SessionID, question: string) {
   return Effect.gen(function* () {
-    // a. Read the target's main slice + compute the watermark boundary.
-    const msgs = yield* deps.sessions.messages({ sessionID: targetSessionID, agentID: "main" })
-    const watermark = yield* deps.sessions.lastMainMessageID(targetSessionID)
-    // Graceful: a target with no main-slice history (or no user message) can't
-    // be snapshotted — buildPrefix needs a user message and there is nothing to
-    // ask about. Answer directly instead of spawning.
+    // a. Resolve the target's persisted history and the slice to snapshot.
+    // A child created via `session create` runs as a PEER actor whose actorID
+    // === its own sessionID, so SessionPrompt persists its turns under
+    // agent_id = <targetSessionID> — NOT "main". Reading only the "main" slice
+    // (the old behaviour) therefore saw an empty history for every peer child
+    // (isolated or idle alike) and reported "no activity" even after real turns.
+    // Read ALL slices, then pick the slice that actually holds the child's
+    // conversation: "main" for an orchestrator/main session, else the peer's
+    // own-session slice. This answers from FROZEN persisted history regardless
+    // of whether the child is still running, went idle, or was isolated.
+    const all = yield* deps.sessions.messages({ sessionID: targetSessionID, agentID: "*" })
+    const sliceOf = (agentID: string) =>
+      all.filter((m) => (m.info.agentID ?? "main") === agentID)
+    const mainSlice = sliceOf("main")
+    // Prefer "main" when it carries real activity; otherwise fall back to the
+    // peer child's own-session slice (agent_id === targetSessionID).
+    const msgs = mainSlice.some((m) => m.info.role === "user") ? mainSlice : sliceOf(targetSessionID)
+    const watermark = msgs.at(-1)?.info.id
+    // Graceful: a target whose selected slice has no history (or no user
+    // message) can't be snapshotted — buildPrefix needs a user message and
+    // there is nothing to ask about. Answer directly instead of spawning.
     const hasUserMessage = msgs.some((m) => m.info.role === "user")
     if (!watermark || msgs.length === 0 || !hasUserMessage)
       return `(session ${targetSessionID} has no activity yet — nothing to ask about.)`

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -932,4 +932,52 @@ describe("session tool ask (fork-query) functional", () => {
     ),
     60000,
   )
+
+  // Regression: a PEER child (created via `session create`) persists its turns
+  // under agent_id = <its own sessionID>, NOT "main". The old forkQuery read
+  // only the "main" slice, so `ask` reported "no activity yet" for every peer
+  // child — the orchestrator's diagnostic blind spot. Here the target has real
+  // history ONLY under its own-session slice; ask must still answer from it.
+  askIt.live("ask answers from a peer child's own-session slice (no false no-activity)", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const sessions = yield* Session.Service
+
+        const target = yield* sessions.create({
+          title: "Peer child with history",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        // History lives under agent_id === target.id (the peer's own slice),
+        // exactly as SessionPrompt persists a peer actor's turns — the "main"
+        // slice is left empty on purpose to mirror a real peer child.
+        yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user" as const,
+          sessionID: target.id,
+          agentID: target.id,
+          time: { created: Date.now() },
+          agent: "build",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+        } as unknown as MessageV2.Info)
+
+        yield* llm.text("The child read the config and is wiring the login route.")
+
+        const info = yield* SessionTool
+        const tool = yield* info.init()
+        const result = yield* tool.execute(
+          { operation: { action: "ask", session_id: target.id, question: "what did you find?" } },
+          ctx(target.id),
+        )
+
+        expect(result.title).toBe(`Asked ${target.id}`)
+        expect(result.output.length).toBeGreaterThan(0)
+        expect(result.output).not.toContain("no activity yet")
+        // A fork child was spawned to answer (the empty-history path does not).
+        const children = yield* sessions.children(target.id)
+        expect(children.length).toBe(1)
+      }),
+      { git: true, config: askProviderCfg },
+    ),
+    60000,
+  )
 })


### PR DESCRIPTION
## Summary
- Fixes an orchestrator observability blind spot: `session ask` returned `(session <id> has no activity yet — nothing to ask about)` for isolated/idle **peer** child sessions even after they ran real turns, so a stalled or zero-output child could not be interrogated.

## Root cause
`forkQuery` in `packages/opencode/src/tool/session.ts` read the target's history from the **`"main"` slice only** (`messages({ agentID: "main" })` + `lastMainMessageID`, which filter `agent_id = "main"`). A child created via `session create` runs as a **peer actor** whose `actorID === its own sessionID` (`actor/spawn.ts:642-664`), and `SessionPrompt.prompt` persists its turns under `agentID: actorID` → `agent_id = <childSessionID>` (`actor/spawn.ts:230-233`). So a peer child's `"main"` slice is always empty and `ask` fell into the no-activity path regardless of real turns. Isolation was orthogonal — a pure slice-selector mismatch.

## Fix
`forkQuery` now reads the target's **cross-slice** history (`agentID: "*"`) and snapshots the slice that actually holds the conversation: `"main"` when it carries a user message, otherwise the peer child's own-session slice (`agent_id === targetSessionID`). The watermark is derived from that same slice. The read-only, frozen-snapshot nature of `ask` is unchanged; a child with genuinely zero persisted history still returns the correct no-activity message.

## Test
Added a regression test in `test/tool/session-tool.test.ts`: a target whose history lives only under `agent_id = <sessionID>` (a real peer child) now gets a real answer instead of "no activity". Verified it **fails against the pre-fix code** (reproduces the exact "no activity yet" string) and **passes with the fix**.

## Verification
- `bun typecheck` → EXIT 0
- `bun test test/tool/session-tool.test.ts test/server/ask-route-fork-query.test.ts` → 33 pass / 1 skip / 0 fail

Only `packages/opencode` touched.

Co-authored-by: MiMo-Code <noreply@mimo.xiaomi.com>