### PR TITLE
test: replace internal gateway name with neutral placeholder

### DIFF
--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2512,10 +2512,10 @@ describe("ProviderTransform.message - cache control on gateway", () => {
 
   test("openai-compatible with claude in model id does NOT trigger caching", () => {
     const model = createModel({
-      id: "mimorouter/claude-opus-4-8",
+      id: "gateway/claude-opus-4-8",
       providerID: "custom",
       api: {
-        id: "mimorouter/claude-opus-4-8",
+        id: "gateway/claude-opus-4-8",
         url: "https://proxy.example.com/v1",
         npm: "@ai-sdk/openai-compatible",
       },


### PR DESCRIPTION
## Summary

Removes an internal service name that inadvertently entered the open-source repo through a test fixture.

`packages/opencode/test/provider/transform.test.ts` used a real internal service name (`mimorouter/...`) as the slash-style model id in the "openai-compatible with claude in model id does NOT trigger caching" test. This swaps it for a neutral placeholder `gateway/claude-opus-4-8`.

## Details

- 2 occurrences replaced (`id` on both the model and its `api` block).
- Only the string fixture changed — the tested behavior (a slash-style model id containing "claude" must NOT trigger prompt caching) is unchanged.
- `bun typecheck` passes (EXIT 0); `transform.test.ts` green (188 pass / 0 fail).
- Repo-wide `git grep mimorouter` returns zero matches on this branch.