### PR TITLE
fix(provider): never send a provider-rejected assistant prefill (safe guard + reactive backstop)

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -241,6 +241,115 @@ function supportsCacheMarkers(model: Provider.Model): boolean {
   return false
 }
 
+
+// A trailing assistant "prefill" — a conversation ending with an assistant
+// message the model would continue from — is a pattern some backends (notably
+// the Bedrock Converse API) hard-400 on: "This model does not support assistant
+// message prefill. The conversation must end with a user message." Our harness
+// never *intends* to steer output with a prefill; a trailing assistant on the
+// wire is always residue: an interrupted generation, an invalid-output/text-tool
+// recovery turn, or a completed reply that a re-entry path (a ReAct step or a
+// resumed/continued turn — see session/prompt.ts request assembly) sent without
+// appending a following user turn.
+//
+// The original fix here dropped the trailing assistant run UNCONDITIONALLY. That
+// is unsafe: when the trailing assistant is a COMPLETED, content-bearing reply
+// (which is exactly the organic case that produced the live Bedrock 400), a bare
+// drop DELETES that reply's content from the request. Losing a real answer from
+// the transcript is worse than the 400 it avoids.
+//
+// The safe fix keeps every message and instead APPENDS a minimal continuation
+// user turn so the conversation ends with a user message without discarding any
+// content. At this choke point we only have `ModelMessage` (role + content); the
+// `finish`/`error` completeness metadata lives upstream on `MessageV2.Assistant`
+// and isn't visible here, so we can't tell "incomplete residue" from "completed
+// reply" — appending is the content-preserving choice for both. A truly empty
+// trailing assistant (no text and no tool-call — pure residue with nothing to
+// preserve) is dropped instead, since there is no content to keep.
+//
+// A trailing *tool* message is left untouched: providers accept a conversation
+// ending in a tool result (it is the observation half of a tool call), and it is
+// not an assistant prefill.
+const CONTINUATION_PROMPT = "Continue."
+
+// True when an assistant ModelMessage carries no renderable content (no text and
+// no tool-call) — pure residue we can drop without losing anything.
+function isEmptyAssistant(msg: ModelMessage): boolean {
+  if (msg.role !== "assistant") return false
+  if (typeof msg.content === "string") return msg.content.trim() === ""
+  if (!Array.isArray(msg.content)) return true
+  // Only text and tool-call count as preservable content. A reasoning-only or
+  // step-start-only trailing assistant is residue (the model never emitted a
+  // final answer or a tool call) — matching MessageV2.toModelMessages, which
+  // skips an aborted assistant that carries only step-start/reasoning parts.
+  return !msg.content.some(
+    (part) => (part.type === "text" && part.text.trim() !== "") || part.type === "tool-call",
+  )
+}
+
+// Pre-send guard: guarantee the conversation never ends with an assistant
+// (prefill) message that a provider like Bedrock rejects, WITHOUT deleting a
+// completed reply's content. Empty trailing assistants (residue) are dropped;
+// any content-bearing trailing assistant is preserved and a minimal continuation
+// user turn is appended so the list ends with a user message. Runs at the
+// pre-send choke point in `message()`, so it also self-heals history that
+// already ends in an assistant turn.
+export function ensureTrailingUserMessage(msgs: ModelMessage[]): ModelMessage[] {
+  // Drop only trailing EMPTY assistant residue (nothing to preserve).
+  let end = msgs.length
+  while (end > 0 && isEmptyAssistant(msgs[end - 1])) end--
+  const trimmed = end === msgs.length ? msgs : msgs.slice(0, end)
+  const last = trimmed[trimmed.length - 1]
+  // Already ends with user or tool (or empty) — safe to send as-is.
+  if (!last || last.role !== "assistant") return trimmed
+  // A content-bearing assistant is legitimately last: keep it and append a
+  // minimal user turn so the request ends with a user message.
+  return [...trimmed, { role: "user", content: CONTINUATION_PROMPT }]
+}
+
+// Hard prune of the trailing assistant run, discarding its content. Unlike
+// `ensureTrailingUserMessage` this DOES delete content, so it is used only by the
+// reactive backstop in session/llm.ts — after a provider has already returned the
+// deterministic prefill-rejection 400 for a request the proactive guard did not
+// (or could not) neutralize. In that last-resort case dropping is preferable to
+// re-failing, and it is exported for that single consumer.
+export function dropTrailingAssistantPrefill(msgs: ModelMessage[]): ModelMessage[] {
+  let end = msgs.length
+  while (end > 0 && msgs[end - 1].role === "assistant") end--
+  if (end === msgs.length) return msgs
+  return msgs.slice(0, end)
+}
+
+// Signature of the non-retryable 400 a Bedrock Converse backend returns when the
+// conversation ends with an assistant (prefill) message. The primary defense is
+// the proactive `ensureTrailingUserMessage` guard in `message()`, so we should
+// never send a trailing assistant prefill in the first place. This regex backs
+// the reactive backstop in session/llm.ts: if any path still slips a trailing
+// assistant through to the wire (e.g. a provider-side transform re-adds one) and
+// the backend rejects it, we detect the rejection and reprune. The error body
+// reads:
+//   "This model does not support assistant message prefill. The conversation
+//    must end with a user message." (Service: BedrockRuntime)
+// Matching the deterministic failure text is provider-agnostic: it works
+// regardless of gateway naming, providerID, or model-id namespace. We inspect
+// both the error message and the raw response body, case-insensitively, and key
+// only on the specific prefill-rejection phrase — not all 400s.
+const ASSISTANT_PREFILL_REJECTION = /does not support assistant message prefill|must end with a user message/i
+
+export function isAssistantPrefillRejection(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false
+  const e = error as { message?: unknown; responseBody?: unknown; statusCode?: unknown }
+  const status = typeof e.statusCode === "string" ? Number.parseInt(e.statusCode, 10) : e.statusCode
+  // The prefill rejection is always a 400; require it so an unrelated error that
+  // happens to echo the phrase (e.g. our own log line) can't trigger a reprune.
+  if (typeof status === "number" && !Number.isNaN(status) && status !== 400) return false
+  const haystack = [
+    typeof e.message === "string" ? e.message : "",
+    typeof e.responseBody === "string" ? e.responseBody : "",
+  ].join("\n")
+  return ASSISTANT_PREFILL_REJECTION.test(haystack)
+}
+
 // The cache-control marker shape differs per provider/SDK. This is the single
 // source of truth, keyed by the SDK provider-options namespace. `applyCaching`
 // attaches the whole object (keyed by stored providerID) and lets `message()`
