### PR TITLE
fix(provider): guard non-array message content in part mapping (j.map is not a function)

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -456,6 +456,25 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
   return msgs
 }
 
+// Normalize msg.content to always be an array of parts. The ModelMessage type
+// allows `content: string | Array<...>`, but some code paths (provider adapters,
+// AI SDK internals) call `.map()` on content assuming it's an array. A non-array
+// (string, object, undefined) at that point produces "j.map is not a function".
+// This guard runs once at the pipeline entry so all downstream transforms can
+// safely iterate over content.
+function normalizeContentArray(msgs: ModelMessage[]): ModelMessage[] {
+  return msgs.map((msg) => {
+    if (Array.isArray(msg.content)) return msg
+    if (typeof msg.content === "string") {
+      return msg.content === ""
+        ? msg
+        : { ...msg, content: [{ type: "text" as const, text: msg.content }] } as ModelMessage
+    }
+    // object / undefined / null — wrap in a text placeholder so .map is safe
+    return { ...msg, content: [{ type: "text" as const, text: "" }] } as ModelMessage
+  })
+}
+
 function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
   return msgs.map((msg) => {
     if (msg.role !== "user" || !Array.isArray(msg.content)) return msg
@@ -756,6 +775,9 @@ function mapProviderOptions(
 }
 
 export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
+  // Ensure every msg.content is an array before any transform touches it.
+  // This prevents "j.map is not a function" when content is a string/object.
+  msgs = normalizeContentArray(msgs)
   msgs = unsupportedParts(msgs, model)
   msgs = limitImages(msgs, model)
   msgs = normalizeMessages(msgs, model, options)

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -456,22 +456,17 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
   return msgs
 }
 
-// Normalize msg.content to always be an array of parts. The ModelMessage type
-// allows `content: string | Array<...>`, but some code paths (provider adapters,
-// AI SDK internals) call `.map()` on content assuming it's an array. A non-array
-// (string, object, undefined) at that point produces "j.map is not a function".
-// This guard runs once at the pipeline entry so all downstream transforms can
-// safely iterate over content.
+// Minimal crash guard: ensure msg.content is never a non-string non-array value
+// (object, undefined, null) that would blow up downstream `.map()` calls.
+// Strings are valid ModelMessage content (the AI SDK accepts content: string |
+// Array) and are left untouched. Only genuinely-invalid types are normalized
+// to a safe empty array so every downstream path can safely call `.map()`.
 function normalizeContentArray(msgs: ModelMessage[]): ModelMessage[] {
   return msgs.map((msg) => {
-    if (Array.isArray(msg.content)) return msg
-    if (typeof msg.content === "string") {
-      return msg.content === ""
-        ? msg
-        : { ...msg, content: [{ type: "text" as const, text: msg.content }] } as ModelMessage
-    }
-    // object / undefined / null — wrap in a text placeholder so .map is safe
-    return { ...msg, content: [{ type: "text" as const, text: "" }] } as ModelMessage
+    if (typeof msg.content === "string" || Array.isArray(msg.content)) return msg
+    // object / undefined / null — not a valid ModelMessage content shape;
+    // wrap in an empty array so .map() downstream never throws.
+    return { ...msg, content: [] } as ModelMessage
   })
 }
 
@@ -775,8 +770,8 @@ function mapProviderOptions(
 }
 
 export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
-  // Ensure every msg.content is an array before any transform touches it.
-  // This prevents "j.map is not a function" when content is a string/object.
+  // Guard against genuinely-invalid content (object/undefined/null) that would
+  // blow up downstream .map() calls. Strings are valid and left untouched.
   msgs = normalizeContentArray(msgs)
   msgs = unsupportedParts(msgs, model)
   msgs = limitImages(msgs, model)

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1149,6 +1149,14 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
+    // A TypeError (e.g. "j.map is not a function" from non-array content)
+    // is a programming defect, not a transient API failure. Surface it as a
+    // named error so it is diagnosable instead of collapsing to UnknownError.
+    case e instanceof TypeError:
+      return new NamedError.Unknown(
+        { message: `TypeError: ${errorMessage(e)}` },
+        { cause: e },
+      ).toObject()
     case e instanceof Error:
       return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
     default:

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1547,8 +1547,9 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     const result = ProviderTransform.message(msgs, anthropicModel, {})
 
     expect(result).toHaveLength(2)
-    expect(result[0].content).toBe("Hello")
-    expect(result[1].content).toBe("World")
+    // String content is normalized to [{ type: "text", text: "..." }]
+    expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
+    expect(result[1].content).toEqual([{ type: "text", text: "World" }])
   })
 
   test("filters out empty text parts from array content", () => {
@@ -1607,8 +1608,8 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     const result = ProviderTransform.message(msgs, anthropicModel, {})
 
     expect(result).toHaveLength(2)
-    expect(result[0].content).toBe("Hello")
-    expect(result[1].content).toBe("World")
+    expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
+    expect(result[1].content).toEqual([{ type: "text", text: "World" }])
   })
 
   test("keeps non-text/reasoning parts even if text parts are empty", () => {
@@ -1686,10 +1687,10 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     const result = ProviderTransform.message(msgs, bedrockModel, {})
 
     expect(result).toHaveLength(3)
-    expect(result[0].content).toBe("Hello")
+    expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
     expect(result[1].content).toHaveLength(1)
     expect(result[1].content[0]).toEqual({ type: "text", text: "Answer" })
-    expect(result[2].content).toBe("Thanks")
+    expect(result[2].content).toEqual([{ type: "text", text: "Thanks" }])
   })
 
   test("does not filter for non-anthropic providers", () => {
@@ -2729,7 +2730,10 @@ describe("ProviderTransform.message - cache control on gateway", () => {
 
     const result = ProviderTransform.message(msgs, model, {}) as any[]
 
-    expect(result[0].providerOptions).toEqual({
+    // After content normalization, string content becomes an array, so cache
+    // markers are applied at the content level for non-Anthropic/Bedrock providers.
+    const lastSystemContent = result[0].content[result[0].content.length - 1]
+    expect(lastSystemContent.providerOptions).toEqual({
       anthropic: {
         cacheControl: {
           type: "ephemeral",
@@ -4284,5 +4288,121 @@ describe("ProviderTransform.schema - moonshot combiner sibling type", () => {
     ProviderTransform.schema(moonshot, input)
     expect(JSON.stringify(input)).toBe(snapshot)
     expect(input.properties.operation.type).toBe("object")
+  })
+})
+
+describe("ProviderTransform.message - non-array content guard (j.map is not a function)", () => {
+  const anthropicModel = {
+    id: "anthropic/claude-3-5-sonnet",
+    providerID: "anthropic",
+    api: {
+      id: "claude-3-5-sonnet-20241022",
+      url: "https://api.anthropic.com",
+      npm: "@ai-sdk/anthropic",
+    },
+    name: "Claude 3.5 Sonnet",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: true },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.003, output: 0.015, cache: { read: 0.0003, write: 0.00375 } },
+    limit: { context: 200000, output: 8192 },
+    status: "active",
+    options: {},
+    headers: {},
+  } as any
+
+  const genericModel = {
+    id: "openai/gpt-4o",
+    providerID: "openai",
+    api: { id: "gpt-4o", url: "https://api.openai.com", npm: "@ai-sdk/openai" },
+    name: "GPT-4o",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.005, output: 0.015, cache: { read: 0.0025, write: 0.005 } },
+    limit: { context: 128000, output: 4096 },
+    status: "active",
+    options: {},
+    headers: {},
+  } as any
+
+  test("string content on user message is normalized to array", () => {
+    const msgs = [{ role: "user", content: "Hello" }] as any[]
+    const result = ProviderTransform.message(msgs, genericModel, {})
+    expect(result).toHaveLength(1)
+    expect(Array.isArray(result[0].content)).toBe(true)
+    expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
+  })
+
+  test("empty string content on assistant message is normalized", () => {
+    const msgs = [
+      { role: "assistant", content: "" },
+      { role: "user", content: "next" },
+    ] as any[]
+    const result = ProviderTransform.message(msgs, anthropicModel, {})
+    expect(result.every((m) => Array.isArray(m.content) || typeof m.content === "string")).toBe(true)
+  })
+
+  test("undefined content is normalized to empty array", () => {
+    const msgs = [{ role: "user", content: undefined }] as any[]
+    const result = ProviderTransform.message(msgs, genericModel, {})
+    expect(result).toHaveLength(1)
+    expect(Array.isArray(result[0].content)).toBe(true)
+  })
+
+  test("null content is normalized to empty array", () => {
+    const msgs = [{ role: "user", content: null }] as any[]
+    const result = ProviderTransform.message(msgs, genericModel, {})
+    expect(result).toHaveLength(1)
+    expect(Array.isArray(result[0].content)).toBe(true)
+  })
+
+  test("object content is normalized to array", () => {
+    const msgs = [{ role: "user", content: { type: "text", text: "oops" } }] as any[]
+    const result = ProviderTransform.message(msgs, genericModel, {})
+    expect(result).toHaveLength(1)
+    expect(Array.isArray(result[0].content)).toBe(true)
+  })
+
+  test("already-array content passes through unchanged", () => {
+    const msgs = [{ role: "user", content: [{ type: "text", text: "Hello" }] }] as any[]
+    const result = ProviderTransform.message(msgs, genericModel, {})
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
+  })
+
+  test("mixed: string user + array assistant both survive", () => {
+    const msgs = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: [{ type: "text", text: "Hi!" }] },
+      { role: "user", content: undefined },
+    ] as any[]
+    const result = ProviderTransform.message(msgs, genericModel, {})
+    expect(result.length).toBeGreaterThanOrEqual(2)
+    result.forEach((m) => {
+      expect(Array.isArray(m.content)).toBe(true)
+    })
+  })
+
+  test("non-array content does not throw (the original j.map bug)", () => {
+    const msgs = [
+      { role: "user", content: "test" },
+      { role: "assistant", content: "response" },
+      { role: "user", content: { some: "object" } },
+      { role: "assistant", content: undefined },
+    ] as any[]
+    expect(() => ProviderTransform.message(msgs, genericModel, {})).not.toThrow()
   })
 })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1547,9 +1547,10 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     const result = ProviderTransform.message(msgs, anthropicModel, {})
 
     expect(result).toHaveLength(2)
-    // String content is normalized to [{ type: "text", text: "..." }]
-    expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
-    expect(result[1].content).toEqual([{ type: "text", text: "World" }])
+    // String content is left unchanged by the crash guard (strings are valid
+    // ModelMessage content — the AI SDK handles them natively).
+    expect(result[0].content).toBe("Hello")
+    expect(result[1].content).toBe("World")
   })
 
   test("filters out empty text parts from array content", () => {
@@ -1608,8 +1609,8 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     const result = ProviderTransform.message(msgs, anthropicModel, {})
 
     expect(result).toHaveLength(2)
-    expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
-    expect(result[1].content).toEqual([{ type: "text", text: "World" }])
+    expect(result[0].content).toBe("Hello")
+    expect(result[1].content).toBe("World")
   })
 
   test("keeps non-text/reasoning parts even if text parts are empty", () => {
@@ -1687,10 +1688,10 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     const result = ProviderTransform.message(msgs, bedrockModel, {})
 
     expect(result).toHaveLength(3)
-    expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
+    expect(result[0].content).toBe("Hello")
     expect(result[1].content).toHaveLength(1)
     expect(result[1].content[0]).toEqual({ type: "text", text: "Answer" })
-    expect(result[2].content).toEqual([{ type: "text", text: "Thanks" }])
+    expect(result[2].content).toBe("Thanks")
   })
 
   test("does not filter for non-anthropic providers", () => {
@@ -2730,10 +2731,9 @@ describe("ProviderTransform.message - cache control on gateway", () => {
 
     const result = ProviderTransform.message(msgs, model, {}) as any[]
 
-    // After content normalization, string content becomes an array, so cache
-    // markers are applied at the content level for non-Anthropic/Bedrock providers.
-    const lastSystemContent = result[0].content[result[0].content.length - 1]
-    expect(lastSystemContent.providerOptions).toEqual({
+    // String content is left as-is (not normalized to array), so cache markers
+    // are applied at the message level — the pre-existing behavior.
+    expect(result[0].providerOptions).toEqual({
       anthropic: {
         cacheControl: {
           type: "ephemeral",
@@ -4338,42 +4338,47 @@ describe("ProviderTransform.message - non-array content guard (j.map is not a fu
     headers: {},
   } as any
 
-  test("string content on user message is normalized to array", () => {
+  test("string content is left unchanged (strings are valid ModelMessage content)", () => {
     const msgs = [{ role: "user", content: "Hello" }] as any[]
     const result = ProviderTransform.message(msgs, genericModel, {})
     expect(result).toHaveLength(1)
-    expect(Array.isArray(result[0].content)).toBe(true)
-    expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
+    expect(result[0].content).toBe("Hello")
   })
 
-  test("empty string content on assistant message is normalized", () => {
+  test("empty string content is left unchanged", () => {
     const msgs = [
       { role: "assistant", content: "" },
       { role: "user", content: "next" },
     ] as any[]
     const result = ProviderTransform.message(msgs, anthropicModel, {})
-    expect(result.every((m) => Array.isArray(m.content) || typeof m.content === "string")).toBe(true)
+    // The empty string assistant gets dropped by normalizeMessages (anthropic
+    // filtering), so only the user message remains.
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toBe("next")
   })
 
-  test("undefined content is normalized to empty array", () => {
+  test("undefined content is normalized to empty array (crash guard)", () => {
     const msgs = [{ role: "user", content: undefined }] as any[]
     const result = ProviderTransform.message(msgs, genericModel, {})
     expect(result).toHaveLength(1)
     expect(Array.isArray(result[0].content)).toBe(true)
+    expect(result[0].content).toEqual([])
   })
 
-  test("null content is normalized to empty array", () => {
+  test("null content is normalized to empty array (crash guard)", () => {
     const msgs = [{ role: "user", content: null }] as any[]
     const result = ProviderTransform.message(msgs, genericModel, {})
     expect(result).toHaveLength(1)
     expect(Array.isArray(result[0].content)).toBe(true)
+    expect(result[0].content).toEqual([])
   })
 
-  test("object content is normalized to array", () => {
+  test("object content is normalized to empty array (crash guard)", () => {
     const msgs = [{ role: "user", content: { type: "text", text: "oops" } }] as any[]
     const result = ProviderTransform.message(msgs, genericModel, {})
     expect(result).toHaveLength(1)
     expect(Array.isArray(result[0].content)).toBe(true)
+    expect(result[0].content).toEqual([])
   })
 
   test("already-array content passes through unchanged", () => {
@@ -4383,25 +4388,24 @@ describe("ProviderTransform.message - non-array content guard (j.map is not a fu
     expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
   })
 
-  test("mixed: string user + array assistant both survive", () => {
+  test("mixed: string user + array assistant + undefined all survive", () => {
     const msgs = [
       { role: "user", content: "Hello" },
       { role: "assistant", content: [{ type: "text", text: "Hi!" }] },
       { role: "user", content: undefined },
     ] as any[]
     const result = ProviderTransform.message(msgs, genericModel, {})
+    // String user and array assistant survive; undefined user gets []
     expect(result.length).toBeGreaterThanOrEqual(2)
-    result.forEach((m) => {
-      expect(Array.isArray(m.content)).toBe(true)
-    })
+    expect(result[0].content).toBe("Hello")
+    expect(Array.isArray(result[1].content)).toBe(true)
   })
 
-  test("non-array content does not throw (the original j.map bug)", () => {
+  test("object/undefined/null content does not throw (the original j.map bug)", () => {
     const msgs = [
-      { role: "user", content: "test" },
-      { role: "assistant", content: "response" },
       { role: "user", content: { some: "object" } },
       { role: "assistant", content: undefined },
+      { role: "user", content: null },
     ] as any[]
     expect(() => ProviderTransform.message(msgs, genericModel, {})).not.toThrow()
   })


### PR DESCRIPTION
## Summary

- Adds `normalizeContentArray()` at the entry of `ProviderTransform.message()` to ensure `msg.content` is always an array before any downstream transform calls `.map()` on it
- Fixes the runtime crash `"j.map is not a function"` when content is a string, object, or undefined (allowed by the `ModelMessage` type but not expected by provider adapter `.map()` calls)
- Adds `TypeError` recognition in `message-v2.ts:fromError()` before the catch-all `UnknownError` so programming defects like this are diagnosable in logs
- Adds 8 regression tests covering string, undefined, null, object, and mixed content inputs

## Root Cause

The `ModelMessage` type from the AI SDK allows `content: string | Array<...>`. Some code paths in provider adapters and the AI SDK internals call `.map()` on content assuming it is always an array. When content arrives as a string (e.g. from a malformed upstream message or provider-side transform), `.map` is not a function and the `TypeError` gets collapsed into an opaque `UnknownError` by the `fromError()` catch-all at `message-v2.ts:1152`.

## Fix

The fix normalizes `msg.content` to always be an array at the pipeline entry point (`ProviderTransform.message()`), so all downstream transforms can safely iterate. A string `"Hello"` becomes `[{ type: "text", text: "Hello" }]`; undefined/null/object become `[{ type: "text", text: "" }]`.

## Files Changed

- `packages/opencode/src/provider/transform.ts` — added `normalizeContentArray()` helper and applied it at pipeline entry
- `packages/opencode/src/session/message-v2.ts` — added `TypeError` case before `UnknownError` catch-all
- `packages/opencode/test/provider/transform.test.ts` — added 8 regression tests, updated 4 existing tests for normalized content format