### PR TITLE
fix(tui): skip app-level right-click paste on Windows Terminal to avoid double-insert

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -69,7 +69,7 @@ import { TuiConfigProvider, useTuiConfig } from "./context/tui-config"
 import { TuiConfig } from "@/cli/cmd/tui/config/tui"
 import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
-import { isPlainTerminal } from "./util/terminal"
+import { isPlainTerminal, isWindowsTerminal } from "./util/terminal"
 
 import type { EventSource } from "./context/sdk"
 import { DialogVariant } from "./component/dialog-variant"
@@ -1294,7 +1294,11 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           return
         }
 
-        promptRef.current?.paste()
+        // Windows Terminal (and WSL launched from it) already pastes on
+        // right-click, so calling paste() here double-inserts (notably images).
+        // Skip it there; other terminals don't self-paste, so this stays the
+        // right-click paste path.
+        if (!isWindowsTerminal()) promptRef.current?.paste()
         evt.preventDefault()
         evt.stopPropagation()
       }}

--- a/packages/opencode/src/cli/cmd/tui/util/terminal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/terminal.ts
@@ -9,6 +9,15 @@ export function isMacNativeTerminal(input?: { platform?: NodeJS.Platform; termPr
   )
 }
 
+export function isWindowsTerminal(input?: { wtSession?: string }) {
+  // Windows Terminal — and WSL sessions launched from it — set WT_SESSION to a
+  // GUID. Used to skip the app-level right-click paste there: Windows Terminal
+  // already performs its own right-click paste, so triggering paste() again
+  // double-inserts (notably images). Other terminals don't self-paste on
+  // right-click, so they keep relying on the app-level paste.
+  return !!(input?.wtSession ?? process.env.WT_SESSION)
+}
+
 export function isPlainTerminal(input?: { platform?: NodeJS.Platform; termProgram?: string; plain?: string }) {
   const plain = input?.plain ?? process.env.MIMOCODE_TUI_PLAIN
   if (plain === "false" || plain === "0") return false

--- a/packages/opencode/test/terminal.test.ts
+++ b/packages/opencode/test/terminal.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { isWindowsTerminal } from "../src/cli/cmd/tui/util/terminal"
+
+describe("isWindowsTerminal", () => {
+  const originalWTSession = process.env.WT_SESSION
+
+  beforeEach(() => {
+    delete process.env.WT_SESSION
+  })
+
+  afterEach(() => {
+    if (originalWTSession !== undefined) {
+      process.env.WT_SESSION = originalWTSession
+    } else {
+      delete process.env.WT_SESSION
+    }
+  })
+
+  test("returns true when wtSession input is set", () => {
+    expect(isWindowsTerminal({ wtSession: "some-guid" })).toBe(true)
+  })
+
+  test("returns true when wtSession input is empty string", () => {
+    expect(isWindowsTerminal({ wtSession: "" })).toBe(false)
+  })
+
+  test("returns false when wtSession input is undefined", () => {
+    expect(isWindowsTerminal({ wtSession: undefined })).toBe(false)
+  })
+
+  test("returns true when WT_SESSION env var is set", () => {
+    process.env.WT_SESSION = "abc-123-guid"
+    expect(isWindowsTerminal()).toBe(true)
+  })
+
+  test("returns false when WT_SESSION env var is not set", () => {
+    expect(isWindowsTerminal()).toBe(false)
+  })
+
+  test("input wtSession takes precedence over env var", () => {
+    process.env.WT_SESSION = "env-guid"
+    expect(isWindowsTerminal({ wtSession: "input-guid" })).toBe(true)
+  })
+
+  test("returns false when input is undefined and no env var", () => {
+    expect(isWindowsTerminal()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `isWindowsTerminal()` helper that detects Windows Terminal (and WSL sessions launched from it) via the `WT_SESSION` environment variable
- Guard the app-level `promptRef.current?.paste()` call in the right-click handler to skip when Windows Terminal is detected, preventing double-insert of clipboard content (notably images)
- Other terminals that don't self-paste on right-click remain unaffected

## Problem

Windows Terminal already performs its own right-click paste. When the app's `onMouseDown` handler also calls `paste()`, content is inserted twice — this is especially visible with image pastes that create duplicate image blocks.

## Changes

| File | Change |
|------|--------|
| `packages/opencode/src/cli/cmd/tui/util/terminal.ts` | Add `isWindowsTerminal()` — returns true when `WT_SESSION` env var (or explicit input) is set |
| `packages/opencode/src/cli/cmd/tui/app.tsx` | Import `isWindowsTerminal`, wrap `promptRef.current?.paste()` in `if (!isWindowsTerminal())` guard |
| `packages/opencode/test/terminal.test.ts` | New test file covering `isWindowsTerminal` behavior (env var, input param, precedence) |

## Verification

- `bun typecheck` — 12/12 packages pass (0 errors)
- `bun test test/terminal.test.ts` — 7/7 tests pass