### PR TITLE
feat(skill): add uv/PEP 723 support to docx-official skill

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/README.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/README.md
@@ -31,7 +31,16 @@ right sub-guide.
 
 ## Quick start
 
-Install once:
+All scripts include [PEP 723](https://peps.python.org/pep-0723/) inline metadata, so
+`uv run` resolves dependencies automatically:
+
+```bash
+uv run scripts/audit.py report.docx           # opens cleanly?
+uv run scripts/extract_text.py report.docx    # what does it actually say?
+uv run scripts/render_pdf.py report.docx      # visual sanity check
+```
+
+If you don't use `uv`, install dependencies once:
 
 ```bash
 python3 -m pip install --upgrade python-docx lxml
@@ -53,9 +62,9 @@ doc.save("report.docx")
 Run the standard QA loop:
 
 ```bash
-python scripts/audit.py report.docx           # opens cleanly?
-python scripts/extract_text.py report.docx            # what does it actually say?
-python scripts/render_pdf.py report.docx             # visual sanity check
+uv run scripts/audit.py report.docx           # opens cleanly?
+uv run scripts/extract_text.py report.docx            # what does it actually say?
+uv run scripts/render_pdf.py report.docx             # visual sanity check
 ```
 
 ## Design goals

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/SKILL.md
@@ -38,6 +38,8 @@ python3 -m pip install --upgrade python-docx lxml
 #   Poppler   (for pdf → image, QA loop):   brew install poppler
 ```
 
+Alternatively, if this skill lives in a persistent workspace you can `uv init` a project, `uv add python-docx lxml`, and run scripts with `uv run scripts/...` from the project root — this gives you a lockfile and reproducible environment.
+
 All scripts here use the standard library plus `python-docx`. No proprietary dependencies.
 
 ## Common commands

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/SKILL.md
@@ -22,6 +22,14 @@ If the task mixes several of these, do them in this order: **read → plan → e
 
 ## One-time environment setup
 
+All scripts include [PEP 723](https://peps.python.org/pep-0723/) inline metadata, so `uv run` resolves dependencies automatically — no manual install step needed. Just run:
+
+```bash
+uv run scripts/extract_text.py input.docx
+```
+
+If you don't use `uv`, install dependencies once:
+
 ```bash
 python3 -m pip install --upgrade python-docx lxml
 # Optional but recommended:
@@ -36,25 +44,25 @@ All scripts here use the standard library plus `python-docx`. No proprietary dep
 
 ```bash
 # 1. Extract plain text (best for "what does this file say?" questions)
-python scripts/extract_text.py input.docx > input.txt
+uv run scripts/extract_text.py input.docx > input.txt
 
 # 2. Explode a .docx into readable XML for structural surgery
-python scripts/explode.py input.docx exploded/
+uv run scripts/explode.py input.docx exploded/
 
 # 3. Assemble an exploded directory into a fresh .docx
-python scripts/assemble.py exploded/ output.docx
+uv run scripts/assemble.py exploded/ output.docx
 
 # 4. Render a .docx as PDF (used for visual QA)
-python scripts/render_pdf.py output.docx           # writes output.pdf next to it
+uv run scripts/render_pdf.py output.docx           # writes output.pdf next to it
 
 # 5. Well-formedness check (ZIP integrity + parseable XML + python-docx open)
-python scripts/audit.py output.docx
+uv run scripts/audit.py output.docx
 
 # 6. Accept every tracked change without needing Word/LibreOffice
-python scripts/resolve_revisions.py reviewed.docx clean.docx
+uv run scripts/resolve_revisions.py reviewed.docx clean.docx
 
 # 7. Add a comment to an exploded directory
-python scripts/annotate.py exploded/ "Please check" --author "Reviewer" --anchor "text"
+uv run scripts/annotate.py exploded/ "Please check" --author "Reviewer" --anchor "text"
 ```
 
 Every script is a small, self-contained Python file. Read the top of the file for full CLI options.
@@ -100,11 +108,11 @@ Ask the user which one to use. If you cannot ask, default to the region implied 
 
 1. **Open cleanly** — no repair prompt.
    ```bash
-   python -c "import docx; docx.Document('output.docx')"   # loads without exceptions
+   uv run python -c "import docx; docx.Document('output.docx')"   # loads without exceptions
    ```
 2. **Text integrity** — no placeholder residue.
    ```bash
-   python scripts/extract_text.py output.docx | grep -Ei "TODO|TBD|\{\{|lorem|xxxx"
+   uv run scripts/extract_text.py output.docx | grep -Ei "TODO|TBD|\{\{|lorem|xxxx"
    ```
    Grep must return nothing.
 3. **Visual sanity** — render a PDF, open the first and last pages, scan for:
@@ -113,11 +121,11 @@ Ask the user which one to use. If you cannot ask, default to the region implied 
    - Images pushed to their own page because they exceeded content width.
    - Missing page numbers, wrong header/footer content.
    ```bash
-   python scripts/render_pdf.py output.docx
+   uv run scripts/render_pdf.py output.docx
    ```
 4. **Style hygiene** — every heading uses a real style, not just bold+large text:
    ```bash
-   python -c "
+   uv run python -c "
    import docx; d = docx.Document('output.docx')
    for p in d.paragraphs:
        if p.text and p.style.name == 'Normal' and p.runs and p.runs[0].bold:

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
@@ -320,9 +320,9 @@ python your_generator.py --out out/report.docx --data data.json
 Then run the four QA steps from `SKILL.md` — the ones you must never skip:
 
 ```bash
-python -c "import docx; docx.Document('out/report.docx')"
-python scripts/extract_text.py out/report.docx | grep -Ei "TODO|TBD|\{\{"
-python scripts/render_pdf.py out/report.docx
+uv run python -c "import docx; docx.Document('out/report.docx')"
+uv run scripts/extract_text.py out/report.docx | grep -Ei "TODO|TBD|\{\{"
+uv run scripts/render_pdf.py out/report.docx
 ```
 
 If the import check raises or the grep matches anything, treat it as a build

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/edit.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/edit.md
@@ -127,9 +127,9 @@ carries formatting you need to keep, run the `substitute()` helper over
 Use only when Workflow A cannot express the change (e.g. rewriting a `w:sdt` structured document tag, editing custom XML parts, splicing two documents together preserving numbering IDs).
 
 ```bash
-python scripts/explode.py template.docx exploded/
+uv run scripts/explode.py template.docx exploded/
 # … edit exploded/word/document.xml (or others) …
-python scripts/assemble.py exploded/ output.docx --sanity
+uv run scripts/assemble.py exploded/ output.docx --sanity
 ```
 
 `explode.py` pretty-prints every XML file so diffs are readable. `assemble.py` writes parts in the order declared by `[Content_Types].xml` with fixed mtimes, so a reassemble of an unchanged tree produces a byte-identical archive. Pass `--sanity` to run the required-parts and ZIP-integrity probes after writing.
@@ -202,10 +202,10 @@ Comments and revision marks live in separate XML parts. Three modes:
 Use the bundled script against an exploded directory:
 
 ```bash
-python scripts/explode.py template.docx exploded/
-python scripts/annotate.py exploded/ "Please double-check this figure." \
+uv run scripts/explode.py template.docx exploded/
+uv run scripts/annotate.py exploded/ "Please double-check this figure." \
     --author "Reviewer" --anchor '$4.2M'
-python scripts/assemble.py exploded/ commented.docx
+uv run scripts/assemble.py exploded/ commented.docx
 ```
 
 `annotate.py` wires up all three files that OOXML requires (`comments.xml`, the `.rels` entry, `[Content_Types].xml`) and inserts the anchor markers into `document.xml`. If the anchor string isn't found, it prints an XML snippet to paste in by hand.
@@ -235,7 +235,7 @@ if comments is not None:
 Use the bundled script — it walks the OOXML directly with `lxml` and needs no LibreOffice round-trip:
 
 ```bash
-python scripts/resolve_revisions.py reviewed.docx clean.docx
+uv run scripts/resolve_revisions.py reviewed.docx clean.docx
 ```
 
 Semantics: `<w:ins>` blocks are unwrapped (their content stays), `<w:del>` blocks are removed, formatting-change markers (`w:rPrChange`, `w:pPrChange`, …) are stripped, and paragraphs whose pilcrow is marked deleted are merged with the following paragraph — the same rules Word's *Accept All* applies.
@@ -251,7 +251,7 @@ soffice --headless --convert-to docx --outdir out/ reviewed.docx
 Word's error dialog rarely tells you what's wrong. Diagnose:
 
 ```bash
-python -c "
+uv run python -c "
 import zipfile, xml.etree.ElementTree as ET
 with zipfile.ZipFile('broken.docx') as z:
     for name in z.namelist():

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/read.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/read.md
@@ -13,9 +13,9 @@ Always start with the cheapest option that answers the question. If a user asks 
 ## Level 1 — plain text
 
 ```bash
-python scripts/extract_text.py input.docx                # body text to stdout
-python scripts/extract_text.py input.docx --out file.txt # write to a file
-python scripts/extract_text.py input.docx --all          # include headers, footers, footnotes, endnotes, comments
+uv run scripts/extract_text.py input.docx                # body text to stdout
+uv run scripts/extract_text.py input.docx --out file.txt # write to a file
+uv run scripts/extract_text.py input.docx --all          # include headers, footers, footnotes, endnotes, comments
 ```
 
 Output goes to stdout by default. Redirect where you need it.
@@ -106,7 +106,7 @@ If either is non-zero, tell the user the document has unaccepted changes before 
 When the structure walk misses something (custom XML parts, SDT / structured document tags, complex field switches):
 
 ```bash
-python scripts/explode.py input.docx exploded/
+uv run scripts/explode.py input.docx exploded/
 xmllint --format exploded/word/document.xml | less
 ```
 
@@ -155,7 +155,7 @@ To reproduce numbering exactly when regenerating, keep the original `numbering.x
 ### "Summarize this file"
 
 ```bash
-python scripts/extract_text.py --all report.docx > report.txt
+uv run scripts/extract_text.py --all report.docx > report.txt
 ```
 
 Then feed `report.txt` to your LLM. If you need heading structure preserved for the summary, iterate `python-docx` and emit your own Markdown — see the outlining snippet above.

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/annotate.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/annotate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["lxml"]
+# dependencies = ["lxml>=4.9"]
 # ///
 """Annotate an exploded `.docx` directory tree with a review comment.
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/annotate.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/annotate.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["lxml"]
+# ///
 """Annotate an exploded `.docx` directory tree with a review comment.
 
 Alternate implementation notes:
@@ -12,7 +16,7 @@ Alternate implementation notes:
       keeps its original formatting.
 
 Usage:
-    python annotate.py <exploded_dir> "comment text" [--author NAME] \
+    uv run annotate.py <exploded_dir> "comment text" [--author NAME] \
         [--anchor "text found in document.xml"]
 """
 from __future__ import annotations
@@ -27,7 +31,8 @@ from pathlib import Path
 try:
     from lxml import etree as _et
 except ImportError as exc:  # pragma: no cover
-    sys.stderr.write("annotate.py needs `lxml`. Install with: pip install lxml\n")
+    sys.stderr.write("annotate.py needs `lxml`. Run with `uv run annotate.py` (auto-installs) "
+                     "or: pip install lxml\n")
     raise
 
 _W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/assemble.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/assemble.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["lxml"]
+# dependencies = ["lxml>=4.9"]
 # ///
 """Assemble an exploded `.docx` directory tree back into a `.docx`.
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/assemble.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/assemble.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["lxml"]
+# ///
 """Assemble an exploded `.docx` directory tree back into a `.docx`.
 
 Alternate implementation notes:
@@ -12,7 +16,7 @@ Alternate implementation notes:
       Useful for reproducible builds and content-addressed caches.
 
 Usage:
-    python assemble.py <source_dir> <destination.docx> [--sanity]
+    uv run assemble.py <source_dir> <destination.docx> [--sanity]
 """
 from __future__ import annotations
 
@@ -25,7 +29,8 @@ from typing import Iterable
 try:
     from lxml import etree as _et
 except ImportError as exc:  # pragma: no cover
-    sys.stderr.write("assemble.py needs `lxml`. Install with: pip install lxml\n")
+    sys.stderr.write("assemble.py needs `lxml`. Run with `uv run assemble.py` (auto-installs) "
+                     "or: pip install lxml\n")
     raise
 
 _CONTENT_TYPES_NAME = "[Content_Types].xml"

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/audit.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/audit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["python-docx", "lxml"]
+# dependencies = ["python-docx>=1.0", "lxml>=4.9"]
 # ///
 """Report-style well-formedness inspection of a `.docx` file.
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/audit.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/audit.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["python-docx", "lxml"]
+# ///
 """Report-style well-formedness inspection of a `.docx` file.
 
 Alternate implementation notes:
@@ -17,7 +21,7 @@ Statuses:
 Exit code is 0 if no FAIL findings, 1 otherwise. 2 for argument errors.
 
 Usage:
-    python audit.py <file.docx> [--json]
+    uv run audit.py <file.docx> [--json]
 """
 from __future__ import annotations
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/explode.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/explode.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["lxml"]
+# ///
 """Explode a `.docx` archive into a browsable folder of pretty-printed XML.
 
 Alternate implementation notes:
@@ -10,7 +14,7 @@ Alternate implementation notes:
       keeps the "raw bytes are on disk" invariant available for debugging.
 
 Usage:
-    python explode.py <input.docx> <destination_dir> [--verbatim]
+    uv run explode.py <input.docx> <destination_dir> [--verbatim]
 
 Exit code 0 on success, 2 on argument or I/O errors.
 """
@@ -24,7 +28,8 @@ from pathlib import Path
 try:
     from lxml import etree as _et
 except ImportError as exc:  # pragma: no cover
-    sys.stderr.write("explode.py needs `lxml`. Install with: pip install lxml\n")
+    sys.stderr.write("explode.py needs `lxml`. Run with `uv run explode.py` (auto-installs) "
+                     "or: pip install lxml\n")
     raise
 
 XML_KINDS = frozenset({".xml", ".rels"})

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/explode.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/explode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["lxml"]
+# dependencies = ["lxml>=4.9"]
 # ///
 """Explode a `.docx` archive into a browsable folder of pretty-printed XML.
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/extract_text.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/extract_text.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["lxml"]
+# ///
 """Extract plain text from a `.docx` using XPath expressions.
 
 Alternate implementation notes:
@@ -11,9 +15,9 @@ Alternate implementation notes:
       subset of lxml's.
 
 Usage:
-    python extract_text.py <input.docx>
-    python extract_text.py <input.docx> --out out.txt
-    python extract_text.py <input.docx> --include-notes --include-comments
+    uv run extract_text.py <input.docx>
+    uv run extract_text.py <input.docx> --out out.txt
+    uv run extract_text.py <input.docx> --include-notes --include-comments
 """
 from __future__ import annotations
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/extract_text.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/extract_text.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["lxml"]
+# dependencies = ["lxml>=4.9"]
 # ///
 """Extract plain text from a `.docx` using XPath expressions.
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/render_pdf.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/render_pdf.py
@@ -7,7 +7,7 @@ Alternate implementation notes:
       doesn't ship the rest of the toolkit.
 
 Usage:
-    python render_pdf.py <input.docx> [--out-dir out/]
+    uv run render_pdf.py <input.docx> [--out-dir out/]
 """
 from __future__ import annotations
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/resolve_revisions.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/resolve_revisions.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["lxml"]
+# ///
 """Resolve every tracked revision in a `.docx` (accept-all semantics).
 
 Alternate implementation notes:
@@ -14,7 +18,7 @@ Alternate implementation notes:
       XSLT-shaped transform.
 
 Usage:
-    python resolve_revisions.py <input.docx> <output.docx>
+    uv run resolve_revisions.py <input.docx> <output.docx>
 """
 from __future__ import annotations
 
@@ -27,8 +31,8 @@ from typing import Iterable
 try:
     from lxml import etree as _et
 except ImportError as exc:  # pragma: no cover
-    sys.stderr.write("resolve_revisions.py needs `lxml`. "
-                     "Install with: pip install lxml\n")
+    sys.stderr.write("resolve_revisions.py needs `lxml`. Run with `uv run resolve_revisions.py` "
+                     "(auto-installs) or: pip install lxml\n")
     raise
 
 _W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/resolve_revisions.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/resolve_revisions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["lxml"]
+# dependencies = ["lxml>=4.9"]
 # ///
 """Resolve every tracked revision in a `.docx` (accept-all semantics).
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/transcode.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/transcode.py
@@ -10,8 +10,8 @@ Alternate implementation notes:
       knows how to write.
 
 Usage:
-    python transcode.py <input> --to pdf
-    python transcode.py <input> --to png --dpi 200 --out-dir out/
+    uv run transcode.py <input> --to pdf
+    uv run transcode.py <input> --to png --dpi 200 --out-dir out/
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Add PEP 723 inline script metadata to all Python scripts in `docx-official`, enabling `uv run scripts/...` to resolve dependencies automatically without manual install
- Update all command examples across SKILL.md, README.md, create.md, edit.md, read.md to use `uv run`
- Preserve `python3 -m pip install` as fallback for non-uv environments
- Pin version constraints (`lxml>=4.9`, `python-docx>=1.0`)
- Mention `uv init` as an alternative for persistent workspaces with lockfile

## Follow-up (separate PRs)

- xlsx-official: same uv treatment (has `runtime/` subpackage — may need `uv init` approach instead)
- pdf-official: same uv treatment (heavy deps)
- pptx-official: clarify "self-contained" claim in docs — `render_pdf.py`, `render_slides.py`, `contact_sheet.py` import from local `soffice_bridge.py`