### PR TITLE
feat: gate builtin skills by CLI availability

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/claude-code/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/claude-code/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: claude-code
+description: "Delegate coding tasks to Claude Code CLI (v2.1+) via the terminal. Use this skill whenever the task involves writing/fixing/refactoring code, reviewing diffs or PRs, running tests, git workflows, or any multi-step change to a codebase — even if the user doesn't say 'Claude Code'. Covers print mode (-p), interactive tmux sessions, and background (--bg) orchestration."
+version: 2.0.0
+license: MIT
+platforms: [linux, macos, windows]
+---
+
+# Claude Code Delegation
+
+Delegate coding work to Claude Code, Anthropic's autonomous coding agent CLI.
+
+**Setup (once):** `npm install -g @anthropic-ai/claude-code && claude auth login` · verify with `claude auth status` / `claude doctor`. CI token: `claude setup-token`. Full auth/install variants → `references/flags.md`.
+
+**Platform check (before running anything):** detect the OS first. All shell examples in this skill are POSIX (bash). Linux/macOS run them as-is. On **Windows**, run Claude Code natively in PowerShell/Git Bash for print and background modes, but interactive tmux orchestration requires **WSL**. Shell-syntax translation table (quoting, env vars, piping, paths) → `references/platforms.md`.
+
+## Mode Selection (decide FIRST)
+
+| Task shape | Mode | Why |
+|---|---|---|
+| One-shot task: fix bug, add feature, review diff, extract data | **Print `-p`** ← default | No PTY, no dialogs, structured output |
+| Multi-turn iterate: refactor → review → fix → test; needs slash commands | **Interactive tmux** → `references/interactive-tmux.md` | Full REPL, requires dialog handling |
+| Long-running, shouldn't block; large fan-out supervision | **Background `--bg`** | Native supervision via `claude agents` |
+| High-stakes PR review | **`claude ultrareview [pr#]`** | Cloud multi-agent, exit-code driven (uploads diff to cloud — never on branches with secrets) |
+
+Do NOT hand-roll tmux fan-outs for parallel work — prefer `--bg` + `claude agents --json --all`.
+
+## Print Mode (the 90% path)
+
+```
+terminal(command="claude -p 'Fix the auth bug in src/auth.py' \
+  --allowedTools 'Read,Edit' --max-turns 10 --output-format json",
+  workdir="/path/to/project", timeout=180)
+```
+
+**Always set:** `workdir` · `--max-turns` (5–10; print-mode only) · `--allowedTools` (least privilege: `Read,Edit,Write,Bash`, patterns like `Bash(git *)`).
+
+**JSON result fields:** `result` (text) · `session_id` (for resume) · `subtype` (`success` | `error_max_turns` | `error_budget`) · `total_cost_usd` · `num_turns` · `structured_output` (with `--json-schema`).
+
+**Common variants:**
+
+```bash
+git diff main... | claude -p 'Review for bugs' --max-turns 1     # pipe input, cheapest review
+claude -p 'Continue: add pooling' --resume <session_id>          # resume; --continue = latest in cwd; --fork-session = branch
+claude -p 'List functions' --output-format json --json-schema '<schema>' --max-turns 5   # structured extraction (needs turns to read files)
+claude --bare -p 'task' --settings ci.json                       # CI: skips hooks/plugins/CLAUDE.md; auth = ANTHROPIC_API_KEY only
+claude -p 'task' --max-budget-usd 0.50 --fallback-model haiku    # cost cap (min ~$0.05) + overload fallback
+```
+
+Streaming, stream-json events, bidirectional input, cache-reuse (`--exclude-dynamic-system-prompt-sections`) → `references/print-mode.md`.
+
+## Background Mode
+
+```bash
+claude --bg 'investigate flaky test in tests/api.test.ts'   # NOT compatible with -p
+claude agents --json --all                                   # list/inspect
+claude attach <id> | logs <id> | stop <id> | respawn <id> | rm <id>
+```
+
+## Guardrails & Gotchas (violations break agents)
+
+1. **`-p` auto-skips trust/permission dialogs** (any non-TTY does) — only run in trusted directories.
+2. **Interactive mode = tmux required** (Windows: only inside WSL — never attempt tmux in PowerShell/cmd; fall back to `-p` or `--bg`); two startup dialogs, and the `--dangerously-skip-permissions` dialog defaults to **"No, exit"** (must send `Down` then `Enter`). Full patterns → `references/interactive-tmux.md`.
+3. **Session resume is per-directory** — `--continue` only finds sessions from the same cwd.
+4. **Slash commands don't work in `-p`** — describe the task in natural language instead.
+5. **Context >70% degrades quality** — in interactive sessions monitor `/context`, use `/compact`.
+6. **Clean up**: kill tmux sessions and `claude stop/rm` background sessions when done.
+7. **Don't kill slow sessions** — capture progress first (`tmux capture-pane` / `claude logs`).
+8. **Report back**: after completion, summarize what changed (use the JSON `result` + `git diff`).
+
+## References (read on demand)
+
+| File | Read when |
+|---|---|
+| `references/print-mode.md` | Streaming output, stream-json events, piping, schemas, session mgmt, cache reuse |
+| `references/interactive-tmux.md` | Any tmux/PTY session: dialogs, send-keys, monitoring, slash commands, shortcuts |
+| `references/flags.md` | Full CLI flag & subcommand tables, auth variants, env vars, model/effort selection |
+| `references/config.md` | CLAUDE.md/memory, settings hierarchy, custom agents, hooks, MCP, plugins, project purge |
+| `references/platforms.md` | Running on Windows (PowerShell/Git Bash/WSL) or macOS: shell translation, paths, per-OS gotchas |

--- a/packages/opencode/src/skill/builtin/.bundle/claude-code/references/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/claude-code/references/config.md
@@ -1,0 +1,160 @@
+# Configuration: Settings, Memory, Agents, Hooks, MCP, Plugins
+
+## Settings Hierarchy (highest → lowest)
+
+1. CLI flags
+2. `.claude/settings.local.json` (personal, gitignored)
+3. `.claude/settings.json` (team, git-tracked)
+4. `~/.claude/settings.json` (global)
+
+### Permissions in settings
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(npm run lint:*)", "WebSearch", "Read"],
+    "ask": ["Write(*.ts)", "Bash(git push*)"],
+    "deny": ["Read(.env)", "Bash(rm -rf *)"]
+  }
+}
+```
+
+## CLAUDE.md & Memory
+
+Hierarchy: `~/.claude/CLAUDE.md` (global) → `./CLAUDE.md` (project, tracked) → `.claude/CLAUDE.local.md` (personal, gitignored). Auto-loaded from project root; survives `/compact`. Quick-add interactively with `#` prefix.
+
+Be specific: "2-space indentation for YAML, 4-space for Python", "test files end in `.test.ts`" — not "write good code".
+
+Example:
+```markdown
+# Project: My API
+## Architecture
+- FastAPI + SQLAlchemy, PostgreSQL, Redis cache; pytest, 90% coverage target
+## Key Commands
+- `make test` / `make lint` (ruff+mypy) / `make dev` (:8000)
+## Code Standards
+- Type hints on public functions; Google-style docstrings; no wildcard imports
+```
+
+### Rules directory (modular CLAUDE.md)
+- Project: `.claude/rules/*.md` (team, tracked)
+- User: `~/.claude/rules/*.md` (personal, global)
+
+Each `.md` loads as additional context — cleaner than one giant CLAUDE.md.
+
+### Auto-memory
+Claude stores learned context in `~/.claude/projects/<project>/memory/` (25KB / 200 lines per project). Separate from CLAUDE.md. Wipe with `claude project purge`.
+
+## Custom Slash Commands & Skills
+
+Slash command: `.claude/commands/<name>.md` (project) or `~/.claude/commands/<name>.md` (personal); `$ARGUMENTS` is replaced with user input. Invoked manually: `/deploy production`.
+
+Skill: `.claude/skills/<name>.md` — invoked automatically by natural-language match, no manual trigger.
+
+## Custom Subagents
+
+Priority: `.claude/agents/` (project) → `--agents` CLI flag (session) → `~/.claude/agents/` (personal).
+
+```markdown
+# .claude/agents/security-reviewer.md
+---
+name: security-reviewer
+description: Security-focused code review
+model: opus
+tools: [Read, Bash]
+---
+You are a senior security engineer. Review for injection, authz flaws, secrets, unsafe deserialization.
+```
+
+Invoke: `@security-reviewer review the auth module`. Orchestrate: "Use @db-expert to optimize queries, then @security to audit."
+
+Dynamic via CLI:
+```
+claude --agents '{"reviewer": {"description": "Reviews code", "prompt": "You are a performance-focused reviewer"}}' -p 'Use @reviewer to check auth.py'
+```
+
+Shared instructions for all subagents: `claude --append-subagent-system-prompt "Never edit tests without asking." -p "task"`
+
+## Hooks
+
+Configure in `.claude/settings.json` or `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Write(*.py)",
+      "hooks": [{"type": "command", "command": "ruff check --fix $CLAUDE_FILE_PATHS"}]
+    }],
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{"type": "command", "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'rm -rf|git push.*--force'; then echo 'Blocked!' && exit 2; fi"}]
+    }]
+  }
+}
+```
+
+| Hook | Fires | Use |
+|---|---|---|
+| `UserPromptSubmit` | Before processing a prompt | Validation, logging |
+| `PreToolUse` | Before tool execution | Security gates (exit 2 = block) |
+| `PostToolUse` | After tool finishes | Auto-format, lint |
+| `Notification` | Permission requests / input waits | Alerts |
+| `Stop` | Response finished | Completion logging |
+| `SubagentStop` | Subagent completes | Orchestration |
+| `PreCompact` | Before context compaction | Backup transcripts |
+| `SessionStart` | Session begins | Load dev context |
+
+Env vars in hooks: `CLAUDE_PROJECT_DIR`, `CLAUDE_FILE_PATHS`, `CLAUDE_TOOL_INPUT`.
+Observe hooks while scripting: `--output-format stream-json --verbose --include-hook-events`.
+
+## MCP
+
+```bash
+claude mcp add -s user github -- npx @modelcontextprotocol/server-github   # stdio
+claude mcp add -e API_KEY=xxx my-server -- npx my-mcp-server               # stdio + env
+claude mcp add --transport http sentry https://mcp.sentry.dev/mcp          # HTTP
+claude mcp add --transport http corridor https://app.corridor.dev/api/mcp --header 'Authorization: Bearer ...'
+claude mcp add-json my-server '{"command":"node","args":["server.js"]}'
+claude mcp add-from-claude-desktop            # import (macOS/WSL)
+claude mcp list | get <name> | remove <name>
+claude mcp login <name> | logout <name>       # OAuth (v2.1.186+)
+claude mcp reset-project-choices              # reset per-project .mcp.json approvals
+claude mcp serve                              # expose Claude Code itself as an MCP server
+```
+
+Scopes: `-s user` (global, `~/.claude.json`) · `-s local` (project personal, `settings.local.json`) · `-s project` (team, `settings.json`).
+
+CI/print: `claude --bare -p 'Query database' --mcp-config mcp-servers.json --strict-mcp-config`
+
+In chat, reference resources: `@github:issue://123`
+
+Limits: tool descriptions capped 2KB/server; result size capped by default (`maxResultSizeChars` annotation allows up to 500K chars); cap output with `MAX_MCP_OUTPUT_TOKENS`. Transports: `stdio`, `http`, `sse`.
+
+## Plugins
+
+`claude plugin` (alias `plugins`):
+
+| Subcommand | Purpose |
+|---|---|
+| `install\|i <plugin>` | Install (`plugin@marketplace` to pin) |
+| `uninstall\|remove` / `enable` / `disable` / `update` | Lifecycle (update needs restart) |
+| `list` / `details <name>` | Inventory + projected token cost |
+| `marketplace` | Add/list/remove marketplaces |
+| `prune` / `autoremove` | Remove orphaned auto-installed deps |
+| `validate <path>` / `tag [path]` | Validate manifest / create `{name}--v{version}` git tag |
+
+Session-only (no install): `claude --plugin-dir ./my-plugin --plugin-dir B.zip` or `--plugin-url https://example.com/plugin.zip`
+
+## Project State Purge
+
+Wipes transcripts, task lists, debug logs, file-edit history, prompt history, and the `~/.claude.json` entry. **Irreversible — always `--dry-run` first.**
+
+```bash
+claude project purge /path/to/project --dry-run
+claude project purge /path/to/project -y      # non-interactive
+claude project purge /path/to/project -i      # per-item confirm
+claude project purge --all -y                 # everything (dangerous)
+```
+
+Use before publishing repros, when disk grows, or to force fresh auto-memory.

