### PR TITLE
fix(session): support colon in multi-skill mention regex for compose:* skills

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -681,7 +681,7 @@ ${entries}
             .replace(/`[^`\n]*`/g, " ")
           const mentioned: string[] = []
           const seen = new Set<string>()
-          const mentionRe = /(?:^|\s)\/([A-Za-z][A-Za-z0-9_-]*)(?=[^A-Za-z0-9_-]|$)/g
+          const mentionRe = /(?:^|\s)\/([A-Za-z][A-Za-z0-9_:-]*)(?=[^A-Za-z0-9_:-]|$)/g
           for (const m of stripped.matchAll(mentionRe)) {
             const name = m[1]
             if (!name || seen.has(name)) continue

--- a/packages/opencode/test/session/prompt-skill-mention.test.ts
+++ b/packages/opencode/test/session/prompt-skill-mention.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+
+// This regex is duplicated from src/session/prompt.ts:684 to pin its behavior.
+// If the source regex changes, this test must be updated to match.
+const mentionRe = /(?:^|\s)\/([A-Za-z][A-Za-z0-9_:-]*)(?=[^A-Za-z0-9_:-]|$)/g
+
+function extractMentions(text: string) {
+  return [...text.matchAll(mentionRe)].map((m) => m[1])
+}
+
+describe("skill mention regex", () => {
+  test("captures colon-namespaced skills", () => {
+    expect(extractMentions("please use /compose:worktree for this")).toEqual(["compose:worktree"])
+  })
+
+  test("captures multiple colon-namespaced skills", () => {
+    expect(extractMentions("use /compose:worktree and /compose:tdd together")).toEqual([
+      "compose:worktree",
+      "compose:tdd",
+    ])
+  })
+
+  test("captures plain skill names", () => {
+    expect(extractMentions("load /effect skill")).toEqual(["effect"])
+  })
+
+  test("captures hyphenated skill names", () => {
+    expect(extractMentions("use /deep-research for this")).toEqual(["deep-research"])
+  })
+
+  test("does not match URL paths", () => {
+    expect(extractMentions("visit https://example.com/api")).toEqual([])
+  })
+
+  test("does not match slash without preceding whitespace", () => {
+    expect(extractMentions("path/to/file")).toEqual([])
+  })
+
+  test("captures skill at start of string", () => {
+    expect(extractMentions("/compose:brainstorm then implement")).toEqual(["compose:brainstorm"])
+  })
+
+  test("does not capture names starting with a digit", () => {
+    expect(extractMentions("use /3dscan thing")).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `:` to the skill-mention regex in `session/prompt.ts` so that `compose:*` namespaced skills (e.g. `/compose:worktree`, `/compose:tdd`) are correctly detected when referenced mid-message
- Adds regression tests pinning the regex behavior for colon-namespaced, hyphenated, and plain skill names

## Context

- **#1654** introduced mid-message `/skill-name` auto-loading with `mentionRe` regex, but the character class `[A-Za-z0-9_-]` excluded `:`, silently breaking all `compose:*` skill references
- **#1697** fixed related TUI autocomplete bugs but did not touch the server-side regex

## Problem

When a user types `/compose:worktree` mid-message, the regex only captures `compose` (stopping at `:`). Since no skill named `compose` exists, the auto-load silently fails. The TUI autocomplete works fine (it uses whitespace-based boundary detection), creating a client/server inconsistency.

## Fix

```diff
- const mentionRe = /(?:^|\s)\/([A-Za-z][A-Za-z0-9_-]*)(?=[^A-Za-z0-9_-]|$)/g
+ const mentionRe = /(?:^|\s)\/([A-Za-z][A-Za-z0-9_:-]*)(?=[^A-Za-z0-9_:-]|$)/g
```

No risk of false positives — even if the regex overcaptures, `availableSkills.some(s => s.name === name)` at line 688 acts as the real gate.

## Test plan

- `bun test test/session/prompt-skill-mention.test.ts` — 8 tests pass covering colon-namespaced, hyphenated, plain names, URL non-matching, and edge cases
- `bun typecheck` — all 12 packages pass