### PR TITLE
fix(task): rewrite main-session gate prompt to prevent self-answering

### DIFF
--- a/packages/opencode/src/task/gate.ts
+++ b/packages/opencode/src/task/gate.ts
@@ -54,16 +54,29 @@ const buildReentryText = (
     mode === "subagent"
       ? "You are about to finish, but these tasks you own are still unfinished:"
       : "You are about to finish, but these tasks in this session are still unfinished:"
-  const closingLine =
-    mode === "subagent"
-      ? "Then re-emit your final message starting with the **Status**/**Summary** header."
-      : "Then continue or respond."
+  if (mode === "subagent") {
+    return [
+      "<system-reminder>",
+      headline,
+      ...incomplete.map((t) => `- ${t.id} (${t.status}): ${t.summary}`),
+      "For EACH: complete the work then `task done <id> <summary>`, or `task abandon <id> <reason>` if it is genuinely not needed.",
+      "Then re-emit your final message starting with the **Status**/**Summary** header.",
+      "</system-reminder>",
+    ].join("\n")
+  }
   return [
     "<system-reminder>",
     headline,
     ...incomplete.map((t) => `- ${t.id} (${t.status}): ${t.summary}`),
-    "For EACH: complete the work then `task done <id> <summary>`, or `task abandon <id> <reason>` if it is genuinely not needed.",
-    closingLine,
+    "",
+    "For each task, pick the appropriate action:",
+    "- If you need user input to proceed: use the `question` tool to ask — it supports structured choices, open-ended free-text (pass empty options), and recommended options. Do NOT end your turn with an unanswered natural-language question.",
+    "- If the work is incomplete and you can continue without user input: continue working, then `task done <id> \"<summary>\"` when finished",
+    "- If already complete: `task done <id> \"<summary>\"`",
+    "- If blocked on something external: `task block <id> \"<reason>\"`",
+    "- If no longer needed: `task abandon <id> \"<reason>\"`",
+    "",
+    "Do NOT answer your own questions or assume user intent. If you asked something, get the answer via `question` before proceeding.",
     "</system-reminder>",
   ].join("\n")
 }

--- a/packages/opencode/test/task/gate.test.ts
+++ b/packages/opencode/test/task/gate.test.ts
@@ -65,8 +65,9 @@ describe("TaskGate.decide", () => {
         expect(result.incompleteTasks).toEqual(["T1"])
         expect(result.reentryText).toContain("<system-reminder>")
         expect(result.reentryText).toContain("T1 (open): Refactor parser")
-        expect(result.reentryText).toContain("`task done <id> <summary>`")
-        expect(result.reentryText).toContain("Then continue or respond.")
+        expect(result.reentryText).toContain("`task done <id>")
+        expect(result.reentryText).toContain("`question` tool")
+        expect(result.reentryText).toContain("Do NOT answer your own questions")
         expect(result.reentryText).not.toContain("Status")
         // Main-mode headline must NOT claim ownership: owner=undefined picks
         // up subagent-orphaned tasks the main agent didn't create. Saying


### PR DESCRIPTION
## Summary

- Rewrite task gate's main-session reentry prompt from "complete the work then continue or respond" to a structured decision tree that prevents the model from self-answering
- Offer `question` tool as the primary exit path when user input is needed
- Add explicit negative constraints: "Do NOT answer your own questions or assume user intent"

## Problem

When the model's turn is classified as "final" with open/in_progress tasks, the task gate injects a synthetic user message. The old prompt said:

```
For EACH: complete the work then `task done <id> <summary>`, or `task abandon <id> <reason>` if it is genuinely not needed.
Then continue or respond.
```

This caused the model to, after asking the user a question:
1. Receive the gate nudge saying "complete the work"
2. Answer its own question ("I'll just fix the core logic")
3. Start implementing, ignoring that the user never responded

## Solution

Replace the main-session gate prompt with a structured decision tree:

1. Need user input → use `question` tool (supports choices, free-text via empty options, recommendations)
2. Work incomplete, no user input needed → continue working, then `task done`
3. Already complete → `task done`
4. Blocked externally → `task block`
5. No longer needed → `task abandon`

When the model uses the `question` tool, the turn is not classified as "final" (pending tool call), so the gate never re-fires.

Subagent path is unchanged.