### PR TITLE
fix(tui): use opentui _hasManualScroll to fix sticky scroll timing race

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1164,7 +1164,23 @@ export function Session() {
       (agentID, prevAgentID) => {
         if (!prevAgentID) return
         if (scroll && !scroll.isDestroyed) {
-          if (scroll.scrollTop >= scroll.scrollHeight - 1) scrollByAgent.delete(prevAgentID)
+          // Determine whether the user was in "follow bottom" (sticky scroll) mode.
+          //
+          // A pixel-based check (`scrollTop >= scrollHeight - 1`) is racy here: the
+          // SolidJS effect fires after reactive renders that may have already grown
+          // scrollHeight (e.g. new streaming content, navigation chrome), but the
+          // framework's sticky-scroll adjustment (recalculateBarProps → applyStickyStart)
+          // hasn't run yet, leaving scrollTop momentarily behind scrollHeight.
+          //
+          // Instead, read opentui's internal `_hasManualScroll` flag — the authoritative
+          // "has the user scrolled away from the sticky edge" state. It's set true only
+          // on user-initiated scroll away from the sticky position, and reset false when
+          // the user scrolls back. This is immune to content-growth timing.
+          //
+          // If the field is absent (opentui internals changed), fall back to "at bottom"
+          // (safe direction — next visit will toBottom rather than restore a stale offset).
+          const hasManualScroll = (scroll as unknown as { _hasManualScroll?: boolean })._hasManualScroll
+          if (!hasManualScroll) scrollByAgent.delete(prevAgentID)
           else scrollByAgent.set(prevAgentID, scroll.scrollTop)
         }
         const saved = scrollByAgent.get(agentID)


### PR DESCRIPTION
## Summary

Follow-up fix for #1685 — the scroll position save/restore logic introduced there has a timing race that causes the scroll to incorrectly land in the middle instead of the bottom when returning to a previously-at-bottom agent view.

## Problem

When switching agent views (e.g. leaving a subagent back to main), the pixel-based at-bottom check:

```ts
if (scroll.scrollTop >= scroll.scrollHeight - 1)
```

is racy because:
1. SolidJS's `createEffect(on(...))` fires **after** reactive renders that may have already grown `scrollHeight` (new streaming content, navigation chrome being added on leave)
2. opentui's sticky-scroll adjustment (`recalculateBarProps → applyStickyStart`) hasn't had a chance to sync `scrollTop` to the new max yet
3. Result: `scrollTop` momentarily lags `scrollHeight`, the check fails, and a stale mid-scroll offset gets saved

Next time you visit that view, it restores the stale offset instead of snapping to bottom.

## Fix

Replace the pixel check with opentui's internal `_hasManualScroll` flag — the authoritative source of truth for "has the user scrolled away from the sticky edge". This flag:
- Is set `true` only on user-initiated scroll away from the sticky position
- Is reset `false` when the user scrolls back to the edge
- Tracks **user intent**, not instantaneous pixel position → immune to content-growth timing

Accessed via narrow cast (`as unknown as { _hasManualScroll?: boolean }`) with safe fallback to "at bottom" if the field is ever removed.

## Related

- #1685 — introduced the save/restore scroll logic (this PR fixes a race in that logic)
- #1694 — prior follow-up that fixed first-navigation case