### PR TITLE
feat: sticky agent mode — mode locking + permission-based skill scoping

### DIFF
--- a/docs/compose/reports/sticky-agent-mode.md
+++ b/docs/compose/reports/sticky-agent-mode.md
@@ -1,0 +1,119 @@
+---
+feature: sticky-agent-mode
+status: proposed
+specs: []
+plans: []
+branch: feat/sticky-agent-mode
+---
+
+# Sticky Agent Mode — Final Report
+
+## What Was Built
+
+An experimental mode-locking system where agent selection is permanent for the duration of a session. Once a session has content (any user message), the user cannot switch to a different mode group. Build and Plan form a single free-switch group; all other agents (Compose, etc.) are isolated — once you're in Compose, you stay in Compose until `/new`.
+
+Three supporting changes enable a clean per-mode experience:
+
+1. **Permission-based skill scoping** — compose skills use `deny`/`allow` permissions instead of `hidden: true`
+2. **Plan tools scoped to build/plan** — `plan_enter`/`plan_exit` denied by default, allowed only for build/plan (keeping compose's tool list clean)
+3. **Removed `composeSkillsBlock()` injection** — compose skills appear naturally in the system prompt via `available(agent)`
+
+## Architecture
+
+### Sticky Mode (TUI)
+
+**File:** `packages/opencode/src/cli/cmd/tui/context/local.tsx`
+
+- `agentStore.sessionHasMessages` — reactive boolean derived from `!!lastUserMessage()`
+- `FREE_SWITCH_GROUP = ["build", "plan"]` — agents that can freely switch between each other
+- `canSwitchTo(target)` — returns true if: no messages yet, OR target is self, OR both current and target are in the same group
+- `set(name)` — unguarded, for system/programmatic use (session restore, plan tools, CLI)
+- `userSwitch(name)` — guarded, for user actions (dialog, voice). Shows contextual toast when blocked
+- `move(direction)` — cycles through agents, skipping blocked ones. Toast only when no valid target exists
+- `switchBlockedToast()` — shows subset message (build/plan group) or locked message (compose isolated)
+
+**File:** `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
+
+```ts
+createEffect(() => {
+  local.agent.setSessionHasMessages(!!lastUserMessage())
+})
+```
+
+Single reactive effect — no manual lock/unlock. Naturally handles `/new` (empty session = unlocked), `/session` (has messages = locked), and message submission.
+
+### Permission-Based Skill Scoping
+
+**File:** `packages/opencode/src/agent/agent.ts`
+
+- `defaults` includes `skill: { "*": "allow", "compose:*": "deny" }`
+- Compose agent overrides with `skill: { "compose:*": "allow" }`
+
+**File:** `packages/opencode/src/skill/index.ts`
+
+- `Skill.available()` no longer filters `!sk.hidden` — relies entirely on permission
+
+### Plan Tools Scoping
+
+**File:** `packages/opencode/src/agent/agent.ts`
+
+- `defaults` includes `plan_enter: "deny"`, `plan_exit: "deny"`
+- Build agent: `plan_enter: "allow"`, `plan_exit: "allow"`
+- Plan agent: `plan_enter: "allow"`, `plan_exit: "allow"`
+- Both agents see BOTH tools (symmetric, no list mutation on build↔plan switch)
+
+**No registry.ts changes needed** — `llm.ts:resolveTools()` already uses `Permission.disabled()` to strip denied tools before sending them to the model. The permission rules in agent.ts are sufficient.
+
+### Compose Prompt Cleanup
+
+**File:** `packages/opencode/src/session/prompt.ts`
+
+- `composeSkillsBlock()` import and call removed
+- Only `{{compose_docs_dir}}` substitution remains in PROMPT_COMPOSE
+
+**File:** `packages/opencode/src/session/prompt/compose.txt`
+
+- "Compose Skills Visibility" section simplified: skills are in the normal listing
+- Subagent guidance: "distill instructions into prompts"
+
+### Design Decisions
+
+**`set()` vs `userSwitch()` separation:** The guard only applies to user-initiated actions (Tab, dialog, voice). System paths (session restore, plan_enter/plan_exit, CLI --agent) use `set()` directly and are never blocked. This avoids a fragile whitelist of "force" call sites.
+
+**Reactive `sessionHasMessages` from `lastUserMessage()`:** No manual lock/unlock state. The signal is derived from actual session content, so `/new`, `/session`, and submits all work correctly without explicit handling.
+
+**`move()` skips blocked agents:** Tab cycles within the allowed group instead of stopping at the first blocked agent. Toast only shows when the entire group has been exhausted (e.g., compose mode with no other compose-group agents).
+
+**Self-switch always allowed:** `canSwitchTo` returns true when `current === target`. Prevents false toast on no-op switches (e.g., compose user selecting compose in `/agents` dialog).
+
+**Contextual toast messages:** Two variants — "只能在 build, plan 之间切换" when in the group but target is outside, "进入 compose 模式后无法切换" when isolated with no valid targets.
+
+**Plan tools: symmetric allow in build/plan, deny in defaults:** Future agents automatically inherit the deny. Build and plan both see both tools (no list mutation within the group). This is NOT a revert of #1207 — #1207 made plan tools visible to ALL agents; this scopes them to the build/plan group only, possible because sticky mode prevents cross-group switching.
+
+**Permission in defaults (deny) + specific agent override (allow):** Used for both skills (`compose:*`) and tools (`plan_enter`/`plan_exit`). Future agents automatically inherit all deny rules. Only the relevant agent explicitly opts in.
+
+## Usage
+
+- **New session:** Mode selector works normally (Tab cycles all agents)
+- **After first message:** Mode is locked to the current group
+  - Build/Plan: Tab cycles between them. Toast when trying to reach Compose
+  - Compose: Tab shows toast — cannot switch mid-session
+- **`/new`:** Creates empty session → mode unlocked again
+- **`/session`:** Enters existing session → mode locked to that session's agent
+- **Self-switch:** Always allowed (no-op, no toast)
+
+## Verification
+
+- `bun typecheck` — clean
+- `bun test test/session/prompt-skill-mention.test.ts` — 8/8 pass
+- `bun test test/permission` — 141/141 pass
+- `bun test test/agent/agent.test.ts` — 48/48 pass
+
+## Design Notes
+
+Key constraints that shaped the final approach:
+
+- Guard must separate system paths (`set()`) from user actions (`userSwitch()`) — putting the guard directly in `set()` requires a fragile whitelist for session restore, plan tools, and CLI
+- Sticky state must be **derived** (`!!lastUserMessage()`), not manually managed — a boolean `lock()` breaks on `/new` and `/session` transitions
+- `move()` must skip blocked agents rather than stopping — otherwise Tab appears broken when the next agent in order is blocked
+- Plan tools use the existing `Permission.disabled()` pipeline in `llm.ts:resolveTools()` — no registry changes needed

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -105,6 +105,12 @@ export const layer = Layer.effect(
         const defaults = Permission.fromConfig({
           "*": "allow",
           doom_loop: "ask",
+          skill: {
+            "*": "allow",
+            "compose:*": "deny",
+          },
+          plan_enter: "deny",
+          plan_exit: "deny",
           external_directory: {
             "*": "ask",
             ...Object.fromEntries(whitelistedDirs.map((dir) => [dir, "allow"])),
@@ -131,6 +137,8 @@ export const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 question: "allow",
+                plan_enter: "allow",
+                plan_exit: "allow",
               }),
               user,
             ),
@@ -169,6 +177,8 @@ export const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 question: "allow",
+                plan_enter: "allow",
+                plan_exit: "allow",
                 external_directory: {
                   [path.join(Global.Path.data, "plans", "*")]: "allow",
                 },
@@ -206,6 +216,7 @@ export const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 question: "allow",
+                skill: { "compose:*": "allow" },
               }),
               user,
             ),

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -23,7 +23,7 @@ export function DialogAgent() {
       current={local.agent.current()?.name}
       options={options()}
       onSelect={(option) => {
-        local.agent.set(option.value)
+        local.agent.userSwitch(option.value)
         dialog.clear()
       }}
     />

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -191,7 +191,7 @@ export function Prompt(props: PromptProps) {
 
   function voiceSwitchAgent(name: string) {
     const match = local.agent.list().find((x) => x.name.toLowerCase() === name.toLowerCase())
-    if (match) local.agent.set(match.name)
+    if (match) local.agent.userSwitch(match.name)
     else toast.show({ message: t("tui.voice.error.unknown_agent", { name: name }), variant: "error", duration: 3000 })
   }
 
@@ -507,6 +507,11 @@ export function Prompt(props: PromptProps) {
     ),
   )
 
+  // Derive sticky mode from whether session has messages
+  createEffect(() => {
+    local.agent.setSessionHasMessages(!!lastUserMessage())
+  })
+
   // Initialize agent/model/variant from last user message when session changes
   let syncedSessionID: string | undefined
   createEffect(() => {
@@ -515,7 +520,6 @@ export function Prompt(props: PromptProps) {
 
     if (sessionID !== syncedSessionID) {
       if (!sessionID || !msg) return
-
       syncedSessionID = sessionID
 
       // Only set agent if it's a primary agent (not a subagent)

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -111,23 +111,21 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           this.set(name)
         },
         move(direction: 1 | -1) {
-          batch(() => {
-            const current = this.current()
-            if (!current) return
-            const list = agents()
-            const currentIdx = list.findIndex((x) => x.name === current.name)
-            for (let i = 1; i < list.length; i++) {
-              let idx = currentIdx + direction * i
-              idx = ((idx % list.length) + list.length) % list.length
-              const candidate = list[idx]
-              if (!candidate) continue
-              if (canSwitchTo(candidate.name)) {
-                setAgentStore("current", candidate.name)
-                return
-              }
+          const current = this.current()
+          if (!current) return
+          const list = agents()
+          const currentIdx = list.findIndex((x) => x.name === current.name)
+          for (let i = 1; i < list.length; i++) {
+            let idx = currentIdx + direction * i
+            idx = ((idx % list.length) + list.length) % list.length
+            const candidate = list[idx]
+            if (!candidate) continue
+            if (canSwitchTo(candidate.name)) {
+              setAgentStore("current", candidate.name)
+              return
             }
-            switchBlockedToast()
-          })
+          }
+          switchBlockedToast()
         },
         setSessionHasMessages(value: boolean) {
           setAgentStore("sessionHasMessages", value)

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -49,7 +49,34 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const visibleAgents = createMemo(() => sync.data.agent.filter((x) => !x.hidden))
       const [agentStore, setAgentStore] = createStore({
         current: undefined as string | undefined,
+        sessionHasMessages: false,
       })
+      const FREE_SWITCH_GROUP = ["build", "plan"]
+      const canSwitchTo = (target: string) => {
+        if (!agentStore.sessionHasMessages) return true
+        const current = agentStore.current
+        if (!current) return true
+        if (current === target) return true
+        const currentInGroup = FREE_SWITCH_GROUP.includes(current)
+        const targetInGroup = FREE_SWITCH_GROUP.includes(target)
+        return currentInGroup && targetInGroup
+      }
+      const switchBlockedToast = () => {
+        const current = agentStore.current ?? ""
+        if (FREE_SWITCH_GROUP.includes(current)) {
+          toast.show({
+            variant: "warning",
+            message: t("tui.agent.locked.subset", { agents: FREE_SWITCH_GROUP.join(", ") }),
+            duration: 3000,
+          })
+        } else {
+          toast.show({
+            variant: "warning",
+            message: t("tui.agent.locked", { mode: current }),
+            duration: 3000,
+          })
+        }
+      }
       const { theme } = useTheme()
       const colors = createMemo(() => [
         theme.secondary,
@@ -76,16 +103,34 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             })
           setAgentStore("current", name)
         },
+        userSwitch(name: string) {
+          if (!canSwitchTo(name)) {
+            switchBlockedToast()
+            return
+          }
+          this.set(name)
+        },
         move(direction: 1 | -1) {
           batch(() => {
             const current = this.current()
             if (!current) return
-            let next = agents().findIndex((x) => x.name === current.name) + direction
-            if (next < 0) next = agents().length - 1
-            if (next >= agents().length) next = 0
-            const value = agents()[next]
-            setAgentStore("current", value.name)
+            const list = agents()
+            const currentIdx = list.findIndex((x) => x.name === current.name)
+            for (let i = 1; i < list.length; i++) {
+              let idx = currentIdx + direction * i
+              idx = ((idx % list.length) + list.length) % list.length
+              const candidate = list[idx]
+              if (!candidate) continue
+              if (canSwitchTo(candidate.name)) {
+                setAgentStore("current", candidate.name)
+                return
+              }
+            }
+            switchBlockedToast()
           })
+        },
+        setSessionHasMessages(value: boolean) {
+          setAgentStore("sessionHasMessages", value)
         },
         color(name: string) {
           const index = visibleAgents().findIndex((x) => x.name === name)

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -275,6 +275,8 @@ export const dict: Record<string, string> = {
   "tui.command.variant.cycle.title": "Variant cycle",
   "tui.command.variant.list.title": "Switch model variant",
   "tui.command.agent.cycle.reverse.title": "Agent cycle reverse",
+  "tui.agent.locked": "Cannot switch mode mid-session after entering {{mode}} mode",
+  "tui.agent.locked.subset": "In this session, you can only switch between {{agents}}",
   "tui.command.provider.login.title": "Login",
   "tui.command.provider.connect.title": "Connect provider",
   "tui.command.provider.logout.title": "Logout",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -351,6 +351,8 @@ export const dict = {
   "tui.command.variant.cycle.title": "Ciclo de variantes",
   "tui.command.variant.list.title": "Cambiar variante de modelo",
   "tui.command.agent.cycle.reverse.title": "Ciclo de agentes (inverso)",
+  "tui.agent.locked": "No se puede cambiar de modo después de entrar en modo {{mode}}",
+  "tui.agent.locked.subset": "En esta sesión, solo puede cambiar entre {{agents}}",
   "tui.command.provider.login.title": "Iniciar sesión",
   "tui.command.provider.connect.title": "Conectar proveedor",
   "tui.command.provider.logout.title": "Cerrar sesión",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -339,6 +339,8 @@ export const dict = {
   "tui.command.variant.cycle.title": "Cycle de variantes",
   "tui.command.variant.list.title": "Changer de variante de modèle",
   "tui.command.agent.cycle.reverse.title": "Cycle d'agents (inverse)",
+  "tui.agent.locked": "Impossible de changer de mode après être entré en mode {{mode}}",
+  "tui.agent.locked.subset": "Dans cette session, vous pouvez uniquement basculer entre {{agents}}",
   "tui.command.provider.login.title": "Connexion",
   "tui.command.provider.connect.title": "Connecter un fournisseur",
   "tui.command.provider.logout.title": "Déconnexion",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -284,6 +284,8 @@ export const dict = {
   "tui.command.variant.cycle.title": "バリアントを循環",
   "tui.command.variant.list.title": "モデルバリアントを切り替え",
   "tui.command.agent.cycle.reverse.title": "エージェントを逆循環",
+  "tui.agent.locked": "{{mode}} モードに入った後はモードを切り替えできません",
+  "tui.agent.locked.subset": "このセッションでは {{agents}} の間でのみ切り替え可能です",
   "tui.command.provider.login.title": "ログイン",
   "tui.command.provider.connect.title": "プロバイダに接続",
   "tui.command.provider.logout.title": "ログアウト",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -354,6 +354,8 @@ export const dict = {
   "tui.command.variant.cycle.title": "Цикл вариантов",
   "tui.command.variant.list.title": "Сменить вариант модели",
   "tui.command.agent.cycle.reverse.title": "Цикл агентов (в обратном порядке)",
+  "tui.agent.locked": "Невозможно сменить режим после входа в {{mode}}",
+  "tui.agent.locked.subset": "В этой сессии можно переключаться только между {{agents}}",
   "tui.command.provider.login.title": "Войти",
   "tui.command.provider.connect.title": "Подключить провайдера",
   "tui.command.provider.logout.title": "Выйти",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -260,6 +260,8 @@ export const dict = {
   "tui.command.variant.cycle.title": "循环切换模型变体",
   "tui.command.variant.list.title": "切换模型变体",
   "tui.command.agent.cycle.reverse.title": "反向循环切换智能体",
+  "tui.agent.locked": "进入 {{mode}} 模式后无法在运行中切换模式",
+  "tui.agent.locked.subset": "已开始的会话中，只能在 {{agents}} 之间切换",
   "tui.command.provider.login.title": "登录",
   "tui.command.provider.connect.title": "连接服务商",
   "tui.command.provider.logout.title": "登出",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -260,6 +260,8 @@ export const dict = {
   "tui.command.variant.cycle.title": "循環切換模型變體",
   "tui.command.variant.list.title": "切換模型變體",
   "tui.command.agent.cycle.reverse.title": "反向循環切換智慧代理",
+  "tui.agent.locked": "進入 {{mode}} 模式後無法在運行中切換模式",
+  "tui.agent.locked.subset": "已開始的會話中，只能在 {{agents}} 之間切換",
   "tui.command.provider.login.title": "登入",
   "tui.command.provider.connect.title": "連線供應商",
   "tui.command.provider.logout.title": "登出",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -61,7 +61,6 @@ import {
   EMPTY_STEP_RECOVERY_REPLAN,
   isEmptyStep,
 } from "../session/prompt/empty-step-detection"
-import { composeSkillsBlock } from "@/skill/compose/extract"
 import { builtinSkillRoot, matchDocumentSkills } from "@/skill/builtin/extract"
 import { ToolRegistry } from "../tool"
 import { MCP } from "../mcp"
@@ -651,12 +650,10 @@ export const layer = Layer.effect(
         (msg) => msg.info.role === "user" && msg.info.agent === "compose",
       )
       if (composeModeMsg) {
-        const composeModeBlock = composeSkillsBlock()
         const ctx = yield* InstanceState.context
         const composeCfg = (yield* config.get()).compose
         const docsDir = ConfigCompose.resolveDocsDir(ctx.worktree, composeCfg)
         const text = PROMPT_COMPOSE
-          .replace("{{compose_skills}}", composeModeBlock)
           .replace("{{compose_docs_dir}}", `Save compose skill outputs: specs in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`)
         composeModeMsg.parts.unshift({
           id: PartID.ascending(),
@@ -703,7 +700,7 @@ ${entries}
         (p) => p.type === "text" && p.text.startsWith('<skill_content name="'),
       )
       if (!alreadyWrapped) {
-        // Use all() to include hidden skills (primarily compose:*) — respect the user's explicit /mention action
+        // Use all() to bypass per-agent permission filtering — respect the user's explicit /mention action
         const allSkills = yield* sys.all()
         if (allSkills.length > 0) {
           const bodyText = userMessage.parts

--- a/packages/opencode/src/session/prompt/compose.txt
+++ b/packages/opencode/src/session/prompt/compose.txt
@@ -113,13 +113,11 @@ Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
 
 ## Compose Skills Visibility
 
-The `<available_skills>` block below lists additional skills exclusive to compose mode. They are invoked via the skill tool identically to any other skill.
+Compose skills (compose:ask, compose:worktree, compose:tdd, etc.) are listed in the normal skills section above. They are invoked via the skill tool identically to any other skill.
 
-**Dispatching subagents with skills:**
+**Dispatching subagents:**
 
-Subagents do not automatically see compose skills. To have a subagent follow a compose skill, pass the relevant `<available_skills>` block (or subset) in the subagent's prompt.
-
-{{compose_skills}}
+Subagents are leaf workers that execute specific instructions. When dispatching a subagent, distill the relevant skill's guidance into concrete instructions in its prompt.
 
 ## Output Directories
 

--- a/packages/opencode/src/skill/compose/.bundle/ask/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/ask/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:ask
-hidden: true
 description: "Use whenever you need a decision, clarification, or approval from the user — covers how to ask with the question tool, and how to resolve the decision yourself when no user is available (question tool absent, or a [Never-Ask] response)"
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/brainstorm/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/brainstorm/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:brainstorm
-hidden: true
 description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/debug/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/debug/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:debug
-hidden: true
 description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/execute/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/execute/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:execute
-hidden: true
 description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/feedback/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/feedback/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:feedback
-hidden: true
 description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/merge/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/merge/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:merge
-hidden: true
 description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/parallel/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/parallel/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:parallel
-hidden: true
 description: Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/plan/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/plan/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:plan
-hidden: true
 description: Use when you have a spec or requirements for a multi-step task, before touching code
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/report/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:report
-hidden: true
 description: "Use after implementation is verified and before merge — consolidates multiple spec iterations into a single final-state report, marks related specs, and records key lessons"
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/review/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:review
-hidden: true
 description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/subagent/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:subagent
-hidden: true
 description: Use when executing implementation plans with independent tasks in the current session
 ---
 
@@ -315,11 +314,11 @@ Done!
 - **compose:merge** - Complete development after all tasks
 
 **Subagents should use:**
-- **compose:tdd** - Subagents follow TDD for each task
+- **compose:tdd** - Distill TDD workflow into subagent prompts (write test first, then implement)
 
-**Important: Passing skills to subagents**
+**Subagent guidance:**
 
-Compose skills do NOT appear in subagents' `available_skills` list by default. When a subagent needs to use a compose skill, pass the relevant `<available_skills>` block (or subset) directly in the subagent's prompt so it can invoke them by name via the skill tool.
+Subagents are leaf workers that execute specific instructions. When a subagent needs to follow a compose skill's workflow (e.g., TDD), distill the relevant guidance into concrete instructions in its prompt.
 
 **Alternative workflow:**
 - **compose:execute** - Use for parallel session instead of same-session execution

--- a/packages/opencode/src/skill/compose/.bundle/tdd/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/tdd/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:tdd
-hidden: true
 description: Use when implementing any feature or bugfix, before writing implementation code
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/verify/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/verify/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:verify
-hidden: true
 description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
 ---
 

--- a/packages/opencode/src/skill/compose/.bundle/worktree/SKILL.md
+++ b/packages/opencode/src/skill/compose/.bundle/worktree/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose:worktree
-hidden: true
 description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - ensures an isolated workspace exists via native tools or git worktree fallback
 ---
 

--- a/packages/opencode/src/skill/compose/extract.ts
+++ b/packages/opencode/src/skill/compose/extract.ts
@@ -1,14 +1,11 @@
 import path from "path"
-import { pathToFileURL } from "url"
 import { Effect } from "effect"
-import matter from "gray-matter"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { Path as GlobalPath } from "@/global"
 import { InstallationLocal, InstallationVersion } from "@/installation/version"
 import { Log } from "@/util"
 import { loadComposeBundle } from "./bundle.macro" with { type: "macro" }
 import { loadComposeBundle as loadComposeBundleDev } from "./bundle.macro"
-import { fallbackSanitization } from "@/config/markdown"
 
 /// Bun macros only resolve in the static import graph of an entry point.
 /// In dynamic import() chains (e.g. plugin tests), the macro is unavailable —
@@ -48,38 +45,3 @@ export const extractComposeBundle = Effect.fn("Skill.extractComposeBundle")(func
   return root
 })
 
-function parseSkillMeta(content: string) {
-  try {
-    return matter(content)
-  } catch {
-    try {
-      return matter(fallbackSanitization(content))
-    } catch {
-      return undefined
-    }
-  }
-}
-
-export function composeSkillsBlock(): string {
-  const root = path.join(GlobalPath.data, "compose", InstallationVersion)
-  const entries: string[] = []
-
-  for (const [skillName, files] of Object.entries(COMPOSE_BUNDLE)) {
-    const skillMd = files["SKILL.md"]
-    if (!skillMd) continue
-    const parsed = parseSkillMeta(skillMd)
-    if (!parsed?.data?.name || !parsed?.data?.description) continue
-
-    const location = pathToFileURL(path.join(root, "skills", skillName, "SKILL.md")).href
-    entries.push(
-      `  <skill>`,
-      `    <name>${parsed.data.name}</name>`,
-      `    <description>${parsed.data.description}</description>`,
-      `    <location>${location}</location>`,
-      `  </skill>`,
-    )
-  }
-
-  if (entries.length === 0) return ""
-  return ["<available_skills>", ...entries, "</available_skills>"].join("\n")
-}

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -304,7 +304,6 @@ export const layer = Layer.effect(
     const available = Effect.fn("Skill.available")(function* (agent?: Agent.Info) {
       const s = yield* InstanceState.get(state)
       let list: Info[] = Object.values(s.skills)
-        .filter((sk) => !sk.hidden)
 
       list = list.toSorted((a, b) => a.name.localeCompare(b.name))
       if (!agent) return list

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -132,6 +132,31 @@ test("build agent unaffected — no hardPermission", async () => {
   })
 })
 
+test("compose:* skills are denied for build/plan, allowed for compose", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agents = await load(tmp.path, (svc) => svc.list())
+      for (const name of ["build", "plan"]) {
+        const agent = agents.find((a) => a.name === name)
+        expect(agent).toBeDefined()
+        expect(Permission.evaluate("skill", "compose:brainstorm", agent!.permission).action).toBe("deny")
+        expect(Permission.evaluate("skill", "compose:tdd", agent!.permission).action).toBe("deny")
+        expect(Permission.evaluate("skill", "compose:review", agent!.permission).action).toBe("deny")
+      }
+      const compose = agents.find((a) => a.name === "compose")
+      expect(compose).toBeDefined()
+      expect(Permission.evaluate("skill", "compose:brainstorm", compose!.permission).action).toBe("allow")
+      expect(Permission.evaluate("skill", "compose:tdd", compose!.permission).action).toBe("allow")
+      expect(Permission.evaluate("skill", "compose:review", compose!.permission).action).toBe("allow")
+      // Non-compose skills remain allowed for all agents
+      expect(Permission.evaluate("skill", "effect", agents.find((a) => a.name === "build")!.permission).action).toBe("allow")
+      expect(Permission.evaluate("skill", "effect", compose!.permission).action).toBe("allow")
+    },
+  })
+})
+
 test("plan_enter and plan_exit are allowed for build and plan agents", async () => {
   await using tmp = await tmpdir()
   await Instance.provide({

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -132,19 +132,33 @@ test("build agent unaffected — no hardPermission", async () => {
   })
 })
 
-test("plan_enter and plan_exit are allowed (not hidden) for all primary agents", async () => {
+test("plan_enter and plan_exit are allowed for build and plan agents", async () => {
   await using tmp = await tmpdir()
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
       const agents = await load(tmp.path, (svc) => svc.list())
-      const primaryAgents = agents.filter((a) => a.mode === "primary")
-      expect(primaryAgents.length).toBeGreaterThanOrEqual(3)
-      for (const agent of primaryAgents) {
-        const disabled = Permission.disabled(["plan_enter", "plan_exit"], agent.permission)
+      for (const name of ["build", "plan"]) {
+        const agent = agents.find((a) => a.name === name)
+        expect(agent).toBeDefined()
+        const disabled = Permission.disabled(["plan_enter", "plan_exit"], agent!.permission)
         expect(disabled.has("plan_enter")).toBe(false)
         expect(disabled.has("plan_exit")).toBe(false)
       }
+    },
+  })
+})
+
+test("plan_enter and plan_exit are denied for compose agent", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const compose = await load(tmp.path, (svc) => svc.get("compose"))
+      expect(compose).toBeDefined()
+      const disabled = Permission.disabled(["plan_enter", "plan_exit"], compose!.permission)
+      expect(disabled.has("plan_enter")).toBe(true)
+      expect(disabled.has("plan_exit")).toBe(true)
     },
   })
 })


### PR DESCRIPTION
## Summary

Lock agent mode after the first message in a session, ensuring a stable system prompt (skills + tools) throughout the conversation. Supporting change: replace `hidden: true` with a permission-based scoping system for compose skills and plan tools.

## Motivation

Mode-switching mid-session causes prefix cache invalidation (the system prompt changes when skills/tools change). This is both a performance cost and a source of confusion — the model's context shifts underneath the user. By locking mode after the first message:

1. **Stable prefix cache** — system prompt is fixed for the entire session
2. **Clear UX contract** — the user commits to a mode at session start
3. **Clean permission model** — future agents auto-inherit deny rules, no per-agent configuration needed

## Changes

### 1. Sticky Mode (TUI)

- `FREE_SWITCH_GROUP = ["build", "plan"]` — can freely switch between these
- All other modes (Compose, etc.) are isolated once entered
- `set()` (system) vs `userSwitch()` (user) separation — only user actions are guarded
- Reactive derivation from `lastUserMessage()` — `/new` and `/session` work correctly without manual lock/unlock
- Contextual toast messages when blocked

### 2. Permission-Based Skill and Tool Scoping

- Compose skills: `defaults deny compose:*`, compose agent explicitly allows
- Plan tools: `defaults deny plan_enter/plan_exit`, build+plan allow (symmetric)
- `Skill.available()` relies on permissions, not `hidden` flag
- Remove `composeSkillsBlock()` injection — skills appear naturally in the system prompt

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| `set()` vs `userSwitch()` | Only guard user actions; system paths (session restore, CLI) are never blocked |
| Reactive `!!lastUserMessage()` | No manual lock state; handles all session transitions naturally |
| `move()` skips blocked agents | Tab cycles within group, doesn't stop at first blocked entry |
| Symmetric plan tools in build/plan | No tool list mutation on build↔plan switch |
| Permission defaults deny + allow | Future agents auto-inherit deny, no per-agent config needed |

## Breaking Changes (need discussion)

1. **Custom modes**: User-defined agents not in `FREE_SWITCH_GROUP` are treated as isolated. Would need group configuration support.
2. **`hidden: true` deprecated**: Skills relying on hidden must migrate to permission config.
3. **Plan tools hidden from compose**: Compose agent no longer sees `plan_enter`/`plan_exit`.

## Tests

- `bun typecheck` — clean
- `bun test test/agent/agent.test.ts` — 48/48 pass
- `bun test test/session/prompt-skill-mention.test.ts` — 8/8 pass
- `bun test test/permission` — 141/141 pass

## Open Questions

- Should `FREE_SWITCH_GROUP` be configurable (e.g., user-defined agents can declare their group)?
- Should there be a `/unlock` escape hatch for power users?
- Is one-session-one-mode too strict for workflows that genuinely need mode changes mid-conversation?

Supersedes #1719 (experimental branch, closed).