### PR TITLE
fix(session): halt on repeated empty/no-op tool calls (model-loop guard)

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -89,6 +89,10 @@ export const Flag = {
   MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT: number("MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT") ?? 3,
   MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT: number("MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT") ?? 2,
   MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT: number("MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT") ?? 2,
+  // Empty/no-op tool-call loop guard: number of soft nudges (remind → replan)
+  // before the harness hard-halts the turn. N consecutive empty steps beyond
+  // this many recovery attempts terminates the turn. Mirrors TEXT_NGRAM_MAX_RECOVERY.
+  MIMOCODE_EMPTY_STEP_MAX_RECOVERY: number("MIMOCODE_EMPTY_STEP_MAX_RECOVERY") ?? 2,
 
   // Consecutive-block repetition detection for streamed reasoning + text.
   // A block of at least N tokens repeating REPEAT_THRESHOLD times consecutively

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -53,6 +53,12 @@ import {
   TEXT_NGRAM_RECOVERY_REMIND,
   TEXT_NGRAM_RECOVERY_REPLAN,
 } from "../session/prompt/text-ngram-detection"
+import {
+  EMPTY_STEP_MAX_RECOVERY,
+  EMPTY_STEP_RECOVERY_REMIND,
+  EMPTY_STEP_RECOVERY_REPLAN,
+  isEmptyStep,
+} from "../session/prompt/empty-step-detection"
 import { composeSkillsBlock } from "@/skill/compose/extract"
 import { builtinSkillRoot, matchDocumentSkills } from "@/skill/builtin/extract"
 import { ToolRegistry } from "../tool"
@@ -2084,6 +2090,19 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         // prose text instead of a structured tool_use). Local to runLoop so each
         // fresh user turn starts clean.
         let textToolCallRetries = 0
+        // Consecutive empty/no-op tool-call steps in this turn. Counts steps
+        // where the model "called a tool" with empty/invalid input, or produced
+        // no valid tool part and no substantive output at all (see isEmptyStep).
+        // A single non-empty step resets it. Escalates soft (remind → replan)
+        // then hard-halts once it exceeds EMPTY_STEP_MAX_RECOVERY, mirroring the
+        // text-ngram ladder. Local to runLoop so a fresh user turn starts clean.
+        let emptyStepStreak = 0
+        // Set true when a guard hard-halts the turn (currently the empty-step
+        // guard). A hard halt is terminal: it must break out immediately and
+        // NOT be re-entered by the taskGate / goalGate ReAct gates, which would
+        // otherwise inject a fresh user turn and re-drive a still-degraded model
+        // into the same loop.
+        let hardHalt = false
         const resolvedAgentID = agentID ?? "main"
         // Tracks plugin-driven cancellation (session.pre OR any session.userQuery.pre)
         // so session.post reports outcome="cancelled" instead of "error".
@@ -2633,6 +2652,90 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           yield* slog.info("text n-gram: recovery injected", { attempt: textNgramRecoveryAttempts })
           return true
         })
