### PR TITLE
docs(skill): add theme font pitfall to docx, clarify pptx script deps

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
@@ -250,6 +250,7 @@ def ref(paragraph, name):
 | Table borders vanish on save | You cleared `table.style` after populating cells | Set `table.style` **before** populating; don't reassign later. |
 | Image renders huge | Only `width` or `height` supplied ≥ page width | Compute `Cm(15)` (roughly page-content width) and let the other axis auto-scale. |
 | File opens with "content had problems" | Manually inserted XML with unbalanced tags | Reopen the exploded directory, run `xmllint --noout word/document.xml`, fix the offending element. |
+| "Missing font" warning on open (Cambria, Calibri, CJK fonts) | `python-docx` default template embeds font references in theme XML that may not be installed | Patch the theme after `Document()` — see recipe below. |
 | Chinese / non-ASCII text renders as `??` in some viewers | Font run has no East-Asian font | Set both `rFonts.ascii` and `rFonts.eastAsia`: `run.font.name = "Calibri"; run._element.rPr.rFonts.set(qn("w:eastAsia"), "Microsoft YaHei")` |
 
 ## Recipes
@@ -308,6 +309,38 @@ def shade_paragraph(paragraph, hex_color="F2F4F7"):
 p = doc.add_paragraph("Note: figures are unaudited.")
 shade_paragraph(p, "FFF4CE")
 ```
+
+### Patch default theme fonts (suppress "missing font" warnings)
+
+`Document()` ships with a theme referencing Cambria, Calibri, and CJK fallback fonts (MS Gothic, MS Mincho) that may not exist on the target system. Viewers warn about them even when every run has an explicit font. Patch the theme right after creation:
+
+```python
+from lxml import etree
+from docx.oxml.ns import qn
+
+doc = Document()
+
+# --- patch theme to use safe fonts ---
+theme_rel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
+theme_part = doc.part.part_related_by(theme_rel)
+theme_xml = etree.fromstring(theme_part.blob)
+
+for elem in theme_xml.iter():
+    tf = elem.get("typeface", "")
+    if tf in ("Cambria", "Calibri"):
+        elem.set("typeface", "Times New Roman")    # or your preferred Latin font
+    elif elem.tag.endswith("}font") and elem.get("script", "") in ("Hans", "Hant", "Jpan", "Hang"):
+        elem.set("typeface", "SimSun")             # or your preferred CJK font
+
+theme_part._blob = etree.tostring(theme_xml, xml_declaration=True, encoding="UTF-8", standalone=True)
+
+# --- patch Courier → Courier New in macro styles ---
+for style in doc.styles:
+    if hasattr(style, "font") and style.font.name == "Courier":
+        style.font.name = "Courier New"
+```
+
+Call this once, immediately after `Document()`, before adding content. Choose fonts you know exist on your target audience's systems. For CJK documents the most portable choices are SimSun / 宋体 (Chinese), MS Mincho (Japanese), or Malgun Gothic (Korean).
 
 ## Testing your generator
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
@@ -316,21 +316,20 @@ shade_paragraph(p, "FFF4CE")
 
 ```python
 from lxml import etree
-from docx.oxml.ns import qn
 
 doc = Document()
 
-# --- patch theme to use safe fonts ---
+# --- patch theme font definitions ---
 theme_rel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
 theme_part = doc.part.part_related_by(theme_rel)
 theme_xml = etree.fromstring(theme_part.blob)
 
-for elem in theme_xml.iter():
-    tf = elem.get("typeface", "")
-    if tf in ("Cambria", "Calibri"):
-        elem.set("typeface", "Times New Roman")    # or your preferred Latin font
-    elif elem.tag.endswith("}font") and elem.get("script", "") in ("Hans", "Hant", "Jpan", "Hang"):
-        elem.set("typeface", "SimSun")             # or your preferred CJK font
+ns = {"a": "http://schemas.openxmlformats.org/drawingml/2006/main"}
+for latin in theme_xml.xpath("//a:majorFont/a:latin | //a:minorFont/a:latin", namespaces=ns):
+    latin.set("typeface", "Times New Roman")       # or your preferred Latin font
+for font in theme_xml.xpath("//a:majorFont/a:font | //a:minorFont/a:font", namespaces=ns):
+    if font.get("script", "") in ("Hans", "Hant", "Jpan", "Hang"):
+        font.set("typeface", "SimSun")             # or your preferred CJK font
 
 theme_part._blob = etree.tostring(theme_xml, xml_declaration=True, encoding="UTF-8", standalone=True)
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
@@ -161,8 +161,10 @@ uv run scripts/insert_slide.py unpacked/ --blank-from slideLayout5.xml
 uv run scripts/diagnose.py output.pptx
 ```
 
-Every script is a small, self-contained Python file. Read the top of the file
-for its full CLI options.
+Every script is a small Python CLI. Some scripts (e.g. `render_pdf.py`,
+`render_slides.py`, `contact_sheet.py`) import from a shared helper
+(`soffice_bridge.py`) in the same directory — copy them together. Read the top
+of each file for its full CLI options.
 
 ## Live preview
 
@@ -393,7 +395,8 @@ isn't, inform the user and offer to spawn a vision subagent instead.
 - **Reading / extracting**: [`read.md`](read.md) — plain-text export
   (including speaker notes), structural walk, metadata, thumbnails, image
   extraction, conversion to PDF / PNG for QA.
-- **Scripts**: [`scripts/`](scripts/) — self-contained CLI utilities.
+- **Scripts**: [`scripts/`](scripts/) — CLI utilities (some share a local
+  `soffice_bridge.py` helper; copy together when extracting).
 - **Live preview**: [`scripts/preview.ts`](scripts/preview.ts) — launcher
   (start/stop); [`scripts/preview_server.ts`](scripts/preview_server.ts) —
   background server that watches .pptx, converts to PDF, serves with


### PR DESCRIPTION
Follow-up to #1739 (uv/PEP 723 support for docx-official).

## Summary

- **docx-official/create.md**: Add "missing font" warning to Common pitfalls table + XPath-targeted recipe for patching theme XML to use universally available fonts (verified with round-trip test). Prevents Cambria/Calibri/CJK font warnings on systems without those fonts.
- **pptx-official/SKILL.md**: Replace misleading "self-contained" claim — some scripts (`render_pdf.py`, `render_slides.py`, `contact_sheet.py`) import from a shared `soffice_bridge.py` helper. Updated wording to clarify "copy them together when extracting".

## Remaining follow-up (separate PRs)

- xlsx-official: uv treatment (has `runtime/` subpackage — likely needs `uv init` approach)
- pdf-official: uv treatment (heavy deps — pypdf, pdfplumber, pypdfium2, reportlab, Pillow)