@@ -590,6 +699,10 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
   msgs = unsupportedParts(msgs, model)
   msgs = limitImages(msgs, model)
   msgs = normalizeMessages(msgs, model, options)
+  // SAFE prefill guard: never let the request end with an assistant (prefill)
+  // message a provider (e.g. Bedrock) would reject, without deleting a completed
+  // reply. Drops only empty residue; appends a continuation user turn otherwise.
+  msgs = ensureTrailingUserMessage(msgs)
   if (supportsCacheMarkers(model)) {
     msgs = applyCaching(msgs, model)
   }

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import { Provider } from "@/provider"
 import { Log } from "@/util"
-import { Context, Duration, Effect, Layer, Record, Schedule, Ref } from "effect"
+import { Context, Duration, Effect, Layer, Record, Schedule, Ref, Cause } from "effect"
 import * as Stream from "effect/Stream"
 import { streamText, wrapLanguageModel, type ModelMessage, type Tool, tool, jsonSchema } from "ai"
 import { mergeDeep, pipe } from "remeda"
@@ -198,6 +198,12 @@ export type StreamInput = {
 
 export type StreamRequest = StreamInput & {
   abort: AbortSignal
+  // Set on the reactive one-shot retry after a Bedrock/gateway prefill-rejection
+  // 400: hard-prune the trailing assistant (prefill) message(s) before building
+  // the request so the resend ends with a user/tool message. See stream(). The
+  // proactive guard (ProviderTransform.ensureTrailingUserMessage in message())
+  // normally makes this unnecessary; this is a last-resort backstop.
+  dropAssistantPrefill?: boolean
 }
 
 export type Event = Result["fullStream"] extends AsyncIterable<infer T> ? T : never
@@ -360,10 +366,23 @@ const live: Layer.Layer<
       }
 
       const isWorkflow = language instanceof GitLabWorkflowLanguageModel
+      // Reactive prefill-rejection backstop. The PRIMARY mechanism is the
+      // proactive guard in ProviderTransform.message()
+      // (ensureTrailingUserMessage): we never send a request ending in an
+      // assistant (prefill) turn, and we never delete a completed reply to do so.
+      // This reactive path is defense-in-depth: if any code path still slips a
+      // trailing assistant through to the wire (e.g. a provider-side transform
+      // re-adds one) and the backend 400s on it, run() re-runs with this flag set
+      // to hard-prune the trailing assistant turn(s) so the resend ends with a
+      // user/tool message. It should effectively never fire, but keeping it is
+      // cheap and safe.
+      const requestMessages = input.dropAssistantPrefill
+        ? ProviderTransform.dropTrailingAssistantPrefill(input.messages)
+        : input.messages
       const messages = isOpenaiOauth
-        ? input.messages
+        ? requestMessages
         : isWorkflow
