### PR TITLE
exp: sticky agent mode — mode locking + permission-based skill scoping

### DIFF
--- a/docs/compose/reports/sticky-agent-mode.md
+++ b/docs/compose/reports/sticky-agent-mode.md
@@ -4,7 +4,7 @@ status: experimental
 specs: []
 plans: []
 branch: exp/sticky-agent-mode
-commits: e418785e..fe72d4e2
+commits: e418785e..6760950e
 ---
 
 # Sticky Agent Mode — Final Report
@@ -13,7 +13,11 @@ commits: e418785e..fe72d4e2
 
 An experimental mode-locking system where agent selection is permanent for the duration of a session. Once a session has content (any user message), the user cannot switch to a different mode group. Build and Plan form a single free-switch group; all other agents (Compose, etc.) are isolated — once you're in Compose, you stay in Compose until `/new`.
 
-Alongside this, compose skills are migrated from `hidden: true` to permission-based scoping. The compose agent's permission allows `compose:*` skills; all other agents deny them. This eliminates the hardcoded `composeSkillsBlock()` injection — compose skills appear in the normal system prompt skill listing when the compose agent is active.
+Three supporting changes enable a clean per-mode experience:
+
+1. **Permission-based skill scoping** — compose skills use `deny`/`allow` permissions instead of `hidden: true`
+2. **Plan tools scoped to build/plan** — `plan_enter`/`plan_exit` denied by default, allowed only for build/plan (keeping compose's tool list clean)
+3. **Removed `composeSkillsBlock()` injection** — compose skills appear naturally in the system prompt via `available(agent)`
 
 ## Architecture
 
@@ -23,10 +27,11 @@ Alongside this, compose skills are migrated from `hidden: true` to permission-ba
 
 - `agentStore.sessionHasMessages` — reactive boolean derived from `!!lastUserMessage()`
 - `FREE_SWITCH_GROUP = ["build", "plan"]` — agents that can freely switch between each other
-- `canSwitchTo(target)` — returns true if: no messages yet, OR both current and target are in the same group
+- `canSwitchTo(target)` — returns true if: no messages yet, OR target is self, OR both current and target are in the same group
 - `set(name)` — unguarded, for system/programmatic use (session restore, plan tools, CLI)
-- `userSwitch(name)` — guarded, for user actions (dialog, voice). Shows toast when blocked
+- `userSwitch(name)` — guarded, for user actions (dialog, voice). Shows contextual toast when blocked
 - `move(direction)` — cycles through agents, skipping blocked ones. Toast only when no valid target exists
+- `switchBlockedToast()` — shows subset message (build/plan group) or locked message (compose isolated)
 
 **File:** `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
 
@@ -49,9 +54,16 @@ Single reactive effect — no manual lock/unlock. Naturally handles `/new` (empt
 
 - `Skill.available()` no longer filters `!sk.hidden` — relies entirely on permission
 
-**File:** `packages/opencode/src/skill/compose/.bundle/*/SKILL.md`
+### Plan Tools Scoping
 
-- All 14 compose skills: `hidden: true` removed from frontmatter
+**File:** `packages/opencode/src/agent/agent.ts`
+
+- `defaults` includes `plan_enter: "deny"`, `plan_exit: "deny"`
+- Build agent: `plan_enter: "allow"`, `plan_exit: "allow"`
+- Plan agent: `plan_enter: "allow"`, `plan_exit: "allow"`
+- Both agents see BOTH tools (symmetric, no list mutation on build↔plan switch)
+
+**No registry.ts changes needed** — `llm.ts:resolveTools()` already uses `Permission.disabled()` to strip denied tools before sending them to the model. The permission rules in agent.ts are sufficient.
 
 ### Compose Prompt Cleanup
 
@@ -63,7 +75,7 @@ Single reactive effect — no manual lock/unlock. Naturally handles `/new` (empt
 **File:** `packages/opencode/src/session/prompt/compose.txt`
 
 - "Compose Skills Visibility" section simplified: skills are in the normal listing
-- Subagent guidance: "distill instructions" instead of "pass skill lists"
+- Subagent guidance: "distill instructions into prompts"
 
 ### Design Decisions
 
@@ -73,9 +85,13 @@ Single reactive effect — no manual lock/unlock. Naturally handles `/new` (empt
 
 **`move()` skips blocked agents:** Tab cycles within the allowed group instead of stopping at the first blocked agent. Toast only shows when the entire group has been exhausted (e.g., compose mode with no other compose-group agents).
 
-**Permission in defaults (deny) + compose override (allow):** Future agents automatically inherit the `compose:*` deny. Only the compose agent explicitly opts in. This is more future-proof than denying on each non-compose agent individually.
+**Self-switch always allowed:** `canSwitchTo` returns true when `current === target`. Prevents false toast on no-op switches (e.g., compose user selecting compose in `/agents` dialog).
 
-**Subagent distillation model:** Compose skills instruct the orchestrator to distill guidance into concrete subagent prompts, rather than passing `<available_skills>` blocks. Subagents are leaf workers — they don't need orchestration skills.
+**Contextual toast messages:** Two variants — "只能在 build, plan 之间切换" when in the group but target is outside, "进入 compose 模式后无法切换" when isolated with no valid targets.
+
+**Plan tools: symmetric allow in build/plan, deny in defaults:** Future agents automatically inherit the deny. Build and plan both see both tools (no list mutation within the group). This is NOT a revert of #1207 — #1207 made plan tools visible to ALL agents; this scopes them to the build/plan group only, possible because sticky mode prevents cross-group switching.
+
+**Permission in defaults (deny) + specific agent override (allow):** Used for both skills (`compose:*`) and tools (`plan_enter`/`plan_exit`). Future agents automatically inherit all deny rules. Only the relevant agent explicitly opts in.
 
 ## Usage
 
@@ -83,17 +99,18 @@ This is an experimental branch (`exp/sticky-agent-mode`). Behavior:
 
 - **New session:** Mode selector works normally (Tab cycles all agents)
 - **After first message:** Mode is locked to the current group
-  - Build/Plan: can Tab between them freely
+  - Build/Plan: Tab cycles between them. Toast: "只能在 build, plan 之间切换" if trying `/agents` to compose
   - Compose: Tab shows toast — "进入 compose 模式后无法在运行中切换模式"
 - **`/new`:** Creates empty session → mode unlocked again
 - **`/session`:** Enters existing session → mode locked to that session's agent
+- **Self-switch:** Always allowed (no-op, no toast)
 
 ## Verification
 
 - `bun typecheck` — clean (0 errors)
 - `bun test test/session/prompt-skill-mention.test.ts` — 8/8 pass
 - `bun test test/permission` — 141/141 pass
-- Manual TUI testing: Tab cycling, `/session`, `/new`, toast messages
+- Manual TUI testing: Tab cycling, `/session`, `/new`, `/agents` dialog, toast messages
 
 ## Journey Log
 
@@ -101,6 +118,9 @@ This is an experimental branch (`exp/sticky-agent-mode`). Behavior:
 
 - [dead end] `lock()` boolean — persisted after `/new`, broke mode switching on new sessions
 - [dead end] Guard in `set()` with `{ force: true }` bypass — fragile, missed system call sites
+- [dead end] Hardcoded plan tool filter in registry.ts — unnecessary, `llm.ts:resolveTools` already uses `Permission.disabled()` generically
 - [pivot] Switched to reactive `!!lastUserMessage()` derivation — handles all session transitions naturally
 - [pivot] Separated `set()` (system) from `userSwitch()` (user) — eliminated the whitelist problem entirely
-- [lesson] `move()` must skip blocked agents, not stop at the first one — otherwise Tab breaks within the allowed group
+- [pivot] Plan tools: defaults deny + build/plan allow (symmetric) — differs from pre-#1207 (asymmetric) but stays stable within the group
+- [lesson] `move()` must skip blocked agents, not stop at the first one
+- [lesson] Self-switch (`current === target`) must always pass — otherwise no-op triggers false toast

--- a/docs/compose/reports/sticky-agent-mode.md
+++ b/docs/compose/reports/sticky-agent-mode.md
@@ -1,0 +1,106 @@
+---
+feature: sticky-agent-mode
+status: experimental
+specs: []
+plans: []
+branch: exp/sticky-agent-mode
+commits: e418785e..fe72d4e2
+---
+
+# Sticky Agent Mode — Final Report
+
+## What Was Built
+
+An experimental mode-locking system where agent selection is permanent for the duration of a session. Once a session has content (any user message), the user cannot switch to a different mode group. Build and Plan form a single free-switch group; all other agents (Compose, etc.) are isolated — once you're in Compose, you stay in Compose until `/new`.
+
+Alongside this, compose skills are migrated from `hidden: true` to permission-based scoping. The compose agent's permission allows `compose:*` skills; all other agents deny them. This eliminates the hardcoded `composeSkillsBlock()` injection — compose skills appear in the normal system prompt skill listing when the compose agent is active.
+
+## Architecture
+
+### Sticky Mode (TUI)
+
+**File:** `packages/opencode/src/cli/cmd/tui/context/local.tsx`
+
+- `agentStore.sessionHasMessages` — reactive boolean derived from `!!lastUserMessage()`
+- `FREE_SWITCH_GROUP = ["build", "plan"]` — agents that can freely switch between each other
+- `canSwitchTo(target)` — returns true if: no messages yet, OR both current and target are in the same group
+- `set(name)` — unguarded, for system/programmatic use (session restore, plan tools, CLI)
+- `userSwitch(name)` — guarded, for user actions (dialog, voice). Shows toast when blocked
+- `move(direction)` — cycles through agents, skipping blocked ones. Toast only when no valid target exists
+
+**File:** `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
+
+```ts
+createEffect(() => {
+  local.agent.setSessionHasMessages(!!lastUserMessage())
+})
+```
+
+Single reactive effect — no manual lock/unlock. Naturally handles `/new` (empty session = unlocked), `/session` (has messages = locked), and message submission.
+
+### Permission-Based Skill Scoping
+
+**File:** `packages/opencode/src/agent/agent.ts`
+
+- `defaults` includes `skill: { "*": "allow", "compose:*": "deny" }`
+- Compose agent overrides with `skill: { "compose:*": "allow" }`
+
+**File:** `packages/opencode/src/skill/index.ts`
+
+- `Skill.available()` no longer filters `!sk.hidden` — relies entirely on permission
+
+**File:** `packages/opencode/src/skill/compose/.bundle/*/SKILL.md`
+
+- All 14 compose skills: `hidden: true` removed from frontmatter
+
+### Compose Prompt Cleanup
+
+**File:** `packages/opencode/src/session/prompt.ts`
+
+- `composeSkillsBlock()` import and call removed
+- Only `{{compose_docs_dir}}` substitution remains in PROMPT_COMPOSE
+
+**File:** `packages/opencode/src/session/prompt/compose.txt`
+
+- "Compose Skills Visibility" section simplified: skills are in the normal listing
+- Subagent guidance: "distill instructions" instead of "pass skill lists"
+
+### Design Decisions
+
+**`set()` vs `userSwitch()` separation:** The guard only applies to user-initiated actions (Tab, dialog, voice). System paths (session restore, plan_enter/plan_exit, CLI --agent) use `set()` directly and are never blocked. This avoids a fragile whitelist of "force" call sites.
+
+**Reactive `sessionHasMessages` from `lastUserMessage()`:** No manual lock/unlock state. The signal is derived from actual session content, so `/new`, `/session`, and submits all work correctly without explicit handling.
+
+**`move()` skips blocked agents:** Tab cycles within the allowed group instead of stopping at the first blocked agent. Toast only shows when the entire group has been exhausted (e.g., compose mode with no other compose-group agents).
+
+**Permission in defaults (deny) + compose override (allow):** Future agents automatically inherit the `compose:*` deny. Only the compose agent explicitly opts in. This is more future-proof than denying on each non-compose agent individually.
+
+**Subagent distillation model:** Compose skills instruct the orchestrator to distill guidance into concrete subagent prompts, rather than passing `<available_skills>` blocks. Subagents are leaf workers — they don't need orchestration skills.
+
+## Usage
+
+This is an experimental branch (`exp/sticky-agent-mode`). Behavior:
+
+- **New session:** Mode selector works normally (Tab cycles all agents)
+- **After first message:** Mode is locked to the current group
+  - Build/Plan: can Tab between them freely
+  - Compose: Tab shows toast — "进入 compose 模式后无法在运行中切换模式"
+- **`/new`:** Creates empty session → mode unlocked again
+- **`/session`:** Enters existing session → mode locked to that session's agent
+
+## Verification
+
+- `bun typecheck` — clean (0 errors)
+- `bun test test/session/prompt-skill-mention.test.ts` — 8/8 pass
+- `bun test test/permission` — 141/141 pass
+- Manual TUI testing: Tab cycling, `/session`, `/new`, toast messages
+
+## Journey Log
+
+> Brief notes on what informed the final design.
+
+- [dead end] `lock()` boolean — persisted after `/new`, broke mode switching on new sessions
+- [dead end] Guard in `set()` with `{ force: true }` bypass — fragile, missed system call sites
+- [pivot] Switched to reactive `!!lastUserMessage()` derivation — handles all session transitions naturally
+- [pivot] Separated `set()` (system) from `userSwitch()` (user) — eliminated the whitelist problem entirely
+- [lesson] `move()` must skip blocked agents, not stop at the first one — otherwise Tab breaks within the allowed group

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -105,6 +105,10 @@ export const layer = Layer.effect(
         const defaults = Permission.fromConfig({
           "*": "allow",
           doom_loop: "ask",
+          skill: {
+            "*": "allow",
+            "compose:*": "deny",
+          },
           external_directory: {
             "*": "ask",
             ...Object.fromEntries(whitelistedDirs.map((dir) => [dir, "allow"])),
@@ -206,6 +210,7 @@ export const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 question: "allow",
+                skill: { "compose:*": "allow" },
               }),
               user,
             ),

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -109,6 +109,8 @@ export const layer = Layer.effect(
             "*": "allow",
             "compose:*": "deny",
           },
+          plan_enter: "deny",
+          plan_exit: "deny",
           external_directory: {
             "*": "ask",
             ...Object.fromEntries(whitelistedDirs.map((dir) => [dir, "allow"])),
@@ -135,6 +137,8 @@ export const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 question: "allow",
+                plan_enter: "allow",
+                plan_exit: "allow",
               }),
               user,
             ),
@@ -173,6 +177,8 @@ export const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 question: "allow",
+                plan_enter: "allow",
+                plan_exit: "allow",
                 external_directory: {
                   [path.join(Global.Path.data, "plans", "*")]: "allow",
                 },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -23,7 +23,7 @@ export function DialogAgent() {
       current={local.agent.current()?.name}
       options={options()}
       onSelect={(option) => {
-        local.agent.set(option.value)
+        local.agent.userSwitch(option.value)
         dialog.clear()
       }}
     />

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -191,7 +191,7 @@ export function Prompt(props: PromptProps) {
 
   function voiceSwitchAgent(name: string) {
     const match = local.agent.list().find((x) => x.name.toLowerCase() === name.toLowerCase())
-    if (match) local.agent.set(match.name)
+    if (match) local.agent.userSwitch(match.name)
     else toast.show({ message: t("tui.voice.error.unknown_agent", { name: name }), variant: "error", duration: 3000 })
   }
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -514,9 +514,16 @@ export function Prompt(props: PromptProps) {
     const msg = lastUserMessage()
 
     if (sessionID !== syncedSessionID) {
-      if (!sessionID || !msg) return
-
       syncedSessionID = sessionID
+
+      // New/empty session — allow free mode switching
+      if (!sessionID || !msg) {
+        local.agent.setSessionHasMessages(false)
+        return
+      }
+
+      // Session has messages — restrict mode switching
+      local.agent.setSessionHasMessages(true)
 
       // Only set agent if it's a primary agent (not a subagent)
       const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
@@ -528,8 +535,6 @@ export function Prompt(props: PromptProps) {
           local.model.variant.set(msg.model.variant)
         }
       }
-      // Session already has messages — lock agent mode
-      local.agent.lock()
     }
   })
 
@@ -1133,7 +1138,7 @@ export function Prompt(props: PromptProps) {
     // Capture mode before it gets reset
     const currentMode = store.mode
     const variant = local.model.variant.current()
-    local.agent.lock()
+    local.agent.setSessionHasMessages(true)
 
     const clientSlash = inputText.startsWith("/")
       ? command.slashes().find((s) => s.display === inputText.trim())

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -507,6 +507,11 @@ export function Prompt(props: PromptProps) {
     ),
   )
 
+  // Derive sticky mode from whether session has messages
+  createEffect(() => {
+    local.agent.setSessionHasMessages(!!lastUserMessage())
+  })
+
   // Initialize agent/model/variant from last user message when session changes
   let syncedSessionID: string | undefined
   createEffect(() => {
@@ -514,16 +519,8 @@ export function Prompt(props: PromptProps) {
     const msg = lastUserMessage()
 
     if (sessionID !== syncedSessionID) {
+      if (!sessionID || !msg) return
       syncedSessionID = sessionID
-
-      // New/empty session — allow free mode switching
-      if (!sessionID || !msg) {
-        local.agent.setSessionHasMessages(false)
-        return
-      }
-
-      // Session has messages — restrict mode switching
-      local.agent.setSessionHasMessages(true)
 
       // Only set agent if it's a primary agent (not a subagent)
       const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
@@ -1138,7 +1135,6 @@ export function Prompt(props: PromptProps) {
     // Capture mode before it gets reset
     const currentMode = store.mode
     const variant = local.model.variant.current()
-    local.agent.setSessionHasMessages(true)
 
     const clientSlash = inputText.startsWith("/")
       ? command.slashes().find((s) => s.display === inputText.trim())

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -528,6 +528,8 @@ export function Prompt(props: PromptProps) {
           local.model.variant.set(msg.model.variant)
         }
       }
+      // Session already has messages — lock agent mode
+      local.agent.lock()
     }
   })
 
@@ -1131,6 +1133,7 @@ export function Prompt(props: PromptProps) {
     // Capture mode before it gets reset
     const currentMode = store.mode
     const variant = local.model.variant.current()
+    local.agent.lock()
 
     const clientSlash = inputText.startsWith("/")
       ? command.slashes().find((s) => s.display === inputText.trim())

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -87,7 +87,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (!canSwitchTo(name)) {
             toast.show({
               variant: "warning",
-              message: t("tui.agent.locked"),
+              message: t("tui.agent.locked", { mode: agentStore.current ?? "" }),
               duration: 3000,
             })
             return
@@ -106,7 +106,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             if (!canSwitchTo(value.name)) {
               toast.show({
                 variant: "warning",
-                message: t("tui.agent.locked"),
+                message: t("tui.agent.locked", { mode: agentStore.current ?? "" }),
                 duration: 3000,
               })
               return

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -98,20 +98,23 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           batch(() => {
             const current = this.current()
             if (!current) return
-            let next = agents().findIndex((x) => x.name === current.name) + direction
-            if (next < 0) next = agents().length - 1
-            if (next >= agents().length) next = 0
-            const value = agents()[next]
-            if (!value) return
-            if (!canSwitchTo(value.name)) {
-              toast.show({
-                variant: "warning",
-                message: t("tui.agent.locked", { mode: agentStore.current ?? "" }),
-                duration: 3000,
-              })
-              return
+            const list = agents()
+            const currentIdx = list.findIndex((x) => x.name === current.name)
+            for (let i = 1; i < list.length; i++) {
+              let idx = currentIdx + direction * i
+              idx = ((idx % list.length) + list.length) % list.length
+              const candidate = list[idx]
+              if (!candidate) continue
+              if (canSwitchTo(candidate.name)) {
+                setAgentStore("current", candidate.name)
+                return
+              }
             }
-            setAgentStore("current", value.name)
+            toast.show({
+              variant: "warning",
+              message: t("tui.agent.locked", { mode: agentStore.current ?? "" }),
+              duration: 3000,
+            })
           })
         },
         setSessionHasMessages(value: boolean) {

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -49,7 +49,17 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const visibleAgents = createMemo(() => sync.data.agent.filter((x) => !x.hidden))
       const [agentStore, setAgentStore] = createStore({
         current: undefined as string | undefined,
+        locked: false,
       })
+      const FREE_SWITCH_GROUP = ["build", "plan"]
+      const canSwitchTo = (target: string) => {
+        if (!agentStore.locked) return true
+        const current = agentStore.current
+        if (!current) return true
+        const currentInGroup = FREE_SWITCH_GROUP.includes(current)
+        const targetInGroup = FREE_SWITCH_GROUP.includes(target)
+        return currentInGroup && targetInGroup
+      }
       const { theme } = useTheme()
       const colors = createMemo(() => [
         theme.secondary,
@@ -74,6 +84,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               message: `Agent not found: ${name}`,
               duration: 3000,
             })
+          if (!canSwitchTo(name)) {
+            toast.show({
+              variant: "warning",
+              message: t("tui.agent.locked"),
+              duration: 3000,
+            })
+            return
+          }
           setAgentStore("current", name)
         },
         move(direction: 1 | -1) {
@@ -84,8 +102,23 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             if (next < 0) next = agents().length - 1
             if (next >= agents().length) next = 0
             const value = agents()[next]
+            if (!value) return
+            if (!canSwitchTo(value.name)) {
+              toast.show({
+                variant: "warning",
+                message: t("tui.agent.locked"),
+                duration: 3000,
+              })
+              return
+            }
             setAgentStore("current", value.name)
           })
+        },
+        lock() {
+          setAgentStore("locked", true)
+        },
+        isLocked() {
+          return agentStore.locked
         },
         color(name: string) {
           const index = visibleAgents().findIndex((x) => x.name === name)

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -84,6 +84,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               message: `Agent not found: ${name}`,
               duration: 3000,
             })
+          setAgentStore("current", name)
+        },
+        userSwitch(name: string) {
           if (!canSwitchTo(name)) {
             toast.show({
               variant: "warning",
@@ -92,7 +95,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             })
             return
           }
-          setAgentStore("current", name)
+          this.set(name)
         },
         move(direction: 1 | -1) {
           batch(() => {

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -56,9 +56,26 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         if (!agentStore.sessionHasMessages) return true
         const current = agentStore.current
         if (!current) return true
+        if (current === target) return true
         const currentInGroup = FREE_SWITCH_GROUP.includes(current)
         const targetInGroup = FREE_SWITCH_GROUP.includes(target)
         return currentInGroup && targetInGroup
+      }
+      const switchBlockedToast = () => {
+        const current = agentStore.current ?? ""
+        if (FREE_SWITCH_GROUP.includes(current)) {
+          toast.show({
+            variant: "warning",
+            message: t("tui.agent.locked.subset", { agents: FREE_SWITCH_GROUP.join(", ") }),
+            duration: 3000,
+          })
+        } else {
+          toast.show({
+            variant: "warning",
+            message: t("tui.agent.locked", { mode: current }),
+            duration: 3000,
+          })
+        }
       }
       const { theme } = useTheme()
       const colors = createMemo(() => [
@@ -88,11 +105,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         },
         userSwitch(name: string) {
           if (!canSwitchTo(name)) {
-            toast.show({
-              variant: "warning",
-              message: t("tui.agent.locked", { mode: agentStore.current ?? "" }),
-              duration: 3000,
-            })
+            switchBlockedToast()
             return
           }
           this.set(name)
@@ -113,11 +126,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
                 return
               }
             }
-            toast.show({
-              variant: "warning",
-              message: t("tui.agent.locked", { mode: agentStore.current ?? "" }),
-              duration: 3000,
-            })
+            switchBlockedToast()
           })
         },
         setSessionHasMessages(value: boolean) {

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -49,11 +49,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const visibleAgents = createMemo(() => sync.data.agent.filter((x) => !x.hidden))
       const [agentStore, setAgentStore] = createStore({
         current: undefined as string | undefined,
-        locked: false,
+        sessionHasMessages: false,
       })
       const FREE_SWITCH_GROUP = ["build", "plan"]
       const canSwitchTo = (target: string) => {
-        if (!agentStore.locked) return true
+        if (!agentStore.sessionHasMessages) return true
         const current = agentStore.current
         if (!current) return true
         const currentInGroup = FREE_SWITCH_GROUP.includes(current)
@@ -114,11 +114,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             setAgentStore("current", value.name)
           })
         },
-        lock() {
-          setAgentStore("locked", true)
-        },
-        isLocked() {
-          return agentStore.locked
+        setSessionHasMessages(value: boolean) {
+          setAgentStore("sessionHasMessages", value)
         },
         color(name: string) {
           const index = visibleAgents().findIndex((x) => x.name === name)

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -276,6 +276,7 @@ export const dict: Record<string, string> = {
   "tui.command.variant.list.title": "Switch model variant",
   "tui.command.agent.cycle.reverse.title": "Agent cycle reverse",
   "tui.agent.locked": "Cannot switch mode mid-session after entering {{mode}} mode",
+  "tui.agent.locked.subset": "In this session, you can only switch between {{agents}}",
   "tui.command.provider.login.title": "Login",
   "tui.command.provider.connect.title": "Connect provider",
   "tui.command.provider.logout.title": "Logout",

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -275,7 +275,7 @@ export const dict: Record<string, string> = {
   "tui.command.variant.cycle.title": "Variant cycle",
   "tui.command.variant.list.title": "Switch model variant",
   "tui.command.agent.cycle.reverse.title": "Agent cycle reverse",
-  "tui.agent.locked": "Cannot switch agent — mode is locked for this session. Use /new to start a new session.",
+  "tui.agent.locked": "Cannot switch mode mid-session after entering {{mode}} mode",
   "tui.command.provider.login.title": "Login",
   "tui.command.provider.connect.title": "Connect provider",
   "tui.command.provider.logout.title": "Logout",

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -275,6 +275,7 @@ export const dict: Record<string, string> = {
   "tui.command.variant.cycle.title": "Variant cycle",
   "tui.command.variant.list.title": "Switch model variant",
   "tui.command.agent.cycle.reverse.title": "Agent cycle reverse",
+  "tui.agent.locked": "Cannot switch agent — mode is locked for this session. Use /new to start a new session.",
   "tui.command.provider.login.title": "Login",
   "tui.command.provider.connect.title": "Connect provider",
   "tui.command.provider.logout.title": "Logout",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -352,6 +352,7 @@ export const dict = {
   "tui.command.variant.list.title": "Cambiar variante de modelo",
   "tui.command.agent.cycle.reverse.title": "Ciclo de agentes (inverso)",
   "tui.agent.locked": "No se puede cambiar de modo después de entrar en modo {{mode}}",
+  "tui.agent.locked.subset": "En esta sesión, solo puede cambiar entre {{agents}}",
   "tui.command.provider.login.title": "Iniciar sesión",
   "tui.command.provider.connect.title": "Conectar proveedor",
   "tui.command.provider.logout.title": "Cerrar sesión",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -351,6 +351,7 @@ export const dict = {
   "tui.command.variant.cycle.title": "Ciclo de variantes",
   "tui.command.variant.list.title": "Cambiar variante de modelo",
   "tui.command.agent.cycle.reverse.title": "Ciclo de agentes (inverso)",
+  "tui.agent.locked": "No se puede cambiar de modo después de entrar en modo {{mode}}",
   "tui.command.provider.login.title": "Iniciar sesión",
   "tui.command.provider.connect.title": "Conectar proveedor",
   "tui.command.provider.logout.title": "Cerrar sesión",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -340,6 +340,7 @@ export const dict = {
   "tui.command.variant.list.title": "Changer de variante de modèle",
   "tui.command.agent.cycle.reverse.title": "Cycle d'agents (inverse)",
   "tui.agent.locked": "Impossible de changer de mode après être entré en mode {{mode}}",
+  "tui.agent.locked.subset": "Dans cette session, vous pouvez uniquement basculer entre {{agents}}",
   "tui.command.provider.login.title": "Connexion",
   "tui.command.provider.connect.title": "Connecter un fournisseur",
   "tui.command.provider.logout.title": "Déconnexion",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -339,6 +339,7 @@ export const dict = {
   "tui.command.variant.cycle.title": "Cycle de variantes",
   "tui.command.variant.list.title": "Changer de variante de modèle",
   "tui.command.agent.cycle.reverse.title": "Cycle d'agents (inverse)",
+  "tui.agent.locked": "Impossible de changer de mode après être entré en mode {{mode}}",
   "tui.command.provider.login.title": "Connexion",
   "tui.command.provider.connect.title": "Connecter un fournisseur",
   "tui.command.provider.logout.title": "Déconnexion",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -284,6 +284,7 @@ export const dict = {
   "tui.command.variant.cycle.title": "バリアントを循環",
   "tui.command.variant.list.title": "モデルバリアントを切り替え",
   "tui.command.agent.cycle.reverse.title": "エージェントを逆循環",
+  "tui.agent.locked": "{{mode}} モードに入った後はモードを切り替えできません",
   "tui.command.provider.login.title": "ログイン",
   "tui.command.provider.connect.title": "プロバイダに接続",
   "tui.command.provider.logout.title": "ログアウト",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -285,6 +285,7 @@ export const dict = {
   "tui.command.variant.list.title": "モデルバリアントを切り替え",
   "tui.command.agent.cycle.reverse.title": "エージェントを逆循環",
   "tui.agent.locked": "{{mode}} モードに入った後はモードを切り替えできません",
+  "tui.agent.locked.subset": "このセッションでは {{agents}} の間でのみ切り替え可能です",
   "tui.command.provider.login.title": "ログイン",
   "tui.command.provider.connect.title": "プロバイダに接続",
   "tui.command.provider.logout.title": "ログアウト",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -354,6 +354,7 @@ export const dict = {
   "tui.command.variant.cycle.title": "Цикл вариантов",
   "tui.command.variant.list.title": "Сменить вариант модели",
   "tui.command.agent.cycle.reverse.title": "Цикл агентов (в обратном порядке)",
+  "tui.agent.locked": "Невозможно сменить режим после входа в {{mode}}",
   "tui.command.provider.login.title": "Войти",
   "tui.command.provider.connect.title": "Подключить провайдера",
   "tui.command.provider.logout.title": "Выйти",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -355,6 +355,7 @@ export const dict = {
   "tui.command.variant.list.title": "Сменить вариант модели",
   "tui.command.agent.cycle.reverse.title": "Цикл агентов (в обратном порядке)",
   "tui.agent.locked": "Невозможно сменить режим после входа в {{mode}}",
+  "tui.agent.locked.subset": "В этой сессии можно переключаться только между {{agents}}",
   "tui.command.provider.login.title": "Войти",
   "tui.command.provider.connect.title": "Подключить провайдера",
   "tui.command.provider.logout.title": "Выйти",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -261,6 +261,7 @@ export const dict = {
   "tui.command.variant.list.title": "切换模型变体",
   "tui.command.agent.cycle.reverse.title": "反向循环切换智能体",
   "tui.agent.locked": "进入 {{mode}} 模式后无法在运行中切换模式",
+  "tui.agent.locked.subset": "已开始的会话中，只能在 {{agents}} 之间切换",
   "tui.command.provider.login.title": "登录",
   "tui.command.provider.connect.title": "连接服务商",
   "tui.command.provider.logout.title": "登出",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -260,6 +260,7 @@ export const dict = {
   "tui.command.variant.cycle.title": "循环切换模型变体",
   "tui.command.variant.list.title": "切换模型变体",
   "tui.command.agent.cycle.reverse.title": "反向循环切换智能体",
+  "tui.agent.locked": "进入 {{mode}} 模式后无法在运行中切换模式",
   "tui.command.provider.login.title": "登录",
   "tui.command.provider.connect.title": "连接服务商",
   "tui.command.provider.logout.title": "登出",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -261,6 +261,7 @@ export const dict = {
   "tui.command.variant.list.title": "切換模型變體",
   "tui.command.agent.cycle.reverse.title": "反向循環切換智慧代理",
   "tui.agent.locked": "進入 {{mode}} 模式後無法在運行中切換模式",
+  "tui.agent.locked.subset": "已開始的會話中，只能在 {{agents}} 之間切換",
   "tui.command.provider.login.title": "登入",
   "tui.command.provider.connect.title": "連線供應商",
   "tui.command.provider.logout.title": "登出",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -260,6 +260,7 @@ export const dict = {
   "tui.command.variant.cycle.title": "循環切換模型變體",
   "tui.command.variant.list.title": "切換模型變體",
   "tui.command.agent.cycle.reverse.title": "反向循環切換智慧代理",
+  "tui.agent.locked": "進入 {{mode}} 模式後無法在運行中切換模式",
   "tui.command.provider.login.title": "登入",
   "tui.command.provider.connect.title": "連線供應商",
   "tui.command.provider.logout.title": "登出",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -700,7 +700,7 @@ ${entries}
         (p) => p.type === "text" && p.text.startsWith('<skill_content name="'),
       )
       if (!alreadyWrapped) {
-        // Use all() to include hidden skills (primarily compose:*) — respect the user's explicit /mention action
+        // Use all() to bypass per-agent permission filtering — respect the user's explicit /mention action
         const allSkills = yield* sys.all()
         if (allSkills.length > 0) {
           const bodyText = userMessage.parts

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -61,7 +61,6 @@ import {
   EMPTY_STEP_RECOVERY_REPLAN,
   isEmptyStep,
 } from "../session/prompt/empty-step-detection"
-import { composeSkillsBlock } from "@/skill/compose/extract"
 import { builtinSkillRoot, matchDocumentSkills } from "@/skill/builtin/extract"
 import { ToolRegistry } from "../tool"
 import { MCP } from "../mcp"
@@ -651,12 +650,10 @@ export const layer = Layer.effect(
         (msg) => msg.info.role === "user" && msg.info.agent === "compose",
       )
       if (composeModeMsg) {
-        const composeModeBlock = composeSkillsBlock()
         const ctx = yield* InstanceState.context
         const composeCfg = (yield* config.get()).compose
         const docsDir = ConfigCompose.resolveDocsDir(ctx.worktree, composeCfg)
         const text = PROMPT_COMPOSE
-          .replace("{{compose_skills}}", composeModeBlock)
           .replace("{{compose_docs_dir}}", `Save compose skill outputs: specs in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`)
         composeModeMsg.parts.unshift({
           id: PartID.ascending(),

--- a/packages/opencode/src/session/prompt/compose.txt
+++ b/packages/opencode/src/session/prompt/compose.txt
@@ -113,13 +113,11 @@ Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
 
 ## Compose Skills Visibility
 
-The `<available_skills>` block below lists additional skills exclusive to compose mode. They are invoked via the skill tool identically to any other skill.
+Compose skills (compose:ask, compose:worktree, compose:tdd, etc.) are listed in the normal skills section above. They are invoked via the skill tool identically to any other skill.
 
-**Dispatching subagents with skills:**
+**Dispatching subagents:**
 
-Subagents do not automatically see compose skills. To have a subagent follow a compose skill, pass the relevant `<available_skills>` block (or subset) in the subagent's prompt.
-
-{{compose_skills}}
+Subagents are leaf workers that execute specific instructions. When dispatching a subagent, distill the relevant skill's guidance into concrete instructions in its prompt.
 
 ## Output Directories
 

--- a/packages/opencode/src/skill/compose/.bundle/ask/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/ask/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:ask
-hidden: true
 description: "Use whenever you need a decision, clarification, or approval from the user — covers how to ask with the question tool, and how to resolve the decision yourself when no user is available (question tool absent, or a [Never-Ask] response)"
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/brainstorm/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/brainstorm/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:brainstorm
-hidden: true
 description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/debug/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/debug/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:debug
-hidden: true
 description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/execute/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/execute/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:execute
-hidden: true
 description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/feedback/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/feedback/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:feedback
-hidden: true
 description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/merge/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/merge/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:merge
-hidden: true
 description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/parallel/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/parallel/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:parallel
-hidden: true
 description: Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/plan/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/plan/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:plan
-hidden: true
 description: Use when you have a spec or requirements for a multi-step task, before touching code
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:report
-hidden: true
 description: "Use after implementation is verified and before merge — consolidates multiple spec iterations into a single final-state report, marks related specs, and records key lessons"
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/review/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:review
-hidden: true
 description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:subagent
-hidden: true
 description: Use when executing implementation plans with independent tasks in the current session
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
@@ -314,11 +314,11 @@ Done!
 - **compose:merge** - Complete development after all tasks
 
 **Subagents should use:**
-- **compose:tdd** - Subagents follow TDD for each task
+- **compose:tdd** - Distill TDD workflow into subagent prompts (write test first, then implement)
 
-**Important: Passing skills to subagents**
+**Subagent guidance:**
 
-Compose skills do NOT appear in subagents' `available_skills` list by default. When a subagent needs to use a compose skill, pass the relevant `<available_skills>` block (or subset) directly in the subagent's prompt so it can invoke them by name via the skill tool.
+Subagents are leaf workers that execute specific instructions. When a subagent needs to follow a compose skill's workflow (e.g., TDD), distill the relevant guidance into concrete instructions in its prompt.
 
 **Alternative workflow:**
 - **compose:execute** - Use for parallel session instead of same-session execution

--- a/packages/opencode/src/skill/compose/.bundle/tdd/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/tdd/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:tdd
-hidden: true
 description: Use when implementing any feature or bugfix, before writing implementation code
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/verify/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/verify/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:verify
-hidden: true
 description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/worktree/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/worktree/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:worktree
-hidden: true
 description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - ensures an isolated workspace exists via native tools or git worktree fallback
 ---
 

--- a/packages/opencode/src/skill/compose/extract.ts
+++ b/packages/opencode/src/skill/compose/extract.ts
@@ -1,14 +1,11 @@
 import path from "path"
-import { pathToFileURL } from "url"
 import { Effect } from "effect"
-import matter from "gray-matter"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { Path as GlobalPath } from "@/global"
 import { InstallationLocal, InstallationVersion } from "@/installation/version"
 import { Log } from "@/util"
 import { loadComposeBundle } from "./bundle.macro" with { type: "macro" }
 import { loadComposeBundle as loadComposeBundleDev } from "./bundle.macro"
-import { fallbackSanitization } from "@/config/markdown"
 
 /// Bun macros only resolve in the static import graph of an entry point.
 /// In dynamic import() chains (e.g. plugin tests), the macro is unavailable —
@@ -48,38 +45,3 @@ export const extractComposeBundle = Effect.fn("Skill.extractComposeBundle")(func
   return root
 })
 
-function parseSkillMeta(content: string) {
-  try {
-    return matter(content)
-  } catch {
-    try {
-      return matter(fallbackSanitization(content))
-    } catch {
-      return undefined
-    }
-  }
-}
-
-export function composeSkillsBlock(): string {
-  const root = path.join(GlobalPath.data, "compose", InstallationVersion)
-  const entries: string[] = []
-
-  for (const [skillName, files] of Object.entries(COMPOSE_BUNDLE)) {
-    const skillMd = files["SKILL.md"]
-    if (!skillMd) continue
-    const parsed = parseSkillMeta(skillMd)
-    if (!parsed?.data?.name || !parsed?.data?.description) continue
-
-    const location = pathToFileURL(path.join(root, "skills", skillName, "SKILL.md")).href
-    entries.push(
-      `  <skill>`,
-      `    <name>${parsed.data.name}</name>`,
-      `    <description>${parsed.data.description}</description>`,
-      `    <location>${location}</location>`,
-      `  </skill>`,
-    )
-  }
-
-  if (entries.length === 0) return ""
-  return ["<available_skills>", ...entries, "</available_skills>"].join("\n")
-}

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -304,7 +304,6 @@ export const layer = Layer.effect(
     const available = Effect.fn("Skill.available")(function* (agent?: Agent.Info) {
       const s = yield* InstanceState.get(state)
       let list: Info[] = Object.values(s.skills)
-        .filter((sk) => !sk.hidden)
 
       list = list.toSorted((a, b) => a.name.localeCompare(b.name))
       if (!agent) return list

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -132,19 +132,33 @@ test("build agent unaffected — no hardPermission", async () => {
   })
 })
 
-test("plan_enter and plan_exit are allowed (not hidden) for all primary agents", async () => {
+test("plan_enter and plan_exit are allowed for build and plan agents", async () => {
   await using tmp = await tmpdir()
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
       const agents = await load(tmp.path, (svc) => svc.list())
-      const primaryAgents = agents.filter((a) => a.mode === "primary")
-      expect(primaryAgents.length).toBeGreaterThanOrEqual(3)
-      for (const agent of primaryAgents) {
-        const disabled = Permission.disabled(["plan_enter", "plan_exit"], agent.permission)
+      for (const name of ["build", "plan"]) {
+        const agent = agents.find((a) => a.name === name)
+        expect(agent).toBeDefined()
+        const disabled = Permission.disabled(["plan_enter", "plan_exit"], agent!.permission)
         expect(disabled.has("plan_enter")).toBe(false)
         expect(disabled.has("plan_exit")).toBe(false)
       }
+    },
+  })
+})
+
+test("plan_enter and plan_exit are denied for compose agent", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const compose = await load(tmp.path, (svc) => svc.get("compose"))
+      expect(compose).toBeDefined()
+      const disabled = Permission.disabled(["plan_enter", "plan_exit"], compose!.permission)
+      expect(disabled.has("plan_enter")).toBe(true)
+      expect(disabled.has("plan_exit")).toBe(true)
     },
   })
 })


### PR DESCRIPTION
## Overview

Experimental branch exploring "mode is immutable within a session" interaction model. **Will not be merged to main** — for trying out and discussion.

## Key Changes

### 1. Sticky Mode

After the first message in a session, the mode is locked:
- **Build / Plan** form a group — can freely switch between them (Tab cycles within group)
- **Compose** and other modes are isolated — cannot switch once entered
- `/new` creates a fresh session and restores free selection

Contextual toasts:
- Build/Plan user tries to switch to compose → "In this session, you can only switch between build, plan"
- Compose user presses Tab → "Cannot switch mode mid-session after entering compose mode"

### 2. Permission Replaces Hidden

- Removed `hidden: true` from all compose skills
- Configured via agent permission: defaults deny `compose:*`, compose agent explicitly allows
- `Skill.available()` no longer filters by hidden — relies entirely on permission system
- Compose skills naturally appear in compose agent's system prompt skill listing

### 3. Plan Tools Scoped to Build/Plan

- Defaults deny `plan_enter`/`plan_exit`, build and plan explicitly allow both (symmetric)
- No registry.ts changes needed — `llm.ts:resolveTools()` already uses `Permission.disabled()` to strip denied tools
- Compose and future agents get a clean tool list automatically
- Differs from pre-#1207 (asymmetric per-agent, caused cache issues) — here both build/plan see both tools

### 4. Removed composeSkillsBlock() Injection

- No more hardcoded `<available_skills>` XML block injection
- compose.txt cleaned: removed `{{compose_skills}}` placeholder
- Subagent guidance updated to "distill instructions" model

## Design Tradeoffs

| Decision | Rationale |
|----------|-----------|
| `set()` vs `userSwitch()` separation | Only guard user actions, don't block system behavior (session restore, plan tools) |
| Reactive `!!lastUserMessage()` | No manual lock/unlock — `/new` and `/session` work correctly by nature |
| `move()` skips blocked agents | Tab cycles within group, doesn't stop at first blocked entry |
| Self-switch always allowed | `current === target` → no-op, no false toast |
| Permission defaults deny + specific allow | Future agents auto-inherit deny, no per-agent config needed |
| Plan tools: symmetric in build/plan | No tool list mutation on build↔plan switch, stable prefix cache |

## ⚠️ Breaking Changes

1. **Custom modes affected**: User-defined agents not in `FREE_SWITCH_GROUP` are treated as isolated (sticky). Would need group configuration support.
2. **`hidden: true` no longer effective**: Skills relying on hidden must migrate to permission config
3. **Subagents can no longer receive `<available_skills>` blocks**: Must distill instructions directly into prompts
4. **Plan tools hidden from compose**: Compose agent no longer sees plan_enter/plan_exit (denied via permission)

## Try It

```bash
git checkout exp/sticky-agent-mode
bun install
bun dev
```

Test:
- Build mode → send message → Tab only switches to Plan
- Build mode → `/agents` → try compose → toast: "only switch between build, plan"
- Compose mode → send message → Tab shows toast
- `/new` → free switching restored
- `/session` into history → auto-locked

## Stability Note

Theoretically more stable due to constrained behavior — the model's system prompt (skills + tools) is fixed for the entire session (no prefix cache invalidation from mode switches). However, this is a breaking change that affects custom mode workflows and is not planned to be merged.

## Tests

- `bun test test/agent/agent.test.ts` — 48/48 pass (includes new plan tool permission tests)
- `bun test test/session/prompt-skill-mention.test.ts` — 8/8 pass
- `bun test test/permission` — 141/141 pass

## Related Files

- Report: `docs/compose/reports/sticky-agent-mode.md`
- TUI core: `packages/opencode/src/cli/cmd/tui/context/local.tsx`
- Permission: `packages/opencode/src/agent/agent.ts`
- Compose cleanup: `packages/opencode/src/session/prompt.ts`, `compose.txt`