### PR TITLE
fix: ensure .mimocode/.gitignore is created when cron-lock acquires the directory

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -29,6 +29,7 @@ import { ConfigAgent } from "./agent"
 import { ConfigCommand } from "./command"
 import { ConfigCompose } from "./compose"
 import { ConfigFormatter } from "./formatter"
+import { MIMOCODE_GITIGNORE_ENTRIES } from "./gitignore"
 import { ConfigHistory } from "./history"
 import { ConfigLayout } from "./layout"
 import { ConfigLSP } from "./lsp"
@@ -640,7 +641,7 @@ export const layer = Layer.effect(
         yield* fs
           .writeFileString(
             gitignore,
-            ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore", ".cron-lock", "scheduled_tasks.json"].join("\n"),
+            MIMOCODE_GITIGNORE_ENTRIES.join("\n"),
           )
           .pipe(
             Effect.catchIf(

--- a/packages/opencode/src/config/gitignore.ts
+++ b/packages/opencode/src/config/gitignore.ts
@@ -1,0 +1,22 @@
+import { stat, writeFile } from "fs/promises"
+import { join } from "path"
+
+export const MIMOCODE_GITIGNORE_ENTRIES = [
+  "node_modules",
+  "package.json",
+  "package-lock.json",
+  "bun.lock",
+  ".gitignore",
+  ".cron-lock",
+  "scheduled_tasks.json",
+]
+
+export async function ensureMimocodeGitignore(dir: string) {
+  const gitignorePath = join(dir, ".gitignore")
+  const exists = await stat(gitignorePath).then(
+    () => true,
+    () => false,
+  )
+  if (exists) return
+  await writeFile(gitignorePath, MIMOCODE_GITIGNORE_ENTRIES.join("\n")).catch(() => {})
+}

--- a/packages/opencode/src/config/index.ts
+++ b/packages/opencode/src/config/index.ts
@@ -1,5 +1,6 @@
 export * as Config from "./config"
 export * as ConfigAgent from "./agent"
+export * as ConfigGitignore from "./gitignore"
 export * as ConfigCommand from "./command"
 export * as ConfigCompose from "./compose"
 export * as ConfigError from "./error"

--- a/packages/opencode/src/cron/cron-lock.ts
+++ b/packages/opencode/src/cron/cron-lock.ts
@@ -3,6 +3,7 @@ import { join } from "path"
 import { mkdir, readFile, rename, unlink, writeFile, open } from "fs/promises"
 import { readFileSync } from "fs"
 import { Log } from "@/util"
+import { ensureMimocodeGitignore } from "@/config/gitignore"
 
 const log = Log.create({ service: "cron-lock" })
 
@@ -199,6 +200,11 @@ export const tryAcquireSchedulerLock = (opts?: { dir?: string; lockIdentity?: st
     const path = getLockFilePath(opts?.dir)
     yield* Effect.tryPromise({
       try: () => mkdir(join(path, ".."), { recursive: true }),
+      catch: () => undefined,
+    }).pipe(Effect.orElseSucceed(() => undefined))
+
+    yield* Effect.tryPromise({
+      try: () => ensureMimocodeGitignore(join(path, "..")),
       catch: () => undefined,
     }).pipe(Effect.orElseSucceed(() => undefined))
 

--- a/packages/opencode/test/cron/cron-lock.test.ts
+++ b/packages/opencode/test/cron/cron-lock.test.ts
@@ -33,6 +33,17 @@ test("acquire returns true on fresh dir and writes lock file", async () => {
   cleanup(dir)
 })
 
+test("creates .gitignore alongside lock file in fresh directory", async () => {
+  const dir = fresh()
+  expect(await run(tryAcquireSchedulerLock({ dir }))).toBe(true)
+  const gitignore = join(dir, ".mimocode", ".gitignore")
+  expect(existsSync(gitignore)).toBe(true)
+  const content = readFileSync(gitignore, "utf-8")
+  expect(content).toContain(".cron-lock")
+  expect(content).toContain("scheduled_tasks.json")
+  cleanup(dir)
+})
+
 test("acquire is idempotent for the same process", async () => {
   const dir = fresh()
   expect(await run(tryAcquireSchedulerLock({ dir }))).toBe(true)


### PR DESCRIPTION
## Summary

- Fixes a gap where `tryAcquireSchedulerLock` creates `.mimocode/` via `mkdir` but never ensures `.gitignore` exists inside it — on a fresh project's first session, `.cron-lock` and `scheduled_tasks.json` are exposed to git.
- Extracts `MIMOCODE_GITIGNORE_ENTRIES` constant and `ensureMimocodeGitignore()` helper into `config/gitignore.ts` so the entries list is defined once.
- Both `config.ts` and `cron-lock.ts` now reference the shared module.

## Context

- #1479 introduced the cron + loop scheduling system including `cron-lock.ts`
- #1629 added `.cron-lock` to the gitignore entries list in `config.ts`, but didn't address the ordering issue: `config.ts:ensureGitignore` only runs for `.mimocode` directories that **already exist** at config load time (found via `afs.up()`). If `.mimocode` is first created by the scheduler lock (fresh project), no `.gitignore` gets written until the next startup.

## Changes

| File | Change |
|------|--------|
| `src/config/gitignore.ts` | **New** — shared constant + async helper |
| `src/config/index.ts` | Self-export for the new module |
| `src/config/config.ts` | Uses shared constant instead of inline array |
| `src/cron/cron-lock.ts` | Calls `ensureMimocodeGitignore` after `mkdir` |
| `test/cron/cron-lock.test.ts` | New test verifying `.gitignore` creation |