-          ? input.messages
+          ? requestMessages
           : [
               ...system.map(
                 (x): ModelMessage => ({
@@ -371,7 +390,7 @@ const live: Layer.Layer<
                   content: x,
                 }),
               ),
-              ...input.messages,
+              ...requestMessages,
             ]
 
       const params = yield* plugin.trigger(
@@ -649,60 +668,113 @@ const live: Layer.Layer<
       })
     })
 
-    const stream: Interface["stream"] = (input) =>
-      Stream.scoped(
-        Stream.unwrap(
-          Effect.gen(function* () {
-            const ctrl = yield* Effect.acquireRelease(
-              Effect.sync(() => new AbortController()),
-              (ctrl) => Effect.sync(() => ctrl.abort()),
-            )
-            const attemptRef = yield* Ref.make(0)
+    const stream: Interface["stream"] = (input) => {
+      // Build the scoped stream for one attempt. `dropAssistantPrefill` forces
+      // run() to hard-prune the trailing assistant prefill before send — used only
+      // by the reactive one-shot retry below.
+      const attempt = (dropAssistantPrefill: boolean) =>
+        Stream.scoped(
+          Stream.unwrap(
+            Effect.gen(function* () {
+              const ctrl = yield* Effect.acquireRelease(
+                Effect.sync(() => new AbortController()),
+                (ctrl) => Effect.sync(() => ctrl.abort()),
+              )
+              const attemptRef = yield* Ref.make(0)
 
-            const publishRetryEvent = (error: unknown, nextAttempt: number) =>
-              Effect.gen(function* () {
-                log.debug("retry attempt", {
-                  sessionID: input.sessionID,
-                  messageID: input.user.id,
-                  attempt: nextAttempt,
-                  reason: error instanceof Error ? error.message : String(error),
-                })
-                if (nextAttempt > 10) return
-                const delayMs = Math.min(500 * 2 ** (nextAttempt - 1), 300_000)
-                yield* Effect.promise(() =>
-                  Bus.publish(Session.Event.RetryAttempt, {
-                    sessionID: SessionID.make(input.sessionID),
+              const publishRetryEvent = (error: unknown, nextAttempt: number) =>
+                Effect.gen(function* () {
+                  log.debug("retry attempt", {
+                    sessionID: input.sessionID,
                     messageID: input.user.id,
                     attempt: nextAttempt,
-                    maxAttempts: 10,
                     reason: error instanceof Error ? error.message : String(error),
-                    nextDelayMs: delayMs,
                   })
-                )
-              })
+                  if (nextAttempt > 10) return
+                  const delayMs = Math.min(500 * 2 ** (nextAttempt - 1), 300_000)
+                  yield* Effect.promise(() =>
+                    Bus.publish(Session.Event.RetryAttempt, {
+                      sessionID: SessionID.make(input.sessionID),
+                      messageID: input.user.id,
+                      attempt: nextAttempt,
+                      maxAttempts: 10,
+                      reason: error instanceof Error ? error.message : String(error),
+                      nextDelayMs: delayMs,
+                    })
+                  )
+                })
 
-            const streamWithTelemetry = run({ ...input, abort: ctrl.signal }).pipe(
-              Effect.tapError((error) => {
-                if (!isTransientCapacityError(error)) return Effect.void
-                return Ref.updateAndGet(attemptRef, (n) => n + 1).pipe(
-                  Effect.flatMap((nextAttempt) => publishRetryEvent(error, nextAttempt))
-                )
-              })
-            )
+              const streamWithTelemetry = run({ ...input, abort: ctrl.signal, dropAssistantPrefill }).pipe(
+                Effect.tapError((error) => {
+                  if (!isTransientCapacityError(error)) return Effect.void
+                  return Ref.updateAndGet(attemptRef, (n) => n + 1).pipe(
+                    Effect.flatMap((nextAttempt) => publishRetryEvent(error, nextAttempt))
+                  )
+                })
+              )
 
-            const result = yield* streamWithTelemetry.pipe(
-              Effect.retry({
-                while: isTransientCapacityError,
-                schedule: persistentRetrySchedule,
-              }),
-            )
+              const result = yield* streamWithTelemetry.pipe(
+                Effect.retry({
+                  while: isTransientCapacityError,
+                  schedule: persistentRetrySchedule,
+                }),
+              )
 
-            return Stream.fromAsyncIterable(result.fullStream, (e) =>
-              e instanceof Error ? e : new Error(String(e)),
-            )
-          }),
-        ),
+              // Structurally identical to the pre-guard stream: a bare scoped
+              // stream over the provider's fullStream. No per-event combinator, no
+              // extra catch layer — so the normal (non-error) event flow and the
+              // AbortController scope teardown are exactly as before. The reactive
+              // prefill retry is layered lazily below and only pays a cost when an
+              // actual error surfaces.
+              return Stream.fromAsyncIterable(result.fullStream, (e) =>
+                e instanceof Error ? e : new Error(String(e)),
+              )
+            }),
+          ),
+        )
+
+      // Promote a prefill-rejection 400 — which arrives as an in-band
+      // `{ type: "error", error }` event, not a stream fault — into a stream
+      // FAILURE so the reactive retry can catch it. `Stream.flatMap` short-circuits
+      // every non-matching event straight through with a pure `Stream.succeed` (no
+      // per-event Effect fiber, unlike `Stream.mapEffect`), and the failing branch
+      // is only ever constructed for the specific error event. On a clean stream
+      // this is a transparent passthrough.
+      const promotePrefillRejection = (stream: Stream.Stream<Event, Error, never>) =>
+        stream.pipe(
+          Stream.flatMap((event) =>
+            event.type === "error" && ProviderTransform.isAssistantPrefillRejection(event.error)
+              ? Stream.fail(event.error instanceof Error ? event.error : new Error(String(event.error)))
+              : Stream.succeed(event),
+          ),
+        )
+
+      // Reactive prefill-rejection backstop. The proactive
+      // ProviderTransform.ensureTrailingUserMessage guard runs on every request,
+      // so we should never send a trailing assistant prefill and this path should
+      // effectively never fire. It remains as defense-in-depth: if any path still
+      // slips a trailing assistant through to the wire and the backend 400s with
+      // "does not support assistant message prefill", we key off that deterministic
+      // error body — not the model id — and retry exactly ONCE with the prefill
+      // hard-pruned. Guarded to a single reprune so a persistent failure surfaces
+      // the retry's OWN error, falling back to the original prefill cause only when
+      // the resend is again prefill-rejected.
+      return promotePrefillRejection(attempt(false)).pipe(
+        Stream.catchCause((primaryCause) => {
+          if (!ProviderTransform.isAssistantPrefillRejection(Cause.squash(primaryCause)))
+            return Stream.failCause(primaryCause)
+          // Pruned resend passes events through untouched: any residual error flows
+          // to the processor and surfaces normally (no promotion, no loop).
+          return attempt(true).pipe(
+            Stream.catchCause((retryCause) =>
+              ProviderTransform.isAssistantPrefillRejection(Cause.squash(retryCause))
+                ? Stream.failCause(primaryCause)
+                : Stream.failCause(retryCause),
+            ),
+          )
+        }),
       )
+    }
 
     return Service.of({ stream, buildSystemArray })
   }),

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1875,10 +1875,10 @@ describe("ProviderTransform.ensureTrailingUserMessage - safe proactive guard (ne
     npm: "@ai-sdk/amazon-bedrock",
   })
   // Gateway exposing an Anthropic-backed model via a dotted id — the live-400 path