--- a/packages/opencode/src/skill/builtin/.bundle/claude-code/references/flags.md
+++ b/packages/opencode/src/skill/builtin/.bundle/claude-code/references/flags.md
@@ -1,0 +1,137 @@
+# CLI Reference (v2.1.140+)
+
+Note: `--help` is incomplete — some flags exist without appearing there.
+
+## Auth & Install
+
+| Command | Purpose |
+|---|---|
+| `claude auth login` | Sign in (default `--claudeai`; also `--console`, `--sso`, `--email you@x.com`) |
+| `claude auth logout` / `auth status [--text]` | Log out / status (JSON default) |
+| `claude setup-token` | Long-lived OAuth token for CI (subscription-only) |
+| `claude doctor` | Read-only install/auto-updater diagnostics |
+| `claude --version` / `update` / `upgrade` | Version / update |
+| `claude install [stable\|latest\|<ver>] [--force]` | Install native build |
+
+## Subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `claude` / `claude "query"` | Interactive REPL (optionally with initial prompt) |
+| `claude -p "query"` | Print mode (one-shot, exits) |
+| `cat file \| claude -p "q"` | Pipe stdin as context |
+| `claude -c` / `claude -r "id"` | Continue latest in cwd / resume by ID or name |
+| `claude --bg "task"` | Supervised background session (not with `-p`, v2.1.198+) |
+| `claude attach/logs/stop/kill/respawn/rm <id>` | Manage background sessions; `respawn --all` after CLI upgrade |
+| `claude agents [--json --all] [--cwd] [--permission-mode]` | List/manage background + configured agents |
+| `claude ultrareview [target] [--json] [--timeout <min>]` | Cloud multi-agent review of branch/PR; exit 0/1; default 30 min |
+| `claude mcp ...` | MCP management → `config.md` |
+| `claude plugin` / `plugins` | Plugin management → `config.md` |
+| `claude project purge [path]` | Delete local project state → `config.md` |
+| `claude auto-mode` | Auto-mode classifier: `config`, `defaults`, `critique` |
+| `claude daemon` | Supervisor diagnostics: `status`, `stop --any --keep-workers` |
+| `claude gateway` | Self-hosted apps gateway for SSO/policy (v2.1.195+) |
+
+## Session & Environment Flags
+
+| Flag | Effect |
+|---|---|
+| `-p, --print` | One-shot non-interactive; skips trust dialog |
+| `-c, --continue` | Resume most recent conversation in cwd |
+| `-r, --resume [value]` | Resume by ID/name (picker if omitted) |
+| `--fork-session` | New session ID on resume, keeps history |
+| `--session-id <uuid>` | Pin a specific UUID |
+| `--no-session-persistence` | Don't save to disk (print only) |
+| `-n, --name <name>` | Display name (prompt box, `/resume`, terminal title) |
+| `--add-dir <paths...>` | Extra working dirs (loads their CLAUDE.md) |
+| `-w, --worktree [name]` | Isolated git worktree at `.claude/worktrees/<name>` |
+| `--tmux [=classic]` | tmux session for worktree (requires `--worktree`) |
+| `--ide` | Auto-connect to IDE |
+| `--chrome` / `--no-chrome` | Chrome integration for web testing |
+| `--from-pr [value]` | Resume session linked to a GitHub/GitLab/Bitbucket PR |
+| `--file <id:path...>` | Download file resources at startup |
+| `--bg "task"` / `--exec "cmd"` | Background session / supervised PTY background job |
+| `--cloud "task"` / `--teleport` | Create web session on claude.ai / resume it locally |
+| `--remote-control [name]` | Remote Control from claude.ai/mobile (`--remote-control-session-name-prefix <p>`) |
+
+## Model & Performance
+
+| Flag | Effect |
+|---|---|
+| `--model <alias>` | `sonnet`, `opus`, `haiku`, or full name |
+| `--effort <level>` | `low`/`medium`/`high`/`xhigh`/`max`/`ultracode` (v2.1.203+) |
+| `--max-turns <n>` | Cap agentic loops (print only) |
+| `--max-budget-usd <n>` | Spend cap (print only; min ~$0.05) |
+| `--fallback-model <m>` | Fallback on overload (print only) |
+| `--advisor <model>` | Server-side advisor: `opus`/`sonnet`/`fable` (v2.1.170+) |
+| `--betas <...>` | Beta API headers (API-key users only) |
+
+## Permission & Safety
+
+| Flag | Effect |
+|---|---|
+| `--dangerously-skip-permissions` | Auto-approve ALL tool use |
+| `--allow-dangerously-skip-permissions` | Enable bypass as an option, not default |
+| `--permission-mode <m>` | `default`, `manual` (v2.1.200+ alias), `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions` |
+| `--allowedTools` / `--disallowedTools <tools...>` | Whitelist / blacklist |
+| `--tools <tools...>` | Override built-in tool set (`""`=none, `"default"`=all) |
+| `--safe-mode` | Disable all customizations (v2.1.169+) |
+
+### Tool name syntax
+```
+Read | Edit | Write | Bash | WebSearch | WebFetch
+Bash(git *) | Bash(git commit *) | Bash(npm run lint:*)
+mcp__<server>__<tool>
+```
+
+## Output & Input
+
+| Flag | Effect |
+|---|---|
+| `--output-format` | `text` (default) / `json` / `stream-json` |
+| `--input-format` | `text` / `stream-json` (print only) |
+| `--json-schema <schema>` | Validated structured output |
+| `--verbose` | Full turn-by-turn |
+| `--include-partial-messages` | Partial chunks (stream-json + print) |
+| `--include-hook-events` | Hook lifecycle events (stream-json only) |
+| `--replay-user-messages` | Re-emit user messages on stdout |
+| `--ax-screen-reader` | Screen-reader-friendly output (v2.1.181+) |
+
+## System Prompt & Context
+
+| Flag | Effect |
+|---|---|
+| `--append-system-prompt <t>` | Add to default system prompt (usually preferred) |
+| `--system-prompt <t>` | Replace entire system prompt |
+| `--append-subagent-system-prompt <t>` | Append to every subagent's system prompt (v2.1.205+) |
+| `--exclude-dynamic-system-prompt-sections` | Per-machine sections → first user message (cache reuse) |
+| `--bare` | Minimal mode → `print-mode.md` |
+| `--agent <name>` / `--agents '<json>'` | Agent override / dynamic subagent definitions |
+| `--mcp-config <...>` / `--strict-mcp-config` | Load MCP servers / ignore all others |
+| `--settings <file-or-json>` | Extra settings |
+| `--setting-sources <s>` | Comma-separated: `user`, `project`, `local` |
+| `--plugin-dir <p>` / `--plugin-url <u>` | Session-only plugins (repeatable) |
+| `--disable-slash-commands` | Disable all skills/slash commands |
+| `--channels <...>` | MCP channel notifications (research preview) |
+
+## Debugging & Teams
+
+| Flag | Effect |
+|---|---|
+| `-d, --debug [filter]` | Debug logging (e.g. `"api,hooks"`, `"!1p,!file"`); `--mcp-debug` deprecated → `--debug mcp` |
+| `--debug-file <path>` | Debug log to file |
+| `--teammate-mode <m>` | Team display: `auto`/`in-process`/`tmux`/`iterm2` (v2.1.186+) |
+| `--brief` | Enable `SendUserMessage` agent-to-user tool |
+
+## Environment Variables
+
+| Variable | Effect |
+|---|---|
+| `ANTHROPIC_API_KEY` | API-key auth (alternative to OAuth) |
+| `CLAUDE_CODE_EFFORT_LEVEL` | Default effort level |
+| `CLAUDE_CODE_SIMPLE=1` | Minimal mode (set by `--bare`) |
+| `MAX_THINKING_TOKENS` | Cap thinking (`0` disables) |
+| `MAX_MCP_OUTPUT_TOKENS` | Cap MCP output (e.g. `50000`) |
+| `MCP_TIMEOUT` | MCP startup timeout ms; `--permission-prompt-tool` waits up to this (v2.1.206+) |
+| `CLAUDE_CODE_NO_FLICKER=1` | Alt-screen rendering, no flicker |
+| `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` | Strip credentials from subprocesses |

