### PR TITLE
fix(inbox): actor-notification wording reflects task status, not just process completion

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1498,8 +1498,11 @@ function UserMessage(props: {
           // structured rows rather than raw <actor-notification> XML.
           const style = createMemo(() => {
             const s = note().status
-            if (s === "completed") return { icon: "✓", fg: theme.success, label: "completed" }
+            if (s === "success") return { icon: "✓", fg: theme.success, label: "completed" }
+            if (s === "partial") return { icon: "◐", fg: theme.warning, label: "partial" }
             if (s === "failed") return { icon: "✗", fg: theme.error, label: "failed" }
+            if (s === "blocked") return { icon: "⊘", fg: theme.error, label: "blocked" }
+            if (s === "finished") return { icon: "⊙", fg: theme.textMuted, label: "finished" }
             if (s === "stalled") return { icon: "⏳", fg: theme.warning, label: "stalled" }
             return { icon: "⊜", fg: theme.textMuted, label: "cancelled" }
           })

--- a/packages/opencode/src/inbox/render.ts
+++ b/packages/opencode/src/inbox/render.ts
@@ -29,9 +29,26 @@ export function renderActorNotification(event: {
 }): string {
   const header = `Background actor "${event.description}" (actor_id: ${event.actorID})`
   if (event.status === "completed") {
-    const statusLine = `Status: ${event.reportedStatus ?? "unknown"}`
+    // event.status is the actor *process lifecycle* — the child ended cleanly.
+    // event.reportedStatus is the *task* outcome the child self-reported via a
+    // `**Status**: ...` header. These are independent: a process can exit
+    // cleanly while the task failed/partial/blocked. Word the top line by the
+    // task outcome so we never imply a success the child didn't claim, and drop
+    // the misleading "Status: unknown" line when nothing was reported.
+    const reported = event.reportedStatus?.toLowerCase()
     const summaryLine = event.reportedSummary ? `\nSummary: ${event.reportedSummary}` : ""
-    return `<actor-notification>\n${header} completed.\n${statusLine}${summaryLine}\nResult: ${event.result ?? "(no output)"}\n</actor-notification>`
+    const resultLine = `\nResult: ${event.result ?? "(no output)"}`
+    // success → the only case that keeps the affirmative "completed" verb.
+    if (reported === "success") {
+      return `<actor-notification>\n${header} completed (success).${summaryLine}${resultLine}\n</actor-notification>`
+    }
+    // partial/failed/blocked → child ran to the end but the task did not fully
+    // succeed. State the outcome; don't say "completed".
+    if (reported === "partial" || reported === "failed" || reported === "blocked") {
+      return `<actor-notification>\n${header} finished with status: ${reported}.${summaryLine}${resultLine}\n</actor-notification>`
+    }
+    // No status reported → neutral "finished" (session ended). No status line.
+    return `<actor-notification>\n${header} finished.${summaryLine}${resultLine}\n</actor-notification>`
   }
   if (event.status === "failed") {
     return `<actor-notification>\n${header} failed.\nError: ${event.error ?? "unknown"}\n</actor-notification>`
@@ -40,10 +57,16 @@ export function renderActorNotification(event: {
 }
 
 export type ParsedActorNotification = {
+  // Reflects the *task* outcome the child reported, not just the process
+  // lifecycle. renderActorNotification's completed branch fans out into
+  // success / partial / failed / blocked / finished (no status reported) based
+  // on reportedStatus; the failed branch (process failure) also maps to
+  // "failed", cancelled → "cancelled".
+  //
   // "stalled" is reserved for a future watchdog-emitted notification;
-  // renderActorNotification never produces it today (only completed/failed/
-  // cancelled). The parse + card styling exist ahead of that producer.
-  status: "completed" | "failed" | "cancelled" | "stalled"
+  // renderActorNotification never produces it today. The parse + card styling
+  // exist ahead of that producer.
+  status: "success" | "partial" | "failed" | "blocked" | "finished" | "cancelled" | "stalled"
   description: string
   summary?: string
 }
@@ -54,12 +77,29 @@ export type ParsedActorNotification = {
 // Returns null for any text that isn't an actor notification.
 export function parseActorNotification(text: string): ParsedActorNotification | null {
   if (!text.trimStart().startsWith("<actor-notification>")) return null
-  const header = text.match(/Background actor "(.*?)" \(actor_id: [^)]*\)\s+(completed|failed|was cancelled|stalled)\b/)
+  // Match the top-line verb + optional reported task status. The completed
+  // process branch renders one of:
+  //   completed (success)            → task succeeded
+  //   finished with status: <s>      → partial / failed / blocked
+  //   finished                       → process ended, no task status reported
+  // and the other lifecycle branches render: failed / was cancelled / stalled.
+  const header = text.match(
+    /Background actor "(.*?)" \(actor_id: [^)]*\)\s+(completed \(success\)|finished with status: (?:partial|failed|blocked)|finished|failed|was cancelled|stalled)(?=[.\s]|$)/,
+  )
   if (!header) return null
   const description = header[1]
   const verb = header[2]
-  const status: ParsedActorNotification["status"] =
-    verb === "completed" ? "completed" : verb === "failed" ? "failed" : verb === "stalled" ? "stalled" : "cancelled"
+  const status: ParsedActorNotification["status"] = verb.startsWith("completed")
+    ? "success"
+    : verb.startsWith("finished with status:")
+      ? (verb.slice("finished with status: ".length) as "partial" | "failed" | "blocked")
+      : verb === "finished"
+        ? "finished"
+        : verb === "failed"
+          ? "failed"
+          : verb === "stalled"
+            ? "stalled"
+            : "cancelled"
   // Prefer the most human-relevant one-liner: Summary > Result > Error.
   // renderActorNotification always emits the Summary line before the Result
   // line, so restrict the Summary match to the region before the first

--- a/packages/opencode/test/inbox/parse-actor-notification.test.ts
+++ b/packages/opencode/test/inbox/parse-actor-notification.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { parseActorNotification, renderActorNotification } from "../../src/inbox/render"
 
 describe("parseActorNotification", () => {
-  test("parses a completed notification with reported status + summary", () => {
+  test("parses a success notification with reported status + summary", () => {
     const text = renderActorNotification({
       actorID: "explore-1",
       description: "Find error recovery",
@@ -12,13 +12,13 @@ describe("parseActorNotification", () => {
       result: "full body here",
     })
     expect(parseActorNotification(text)).toEqual({
-      status: "completed",
+      status: "success",
       description: "Find error recovery",
       summary: "Located 3 recovery sites",
     })
   })
 
-  test("completed without a summary falls back to the Result line", () => {
+  test("success without a summary falls back to the Result line", () => {
     const text = renderActorNotification({
       actorID: "explore-2",
       description: "Scan repo",
@@ -27,13 +27,13 @@ describe("parseActorNotification", () => {
       result: "42 files scanned",
     })
     expect(parseActorNotification(text)).toEqual({
-      status: "completed",
+      status: "success",
       description: "Scan repo",
       summary: "42 files scanned",
     })
   })
 
-  test("completed without a summary does not mistake an embedded Summary: line in the Result body", () => {
+  test("success without a summary does not mistake an embedded Summary: line in the Result body", () => {
     const text = renderActorNotification({
       actorID: "explore-3",
       description: "Draft report",
@@ -42,13 +42,82 @@ describe("parseActorNotification", () => {
       result: "Here is the outline:\nSummary: this is inside the result body\nmore text",
     })
     expect(parseActorNotification(text)).toEqual({
-      status: "completed",
+      status: "success",
       description: "Draft report",
       summary: "Here is the outline:",
     })
   })
 
-  test("parses a failed notification with the Error line as summary", () => {
+  test("a partial task outcome does not imply completion", () => {
+    const text = renderActorNotification({
+      actorID: "general-4",
+      description: "Migrate module",
+      status: "completed",
+      reportedStatus: "partial",
+      reportedSummary: "2 of 3 files migrated",
+      result: "details",
+    })
+    expect(text).toContain("finished with status: partial")
+    expect(text).not.toContain("completed")
+    expect(parseActorNotification(text)).toEqual({
+      status: "partial",
+      description: "Migrate module",
+      summary: "2 of 3 files migrated",
+    })
+  })
+
+  test("a self-reported failed task outcome does not say completed", () => {
+    const text = renderActorNotification({
+      actorID: "general-5",
+      description: "Fix flaky test",
+      status: "completed",
+      reportedStatus: "failed",
+      result: "could not reproduce",
+    })
+    expect(text).toContain("finished with status: failed")
+    expect(text).not.toContain("completed")
+    expect(parseActorNotification(text)).toEqual({
+      status: "failed",
+      description: "Fix flaky test",
+      summary: "could not reproduce",
+    })
+  })
+
+  test("a blocked task outcome maps to blocked", () => {
+    const text = renderActorNotification({
+      actorID: "general-6",
+      description: "Deploy service",
+      status: "completed",
+      reportedStatus: "blocked",
+      reportedSummary: "waiting on credentials",
+      result: "details",
+    })
+    expect(text).toContain("finished with status: blocked")
+    expect(parseActorNotification(text)).toEqual({
+      status: "blocked",
+      description: "Deploy service",
+      summary: "waiting on credentials",
+    })
+  })
+
+  test("no reported status → neutral 'finished', no misleading Status line", () => {
+    const text = renderActorNotification({
+      actorID: "explore-7",
+      description: "Investigate crash",
+      status: "completed",
+      result: "looked around the logger",
+    })
+    expect(text).toContain(") finished.")
+    expect(text).not.toContain("completed")
+    expect(text).not.toContain("Status: unknown")
+    expect(parseActorNotification(text)).toEqual({
+      status: "finished",
+      description: "Investigate crash",
+      summary: "looked around the logger",
+    })
+  })
+
+  test("parses a failed (process) notification with the Error line as summary", () => {
     const text = renderActorNotification({
       actorID: "general-9",
       description: "Type checker review",


### PR DESCRIPTION
## Summary

`renderActorNotification`'s `completed` branch always rendered `Background actor "..." completed. Status: <reportedStatus ∥ unknown>`, conflating two independent facts:

1. **Semantic mix-up** — `event.status === "completed"` describes the background actor's *process* ending cleanly, which is not the same as the child's *task* succeeding. A child can exit cleanly while its task was `failed`/`partial`/`blocked`, yet the user always saw "completed" and assumed success.
2. **"Status: unknown" noise** — `reportedStatus` is scraped from the child's `**Status**:` header; children that don't follow the format fell back to `unknown`, so the misleading `Status: unknown` line showed up constantly.

## Change

The top-line verb is now driven by `reportedStatus` (the real task outcome), not the process lifecycle:

| reportedStatus | wording |
|---|---|
| `success` | `... completed (success).` — the only affirmative case |
| `partial` / `failed` / `blocked` | `... finished with status: <s>.` — never implies success |
| none reported | `... finished.` — neutral, no `Status: unknown` line |

The process-level `failed`/`cancelled` branches are unchanged.

`parseActorNotification` is updated as the exact inverse. Its status enum went from `completed/failed/cancelled/stalled` to `success/partial/failed/blocked/finished/cancelled/stalled`, so render↔parse round-trips cleanly. The TUI card in `routes/session/index.tsx` maps the new statuses to icons/colors (success ✓, partial ◐, blocked ⊘, finished ⊙, etc.).

## Files
- `packages/opencode/src/inbox/render.ts` — render wording + parse inverse + status enum
- `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` — card status→style map
- `packages/opencode/test/inbox/parse-actor-notification.test.ts` — round-trip coverage for every branch

## Verification
- `bun typecheck` → EXIT 0
- `bun test test/inbox/` → 26 pass, 0 fail