+
+        // Empty/no-op tool-call loop guard. Symmetric across main and fork
+        // branches, mirroring handleTextRepeat's soft→hard ladder but keyed on
+        // *empty steps* (empty/invalid tool input, or a fully empty terminal)
+        // rather than repeated text n-grams — the gap TEXT_NGRAM and
+        // stepSignature both miss (an empty tool call has no text to match and
+        // is dropped by stepSignature's undefined path).
+        //
+        // Returns:
+        //   "none"     — the step was NOT empty; streak reset, caller continues
+        //                normal classification.
+        //   "continue" — empty step, still within the soft-nudge budget; a
+        //                remind/replan reminder was injected, caller should loop.
+        //   "halt"     — empty streak exceeded EMPTY_STEP_MAX_RECOVERY; a
+        //                terminal error was published, caller must break.
+        const handleEmptyStep = Effect.fn("SessionPrompt.handleEmptyStep")(function* (input: {
+          lastUser: MessageV2.User
+          assistant: MessageV2.Assistant
+        }) {
+          // Never mask a genuine terminal outcome as an "empty loop": an errored
+          // step, a content-filter/error finish, or an already-resolved
+          // structured/summary step must fall through to its own classifier
+          // handler (writeContentFilterError / writeModelError / final). Those
+          // are terminal safety/error events, not a spinning no-op.
+          if (
+            input.assistant.error ||
+            input.assistant.summary ||
+            input.assistant.structured !== undefined ||
+            input.assistant.finish === "content-filter" ||
+            input.assistant.finish === "error"
+          ) {
+            return "none" as const
+          }
+          const parts = MessageV2.parts(input.assistant.id)
+          if (!isEmptyStep(parts)) {
+            emptyStepStreak = 0
+            return "none" as const
+          }
+          emptyStepStreak++
+          if (emptyStepStreak > EMPTY_STEP_MAX_RECOVERY) {
+            yield* slog.info("empty step: max recovery exceeded, terminating", { streak: emptyStepStreak })
+            hardHalt = true
+            // Discard the empty turn from request history so it can neither
+            // strand the conversation on an assistant prefill nor poison later
+            // context (toModelMessages skips a message whose info.error is set).
+            if (!input.assistant.error) {
+              input.assistant.error = new NamedError.Unknown({
+                message: `Empty tool call loop detected: ${emptyStepStreak} consecutive empty/no-op steps after ${EMPTY_STEP_MAX_RECOVERY} recovery attempts. Session terminated.`,
+              }).toObject()
+              yield* sessions.updateMessage(input.assistant)
+            }
+            yield* bus.publish(Session.Event.Error, {
+              sessionID,
+              error: new NamedError.Unknown({
+                message: `Empty tool call loop detected: ${emptyStepStreak} consecutive empty/no-op steps after ${EMPTY_STEP_MAX_RECOVERY} recovery attempts. Session terminated.`,
+              }).toObject(),
+            })
+            return "halt" as const
+          }
+          const recoveryText =
+            emptyStepStreak === 1 ? EMPTY_STEP_RECOVERY_REMIND : EMPTY_STEP_RECOVERY_REPLAN
+          const reentry = yield* sessions.updateMessage({
+            id: MessageID.ascending(),
+            role: "user" as const,
+            sessionID,
+            agentID: input.lastUser.agentID,
+            agent: input.lastUser.agent,
+            model: input.lastUser.model,
+            tools: input.lastUser.tools,
+            format: input.lastUser.format,
+            time: { created: Date.now() },
+          })
+          yield* sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: reentry.id,
+            sessionID,
+            type: "text",
+            synthetic: true,
+            text: recoveryText,
+          } satisfies MessageV2.TextPart)
+          yield* slog.info("empty step: recovery injected", { streak: emptyStepStreak })
+          return "continue" as const
+        })
+
 
         // content-filter is terminal on first occurrence: re-sending the same
         // turn would just get filtered again, so there is no nudge / counter.
@@ -3330,6 +3433,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 return "break" as const
               }
 