--- a/packages/opencode/src/skill/builtin/.bundle/claude-code/references/interactive-tmux.md
+++ b/packages/opencode/src/skill/builtin/.bundle/claude-code/references/interactive-tmux.md
@@ -1,0 +1,156 @@
+# Interactive Sessions via tmux
+
+Claude Code is a full TUI app — interactive orchestration requires tmux (`capture-pane` for monitoring, `send-keys` for input).
+
+**Platforms:** Linux/macOS run these patterns directly (macOS: `--worktree --tmux` prefers iTerm2 panes; force `--tmux=classic` when parsing capture-pane output). **Windows has no native tmux** — run every pattern in this file inside WSL (`wsl bash -c '...'`), or use print/background mode instead. See `references/platforms.md`.
+
+## Base Pattern
+
+```
+terminal(command="tmux new-session -d -s claude-work -x 140 -y 40")
+terminal(command="tmux send-keys -t claude-work 'cd /path/to/project && claude' Enter")
+terminal(command="sleep 5 && tmux send-keys -t claude-work 'Refactor the auth module to use JWT tokens' Enter")
+terminal(command="sleep 15 && tmux capture-pane -t claude-work -p -S -50")   # monitor
+terminal(command="tmux send-keys -t claude-work 'Now add unit tests for the new JWT code' Enter")
+terminal(command="tmux send-keys -t claude-work '/exit' Enter")
+```
+
+Always `tmux kill-session -t <name>` when done — background sessions persist.
+
+## Startup Dialogs (MUST handle)
+
+### Dialog 1: Workspace trust (first visit to a directory only, then cached)
+```
+❯ 1. Yes, I trust this folder    ← DEFAULT
+  2. No, exit
+```
+Handling: `tmux send-keys -t <session> Enter` (default is correct).
+
+### Dialog 2: Bypass-permissions warning (every `--dangerously-skip-permissions` run)
+```
+❯ 1. No, exit                    ← DEFAULT (WRONG choice!)
+  2. Yes, I accept
+```
+Handling: `tmux send-keys -t <session> Down && sleep 0.3 && tmux send-keys -t <session> Enter`
+
+### Robust launch sequence
+```
+terminal(command="tmux send-keys -t claude-work 'claude --dangerously-skip-permissions \"your task\"' Enter")
+terminal(command="sleep 4 && tmux send-keys -t claude-work Enter")                                    # trust
+terminal(command="sleep 3 && tmux send-keys -t claude-work Down && sleep 0.3 && tmux send-keys -t claude-work Enter")  # bypass
+terminal(command="sleep 15 && tmux capture-pane -t claude-work -p -S -60")
+```
+
+In `-p` / non-TTY mode both dialogs are auto-skipped.
+
+## Monitoring the TUI
+
+```
+tmux capture-pane -t dev -p -S -10
+```
+
+Indicators:
+- `❯` at bottom = waiting for input (done or asking a question)
+- `●` lines = actively using tools
+- `⏵⏵ bypass permissions on` = permissions mode in status bar
+- `◐ medium · /effort` = current effort level
+- `ctrl+o to expand` = truncated tool output
+
+Don't kill slow sessions — check progress instead; Claude may be mid multi-step work.
+
+### Context health (`/context`)
+- < 70%: normal
+- 70–85%: precision dropping → `/compact`
+- > 85%: hallucination risk spikes → `/compact` or `/clear`
+
+## Worktrees & PR Review
+
+```
+claude -w feature-x --tmux         # isolated git worktree at .claude/worktrees/feature-x + tmux session
+                                   # iTerm2 native panes when available; --tmux=classic for traditional tmux
+claude -p 'Review this PR thoroughly' --from-pr 42 --max-turns 10
+claude ultrareview [pr#] [--json] [--timeout <min>]   # cloud multi-agent review; exit 0/1; default 30 min
+```
+
+Deep interactive review:
+```
+terminal(command="tmux new-session -d -s review -x 140 -y 40")
+terminal(command="tmux send-keys -t review 'cd /repo && claude -w pr-review' Enter")
+terminal(command="sleep 5 && tmux send-keys -t review Enter")   # trust dialog
+terminal(command="sleep 2 && tmux send-keys -t review 'Review all changes vs main: bugs, security, race conditions, missing tests.' Enter")
+terminal(command="sleep 30 && tmux capture-pane -t review -p -S -60")
+```
+
+## Slash Commands
+
+### Session & context
+| Command | Purpose |
+|---|---|
+| `/help` | All commands (incl. custom + MCP) |
+| `/compact [focus]` | Compress context; CLAUDE.md survives |
+| `/clear` | Wipe history |
+| `/context` | Context usage grid + tips |
+| `/cost` | Token usage, per-model + cache-hit breakdown |
+| `/resume` | Switch/resume sessions |
+| `/rewind` | Revert to a checkpoint (conversation or code) |
+| `/btw <q>` | Side question without context cost |
+| `/status` | Version/connectivity/session info |
+| `/todos` | Tracked action items |
+| `/exit` / `Ctrl+D` | End session |
+
+### Development
+| Command | Purpose |
+|---|---|
+| `/review` | Code review of current changes |
+| `/security-review` | Security analysis |
+| `/plan [desc]` | Plan mode with auto-start |
+| `/loop [interval]` | Recurring tasks in-session |
+| `/batch` | Auto-create worktrees for large parallel changes (5–30) |
+
+### Config & tools
+| Command | Purpose |
+|---|---|
+| `/model` · `/effort` | Switch model / effort (`low`→`ultracode`) |
+| `/init` · `/memory` | Create / edit CLAUDE.md |
+| `/config` · `/permissions` · `/agents` · `/mcp` · `/add-dir` | Interactive config UIs |
+| `/usage` | Plan limits & rate-limit status |
+| `/voice` | Push-to-talk voice mode |
+| `/release-notes` | Version notes picker |
+
+Slash commands only work interactively — in `-p` mode describe the task in natural language.
+
+## Keyboard Shortcuts & Prefixes
+
+| Key | Action |
+|---|---|
+| `Ctrl+C` / `Ctrl+D` | Cancel / exit |
+| `Ctrl+R` | Reverse-search history |
+| `Ctrl+B` | Background a running task |
+| `Ctrl+V` | Paste image |
+| `Ctrl+O` | Transcript mode (thinking) |
+| `Ctrl+G` / `Ctrl+X Ctrl+E` | External editor |
+| `Esc Esc` | Rewind / summarize |
+| `Shift+Tab` | Cycle permission modes |
+| `Alt+P` / `Alt+T` / `Alt+O` | Model / thinking / Fast Mode toggles |
+| `\`+`Enter`, `Shift+Enter`, `Ctrl+J` | Newline |
+
+| Prefix | Action |
+|---|---|
+| `!` | Direct bash, bypass AI (`!` alone toggles shell mode) |
+| `@` | File/dir reference with autocomplete; also `@agent-name`, `@github:issue://123` |
+| `#` | Quick-add to CLAUDE.md memory |
+| `/` | Slash commands |
+
+Keyword **"ultrathink"** in a prompt = maximum reasoning effort for that turn, regardless of `/effort`.
+
+## Parallel Instances
+
+Hand-rolled tmux fan-out (small scale only):
+
+```
+tmux new-session -d -s task1 -x 140 -y 40 && tmux send-keys -t task1 'cd ~/project && claude -p "Fix auth bug" --allowedTools "Read,Edit" --max-turns 10' Enter
+# ... task2, task3 ...
+for s in task1 task2 task3; do echo "=== $s ==="; tmux capture-pane -t $s -p -S -5; done
+```
+
+For large fan-outs prefer `--bg` + `claude agents --json --all` (native supervision).

