### PR TITLE
fix(session): include hidden skills in free-text /mention detection

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -671,8 +671,9 @@ ${entries}
         (p) => p.type === "text" && p.text.startsWith('<skill_content name="'),
       )
       if (!alreadyWrapped) {
-        const availableSkills = yield* sys.available(input.agent)
-        if (availableSkills.length > 0) {
+        // Use all() to include hidden skills (primarily compose:*) — respect the user's explicit /mention action
+        const allSkills = yield* sys.all()
+        if (allSkills.length > 0) {
           const bodyText = userMessage.parts
             .flatMap((p) => (p.type === "text" ? [p.text] : []))
             .join("\n")
@@ -685,7 +686,7 @@ ${entries}
           for (const m of stripped.matchAll(mentionRe)) {
             const name = m[1]
             if (!name || seen.has(name)) continue
-            if (!availableSkills.some((s) => s.name === name)) continue
+            if (!allSkills.some((s) => s.name === name)) continue
             seen.add(name)
             mentioned.push(name)
           }
@@ -695,7 +696,7 @@ ${entries}
             const toLoad = mentioned.slice(0, MAX_AUTOLOAD)
             const overflow = mentioned.slice(MAX_AUTOLOAD)
             for (const name of toLoad) {
-              const info = availableSkills.find((s) => s.name === name)
+              const info = allSkills.find((s) => s.name === name)
               if (!info) continue
               const part = yield* sessions.updatePart({
                 id: PartID.ascending(),

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -43,6 +43,7 @@ export interface Interface {
   readonly environment: (model: Provider.Model, now: number) => Effect.Effect<string[]>
   readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
   readonly available: (agent?: Agent.Info) => Effect.Effect<Skill.Info[]>
+  readonly all: () => Effect.Effect<Skill.Info[]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SystemPrompt") {}
@@ -125,6 +126,10 @@ export const layer = Layer.effect(
 
       available: Effect.fn("SystemPrompt.available")(function* (agent?: Agent.Info) {
         return yield* skill.available(agent)
+      }),
+
+      all: Effect.fn("SystemPrompt.all")(function* () {
+        return yield* skill.all()
       }),
     })
   }),


### PR DESCRIPTION
## Summary

- PR #1715 fixed the regex to support `:` in skill names, but the mention auto-load still didn't work for `compose:*` skills because `sys.available()` filters out `hidden: true` skills
- Switch the mention detection from `sys.available(input.agent)` to `sys.all()` so all registered skills (including hidden compose skills) are matchable

## Context

The free-text `/skill-name` mention system has two gates:
1. **Regex match** — fixed by #1715 (added `:` to character class)
2. **Skill lookup** — checks if the matched name exists in the skill list

Gate 2 used `available()` which excludes hidden skills. Compose skills are all `hidden: true` (intentionally excluded from the system prompt skill listing for non-compose agents). This PR fixes gate 2 by using `all()` for the mention lookup, while leaving `available()` unchanged for the system prompt skill listing.

## Changes

- `src/session/system.ts`: Add `all()` to `SystemPrompt.Interface`, delegating to `Skill.all()`
- `src/session/prompt.ts`: Use `sys.all()` instead of `sys.available(input.agent)` for mention detection