-  // (mimorouter -> Bedrock). The guard is provider-agnostic so it applies here too.
+  // (gateway -> Bedrock). The guard is provider-agnostic so it applies here too.
   const gatewayModel = withProvider("mimo", {
     id: "anthropic.claude-sonnet-4",
-    url: "http://mimorouter.llmcore.ai.srv/v1/messages",
+    url: "http://gateway.example/v1/messages",
     npm: "@ai-sdk/anthropic",
   })
 
@@ -1968,7 +1968,7 @@ describe("ProviderTransform.ensureTrailingUserMessage - safe proactive guard (ne
     for (const [label, model] of [
       ["anthropic-native", anthropicModel],
       ["bedrock", bedrockModel],
-      ["anthropic gateway (mimorouter)", gatewayModel],
+      ["anthropic gateway", gatewayModel],
     ] as const) {
       test(`${label}: a completed trailing reply is kept and the request ends with a user message`, () => {
         const msgs = [
@@ -2720,10 +2720,10 @@ describe("ProviderTransform.message - cache control on gateway", () => {
 
   test("openai-compatible with claude in model id does NOT trigger caching", () => {
     const model = createModel({
-      id: "mimorouter/claude-opus-4-8",
+      id: "gateway/claude-opus-4-8",
       providerID: "custom",
       api: {
-        id: "mimorouter/claude-opus-4-8",
+        id: "gateway/claude-opus-4-8",
         url: "https://proxy.example.com/v1",
         npm: "@ai-sdk/openai-compatible",
       },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -975,6 +975,7 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
           },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(
@@ -1016,7 +1017,7 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
       {},
     )
 
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
     expect(result[0].content).toEqual([
       {
         type: "tool-call",
@@ -1037,6 +1038,7 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
           { type: "text", text: "Answer" },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(
@@ -1514,11 +1516,12 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
           { type: "text", text: "" },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, anthropicModel, {})
 
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
     expect(result[0].content).toHaveLength(1)
     expect(result[0].content[0]).toEqual({ type: "text", text: "Hello" })
   })
@@ -1533,11 +1536,12 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
           { type: "reasoning", text: "" },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, anthropicModel, {})
 
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
     expect(result[0].content).toHaveLength(1)
     expect(result[0].content[0]).toEqual({ type: "text", text: "Answer" })
   })
@@ -1571,11 +1575,12 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
           { type: "tool-call", toolCallId: "123", toolName: "bash", input: { command: "ls" } },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, anthropicModel, {})
 
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
     expect(result[0].content).toHaveLength(1)
     expect(result[0].content[0]).toEqual({
       type: "tool-call",
@@ -1595,11 +1600,12 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
           { type: "text", text: "Result" },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, anthropicModel, {})
 
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
     expect(result[0].content).toHaveLength(2)
     expect(result[0].content[0]).toEqual({ type: "reasoning", text: "Thinking..." })
     expect(result[0].content[1]).toEqual({ type: "text", text: "Result" })
@@ -1658,11 +1664,12 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
         role: "assistant",
         content: [{ type: "text", text: "" }],
       },
+      { role: "user", content: "next" },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, openaiModel, {})
 
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(3)
     expect(result[0].content).toBe("")
     expect(result[1].content).toHaveLength(1)
   })
@@ -1721,11 +1728,12 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
           { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
 
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
     expect(result[0].content).toMatchObject([
       { type: "text", text: "I checked your home directory and looked for PDF files." },
       { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
@@ -1753,11 +1761,12 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
           { type: "text", text: "I checked your home directory and looked for PDF files." },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, model, {}) as any[]
 
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(3)
     expect(result[0]).toMatchObject({
       role: "assistant",
       content: [{ type: "text", text: "I checked your home directory and looked for PDF files." }],
@@ -1771,6 +1780,242 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     })
   })
 })
+
+describe("ProviderTransform.isAssistantPrefillRejection - error-body detection (defensive backstop)", () => {
+  // Backstop for any path that might still slip a trailing assistant prefill to
+  // the wire despite the unconditional proactive drop. The only reliable signal
+  // for the rejection is the deterministic 400 body, so detection keys off that.
+  const bedrockPrefillBody = JSON.stringify({
+    message: "This model does not support assistant message prefill. The conversation must end with a user message.",
+    Service: "BedrockRuntime",
+  })
+
+  test("detects the AI SDK APICallError shape (statusCode 400 + responseBody)", () => {
+    const error = {
+      name: "AI_APICallError",
+      statusCode: 400,
+      responseBody: bedrockPrefillBody,
+      message: "Bad Request",
+      isRetryable: false,
+    }
+    expect(ProviderTransform.isAssistantPrefillRejection(error)).toBe(true)
+  })
+
+  test("detects the phrase in the error message even when responseBody is absent", () => {
+    const error = {
+      statusCode: 400,
+      message: "This model does not support assistant message prefill.",
+    }
+    expect(ProviderTransform.isAssistantPrefillRejection(error)).toBe(true)
+  })
+
+  test("detects the 'must end with a user message' variant (case-insensitive)", () => {
+    const error = { statusCode: 400, responseBody: "The conversation MUST END WITH A USER MESSAGE." }
+    expect(ProviderTransform.isAssistantPrefillRejection(error)).toBe(true)
+  })
+
+  test("matches when statusCode is a numeric string (some gateways stringify it)", () => {
+    const error = { statusCode: "400", responseBody: bedrockPrefillBody }
+    expect(ProviderTransform.isAssistantPrefillRejection(error)).toBe(true)
+  })
+
+  test("does NOT match an unrelated 400 (no prefill phrase)", () => {
+    const error = { statusCode: 400, responseBody: JSON.stringify({ message: "invalid_request: bad tool schema" }) }
+    expect(ProviderTransform.isAssistantPrefillRejection(error)).toBe(false)
+  })
+
+  test("does NOT match a non-400 status even if the phrase appears (must be the 400 rejection)", () => {
+    const error = { statusCode: 500, responseBody: "does not support assistant message prefill" }
+    expect(ProviderTransform.isAssistantPrefillRejection(error)).toBe(false)
+  })
+
+  test("does NOT match null / undefined / non-object", () => {
+    expect(ProviderTransform.isAssistantPrefillRejection(undefined)).toBe(false)
+    expect(ProviderTransform.isAssistantPrefillRejection(null)).toBe(false)
+    expect(ProviderTransform.isAssistantPrefillRejection("does not support assistant message prefill")).toBe(false)
+  })
+
+  test("matches when statusCode is absent but the phrase is present (stream-body error without a parsed status)", () => {
+    const error = { message: "400 does not support assistant message prefill (Service: BedrockRuntime)" }
+    expect(ProviderTransform.isAssistantPrefillRejection(error)).toBe(true)
+  })
+})
+
+describe("ProviderTransform.ensureTrailingUserMessage - safe proactive guard (never deletes a completed reply)", () => {
+  const withProvider = (providerID: string, api: { id: string; url: string; npm: string }) =>
+    ({
+      id: `${providerID}/${api.id}`,
+      providerID,
+      api,
+      name: api.id,
+      capabilities: {
+        temperature: true,
+        reasoning: false,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: true },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.003, output: 0.015, cache: { read: 0.0003, write: 0.00375 } },
+      limit: { context: 200000, output: 8192 },
+      status: "active",
+      options: {},
+      headers: {},
+    }) as any
+
+  const anthropicModel = withProvider("anthropic", {
+    id: "claude-3-5-sonnet-20241022",
+    url: "https://api.anthropic.com",
+    npm: "@ai-sdk/anthropic",
+  })
+  const bedrockModel = withProvider("amazon-bedrock", {
+    id: "anthropic.claude-opus-4-6",
+    url: "https://bedrock-runtime.us-east-1.amazonaws.com",
+    npm: "@ai-sdk/amazon-bedrock",
+  })
+  // Gateway exposing an Anthropic-backed model via a dotted id — the live-400 path
+  // (mimorouter -> Bedrock). The guard is provider-agnostic so it applies here too.
+  const gatewayModel = withProvider("mimo", {
+    id: "anthropic.claude-sonnet-4",
+    url: "http://mimorouter.llmcore.ai.srv/v1/messages",
+    npm: "@ai-sdk/anthropic",
+  })
+
+  test("preserves a COMPLETED trailing assistant reply and appends a continuation user turn (no content deleted)", () => {
+    const msgs = [
+      { role: "user", content: "q" },
+      { role: "assistant", content: [{ type: "text", text: "the full completed answer" }] },
+    ] as any[]
+    const result = ProviderTransform.ensureTrailingUserMessage(msgs)
+    expect(result).toHaveLength(3)
+    // Reply preserved verbatim...
+    expect(result[1].role).toBe("assistant")
+    expect((result[1].content as any)[0].text).toBe("the full completed answer")
+    // ...and the conversation now ends with a user message.
+    expect(result[result.length - 1].role).toBe("user")
+  })
+
+  test("preserves a trailing assistant that carries a tool-call (real content) via a continuation user turn", () => {
+    const msgs = [
+      { role: "user", content: "read" },
+      { role: "assistant", content: [{ type: "tool-call", toolCallId: "c1", toolName: "read", input: {} }] },
+    ] as any[]
+    const result = ProviderTransform.ensureTrailingUserMessage(msgs)
+    expect(result.some((m) => Array.isArray(m.content) && (m.content[0] as any)?.type === "tool-call")).toBe(true)
+    expect(result[result.length - 1].role).toBe("user")
+  })
+
+  test("drops an INCOMPLETE (empty) trailing assistant (residue) without appending anything", () => {
+    const msgs = [
+      { role: "user", content: "q" },
+      { role: "assistant", content: [] },
+    ] as any[]
+    const result = ProviderTransform.ensureTrailingUserMessage(msgs)
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe("user")
+  })
+
+  test("drops a reasoning-only trailing assistant (residue: no final text/tool-call, matches toModelMessages)", () => {
+    const msgs = [
+      { role: "user", content: "q" },
+      { role: "assistant", content: [{ type: "reasoning", text: "some reasoning" }] },
+    ] as any[]
+    const result = ProviderTransform.ensureTrailingUserMessage(msgs)
+    // A reasoning-only trailing assistant carries no final answer or tool call, so
+    // it is residue (upstream toModelMessages skips such aborted turns). Dropped;
+    // the conversation then ends on the user turn with nothing appended.
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe("user")
+  })
+
+  test("peels trailing empty residue but preserves an earlier content-bearing reply with a continuation turn", () => {
+    const msgs = [
+      { role: "user", content: "go" },
+      { role: "assistant", content: [{ type: "text", text: "real reply" }] },
+      { role: "assistant", content: [] },
+      { role: "assistant", content: "   " },
+    ] as any[]
+    const result = ProviderTransform.ensureTrailingUserMessage(msgs)
+    expect(result.some((m) => Array.isArray(m.content) && (m.content[0] as any)?.text === "real reply")).toBe(true)
+    expect(result[result.length - 1].role).toBe("user")
+  })
+
+  test("leaves a conversation already ending with a user message untouched (identity)", () => {
+    const msgs = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: [{ type: "text", text: "hello" }] },
+      { role: "user", content: "bye" },
+    ] as any[]
+    expect(ProviderTransform.ensureTrailingUserMessage(msgs)).toBe(msgs)
+  })
+
+  test("leaves a trailing tool message untouched (tool result is a valid conversation end, not a prefill)", () => {
+    const msgs = [
+      { role: "user", content: "read" },
+      { role: "assistant", content: [{ type: "tool-call", toolCallId: "c1", toolName: "read", input: {} }] },
+      {
+        role: "tool",
+        content: [{ type: "tool-result", toolCallId: "c1", toolName: "read", output: { type: "text", value: "ok" } }],
+      },
+    ] as any[]
+    const result = ProviderTransform.ensureTrailingUserMessage(msgs)
+    expect(result).toHaveLength(3)
+    expect(result[result.length - 1].role).toBe("tool")
+  })
+
+  describe("end-to-end via message() — every provider ends the request with a user message", () => {
+    for (const [label, model] of [
+      ["anthropic-native", anthropicModel],
+      ["bedrock", bedrockModel],
+      ["anthropic gateway (mimorouter)", gatewayModel],
+    ] as const) {
+      test(`${label}: a completed trailing reply is kept and the request ends with a user message`, () => {
+        const msgs = [
+          { role: "user", content: "Question?" },
+          { role: "assistant", content: [{ type: "text", text: "Completed answer." }] },
+        ] as any[]
+        const result = ProviderTransform.message(msgs, model, {})
+        expect(result[result.length - 1].role).toBe("user")
+        expect(
+          result.some((m: any) => Array.isArray(m.content) && m.content.some((p: any) => p.text === "Completed answer.")),
+        ).toBe(true)
+      })
+    }
+  })
+})
+
+describe("ProviderTransform.dropTrailingAssistantPrefill - hard prune (reactive backstop last resort)", () => {
+  test("drops the entire trailing assistant run, discarding content", () => {
+    const msgs = [
+      { role: "user", content: "go" },
+      { role: "assistant", content: [{ type: "text", text: "first" }] },
+      { role: "assistant", content: [{ type: "text", text: "second" }] },
+    ] as any[]
+    const result = ProviderTransform.dropTrailingAssistantPrefill(msgs)
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe("user")
+  })
+
+  test("only drops the trailing run, preserving mid-conversation assistants", () => {
+    const msgs = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: [{ type: "text", text: "mid" }] },
+      { role: "user", content: "go" },
+      { role: "assistant", content: [{ type: "text", text: "tail" }] },
+    ] as any[]
+    const result = ProviderTransform.dropTrailingAssistantPrefill(msgs)
+    expect(result[result.length - 1].role).toBe("user")
+    expect(result[result.length - 1].content).toBe("go")
+    expect(result.some((m) => Array.isArray(m.content) && (m.content[0] as any)?.text === "mid")).toBe(true)
+  })
+
+  test("leaves a user/tool-terminated list unchanged (identity)", () => {
+    const msgs = [{ role: "user", content: "hi" }] as any[]
+    expect(ProviderTransform.dropTrailingAssistantPrefill(msgs)).toBe(msgs)
+  })
+})
+
 
 describe("ProviderTransform.message - strip openai metadata when store=false", () => {
   const openaiModel = {
@@ -1824,11 +2069,12 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
           },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, openaiModel, { store: false }) as any[]
 
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
     expect(result[0].content[0].providerOptions?.openai?.itemId).toBeUndefined()
     expect(result[0].content[0].providerOptions?.openai?.reasoningEncryptedContent).toBe("encrypted")
     expect(result[0].content[1].providerOptions?.openai?.itemId).toBeUndefined()
@@ -1865,11 +2111,12 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
           },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, zenModel, { store: false }) as any[]
 
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
     expect(result[0].content[0].providerOptions?.openai?.itemId).toBeUndefined()
     expect(result[0].content[0].providerOptions?.openai?.reasoningEncryptedContent).toBe("encrypted")
     expect(result[0].content[1].providerOptions?.openai?.itemId).toBeUndefined()