--- a/packages/opencode/src/skill/builtin/.bundle/claude-code/references/platforms.md
+++ b/packages/opencode/src/skill/builtin/.bundle/claude-code/references/platforms.md
@@ -1,0 +1,120 @@
+# Platform Guide: Windows, macOS, Linux
+
+Detect the OS before issuing any command. Everything in this skill is written in POSIX (bash) syntax; use the translation table below for PowerShell.
+
+## Capability Matrix
+
+| Capability | Linux | macOS | Windows (native) | Windows (WSL) |
+|---|---|---|---|---|
+| Print mode `-p` | ✅ | ✅ | ✅ PowerShell / Git Bash | ✅ |
+| Background `--bg` + `claude agents` | ✅ | ✅ | ✅ | ✅ |
+| Interactive tmux orchestration | ✅ | ✅ | ❌ no tmux — use WSL | ✅ |
+| `--worktree --tmux` | ✅ classic tmux | ✅ iTerm2 native panes (`--tmux=classic` for plain tmux) | ❌ | ✅ classic |
+| `claude mcp add-from-claude-desktop` | ❌ | ✅ | ❌ | ✅ (documented for macOS/WSL) |
+| Credential storage | keyring/plaintext config | Keychain | Credential Manager | keyring |
+
+**Routing rule for agents:** on Windows, prefer `-p` and `--bg` (both dialog-free, shell-agnostic). Only fall back to interactive mode if WSL is available (`wsl --status` succeeds); run the entire tmux pattern from `interactive-tmux.md` inside `wsl bash -c '...'` or a WSL shell session.
+
+## Install & Update per OS
+
+```bash
+# All platforms (needs Node 18+)
+npm install -g @anthropic-ai/claude-code
+
+# Native installer alternative
+claude install stable        # after any existing install; --force to reinstall
+```
+
+- **Linux/macOS:** if `claude` isn't found after npm install, check `npm prefix -g`/`$PATH`.
+- **Windows:** install via an elevated or user-scope npm; requires **Git for Windows** — Claude Code's Bash tool uses Git Bash under the hood on native Windows. Restart the terminal after install so PATH updates.
+- **WSL:** install *inside* the WSL distro (Linux instructions), not on the Windows side, if you intend to orchestrate with tmux.
+
+Verify on any OS: `claude --version && claude doctor`.
+
+## Shell Translation Table (bash → PowerShell)
+
+| Purpose | bash (Linux/macOS/WSL/Git Bash) | PowerShell |
+|---|---|---|
+| Env var (session) | `export ANTHROPIC_API_KEY=sk-...` | `$env:ANTHROPIC_API_KEY = "sk-..."` |
+| Env var (persistent) | add to `~/.bashrc` / `~/.zshrc` | `setx ANTHROPIC_API_KEY "sk-..."` (new shells only) |
+| Pipe file into `-p` | `cat src/auth.py \| claude -p 'Review'` | `Get-Content src/auth.py -Raw \| claude -p 'Review'` |
+| Pipe many files | `cat src/*.py \| claude -p '...'` | `Get-Content src/*.py -Raw \| claude -p '...'` |
+| Pipe git diff | `git diff main... \| claude -p 'Review'` | same — git works identically |
+| Quoting a prompt | `claude -p 'Fix the "auth" bug'` | `claude -p 'Fix the "auth" bug'` (single quotes are literal in both) |
+| Inline JSON args | `--json-schema '{"type":"object"}'` | `--json-schema '{\"type\":\"object\"}'` or here-string `@'...'@` — prefer writing schema/settings to a file and passing the path |
+| Extract session_id | `jq -r .session_id out.json` | `(Get-Content out.json \| ConvertFrom-Json).session_id` |
+| Redirect JSON result | `> /tmp/session.json` | `> $env:TEMP\session.json` |
+| Sequencing | `cmd1 && cmd2` | `cmd1 && cmd2` (PS 7+) or `cmd1; if ($?) { cmd2 }` (PS 5.1) |
+| Home dir | `~` or `$HOME` | `~` or `$env:USERPROFILE` |
+
+**Rule of thumb:** complex nested quoting (inline JSON, jq filters) is fragile in PowerShell — write JSON to a temp file and pass the file path (`--settings file.json`, `--mcp-config file.json`, `--json-schema "$(cat schema.json)"` in bash / `--json-schema (Get-Content schema.json -Raw)` in PS).
+
+## Paths & Config Locations
+
+Same layout on every OS, rooted at the user home:
+
+| Item | Linux/macOS | Windows |
+|---|---|---|
+| Global settings | `~/.claude/settings.json` | `%USERPROFILE%\.claude\settings.json` |
+| Global CLAUDE.md / rules / agents / commands | `~/.claude/...` | `%USERPROFILE%\.claude\...` |
+| MCP user scope | `~/.claude.json` | `%USERPROFILE%\.claude.json` |
+| Auto-memory | `~/.claude/projects/<project>/memory/` | `%USERPROFILE%\.claude\projects\<project>\memory\` |
+| Project files | `./CLAUDE.md`, `.claude/` | same (relative) |
+
+Forward slashes work in most Claude Code path arguments on Windows; prefer them in scripts to avoid backslash-escaping bugs.
+
+**WSL path warning:** WSL sees Windows drives at `/mnt/c/...`, but a project's Claude state is keyed by path — a repo opened from `/mnt/c/repo` (WSL) and `C:\repo` (native) are *different projects* with separate sessions, trust decisions, and auto-memory. Also, running Claude Code from WSL against `/mnt/c/...` incurs slow cross-filesystem I/O; keep WSL-orchestrated repos inside the WSL filesystem when possible.
+
+## Per-OS Gotchas
+
+### Windows (native)
+1. No tmux → interactive orchestration impossible; use `-p` / `--bg`, or WSL.
+2. `python` vs `python3`: Windows typically has `python` (or the `py` launcher) but *not* `python3` — the inverse of the Linux quirk. Claude self-corrects, costing a turn.
+3. `setx` truncates values >1024 chars and only affects *new* shells; use `$env:` for the current session.
+4. Antivirus/Defender can slow `npm install -g` and first launch; exclude the npm global dir if launches hang.
+5. Line endings: set `git config core.autocrlf input` in repos Claude edits from both Windows and WSL, or diffs fill with CRLF noise.
+6. Long-path errors on deep node_modules: enable `git config --system core.longpaths true` and Windows long-path support.
+
+### Windows (WSL)
+1. Detect with `wsl --status` from PowerShell; enter via `wsl` or run one-shots as `wsl bash -c 'cd /path && claude -p "task" --max-turns 5'`.
+2. Auth/config live inside the distro — logging in on native Windows does not authenticate WSL, and vice versa.
+3. tmux patterns from `interactive-tmux.md` work unmodified inside WSL.
+
+### macOS
+1. First-run Gatekeeper/keychain prompts may appear when Claude Code accesses the Keychain for OAuth tokens — approve once; in headless CI contexts prefer `--bare` + `ANTHROPIC_API_KEY` to avoid keychain reads entirely.
+2. `--worktree --tmux` uses iTerm2 native panes when iTerm2 is present; force plain tmux with `--tmux=classic` when your orchestrator parses `tmux capture-pane` output.
+3. Default shell is zsh — irrelevant for `-p` calls, but source `~/.zshrc` (not `.bashrc`) when persisting env vars.
+4. `claude mcp add-from-claude-desktop` works here (and WSL) to import Claude Desktop's MCP servers.
+
+### Linux
+1. `python` symlink often missing (only `python3`) — Claude's first `python` call fails, then self-corrects.
+2. Headless servers: no keychain → OAuth tokens stored in config; for CI prefer `--bare` + `ANTHROPIC_API_KEY` or `claude setup-token`.
+3. tmux availability is assumed by this skill — `apt-get install -y tmux` (or distro equivalent) before interactive orchestration.
+
+## Cross-Platform Recipes
+
+```bash
+# OS detection (bash)
+case "$(uname -s)" in Linux*) os=linux;; Darwin*) os=mac;; MINGW*|MSYS*|CYGWIN*) os=win-gitbash;; esac
+```
+
+```powershell
+# OS/WSL detection (PowerShell)
+$IsWinNative = $env:OS -eq 'Windows_NT'
+$HasWSL = (wsl --status 2>$null); if ($LASTEXITCODE -eq 0) { "WSL available" }
+```
+
+```powershell
+# Windows-native print-mode run with structured output
+claude -p 'Fix the auth bug in src/auth.py' --allowedTools 'Read,Edit' --max-turns 10 --output-format json |
+  Out-File -Encoding utf8 $env:TEMP\result.json
+$r = Get-Content $env:TEMP\result.json | ConvertFrom-Json
+$r.subtype; $r.session_id; $r.total_cost_usd
+```
+
+```powershell
+# Windows: interactive work via WSL tmux from PowerShell
+wsl bash -c "tmux new-session -d -s claude-work -x 140 -y 40"
+wsl bash -c "tmux send-keys -t claude-work 'cd /home/user/project && claude' Enter"
+wsl bash -c "sleep 5 && tmux capture-pane -t claude-work -p -S -50"
+```

--- a/packages/opencode/src/skill/builtin/.bundle/claude-code/references/print-mode.md
+++ b/packages/opencode/src/skill/builtin/.bundle/claude-code/references/print-mode.md
@@ -1,0 +1,138 @@
+# Print Mode Deep Dive
+
+## Structured JSON Output
+
+```
+terminal(command="claude -p 'Analyze auth.py for security issues' --output-format json --max-turns 5", workdir="/project", timeout=120)
+```
+
+Returns:
+
+```json
+{
+  "type": "result",
+  "subtype": "success",
+  "result": "The analysis text...",
+  "session_id": "75e2167f-...",
+  "num_turns": 3,
+  "total_cost_usd": 0.0787,
+  "duration_ms": 10276,
+  "stop_reason": "end_turn",
+  "terminal_reason": "completed",
+  "usage": { "input_tokens": 5, "output_tokens": 603 },
+  "modelUsage": { "claude-sonnet-4-6": { "costUSD": 0.078, "contextWindow": 200000 } }
+}
+```
+
+Key fields: `session_id` (resumption), `num_turns` (loop count), `total_cost_usd` (spend), `subtype` (`success` / `error_max_turns` / `error_budget`).
+
+## Streaming JSON
+
+```
+claude -p 'Write a summary' --output-format stream-json --verbose --include-partial-messages
+```
+
+Newline-delimited JSON events. Live text via jq:
+
+```
+... | jq -rj 'select(.type == "stream_event" and .event.delta.type? == "text_delta") | .event.delta.text'
+```
+
+- Stream includes `system/api_retry` events with `attempt`, `max_retries`, `error` (`rate_limit`, `billing_error`).
+- Add `--include-hook-events` to observe hook lifecycle (stream-json only).
+
+## Bidirectional Streaming
+
+```
+claude -p "task" --input-format stream-json --output-format stream-json --replay-user-messages
+```
+
+`--replay-user-messages` re-emits user messages on stdout for acknowledgment.
+
+## Piped Input
+
+```
+cat src/auth.py | claude -p 'Review this code for bugs' --max-turns 1
+cat src/*.py    | claude -p 'Find all TODO comments' --max-turns 1
+git diff HEAD~3 | claude -p 'Summarize these changes' --max-turns 1
+```
+
+Prefer piping over having Claude read files when you just need analysis of known content (cheaper).
+
+## JSON Schema Extraction
+
+```
+claude -p 'List all functions in src/' --output-format json \
+  --json-schema '{"type":"object","properties":{"functions":{"type":"array","items":{"type":"string"}}},"required":["functions"]}' \
+  --max-turns 5
+```
+
+Parse `structured_output` from the result. Output is validated against the schema before returning. Needs enough `--max-turns` for Claude to read files first.
+
+## Session Management
+
+```bash
+# capture session_id from a first run, then:
+claude -p 'Continue and add connection pooling' --resume <session_id> --max-turns 5
+claude -p 'What did you do last time?' --continue --max-turns 1        # latest session in this cwd
+claude -p 'Try a different approach' --resume <id> --fork-session      # new ID, keeps history
+claude -p 'task' --session-id 550e8400-e29b-41d4-a716-446655440000     # pin a UUID
+claude -p 'task' --no-session-persistence                              # CI: don't save to disk
+```
+
+Resumption requires the same working directory.
+
+## Bare Mode (CI/Scripting)
+
+```
+claude --bare -p 'Run all tests and report failures' --allowedTools 'Read,Bash' --max-turns 10
+```
+
+`--bare` skips hooks, LSP, plugin sync, attribution, auto-memory, background prefetches, keychain reads, and CLAUDE.md auto-discovery. Sets `CLAUDE_CODE_SIMPLE=1`. Auth is strictly `ANTHROPIC_API_KEY` or `apiKeyHelper` via `--settings` (OAuth/keychain never read). Third-party providers (Bedrock/Vertex/Foundry) use their own credentials. Skills still resolve via `/skill-name`.
+
+Selective context loading in bare mode:
+
+| To load | Flag |
+|---|---|
+| System prompt additions | `--append-system-prompt "text"` |
+| Full system prompt override | `--system-prompt "text"` |
+| Extra working dirs (+their CLAUDE.md) | `--add-dir <paths...>` |
+| Settings | `--settings <file-or-json>` |
+| MCP servers | `--mcp-config <file-or-json>` (+ `--strict-mcp-config`) |
+| Custom agents | `--agents '<json>'` |
+| Plugins (session-only) | `--plugin-dir <path>` / `--plugin-url <url>` |
+
+For rock-bottom troubleshooting prefer `--safe-mode` (v2.1.169+, disables all customizations).
+
+## Multi-User Cache Reuse
+
+```
+claude -p --exclude-dynamic-system-prompt-sections "task"
+```
+
+Moves per-machine sections (cwd, env, memory paths, git status) into the first user message → better cross-user prompt-cache hits. Only applies with the default system prompt.
+
+## Overload Fallback
+
+```
+claude -p 'task' --fallback-model haiku --max-turns 5
+```
+
+Auto-falls back when the default model is overloaded (print mode only).
+
+## Cost & Performance Checklist
+
+1. `--max-turns` 5–10 to prevent runaway loops (print-mode only).
+2. `--max-budget-usd` for caps — minimum ~$0.05 (system-prompt cache creation costs this).
+3. `--effort low` for simple tasks; `high`/`xhigh`/`max` for complex; `ultracode` for high-effort codegen.
+4. `--bare` in CI to skip plugin/hook discovery overhead.
+5. `--allowedTools` least-privilege (e.g. `Read` only for reviews).
+6. `--exclude-dynamic-system-prompt-sections` in scripted multi-user runs.
+7. Pipe input instead of file reads for known content.
+8. `--model haiku` for cheap tasks, `opus` for complex multi-step.
+9. Fresh sessions per distinct task — sessions last 5 hours; fresh context is more efficient.
+10. `--no-session-persistence` in CI to avoid disk accumulation.
+
+## Known Quirk
+
+Python binary name mismatch: Linux/macOS often lack a `python` symlink (only `python3`); Windows is the inverse (`python`/`py`, no `python3`). Claude's first attempt may fail, then self-corrects — costs one turn. PowerShell command translation for all recipes in this file → `references/platforms.md`.

--- a/packages/opencode/src/skill/builtin/.bundle/codex/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/codex/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: codex
+description: Run, configure, and troubleshoot OpenAI Codex CLI in non-interactive headless environments. Use for Codex automation in Bash or PowerShell, native Windows or WSL2, shell scripts, CI/CD, Docker, Kubernetes, remote servers, agent harnesses, or batch jobs; for constructing `codex exec` commands; selecting sandbox and approval modes; consuming JSONL events or structured output; resuming sessions; passing prompts through stdin; and handling failures caused by unavailable interactive input such as `request_user_input`.
+---
+
+# Codex CLI
+
+Use Codex CLI as a deterministic, non-interactive worker suitable for automation and agent orchestration.
+
+## Operating Rules
+
+1. Use `codex exec`, not the interactive `codex` TUI.
+2. Pass the task as the positional `PROMPT` argument. Do not use `-p` for the prompt; `-p` selects a profile.
+3. For ordinary unattended code changes, prefer:
+
+```bash
+codex exec \
+  -C /path/to/repo \
+  --sandbox workspace-write \
+  --ask-for-approval never \
+  "<TASK>"
+```
+
+4. Use `--yolo` only inside an externally hardened and disposable runner. It disables Codex approvals and sandboxing.
+5. For harnesses and CI, prefer `--json` plus `--output-last-message`.
+6. Do not make the run depend on a human answering questions. Resolve ambiguity using repository evidence and conservative defaults.
+7. Treat credentials as secrets. Inject `CODEX_API_KEY` only into the single `codex exec` process when possible.
+8. Before giving version-sensitive advice, inspect `codex exec --help` or current official Codex documentation if available.
+9. On Windows, choose one execution environment per task: native PowerShell for Windows toolchains or WSL2 for Linux toolchains. Do not casually mix paths, installations, or authentication across them.
+
+## Choose the Execution Mode
+
+### Read-only analysis
+
+Use when the task must not modify files:
+
+```bash
+codex exec \
+  -C /path/to/repo \
+  --sandbox read-only \
+  --ask-for-approval never \
+  "Analyze the repository and report risks. Do not modify files."
+```
+
+### Workspace-scoped implementation
+
+Use as the default for autonomous repository work:
+
+```bash
+codex exec \
+  -C /path/to/repo \
+  --sandbox workspace-write \
+  --ask-for-approval never \
+  "Implement the task, run relevant tests, and report unresolved blockers."
+```
+
+### Externally isolated unrestricted execution
+
+Use only when the enclosing container, VM, or sandbox enforces the real security boundary:
+
+```bash
+codex exec \
+  -C /workspace/repo \
+  --yolo \
+  "Implement the task and validate the result."
+```
+
+Never recommend `--yolo` on a normal developer machine or a runner containing unrelated secrets, host mounts, SSH keys, cloud credentials, or a Docker socket.
+
+## Construct an Autonomous Prompt
+
+When headless execution could encounter choices, prepend these instructions:
+
+```text
+Work fully autonomously.
+
+Do not ask the user questions and do not request interactive input.
+Inspect the repository and available context before making assumptions.
+When several valid approaches exist, choose the option that:
+1. minimizes unrelated changes,
+2. preserves backward compatibility,
+3. introduces the fewest new dependencies,
+4. avoids destructive or irreversible actions.
+
+Continue until the task is complete or a concrete blocking error is reached.
+Record assumptions, validation performed, and unresolved blockers in the final response.
+```
+
+Do not simulate "always select the first option." Option ordering is not a safety or quality policy. Apply the explicit decision rules above instead.
+
+## Handle `request_user_input` Failures
+
+When Codex reports that `request_user_input` is unavailable in Default mode or non-interactive mode:
+
+1. Confirm the invocation uses `codex exec` and is intentionally headless.
+2. Add the autonomous prompt policy above.
+3. Supply missing decisions in the task prompt or `AGENTS.md` when they are known in advance.
+4. Replace open-ended requests such as "ask me which approach" with deterministic selection criteria.
+5. If the choice is safety-critical, destructive, or impossible to infer, make the run fail clearly rather than selecting randomly.
+6. Do not attempt to emulate terminal keystrokes unless the subprocess itself, rather than Codex, requires input and the workflow explicitly defines the safe answer.
+
+## Pass Prompts and Context
+
+Use a direct positional prompt:
+
+```bash
+codex exec "Summarize the repository structure."
+```
+
+Read the prompt from stdin:
+
+```bash
+codex exec - < prompt.md
+```
+
+Pipe dynamic context while retaining an explicit task:
+
+```bash
+npm test 2>&1 | codex exec "Analyze this test output and fix the repository."
+```
+
+Use `--skip-git-repo-check` only for intentional one-off directories outside Git:
+
+```bash
+codex exec \
+  --skip-git-repo-check \
+  -C /tmp/task \
+  "Analyze the files in this directory."
+```
+
+## Produce Harness-Friendly Output
+
+### Capture only the final message
+
+```bash
+codex exec \
+  -C /workspace/repo \
+  --output-last-message /output/final.md \
+  "Review the codebase."
+```
+
+### Stream JSONL events
+
+```bash
+codex exec \
+  -C /workspace/repo \
+  --json \
+  --sandbox workspace-write \
+  --ask-for-approval never \
+  "Run tests and fix failures." \
+  > /output/events.jsonl
+```
+
+Expect event families such as `thread.started`, `turn.started`, `turn.completed`, `turn.failed`, `item.*`, and `error`.
+
+### Capture events and the final answer together
+
+```bash
+codex exec \
+  -C /workspace/repo \
+  --json \
+  --sandbox workspace-write \
+  --ask-for-approval never \
+  --output-last-message /output/final.md \
+  "Complete the task autonomously." \
+  | tee /output/events.jsonl
+```
+
+Do not parse human-readable progress text when `--json` is available.
+
+## Require Structured Final Output
+
+Create a JSON Schema and pass it with `--output-schema`:
+
+```bash
+codex exec \
+  -C /workspace/repo \
+  --sandbox workspace-write \
+  --ask-for-approval never \
+  --output-schema /input/result.schema.json \
+  --output-last-message /output/result.json \
+  "Implement the task, validate it, and return the requested structured result."
+```
+
+A useful harness schema usually includes:
+
+- `status`: `success`, `partial`, or `failed`
+- `summary`: concise outcome
+- `changed_files`: repository-relative paths
+- `validation`: commands run and results
+- `assumptions`: decisions made without user input
+- `blockers`: concrete unresolved problems
+
+Set `additionalProperties` to `false` when downstream parsing must be strict.
+
+## Resume or Avoid Persistence
+
+Resume the most recent session for the current working directory:
+
+```bash
+codex exec resume --last "Continue the previous task and fix remaining issues."
+```
+
+Resume a specific session:
+
+```bash
+codex exec resume "$SESSION_ID" "Continue with the next stage."
+```
+
+Use an ephemeral run when rollout persistence is undesirable:
+
+```bash
+codex exec --ephemeral "Analyze the repository."
+```
+
+Do not rely on `--last` across unrelated working directories unless deliberately using the relevant all-directory option supported by the installed CLI.
+
+## Authenticate Safely
+
+For a local interactive login:
+
+```bash
+codex login
+```
+
+For a headless machine with device-code login enabled:
+
+```bash
+codex login --device-auth
+```
+
+For a single automated invocation:
+
+```bash
+CODEX_API_KEY="$OPENAI_API_KEY" \
+codex exec --json "Triage the repository."
+```
+
+Do not expose API keys as broad job-level environment variables in jobs that execute repository-controlled code. Never commit or print `~/.codex/auth.json`.
+
+## Windows, PowerShell, and WSL2
+
+For native Windows headless use:
+
+- Install with the official PowerShell installer or npm.
+- Prefer PowerShell 7.4 or newer for JSONL redirection.
+- Build argument arrays and invoke them with `& codex @args`; avoid fragile backtick-heavy command construction.
+- Check `$LASTEXITCODE` after every Codex invocation. PowerShell error preferences alone are not a substitute for checking a native process exit code.
+- Keep stdout JSONL separate from stderr diagnostics. Do not use `2>&1` when stdout must remain parseable JSONL.
+- Configure `%USERPROFILE%\.codex\config.toml` with `[windows] sandbox = "elevated"` when available; use `unelevated` only as the fallback.
+- Preserve the task-level policy `--sandbox workspace-write --ask-for-approval never` for ordinary autonomous edits. The native Windows sandbox implementation and the CLI task policy are separate controls.
+
+For WSL:
+
+- Use WSL2, not WSL1.
+- Install and authenticate Codex inside WSL as a Linux installation.
+- Keep repositories under `~/code/...`, not `/mnt/c/...`, for better performance and fewer permission, symlink, and file-watcher problems.
+- Do not pass credentials through visible `wsl.exe` command-line strings.
+
+See [references/windows.md](references/windows.md) for installation, PowerShell wrappers, JSONL parsing, sandbox configuration, WSL2 patterns, and Windows-specific troubleshooting.
+
+## Container and CI Requirements
+
+When generating a Docker, Kubernetes, or CI design:
+
+- Mount only the intended workspace and output directory.
+- Run as a non-root user when practical.
+- Do not mount the host Docker socket.
+- Do not mount home directories, SSH keys, or cloud credential directories.
+- Restrict network access unless the task explicitly needs it.
+- Apply CPU, memory, process, and execution-time limits outside Codex.
+- Preserve stdout, stderr, exit status, JSONL events, and the final message separately.
+- Validate repository diffs and test results before treating a run as successful.
+- Prefer a fresh worktree or disposable checkout per task.
+
+See [references/recipes.md](references/recipes.md) for ready-to-use shell, Docker, CI, and parser patterns.
+
+## Diagnose Failures
+
+Use this order:
+
+1. Run `codex --version` and `codex exec --help`.
+2. Verify the command uses a positional prompt or `-` for stdin.
+3. Verify the working directory and Git repository status.
+4. Verify authentication without printing secret material.
+5. Check whether sandbox policy blocks required reads, writes, commands, sockets, or network access.
+6. Check whether approval policy is causing an impossible prompt in headless mode.
+7. Inspect stderr and the JSONL `error` or `turn.failed` events.
+8. Re-run with a smaller, deterministic task that reproduces the failure.
+9. Do not silently switch to `--yolo` as a troubleshooting shortcut.
+
+## Completion Standard
+
+For implementation tasks, consider the run complete only when Codex has:
+
+1. inspected the relevant repository context,
+2. made the requested changes,
+3. run the most relevant available validation,
+4. reviewed the resulting diff for unrelated changes,
+5. reported assumptions and unresolved blockers,
+6. produced machine-readable status when requested by the harness.

--- a/packages/opencode/src/skill/builtin/.bundle/codex/agents/openai.yaml
+++ b/packages/opencode/src/skill/builtin/.bundle/codex/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Codex CLI Headless"
+  short_description: "Run Codex autonomously in scripts, CI, Docker, and Kubernetes"

--- a/packages/opencode/src/skill/builtin/.bundle/codex/references/recipes.md
+++ b/packages/opencode/src/skill/builtin/.bundle/codex/references/recipes.md
@@ -1,0 +1,289 @@
+# Codex CLI Headless Recipes
+
+## Contents
+
+- Production shell wrapper
+- JSONL parsing
+- Structured-result schema
+- Docker runner
+- GitHub Actions pattern
+- Kubernetes job pattern
+- Exit classification
+
+## Production Shell Wrapper
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${1:?usage: run-codex.sh REPO TASK_FILE OUTPUT_DIR}"
+task_file="${2:?usage: run-codex.sh REPO TASK_FILE OUTPUT_DIR}"
+out_dir="${3:?usage: run-codex.sh REPO TASK_FILE OUTPUT_DIR}"
+
+mkdir -p "$out_dir"
+
+prompt="$(cat <<'PROMPT'
+Work fully autonomously.
+Do not ask questions or request interactive input.
+Inspect the repository before making assumptions.
+Choose conservative, backward-compatible, non-destructive defaults.
+Run relevant validation and report assumptions and blockers.
+
+Task:
+PROMPT
+)"
+prompt+=$'\n'
+prompt+="$(cat "$task_file")"
+
+set +e
+codex exec \
+  -C "$repo" \
+  --json \
+  --sandbox workspace-write \
+  --ask-for-approval never \
+  --output-last-message "$out_dir/final.md" \
+  "$prompt" \
+  > "$out_dir/events.jsonl" \
+  2> "$out_dir/stderr.log"
+status=$?
+set -e
+
+printf '%s\n' "$status" > "$out_dir/exit-code.txt"
+exit "$status"
+```
+
+## JSONL Parsing
+
+Get the session ID:
+
+```bash
+jq -r 'select(.type == "thread.started") | .thread_id' events.jsonl | head -n 1
+```
+
+Get the last agent message found in events:
+
+```bash
+jq -r '
+  select(.type == "item.completed" and .item.type == "agent_message")
+  | .item.text
+' events.jsonl | tail -n 1
+```
+
+Get failed turns and errors:
+
+```bash
+jq -c 'select(.type == "turn.failed" or .type == "error")' events.jsonl
+```
+
+Get usage records when emitted:
+
+```bash
+jq 'select(.type == "turn.completed") | .usage // empty' events.jsonl
+```
+
+Treat event schemas as versioned interfaces. Parse defensively and tolerate unknown event types.
+
+## Structured-Result Schema
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["success", "partial", "failed"]
+    },
+    "summary": { "type": "string" },
+    "changed_files": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "validation": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "command": { "type": "string" },
+          "result": { "type": "string" }
+        },
+        "required": ["command", "result"],
+        "additionalProperties": false
+      }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "blockers": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": [
+    "status",
+    "summary",
+    "changed_files",
+    "validation",
+    "assumptions",
+    "blockers"
+  ],
+  "additionalProperties": false
+}
+```
+
+## Docker Runner
+
+```dockerfile
+FROM node:22-bookworm
+
+RUN npm install -g @openai/codex \
+    && useradd --create-home --uid 10001 codex
+
+USER codex
+WORKDIR /workspace
+
+ENTRYPOINT ["codex", "exec"]
+```
+
+Safe default invocation:
+
+```bash
+docker run --rm \
+  --network=none \
+  --read-only \
+  --tmpfs /tmp:rw,nosuid,nodev,size=512m \
+  --cpus=2 \
+  --memory=4g \
+  -e CODEX_API_KEY="$OPENAI_API_KEY" \
+  -v "$PWD:/workspace" \
+  -v "$PWD/.codex-output:/output" \
+  codex-headless \
+  -C /workspace \
+  --sandbox workspace-write \
+  --ask-for-approval never \
+  --output-last-message /output/final.md \
+  "Analyze and complete the task autonomously."
+```
+
+A read-only root filesystem can conflict with tools that expect writable cache or home directories. Add narrowly scoped tmpfs or writable mounts rather than disabling isolation broadly.
+
+## GitHub Actions Pattern
+
+Do not expose a Codex credential to a step that runs untrusted repository code. Separate credentialed analysis from untrusted build execution when possible.
+
+```yaml
+name: codex-review
+
+on:
+  workflow_dispatch:
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Run Codex
+        env:
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+        run: |
+          mkdir -p artifacts
+          codex exec \
+            -C "$GITHUB_WORKSPACE" \
+            --json \
+            --sandbox read-only \
+            --ask-for-approval never \
+            --output-last-message artifacts/final.md \
+            "Review the repository without executing project-controlled code." \
+            > artifacts/events.jsonl \
+            2> artifacts/stderr.log
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: codex-output
+          path: artifacts/
+```
+
+Pin third-party actions to immutable commit SHAs in high-security environments.
+
+## Kubernetes Job Pattern
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: codex-headless
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 1800
+  template:
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      containers:
+        - name: codex
+          image: example/codex-headless:latest
+          args:
+            - -C
+            - /workspace
+            - --json
+            - --sandbox
+            - workspace-write
+            - --ask-for-approval
+            - never
+            - --output-last-message
+            - /output/final.md
+            - Work autonomously. Inspect the repository, implement the task, run validation, and report blockers.
+          env:
+            - name: CODEX_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: codex-credentials
+                  key: api-key
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+            - name: output
+              mountPath: /output
+      volumes:
+        - name: workspace
+          emptyDir: {}
+        - name: output
+          emptyDir: {}
+```
+
+Populate the workspace using a trusted init container or a prebuilt task image. Do not grant the Pod broad cluster permissions.
+
+## Exit Classification
+
+Classify a run using multiple signals:
+
+1. Process exit code
+2. Presence of `turn.failed` or `error` events
+3. Structured final `status`, when configured
+4. Expected repository diff
+5. Validation command results
+6. Timeout, OOM, or external runner termination
+
+Do not equate exit code zero with a correct implementation. Conversely, preserve useful partial artifacts from failed runs for diagnosis.

--- a/packages/opencode/src/skill/builtin/.bundle/codex/references/windows.md
+++ b/packages/opencode/src/skill/builtin/.bundle/codex/references/windows.md
@@ -1,0 +1,391 @@
+# Codex CLI Headless on Windows
+
+## Contents
+
+- Choose native Windows or WSL2
+- Install Codex CLI
+- Configure the native Windows sandbox
+- Run headless tasks from PowerShell
+- Capture JSONL and exit status
+- Pass prompts and environment variables
+- Parse JSONL without `jq`
+- Run through WSL2
+- Windows-specific troubleshooting
+
+## Choose Native Windows or WSL2
+
+Use native Windows when the repository and build tools are Windows-native, the task needs PowerShell, MSBuild, Visual Studio tooling, Windows paths, or Windows-specific tests.
+
+Use WSL2 when the repository and toolchain are Linux-native, existing automation assumes Bash, or the native Windows sandbox cannot be enabled in the environment.
+
+Do not mix environments during one task unless necessary. In particular:
+
+- Keep a native Windows repository on an NTFS Windows path such as `C:\src\project`.
+- Keep a WSL2 repository under the Linux filesystem such as `~/code/project`.
+- Avoid running Linux builds repeatedly against `/mnt/c/...`; this is slower and can introduce permission, symlink, file-watcher, and case-sensitivity differences.
+- Install and authenticate Codex separately in each environment where it runs.
+
+WSL1 is not supported by current Codex releases. Use WSL2.
+
+## Install Codex CLI
+
+### Native Windows installer
+
+Run from PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -Command "irm https://chatgpt.com/codex/install.ps1 | iex"
+```
+
+Verify:
+
+```powershell
+codex --version
+codex exec --help
+```
+
+### npm installation
+
+```powershell
+npm install -g @openai/codex
+codex --version
+```
+
+If `codex` is not found after npm installation, inspect the npm global binary directory and ensure it is on `PATH`:
+
+```powershell
+npm prefix -g
+Get-Command codex -ErrorAction SilentlyContinue
+$env:PATH -split ';'
+```
+
+Use PowerShell 7.4 or newer for automation when possible. It preserves native stdout byte streams when redirecting them to files, which is useful for JSONL capture.
+
+## Configure the Native Windows Sandbox
+
+Codex supports native Windows sandbox implementations in `%USERPROFILE%\.codex\config.toml`:
+
+```toml
+[windows]
+sandbox = "elevated"
+```
+
+Prefer `elevated`. It uses dedicated lower-privilege sandbox users, filesystem permission boundaries, firewall rules, and supporting local policy changes.
+
+When administrator-approved setup is unavailable, use the weaker fallback:
+
+```toml
+[windows]
+sandbox = "unelevated"
+```
+
+Do not confuse the Windows sandbox implementation with the task-level CLI policy. Continue to select a task policy such as:
+
+```powershell
+--sandbox workspace-write --ask-for-approval never
+```
+
+For unattended automation, keep sandbox boundaries enabled and set approval to `never`. Do not switch to full access merely because an approval cannot be answered.
+
+Windows 11 is the recommended baseline. Fully updated Windows 10 is best-effort and requires modern console support; older builds are poor targets for headless runners.
+
+## Run a Basic Headless Task from PowerShell
+
+Use an argument array instead of long lines with PowerShell backtick continuations. Backticks are fragile because trailing whitespace breaks them.
+
+```powershell
+$repo = 'C:\src\project'
+$prompt = @'
+Work fully autonomously.
+Do not ask questions or request interactive input.
+Inspect the repository, choose conservative defaults, implement the task,
+run relevant validation, and report assumptions and blockers.
+'@
+
+$codexArgs = @(
+    'exec'
+    '-C', $repo
+    '--sandbox', 'workspace-write'
+    '--ask-for-approval', 'never'
+    $prompt
+)
+
+& codex @codexArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "Codex failed with exit code $LASTEXITCODE"
+}
+```
+
+For read-only work, replace `workspace-write` with `read-only` and state explicitly that no files may be changed.
+
+## Production PowerShell Wrapper
+
+```powershell
+param(
+    [Parameter(Mandatory)]
+    [string] $Repository,
+
+    [Parameter(Mandatory)]
+    [string] $TaskFile,
+
+    [Parameter(Mandatory)]
+    [string] $OutputDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repo = (Resolve-Path -LiteralPath $Repository).Path
+$task = Get-Content -LiteralPath $TaskFile -Raw
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+$out = (Resolve-Path -LiteralPath $OutputDirectory).Path
+
+$prompt = @"
+Work fully autonomously.
+Do not ask questions or request interactive input.
+Inspect the repository before making assumptions.
+Choose conservative, backward-compatible, non-destructive defaults.
+Run relevant validation and report assumptions and blockers.
+
+Task:
+$task
+"@
+
+$codexArgs = @(
+    'exec'
+    '-C', $repo
+    '--json'
+    '--sandbox', 'workspace-write'
+    '--ask-for-approval', 'never'
+    '--output-last-message', (Join-Path $out 'final.md')
+    $prompt
+)
+
+$events = Join-Path $out 'events.jsonl'
+$stderr = Join-Path $out 'stderr.log'
+
+& codex @codexArgs 1> $events 2> $stderr
+$exitCode = $LASTEXITCODE
+Set-Content -LiteralPath (Join-Path $out 'exit-code.txt') -Value $exitCode -Encoding ascii
+
+if ($exitCode -ne 0) {
+    throw "Codex failed with exit code $exitCode. Inspect $stderr and $events."
+}
+```
+
+Use `pwsh` 7.4 or newer to run this wrapper when byte-preserving native redirection matters. Always inspect `$LASTEXITCODE`; `$ErrorActionPreference = 'Stop'` alone does not reliably turn every nonzero native exit into a terminating PowerShell error.
+
+## Capture JSONL and the Final Message
+
+```powershell
+$out = 'C:\codex-output'
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+$codexArgs = @(
+    'exec'
+    '-C', 'C:\src\project'
+    '--json'
+    '--sandbox', 'workspace-write'
+    '--ask-for-approval', 'never'
+    '--output-last-message', (Join-Path $out 'final.md')
+    'Run tests, fix failures, and report assumptions.'
+)
+
+& codex @codexArgs `
+    1> (Join-Path $out 'events.jsonl') `
+    2> (Join-Path $out 'stderr.log')
+
+$exitCode = $LASTEXITCODE
+```
+
+The short redirection example uses backticks only to make the redirection readable. In reusable scripts, prefer a single line or the production wrapper above.
+
+Do not merge stderr into stdout for JSONL output. A command such as `2>&1` can corrupt the JSONL stream with diagnostic text.
+
+## Pass Prompts and Context
+
+Read the entire prompt file as one string:
+
+```powershell
+Get-Content -LiteralPath .\prompt.md -Raw | codex exec -
+```
+
+Pass a prompt as a positional argument:
+
+```powershell
+codex exec 'Analyze this repository. Do not modify files.'
+```
+
+Pass command output as additional stdin context:
+
+```powershell
+npm test 2>&1 | codex exec 'Analyze this test output and fix the repository.'
+```
+
+PowerShell pipelines transport objects and text rather than behaving exactly like Bash byte pipes. For large or encoding-sensitive logs, write the log to a UTF-8 file and include its path in the task, or invoke through WSL2.
+
+## Inject an API Key
+
+For a local shell:
+
+```powershell
+$env:CODEX_API_KEY = $env:OPENAI_API_KEY
+try {
+    codex exec --json 'Triage the repository.'
+    if ($LASTEXITCODE -ne 0) {
+        throw "Codex failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    Remove-Item Env:CODEX_API_KEY -ErrorAction SilentlyContinue
+}
+```
+
+In CI, inject `CODEX_API_KEY` through the runner's secret mechanism and scope it to the Codex step. Remember that repository-controlled subprocesses launched by Codex may inherit the environment. For untrusted repositories, separate credentialed read-only analysis from untrusted build execution.
+
+## Parse JSONL without `jq`
+
+Read all events:
+
+```powershell
+$events = Get-Content -LiteralPath .\events.jsonl |
+    Where-Object { $_.Trim() } |
+    ForEach-Object { $_ | ConvertFrom-Json }
+```
+
+Get the session ID:
+
+```powershell
+$sessionId = $events |
+    Where-Object type -eq 'thread.started' |
+    Select-Object -First 1 -ExpandProperty thread_id
+```
+
+Get failures:
+
+```powershell
+$failures = $events |
+    Where-Object { $_.type -in @('turn.failed', 'error') }
+```
+
+Get the final agent message emitted as an event:
+
+```powershell
+$lastMessage = $events |
+    Where-Object {
+        $_.type -eq 'item.completed' -and
+        $_.item.type -eq 'agent_message'
+    } |
+    Select-Object -Last 1
+
+$lastMessage.item.text
+```
+
+For very large event files, process one line at a time rather than retaining all events in memory.
+
+## Use WSL2
+
+Install WSL from an elevated PowerShell terminal:
+
+```powershell
+wsl --install
+```
+
+Enter WSL:
+
+```powershell
+wsl
+```
+
+Inside the WSL shell, install Codex as Linux software:
+
+```bash
+curl -fsSL https://chatgpt.com/codex/install.sh | sh
+codex --version
+```
+
+Keep repositories in the WSL Linux filesystem:
+
+```bash
+mkdir -p ~/code
+cd ~/code
+git clone https://github.com/example/project.git
+cd project
+
+codex exec \
+  --sandbox workspace-write \
+  --ask-for-approval never \
+  "Implement the task, run tests, and report blockers."
+```
+
+Invoke an already-configured WSL Codex run from PowerShell when needed:
+
+```powershell
+$linuxCommand = 'cd ~/code/project && codex exec --sandbox workspace-write --ask-for-approval never "Run the task autonomously."'
+wsl.exe -d Ubuntu -- bash -lc $linuxCommand
+if ($LASTEXITCODE -ne 0) {
+    throw "WSL Codex failed with exit code $LASTEXITCODE"
+}
+```
+
+For complex orchestration, store the Linux command in a `.sh` script inside WSL and call that script through `wsl.exe`.
+
+Do not pass secrets in a command-line string that can appear in process listings or logs. Configure authentication inside WSL or inject secrets through the WSL job environment.
+
+## Windows-Specific Troubleshooting
+
+### `codex` is not recognized
+
+```powershell
+Get-Command codex -ErrorAction SilentlyContinue
+npm prefix -g
+$env:PATH -split ';'
+```
+
+Restart the terminal after installation if `PATH` was changed.
+
+### Installer is blocked
+
+Use the official one-command installer with `-ExecutionPolicy Bypass` for that process. On enterprise-managed machines, script execution, downloaded binaries, local policy changes, or sandbox setup may still be blocked by policy. Do not weaken machine-wide execution policy without administrator approval.
+
+### Native sandbox setup fails
+
+1. Prefer `elevated` on supported machines.
+2. Try `unelevated` when administrator-approved setup is unavailable.
+3. Use WSL2 when neither native mode works.
+4. Do not diagnose the failure by permanently switching to `--yolo`.
+
+### Access denied or unexpected file boundaries
+
+- Confirm `-C` points to the intended repository.
+- Inspect Windows ACLs, controlled-folder access, antivirus behavior, and enterprise endpoint policy.
+- Avoid repositories under protected or synchronized folders when possible.
+- Use `--add-dir` only for a specific required directory, not an entire drive or user profile.
+
+### JSONL is malformed
+
+- Keep stderr separate from stdout.
+- Use PowerShell 7.4 or newer for native redirection.
+- Do not pipe JSONL through formatting cmdlets.
+- Check the file for startup banners, policy warnings, or non-JSON diagnostics.
+- Parse line by line and tolerate unknown event types.
+
+### Path quoting fails
+
+Use PowerShell argument arrays and literal paths. Do not manually add embedded quote characters around array elements:
+
+```powershell
+$codexArgs = @('exec', '-C', 'C:\src\project with spaces', 'Analyze the project.')
+& codex @codexArgs
+```
+
+### A child command waits for input
+
+The Codex prompt policy prevents Codex from asking the user, but project tools may still prompt. Configure those tools explicitly, for example with package-manager non-interactive flags, environment variables, or command-specific confirmation options. Do not implement a generic "press Enter" or "select the first option" mechanism.
+
+## Official References
+
+- Codex CLI: `https://learn.chatgpt.com/docs/codex/cli`
+- Codex non-interactive mode: `https://learn.chatgpt.com/docs/non-interactive-mode`
+- Native Windows sandbox: `https://learn.chatgpt.com/docs/windows/windows-sandbox`
+- WSL guidance: `https://learn.chatgpt.com/docs/windows/wsl`

--- a/packages/opencode/src/skill/builtin/extract.ts
+++ b/packages/opencode/src/skill/builtin/extract.ts
@@ -5,6 +5,7 @@ import { Flag } from "@/flag/flag"
 import { Path as GlobalPath } from "@/global"
 import { InstallationLocal, InstallationVersion } from "@/installation/version"
 import { Log } from "@/util"
+import { which } from "@/util/which"
 import { loadBuiltinBundle } from "./bundle.macro" with { type: "macro" }
 import { loadBuiltinBundle as loadBuiltinBundleDev } from "./bundle.macro"
 
@@ -15,6 +16,16 @@ export const OFFICIAL_SKILL_NAMES = new Set([
   "xlsx-official",
   "html-to-video-pipeline",
 ])
+
+const REQUIRED_COMMANDS = new Map([
+  ["claude-code", "claude"],
+  ["codex", "codex"],
+])
+
+export function isBuiltinSkillInstalled(name: string, resolve = which) {
+  const command = REQUIRED_COMMANDS.get(name)
+  return !command || resolve(command) !== null
+}
 
 const DOCUMENT_SKILL_TRIGGERS: Array<{
   skill: string
@@ -97,17 +108,33 @@ export const extractBuiltinBundle = Effect.fn("Skill.extractBuiltinBundle")(func
   const skillsRoot = builtinSkillRoot()
   const root = path.dirname(skillsRoot)
   const marker = path.join(root, ".extracted")
+  const enabled = new Set(
+    Object.keys(BUILTIN_BUNDLE).filter(
+      (name) =>
+        !(Flag.MIMOCODE_DISABLE_OFFICIAL_SKILLS && OFFICIAL_SKILL_NAMES.has(name)) &&
+        isBuiltinSkillInstalled(name),
+    ),
+  )
+  const markerContent = JSON.stringify({ version: InstallationVersion, skills: Array.from(enabled).toSorted() })
 
-  if (!InstallationLocal && (yield* fsys.existsSafe(marker))) return root
+  if (
+    !InstallationLocal &&
+    (yield* fsys.existsSafe(marker)) &&
+    (yield* fsys.readFileString(marker).pipe(Effect.orElseSucceed(() => ""))) === markerContent
+  )
+    return root
 
   for (const [skillName, files] of Object.entries(BUILTIN_BUNDLE)) {
-    if (Flag.MIMOCODE_DISABLE_OFFICIAL_SKILLS && OFFICIAL_SKILL_NAMES.has(skillName)) continue
     const skillDir = path.join(skillsRoot, skillName)
+    if (!enabled.has(skillName)) {
+      if (yield* fsys.existsSafe(skillDir)) yield* fsys.remove(skillDir, { recursive: true })
+      continue
+    }
     for (const [relPath, content] of Object.entries(files)) {
       yield* fsys.writeWithDirs(path.join(skillDir, relPath), content)
     }
   }
-  yield* fsys.writeWithDirs(marker, InstallationVersion)
+  yield* fsys.writeWithDirs(marker, markerContent)
   log.info("extracted builtin skills", { root })
   return root
 })

--- a/packages/opencode/test/skill/builtin.test.ts
+++ b/packages/opencode/test/skill/builtin.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { isBuiltinSkillInstalled } from "../../src/skill/builtin/extract"
+
+describe("builtin skills", () => {
+  test("loads Claude Code skill only when claude is installed", () => {
+    expect(isBuiltinSkillInstalled("claude-code", (command) => (command === "claude" ? "/bin/claude" : null))).toBe(
+      true,
+    )
+    expect(isBuiltinSkillInstalled("claude-code", () => null)).toBe(false)
+  })
+
+  test("loads Codex skill only when codex is installed", () => {
+    expect(isBuiltinSkillInstalled("codex", (command) => (command === "codex" ? "/bin/codex" : null))).toBe(true)
+    expect(isBuiltinSkillInstalled("codex", () => null)).toBe(false)
+  })
+
+  test("does not gate unrelated builtin skills", () => {
+    expect(isBuiltinSkillInstalled("pdf-official", () => null)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Only extract `claude-code` and `codex` builtin skills when their respective CLIs (`claude`, `codex`) are installed on the system
- Skills whose required command is missing are skipped and their directories are cleaned up
- The extraction marker now includes the set of enabled skills so re-extraction triggers when available CLIs change

## Changes
- Added `REQUIRED_COMMANDS` map and `isBuiltinSkillInstalled()` function in `extract.ts`
- Updated `extractBuiltinBundle` to filter skills by CLI availability and clean up disabled skill dirs
- Added `claude-code` and `codex` skill bundles under `.bundle/`
- Added unit tests for `isBuiltinSkillInstalled`