+              // Empty/no-op tool-call loop guard (fork branch). Intercept before
+              // classify would `continue` an empty tool-calls step: soft-nudge
+              // within budget, hard-halt once exceeded. A non-empty step returns
+              // "none" and falls through to normal classification.
+              const forkEmptyStep = yield* handleEmptyStep({ lastUser, assistant: handle.message })
+              if (forkEmptyStep === "halt") return "break" as const
+              if (forkEmptyStep === "continue") return "continue" as const
+
               const forkClassification = classifyAssistantStep({
                 phase: "after-process",
                 lastUser,
@@ -3545,6 +3656,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "break" as const
             }
 
+            // Empty/no-op tool-call loop guard (main branch). Intercept before
+            // classify would `continue` an empty tool-calls step: soft-nudge
+            // within budget, hard-halt once exceeded. A non-empty step returns
+            // "none" and falls through to normal classification.
+            const emptyStep = yield* handleEmptyStep({ lastUser, assistant: handle.message })
+            if (emptyStep === "halt") return "break" as const
+            if (emptyStep === "continue") return "continue" as const
+
             const classification = classifyAssistantStep({
               phase: "after-process",
               lastUser,
@@ -3693,6 +3812,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           if (outcome === "break") {
+            // A hard halt is terminal — skip the ReAct re-entry gates so a
+            // degraded model can't be re-driven into the same empty loop.
+            if (hardHalt) break
             if (yield* taskGate(lastUser)) continue
             if (yield* goalGate(lastUser)) continue
             break

--- a/packages/opencode/src/session/prompt/empty-step-detection.ts
+++ b/packages/opencode/src/session/prompt/empty-step-detection.ts
@@ -1,0 +1,113 @@
+import { Flag } from "@/flag/flag"
+import type { MessageV2 } from "../message-v2"
+
+/**
+ * Empty / no-op tool-call loop guard.
+ *
+ * Sibling to text-ngram-detection: the text-ngram ladder only inspects TEXT
+ * parts, so a model that spins by re-emitting content-free tool calls (or by
+ * "calling a tool" that produces no structured tool part at all) slips past it
+ * with no text to match. stepSignature (prompt.ts) also misses this: it signs
+ * only `part.type === "tool"` steps and returns undefined for a step with zero
+ * tool parts, so an empty terminal step is dropped from repeat counting instead
+ * of counted. This module fills that gap with a pure classifier + a soft→hard
+ * recovery ladder mirroring TEXT_NGRAM_MAX_RECOVERY.
+ *
+ * This is a HARNESS backstop for a MODEL bug: a degraded model that keeps
+ * emitting empty/no-op steps will never self-correct from a reminder, so after
+ * a bounded number of soft nudges the harness must hard-halt the turn rather
+ * than spin forever.
+ */
+
+export const EMPTY_STEP_MAX_RECOVERY = Flag.MIMOCODE_EMPTY_STEP_MAX_RECOVERY
+
+/**
+ * Is this assistant step an empty / no-op tool call?
+ *
+ * Two shapes count as empty (mirrors the task's definition):
+ *
+ *  (a) The step emitted one or more client (non-providerExecuted) tool parts,
+ *      but EVERY such tool part has an empty/invalid input — no keys, or only
+ *      keys whose values are null/undefined/empty-string/whitespace. The model
+ *      "called a tool" but passed nothing actionable, so the call cannot make
+ *      progress and re-looping just repeats it.
+ *
+ *  (b) The step produced NO client tool part at all AND no substantive text and
+ *      no substantive reasoning — a fully empty terminal. (This overlaps with
+ *      classify's `invalid`/"empty output", but we count it here too so the
+ *      hard-halt ladder can escalate on a run of them rather than only softly
+ *      nudging via autoContinueInvalidOutput.)
+ *
+ * A step that emits at least one tool part with real input, or any substantive
+ * text/reasoning, is NOT empty — the model is making some kind of progress.
+ *
+ * Provider-executed tool parts (e.g. server-side web search) are ignored for
+ * the "has a tool part" test: they are not client actions and their presence
+ * does not mean the model issued an actionable call.
+ */
+export function isEmptyStep(parts: readonly MessageV2.Part[]): boolean {
+  const clientToolParts = parts.filter(
+    (part): part is Extract<MessageV2.Part, { type: "tool" }> =>
+      part.type === "tool" && !part.metadata?.providerExecuted,
+  )
+
+  if (clientToolParts.length > 0) {
+    // (a) Every client tool part has an empty/invalid input.
+    return clientToolParts.every((part) => isEmptyInput(part.state.input))
+  }
+
+  // (b) No client tool part — empty only if there is also no substantive
+  // text and no substantive reasoning (a pure-empty terminal). A step with a
+  // real text answer or real reasoning is a legitimate (non-loop) outcome.
+  const hasSubstantiveText = parts.some(
+    (part) => part.type === "text" && !part.synthetic && !part.ignored && part.text.trim().length > 0,
+  )
+  if (hasSubstantiveText) return false
+  const hasSubstantiveReasoning = parts.some(
+    (part) => part.type === "reasoning" && part.text.trim().length > 0,
+  )
+  if (hasSubstantiveReasoning) return false
+  return true
+}
+
+/**
+ * An input object counts as empty when it has no keys, or every value is
+ * null/undefined/empty-string/whitespace-only. Nested objects/arrays with any
+ * content count as non-empty (the model passed *something*).
+ */
+function isEmptyInput(input: Record<string, unknown> | undefined | null): boolean {
+  if (input === undefined || input === null) return true
+  const keys = Object.keys(input)
+  if (keys.length === 0) return true
+  return keys.every((k) => isEmptyValue(input[k]))
+}
+
+function isEmptyValue(value: unknown): boolean {
+  if (value === undefined || value === null) return true
+  if (typeof value === "string") return value.trim().length === 0
+  if (Array.isArray(value)) return value.length === 0
+  if (typeof value === "object") return Object.keys(value as Record<string, unknown>).length === 0
+  // number / boolean → the model passed a real value.
+  return false
+}
+
+export const EMPTY_STEP_RECOVERY_REMIND = [
+  "<system-reminder>",
+  "NO PROGRESS: your previous step made no valid tool call and produced no answer",
+  "(the tool call had empty/invalid arguments, or there was no tool call and no text).",
+  "Stop repeating an empty step. Do exactly ONE of these now:",
+  "- Issue a valid tool call with COMPLETE, non-empty arguments, or",
+  "- Reply to the user directly with plain text.",
+  "Do NOT emit another empty or argument-less tool call.",
+  "</system-reminder>",
+].join("\n")
+
+export const EMPTY_STEP_RECOVERY_REPLAN = [
+  "<system-reminder>",
+  "STILL NO PROGRESS: you are repeating empty/no-op tool calls after a reminder.",
+  "This is your final chance before the turn is halted. You MUST either:",
+  "1. Send a single valid tool call whose arguments are fully populated, or",
+  "2. Give the user a plain-text response explaining the result or the blocker.",
+  "Any further empty/argument-less tool call will terminate this turn.",
+  "</system-reminder>",
+].join("\n")

--- a/packages/opencode/test/session/empty-step-detection.test.ts
+++ b/packages/opencode/test/session/empty-step-detection.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test"
+import { isEmptyStep } from "../../src/session/prompt/empty-step-detection"
+import type { MessageV2 } from "../../src/session/message-v2"
+
+// Minimal part builders — only the fields isEmptyStep inspects. Cast through
+// unknown so we don't have to satisfy the full PartBase shape (id/messageID/…)
+// that isEmptyStep never reads.
+function toolPart(input: Record<string, unknown>, opts?: { providerExecuted?: boolean; status?: string }) {
+  return {
+    type: "tool",
+    tool: "read",
+    metadata: opts?.providerExecuted ? { providerExecuted: true } : undefined,
+    state: { status: opts?.status ?? "completed", input },
+  } as unknown as MessageV2.Part
+}
+
+function textPart(text: string, opts?: { synthetic?: boolean; ignored?: boolean }) {
+  return {
+    type: "text",
+    text,
+    synthetic: opts?.synthetic,
+    ignored: opts?.ignored,
+  } as unknown as MessageV2.Part
+}
+
+function reasoningPart(text: string) {
+  return { type: "reasoning", text } as unknown as MessageV2.Part
+}
+
+describe("isEmptyStep — case (a): tool call with empty/invalid input", () => {
+  test("tool call with no keys is empty", () => {
+    expect(isEmptyStep([toolPart({})])).toBe(true)
+  })
+
+  test("tool call whose only values are empty strings/whitespace is empty", () => {
+    expect(isEmptyStep([toolPart({ file_path: "", pattern: "   " })])).toBe(true)
+  })
+
+  test("tool call whose values are null/undefined is empty", () => {
+    expect(isEmptyStep([toolPart({ a: null, b: undefined })])).toBe(true)
+  })
+
+  test("tool call with empty array / empty object values is empty", () => {
+    expect(isEmptyStep([toolPart({ items: [], opts: {} })])).toBe(true)
+  })
+
+  test("tool call with a real string argument is NOT empty", () => {
+    expect(isEmptyStep([toolPart({ file_path: "/tmp/x" })])).toBe(false)
+  })
+
+  test("tool call with a numeric/boolean argument is NOT empty", () => {
+    expect(isEmptyStep([toolPart({ limit: 0 })])).toBe(false)
+    expect(isEmptyStep([toolPart({ flag: false })])).toBe(false)
+  })
+
+  test("all tool parts empty => empty; any non-empty tool part => not empty", () => {
+    expect(isEmptyStep([toolPart({}), toolPart({ x: "" })])).toBe(true)
+    expect(isEmptyStep([toolPart({}), toolPart({ x: "real" })])).toBe(false)
+  })
+
+  test("provider-executed tool part is ignored for the has-tool test", () => {
+    // Only a provider-executed part + no substantive output => empty terminal.
+    expect(isEmptyStep([toolPart({ q: "x" }, { providerExecuted: true })])).toBe(true)
+  })
+})
+
+describe("isEmptyStep — case (b): empty terminal (no valid tool part, no output)", () => {
+  test("completely empty parts array is empty", () => {
+    expect(isEmptyStep([])).toBe(true)
+  })
+
+  test("only a synthetic text part (harness reminder) is empty", () => {
+    expect(isEmptyStep([textPart("<system-reminder>...</system-reminder>", { synthetic: true })])).toBe(true)
+  })
+
+  test("only whitespace text is empty", () => {
+    expect(isEmptyStep([textPart("   \n  ")])).toBe(true)
+  })
+
+  test("substantive text answer is NOT empty", () => {
+    expect(isEmptyStep([textPart("Here is your answer.")])).toBe(false)
+  })
+
+  test("substantive reasoning is NOT empty", () => {
+    expect(isEmptyStep([reasoningPart("Let me think about this...")])).toBe(false)
+  })
+
+  test("ignored text does not count as substantive", () => {
+    expect(isEmptyStep([textPart("stuff", { ignored: true })])).toBe(true)
+  })
+})

--- a/packages/opencode/test/session/empty-step-guard-integration.test.ts
+++ b/packages/opencode/test/session/empty-step-guard-integration.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration tests for the empty/no-op tool-call loop guard (handleEmptyStep +
+ * isEmptyStep). Driven end-to-end through Session.prompt against a scripted
+ * HTTP LLM stub — same harness as classify-integration.test.ts.
+ *
+ * Root cause this guards: a degraded model can spin by emitting empty/no-op
+ * steps (empty terminal, or a tool call with empty arguments). TEXT_NGRAM only
+ * inspects text and stepSignature drops zero-tool steps, so neither counts the
+ * loop. The guard escalates soft (remind → replan) up to
+ * EMPTY_STEP_MAX_RECOVERY, then HARD-HALTS the turn.
+ *
+ * EMPTY_STEP_MAX_RECOVERY defaults to 2, so the ladder is:
+ *   step 1 (empty) → streak 1 → REMIND nudge, continue
+ *   step 2 (empty) → streak 2 → REPLAN nudge, continue
+ *   step 3 (empty) → streak 3 > 2 → terminal error, break
+ * i.e. exactly 3 model calls before the turn is halted.
+ */
+
+import path from "path"
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { EMPTY_STEP_MAX_RECOVERY } from "../../src/session/prompt/empty-step-detection"
+import { Log } from "../../src/util"
+import { tmpdir } from "../fixture/fixture"
+import { startScriptedLLMServer, emptyStopResponse, textStopResponse } from "../lib/scripted-llm-server"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+function run<A, E>(fx: Effect.Effect<A, E, SessionPrompt.Service | Session.Service>) {
+  return Effect.runPromise(
+    fx.pipe(Effect.scoped, Effect.provide(Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer))),
+  )
+}
+
+function writeConfig(dir: string, origin: string) {
+  return Bun.write(
+    path.join(dir, "mimocode.json"),
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      enabled_providers: ["alibaba"],
+      provider: {
+        alibaba: { options: { apiKey: "test-key", baseURL: `${origin}/v1` } },
+      },
+      agent: { build: { model: "alibaba/qwen-plus" } },
+    }),
+  )
+}
+
+describe("empty/no-op tool-call loop guard — integration", () => {
+  test("repeated empty steps HARD-HALT the turn instead of looping forever", async () => {
+    await using tmp = await tmpdir({ git: true })
+    // Every response is an empty stop step. The stub repeats its last entry
+    // forever, so if the guard failed to halt this would spin indefinitely
+    // (the test would hang / time out). We assert it terminates.
+    const stub = startScriptedLLMServer([{ lines: emptyStopResponse() }])
+    try {
+      await writeConfig(tmp.path, stub.origin)
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const prompt = yield* SessionPrompt.Service
+              const session = yield* sessions.create({ title: "empty-step-halt" })
+              const result = yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "build",
+                parts: [{ type: "text", text: "Do the task." }],
+              })
+              // Turn terminated (did not hang) with an error on the assistant.
+              expect(result.info.role).toBe("assistant")
+              if (result.info.role === "assistant") expect(result.info.error).toBeDefined()
+              // Bounded: EMPTY_STEP_MAX_RECOVERY soft nudges + 1 halting step.
+              expect(stub.captures.length).toBe(EMPTY_STEP_MAX_RECOVERY + 1)
+            }),
+          ),
+      })
+    } finally {
+      await stub.stop()
+    }
+  })
+
+  test("a single empty step recovers when the next step produces a real answer (no halt)", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const stub = startScriptedLLMServer([
+      // step 1: empty terminal → streak 1 → REMIND nudge, continue
+      { lines: emptyStopResponse() },
+      // step 2: real answer → streak reset, loop exits cleanly
+      { lines: textStopResponse("here is the real answer") },
+    ])
+    try {
+      await writeConfig(tmp.path, stub.origin)
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const prompt = yield* SessionPrompt.Service
+              const session = yield* sessions.create({ title: "empty-step-recover" })
+              const result = yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "build",
+                parts: [{ type: "text", text: "Do the task." }],
+              })
+              expect(stub.captures.length).toBe(2)
+              expect(result.info.role).toBe("assistant")
+              if (result.info.role === "assistant") expect(result.info.error).toBeUndefined()
+              expect(result.parts.some((p) => p.type === "text" && p.text === "here is the real answer")).toBe(true)
+            }),
+          ),
+      })
+    } finally {
+      await stub.stop()
+    }
+  })
+})

