### PR TITLE
fix(tui): remove duplicate image paste on Windows/WSL right-click

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1197,7 +1197,6 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           return
         }
 
-        promptRef.current?.paste()
         evt.preventDefault()
         evt.stopPropagation()
       }}


### PR DESCRIPTION
## Summary

- 删除 `app.tsx` 中 `onMouseDown` 的 `promptRef.current?.paste()` 调用
- 该调用与终端自身的 bracketed paste 机制重复触发，导致 Windows/WSL 下右键粘贴图片被插入两次

## Root Cause

MiMoCode fork 时在 `onMouseDown` 中新增了 `promptRef.current?.paste()`，上游 opencode 没有这个调用。在 Windows Terminal 中，右键会同时触发：
1. 终端的 bracketed paste → `onPaste` → `pasteFromClipboard()`
2. App 的 `onMouseDown` → `promptRef.current?.paste()` → `pasteFromClipboard()`

文本粘贴不受影响，因为 `onPaste` 直接拿到文本内容处理，不走 `pasteFromClipboard()`。

## Test

- [x] Windows Terminal + WSL 下右键粘贴图片，确认只插入一张
- [x] Ctrl+V 粘贴文本正常
- [x] Ctrl+V 粘贴图片正常

Fixes #1720