### PR TITLE
fix(session): never send an assistant prefill — sweep trailing incomplete assistant regardless of age

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1944,11 +1944,30 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       // 50 min) so a still-active in-flight request is never falsely
       // swept while its retry chain is making progress.
       const ORPHAN_AGE_MS = 3_600_000
-      for (const m of msgs) {
+      // Index of the last assistant message in send order. A TRAILING incomplete
+      // assistant (the conversation currently ends on an assistant that never
+      // stamped `time.completed`) is definitionally abandoned: nothing will ever
+      // complete it, and sending it as-is makes the request end with an assistant
+      // turn — which providers like the Bedrock Converse API reject with a
+      // non-retryable 400 ("must end with a user message"). Sweep such a trailing
+      // orphan IMMEDIATELY, regardless of age, so `toModelMessages` skips it and
+      // the request ends on a user/tool turn. Never touches a COMPLETED reply
+      // (guarded by the `time.completed` check below); a non-trailing incomplete
+      // assistant keeps the age gate so an in-flight retry chain isn't swept.
+      let lastAssistantIndex = -1
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        if (msgs[i].info.role === "assistant") {
+          lastAssistantIndex = i
+          break
+        }
+      }
+      for (let idx = 0; idx < msgs.length; idx++) {
+        const m = msgs[idx]
         if (m.info.role !== "assistant") continue
         if (m.info.time?.completed) continue
+        const isTrailing = idx === lastAssistantIndex && idx === msgs.length - 1
         const created = m.info.time?.created ?? 0
-        if (now - created < ORPHAN_AGE_MS) continue
+        if (!isTrailing && now - created < ORPHAN_AGE_MS) continue
         m.info.time = { ...m.info.time, completed: now }
         m.info.error =
           m.info.error ??

--- a/packages/opencode/test/session/prompt-sweep.test.ts
+++ b/packages/opencode/test/session/prompt-sweep.test.ts
@@ -75,7 +75,7 @@ describe("sweepOrphanAssistants", () => {
     ),
   )
 
-  it.live("leaves a recent (under 60s) incomplete assistant message untouched", () =>
+  it.live("leaves a recent (under 60s) incomplete NON-TRAILING assistant untouched", () =>
     provideTmpdirInstance((dir) =>
       Effect.gen(function* () {
         const sessions = yield* Session.Service
@@ -95,6 +95,18 @@ describe("sweepOrphanAssistants", () => {
         const assistant = makeAssistant(session.id, userMsg.id, dir, { created: now - 1_800_000 })
         yield* sessions.updateMessage(assistant)
 
+        // A trailing user turn after the incomplete assistant makes it NON-trailing,
+        // so the age gate still protects it (it may be a mid-conversation in-flight
+        // retry chain, not an abandoned prefill).
+        yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "default",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: now - 1_000 },
+        })
+
         yield* svc.sweepOrphanAssistants(session.id)
 
         const after = yield* sessions.messages({ sessionID: session.id })
@@ -103,6 +115,41 @@ describe("sweepOrphanAssistants", () => {
         const info = updated!.info as MessageV2.Assistant
         expect(info.time.completed).toBeUndefined()
         expect(info.error).toBeUndefined()
+      }),
+    ),
+  )
+
+  it.live("sweeps a recent (under 60s) incomplete TRAILING assistant regardless of age", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const svc = yield* SessionPrompt.Service
+        const session = yield* sessions.create({})
+
+        const userMsg = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "default",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() - 1_900_000 },
+        })
+
+        // A fresh (well under the 1h gate) incomplete assistant that is the LAST
+        // message: a trailing prefill that would make the next request end on an
+        // assistant turn and 400 on Bedrock. It must be swept regardless of age.
+        const now = Date.now()
+        const assistant = makeAssistant(session.id, userMsg.id, dir, { created: now - 1_000 })
+        yield* sessions.updateMessage(assistant)
+
+        yield* svc.sweepOrphanAssistants(session.id)
+
+        const after = yield* sessions.messages({ sessionID: session.id })
+        const updated = after.find((m) => m.info.id === assistant.id)
+        expect(updated).toBeDefined()
+        const info = updated!.info as MessageV2.Assistant
+        expect(info.time.completed).toBeDefined()
+        expect(info.error).toBeDefined()
       }),
     ),
   )


### PR DESCRIPTION
## Summary

Fixes a real Bedrock 400 (hit live in-session): `This model does not support assistant message prefill. The conversation must end with a user message. (Service: BedrockRuntime)`.

**Root cause:** a conversation ending in an INCOMPLETE assistant message (no `time.completed`) is a trailing prefill — the next request ends on an assistant turn, which the Bedrock Converse API rejects with a non-retryable 400. `sweepOrphanAssistants` kept such an orphan for up to `ORPHAN_AGE_MS` (1h), so a freshly-abandoned trailing assistant leaked into the sent list.

**Fix (at the source, not content-dropping):** sweep a **trailing** incomplete assistant immediately regardless of age → `toModelMessages` skips it → the request ends on a user/tool turn. A COMPLETED reply is never touched (guarded by `time.completed`); a NON-trailing incomplete assistant keeps the 1h age gate so a mid-conversation in-flight retry chain isn't falsely swept.

This is the "harness never PRODUCES a prefill" approach — no content-dropping of completed replies, no provider/model-id guessing.

## Test
- `prompt-sweep.test.ts`: trailing incomplete assistant is swept regardless of age; non-trailing incomplete assistant keeps the age gate; completed assistant untouched. 4 pass.
- `bun typecheck` exit 0; invalid-output-continuation + llm-request-prefix suites pass (no regression).