### PR TITLE
fix(mcp): handle standard tool result fields

### DIFF
--- a/packages/opencode/src/mcp/tool-result.ts
+++ b/packages/opencode/src/mcp/tool-result.ts
@@ -1,0 +1,103 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
+import { isRecord } from "@/util/record"
+
+export type ToolResultAttachment = {
+  mime: string
+  url: string
+  filename?: string
+}
+
+export type ToolResultMetadata = {
+  isError: boolean
+  structuredContent?: CallToolResult["structuredContent"]
+  _meta?: CallToolResult["_meta"]
+  legacyMetadata?: Record<string, unknown>
+}
+
+export type NormalizedToolResult = {
+  content: CallToolResult["content"]
+  structuredContent?: CallToolResult["structuredContent"]
+  isError: boolean
+  output: string
+  attachments: ToolResultAttachment[]
+  metadata: Record<string, unknown> & { mcp: ToolResultMetadata }
+}
+
+/**
+ * Converts a standard MCP CallToolResult into MiMoCode's model-facing text,
+ * attachments, and lossless client metadata.
+ *
+ * MCP servers should normally include a serialized copy of `structuredContent`
+ * in `content`. When they do not, the structured value is appended so it still
+ * reaches the model; exact compact or pretty-printed copies are de-duplicated.
+ * Top-level `_meta` is client-only and is never added to output text.
+ */
+export function normalizeToolResult(result: CallToolResult): NormalizedToolResult {
+  const text: string[] = []
+  const attachments: ToolResultAttachment[] = []
+
+  for (const item of result.content) {
+    if (item.type === "text") {
+      text.push(item.text)
+      continue
+    }
+
+    if (item.type === "image" || item.type === "audio") {
+      attachments.push({
+        mime: item.mimeType,
+        url: `data:${item.mimeType};base64,${item.data}`,
+      })
+      continue
+    }
+
+    if (item.type === "resource_link") {
+      text.push(`${item.title ?? item.name}: ${item.uri}`)
+      continue
+    }
+
+    if (item.type === "resource") {
+      if ("text" in item.resource) text.push(item.resource.text)
+      if ("blob" in item.resource) {
+        const mime = item.resource.mimeType ?? "application/octet-stream"
+        attachments.push({
+          mime,
+          url: `data:${mime};base64,${item.resource.blob}`,
+          filename: item.resource.uri,
+        })
+      }
+    }
+  }
+
+  const legacy = isRecord(result.metadata) ? result.metadata : {}
+  const textOutput = text.join("\n\n")
+  const structured =
+    result.structuredContent === undefined ? undefined : JSON.stringify(result.structuredContent)
+  const prettyStructured =
+    result.structuredContent === undefined ? undefined : JSON.stringify(result.structuredContent, null, 2)
+  const hasVisibleText = text.some((item) => item.trim().length > 0)
+  const alreadySerialized =
+    structured !== undefined &&
+    (textOutput.includes(structured) || (prettyStructured !== undefined && textOutput.includes(prettyStructured)))
+  const output =
+    structured === undefined || alreadySerialized
+      ? textOutput
+      : hasVisibleText
+        ? `${textOutput}\n\nStructured content:\n${structured}`
+        : structured
+
+  const mcp: ToolResultMetadata = {
+    isError: result.isError ?? false,
+    ...(result.structuredContent === undefined ? {} : { structuredContent: result.structuredContent }),
+    ...(result._meta === undefined ? {} : { _meta: result._meta }),
+    ...(Object.keys(legacy).length === 0 ? {} : { legacyMetadata: legacy }),
+  }
+
+  return {
+    content: result.content,
+    ...(result.structuredContent === undefined ? {} : { structuredContent: result.structuredContent }),
+    isError: result.isError ?? false,
+    output,
+    attachments,
+    metadata: { mcp },
+  }
+}

--- a/packages/opencode/src/mcp/tool-result.ts
+++ b/packages/opencode/src/mcp/tool-result.ts
@@ -23,6 +23,16 @@ export type NormalizedToolResult = {
   metadata: Record<string, unknown> & { mcp: ToolResultMetadata }
 }
 
