### PR TITLE
fix(mcp): don't drop a server's tools over one unresolvable $ref schema (#1652)

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -1,5 +1,5 @@
 import { cmd } from "./cmd"
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { createClient } from "../../mcp/client"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import * as prompts from "@clack/prompts"
@@ -760,10 +760,7 @@ export const McpDebugCommand = cmd({
             })
 
             try {
-              const client = new Client({
-                name: "mimocode-debug",
-                version: InstallationVersion,
-              })
+              const client = createClient("mimocode-debug")
               await client.connect(transport)
               prompts.log.success("Connection successful (already authenticated)")
               await client.close()

--- a/packages/opencode/src/mcp/client.ts
+++ b/packages/opencode/src/mcp/client.ts
@@ -1,0 +1,38 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv"
+import type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator } from "@modelcontextprotocol/sdk/validation"
+import { InstallationVersion } from "../installation/version"
+import { Log } from "../util"
+
+const log = Log.create({ service: "mcp" })
+
+// The MCP SDK pre-compiles an ajv validator for every tool's outputSchema right
+// after tools/list (Client.cacheToolMetadata). Some servers — e.g. Google Stitch
+// — ship a tool whose outputSchema has a $ref ajv can't resolve (a #/$defs/…
+// entry the schema never defines), so ajv throws a MissingRefError and the whole
+// tools/list rejects, dropping every tool from that server (#1652).
+//
+// Fail open per tool: keep ajv's strict validation for the schemas it can
+// compile, and skip validation for the ones it can't, so a single exotic schema
+// no longer wipes out an entire server's tool list.
+export class ResilientSchemaValidator implements jsonSchemaValidator {
+  private readonly inner = new AjvJsonSchemaValidator()
+
+  getValidator<T>(schema: JsonSchemaType): JsonSchemaValidator<T> {
+    // ajv compiles synchronously and throws on a reference it can't resolve, so
+    // a sync try/catch is the only way to intercept it before it reaches the SDK.
+    try {
+      return this.inner.getValidator<T>(schema)
+    } catch (error) {
+      log.debug("skipping output validation for a tool whose schema could not be compiled", { error })
+      // Fall back to an always-true schema so the tool still loads and callable.
+      return this.inner.getValidator<T>({})
+    }
+  }
+}
+
+export function createClient(name = "mimocode") {
+  // A fresh validator per client keeps each server's ajv schema cache isolated,
+  // matching the SDK's own default of one AjvJsonSchemaValidator per Client.
+  return new Client({ name, version: InstallationVersion }, { jsonSchemaValidator: new ResilientSchemaValidator() })
+}

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -15,7 +15,7 @@ import { Log } from "../util"
 import { NamedError } from "@mimo-ai/shared/util/error"
 import z from "zod/v4"
 import { Installation } from "../installation"
-import { InstallationVersion } from "../installation/version"
+import { createClient } from "./client"
 import { withTimeout } from "@/util/timeout"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { McpOAuthProvider } from "./oauth-provider"
@@ -273,7 +273,7 @@ export const layer = Layer.effect(
         (t) =>
           Effect.tryPromise({
             try: () => {
-              const client = new Client({ name: "mimocode", version: InstallationVersion })
+              const client = createClient()
               return withTimeout(client.connect(t), timeout).then(() => client)
             },
             catch: (e) => (e instanceof Error ? e : new Error(String(e))),
@@ -777,7 +777,7 @@ export const layer = Layer.effect(
 
       return yield* Effect.tryPromise({
         try: () => {
-          const client = new Client({ name: "mimocode", version: InstallationVersion })
+          const client = createClient()
           return client
             .connect(transport)
             .then(() => ({ authorizationUrl: "", oauthState, client }) satisfies AuthResult)

--- a/packages/opencode/test/mcp/schema-ref.test.ts
+++ b/packages/opencode/test/mcp/schema-ref.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv"
+import type { JsonSchemaType } from "@modelcontextprotocol/sdk/validation"
+import { ResilientSchemaValidator } from "../../src/mcp/client"
+
+// An output schema whose $ref points at a $defs entry it never defines — the
+// dangling reference Google Stitch's upload_design_md ships, which made ajv throw
+// while the SDK compiled the schema and dropped every tool on the server (#1652).
+const danglingOutputSchema: JsonSchemaType = {
+  type: "object",
+  properties: { screens: { type: "array", items: { $ref: "#/$defs/ScreenInstance" } } },
+}
+
+describe("MCP tool-schema validation tolerates an unresolvable $ref (#1652)", () => {
+  test("the SDK's default validator throws on a dangling $ref (root cause)", () => {
+    expect(() => new AjvJsonSchemaValidator().getValidator(danglingOutputSchema)).toThrow(/resolve reference/)
+  })
+
+  test("ResilientSchemaValidator turns the throw into a skipped (accept-all) validation", () => {
+    const validate = new ResilientSchemaValidator().getValidator(danglingOutputSchema)
+    expect(validate({ screens: [] }).valid).toBe(true)
+  })
+
+  test("ResilientSchemaValidator keeps strict validation for schemas ajv can compile", () => {
+    const validate = new ResilientSchemaValidator().getValidator({
+      type: "object",
+      $defs: { Screen: { type: "object", properties: { id: { type: "string" } } } },
+      properties: { screen: { $ref: "#/$defs/Screen" } },
+      required: ["screen"],
+    })
+    expect(validate({ screen: { id: "x" } }).valid).toBe(true)
+    expect(validate({ screen: "not-an-object" }).valid).toBe(false)
+  })
+
+  test("separate validators keep isolated ajv caches (createClient builds one per client)", () => {
+    // Two schemas reusing the same $id but different shapes. createClient() gives
+    // each client its own ResilientSchemaValidator; a shared ajv would let the
+    // second reuse the first's cached $id and mis-validate, so the per-client
+    // instances must stay independent.
+    const schemaA: JsonSchemaType = {
+      $id: "urn:mimo:test:result",
+      type: "object",
+      properties: { a: { type: "number" } },
+      required: ["a"],
+    }
+    const schemaB: JsonSchemaType = {
+      $id: "urn:mimo:test:result",
+      type: "object",
+      properties: { b: { type: "string" } },
+      required: ["b"],
+    }
+    const validateA = new ResilientSchemaValidator().getValidator(schemaA)
+    const validateB = new ResilientSchemaValidator().getValidator(schemaB)
+    expect(validateA({ a: 1 }).valid).toBe(true)
+    expect(validateB({ b: "x" }).valid).toBe(true)
+    expect(validateB({ a: 1 }).valid).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #1652

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adding an MCP server whose tool schemas use `$ref`/`$defs` (Google Stitch here) fails with `can't resolve reference #/$defs/ScreenInstance from id #`, and you lose every tool on that server.

The throw is inside the MCP SDK itself, not the tool-loading code: right after `tools/list` the SDK compiles an ajv validator for each tool's `outputSchema`, and one of Stitch's tools (`upload_design_md`) has an output property that `$ref`s `#/$defs/ScreenInstance` while the schema never defines it — a dangling reference. ajv can't resolve it and throws, and that rejects the whole `listTools()`, so the server ends up contributing nothing.

The SDK lets a caller pass its own validator, but mimocode's MCP client wasn't setting one. This adds a thin wrapper that keeps ajv's normal validation for schemas that compile and skips it for the ones that don't, so one odd schema can't take the whole server down. Every `new Client()` goes through a single `createClient()` helper now.

### How did you verify your code works?

Against the live endpoint (`https://stitch.googleapis.com/mcp`, which lists tools without a key): `mimo mcp list` fails with the ref error and 0 tools before, and connects with all 15 tools after. `test/mcp/schema-ref.test.ts` covers the validator directly — the default ajv validator throws on the dangling `$ref`, and the wrapper stops that throw while still validating compilable schemas strictly and keeping each client's validator isolated. `bun typecheck` and `bun lint` are clean.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