@@ -1892,6 +2139,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
           },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, openaiModel, { store: false }) as any[]
@@ -1923,6 +2171,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
           },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, azureModel, { store: false }) as any[]
@@ -1947,6 +2196,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
           },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     // store=true keeps itemId (stateful Responses API resolves items by id)
@@ -1980,6 +2230,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
           },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     // store=false does NOT strip for non-openai/azure packages
@@ -2014,6 +2265,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
           },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, opencodeModel, { store: false }) as any[]
@@ -2048,6 +2300,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
           },
         ],
       },
+      { role: "user", content: [{ type: "text", text: "next" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
@@ -2526,7 +2779,9 @@ describe("ProviderTransform.message - cache control on gateway", () => {
 
   test("content-level provider marks the last two messages regardless of role", () => {
     // Providers that reach applyCaching honor message-level markers (incl.
-    // assistant), so the double-tail marks the last two messages by position.
+    // assistant). The unconditional prefill drop removes any TRAILING assistant
+    // before caching, so a mid-conversation assistant (index 3) is the "regardless
+    // of role" case: it still gets marked when it lands in the double-tail window.
     const model = createModel({
       providerID: "openrouter",
       api: { id: "anthropic/claude-sonnet-4", url: "https://openrouter.ai/api", npm: "@openrouter/ai-sdk-provider" },
@@ -2535,8 +2790,8 @@ describe("ProviderTransform.message - cache control on gateway", () => {
       { role: "system", content: [{ type: "text", text: "sys" }] },
       { role: "user", content: [{ type: "text", text: "first question" }] },
       { role: "assistant", content: [{ type: "text", text: "first answer" }] },
-      { role: "user", content: [{ type: "text", text: "second question" }] },
       { role: "assistant", content: [{ type: "text", text: "second answer" }] },
+      { role: "user", content: [{ type: "text", text: "second question" }] },
     ] as any[]
 
     const result = ProviderTransform.message(msgs, model, {}) as any[]
@@ -2545,7 +2800,7 @@ describe("ProviderTransform.message - cache control on gateway", () => {
       !!msg.providerOptions?.openrouter ||
       msg.content?.some?.((c: any) => c.providerOptions?.openrouter)
 
-    // The last two messages (index 3 user, 4 assistant) are both marked.
+    // The last two messages (index 3 assistant, 4 user) are both marked.
     expect(hasMarker(result[3])).toBe(true)
     expect(hasMarker(result[4])).toBe(true)
     // Earlier turns are not.


### PR DESCRIPTION
## Summary

Standalone fix extracting the **assistant-prefill handling** out of #1679 (`fix/provider-image-and-bedrock-prefill`) and fixing it correctly. Contains ONLY the prefill fix — no image/downscale changes.

A real Bedrock 400 was observed in production:
> `This model does not support assistant message prefill. The conversation must end with a user message. (Service: BedrockRuntime, 400)`

This proves the harness organically emits a conversation ending in an assistant message that a Bedrock-backed provider rejects.

## The bug in #1679

#1679's `dropTrailingAssistantPrefill` ran **unconditionally** in `message()` and **deleted the entire trailing assistant run — content and all**. When the trailing assistant is a *completed, content-bearing reply* (the organic case: a resumed / mid-turn ReAct re-entry whose last persisted turn is a finished reply), that blanket drop silently **deletes a real answer** from the request the model sees.

## The safe fix

Replace the unconditional content-drop with a content-preserving guard:

- **`ensureTrailingUserMessage(msgs)`** — the proactive pre-send guard in `ProviderTransform.message()`:
  - drops only an **EMPTY / residue** trailing assistant (no text, no tool-call — e.g. an interrupted or reasoning-only turn, matching what `MessageV2.toModelMessages` already skips);
  - for a **content-bearing** trailing assistant, **appends a minimal continuation user turn** so the conversation ends with a user message **without deleting the reply**.
  - a trailing *tool* message (valid observation) is never touched.
  - provider-agnostic (no Bedrock model-id guessing).
- **`dropTrailingAssistantPrefill(msgs)`** — retained as a hard prune used ONLY by the reactive backstop, after a provider has already 400'd on a prefill (last resort).
- **`isAssistantPrefillRejection(error)`** + the reactive one-shot retry in `session/llm.ts` — kept as defense-in-depth: if any path still slips a trailing assistant to the wire and the backend returns the deterministic prefill-rejection 400, we detect it by error body (not model id) and retry once with the prefill pruned.

Net: the harness never sends a provider-rejected assistant prefill, and a legitimate completed reply is never dropped.

## Tests

- `test/provider/transform.test.ts`: 193 pass — new `ensureTrailingUserMessage` safe-guard suite (completed reply kept + continuation appended; empty/reasoning-only residue dropped; tool tail untouched; end-to-end across anthropic / bedrock / mimorouter gateway), `dropTrailingAssistantPrefill` hard-prune suite, `isAssistantPrefillRejection` error-body detection (incl. the live 400 wording). Collateral content-filtering/metadata tests updated to end their fixtures on a user turn.
- `test/session/llm.test.ts`: 14 pass.
- Timing suites `invalid-output-continuation`, `llm-request-prefix`, `main-lifecycle`: pass.
- `bun typecheck`: exit 0.

Co-authored-by: MiMo-Code <noreply@mimo.xiaomi.com>