+function containsSerializedBlock(output: string, serialized: string) {
+  const value = output.replaceAll("\r\n", "\n").trim()
+  return (
+    value === serialized ||
+    value.startsWith(`${serialized}\n`) ||
+    value.endsWith(`\n${serialized}`) ||
+    value.includes(`\n${serialized}\n`)
+  )
+}
+
 /**
  * Converts a standard MCP CallToolResult into MiMoCode's model-facing text,
  * attachments, and lossless client metadata.
@@ -51,7 +61,23 @@ export function normalizeToolResult(result: CallToolResult): NormalizedToolResul
     }
 
     if (item.type === "resource_link") {
-      text.push(`${item.title ?? item.name}: ${item.uri}`)
+      const name = item.title ?? item.name
+      const uri = item.uri.trim()
+      if (/^data:/i.test(uri)) {
+        const inline = uri.match(/^data:([a-z0-9.+-]+\/[a-z0-9.+-]+);base64,([a-z0-9+/]+={0,2})$/i)
+        if (inline) {
+          attachments.push({
+            mime: inline[1],
+            url: uri,
+            filename: name,
+          })
+          text.push(`${name}: [inline ${inline[1]} resource]`)
+        } else {
+          text.push(`${name}: [data URI omitted]`)
+        }
+        continue
+      }
+      text.push(`${name}: ${item.uri}`)
       continue
     }
 
@@ -77,7 +103,8 @@ export function normalizeToolResult(result: CallToolResult): NormalizedToolResul
   const hasVisibleText = text.some((item) => item.trim().length > 0)
   const alreadySerialized =
     structured !== undefined &&
-    (textOutput.includes(structured) || (prettyStructured !== undefined && textOutput.includes(prettyStructured)))
+    (containsSerializedBlock(textOutput, structured) ||
+      (prettyStructured !== undefined && containsSerializedBlock(textOutput, prettyStructured)))
   const output =
     structured === undefined || alreadySerialized
       ? textOutput

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -394,13 +394,6 @@ function base64ByteSize(base64: string): number {
   return Math.floor((base64.length * 3) / 4) - padding
 }
 
-// Returns the decoded byte size of a base64 data URL, or undefined for inputs
-// that aren't data URLs (remote URLs, raw binary) and therefore can't be sized.
-function imageByteSize(image: string): number | undefined {
-  if (!image.startsWith("data:")) return undefined
-  return base64ByteSize(image.slice(image.indexOf(",") + 1))
-}
-
 // Split a data URL into its mime + raw base64. Returns undefined for anything
 // that isn't a base64 data URL.
 function parseDataUrl(image: string): { mime: string; base64: string } | undefined {
@@ -409,6 +402,49 @@ function parseDataUrl(image: string): { mime: string; base64: string } | undefin
   if (comma === -1) return undefined
   const mime = image.slice(5, image.indexOf(";") === -1 ? comma : image.indexOf(";"))
   return { mime, base64: image.slice(comma + 1) }
+}
+
+type ImagePayload =
+  | { kind: "data-url" | "base64"; mime?: string; base64: string; size: number }
+  | { kind: "bytes"; mime?: string; bytes: Uint8Array; size: number }
+
+function isRawBase64(value: string) {
+  if (!value || value.length % 4 === 1) return false
+  return /^[a-z0-9+/_-]+={0,2}$/i.test(value)
+}
+
+function compactBase64(value: string) {
+  return value.replace(/[\t\n\f\r ]/g, "")
+}
+
+// AI SDK normalizes user files before middleware runs: data URLs become raw
+// base64 strings, binary DataContent becomes Uint8Array, and remote URLs remain
+// URL objects. Accept the pre-conversion data-URL shape too because tests and
+// a few internal callers still pass ModelMessage values directly.
+function imagePayload(value: unknown, mediaType?: string): ImagePayload | undefined {
+  if (value instanceof URL) return undefined
+  if (typeof value === "string") {
+    const parsed = parseDataUrl(value)
+    if (parsed) {
+      const base64 = compactBase64(parsed.base64)
+      if (!isRawBase64(base64)) return undefined
+      return {
+        kind: "data-url",
+        mime: parsed.mime || mediaType,
+        base64,
+        size: base64ByteSize(base64),
+      }
+    }
+
+    const base64 = compactBase64(value)
+    if (!isRawBase64(base64)) return undefined
+    return { kind: "base64", mime: mediaType, base64, size: base64ByteSize(base64) }
+  }
+
+  const bytes =
+    value instanceof ArrayBuffer ? new Uint8Array(value) : value instanceof Uint8Array ? value : undefined
+  if (!bytes) return undefined
+  return { kind: "bytes", mime: mediaType, bytes, size: bytes.byteLength }
 }
 
 // Bring one oversized image under maxSize: recompress if we can decode it,
@@ -469,11 +505,12 @@ function providerImageCap(model: Provider.Model): number {
 }
 
 // Two responsibilities:
-// 1. Count cap (maxImages): drop the oldest excess *user* prompt images.
+// 1. Count cap (maxImages): drop the oldest excess *user* prompt images,
+//    including image-typed `file` parts produced by synthetic tool attachments.
 // 2. Size cap (maxSize): for EVERY image the provider would measure — user
-//    `image` parts AND tool-result `media`/`image-data`/`file-data` parts on
-//    tool/assistant messages — recompress oversized ones under the limit, or
-//    strip them to a text placeholder.
+//    `image`/image-`file` parts AND tool-result `media`/`image-data`/`file-data`
+//    parts on tool/assistant messages — recompress oversized ones under the
+//    limit, or strip them to a text placeholder.
 //
 // The size cap is PROVIDER-AWARE (providerImageCap): only Anthropic/Bedrock have
 // the ~5 MB hard limit, so only they get DEFAULT_MAX_IMAGE_BYTES; other providers
@@ -497,7 +534,10 @@ function limitImages(msgs: ModelMessage[], model: Provider.Model): ModelMessage[
   const total = msgs.reduce(
     (sum, msg) =>
       msg.role === "user" && Array.isArray(msg.content)
-        ? sum + msg.content.filter((part) => part.type === "image").length
+        ? sum +
+          msg.content.filter(
+            (part) => part.type === "image" || (part.type === "file" && part.mediaType.startsWith("image/")),
+          ).length
         : sum,
     0,
   )
@@ -550,19 +590,39 @@ function limitImages(msgs: ModelMessage[], model: Provider.Model): ModelMessage[
 
     if (msg.role !== "user") return msg
     const content = msg.content.map((part) => {
-      if (part.type !== "image") return part
+      const isImageFile = part.type === "file" && part.mediaType.startsWith("image/")
+      if (part.type !== "image" && !isImageFile) return part
       if (toDrop > 0) {
         toDrop--
-        return { type: "text" as const, text: `[Image omitted: exceeds the configured limit of ${maxImages} prompt image(s).]` }
+        return {
+          type: "text" as const,
+          text: `[Image omitted: exceeds the configured limit of ${maxImages} prompt image(s).]`,
+        }
       }
-      const size = imageByteSize(String(part.image))
-      if (size === undefined || size <= maxSize) return part
-      const parsed = parseDataUrl(String(part.image))
-      if (parsed && parsed.mime.startsWith("image/")) {
-        const shrunk = shrinkBase64(parsed.mime, parsed.base64, maxSize)
-        if (shrunk) return { ...part, image: `data:${shrunk.mime};base64,${shrunk.base64}` }
+      const payload = imagePayload(
+        part.type === "image" ? part.image : part.data,
+        part.mediaType,
+      )
+      if (!payload || payload.size <= maxSize) return part
+      if (payload.mime?.startsWith("image/")) {
+        const base64 =
+          payload.kind === "bytes"
+            ? Buffer.from(payload.bytes.buffer, payload.bytes.byteOffset, payload.bytes.byteLength).toString("base64")
+            : payload.base64
+        const shrunk = shrinkBase64(payload.mime, base64, maxSize)
+        if (shrunk) {
+          const data =
+            payload.kind === "data-url"
+              ? `data:${shrunk.mime};base64,${shrunk.base64}`
+              : payload.kind === "bytes"
+                ? new Uint8Array(Buffer.from(shrunk.base64, "base64"))
+                : shrunk.base64
+          return part.type === "image"
+            ? { ...part, image: data, mediaType: shrunk.mime }
+            : { ...part, data, mediaType: shrunk.mime }
+        }
       }
-      return { type: "text" as const, text: OVERSIZE_PLACEHOLDER(size, maxSize) }
+      return { type: "text" as const, text: OVERSIZE_PLACEHOLDER(payload.size, maxSize) }
     })
     return { ...msg, content }
   })

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -344,6 +344,7 @@ export const ToolStateError = z
       start: z.number(),
       end: z.number(),
     }),
+    attachments: FilePart.array().optional(),
   })
   .meta({
     ref: "ToolStateError",
@@ -788,6 +789,8 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
             })
           }
           if (part.state.status === "error") {
+            const attachments = options?.stripMedia ? [] : (part.state.attachments ?? [])
+            media.push(...attachments.filter((attachment) => isMedia(attachment.mime)))
             const output = part.state.metadata?.interrupted === true ? part.state.metadata.output : undefined
             if (typeof output === "string") {
               assistantMessage.parts.push({

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -9,7 +9,6 @@ import { SyncEvent } from "../sync"
 import { Database, NotFoundError, and, desc, eq, inArray, lt, or } from "@/storage"
 import { MessageTable, PartTable, SessionTable } from "./session.sql"
 import { ProviderError } from "@/provider"
-import { iife } from "@/util/iife"
 import { errorMessage } from "@/util/error"
 import { isMedia } from "@/util/media"
 import type { SystemError } from "bun"
@@ -17,6 +16,12 @@ import type { Provider } from "@/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect } from "effect"
 import { EffectLogger } from "@/effect"
+import {
+  inlineToolAttachment,
+  routeToolAttachment,
+  toolAttachmentFilename,
+  toolAttachmentPlaceholder,
+} from "./tool-attachment"
 
 /** Error shape thrown by Bun's fetch() when gzip/br decompression fails mid-stream */
 interface FetchDecompressionError extends Error {
@@ -25,7 +30,7 @@ interface FetchDecompressionError extends Error {
   path: string
 }
 
-export const SYNTHETIC_ATTACHMENT_PROMPT = "Attached image(s) from tool result:"
+export const SYNTHETIC_ATTACHMENT_PROMPT = "Attached file(s) from tool result:"
 export { isMedia }
 
 export const OutputLengthError = NamedError.create("MessageOutputLengthError", z.object({}))
@@ -620,23 +625,6 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 ) {
   const result: UIMessage[] = []
   const toolNames = new Set<string>()
-  // Track media from tool results that need to be injected as user messages
-  // for providers that don't support media in tool results.
-  //
-  // OpenAI-compatible APIs only support string content in tool results, so media
-  // must be extracted and injected as a user message. Anthropic/Bedrock can keep
-  // media nested in tool results; Gemini 3 supports it, but earlier Gemini models
-  // need the extracted-user-message path.
-  const supportsMediaInToolResults = (() => {
-    if (model.api.npm === "@ai-sdk/anthropic") return true
-    if (model.api.npm === "@ai-sdk/amazon-bedrock") return true
-    if (model.api.npm === "@ai-sdk/google-vertex/anthropic") return true
-    if (model.api.npm === "@ai-sdk/google") {
-      const id = model.api.id.toLowerCase()
-      return id.includes("gemini-3") && !id.includes("gemini-2")
-    }
-    return false
-  })()
 
   const toModelOutput = (options: { toolCallId: string; input: unknown; output: unknown }) => {
     const output = options.output
@@ -649,22 +637,29 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         text: string
         attachments?: Array<{ mime: string; url: string; filename?: string }>
       }
-      const attachments = (outputObject.attachments ?? []).filter((attachment) => {
-        return attachment.url.startsWith("data:") && attachment.url.includes(",")
+      const attachments = (outputObject.attachments ?? []).flatMap((attachment) => {
+        const inline = inlineToolAttachment(attachment)
+        return inline ? [{ ...attachment, ...inline }] : []
       })
 
       return {
         type: "content",
         value: [
           { type: "text", text: outputObject.text },
-          ...attachments.map((attachment) => ({
-            type: "media",
-            mediaType: attachment.mime,
-            data: iife(() => {
-              const commaIndex = attachment.url.indexOf(",")
-              return commaIndex === -1 ? attachment.url : attachment.url.slice(commaIndex + 1)
-            }),
-          })),
+          ...attachments.map((attachment) =>
+            attachment.mime.startsWith("image/")
+              ? {
+                  type: "image-data" as const,
+                  mediaType: attachment.mediaType,
+                  data: attachment.data,
+                }
+              : {
+                  type: "file-data" as const,
+                  mediaType: attachment.mediaType,
+                  data: attachment.data,
+                  filename: toolAttachmentFilename(attachment),
+                },
+          ),
         ],
       }
     }
@@ -728,7 +723,51 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 
     if (msg.info.role === "assistant") {
       const differentModel = `${model.providerID}/${model.id}` !== `${msg.info.providerID}/${msg.info.modelID}`
-      const media: Array<{ mime: string; url: string; filename?: string }> = []
+      const syntheticGroups: Array<{
+        tool: string
+        callID: string
+        status: "completed" | "error"
+        parts: Array<
+          { type: "file"; url: string; mediaType: string; filename?: string } | { type: "text"; text: string }
+        >
+      }> = []
+      const routeAttachments = (input: {
+        tool: string
+        callID: string
+        status: "completed" | "error"
+        attachments: FilePart[]
+        allowNative: boolean
+      }) => {
+        const native: FilePart[] = []
+        const parts: (typeof syntheticGroups)[number]["parts"] = []
+        for (const attachment of input.attachments) {
+          const route = routeToolAttachment({ model, attachment, allowNative: input.allowNative })
+          if (route === "native") native.push(attachment)
+          if (route === "synthetic") {
+            parts.push({
+              type: "file",
+              url: attachment.url,
+              mediaType: attachment.mime,
+              filename: toolAttachmentFilename(attachment),
+            })
+          }
+          if (route === "placeholder") {
+            parts.push({
+              type: "text",
+              text: toolAttachmentPlaceholder(attachment),
+            })
+          }
+        }
+        if (parts.length > 0) {
+          syntheticGroups.push({
+            tool: input.tool,
+            callID: input.callID,
+            status: input.status,
+            parts,
+          })
+        }
+        return native
+      }
 
       if (
         msg.info.error &&
@@ -760,15 +799,13 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           if (part.state.status === "completed") {
             const outputText = part.state.time.compacted ? "[Old tool result content cleared]" : part.state.output
             const attachments = part.state.time.compacted || options?.stripMedia ? [] : (part.state.attachments ?? [])
-
-            // For providers that don't support media in tool results, extract media files
-            // (images, PDFs) to be sent as a separate user message
-            const mediaAttachments = attachments.filter((a) => isMedia(a.mime))
-            const nonMediaAttachments = attachments.filter((a) => !isMedia(a.mime))
-            if (!supportsMediaInToolResults && mediaAttachments.length > 0) {
-              media.push(...mediaAttachments)
-            }
-            const finalAttachments = supportsMediaInToolResults ? attachments : nonMediaAttachments
+            const finalAttachments = routeAttachments({
+              tool: part.tool,
+              callID: part.callID,
+              status: "completed",
+              attachments,
+              allowNative: true,
+            })
 
             const output =
               finalAttachments.length > 0
@@ -790,7 +827,13 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           }
           if (part.state.status === "error") {
             const attachments = options?.stripMedia ? [] : (part.state.attachments ?? [])
-            media.push(...attachments.filter((attachment) => isMedia(attachment.mime)))
+            routeAttachments({
+              tool: part.tool,
+              callID: part.callID,
+              status: "error",
+              attachments,
+              allowNative: false,
+            })
             const output = part.state.metadata?.interrupted === true ? part.state.metadata.output : undefined
             if (typeof output === "string") {
               assistantMessage.parts.push({
@@ -837,9 +880,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
       }
       if (assistantMessage.parts.length > 0) {
         result.push(assistantMessage)
-        // Inject pending media as a user message for providers that don't support
-        // media (images, PDFs) in tool results
-        if (media.length > 0) {
+        if (syntheticGroups.length > 0) {
           result.push({
             id: MessageID.ascending(),
             role: "user",
@@ -848,12 +889,13 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
                 type: "text" as const,
                 text: SYNTHETIC_ATTACHMENT_PROMPT,
               },
-              ...media.map((attachment) => ({
-                type: "file" as const,
-                url: attachment.url,
-                mediaType: attachment.mime,
-                filename: attachment.filename,
-              })),
+              ...syntheticGroups.flatMap((group) => [
+                {
+                  type: "text" as const,
+                  text: `Tool "${group.tool}" call ${group.callID} ${group.status === "error" ? "failed" : "completed"}:`,
+                },
+                ...group.parts,
+              ]),
             ],
           })
         }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -21,7 +21,7 @@ import type { Provider } from "@/provider"
 import { Question } from "@/question"
 import { errorMessage } from "@/util/error"
 import { isRecoverableError } from "@/tool/recoverable"
-import { getToolResultMetadata } from "@/tool/result-error"
+import { getToolResultAttachments, getToolResultMetadata } from "@/tool/result-error"
 import { Log } from "@/util"
 import { isRecord } from "@/util/record"
 import { createTextNgramMonitor, type TextNgramMonitor } from "./prompt/text-ngram-detection"
@@ -296,6 +296,10 @@ export const layer: Layer.Layer<
           ...getToolResultMetadata(error),
           ...(recoverable ? { recoverable: true } : {}),
         }
+        const attachments = getToolResultAttachments(error)?.flatMap((attachment) => {
+          const parsed = MessageV2.FilePart.safeParse(attachment)
+          return parsed.success ? [parsed.data] : []
+        })
         yield* session.updatePart({
           ...match.part,
           state: {
@@ -303,6 +307,7 @@ export const layer: Layer.Layer<
             input: match.part.state.input,
             error: errorMessage(error),
             ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+            ...(attachments && attachments.length > 0 ? { attachments } : {}),
             time: { start: match.part.state.time.start, end: Date.now() },
           },
         })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -21,6 +21,7 @@ import type { Provider } from "@/provider"
 import { Question } from "@/question"
 import { errorMessage } from "@/util/error"
 import { isRecoverableError } from "@/tool/recoverable"
+import { getToolResultMetadata } from "@/tool/result-error"
 import { Log } from "@/util"
 import { isRecord } from "@/util/record"
 import { createTextNgramMonitor, type TextNgramMonitor } from "./prompt/text-ngram-detection"
@@ -290,13 +291,18 @@ export const layer: Layer.Layer<
         // id) carry a marker the TUI reads to render them muted instead of as a red
         // error block. The full actionable message still flows to the model.
         const recoverable = isRecoverableError(error)
+        const metadata = {
+          ...match.part.state.metadata,
+          ...getToolResultMetadata(error),
+          ...(recoverable ? { recoverable: true } : {}),
+        }
         yield* session.updatePart({
           ...match.part,
           state: {
             status: "error",
             input: match.part.state.input,
             error: errorMessage(error),
-            ...(recoverable ? { metadata: { ...match.part.state.metadata, recoverable: true } } : {}),
+            ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
             time: { start: match.part.state.time.start, end: Date.now() },
           },
         })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -63,6 +63,7 @@ import { composeSkillsBlock } from "@/skill/compose/extract"
 import { builtinSkillRoot, matchDocumentSkills } from "@/skill/builtin/extract"
 import { ToolRegistry } from "../tool"
 import { MCP } from "../mcp"
+import { normalizeToolResult } from "../mcp/tool-result"
 import { LSP } from "../lsp"
 import { Flag } from "../flag/flag"
 import { ulid } from "ulid"
@@ -111,6 +112,7 @@ import { Team } from "@/team"
 import { ActorRegistry } from "@/actor/registry"
 import { Metrics } from "@/metrics"
 import { resolveInvocationStyle, type ToolStyleConfig } from "../tool/invocation-style"
+import { ToolResultError } from "../tool/result-error"
 import { shouldAutoDream, shouldAutoDistill, DREAM_TASK, DISTILL_TASK, AUTO_DREAM_TITLE, AUTO_DISTILL_TITLE } from "./auto-dream"
 
 // @ts-ignore
@@ -1126,70 +1128,67 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.promise(() =>
                 execute(mcpBeforeOutput.args, opts),
               )
-              log.debug("tool execute done (mcp)", {
-                tool: key,
-                callID,
-                durationMs: Date.now() - startTs,
-                ok: true,
-              })
               yield* plugin.trigger(
                 "tool.execute.after",
                 { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
                 result,
               )
 
-              const textParts: string[] = []
+              const normalized = normalizeToolResult(result)
+              log.debug("tool execute done (mcp)", {
+                tool: key,
+                callID,
+                durationMs: Date.now() - startTs,
+                ok: !normalized.isError,
+              })
+
+              const truncated = yield* truncate.output(
+                normalized.output,
+                { outcome: normalized.isError ? "error" : "success" },
+                input.agent,
+              )
+              const metadata = {
+                ...normalized.metadata,
+                truncated: truncated.truncated,
+                ...(truncated.truncated && { outputPath: truncated.outputPath }),
+              }
+
+              if (normalized.isError) {
+                return yield* Effect.fail(
+                  new ToolResultError(truncated.content.trim() || "MCP tool execution failed", metadata),
+                )
+              }
+
               yield* bus
                 .publish(Metrics.ToolCall, {
                   sessionID: ctx.sessionID,
                   tool_name: key,
                   input_bytes: Metrics.jsonByteLength(args),
-                  output_bytes: Metrics.jsonByteLength(result.content ?? ""),
+                  output_bytes: Metrics.jsonByteLength({
+                    content: normalized.content,
+                    structuredContent: normalized.structuredContent,
+                  }),
                   tool_call_id: opts.toolCallId,
                   tool_call_status: "success",
                 })
                 .pipe(Effect.ignore)
-              const attachments: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[] = []
-              for (const contentItem of result.content) {
-                if (contentItem.type === "text") textParts.push(contentItem.text)
-                else if (contentItem.type === "image") {
-                  attachments.push({
-                    type: "file",
-                    mime: contentItem.mimeType,
-                    url: `data:${contentItem.mimeType};base64,${contentItem.data}`,
-                  })
-                } else if (contentItem.type === "resource") {
-                  const { resource } = contentItem
-                  if (resource.text) textParts.push(resource.text)
-                  if (resource.blob) {
-                    attachments.push({
-                      type: "file",
-                      mime: resource.mimeType ?? "application/octet-stream",
-                      url: `data:${resource.mimeType ?? "application/octet-stream"};base64,${resource.blob}`,
-                      filename: resource.uri,
-                    })
-                  }
-                }
-              }
-
-              const truncated = yield* truncate.output(textParts.join("\n\n"), {}, input.agent)
-              const metadata = {
-                ...result.metadata,
-                truncated: truncated.truncated,
-                ...(truncated.truncated && { outputPath: truncated.outputPath }),
-              }
 
               const output = {
                 title: "",
                 metadata,
                 output: truncated.content,
-                attachments: attachments.map((attachment) => ({
+                attachments: normalized.attachments.map((attachment) => ({
+                  type: "file" as const,
                   ...attachment,
                   id: PartID.ascending(),
                   sessionID: ctx.sessionID,
                   messageID: input.processor.message.id,
                 })),
-                content: result.content,
+                content: normalized.content,
+                ...(normalized.structuredContent === undefined
+                  ? {}
+                  : { structuredContent: normalized.structuredContent }),
+                isError: false,
               }
               if (opts.abortSignal?.aborted) {
                 yield* input.processor.completeToolCall(opts.toolCallId, output)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1152,10 +1152,21 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 truncated: truncated.truncated,
                 ...(truncated.truncated && { outputPath: truncated.outputPath }),
               }
+              const attachments = normalized.attachments.map((attachment) => ({
+                type: "file" as const,
+                ...attachment,
+                id: PartID.ascending(),
+                sessionID: ctx.sessionID,
+                messageID: input.processor.message.id,
+              }))
 
               if (normalized.isError) {
                 return yield* Effect.fail(
-                  new ToolResultError(truncated.content.trim() || "MCP tool execution failed", metadata),
+                  new ToolResultError(
+                    truncated.content.trim() || "MCP tool execution failed",
+                    metadata,
+                    attachments,
+                  ),
                 )
               }
 
@@ -1177,13 +1188,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 title: "",
                 metadata,
                 output: truncated.content,
-                attachments: normalized.attachments.map((attachment) => ({
-                  type: "file" as const,
-                  ...attachment,
-                  id: PartID.ascending(),
-                  sessionID: ctx.sessionID,
-                  messageID: input.processor.message.id,
-                })),
+                attachments,
                 content: normalized.content,
                 ...(normalized.structuredContent === undefined
                   ? {}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1189,11 +1189,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 metadata,
                 output: truncated.content,
                 attachments,
-                content: normalized.content,
-                ...(normalized.structuredContent === undefined
-                  ? {}
-                  : { structuredContent: normalized.structuredContent }),
-                isError: false,
               }
               if (opts.abortSignal?.aborted) {
                 yield* input.processor.completeToolCall(opts.toolCallId, output)

--- a/packages/opencode/src/session/tool-attachment.ts
+++ b/packages/opencode/src/session/tool-attachment.ts
@@ -17,6 +17,9 @@ const ANTHROPIC_PACKAGES = new Set(["@ai-sdk/anthropic", "@ai-sdk/google-vertex/
 const GOOGLE_PACKAGES = new Set(["@ai-sdk/google", "@ai-sdk/google-vertex"])
 
 function isGemini3(model: Provider.Model) {
+  // Keep this aligned with @ai-sdk/google's functionResponse.parts gate.
+  // Prefixed or case-variant IDs must use synthetic attachments; routing them
+  // as native would make the provider serialize binary parts as legacy JSON.
   return model.api.id.startsWith("gemini-3")
 }
 

--- a/packages/opencode/src/session/tool-attachment.ts
+++ b/packages/opencode/src/session/tool-attachment.ts
@@ -1,0 +1,143 @@
+import type { Provider } from "@/provider"
+
+export type ToolAttachment = {
+  mime: string
+  url: string
+  filename?: string
+}
+
+export type ToolAttachmentRoute = "native" | "synthetic" | "placeholder"
+
+const MAX_ATTACHMENT_NAME_LENGTH = 120
+const SAFE_IMAGE_MIMES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"])
+const OPENAI_AUDIO_MIMES = new Set(["audio/wav", "audio/mp3", "audio/mpeg"])
+const BEDROCK_TEXT_MIMES = new Set(["text/csv", "text/html", "text/plain", "text/markdown"])
+const OPENAI_CHAT_PACKAGES = new Set(["@ai-sdk/openai-compatible"])
+const ANTHROPIC_PACKAGES = new Set(["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"])
+const GOOGLE_PACKAGES = new Set(["@ai-sdk/google", "@ai-sdk/google-vertex"])
+
+function isGemini3(model: Provider.Model) {
+  return model.api.id.startsWith("gemini-3")
+}
+
+function isInlineAttachment(attachment: ToolAttachment) {
+  return inlineToolAttachment(attachment) !== undefined
+}
+
+function isRemoteURL(url: string) {
+  return /^https?:\/\//i.test(url)
+}
+
+function modelAcceptsMime(model: Provider.Model, mime: string) {
+  if (mime.startsWith("image/")) return SAFE_IMAGE_MIMES.has(mime) && model.capabilities.input.image
+  if (mime === "application/pdf") return model.capabilities.input.pdf
+  if (mime.startsWith("audio/")) return model.capabilities.input.audio
+  if (mime.startsWith("video/")) return model.capabilities.input.video
+  if (mime.startsWith("text/")) return model.capabilities.input.text
+  return false
+}
+
+function providerAcceptsSynthetic(model: Provider.Model, attachment: ToolAttachment) {
+  const npm = model.api.npm
+  const mime = attachment.mime
+
+  if (SAFE_IMAGE_MIMES.has(mime)) return isInlineAttachment(attachment) || isRemoteURL(attachment.url)
+  if (mime === "application/pdf") return isInlineAttachment(attachment)
+  if (mime.startsWith("audio/")) {
+    if (!isInlineAttachment(attachment)) return false
+    if (OPENAI_CHAT_PACKAGES.has(npm)) return OPENAI_AUDIO_MIMES.has(mime)
+    return GOOGLE_PACKAGES.has(npm)
+  }
+  if (mime.startsWith("video/")) return isInlineAttachment(attachment) && GOOGLE_PACKAGES.has(npm)
+  if (mime.startsWith("text/")) {
+    if (!isInlineAttachment(attachment)) return false
+    if (OPENAI_CHAT_PACKAGES.has(npm) || GOOGLE_PACKAGES.has(npm)) return true
+    if (npm === "@ai-sdk/amazon-bedrock") return BEDROCK_TEXT_MIMES.has(mime)
+    return ANTHROPIC_PACKAGES.has(npm) && mime === "text/plain"
+  }
+  return false
+}
+
+function providerAcceptsNative(model: Provider.Model, attachment: ToolAttachment) {
+  if (!isInlineAttachment(attachment)) return false
+  const npm = model.api.npm
+  const mime = attachment.mime
+
+  if (ANTHROPIC_PACKAGES.has(npm) || npm === "@ai-sdk/amazon-bedrock") {
+    return SAFE_IMAGE_MIMES.has(mime) || mime === "application/pdf"
+  }
+  if (GOOGLE_PACKAGES.has(npm) && isGemini3(model)) {
+    return (
+      SAFE_IMAGE_MIMES.has(mime) || mime === "application/pdf" || mime.startsWith("audio/") || mime.startsWith("video/")
+    )
+  }
+  return false
+}
+
+export function routeToolAttachment(input: {
+  model: Provider.Model
+  attachment: ToolAttachment
+  allowNative: boolean
+}): ToolAttachmentRoute {
+  if (!modelAcceptsMime(input.model, input.attachment.mime)) return "placeholder"
+  if (input.allowNative && providerAcceptsNative(input.model, input.attachment)) return "native"
+  if (providerAcceptsSynthetic(input.model, input.attachment)) return "synthetic"
+  return "placeholder"
+}
+
+export function inlineToolAttachment(attachment: ToolAttachment) {
+  const match = attachment.url.match(/^data:([^;,]+);base64,([a-z0-9+/]+={0,2})$/i)
+  if (!match) return undefined
+  if (match[1].toLowerCase() !== attachment.mime.toLowerCase()) return undefined
+  return {
+    data: match[2],
+    mediaType: attachment.mime,
+  }
+}
+
+function boundedAttachmentName(filename: string) {
+  const normalized = filename.trim()
+  if (/^data:/i.test(normalized)) {
+    const mime = normalized
+      .slice(5)
+      .split(/[;,]/, 1)[0]
+      ?.replace(/[^a-z0-9.+/-]/gi, "")
+      .slice(0, 80)
+    return mime ? `data URI (${mime})` : "data URI"
+  }
+
+  let value = normalized
+  try {
+    const url = new URL(normalized)
+    const segments = url.pathname.split("/").filter(Boolean)
+    const tail = segments.at(-1)
+    value = tail ? decodeURIComponent(tail) : url.hostname || url.protocol.slice(0, -1)
+  } catch {
+    value = normalized.split(/[\\/]/).at(-1) ?? normalized
+    value = value.split(/[?#]/, 1)[0] ?? value
+  }
+
+  const clean = value
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+    .replaceAll('"', "'")
+    .replace(/\s+/g, " ")
+    .trim()
+  if (!clean) return "attachment"
+  if (clean.length <= MAX_ATTACHMENT_NAME_LENGTH) return clean
+  return `${clean.slice(0, MAX_ATTACHMENT_NAME_LENGTH - 3)}...`
+}
+
+export function toolAttachmentFilename(attachment: ToolAttachment) {
+  if (!attachment.filename || /^data:/i.test(attachment.filename.trim())) return undefined
+  const safe = boundedAttachmentName(attachment.filename)
+    .replace(/[^a-z0-9 .()-]/gi, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[ .-]+|[ .-]+$/g, "")
+  return safe || undefined
+}
+
+export function toolAttachmentPlaceholder(attachment: ToolAttachment) {
+  const name = attachment.filename ? `"${boundedAttachmentName(attachment.filename)}"` : "an unnamed attachment"
+  const mime = attachment.mime.replace(/[^a-z0-9.+/-]/gi, "").slice(0, 80) || "unknown"
+  return `[Tool attachment ${name} (${mime}) was retained but cannot be safely sent to this model/provider.]`
+}

--- a/packages/opencode/src/session/trajectory.ts
+++ b/packages/opencode/src/session/trajectory.ts
@@ -20,7 +20,7 @@ function serializeFilePart(part: MessageV2.FilePart): MessageV2.FilePart {
  * Mutation is shallow — original part is not modified.
  */
 function sanitizeToolState(state: MessageV2.ToolPart["state"]): MessageV2.ToolPart["state"] {
-  if (state.status === "completed" && state.attachments && state.attachments.length > 0) {
+  if ("attachments" in state && state.attachments && state.attachments.length > 0) {
     return { ...state, attachments: state.attachments.map(serializeFilePart) }
   }
   return state

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -12,6 +12,7 @@ import type { SessionID } from "@/session/schema"
 import { Database, eq } from "@/storage"
 import { Config } from "@/config"
 import { Log } from "@/util"
+import { isRecord } from "@/util/record"
 import { SessionShareTable } from "./share.sql"
 
 const log = Log.create({ service: "share-next" })
@@ -105,6 +106,26 @@ function key(item: Data) {
   }
 }
 
+function shareable(item: Data): Data {
+  if (item.type !== "part" || item.data.type !== "tool" || !("metadata" in item.data.state)) return item
+
+  const metadata = item.data.state.metadata
+  if (!isRecord(metadata) || !isRecord(metadata.mcp) || !("_meta" in metadata.mcp)) return item
+
+  const mcp = { ...metadata.mcp }
+  delete mcp._meta
+  return {
+    ...item,
+    data: {
+      ...item.data,
+      state: {
+        ...item.data.state,
+        metadata: { ...metadata, mcp },
+      },
+    },
+  } as Data
+}
+
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -126,12 +147,13 @@ export const layer = Layer.effect(
         const existing = s.queue.get(sessionID)
         if (existing) {
           for (const item of data) {
-            existing.set(key(item), item)
+            const safe = shareable(item)
+            existing.set(key(safe), safe)
           }
           return
         }
 
-        const next = new Map(data.map((item) => [key(item), item]))
+        const next = new Map(data.map(shareable).map((item) => [key(item), item]))
         s.queue.set(sessionID, next)
         yield* flush(sessionID).pipe(
           Effect.delay(1000),

--- a/packages/opencode/src/tool/result-error.ts
+++ b/packages/opencode/src/tool/result-error.ts
@@ -1,0 +1,22 @@
+import { isRecord } from "@/util/record"
+
+/**
+ * A tool execution error that carries metadata to the persisted error state.
+ * The structural fallback keeps the metadata available across runtime or realm
+ * boundaries where `instanceof` is not reliable.
+ */
+export class ToolResultError extends Error {
+  readonly toolResultMetadata: Record<string, unknown>
+
+  constructor(message: string, metadata: Record<string, unknown>, options?: ErrorOptions) {
+    super(message, options)
+    this.name = "ToolResultError"
+    this.toolResultMetadata = metadata
+  }
+}
+
+export function getToolResultMetadata(error: unknown): Record<string, unknown> | undefined {
+  if (error instanceof ToolResultError) return error.toolResultMetadata
+  if (!isRecord(error) || !isRecord(error.toolResultMetadata)) return undefined
+  return error.toolResultMetadata
+}

--- a/packages/opencode/src/tool/result-error.ts
+++ b/packages/opencode/src/tool/result-error.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@/util/record"
+import type { MessageV2 } from "@/session/message-v2"
 
 /**
  * A tool execution error that carries metadata to the persisted error state.
@@ -7,11 +8,18 @@ import { isRecord } from "@/util/record"
  */
 export class ToolResultError extends Error {
   readonly toolResultMetadata: Record<string, unknown>
+  readonly toolResultAttachments: MessageV2.FilePart[]
 
-  constructor(message: string, metadata: Record<string, unknown>, options?: ErrorOptions) {
+  constructor(
+    message: string,
+    metadata: Record<string, unknown>,
+    attachments: MessageV2.FilePart[] = [],
+    options?: ErrorOptions,
+  ) {
     super(message, options)
     this.name = "ToolResultError"
     this.toolResultMetadata = metadata
+    this.toolResultAttachments = attachments
   }
 }
 
@@ -19,4 +27,10 @@ export function getToolResultMetadata(error: unknown): Record<string, unknown> |
   if (error instanceof ToolResultError) return error.toolResultMetadata
   if (!isRecord(error) || !isRecord(error.toolResultMetadata)) return undefined
   return error.toolResultMetadata
+}
+
+export function getToolResultAttachments(error: unknown): readonly unknown[] | undefined {
+  if (error instanceof ToolResultError) return error.toolResultAttachments
+  if (!isRecord(error) || !Array.isArray(error.toolResultAttachments)) return undefined
+  return error.toolResultAttachments
 }

--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -27,6 +27,7 @@ export interface Options {
   maxBytes?: number
   direction?: "head" | "tail" | "head+tail"
   pressureCaps?: boolean
+  outcome?: "success" | "error"
 }
 
 function hasActorTool(agent?: Agent.Info) {
@@ -77,6 +78,14 @@ export const layer = Layer.effect(
       let maxBytes = options.maxBytes ?? MAX_BYTES
       const direction = options.direction ?? "head+tail"
       const pressureCaps = options.pressureCaps ?? false
+      const outcome = options.outcome ?? "success"
+
+      const hint = (file: string) => {
+        const result = outcome === "error" ? "failed" : "succeeded"
+        return hasActorTool(agent)
+          ? `The tool call ${result} but the output was truncated. Full output saved to: ${file}\nUse the actor tool to have explore agent process this file with Grep and Read (with offset/limit). Do NOT read the full file yourself - delegate to save context.`
+          : `The tool call ${result} but the output was truncated. Full output saved to: ${file}\nUse Grep to search the full content or Read with offset/limit to view specific sections.`
+      }
 
       if (pressureCaps) {
         maxLines = Math.floor(maxLines / 2)
@@ -125,12 +134,8 @@ export const layer = Layer.effect(
           const omitted = lines.length - headOut.length - tailOut.length
           const file = yield* write(text)
 
-          const hintText = hasActorTool(agent)
-            ? `The tool call succeeded but the output was truncated. Full output saved to: ${file}\nUse the actor tool to have explore agent process this file with Grep and Read (with offset/limit). Do NOT read the full file yourself - delegate to save context.`
-            : `The tool call succeeded but the output was truncated. Full output saved to: ${file}\nUse Grep to search the full content or Read with offset/limit to view specific sections.`
-
           return {
-            content: `${headOut.join("\n")}\n\n... ${omitted} lines omitted — showing head and tail ...\n\n${tailOut.join("\n")}\n\n${hintText}`,
+            content: `${headOut.join("\n")}\n\n... ${omitted} lines omitted — showing head and tail ...\n\n${tailOut.join("\n")}\n\n${hint(file)}`,
             truncated: true,
             outputPath: file,
           } as const
@@ -170,15 +175,11 @@ export const layer = Layer.effect(
       const preview = out.join("\n")
       const file = yield* write(text)
 
-      const hintText = hasActorTool(agent)
-        ? `The tool call succeeded but the output was truncated. Full output saved to: ${file}\nUse the actor tool to have explore agent process this file with Grep and Read (with offset/limit). Do NOT read the full file yourself - delegate to save context.`
-        : `The tool call succeeded but the output was truncated. Full output saved to: ${file}\nUse Grep to search the full content or Read with offset/limit to view specific sections.`
-
       return {
         content:
           direction === "head" || direction === "head+tail"
-            ? `${preview}\n\n...${removed} ${unit} truncated...\n\n${hintText}`
-            : `...${removed} ${unit} truncated...\n\n${hintText}\n\n${preview}`,
+            ? `${preview}\n\n...${removed} ${unit} truncated...\n\n${hint(file)}`
+            : `...${removed} ${unit} truncated...\n\n${hint(file)}\n\n${preview}`,
         truncated: true,
         outputPath: file,
       } as const

--- a/packages/opencode/test/mcp/tool-result.test.ts
+++ b/packages/opencode/test/mcp/tool-result.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import { CallToolResultSchema, type CallToolResult } from "@modelcontextprotocol/sdk/types.js"
+import { normalizeToolResult } from "../../src/mcp/tool-result"
+
+function parseResult(result: CallToolResult) {
+  return CallToolResultSchema.parse(result)
+}
+
+describe("MCP tool result normalization", () => {
+  test("preserves standard fields and classifies tool execution errors", () => {
+    const result: CallToolResult = {
+      content: [{ type: "text", text: "Message was not sent" }],
+      structuredContent: { sent: false, reason: "composer rejected the request" },
+      isError: true,
+      _meta: { traceId: "private-trace-id" },
+    }
+
+    const received = parseResult(result)
+    const normalized = normalizeToolResult(received)
+
+    expect(received).toEqual(result)
+    expect(normalized.isError).toBe(true)
+    expect(normalized.content).toEqual(result.content)
+    expect(normalized.output).toBe(
+      'Message was not sent\n\nStructured content:\n{"sent":false,"reason":"composer rejected the request"}',
+    )
+    expect(normalized.metadata.mcp).toEqual({
+      structuredContent: result.structuredContent,
+      isError: true,
+      _meta: result._meta,
+    })
+    expect(normalized.output).not.toContain("private-trace-id")
+  })
+
+  test("uses structured content as a fallback without exposing _meta", () => {
+    const result: CallToolResult = {
+      content: [{ type: "text", text: "   " }],
+      structuredContent: { changed: true, windowID: 42 },
+      _meta: { privateToken: "do-not-send-to-model" },
+    }
+
+    const normalized = normalizeToolResult(parseResult(result))
+
+    expect(normalized.isError).toBe(false)
+    expect(normalized.output).toBe('{"changed":true,"windowID":42}')
+    expect(normalized.output).not.toContain("do-not-send-to-model")
+    expect(normalized.metadata.mcp).toEqual({
+      structuredContent: result.structuredContent,
+      isError: false,
+      _meta: result._meta,
+    })
+  })
+
+  test("converts inline media and resource links while retaining raw content", () => {
+    const result: CallToolResult = {
+      content: [
+        { type: "audio", data: "YXVkaW8=", mimeType: "audio/wav" },
+        { type: "resource_link", uri: "file:///tmp/report.txt", name: "report" },
+      ],
+    }
+
+    const normalized = normalizeToolResult(parseResult(result))
+
+    expect(normalized.output).toBe("report: file:///tmp/report.txt")
+    expect(normalized.attachments).toEqual([
+      {
+        mime: "audio/wav",
+        url: "data:audio/wav;base64,YXVkaW8=",
+      },
+    ])
+    expect(normalized.content).toEqual(result.content)
+  })
+
+  test("does not duplicate structured content already serialized by the server", () => {
+    const result: CallToolResult = {
+      content: [{ type: "text", text: 'Result:\n{\n  "changed": true\n}' }],
+      structuredContent: { changed: true },
+    }
+
+    const normalized = normalizeToolResult(parseResult(result))
+
+    expect(normalized.output).toBe('Result:\n{\n  "changed": true\n}')
+  })
+})

--- a/packages/opencode/test/mcp/tool-result.test.ts
+++ b/packages/opencode/test/mcp/tool-result.test.ts
@@ -9,7 +9,10 @@ function parseResult(result: CallToolResult) {
 describe("MCP tool result normalization", () => {
   test("preserves standard fields and classifies tool execution errors", () => {
     const result: CallToolResult = {
-      content: [{ type: "text", text: "Message was not sent" }],
+      content: [
+        { type: "text", text: "Message was not sent" },
+        { type: "image", data: "Zm9v", mimeType: "image/png" },
+      ],
       structuredContent: { sent: false, reason: "composer rejected the request" },
       isError: true,
       _meta: { traceId: "private-trace-id" },
@@ -24,6 +27,12 @@ describe("MCP tool result normalization", () => {
     expect(normalized.output).toBe(
       'Message was not sent\n\nStructured content:\n{"sent":false,"reason":"composer rejected the request"}',
     )
+    expect(normalized.attachments).toEqual([
+      {
+        mime: "image/png",
+        url: "data:image/png;base64,Zm9v",
+      },
+    ])
     expect(normalized.metadata.mcp).toEqual({
       structuredContent: result.structuredContent,
       isError: true,

--- a/packages/opencode/test/mcp/tool-result.test.ts
+++ b/packages/opencode/test/mcp/tool-result.test.ts
@@ -61,22 +61,58 @@ describe("MCP tool result normalization", () => {
   })
 
   test("converts inline media and resource links while retaining raw content", () => {
+    const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
     const result: CallToolResult = {
       content: [
         { type: "audio", data: "YXVkaW8=", mimeType: "audio/wav" },
+        {
+          type: "resource",
+          resource: {
+            uri: "mcp://diagnostic.txt",
+            text: "Resource diagnostic",
+            mimeType: "text/plain",
+          },
+        },
+        {
+          type: "resource",
+          resource: {
+            uri: "mcp://screenshot.png",
+            blob: png,
+            mimeType: "image/png",
+          },
+        },
+        {
+          type: "resource",
+          resource: {
+            uri: "mcp://diagnostic.bin",
+            blob: "AAE=",
+          },
+        },
         { type: "resource_link", uri: "file:///tmp/report.txt", name: "report" },
       ],
     }
 
     const normalized = normalizeToolResult(parseResult(result))
 
-    expect(normalized.output).toBe("report: file:///tmp/report.txt")
+    expect(normalized.output).toBe("Resource diagnostic\n\nreport: file:///tmp/report.txt")
     expect(normalized.attachments).toEqual([
       {
         mime: "audio/wav",
         url: "data:audio/wav;base64,YXVkaW8=",
       },
+      {
+        mime: "image/png",
+        url: `data:image/png;base64,${png}`,
+        filename: "mcp://screenshot.png",
+      },
+      {
+        mime: "application/octet-stream",
+        url: "data:application/octet-stream;base64,AAE=",
+        filename: "mcp://diagnostic.bin",
+      },
     ])
+    expect(normalized.output).not.toContain(png)
+    expect(normalized.output).not.toContain("AAE=")
     expect(normalized.content).toEqual(result.content)
   })
 
@@ -89,5 +125,49 @@ describe("MCP tool result normalization", () => {
     const normalized = normalizeToolResult(parseResult(result))
 
     expect(normalized.output).toBe('Result:\n{\n  "changed": true\n}')
+  })
+
+  test("extracts base64 data resource links without exposing their payload as text", () => {
+    const payload = "AQIDBAUGBwgJ"
+    const result: CallToolResult = {
+      content: [
+        {
+          type: "resource_link",
+          uri: `data:application/octet-stream;base64,${payload}`,
+          name: "binary",
+        },
+        {
+          type: "resource_link",
+          uri: "data:text/plain,secret-payload",
+          name: "inline text",
+        },
+      ],
+    }
+
+    const normalized = normalizeToolResult(parseResult(result))
+
+    expect(normalized.output).toBe(
+      "binary: [inline application/octet-stream resource]\n\ninline text: [data URI omitted]",
+    )
+    expect(normalized.output).not.toContain(payload)
+    expect(normalized.output).not.toContain("secret-payload")
+    expect(normalized.attachments).toEqual([
+      {
+        mime: "application/octet-stream",
+        url: `data:application/octet-stream;base64,${payload}`,
+        filename: "binary",
+      },
+    ])
+  })
+
+  test("does not mistake a short JSON substring for serialized structured content", () => {
+    const result: CallToolResult = {
+      content: [{ type: "text", text: "Processed an empty {} template" }],
+      structuredContent: {},
+    }
+
+    const normalized = normalizeToolResult(parseResult(result))
+
+    expect(normalized.output).toBe("Processed an empty {} template\n\nStructured content:\n{}")
   })
 })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1378,6 +1378,7 @@ describe("ProviderTransform.message - provider-aware image size cap", () => {
   // cap path it would be STRIPPED to a placeholder — which makes "left untouched"
   // an unambiguous signal that no cap was applied.
   const sixMbJunk = Buffer.alloc(6_000_000, 0x42).toString("base64")
+  const wrappedSixMbJunk = sixMbJunk.replace(/.{76}/g, "$&\n")
 
   test("baseline: fixture exceeds the anthropic 5MB hard limit", () => {
     expect(base64ByteSize(sixMbJunk)).toBeGreaterThan(PROVIDER_HARD_LIMIT)
@@ -1401,6 +1402,14 @@ describe("ProviderTransform.message - provider-aware image size cap", () => {
       },
     ] as any[]
 
+  const fileMsgs = (data: string | Uint8Array | URL) =>
+    [
+      {
+        role: "user",
+        content: [{ type: "file", mediaType: "image/webp", filename: "capture.webp", data }],
+      },
+    ] as any[]
+
   test("anthropic: strips an oversized undecodable user image (cap enforced)", () => {
     const model = withApi("anthropic", {
       id: "claude-3-5-sonnet-20241022",
@@ -1410,6 +1419,31 @@ describe("ProviderTransform.message - provider-aware image size cap", () => {
     const part = (ProviderTransform.message(userMsgs(), model, {})[0].content as any[])[0]
     expect(part.type).toBe("text")
     expect(part.text).toContain("Image omitted")
+  })
+
+  test("anthropic: caps normalized raw-base64 and byte-array image files", () => {
+    const model = withApi("anthropic", {
+      id: "claude-3-5-sonnet-20241022",
+      url: "https://api.anthropic.com",
+      npm: "@ai-sdk/anthropic",
+    })
+
+    for (const data of [sixMbJunk, wrappedSixMbJunk, Buffer.from(sixMbJunk, "base64")]) {
+      const part = (ProviderTransform.message(fileMsgs(data), model, {})[0].content as any[])[0]
+      expect(part.type).toBe("text")
+      expect(part.text).toContain("Image omitted")
+    }
+  })
+
+  test("anthropic: leaves remote image-file URLs untouched", () => {
+    const model = withApi("anthropic", {
+      id: "claude-3-5-sonnet-20241022",
+      url: "https://api.anthropic.com",
+      npm: "@ai-sdk/anthropic",
+    })
+    const remote = new URL("https://example.com/capture.webp")
+    const part = (ProviderTransform.message(fileMsgs(remote), model, {})[0].content as any[])[0]
+    expect(part).toEqual({ type: "file", mediaType: "image/webp", filename: "capture.webp", data: remote })
   })
 
   test("bedrock: strips an oversized undecodable tool-result image (cap enforced)", () => {
@@ -1427,6 +1461,17 @@ describe("ProviderTransform.message - provider-aware image size cap", () => {
     const model = withApi("openai", { id: "gpt-4o", url: "https://api.openai.com", npm: "@ai-sdk/openai" })
     const part = (ProviderTransform.message(userMsgs(), model, {})[0].content as any[])[0]
     expect(part).toEqual({ type: "image", image: `data:image/webp;base64,${sixMbJunk}` })
+  })
+
+  test("openai: leaves a 6MB raw-base64 image file UNTOUCHED (no cap for non-anthropic)", () => {
+    const model = withApi("openai", { id: "gpt-4o", url: "https://api.openai.com", npm: "@ai-sdk/openai" })
+    const part = (ProviderTransform.message(fileMsgs(sixMbJunk), model, {})[0].content as any[])[0]
+    expect(part).toEqual({
+      type: "file",
+      mediaType: "image/webp",
+      filename: "capture.webp",
+      data: sixMbJunk,
+    })
   })
 
   test("openai: leaves a 6MB tool-result image UNTOUCHED (no cap for non-anthropic)", () => {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -917,6 +917,7 @@ describe("session.llm.stream", () => {
 
     const source = await loadFixture("anthropic", "claude-opus-4-6")
     const model = source.model
+    const pdf = "JVBERi0xLjQKJSVFT0YK"
     const chunks = [
       {
         type: "message_start",
@@ -1060,6 +1061,17 @@ describe("session.llm.stream", () => {
                   metadata: {},
                   title: "root",
                   time: { start: 10, end: 11 },
+                  attachments: [
+                    {
+                      id: "p_read_pdf",
+                      sessionID,
+                      messageID: "msg_call",
+                      type: "file",
+                      mime: "application/pdf",
+                      filename: "report.pdf",
+                      url: `data:application/pdf;base64,${pdf}`,
+                    },
+                  ],
                 },
               },
               {
@@ -1153,7 +1165,17 @@ describe("session.llm.stream", () => {
               {
                 type: "tool_result",
                 tool_use_id: "toolu_01N8mDEzG8DSTs7UPHFtmgCT",
-                content: "<path>/root</path>",
+                content: [
+                  { type: "text", text: "<path>/root</path>" },
+                  {
+                    type: "document",
+                    source: {
+                      type: "base64",
+                      media_type: "application/pdf",
+                      data: pdf,
+                    },
+                  },
+                ],
               },
               {
                 cache_control: { type: "ephemeral" },

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -770,6 +770,86 @@ describe("session.message-v2.toModelMessage", () => {
     )
   })
 
+  test("caps oversized synthetic error images before sending them to Anthropic", async () => {
+    const anthropicModel = withInputCapabilities(
+      { image: true },
+      {
+        ...model,
+        id: ModelID.make("anthropic/claude-opus-4-7"),
+        providerID: ProviderID.make("anthropic"),
+        api: {
+          id: "claude-opus-4-7-20250805",
+          url: "https://api.anthropic.com",
+          npm: "@ai-sdk/anthropic",
+        },
+      },
+    )
+    const oversized = Buffer.alloc(6_000_000, 0x42).toString("base64")
+    const userID = "m-user-oversized-error"
+    const assistantID = "m-assistant-oversized-error"
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [{ ...basePart(userID, "u1-oversized-error"), type: "text", text: "run tool" }] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1-oversized-error"),
+            type: "tool",
+            callID: "call-oversized-error",
+            tool: "computer",
+            state: {
+              status: "error",
+              input: {},
+              error: "capture failed",
+              time: { start: 0, end: 1 },
+              metadata: {},
+              attachments: [
+                {
+                  ...basePart(assistantID, "file-oversized-error"),
+                  type: "file",
+                  mime: "image/webp",
+                  filename: "error-state.webp",
+                  url: `data:image/webp;base64,${oversized}`,
+                },
+              ],
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const messages = await MessageV2.toModelMessages(input, anthropicModel)
+    const synthetic = messages.at(-1)
+    expect(synthetic?.role).toBe("user")
+    expect(
+      Array.isArray(synthetic?.content) &&
+        synthetic.content.some((part) => part.type === "file" && part.mediaType === "image/webp"),
+    ).toBe(true)
+
+    // streamText converts data URLs to raw base64 before invoking the model
+    // middleware where ProviderTransform.message runs.
+    const providerPrompt = messages.map((message) => {
+      if (message !== synthetic || message.role !== "user" || !Array.isArray(message.content)) return message
+      return {
+        ...message,
+        content: message.content.map((part) =>
+          part.type === "file" && part.mediaType === "image/webp" ? { ...part, data: oversized } : part,
+        ),
+      }
+    })
+    const transformed = ProviderTransform.message(providerPrompt, anthropicModel, {})
+    const content = transformed.at(-1)?.content
+    expect(
+      Array.isArray(content) && content.some((part) => part.type === "text" && part.text.includes("Image omitted")),
+    ).toBe(true)
+    expect(
+      Array.isArray(content) && content.some((part) => part.type === "file" && part.mediaType === "image/webp"),
+    ).toBe(false)
+  })
+
   test("keeps synthetic attachments correlated with multiple tool calls", async () => {
     const userID = "m-user-groups"
     const assistantID = "m-assistant-groups"

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -588,7 +588,7 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
-  test("converts assistant tool error into error-text tool result", async () => {
+  test("preserves tool error media as a synthetic user message", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"
 
@@ -617,6 +617,15 @@ describe("session.message-v2.toModelMessage", () => {
               error: "nope",
               time: { start: 0, end: 1 },
               metadata: {},
+              attachments: [
+                {
+                  ...basePart(assistantID, "file-1"),
+                  type: "file",
+                  mime: "image/png",
+                  filename: "error-state.png",
+                  url: "data:image/png;base64,Zm9v",
+                },
+              ],
             },
             metadata: { openai: { tool: "meta" } },
           },
@@ -624,7 +633,8 @@ describe("session.message-v2.toModelMessage", () => {
       },
     ]
 
-    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+    const messages = await MessageV2.toModelMessages(input, model)
+    expect(messages).toStrictEqual([
       {
         role: "user",
         content: [{ type: "text", text: "run tool" }],
@@ -654,7 +664,21 @@ describe("session.message-v2.toModelMessage", () => {
           },
         ],
       },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: MessageV2.SYNTHETIC_ATTACHMENT_PROMPT },
+          {
+            type: "file",
+            mediaType: "image/png",
+            filename: "error-state.png",
+            data: "data:image/png;base64,Zm9v",
+          },
+        ],
+      },
     ])
+
+    expect(await MessageV2.toModelMessages(input, model, { stripMedia: true })).toStrictEqual(messages.slice(0, -1))
   })
 
   test("forwards partial bash output for aborted tool calls", async () => {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -9,6 +9,9 @@ import { Question } from "../../src/question"
 
 const sessionID = SessionID.make("session")
 const providerID = ProviderID.make("test")
+const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+const wavBase64 = "UklGRiUAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQEAAACA"
+const binaryBase64 = "YmluYXJ5"
 const model: Provider.Model = {
   id: ModelID.make("test-model"),
   providerID,
@@ -56,6 +59,24 @@ const model: Provider.Model = {
   options: {},
   headers: {},
   release_date: "2026-01-01",
+}
+const openAICompatibleModel: Provider.Model = {
+  ...model,
+  api: { ...model.api, npm: "@ai-sdk/openai-compatible" },
+}
+
+function withInputCapabilities(
+  input: Partial<Provider.Model["capabilities"]["input"]>,
+  base: Provider.Model = model,
+): Provider.Model {
+  return {
+    ...base,
+    capabilities: {
+      ...base.capabilities,
+      attachment: true,
+      input: { ...base.capabilities.input, ...input },
+    },
+  }
 }
 
 function userInfo(id: string): MessageV2.User {
@@ -262,9 +283,10 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
-  test("extracts tool-result media into a user message for openai models", async () => {
+  test("routes supported and unsupported tool-result files for OpenAI-compatible Chat models", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"
+    const mediaModel = withInputCapabilities({ image: true, audio: true }, openAICompatibleModel)
 
     const input: MessageV2.WithParts[] = [
       {
@@ -304,7 +326,21 @@ describe("session.message-v2.toModelMessage", () => {
                   type: "file",
                   mime: "image/png",
                   filename: "attachment.png",
-                  url: "data:image/png;base64,Zm9v",
+                  url: `data:image/png;base64,${pngBase64}`,
+                },
+                {
+                  ...basePart(assistantID, "file-2"),
+                  type: "file",
+                  mime: "audio/wav",
+                  filename: "attachment.wav",
+                  url: `data:audio/wav;base64,${wavBase64}`,
+                },
+                {
+                  ...basePart(assistantID, "file-3"),
+                  type: "file",
+                  mime: "application/octet-stream",
+                  filename: "attachment.bin",
+                  url: `data:application/octet-stream;base64,${binaryBase64}`,
                 },
               ],
             },
@@ -314,7 +350,8 @@ describe("session.message-v2.toModelMessage", () => {
       },
     ]
 
-    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+    const messages = await MessageV2.toModelMessages(input, mediaModel)
+    expect(messages).toStrictEqual([
       {
         role: "user",
         content: [{ type: "text", text: "run tool" }],
@@ -352,15 +389,27 @@ describe("session.message-v2.toModelMessage", () => {
         role: "user",
         content: [
           { type: "text", text: MessageV2.SYNTHETIC_ATTACHMENT_PROMPT },
+          { type: "text", text: 'Tool "bash" call call-1 completed:' },
           {
             type: "file",
             mediaType: "image/png",
             filename: "attachment.png",
-            data: "data:image/png;base64,Zm9v",
+            data: `data:image/png;base64,${pngBase64}`,
+          },
+          {
+            type: "file",
+            mediaType: "audio/wav",
+            filename: "attachment.wav",
+            data: `data:audio/wav;base64,${wavBase64}`,
+          },
+          {
+            type: "text",
+            text: '[Tool attachment "attachment.bin" (application/octet-stream) was retained but cannot be safely sent to this model/provider.]',
           },
         ],
       },
     ])
+    expect(JSON.stringify(messages)).not.toContain(binaryBase64)
   })
 
   test("preserves jpeg tool-result media for anthropic models", async () => {
@@ -440,7 +489,7 @@ describe("session.message-v2.toModelMessage", () => {
         type: "content",
         value: [
           { type: "text", text: "Image read successfully" },
-          { type: "media", mediaType: "image/jpeg", data: jpeg },
+          { type: "image-data", mediaType: "image/jpeg", data: jpeg },
         ],
       },
     })
@@ -588,9 +637,10 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
-  test("preserves tool error media as a synthetic user message", async () => {
+  test("preserves tool error media for OpenAI-compatible Chat models", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"
+    const mediaModel = withInputCapabilities({ image: true, audio: true }, openAICompatibleModel)
 
     const input: MessageV2.WithParts[] = [
       {
@@ -623,7 +673,28 @@ describe("session.message-v2.toModelMessage", () => {
                   type: "file",
                   mime: "image/png",
                   filename: "error-state.png",
-                  url: "data:image/png;base64,Zm9v",
+                  url: `data:image/png;base64,${pngBase64}`,
+                },
+                {
+                  ...basePart(assistantID, "file-2"),
+                  type: "file",
+                  mime: "audio/wav",
+                  filename: "error.wav",
+                  url: `data:audio/wav;base64,${wavBase64}`,
+                },
+                {
+                  ...basePart(assistantID, "file-3"),
+                  type: "file",
+                  mime: "audio/ogg",
+                  filename: "unsupported.ogg",
+                  url: "data:audio/ogg;base64,T2dnUw==",
+                },
+                {
+                  ...basePart(assistantID, "file-4"),
+                  type: "file",
+                  mime: "application/octet-stream",
+                  filename: "diagnostic.bin",
+                  url: `data:application/octet-stream;base64,${binaryBase64}`,
                 },
               ],
             },
@@ -633,7 +704,7 @@ describe("session.message-v2.toModelMessage", () => {
       },
     ]
 
-    const messages = await MessageV2.toModelMessages(input, model)
+    const messages = await MessageV2.toModelMessages(input, mediaModel)
     expect(messages).toStrictEqual([
       {
         role: "user",
@@ -668,17 +739,129 @@ describe("session.message-v2.toModelMessage", () => {
         role: "user",
         content: [
           { type: "text", text: MessageV2.SYNTHETIC_ATTACHMENT_PROMPT },
+          { type: "text", text: 'Tool "bash" call call-1 failed:' },
           {
             type: "file",
             mediaType: "image/png",
             filename: "error-state.png",
-            data: "data:image/png;base64,Zm9v",
+            data: `data:image/png;base64,${pngBase64}`,
+          },
+          {
+            type: "file",
+            mediaType: "audio/wav",
+            filename: "error.wav",
+            data: `data:audio/wav;base64,${wavBase64}`,
+          },
+          {
+            type: "text",
+            text: '[Tool attachment "unsupported.ogg" (audio/ogg) was retained but cannot be safely sent to this model/provider.]',
+          },
+          {
+            type: "text",
+            text: '[Tool attachment "diagnostic.bin" (application/octet-stream) was retained but cannot be safely sent to this model/provider.]',
           },
         ],
       },
     ])
 
-    expect(await MessageV2.toModelMessages(input, model, { stripMedia: true })).toStrictEqual(messages.slice(0, -1))
+    expect(JSON.stringify(messages)).not.toContain(binaryBase64)
+    expect(await MessageV2.toModelMessages(input, mediaModel, { stripMedia: true })).toStrictEqual(
+      messages.slice(0, -1),
+    )
+  })
+
+  test("keeps synthetic attachments correlated with multiple tool calls", async () => {
+    const userID = "m-user-groups"
+    const assistantID = "m-assistant-groups"
+    const mediaModel = withInputCapabilities({ image: true })
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u-groups"),
+            type: "text",
+            text: "run both tools",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "tool-image"),
+            type: "tool",
+            callID: "call-image",
+            tool: "screenshot",
+            state: {
+              status: "completed",
+              input: {},
+              output: "captured",
+              title: "Screenshot",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments: [
+                {
+                  ...basePart(assistantID, "group-image"),
+                  type: "file",
+                  mime: "image/png",
+                  filename: "screen.png",
+                  url: `data:image/png;base64,${pngBase64}`,
+                },
+              ],
+            },
+          },
+          {
+            ...basePart(assistantID, "tool-error"),
+            type: "tool",
+            callID: "call-error",
+            tool: "upload",
+            state: {
+              status: "error",
+              input: {},
+              error: "upload failed",
+              metadata: {},
+              time: { start: 2, end: 3 },
+              attachments: [
+                {
+                  ...basePart(assistantID, "group-binary"),
+                  type: "file",
+                  mime: "application/octet-stream",
+                  filename: "upload.bin",
+                  url: `data:application/octet-stream;base64,${binaryBase64}`,
+                },
+              ],
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const messages = await MessageV2.toModelMessages(input, mediaModel)
+    const synthetic = messages.filter(
+      (message) =>
+        message.role === "user" &&
+        Array.isArray(message.content) &&
+        message.content.some((part) => part.type === "text" && part.text === "Attached file(s) from tool result:"),
+    )
+
+    expect(synthetic).toHaveLength(1)
+    expect(synthetic[0]?.content).toStrictEqual([
+      { type: "text", text: "Attached file(s) from tool result:" },
+      { type: "text", text: 'Tool "screenshot" call call-image completed:' },
+      {
+        type: "file",
+        mediaType: "image/png",
+        filename: "screen.png",
+        data: `data:image/png;base64,${pngBase64}`,
+      },
+      { type: "text", text: 'Tool "upload" call call-error failed:' },
+      {
+        type: "text",
+        text: '[Tool attachment "upload.bin" (application/octet-stream) was retained but cannot be safely sent to this model/provider.]',
+      },
+    ])
+    expect(JSON.stringify(messages)).not.toContain(binaryBase64)
   })
 
   test("forwards partial bash output for aborted tool calls", async () => {

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -265,8 +265,12 @@ function makeHttp(mcpService = mcp) {
 
 const it = testEffect(makeHttp())
 const mcpLegacyMetadata = { interrupted: true, output: "must not become a successful result" }
+const mcpErrorImageURL = "data:image/png;base64,Zm9v"
 const mcpErrorResult: CallToolResult = {
-  content: [{ type: "text", text: "Message was not sent" }],
+  content: [
+    { type: "text", text: "Message was not sent" },
+    { type: "image", data: "Zm9v", mimeType: "image/png" },
+  ],
   structuredContent: { sent: false, reason: "composer rejected the request" },
   isError: true,
   _meta: { privateToken: "do-not-send-to-model" },
@@ -337,6 +341,30 @@ function providerCfg(url: string) {
         options: {
           ...cfg.provider.test.options,
           baseURL: url,
+        },
+      },
+    },
+  }
+}
+
+function imageProviderCfg(url: string) {
+  const config = providerCfg(url)
+  return {
+    ...config,
+    provider: {
+      ...config.provider,
+      test: {
+        ...config.provider.test,
+        models: {
+          ...config.provider.test.models,
+          "test-model": {
+            ...config.provider.test.models["test-model"],
+            attachment: true,
+            modalities: {
+              input: ["text", "image"] as ("text" | "image")[],
+              output: ["text"] as "text"[],
+            },
+          },
         },
       },
     },
@@ -639,6 +667,14 @@ mcpIt.live("MCP isError becomes a tool error without losing standard result fiel
         _meta: mcpErrorResult._meta,
         legacyMetadata: mcpLegacyMetadata,
       })
+      expect(tool.state.attachments).toHaveLength(1)
+      expect(tool.state.attachments?.[0]).toMatchObject({
+        type: "file",
+        mime: "image/png",
+        url: mcpErrorImageURL,
+        sessionID: session.id,
+        messageID: tool.messageID,
+      })
       expect(statuses).toEqual(["error"])
       expect(result.parts.some((part) => part.type === "text" && part.text === "I saw that sending failed")).toBe(true)
 
@@ -648,8 +684,19 @@ mcpIt.live("MCP isError becomes a tool error without losing standard result fiel
       expect(followup).toContain("composer rejected the request")
       expect(followup).not.toContain("must not become a successful result")
       expect(followup).not.toContain("do-not-send-to-model")
+      expect(requests[1]).toMatchObject({
+        messages: expect.arrayContaining([
+          {
+            role: "user",
+            content: expect.arrayContaining([
+              { type: "text", text: MessageV2.SYNTHETIC_ATTACHMENT_PROMPT },
+              { type: "image_url", image_url: { url: mcpErrorImageURL } },
+            ]),
+          },
+        ]),
+      })
     }),
-    { git: true, config: providerCfg },
+    { git: true, config: imageProviderCfg },
   ),
 )
 

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -2,6 +2,8 @@ import { Worktree } from "../../src/worktree"
 import { NodeFileSystem } from "@effect/platform-node"
 import { FetchHttpClient } from "effect/unstable/http"
 import { afterEach, expect } from "bun:test"
+import { dynamicTool, jsonSchema, type Tool as AITool } from "ai"
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import { Cause, Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import path from "path"
 import { Agent as AgentSvc } from "../../src/agent/agent"
@@ -56,6 +58,7 @@ import { provideTmpdirInstance, provideTmpdirServer } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { reply, TestLLMServer } from "../lib/llm-server"
 import { Inbox } from "../../src/inbox"
+import { Metrics } from "../../src/metrics"
 
 void Log.init({ print: false })
 
@@ -118,28 +121,32 @@ function errorTool(parts: MessageV2.Part[]) {
   return part?.state.status === "error" ? (part as ErrorToolPart) : undefined
 }
 
-const mcp = Layer.succeed(
-  MCP.Service,
-  MCP.Service.of({
-    status: () => Effect.succeed({}),
-    clients: () => Effect.succeed({}),
-    tools: () => Effect.succeed({}),
-    prompts: () => Effect.succeed({}),
-    resources: () => Effect.succeed({}),
-    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
-    connect: () => Effect.void,
-    disconnect: () => Effect.void,
-    getPrompt: () => Effect.succeed(undefined),
-    readResource: () => Effect.succeed(undefined),
-    startAuth: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
-    authenticate: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
-    finishAuth: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
-    removeAuth: () => Effect.void,
-    supportsOAuth: () => Effect.succeed(false),
-    hasStoredTokens: () => Effect.succeed(false),
-    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
-  }),
-)
+function mcpLayer(tools: () => Record<string, AITool> = () => ({})) {
+  return Layer.succeed(
+    MCP.Service,
+    MCP.Service.of({
+      status: () => Effect.succeed({}),
+      clients: () => Effect.succeed({}),
+      tools: () => Effect.sync(tools),
+      prompts: () => Effect.succeed({}),
+      resources: () => Effect.succeed({}),
+      add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+      connect: () => Effect.void,
+      disconnect: () => Effect.void,
+      getPrompt: () => Effect.succeed(undefined),
+      readResource: () => Effect.succeed(undefined),
+      startAuth: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
+      authenticate: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
+      finishAuth: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
+      removeAuth: () => Effect.void,
+      supportsOAuth: () => Effect.succeed(false),
+      hasStoredTokens: () => Effect.succeed(false),
+      getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+    }),
+  )
+}
+
+const mcp = mcpLayer()
 
 const lsp = Layer.succeed(
   LSP.Service,
@@ -164,7 +171,7 @@ const lsp = Layer.succeed(
 const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const run = SessionRunState.layer.pipe(Layer.provide(status))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
-function makeHttp() {
+function makeHttp(mcpService = mcp) {
   const taskRegistry = ActorRegistry.defaultLayer
   const deps = Layer.mergeAll(
     Session.defaultLayer,
@@ -178,7 +185,7 @@ function makeHttp() {
     Config.defaultLayer,
     ProviderSvc.defaultLayer,
     lsp,
-    mcp,
+    mcpService,
     AppFileSystem.defaultLayer,
     status,
     taskRegistry,
@@ -257,6 +264,35 @@ function makeHttp() {
 }
 
 const it = testEffect(makeHttp())
+const mcpLegacyMetadata = { interrupted: true, output: "must not become a successful result" }
+const mcpErrorResult: CallToolResult = {
+  content: [{ type: "text", text: "Message was not sent" }],
+  structuredContent: { sent: false, reason: "composer rejected the request" },
+  isError: true,
+  _meta: { privateToken: "do-not-send-to-model" },
+  metadata: mcpLegacyMetadata,
+}
+const mcpSuccessResult: CallToolResult = {
+  content: [{ type: "text", text: "Window updated" }],
+  structuredContent: { changed: true, windowID: 42 },
+  _meta: { privateToken: "success-meta-is-client-only" },
+}
+const mcpIt = testEffect(
+  makeHttp(
+    mcpLayer(() => ({
+      mcp_result: dynamicTool({
+        description: "Return a standard MCP tool execution error",
+        inputSchema: jsonSchema({ type: "object", properties: {}, additionalProperties: false }),
+        execute: async () => mcpErrorResult,
+      }),
+      mcp_success: dynamicTool({
+        description: "Return a standard structured MCP success result",
+        inputSchema: jsonSchema({ type: "object", properties: {}, additionalProperties: false }),
+        execute: async () => mcpSuccessResult,
+      }),
+    })),
+  ),
+)
 const unix = process.platform !== "win32" ? it.live : it.live.skip
 
 // Config that registers a custom "test" provider with a "test-model" model
@@ -549,6 +585,129 @@ it.live("loop continues when finish is tool-calls", () =>
         expect(result.parts.some((part) => part.type === "text" && part.text === "second")).toBe(true)
         expect(result.info.finish).toBe("stop")
       }
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+mcpIt.live("MCP isError becomes a tool error without losing standard result fields", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const bus = yield* Bus.Service
+      const metricSeen = defer<void>()
+      const statuses: string[] = []
+      const session = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      const off = yield* bus.subscribeCallback(Metrics.ToolCall, (event) => {
+        if (event.properties.sessionID !== session.id || event.properties.tool_name !== "mcp_result") return
+        statuses.push(event.properties.tool_call_status)
+        metricSeen.resolve()
+      })
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "send the message" }],
+      })
+      yield* llm.tool("mcp_result", {})
+      yield* llm.text("I saw that sending failed")
+
+      const result = yield* prompt.loop({ sessionID: session.id })
+      yield* Effect.promise(() => metricSeen.promise)
+      off()
+
+      const tool = (yield* MessageV2.filterCompactedEffect(session.id))
+        .flatMap((message) => message.parts)
+        .find(
+          (part): part is ErrorToolPart =>
+            part.type === "tool" && part.tool === "mcp_result" && part.state.status === "error",
+        )
+      expect(tool).toBeDefined()
+      if (!tool) return
+
+      expect(tool.state.error).toBe(
+        'Message was not sent\n\nStructured content:\n{"sent":false,"reason":"composer rejected the request"}',
+      )
+      expect(tool.state.metadata?.mcp).toEqual({
+        structuredContent: mcpErrorResult.structuredContent,
+        isError: true,
+        _meta: mcpErrorResult._meta,
+        legacyMetadata: mcpLegacyMetadata,
+      })
+      expect(statuses).toEqual(["error"])
+      expect(result.parts.some((part) => part.type === "text" && part.text === "I saw that sending failed")).toBe(true)
+
+      const requests = yield* llm.inputs
+      const followup = JSON.stringify(requests[1])
+      expect(followup).toContain("Message was not sent")
+      expect(followup).toContain("composer rejected the request")
+      expect(followup).not.toContain("must not become a successful result")
+      expect(followup).not.toContain("do-not-send-to-model")
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+mcpIt.live("MCP structuredContent is persisted and reaches the model alongside text", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const bus = yield* Bus.Service
+      const metricSeen = defer<void>()
+      const statuses: string[] = []
+      const session = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      const off = yield* bus.subscribeCallback(Metrics.ToolCall, (event) => {
+        if (event.properties.sessionID !== session.id || event.properties.tool_name !== "mcp_success") return
+        statuses.push(event.properties.tool_call_status)
+        metricSeen.resolve()
+      })
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "inspect the window" }],
+      })
+      yield* llm.tool("mcp_success", {})
+      yield* llm.text("The window changed")
+
+      yield* prompt.loop({ sessionID: session.id })
+      yield* Effect.promise(() => metricSeen.promise)
+      off()
+
+      const tool = (yield* MessageV2.filterCompactedEffect(session.id))
+        .flatMap((message) => message.parts)
+        .find(
+          (part): part is CompletedToolPart =>
+            part.type === "tool" && part.tool === "mcp_success" && part.state.status === "completed",
+        )
+      expect(tool).toBeDefined()
+      if (!tool) return
+
+      expect(tool.state.output).toBe(
+        'Window updated\n\nStructured content:\n{"changed":true,"windowID":42}',
+      )
+      expect(tool.state.metadata.mcp).toEqual({
+        structuredContent: mcpSuccessResult.structuredContent,
+        isError: false,
+        _meta: mcpSuccessResult._meta,
+      })
+      expect(statuses).toEqual(["success"])
+
+      const requests = yield* llm.inputs
+      const followup = JSON.stringify(requests[1])
+      expect(followup).toContain("Window updated")
+      expect(followup).toContain('{\\"changed\\":true,\\"windowID\\":42}')
+      expect(followup).not.toContain("success-meta-is-client-only")
     }),
     { git: true, config: providerCfg },
   ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -265,11 +265,30 @@ function makeHttp(mcpService = mcp) {
 
 const it = testEffect(makeHttp())
 const mcpLegacyMetadata = { interrupted: true, output: "must not become a successful result" }
-const mcpErrorImageURL = "data:image/png;base64,Zm9v"
+const mcpErrorImage = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+const mcpErrorAudio = "UklGRiUAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQEAAACA"
+const mcpErrorBinary = "AQIDBAUGBwgJ"
+const mcpErrorImageURL = `data:image/png;base64,${mcpErrorImage}`
 const mcpErrorResult: CallToolResult = {
   content: [
     { type: "text", text: "Message was not sent" },
-    { type: "image", data: "Zm9v", mimeType: "image/png" },
+    { type: "image", data: mcpErrorImage, mimeType: "image/png" },
+    {
+      type: "resource",
+      resource: {
+        uri: "mcp://diagnostic.txt",
+        text: "Resource diagnostic",
+        mimeType: "text/plain",
+      },
+    },
+    { type: "audio", data: mcpErrorAudio, mimeType: "audio/wav" },
+    {
+      type: "resource",
+      resource: {
+        uri: "mcp://diagnostic.bin",
+        blob: mcpErrorBinary,
+      },
+    },
   ],
   structuredContent: { sent: false, reason: "composer rejected the request" },
   isError: true,
@@ -347,7 +366,7 @@ function providerCfg(url: string) {
   }
 }
 
-function imageProviderCfg(url: string) {
+function mediaProviderCfg(url: string) {
   const config = providerCfg(url)
   return {
     ...config,
@@ -361,7 +380,7 @@ function imageProviderCfg(url: string) {
             ...config.provider.test.models["test-model"],
             attachment: true,
             modalities: {
-              input: ["text", "image"] as ("text" | "image")[],
+              input: ["text", "image", "audio"] as ("text" | "image" | "audio")[],
               output: ["text"] as "text"[],
             },
           },
@@ -659,7 +678,7 @@ mcpIt.live("MCP isError becomes a tool error without losing standard result fiel
       if (!tool) return
 
       expect(tool.state.error).toBe(
-        'Message was not sent\n\nStructured content:\n{"sent":false,"reason":"composer rejected the request"}',
+        'Message was not sent\n\nResource diagnostic\n\nStructured content:\n{"sent":false,"reason":"composer rejected the request"}',
       )
       expect(tool.state.metadata?.mcp).toEqual({
         structuredContent: mcpErrorResult.structuredContent,
@@ -667,11 +686,26 @@ mcpIt.live("MCP isError becomes a tool error without losing standard result fiel
         _meta: mcpErrorResult._meta,
         legacyMetadata: mcpLegacyMetadata,
       })
-      expect(tool.state.attachments).toHaveLength(1)
+      expect(tool.state.attachments).toHaveLength(3)
       expect(tool.state.attachments?.[0]).toMatchObject({
         type: "file",
         mime: "image/png",
         url: mcpErrorImageURL,
+        sessionID: session.id,
+        messageID: tool.messageID,
+      })
+      expect(tool.state.attachments?.[1]).toMatchObject({
+        type: "file",
+        mime: "audio/wav",
+        url: `data:audio/wav;base64,${mcpErrorAudio}`,
+        sessionID: session.id,
+        messageID: tool.messageID,
+      })
+      expect(tool.state.attachments?.[2]).toMatchObject({
+        type: "file",
+        mime: "application/octet-stream",
+        url: `data:application/octet-stream;base64,${mcpErrorBinary}`,
+        filename: "mcp://diagnostic.bin",
         sessionID: session.id,
         messageID: tool.messageID,
       })
@@ -681,7 +715,14 @@ mcpIt.live("MCP isError becomes a tool error without losing standard result fiel
       const requests = yield* llm.inputs
       const followup = JSON.stringify(requests[1])
       expect(followup).toContain("Message was not sent")
+      expect(followup).toContain("Resource diagnostic")
       expect(followup).toContain("composer rejected the request")
+      expect(followup).toContain('Tool \\"mcp_result\\" call')
+      expect(followup).toContain("failed:")
+      expect(followup).toContain("diagnostic.bin")
+      expect(followup).not.toContain("mcp://diagnostic.bin")
+      expect(followup).toContain("application/octet-stream")
+      expect(followup).not.toContain(mcpErrorBinary)
       expect(followup).not.toContain("must not become a successful result")
       expect(followup).not.toContain("do-not-send-to-model")
       expect(requests[1]).toMatchObject({
@@ -691,12 +732,13 @@ mcpIt.live("MCP isError becomes a tool error without losing standard result fiel
             content: expect.arrayContaining([
               { type: "text", text: MessageV2.SYNTHETIC_ATTACHMENT_PROMPT },
               { type: "image_url", image_url: { url: mcpErrorImageURL } },
+              { type: "input_audio", input_audio: { data: mcpErrorAudio, format: "wav" } },
             ]),
           },
         ]),
       })
     }),
-    { git: true, config: imageProviderCfg },
+    { git: true, config: mediaProviderCfg },
   ),
 )
 

--- a/packages/opencode/test/session/tool-attachment.test.ts
+++ b/packages/opencode/test/session/tool-attachment.test.ts
@@ -121,6 +121,10 @@ describe("session tool attachment routing", () => {
     expect(routeToolAttachment({ model: prefixed, attachment: attachment("audio/wav"), allowNative: true })).toBe(
       "synthetic",
     )
+    const modelsPrefixed = makeModel({ npm: "@ai-sdk/google", id: "models/gemini-3-pro-preview", audio: true })
+    expect(routeToolAttachment({ model: modelsPrefixed, attachment: attachment("audio/wav"), allowNative: true })).toBe(
+      "synthetic",
+    )
     const uppercase = makeModel({ npm: "@ai-sdk/google", id: "GEMINI-3-PRO-PREVIEW", audio: true })
     expect(routeToolAttachment({ model: uppercase, attachment: attachment("audio/wav"), allowNative: true })).toBe(
       "synthetic",

--- a/packages/opencode/test/session/tool-attachment.test.ts
+++ b/packages/opencode/test/session/tool-attachment.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test"
+import type { Provider } from "../../src/provider"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import {
+  inlineToolAttachment,
+  routeToolAttachment,
+  toolAttachmentFilename,
+  toolAttachmentPlaceholder,
+} from "../../src/session/tool-attachment"
+
+function makeModel(input: {
+  npm: string
+  id?: string
+  image?: boolean
+  audio?: boolean
+  video?: boolean
+  pdf?: boolean
+}): Provider.Model {
+  return {
+    id: ModelID.make(input.id ?? "test-model"),
+    providerID: ProviderID.make("test"),
+    api: {
+      id: input.id ?? "test-model",
+      url: "https://example.com",
+      npm: input.npm,
+    },
+    name: "Test Model",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: true,
+      toolcall: true,
+      input: {
+        text: true,
+        image: input.image ?? false,
+        audio: input.audio ?? false,
+        video: input.video ?? false,
+        pdf: input.pdf ?? false,
+      },
+      output: { text: true, image: false, audio: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 0, input: 0, output: 0 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-01-01",
+  }
+}
+
+const attachment = (mime: string) => ({
+  mime,
+  url: `data:${mime};base64,Zm9v`,
+  filename: `result.${mime.split("/")[1]}`,
+})
+
+describe("session tool attachment routing", () => {
+  test("uses only OpenAI-compatible input formats that the adapter accepts", () => {
+    const model = makeModel({
+      npm: "@ai-sdk/openai-compatible",
+      image: true,
+      audio: true,
+      pdf: true,
+    })
+
+    expect(routeToolAttachment({ model, attachment: attachment("image/png"), allowNative: true })).toBe("synthetic")
+    expect(routeToolAttachment({ model, attachment: attachment("audio/wav"), allowNative: true })).toBe("synthetic")
+    expect(routeToolAttachment({ model, attachment: attachment("audio/ogg"), allowNative: true })).toBe("placeholder")
+    expect(routeToolAttachment({ model, attachment: attachment("application/octet-stream"), allowNative: true })).toBe(
+      "placeholder",
+    )
+    expect(routeToolAttachment({ model, attachment: attachment("image/svg+xml"), allowNative: true })).toBe(
+      "placeholder",
+    )
+  })
+
+  test("does not send audio or text files through the OpenAI Responses adapter", () => {
+    for (const npm of ["@ai-sdk/openai", "@ai-sdk/azure"]) {
+      const model = makeModel({ npm, image: true, audio: true, pdf: true })
+
+      expect(routeToolAttachment({ model, attachment: attachment("image/png"), allowNative: false })).toBe("synthetic")
+      expect(routeToolAttachment({ model, attachment: attachment("application/pdf"), allowNative: false })).toBe(
+        "synthetic",
+      )
+      expect(routeToolAttachment({ model, attachment: attachment("audio/wav"), allowNative: false })).toBe(
+        "placeholder",
+      )
+      expect(routeToolAttachment({ model, attachment: attachment("text/plain"), allowNative: false })).toBe(
+        "placeholder",
+      )
+    }
+  })
+
+  test("keeps supported Anthropic files native only for successful tool results", () => {
+    const model = makeModel({ npm: "@ai-sdk/anthropic", image: true, audio: true, pdf: true })
+
+    expect(routeToolAttachment({ model, attachment: attachment("image/jpeg"), allowNative: true })).toBe("native")
+    expect(routeToolAttachment({ model, attachment: attachment("application/pdf"), allowNative: true })).toBe("native")
+    expect(routeToolAttachment({ model, attachment: attachment("image/jpeg"), allowNative: false })).toBe("synthetic")
+    expect(routeToolAttachment({ model, attachment: attachment("audio/wav"), allowNative: false })).toBe("placeholder")
+  })
+
+  test("uses Gemini 3 native multimodal tool results and synthetic error files", () => {
+    const model = makeModel({
+      npm: "@ai-sdk/google",
+      id: "gemini-3-pro-preview",
+      audio: true,
+      video: true,
+    })
+
+    expect(routeToolAttachment({ model, attachment: attachment("audio/wav"), allowNative: true })).toBe("native")
+    expect(routeToolAttachment({ model, attachment: attachment("video/mp4"), allowNative: true })).toBe("native")
+    expect(routeToolAttachment({ model, attachment: attachment("audio/wav"), allowNative: false })).toBe("synthetic")
+
+    const prefixed = makeModel({
+      npm: "@ai-sdk/google",
+      id: "proxy/gemini-3-pro-preview",
+      audio: true,
+    })
+    expect(routeToolAttachment({ model: prefixed, attachment: attachment("audio/wav"), allowNative: true })).toBe(
+      "synthetic",
+    )
+    const uppercase = makeModel({ npm: "@ai-sdk/google", id: "GEMINI-3-PRO-PREVIEW", audio: true })
+    expect(routeToolAttachment({ model: uppercase, attachment: attachment("audio/wav"), allowNative: true })).toBe(
+      "synthetic",
+    )
+  })
+
+  test("downgrades files disabled by model capabilities", () => {
+    const model = makeModel({ npm: "@ai-sdk/openai-compatible" })
+
+    expect(routeToolAttachment({ model, attachment: attachment("image/png"), allowNative: false })).toBe("placeholder")
+    expect(routeToolAttachment({ model, attachment: attachment("audio/wav"), allowNative: false })).toBe("placeholder")
+  })
+
+  test("limits Bedrock synthetic text files to media types supported by its adapter", () => {
+    const model = makeModel({ npm: "@ai-sdk/amazon-bedrock" })
+
+    expect(routeToolAttachment({ model, attachment: attachment("text/plain"), allowNative: false })).toBe("synthetic")
+    expect(routeToolAttachment({ model, attachment: attachment("text/css"), allowNative: false })).toBe("placeholder")
+  })
+
+  test("extracts base64 payloads for native tool-result content", () => {
+    expect(inlineToolAttachment(attachment("image/png"))).toEqual({
+      data: "Zm9v",
+      mediaType: "image/png",
+    })
+    expect(inlineToolAttachment({ mime: "image/png", url: "https://example.com/image.png" })).toBeUndefined()
+    expect(inlineToolAttachment({ mime: "image/png", url: "data:image/png;base64," })).toBeUndefined()
+    expect(inlineToolAttachment({ mime: "image/png", url: "data:audio/wav;base64,Zm9v" })).toBeUndefined()
+  })
+
+  test("sanitizes untrusted resource URIs used as attachment names", () => {
+    const dataURI = {
+      mime: "application/octet-stream",
+      url: "data:application/octet-stream;base64,Zm9v",
+      filename: "  data:application/octet-stream;base64,AQIDBAUGBwgJ  ",
+    }
+
+    expect(toolAttachmentPlaceholder(dataURI)).toBe(
+      '[Tool attachment "data URI (application/octet-stream)" (application/octet-stream) was retained but cannot be safely sent to this model/provider.]',
+    )
+    expect(toolAttachmentPlaceholder(dataURI)).not.toContain("AQIDBAUGBwgJ")
+    expect(toolAttachmentFilename(dataURI)).toBeUndefined()
+    expect(
+      toolAttachmentFilename({
+        mime: "image/png",
+        url: "data:image/png;base64,Zm9v",
+        filename: "mcp://files/screenshot.png?token=secret",
+      }),
+    ).toBe("screenshot.png")
+  })
+})

--- a/packages/opencode/test/session/trajectory.test.ts
+++ b/packages/opencode/test/session/trajectory.test.ts
@@ -217,6 +217,31 @@ describe("serializeTrajectoryMessages", () => {
               ],
             },
           },
+          {
+            id: PartID.make("part_e"),
+            messageID: asstID,
+            sessionID,
+            type: "tool",
+            tool: "click",
+            callID: "call_e",
+            state: {
+              status: "error",
+              input: {},
+              error: "click failed",
+              metadata: {},
+              time: { start: 3, end: 4 },
+              attachments: [
+                {
+                  id: PartID.make("part_error_att"),
+                  messageID: asstID,
+                  sessionID,
+                  type: "file",
+                  mime: "image/jpeg",
+                  url: "data:image/jpeg;base64,CCCCCCCCCCC",
+                },
+              ],
+            },
+          },
         ],
       },
     ]
@@ -232,5 +257,8 @@ describe("serializeTrajectoryMessages", () => {
     const toolPart = out[1]?.parts[0] as any
     expect(toolPart.state.attachments[0].url).toBe("[data-url:image/png]")
     expect(toolPart.state.attachments[0].mime).toBe("image/png")
+    const errorToolPart = out[1]?.parts[1] as any
+    expect(errorToolPart.state.attachments[0].url).toBe("[data-url:image/jpeg]")
+    expect(errorToolPart.state.attachments[0].mime).toBe("image/jpeg")
   })
 })

--- a/packages/opencode/test/share/share-next.test.ts
+++ b/packages/opencode/test/share/share-next.test.ts
@@ -10,8 +10,10 @@ import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { Bus } from "../../src/bus"
 import { Config } from "../../src/config"
 import { Provider } from "../../src/provider"
+import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session"
-import type { SessionID } from "../../src/session/schema"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { ShareNext } from "../../src/share"
 import { SessionShareTable } from "../../src/share/share.sql"
 import { Database, eq } from "../../src/storage"
@@ -231,6 +233,103 @@ describe("ShareNext", () => {
         expect(Exit.isFailure(exit)).toBe(true)
         expect(share(session.id)).toBeUndefined()
       }),
+    ),
+  )
+
+  it.live("redacts MCP _meta from full and incremental share syncs", () =>
+    provideTmpdirInstance(
+      () => {
+        const syncBodies: string[] = []
+        const client = HttpClient.make((req) => {
+          if (req.url.endsWith("/sync") && req.body._tag === "Uint8Array") {
+            syncBodies.push(new TextDecoder().decode(req.body.body))
+            return Effect.succeed(json(req, { ok: true }))
+          }
+          return Effect.succeed(
+            json(req, {
+              id: "shr_abc",
+              url: "https://legacy-share.example.com/share/abc",
+              secret: "sec_123",
+            }),
+          )
+        })
+
+        return Effect.gen(function* () {
+          const share = yield* ShareNext.Service
+          const session = yield* Session.Service
+          const bus = yield* Bus.Service
+          const info = yield* session.create({ title: "MCP metadata" })
+          const messageID = MessageID.ascending()
+          const partID = PartID.ascending()
+          const toolPart = (token: string, changed: boolean) => ({
+            id: partID,
+            messageID,
+            sessionID: info.id,
+            type: "tool" as const,
+            tool: "mcp_window",
+            callID: "call_1",
+            state: {
+              status: "completed" as const,
+              input: {},
+              output: "Window updated",
+              title: "",
+              metadata: {
+                mcp: {
+                  isError: false,
+                  structuredContent: { changed },
+                  _meta: { token },
+                },
+              },
+              time: { start: 1, end: 2 },
+            },
+          })
+
+          yield* session.updateMessage({
+            id: messageID,
+            sessionID: info.id,
+            role: "assistant",
+            parentID: MessageID.ascending(),
+            modelID: ModelID.make("test-model"),
+            providerID: ProviderID.make("test-provider"),
+            mode: "",
+            agent: "build",
+            path: { cwd: process.cwd(), root: process.cwd() },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            time: { created: 1, completed: 2 },
+          })
+          yield* session.updatePart(toolPart("full-sync-secret", true))
+
+          yield* share.create(info.id)
+          yield* Effect.sleep(1_250)
+
+          expect(syncBodies).toHaveLength(1)
+          expect(syncBodies[0]).not.toContain("full-sync-secret")
+          expect(syncBodies[0]).not.toContain('"_meta"')
+          expect(syncBodies[0]).toContain('"isError":false')
+          expect(syncBodies[0]).toContain('"structuredContent":{"changed":true}')
+
+          const incremental = toolPart("incremental-sync-secret", false)
+          yield* session.updatePart(incremental)
+          yield* bus.publish(MessageV2.Event.PartUpdated, {
+            sessionID: info.id,
+            part: incremental,
+            time: Date.now(),
+          })
+          yield* Effect.sleep(1_250)
+
+          expect(syncBodies).toHaveLength(2)
+          expect(syncBodies[1]).not.toContain("incremental-sync-secret")
+          expect(syncBodies[1]).not.toContain('"_meta"')
+          expect(syncBodies[1]).toContain('"structuredContent":{"changed":false}')
+
+          const local = yield* session.getPart({ sessionID: info.id, messageID, partID })
+          expect(local?.type).toBe("tool")
+          if (local?.type !== "tool" || local.state.status !== "completed") return
+          expect(local.state.metadata.mcp._meta).toEqual({ token: "incremental-sync-secret" })
+        }).pipe(Effect.provide(wired(client)))
+      },
+      { config: { enterprise: { url: "https://legacy-share.example.com" } } },
     ),
   )
 

--- a/packages/opencode/test/tool/truncation.test.ts
+++ b/packages/opencode/test/tool/truncation.test.ts
@@ -124,6 +124,18 @@ describe("Truncate", () => {
       }),
     )
 
+    it.live("labels truncated error output as failed", () =>
+      Effect.gen(function* () {
+        const svc = yield* Truncate.Service
+        const content = Array.from({ length: 100 }, (_, i) => `error line ${i}`).join("\n")
+        const result = yield* svc.output(content, { maxLines: 10, outcome: "error" })
+
+        expect(result.truncated).toBe(true)
+        expect(result.content).toContain("The tool call failed but the output was truncated")
+        expect(result.content).not.toContain("The tool call succeeded")
+      }),
+    )
+
     it.live("suggests actor tool when agent has actor permission", () =>
       Effect.gen(function* () {
         const svc = yield* Truncate.Service

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -287,6 +287,7 @@ export type ToolStateError = {
     start: number
     end: number
   }
+  attachments?: Array<FilePart>
 }
 
 export type ToolState = ToolStatePending | ToolStateRunning | ToolStateCompleted | ToolStateError

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1177,6 +1177,7 @@ export type ToolStateError = {
     start: number
     end: number
   }
+  attachments?: Array<FilePart>
 }
 
 export type ToolState = ToolStatePending | ToolStateRunning | ToolStateCompleted | ToolStateError

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11413,6 +11413,12 @@
               }
             },
             "required": ["start", "end"]
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilePart"
+            }
           }
         },
         "required": ["status", "input", "error", "time"]


### PR DESCRIPTION
## Summary

MiMoCode currently parses MCP tool results with the SDK schema but only surfaces a subset of the result, so protocol-level failures can look successful and structured payloads can disappear from the next model turn. This change normalizes the standard MCP result fields end to end and preserves their intended visibility boundaries.

## Standard MCP result behavior

| Field | MiMoCode behavior after this change |
| --- | --- |
| `content` | Normalizes text, image, audio, embedded resource, and resource-link blocks into model-visible text and attachments. |
| `isError` | Produces a real tool error state while retaining the server's error content and metadata. |
| `structuredContent` | Persists the structured value and adds a de-duplicated JSON representation to model-visible output when needed. |
| `_meta` | Preserves client-only metadata locally, excludes it from model input, and redacts it from shared-session payloads. |

Legacy non-standard `metadata` is isolated under `mcp.legacyMetadata` so it cannot collide with MiMoCode's internal `interrupted`, `recoverable`, or truncation state. Truncated MCP failures now also describe the call as failed instead of successful.

## Verification

- `bun typecheck`
- `bun test test/mcp --timeout 30000` (37 passed)
- `bun test test/session/prompt-effect.test.ts --timeout 30000` (35 passed, 2 skipped)
- `bun test test/session/processor-effect.test.ts --timeout 30000` (11 passed, 1 skipped)
- `bun test test/share/share-next.test.ts --timeout 30000` (8 passed)
- `bun test test/tool/truncation.test.ts --timeout 30000` (18 passed)
- Targeted `oxlint` run (0 errors)
- Pre-push workspace typecheck (12 packages passed)

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (context size undisclosed, extended reasoning) via [Codex](https://openai.com/codex/)
