### PR TITLE
fix(session): single-empty-call retry + schema-aware empty-step (replaces #1726)

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -89,10 +89,9 @@ export const Flag = {
   MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT: number("MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT") ?? 3,
   MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT: number("MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT") ?? 2,
   MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT: number("MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT") ?? 2,
-  // Empty/no-op tool-call loop guard: number of soft nudges (remind → replan)
-  // before the harness hard-halts the turn. N consecutive empty steps beyond
-  // this many recovery attempts terminates the turn. Mirrors TEXT_NGRAM_MAX_RECOVERY.
-  MIMOCODE_EMPTY_STEP_MAX_RECOVERY: number("MIMOCODE_EMPTY_STEP_MAX_RECOVERY") ?? 2,
+  // Empty tool-call retry limit: number of retries for a single empty tool
+  // call before the harness terminates the turn. Mirrors TEXT_TOOL_CALL_RETRY_LIMIT.
+  MIMOCODE_EMPTY_TOOL_CALL_RETRY_LIMIT: number("MIMOCODE_EMPTY_TOOL_CALL_RETRY_LIMIT") ?? 2,
 
   // Consecutive-block repetition detection for streamed reasoning + text.
   // A block of at least N tokens repeating REPEAT_THRESHOLD times consecutively

--- a/packages/opencode/src/session/classify.ts
+++ b/packages/opencode/src/session/classify.ts
@@ -46,7 +46,11 @@ export function classifyAssistantStep(input: {
   // terminal failures. Without this guard, classify mis-routes errored steps
   // to "continue", runLoop re-enters and gets stranded on permission.ask
   // from the in-flight tool that won't ever resolve. See Spec ③.
+  // Also skip when assistant.error is already set — the turn was discarded
+  // (e.g. empty-tool-call exhaustion) and must fall through to `failed` at
+  // #5 instead of re-entering the loop on a stale completed tool part.
   if (
+    !assistant.error &&
     input.parts.some(
       (part) =>
         part.type === "tool" &&

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -67,6 +67,7 @@ export const ContextOverflowError = NamedError.create(
 )
 export const InvalidOutputError = NamedError.create("InvalidOutputError", z.object({ message: z.string() }))
 export const TextToolCallError = NamedError.create("TextToolCallError", z.object({ message: z.string() }))
+export const EmptyToolCallError = NamedError.create("EmptyToolCallError", z.object({ message: z.string() }))
 export const ContentFilterError = NamedError.create("ContentFilterError", z.object({ message: z.string() }))
 export const ModelError = NamedError.create("ModelError", z.object({ message: z.string() }))
 
@@ -453,6 +454,7 @@ export const Assistant = Base.extend({
       ContextOverflowError.Schema,
       InvalidOutputError.Schema,
       TextToolCallError.Schema,
+      EmptyToolCallError.Schema,
       ContentFilterError.Schema,
       ModelError.Schema,
       APIError.Schema,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -27,7 +27,6 @@ import { isRecord } from "@/util/record"
 import { createTextNgramMonitor, type TextNgramMonitor } from "./prompt/text-ngram-detection"
 
 const DOOM_LOOP_THRESHOLD = 3
-const EMPTY_STEP_THRESHOLD = 3
 const log = Log.create({ service: "session.processor" })
 
 export type Result = "overflow" | "stop" | "continue" | "text-repeat"
@@ -150,7 +149,6 @@ interface ProcessorContext extends Input {
   stepPartIds: PartID[]
   textNgramMonitor: TextNgramMonitor | undefined
   textNgramRepeat: boolean
-  emptyStepCount: number
 }
 
 type StreamEvent = Event
@@ -207,7 +205,6 @@ export const layer: Layer.Layer<
         stepPartIds: [],
         textNgramMonitor: undefined,
         textNgramRepeat: false,
-        emptyStepCount: 0,
       }
       let aborted = false
       // Only the main agent owns session-level status. Subagents (explore,
@@ -326,22 +323,6 @@ export const layer: Layer.Layer<
         if (ctx.textNgramMonitor.append(text)) ctx.textNgramRepeat = true
       }
 
-      const isEmptyInput = (input: Record<string, unknown> | undefined | null): boolean => {
-        if (input === undefined || input === null) return true
-        // Filter out meta/underscore-prefixed fields — they are harness
-        // bookkeeping, not actionable tool arguments.
-        const keys = Object.keys(input).filter((k) => !k.startsWith("_"))
-        if (keys.length === 0) return true
-        return keys.every((k) => {
-          const v = input[k]
-          if (v === undefined || v === null) return true
-          if (typeof v === "string") return v.trim().length === 0
-          if (Array.isArray(v)) return v.length === 0
-          if (typeof v === "object") return Object.keys(v as Record<string, unknown>).length === 0
-          return false
-        })
-      }
-
       const handleEvent = Effect.fnUntraced(function* (value: StreamEvent) {
         switch (value.type) {
           case "start":
@@ -437,17 +418,6 @@ export const layer: Layer.Layer<
                 ? { ...value.providerMetadata, providerExecuted: true }
                 : value.providerMetadata,
             }))
-
-            // Unconditional empty-step guard: genuine empty tool calls always
-            // counted, regardless of error/summary/structured/finish state.
-            if (isEmptyInput(value.input)) {
-              ctx.emptyStepCount++
-              if (ctx.emptyStepCount >= EMPTY_STEP_THRESHOLD) {
-                throw new Error(`Empty tool call loop detected: ${ctx.emptyStepCount} consecutive empty tool calls. Session terminated.`)
-              }
-              return
-            }
-            ctx.emptyStepCount = 0
 
             const parts = MessageV2.parts(ctx.assistantMessage.id)
             const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -27,6 +27,7 @@ import { isRecord } from "@/util/record"
 import { createTextNgramMonitor, type TextNgramMonitor } from "./prompt/text-ngram-detection"
 
 const DOOM_LOOP_THRESHOLD = 3
+const EMPTY_STEP_THRESHOLD = 3
 const log = Log.create({ service: "session.processor" })
 
 export type Result = "overflow" | "stop" | "continue" | "text-repeat"
@@ -149,6 +150,7 @@ interface ProcessorContext extends Input {
   stepPartIds: PartID[]
   textNgramMonitor: TextNgramMonitor | undefined
   textNgramRepeat: boolean
+  emptyStepCount: number
 }
 
 type StreamEvent = Event
@@ -205,6 +207,7 @@ export const layer: Layer.Layer<
         stepPartIds: [],
         textNgramMonitor: undefined,
         textNgramRepeat: false,
+        emptyStepCount: 0,
       }
       let aborted = false
       // Only the main agent owns session-level status. Subagents (explore,
@@ -323,6 +326,22 @@ export const layer: Layer.Layer<
         if (ctx.textNgramMonitor.append(text)) ctx.textNgramRepeat = true
       }
 
+      const isEmptyInput = (input: Record<string, unknown> | undefined | null): boolean => {
+        if (input === undefined || input === null) return true
+        // Filter out meta/underscore-prefixed fields — they are harness
+        // bookkeeping, not actionable tool arguments.
+        const keys = Object.keys(input).filter((k) => !k.startsWith("_"))
+        if (keys.length === 0) return true
+        return keys.every((k) => {
+          const v = input[k]
+          if (v === undefined || v === null) return true
+          if (typeof v === "string") return v.trim().length === 0
+          if (Array.isArray(v)) return v.length === 0
+          if (typeof v === "object") return Object.keys(v as Record<string, unknown>).length === 0
+          return false
+        })
+      }
+
       const handleEvent = Effect.fnUntraced(function* (value: StreamEvent) {
         switch (value.type) {
           case "start":
@@ -418,6 +437,17 @@ export const layer: Layer.Layer<
                 ? { ...value.providerMetadata, providerExecuted: true }
                 : value.providerMetadata,
             }))
+
+            // Unconditional empty-step guard: genuine empty tool calls always
+            // counted, regardless of error/summary/structured/finish state.
+            if (isEmptyInput(value.input)) {
+              ctx.emptyStepCount++
+              if (ctx.emptyStepCount >= EMPTY_STEP_THRESHOLD) {
+                throw new Error(`Empty tool call loop detected: ${ctx.emptyStepCount} consecutive empty tool calls. Session terminated.`)
+              }
+              return
+            }
+            ctx.emptyStepCount = 0
 
             const parts = MessageV2.parts(ctx.assistantMessage.id)
             const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -56,9 +56,6 @@ import {
   TEXT_NGRAM_RECOVERY_REPLAN,
 } from "../session/prompt/text-ngram-detection"
 import {
-  EMPTY_STEP_MAX_RECOVERY,
-  EMPTY_STEP_RECOVERY_REMIND,
-  EMPTY_STEP_RECOVERY_REPLAN,
   isEmptyStep,
 } from "../session/prompt/empty-step-detection"
 import { builtinSkillRoot, matchDocumentSkills } from "@/skill/builtin/extract"
@@ -248,6 +245,7 @@ const PREDICT_NUDGE = `Based on the conversation above, write the user's most li
 const OUTPUT_LENGTH_CONTINUATION_LIMIT = Flag.MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT
 const INVALID_OUTPUT_CONTINUATION_LIMIT = Flag.MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT
 const TEXT_TOOL_CALL_RETRY_LIMIT = Flag.MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT
+const EMPTY_TOOL_CALL_RETRY_LIMIT = Flag.MIMOCODE_EMPTY_TOOL_CALL_RETRY_LIMIT
 
 const log = Log.create({ service: "session.prompt" })
 
@@ -2142,19 +2140,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         // prose text instead of a structured tool_use). Local to runLoop so each
         // fresh user turn starts clean.
         let textToolCallRetries = 0
-        // Consecutive empty/no-op tool-call steps in this turn. Counts steps
-        // where the model "called a tool" with empty/invalid input, or produced
-        // no valid tool part and no substantive output at all (see isEmptyStep).
-        // A single non-empty step resets it. Escalates soft (remind → replan)
-        // then hard-halts once it exceeds EMPTY_STEP_MAX_RECOVERY, mirroring the
-        // text-ngram ladder. Local to runLoop so a fresh user turn starts clean.
-        let emptyStepStreak = 0
-        // Set true when a guard hard-halts the turn (currently the empty-step
-        // guard). A hard halt is terminal: it must break out immediately and
-        // NOT be re-entered by the taskGate / goalGate ReAct gates, which would
-        // otherwise inject a fresh user turn and re-drive a still-degraded model
-        // into the same loop.
-        let hardHalt = false
+        // Bounded retries for empty tool calls (model called a tool with
+        // empty/invalid arguments, or produced a fully empty terminal).
+        // Mirrors textToolCallRetries. Local to runLoop, resets per user turn.
+        let emptyToolCallRetries = 0
         const resolvedAgentID = agentID ?? "main"
         // Tracks plugin-driven cancellation (session.pre OR any session.userQuery.pre)
         // so session.post reports outcome="cancelled" instead of "error".
@@ -2707,21 +2696,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           return true
         })
 
-        // Empty/no-op tool-call loop guard. Symmetric across main and fork
-        // branches, mirroring handleTextRepeat's soft→hard ladder but keyed on
-        // *empty steps* (empty/invalid tool input, or a fully empty terminal)
-        // rather than repeated text n-grams — the gap TEXT_NGRAM and
-        // stepSignature both miss (an empty tool call has no text to match and
-        // is dropped by stepSignature's undefined path).
-        //
-        // Returns:
-        //   "none"     — the step was NOT empty; streak reset, caller continues
-        //                normal classification.
-        //   "continue" — empty step, still within the soft-nudge budget; a
-        //                remind/replan reminder was injected, caller should loop.
-        //   "halt"     — empty streak exceeded EMPTY_STEP_MAX_RECOVERY; a
-        //                terminal error was published, caller must break.
-        const handleEmptyStep = Effect.fn("SessionPrompt.handleEmptyStep")(function* (input: {
+        // Empty tool-call retry. A single empty tool call (empty/invalid
+        // arguments, or a fully empty terminal) is an invalid output — it must
+        // IMMEDIATELY trigger a RETRY that makes the model re-emit a valid call.
+        // The bad assistant turn is DISCARDED from history (error-tagged), and a
+        // synthetic user turn is appended to re-drive generation — mirrors
+        // autoRetryTextToolCall exactly. On exhaustion the error stays terminal.
+        // Returns true ⇒ continue; false ⇒ break.
+        const autoRetryEmptyToolCall = Effect.fn("SessionPrompt.autoRetryEmptyToolCall")(function* (input: {
           lastUser: MessageV2.User
           assistant: MessageV2.Assistant
         }) {
@@ -2737,40 +2719,34 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             input.assistant.finish === "content-filter" ||
             input.assistant.finish === "error"
           ) {
-            return "none" as const
+            return false
           }
           const parts = MessageV2.parts(input.assistant.id)
-          if (!isEmptyStep(parts)) {
-            emptyStepStreak = 0
-            return "none" as const
-          }
-          emptyStepStreak++
-          if (emptyStepStreak > EMPTY_STEP_MAX_RECOVERY) {
-            yield* slog.info("empty step: max recovery exceeded, terminating", { streak: emptyStepStreak })
-            hardHalt = true
-            // Discard the empty turn from request history so it can neither
-            // strand the conversation on an assistant prefill nor poison later
-            // context (toModelMessages skips a message whose info.error is set).
-            if (!input.assistant.error) {
-              input.assistant.error = new NamedError.Unknown({
-                message: `Empty tool call loop detected: ${emptyStepStreak} consecutive empty/no-op steps after ${EMPTY_STEP_MAX_RECOVERY} recovery attempts. Session terminated.`,
-              }).toObject()
-              yield* sessions.updateMessage(input.assistant)
-            }
+          if (!isEmptyStep(parts)) return false
+          // Discard the bad turn from request history: toModelMessages skips a
+          // message whose info.error is set, so it can neither strand the
+          // conversation on an assistant turn nor poison later context.
+          input.assistant.error = new MessageV2.EmptyToolCallError({
+            message: "Model emitted an empty or argument-less tool call.",
+          }).toObject()
+          yield* sessions.updateMessage(input.assistant)
+          if (emptyToolCallRetries >= EMPTY_TOOL_CALL_RETRY_LIMIT) {
             yield* bus.publish(Session.Event.Error, {
-              sessionID,
-              error: new NamedError.Unknown({
-                message: `Empty tool call loop detected: ${emptyStepStreak} consecutive empty/no-op steps after ${EMPTY_STEP_MAX_RECOVERY} recovery attempts. Session terminated.`,
-              }).toObject(),
+              sessionID: input.assistant.sessionID,
+              error: input.assistant.error,
             })
-            return "halt" as const
+            return false
           }
-          const recoveryText =
-            emptyStepStreak === 1 ? EMPTY_STEP_RECOVERY_REMIND : EMPTY_STEP_RECOVERY_REPLAN
-          const reentry = yield* sessions.updateMessage({
+          emptyToolCallRetries++
+          yield* slog.info("retrying empty tool call", { attempt: emptyToolCallRetries })
+          // Append a synthetic user turn so the discarded assistant becomes stale
+          // (classify staleness guard) AND the loop reaches generation — mirrors
+          // autoRetryTextToolCall. Without this the loop re-enters, re-detects
+          // the same turn, and burns retries with zero model calls.
+          const msg = yield* sessions.updateMessage({
             id: MessageID.ascending(),
             role: "user" as const,
-            sessionID,
+            sessionID: input.lastUser.sessionID,
             agentID: input.lastUser.agentID,
             agent: input.lastUser.agent,
             model: input.lastUser.model,
@@ -2780,14 +2756,20 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           })
           yield* sessions.updatePart({
             id: PartID.ascending(),
-            messageID: reentry.id,
-            sessionID,
+            messageID: msg.id,
+            sessionID: msg.sessionID,
             type: "text",
             synthetic: true,
-            text: recoveryText,
+            text: [
+              "<system-reminder>",
+              "Your previous tool call had empty or invalid arguments.",
+              "Re-issue a valid tool call with complete, non-empty arguments,",
+              "or reply to the user directly with plain text.",
+              "Do NOT emit another empty or argument-less tool call.",
+              "</system-reminder>",
+            ].join("\n"),
           } satisfies MessageV2.TextPart)
-          yield* slog.info("empty step: recovery injected", { streak: emptyStepStreak })
-          return "continue" as const
+          return true
         })
 
 
@@ -2940,6 +2922,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               yield* slog.info("exiting loop", { classification: classification.type })
               break
             }
+            // Empty tool-call retry (existing-assistant branch). A single
+            // empty tool call triggers immediate retry — discard bad turn +
+            // synthetic user message + continue. Catches empty tool calls
+            // before classify routes them to "continue" (pending tool parts).
+            if (yield* autoRetryEmptyToolCall({ lastUser, assistant: lastAssistant })) continue
             if (classification.type === "think-only" || classification.type === "invalid") {
               const reason = classification.type === "invalid" ? classification.reason : "think-only"
               if (yield* autoContinueInvalidOutput({ lastUser, assistant: lastAssistant, reason })) continue
@@ -3493,13 +3480,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 return "break" as const
               }
 
-              // Empty/no-op tool-call loop guard (fork branch). Intercept before
-              // classify would `continue` an empty tool-calls step: soft-nudge
-              // within budget, hard-halt once exceeded. A non-empty step returns
-              // "none" and falls through to normal classification.
-              const forkEmptyStep = yield* handleEmptyStep({ lastUser, assistant: handle.message })
-              if (forkEmptyStep === "halt") return "break" as const
-              if (forkEmptyStep === "continue") return "continue" as const
+              // Empty tool-call retry (fork branch). A single empty tool call
+              // triggers immediate retry — discard bad turn + synthetic user
+              // message + continue. On exhaustion, break.
+              if (yield* autoRetryEmptyToolCall({ lastUser, assistant: handle.message })) return "continue" as const
 
               const forkClassification = classifyAssistantStep({
                 phase: "after-process",
@@ -3719,13 +3703,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "break" as const
             }
 
-            // Empty/no-op tool-call loop guard (main branch). Intercept before
-            // classify would `continue` an empty tool-calls step: soft-nudge
-            // within budget, hard-halt once exceeded. A non-empty step returns
-            // "none" and falls through to normal classification.
-            const emptyStep = yield* handleEmptyStep({ lastUser, assistant: handle.message })
-            if (emptyStep === "halt") return "break" as const
-            if (emptyStep === "continue") return "continue" as const
+            // Empty tool-call retry (main branch). A single empty tool call
+            // triggers immediate retry — discard bad turn + synthetic user
+            // message + continue. On exhaustion, break.
+            if (yield* autoRetryEmptyToolCall({ lastUser, assistant: handle.message })) return "continue" as const
 
             const classification = classifyAssistantStep({
               phase: "after-process",
@@ -3875,9 +3856,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           if (outcome === "break") {
-            // A hard halt is terminal — skip the ReAct re-entry gates so a
-            // degraded model can't be re-driven into the same empty loop.
-            if (hardHalt) break
             if (yield* taskGate(lastUser)) continue
             if (yield* goalGate(lastUser)) continue
             break

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -317,8 +317,16 @@ export const layer = Layer.effect(
       if (schema instanceof z.ZodObject) {
         const shape = schema.shape as Record<string, unknown>
         const keys = Object.keys(shape)
-        // Tool has required args if any shape key is NOT wrapped in ZodOptional.
-        const hasRequired = keys.some((k) => !(shape[k] instanceof z.ZodOptional))
+        // Tool has required args if any shape key is NOT wrapped in ZodOptional
+        // or in ZodDefault/ZodNullable (which also make a field non-required).
+        const hasRequired = keys.some((k) => {
+          let type = shape[k]
+          // Unwrap ZodDefault / ZodNullable wrappers to reach the inner type.
+          while (type instanceof z.ZodDefault || type instanceof z.ZodNullable) {
+            type = type.unwrap()
+          }
+          return !(type instanceof z.ZodOptional)
+        })
         toolHasRequiredArgs.set(def.id, hasRequired)
       } else {
         // Unknown schema shape — assume it accepts args (safe default).
@@ -2742,10 +2750,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             input.assistant.finish === "content-filter" ||
             input.assistant.finish === "error"
           ) {
-            return false
+            return "skip" as const
           }
           const parts = MessageV2.parts(input.assistant.id)
-          if (!isEmptyStep(parts, { toolHasArgs })) return false
+          if (!isEmptyStep(parts, { toolHasArgs })) return "skip" as const
           // Discard the bad turn from request history: toModelMessages skips a
           // message whose info.error is set, so it can neither strand the
           // conversation on an assistant turn nor poison later context.
@@ -2758,7 +2766,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               sessionID: input.assistant.sessionID,
               error: input.assistant.error,
             })
-            return false
+            return "break" as const
           }
           emptyToolCallRetries++
           yield* slog.info("retrying empty tool call", { attempt: emptyToolCallRetries })
@@ -2792,7 +2800,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               "</system-reminder>",
             ].join("\n"),
           } satisfies MessageV2.TextPart)
-          return true
+          return "retry" as const
         })
 
 
@@ -2949,7 +2957,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // empty tool call triggers immediate retry — discard bad turn +
             // synthetic user message + continue. Catches empty tool calls
             // before classify routes them to "continue" (pending tool parts).
-            if (yield* autoRetryEmptyToolCall({ lastUser, assistant: lastAssistant })) continue
+            // On exhaustion, break explicitly to guarantee termination even if
+            // classify's step #1 would otherwise return "continue".
+            const emptyResult = yield* autoRetryEmptyToolCall({ lastUser, assistant: lastAssistant })
+            if (emptyResult === "retry") continue
+            if (emptyResult === "break") {
+              yield* slog.info("exiting loop", { classification: "empty-tool-exhausted" })
+              break
+            }
             if (classification.type === "think-only" || classification.type === "invalid") {
               const reason = classification.type === "invalid" ? classification.reason : "think-only"
               if (yield* autoContinueInvalidOutput({ lastUser, assistant: lastAssistant, reason })) continue
@@ -3506,7 +3521,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               // Empty tool-call retry (fork branch). A single empty tool call
               // triggers immediate retry — discard bad turn + synthetic user
               // message + continue. On exhaustion, break.
-              if (yield* autoRetryEmptyToolCall({ lastUser, assistant: handle.message })) return "continue" as const
+              const emptyResult = yield* autoRetryEmptyToolCall({ lastUser, assistant: handle.message })
+              if (emptyResult === "retry") return "continue" as const
+              if (emptyResult === "break") return "break" as const
 
               const forkClassification = classifyAssistantStep({
                 phase: "after-process",
@@ -3729,7 +3746,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // Empty tool-call retry (main branch). A single empty tool call
             // triggers immediate retry — discard bad turn + synthetic user
             // message + continue. On exhaustion, break.
-            if (yield* autoRetryEmptyToolCall({ lastUser, assistant: handle.message })) return "continue" as const
+            const emptyResult = yield* autoRetryEmptyToolCall({ lastUser, assistant: handle.message })
+            if (emptyResult === "retry") return "continue" as const
+            if (emptyResult === "break") return "break" as const
 
             const classification = classifyAssistantStep({
               phase: "after-process",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -57,6 +57,7 @@ import {
 } from "../session/prompt/text-ngram-detection"
 import {
   isEmptyStep,
+  type IsEmptyStepOptions,
 } from "../session/prompt/empty-step-detection"
 import { builtinSkillRoot, matchDocumentSkills } from "@/skill/builtin/extract"
 import { ToolRegistry } from "../tool"
@@ -304,6 +305,28 @@ export const layer = Layer.effect(
     const llm = yield* LLM.Service
     const actorRegistry = yield* ActorRegistry.Service
     const inbox = yield* Inbox.Service
+
+    // Build a lookup: tool name → whether its parameter schema has required
+    // fields. Tools whose schema is z.object({}) (no required params) are
+    // called with {} legitimately and must NOT be flagged by isEmptyStep.
+    const toolDefs = yield* registry.all()
+    const toolHasRequiredArgs = new Map<string, boolean>()
+    for (const def of toolDefs) {
+      const schema = def.parameters
+      // z.object({}) has an empty shape — no required params.
+      if (schema instanceof z.ZodObject) {
+        const shape = schema.shape as Record<string, unknown>
+        const keys = Object.keys(shape)
+        // Tool has required args if any shape key is NOT wrapped in ZodOptional.
+        const hasRequired = keys.some((k) => !(shape[k] instanceof z.ZodOptional))
+        toolHasRequiredArgs.set(def.id, hasRequired)
+      } else {
+        // Unknown schema shape — assume it accepts args (safe default).
+        toolHasRequiredArgs.set(def.id, true)
+      }
+    }
+    const toolHasArgs: IsEmptyStepOptions["toolHasArgs"] = (name) =>
+      toolHasRequiredArgs.get(name) ?? true
 
     // Track sessions that have already shown the "loaded instructions" toast so we
     // surface it once per primary session rather than on every run-loop turn.
@@ -2722,7 +2745,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             return false
           }
           const parts = MessageV2.parts(input.assistant.id)
-          if (!isEmptyStep(parts)) return false
+          if (!isEmptyStep(parts, { toolHasArgs })) return false
           // Discard the bad turn from request history: toModelMessages skips a
           // message whose info.error is set, so it can neither strand the
           // conversation on an assistant turn nor poison later context.

--- a/packages/opencode/src/session/prompt/empty-step-detection.ts
+++ b/packages/opencode/src/session/prompt/empty-step-detection.ts
@@ -21,16 +21,31 @@ import type { MessageV2 } from "../message-v2"
  * does not mean the model issued an actionable call.
  */
 
+export interface IsEmptyStepOptions {
+  /**
+   * Given a tool name, return whether the tool's parameter schema accepts
+   * required arguments. Tools whose schema is z.object({}) (no required
+   * params) or all-optional always return valid calls with {} — they must
+   * NOT be flagged as empty.
+   *
+   * When omitted the check degrades to the legacy behaviour (all {} inputs
+   * flagged), which is backwards-compatible but will false-positive on
+   * no-arg tools like plan_exit / plan_enter.
+   */
+  toolHasArgs?: (toolName: string) => boolean
+}
+
 /**
  * Is this assistant step an empty / no-op tool call?
  *
  * Two shapes count as empty (mirrors the task's definition):
  *
  *  (a) The step emitted one or more client (non-providerExecuted) tool parts,
- *      but EVERY such tool part has an empty/invalid input — no keys, or only
- *      keys whose values are null/undefined/empty-string/whitespace. The model
- *      "called a tool" but passed nothing actionable, so the call cannot make
- *      progress and re-looping just repeats it.
+ *      but EVERY such tool part has an empty/invalid input AND the tool
+ *      actually accepts required arguments. A no-arg tool (schema z.object({}))
+ *      called with {} is legitimate and is NOT flagged. Additionally, if the
+ *      step carries substantive text or reasoning alongside the tool call(s),
+ *      it is not treated as empty.
  *
  *  (b) The step produced NO client tool part at all AND no substantive text and
  *      no substantive reasoning — a fully empty terminal. (This overlaps with
@@ -43,29 +58,43 @@ import type { MessageV2 } from "../message-v2"
  * the "has a tool part" test: they are not client actions and their presence
  * does not mean the model issued an actionable call.
  */
-export function isEmptyStep(parts: readonly MessageV2.Part[]): boolean {
+export function isEmptyStep(parts: readonly MessageV2.Part[], opts?: IsEmptyStepOptions): boolean {
   const clientToolParts = parts.filter(
     (part): part is Extract<MessageV2.Part, { type: "tool" }> =>
       part.type === "tool" && !part.metadata?.providerExecuted,
   )
 
   if (clientToolParts.length > 0) {
-    // (a) Every client tool part has an empty/invalid input.
-    return clientToolParts.every((part) => isEmptyInput(part.state.input))
+    // If the step carries substantive text or reasoning alongside tool calls,
+    // the model is making progress — don't treat as empty regardless of input.
+    if (hasSubstantiveContent(parts)) return false
+
+    // (a) Every client tool part has an empty/invalid input AND actually
+    //     accepts required arguments. A no-arg tool (schema z.object({}))
+    //     called with {} is a legitimate invocation — skip it.
+    return clientToolParts.every((part) => {
+      // If we can't introspect the schema, fall through to legacy behaviour.
+      const hasArgs = opts?.toolHasArgs?.(part.tool) ?? true
+      return hasArgs && isEmptyInput(part.state.input)
+    })
   }
 
   // (b) No client tool part — empty only if there is also no substantive
   // text and no substantive reasoning (a pure-empty terminal). A step with a
   // real text answer or real reasoning is a legitimate (non-loop) outcome.
+  return !hasSubstantiveContent(parts)
+}
+
+/** Does this step carry any substantive text or reasoning? */
+function hasSubstantiveContent(parts: readonly MessageV2.Part[]): boolean {
   const hasSubstantiveText = parts.some(
     (part) => part.type === "text" && !part.synthetic && !part.ignored && part.text.trim().length > 0,
   )
-  if (hasSubstantiveText) return false
+  if (hasSubstantiveText) return true
   const hasSubstantiveReasoning = parts.some(
     (part) => part.type === "reasoning" && part.text.trim().length > 0,
   )
-  if (hasSubstantiveReasoning) return false
-  return true
+  return hasSubstantiveReasoning
 }
 
 /**

--- a/packages/opencode/src/session/prompt/empty-step-detection.ts
+++ b/packages/opencode/src/session/prompt/empty-step-detection.ts
@@ -1,25 +1,25 @@
-import { Flag } from "@/flag/flag"
 import type { MessageV2 } from "../message-v2"
 
 /**
- * Empty / no-op tool-call loop guard.
+ * Empty / no-op tool-call detection.
  *
- * Sibling to text-ngram-detection: the text-ngram ladder only inspects TEXT
- * parts, so a model that spins by re-emitting content-free tool calls (or by
- * "calling a tool" that produces no structured tool part at all) slips past it
- * with no text to match. stepSignature (prompt.ts) also misses this: it signs
- * only `part.type === "tool"` steps and returns undefined for a step with zero
- * tool parts, so an empty terminal step is dropped from repeat counting instead
- * of counted. This module fills that gap with a pure classifier + a soft→hard
- * recovery ladder mirroring TEXT_NGRAM_MAX_RECOVERY.
+ * Detects two shapes of invalid assistant output:
  *
- * This is a HARNESS backstop for a MODEL bug: a degraded model that keeps
- * emitting empty/no-op steps will never self-correct from a reminder, so after
- * a bounded number of soft nudges the harness must hard-halt the turn rather
- * than spin forever.
+ *  (a) The step emitted one or more client (non-providerExecuted) tool parts,
+ *      but EVERY such tool part has an empty/invalid input — no keys, or only
+ *      keys whose values are null/undefined/empty-string/whitespace. The model
+ *      "called a tool" but passed nothing actionable.
+ *
+ *  (b) The step produced NO client tool part at all AND no substantive text and
+ *      no substantive reasoning — a fully empty terminal.
+ *
+ * A step that emits at least one tool part with real input, or any substantive
+ * text/reasoning, is NOT empty — the model is making some kind of progress.
+ *
+ * Provider-executed tool parts (e.g. server-side web search) are ignored for
+ * the "has a tool part" test: they are not client actions and their presence
+ * does not mean the model issued an actionable call.
  */
-
-export const EMPTY_STEP_MAX_RECOVERY = Flag.MIMOCODE_EMPTY_STEP_MAX_RECOVERY
 
 /**
  * Is this assistant step an empty / no-op tool call?
@@ -34,9 +34,7 @@ export const EMPTY_STEP_MAX_RECOVERY = Flag.MIMOCODE_EMPTY_STEP_MAX_RECOVERY
  *
  *  (b) The step produced NO client tool part at all AND no substantive text and
  *      no substantive reasoning — a fully empty terminal. (This overlaps with
- *      classify's `invalid`/"empty output", but we count it here too so the
- *      hard-halt ladder can escalate on a run of them rather than only softly
- *      nudging via autoContinueInvalidOutput.)
+ *      classify's `invalid`/"empty output".)
  *
  * A step that emits at least one tool part with real input, or any substantive
  * text/reasoning, is NOT empty — the model is making some kind of progress.
@@ -71,13 +69,17 @@ export function isEmptyStep(parts: readonly MessageV2.Part[]): boolean {
 }
 
 /**
- * An input object counts as empty when it has no keys, or every value is
- * null/undefined/empty-string/whitespace-only. Nested objects/arrays with any
- * content count as non-empty (the model passed *something*).
+ * An input object counts as empty when it has no (non-meta) keys, or every
+ * value is null/undefined/empty-string/whitespace-only. Keys prefixed with
+ * "_" (harness bookkeeping like _meta) are excluded from the check.
+ * Nested objects/arrays with any content count as non-empty (the model
+ * passed *something*).
  */
-function isEmptyInput(input: Record<string, unknown> | undefined | null): boolean {
+export function isEmptyInput(input: Record<string, unknown> | undefined | null): boolean {
   if (input === undefined || input === null) return true
-  const keys = Object.keys(input)
+  // Filter out meta/underscore-prefixed fields — they are harness
+  // bookkeeping, not actionable tool arguments.
+  const keys = Object.keys(input).filter((k) => !k.startsWith("_"))
   if (keys.length === 0) return true
   return keys.every((k) => isEmptyValue(input[k]))
 }
@@ -90,24 +92,3 @@ function isEmptyValue(value: unknown): boolean {
   // number / boolean → the model passed a real value.
   return false
 }
-
-export const EMPTY_STEP_RECOVERY_REMIND = [
-  "<system-reminder>",
-  "NO PROGRESS: your previous step made no valid tool call and produced no answer",
-  "(the tool call had empty/invalid arguments, or there was no tool call and no text).",
-  "Stop repeating an empty step. Do exactly ONE of these now:",
-  "- Issue a valid tool call with COMPLETE, non-empty arguments, or",
-  "- Reply to the user directly with plain text.",
-  "Do NOT emit another empty or argument-less tool call.",
-  "</system-reminder>",
-].join("\n")
-
-export const EMPTY_STEP_RECOVERY_REPLAN = [
-  "<system-reminder>",
-  "STILL NO PROGRESS: you are repeating empty/no-op tool calls after a reminder.",
-  "This is your final chance before the turn is halted. You MUST either:",
-  "1. Send a single valid tool call whose arguments are fully populated, or",
-  "2. Give the user a plain-text response explaining the result or the blocker.",
-  "Any further empty/argument-less tool call will terminate this turn.",
-  "</system-reminder>",
-].join("\n")

--- a/packages/opencode/test/session/empty-step-detection.test.ts
+++ b/packages/opencode/test/session/empty-step-detection.test.ts
@@ -5,10 +5,10 @@ import type { MessageV2 } from "../../src/session/message-v2"
 // Minimal part builders — only the fields isEmptyStep inspects. Cast through
 // unknown so we don't have to satisfy the full PartBase shape (id/messageID/…)
 // that isEmptyStep never reads.
-function toolPart(input: Record<string, unknown>, opts?: { providerExecuted?: boolean; status?: string }) {
+function toolPart(input: Record<string, unknown>, opts?: { providerExecuted?: boolean; status?: string; name?: string }) {
   return {
     type: "tool",
-    tool: "read",
+    tool: opts?.name ?? "read",
     metadata: opts?.providerExecuted ? { providerExecuted: true } : undefined,
     state: { status: opts?.status ?? "completed", input },
   } as unknown as MessageV2.Part
@@ -26,6 +26,9 @@ function textPart(text: string, opts?: { synthetic?: boolean; ignored?: boolean 
 function reasoningPart(text: string) {
   return { type: "reasoning", text } as unknown as MessageV2.Part
 }
+
+// toolHasArgs lookup: "plan_exit" and "plan_enter" have no required params.
+const toolHasArgs = (name: string) => name !== "plan_exit" && name !== "plan_enter"
 
 describe("isEmptyStep — case (a): tool call with empty/invalid input", () => {
   test("tool call with no keys is empty", () => {
@@ -61,6 +64,52 @@ describe("isEmptyStep — case (a): tool call with empty/invalid input", () => {
   test("provider-executed tool part is ignored for the has-tool test", () => {
     // Only a provider-executed part + no substantive output => empty terminal.
     expect(isEmptyStep([toolPart({ q: "x" }, { providerExecuted: true })])).toBe(true)
+  })
+})
+
+describe("isEmptyStep — schema-aware: no-arg tools are not flagged", () => {
+  test("no-arg tool (plan_exit) called with {} is NOT flagged empty", () => {
+    expect(isEmptyStep([toolPart({}, { name: "plan_exit" })], { toolHasArgs })).toBe(false)
+  })
+
+  test("no-arg tool (plan_enter) called with {} is NOT flagged empty", () => {
+    expect(isEmptyStep([toolPart({}, { name: "plan_enter" })], { toolHasArgs })).toBe(false)
+  })
+
+  test("args-accepting tool (read) called with {} IS still flagged empty", () => {
+    expect(isEmptyStep([toolPart({}, { name: "read" })], { toolHasArgs })).toBe(true)
+  })
+
+  test("without toolHasArgs, legacy behaviour: all {} inputs flagged", () => {
+    // No opts → defaults to hasArgs=true for all tools (backwards-compat).
+    expect(isEmptyStep([toolPart({}, { name: "plan_exit" })])).toBe(true)
+  })
+
+  test("no-arg tool with substantive text alongside is NOT empty", () => {
+    expect(
+      isEmptyStep(
+        [textPart("Exiting plan mode."), toolPart({}, { name: "plan_exit" })],
+        { toolHasArgs },
+      ),
+    ).toBe(false)
+  })
+
+  test("args-accepting tool with substantive text alongside is NOT empty", () => {
+    expect(
+      isEmptyStep(
+        [textPart("Reading the file."), toolPart({}, { name: "read" })],
+        { toolHasArgs },
+      ),
+    ).toBe(false)
+  })
+
+  test("no-arg tool with substantive reasoning alongside is NOT empty", () => {
+    expect(
+      isEmptyStep(
+        [reasoningPart("Let me exit plan mode."), toolPart({}, { name: "plan_exit" })],
+        { toolHasArgs },
+      ),
+    ).toBe(false)
   })
 })
 

--- a/packages/opencode/test/session/empty-step-guard-integration.test.ts
+++ b/packages/opencode/test/session/empty-step-guard-integration.test.ts
@@ -1,18 +1,23 @@
 /**
- * Integration tests for the empty/no-op tool-call loop guard (handleEmptyStep +
+ * Integration tests for the empty tool-call retry guard (autoRetryEmptyToolCall +
  * isEmptyStep). Driven end-to-end through Session.prompt against a scripted
  * HTTP LLM stub — same harness as classify-integration.test.ts.
  *
  * Root cause this guards: a degraded model can spin by emitting empty/no-op
  * steps (empty terminal, or a tool call with empty arguments). TEXT_NGRAM only
  * inspects text and stepSignature drops zero-tool steps, so neither counts the
- * loop. The guard escalates soft (remind → replan) up to
- * EMPTY_STEP_MAX_RECOVERY, then HARD-HALTS the turn.
+ * loop.
  *
- * EMPTY_STEP_MAX_RECOVERY defaults to 2, so the ladder is:
- *   step 1 (empty) → streak 1 → REMIND nudge, continue
- *   step 2 (empty) → streak 2 → REPLAN nudge, continue
- *   step 3 (empty) → streak 3 > 2 → terminal error, break
+ * Design: a SINGLE empty tool call is an invalid output — it IMMEDIATELY
+ * triggers a RETRY that makes the model re-emit a valid call. The bad
+ * assistant turn is DISCARDED (error-tagged) and a synthetic user turn is
+ * appended to re-drive generation. On exhaustion (EMPTY_TOOL_CALL_RETRY_LIMIT
+ * retries) the turn is terminated.
+ *
+ * EMPTY_TOOL_CALL_RETRY_LIMIT defaults to 2, so the ladder is:
+ *   call 1 (empty) → retry 1 (error-tagged, synthetic user appended)
+ *   call 2 (empty) → retry 2 (error-tagged, synthetic user appended)
+ *   call 3 (empty) → exhaustion → terminal error, break
  * i.e. exactly 3 model calls before the turn is halted.
  */
 
@@ -22,7 +27,8 @@ import { Effect, Layer } from "effect"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
 import { SessionPrompt } from "../../src/session/prompt"
-import { EMPTY_STEP_MAX_RECOVERY } from "../../src/session/prompt/empty-step-detection"
+import { MessageV2 } from "../../src/session/message-v2"
+import { Flag } from "../../src/flag/flag"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
 import { startScriptedLLMServer, emptyStopResponse, textStopResponse } from "../lib/scripted-llm-server"
@@ -53,12 +59,13 @@ function writeConfig(dir: string, origin: string) {
   )
 }
 
-describe("empty/no-op tool-call loop guard — integration", () => {
-  test("repeated empty steps HARD-HALT the turn instead of looping forever", async () => {
+describe("empty tool-call retry — integration", () => {
+  test("repeated empty steps exhaust retries and halt the turn", async () => {
     await using tmp = await tmpdir({ git: true })
     // Every response is an empty stop step. The stub repeats its last entry
-    // forever, so if the guard failed to halt this would spin indefinitely
-    // (the test would hang / time out). We assert it terminates.
+    // forever, so if the retry guard failed to halt this would spin indefinitely
+    // (the test would hang / time out). We assert it terminates after retries
+    // are exhausted.
     const stub = startScriptedLLMServer([{ lines: emptyStopResponse() }])
     try {
       await writeConfig(tmp.path, stub.origin)
@@ -78,8 +85,8 @@ describe("empty/no-op tool-call loop guard — integration", () => {
               // Turn terminated (did not hang) with an error on the assistant.
               expect(result.info.role).toBe("assistant")
               if (result.info.role === "assistant") expect(result.info.error).toBeDefined()
-              // Bounded: EMPTY_STEP_MAX_RECOVERY soft nudges + 1 halting step.
-              expect(stub.captures.length).toBe(EMPTY_STEP_MAX_RECOVERY + 1)
+              // Bounded: EMPTY_TOOL_CALL_RETRY_LIMIT retries + 1 initial call.
+              expect(stub.captures.length).toBe(Flag.MIMOCODE_EMPTY_TOOL_CALL_RETRY_LIMIT + 1)
             }),
           ),
       })
@@ -88,12 +95,12 @@ describe("empty/no-op tool-call loop guard — integration", () => {
     }
   })
 
-  test("a single empty step recovers when the next step produces a real answer (no halt)", async () => {
+  test("a single empty step triggers retry and recovers on next valid answer", async () => {
     await using tmp = await tmpdir({ git: true })
     const stub = startScriptedLLMServer([
-      // step 1: empty terminal → streak 1 → REMIND nudge, continue
+      // call 1: empty terminal → retry (error-tagged, synthetic user appended)
       { lines: emptyStopResponse() },
-      // step 2: real answer → streak reset, loop exits cleanly
+      // call 2: real answer → loop exits cleanly
       { lines: textStopResponse("here is the real answer") },
     ])
     try {
@@ -111,10 +118,56 @@ describe("empty/no-op tool-call loop guard — integration", () => {
                 agent: "build",
                 parts: [{ type: "text", text: "Do the task." }],
               })
+              // First empty call → retry; second call → valid text. 2 total LLM calls.
               expect(stub.captures.length).toBe(2)
               expect(result.info.role).toBe("assistant")
               if (result.info.role === "assistant") expect(result.info.error).toBeUndefined()
               expect(result.parts.some((p) => p.type === "text" && p.text === "here is the real answer")).toBe(true)
+            }),
+          ),
+      })
+    } finally {
+      await stub.stop()
+    }
+  })
+
+  test("single empty step is discarded (error-tagged) from context", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const stub = startScriptedLLMServer([
+      { lines: emptyStopResponse() },
+      { lines: textStopResponse("final answer after retry") },
+    ])
+    try {
+      await writeConfig(tmp.path, stub.origin)
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const prompt = yield* SessionPrompt.Service
+              const session = yield* sessions.create({ title: "empty-step-discard" })
+              const result = yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "build",
+                parts: [{ type: "text", text: "Do the task." }],
+              })
+              // The first (empty) assistant turn should be error-tagged (discarded)
+              // and not kept in context. The second turn should be the valid one.
+              const messages = yield* sessions.messages({ sessionID: session.id, agentID: "main" })
+              const assistantMessages = messages.filter(
+                (m) => m.info.role === "assistant",
+              ) as Array<{ info: MessageV2.Assistant; parts: MessageV2.Part[] }>
+              // First assistant message should have an error (discarded)
+              expect(assistantMessages.length).toBeGreaterThanOrEqual(1)
+              if (assistantMessages[0]) {
+                expect(assistantMessages[0].info.error).toBeDefined()
+                expect(assistantMessages[0].info.error?.name).toBe("EmptyToolCallError")
+              }
+              // Final result should have no error
+              if (result.info.role === "assistant") {
+                expect(result.info.error).toBeUndefined()
+              }
             }),
           ),
       })

--- a/packages/opencode/test/session/empty-step-guard-integration.test.ts
+++ b/packages/opencode/test/session/empty-step-guard-integration.test.ts
@@ -31,7 +31,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { Flag } from "../../src/flag/flag"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
-import { startScriptedLLMServer, emptyStopResponse, textStopResponse } from "../lib/scripted-llm-server"
+import { startScriptedLLMServer, emptyStopResponse, textStopResponse, toolCallResponse } from "../lib/scripted-llm-server"
 
 void Log.init({ print: false })
 
@@ -168,6 +168,47 @@ describe("empty tool-call retry — integration", () => {
               if (result.info.role === "assistant") {
                 expect(result.info.error).toBeUndefined()
               }
+            }),
+          ),
+      })
+    } finally {
+      await stub.stop()
+    }
+  })
+
+  test("case-(a) empty call with live completed tool part: exhaustion terminates loop", async () => {
+    // Regression: a tool call with empty args {} that executes to status=completed
+    // (e.g. bash {command:' '} that runs successfully) was previously classified
+    // as "continue" by classify step #1 (completed tool part), causing the loop
+    // to re-drive indefinitely after retry exhaustion. The fix adds !assistant.error
+    // to classify step #1 and makes autoRetryEmptyToolCall return "break" on
+    // exhaustion so the caller terminates explicitly.
+    await using tmp = await tmpdir({ git: true })
+    // Every response is a tool call with empty args. The stub repeats its last
+    // entry forever, so if the guard failed to halt this would spin indefinitely.
+    const stub = startScriptedLLMServer([
+      { lines: toolCallResponse({ id: "call_0", name: "bash", args: "{}" }) },
+    ])
+    try {
+      await writeConfig(tmp.path, stub.origin)
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const prompt = yield* SessionPrompt.Service
+              const session = yield* sessions.create({ title: "empty-tool-part-halt" })
+              const result = yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "build",
+                parts: [{ type: "text", text: "Run a command." }],
+              })
+              // Turn terminated (did not hang) with an error on the assistant.
+              expect(result.info.role).toBe("assistant")
+              if (result.info.role === "assistant") expect(result.info.error).toBeDefined()
+              // Bounded: EMPTY_TOOL_CALL_RETRY_LIMIT retries + 1 initial call.
+              expect(stub.captures.length).toBe(Flag.MIMOCODE_EMPTY_TOOL_CALL_RETRY_LIMIT + 1)
             }),
           ),
       })

--- a/packages/opencode/test/session/invalid-output-continuation.test.ts
+++ b/packages/opencode/test/session/invalid-output-continuation.test.ts
@@ -115,12 +115,11 @@ describe("invalid-output continuation — integration", () => {
     }
   })
 
-  test("repeated empty output is caught by the empty-step guard and halts the turn", async () => {
+  test("repeated empty output exhausts retry limit and halts the turn", async () => {
     await using tmp = await tmpdir({ git: true })
     // Server repeats the last entry, so every call returns an empty stop.
-    // The empty/no-op tool-call guard (empty-step-detection) intercepts these
-    // empty terminals BEFORE autoContinueInvalidOutput and hard-halts the turn
-    // after EMPTY_STEP_MAX_RECOVERY soft nudges + 1 halting step.
+    // The empty tool-call retry guard (autoRetryEmptyToolCall) intercepts these
+    // and retries up to EMPTY_TOOL_CALL_RETRY_LIMIT, then terminates the turn.
     const stub = startScriptedLLMServer([{ lines: emptyStopResponse() }])
     try {
       await writeConfig(tmp.path, stub.origin)
@@ -137,8 +136,8 @@ describe("invalid-output continuation — integration", () => {
                 agent: "build",
                 parts: [{ type: "text", text: "Answer my question." }],
               })
-              // EMPTY_STEP_MAX_RECOVERY soft nudges + 1 halting step.
-              expect(stub.captures.length).toBe(Flag.MIMOCODE_EMPTY_STEP_MAX_RECOVERY + 1)
+              // EMPTY_TOOL_CALL_RETRY_LIMIT retries + 1 initial call.
+              expect(stub.captures.length).toBe(Flag.MIMOCODE_EMPTY_TOOL_CALL_RETRY_LIMIT + 1)
               expect(result.info.role).toBe("assistant")
               if (result.info.role === "assistant") {
                 expect(result.info.error).toBeDefined()

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1,6 +1,7 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { expect } from "bun:test"
 import { Cause, Effect, Exit, Fiber, Layer } from "effect"
+import { tool, jsonSchema } from "ai"
 import path from "path"
 import type { Agent } from "../../src/agent/agent"
 import { Agent as AgentSvc } from "../../src/agent/agent"
@@ -847,6 +848,72 @@ it.live("session.processor effect tests mark interruptions aborted without manua
           expect(stored.info.error?.name).toBe("MessageAbortedError")
         }
         expect(state).toMatchObject({ type: "idle" })
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests stop on 3 consecutive empty tool calls", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        // Single response with 3 empty tool calls: two {}, one {_meta:'harmless'}.
+        yield* llm.push(
+          raw({
+            head: [
+              { id: "chatcmpl-test", object: "chat.completion.chunk", choices: [{ delta: { role: "assistant" } }] },
+              { id: "chatcmpl-test", object: "chat.completion.chunk", choices: [{ delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "bash", arguments: "" } }] } }] },
+              { id: "chatcmpl-test", object: "chat.completion.chunk", choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: "{}" } }] } }] },
+              { id: "chatcmpl-test", object: "chat.completion.chunk", choices: [{ delta: { tool_calls: [{ index: 1, id: "call_2", type: "function", function: { name: "bash", arguments: "" } }] } }] },
+              { id: "chatcmpl-test", object: "chat.completion.chunk", choices: [{ delta: { tool_calls: [{ index: 1, function: { arguments: "{}" } }] } }] },
+              { id: "chatcmpl-test", object: "chat.completion.chunk", choices: [{ delta: { tool_calls: [{ index: 2, id: "call_3", type: "function", function: { name: "bash", arguments: "" } }] } }] },
+              { id: "chatcmpl-test", object: "chat.completion.chunk", choices: [{ delta: { tool_calls: [{ index: 2, function: { arguments: '{"_meta":"harmless"}' } }] } }] },
+            ],
+            tail: [
+              { id: "chatcmpl-test", object: "chat.completion.chunk", choices: [{ delta: {}, finish_reason: "tool_calls" }] },
+            ],
+          }),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "empty steps")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        // Register a no-op tool so the AI SDK accepts the tool calls.
+        const noopTool = tool({
+          description: "no-op",
+          inputSchema: jsonSchema({ type: "object", properties: {} }),
+          execute: async () => ({ output: "", title: "", metadata: {} }),
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "empty steps" }],
+          tools: { bash: noopTool },
+        })
+
+        expect(value).toBe("stop")
+        expect(handle.message.error).toBeDefined()
+        expect(handle.message.error?.name).toBe("UnknownError")
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -853,13 +853,15 @@ it.live("session.processor effect tests mark interruptions aborted without manua
   ),
 )
 
-it.live("session.processor effect tests stop on 3 consecutive empty tool calls", () =>
+it.live("session.processor effect tests: empty tool calls execute normally (retry handled by prompt loop)", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
         const { processors, session, provider } = yield* boot()
 
         // Single response with 3 empty tool calls: two {}, one {_meta:'harmless'}.
+        // The processor no longer has a threshold-halt guard — empty tool calls
+        // execute normally. Retry logic lives in the prompt loop (autoRetryEmptyToolCall).
         yield* llm.push(
           raw({
             head: [
@@ -911,9 +913,11 @@ it.live("session.processor effect tests stop on 3 consecutive empty tool calls",
           tools: { bash: noopTool },
         })
 
-        expect(value).toBe("stop")
-        expect(handle.message.error).toBeDefined()
-        expect(handle.message.error?.name).toBe("UnknownError")
+        // Processor no longer halts on empty tool calls — it returns "continue"
+        // (there are pending tool parts) so the prompt loop can handle retries.
+        expect(value).toBe("continue")
+        // No error on the message — processor executed the tools normally.
+        expect(handle.message.error).toBeUndefined()
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),


### PR DESCRIPTION
Reopens work from #1726 (auto-closed by a rebase force-push). Empty tool calls trigger an immediate single retry (mirrors autoRetryTextToolCall) instead of threshold-halt; isEmptyStep is schema-aware so no-arg tools like plan_exit called with {} are not false-flagged.