--- a/packages/opencode/test/session/invalid-output-continuation.test.ts
+++ b/packages/opencode/test/session/invalid-output-continuation.test.ts
@@ -115,9 +115,12 @@ describe("invalid-output continuation — integration", () => {
     }
   })
 
-  test("repeated empty output exhausts the shared limit and writes InvalidOutputError", async () => {
+  test("repeated empty output is caught by the empty-step guard and halts the turn", async () => {
     await using tmp = await tmpdir({ git: true })
     // Server repeats the last entry, so every call returns an empty stop.
+    // The empty/no-op tool-call guard (empty-step-detection) intercepts these
+    // empty terminals BEFORE autoContinueInvalidOutput and hard-halts the turn
+    // after EMPTY_STEP_MAX_RECOVERY soft nudges + 1 halting step.
     const stub = startScriptedLLMServer([{ lines: emptyStopResponse() }])
     try {
       await writeConfig(tmp.path, stub.origin)
@@ -134,11 +137,11 @@ describe("invalid-output continuation — integration", () => {
                 agent: "build",
                 parts: [{ type: "text", text: "Answer my question." }],
               })
-              // limit nudges + 1 final attempt that trips the terminal error.
-              expect(stub.captures.length).toBe(Flag.MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT + 1)
+              // EMPTY_STEP_MAX_RECOVERY soft nudges + 1 halting step.
+              expect(stub.captures.length).toBe(Flag.MIMOCODE_EMPTY_STEP_MAX_RECOVERY + 1)
               expect(result.info.role).toBe("assistant")
               if (result.info.role === "assistant") {
-                expect(result.info.error?.name).toBe("InvalidOutputError")
+                expect(result.info.error).toBeDefined()
               }
             }),
           ),


### PR DESCRIPTION
## Root cause

A degraded model can spin the run loop by emitting **empty/no-op steps** that make no forward progress:

- **(a)** a tool call with **empty/invalid arguments** (no keys, or every value null/empty/whitespace), or
- **(b)** a "tool call" that produces **no valid client tool part and no substantive text/reasoning** (an empty terminal).

Neither existing guard catches this:

- **text-ngram / TEXT_LOOP** (`prompt.ts`) only inspects **text parts** — an empty tool call has no text to match, so it slips through.
- **Repeated-step nudge** (`stepSignature`) signs only `part.type === "tool"` steps and **returns `undefined` for a zero-tool step**, so an empty terminal is dropped from repeat counting instead of counted; and it only soft-nudges, which a degraded model ignores.

Net effect: the turn spins with zero progress → the session hangs. This is a **model bug**, so the harness must backstop it rather than rely on reminding a model too degraded to self-correct.

## Fix — layered soft→hard guard (mirrors the TEXT_NGRAM ladder)

1. **Detection** — new pure classifier `isEmptyStep` (`session/prompt/empty-step-detection.ts`) recognizes both empty shapes (a) and (b). Substantive text or reasoning, or any tool part with real input, counts as progress and is **not** empty. Provider-executed tool parts are ignored for the has-a-tool test.
2. **Soft → hard escalation** — `handleEmptyStep` in `runLoop` counts consecutive empty steps per turn:
   - streak 1 → inject a strong **REMIND** system-reminder, continue
   - streak 2 → inject **REPLAN**, continue
   - streak > `EMPTY_STEP_MAX_RECOVERY` (default **2**) → **hard-halt** the turn: publish a terminal error, set `assistant.error`, break — instead of nudging forever.
   - A single non-empty step resets the streak.
3. **Hard halt is terminal** — bypasses the `taskGate` / `goalGate` ReAct re-entry gates so a still-degraded model can't be re-driven into the same loop.
4. Wired into **both** the main and fork classification branches, before `classify` would otherwise `continue` an empty tool-calls step. Terminal outcomes (content-filter / error finish, errored / structured / summary) are **excluded** so genuine safety/error events still route to their own handlers.
5. New flag `MIMOCODE_EMPTY_STEP_MAX_RECOVERY` (default 2).

## Tests

- **Unit** (`empty-step-detection.test.ts`): `isEmptyStep` across both empty shapes and non-empty / recovery cases.
- **Integration** (`empty-step-guard-integration.test.ts`): N consecutive empty steps **hard-halt** the turn (bounded to `EMPTY_STEP_MAX_RECOVERY + 1` model calls, error set) rather than looping forever; a single empty step **recovers** when a real answer follows.
- Updated `invalid-output-continuation.test.ts`: the empty-step guard now supersedes `autoContinueInvalidOutput` for repeated empty terminals.

`bun typecheck` → EXIT 0. Affected + new suites green.

## Files

- `packages/opencode/src/session/prompt/empty-step-detection.ts` (new)
- `packages/opencode/src/session/prompt.ts`
- `packages/opencode/src/flag/flag.ts`
- `packages/opencode/test/session/empty-step-detection.test.ts` (new)
- `packages/opencode/test/session/empty-step-guard-integration.test.ts` (new)
- `packages/opencode/test/session/invalid-output-continuation.test.ts`