### PR TITLE
feat(tui): add i18n descriptions for codex and claude-code skills

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -214,6 +214,8 @@ export const dict: Record<string, string> = {
   "tui.skill.skill-creator.description": "Create, review, and improve agent skills",
   "tui.skill.drive-mimo.description": "Programmatically drive another MiMoCode process — headless JSON events or interactive TUI via tmux",
   "tui.skill.research-paper-writing.description": "Draft, polish, and reviewer-style critique for academic papers",
+  "tui.skill.codex.description": "Run Codex CLI autonomously in scripts, CI, Docker, and Kubernetes",
+  "tui.skill.claude-code.description": "Delegate coding tasks to Claude Code CLI",
   "tui.skill.design-blueprint.description":
     "Produce a design blueprint (DESIGN.md + Decision Trace) before mocking up any visual",
   "tui.skill.super-research.description":

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -290,6 +290,8 @@ export const dict = {
   "tui.skill.skill-creator.description": "Crea, revisa y mejora skills de agente",
   "tui.skill.drive-mimo.description": "Controla programáticamente otro proceso MiMoCode — eventos JSON headless o TUI interactiva vía tmux",
   "tui.skill.research-paper-writing.description": "Redacta, pule y critica artículos académicos con perspectiva de revisor",
+  "tui.skill.codex.description": "Ejecuta Codex CLI de forma autónoma en scripts, CI, Docker y Kubernetes",
+  "tui.skill.claude-code.description": "Delega tareas de programación a Claude Code CLI",
   "tui.skill.design-blueprint.description":
     "Producir un plano de diseño (DESIGN.md + Decision Trace) antes de crear cualquier mockup",
   "tui.skill.super-research.description":

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -278,6 +278,8 @@ export const dict = {
   "tui.skill.skill-creator.description": "Créer, réviser et améliorer des skills d'agent",
   "tui.skill.drive-mimo.description": "Piloter un autre processus MiMoCode — événements JSON headless ou TUI interactive via tmux",
   "tui.skill.research-paper-writing.description": "Rédiger, polir et critiquer des articles académiques avec l'œil d'un relecteur",
+  "tui.skill.codex.description": "Exécuter Codex CLI de façon autonome dans les scripts, la CI, Docker et Kubernetes",
+  "tui.skill.claude-code.description": "Déléguer des tâches de programmation à Claude Code CLI",
   "tui.skill.design-blueprint.description":
     "Produire un plan de design (DESIGN.md + Decision Trace) avant tout mockup",
   "tui.skill.super-research.description":

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -227,6 +227,8 @@ export const dict = {
   "tui.skill.skill-creator.description": "エージェントスキルの作成・レビュー・改善",
   "tui.skill.drive-mimo.description": "別の MiMoCode プロセスをプログラムで操作——ヘッドレス JSON イベントまたは tmux 経由のインタラクティブ TUI",
   "tui.skill.research-paper-writing.description": "学術論文の執筆・推敲・査読者視点の批評",
+  "tui.skill.codex.description": "スクリプト、CI、Docker、Kubernetes で Codex CLI を自律実行",
+  "tui.skill.claude-code.description": "コーディングタスクを Claude Code CLI に委任",
   "tui.skill.design-blueprint.description": "モックアップ着手前に設計仕様（DESIGN.md + Decision Trace）を作成",
   "tui.skill.super-research.description": "自律型研究——実験ループ、調査、量的分析、ベンチマーク、根本原因調査、アブレーション、論文再現、論文執筆",
   "tui.skill.deep-research.description": "深層マルチソース調査、クロスチェック付き引用レポート",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -293,6 +293,8 @@ export const dict = {
   "tui.skill.skill-creator.description": "Создание, проверка и улучшение skills агента",
   "tui.skill.drive-mimo.description": "Программное управление другим процессом MiMoCode — headless JSON-события или интерактивный TUI через tmux",
   "tui.skill.research-paper-writing.description": "Написание, полировка и рецензирование научных статей",
+  "tui.skill.codex.description": "Автономный запуск Codex CLI в скриптах, CI, Docker и Kubernetes",
+  "tui.skill.claude-code.description": "Делегирование задач программирования Claude Code CLI",
   "tui.skill.design-blueprint.description":
     "Создать проектную спецификацию (DESIGN.md + Decision Trace) до макетов",
   "tui.skill.super-research.description":

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -203,6 +203,8 @@ export const dict = {
   "tui.skill.skill-creator.description": "创建、审查与改进 Agent 技能",
   "tui.skill.drive-mimo.description": "以编程方式驱动另一个 MiMoCode 进程——无头 JSON 事件或通过 tmux 交互",
   "tui.skill.research-paper-writing.description": "撰写、润色学术论文，并以审稿人视角提前把关",
+  "tui.skill.codex.description": "在脚本、CI、Docker 和 Kubernetes 中自主运行 Codex CLI",
+  "tui.skill.claude-code.description": "将编码任务委派给 Claude Code CLI",
   "tui.skill.design-blueprint.description": "先出设计蓝图（DESIGN.md + 决策轨迹）再动手做视觉",
   "tui.skill.super-research.description": "自主研究——实验循环、主题调研、量化分析、对比评测、根因排查、消融实验、复现论文、写论文",
   "tui.skill.deep-research.description": "深度多源调研，交叉验证并生成引用报告",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -203,6 +203,8 @@ export const dict = {
   "tui.skill.skill-creator.description": "建立、審查與改進 Agent 技能",
   "tui.skill.drive-mimo.description": "以程式化方式驅動另一個 MiMoCode 程序——無頭 JSON 事件或透過 tmux 互動",
   "tui.skill.research-paper-writing.description": "撰寫、潤色學術論文，並以審稿人視角提前把關",
+  "tui.skill.codex.description": "在腳本、CI、Docker 和 Kubernetes 中自主執行 Codex CLI",
+  "tui.skill.claude-code.description": "將程式設計任務委派給 Claude Code CLI",
   "tui.skill.design-blueprint.description": "先出設計藍圖（DESIGN.md + 決策軌跡）再動手做視覺",
   "tui.skill.super-research.description": "自主研究——實驗迴圈、主題調研、量化分析、對比評測、根因排查、消融實驗、複現論文、寫論文",
   "tui.skill.deep-research.description": "深度多源調研，交叉驗證並生成引用報告",

--- a/packages/opencode/test/skill/skill-description.test.ts
+++ b/packages/opencode/test/skill/skill-description.test.ts
@@ -1,5 +1,12 @@
 import { describe, test, expect } from "bun:test"
 import { skillDescription } from "../../src/cli/cmd/tui/i18n/skill"
+import { dict as en } from "../../src/cli/cmd/tui/i18n/en"
+import { dict as es } from "../../src/cli/cmd/tui/i18n/es"
+import { dict as fr } from "../../src/cli/cmd/tui/i18n/fr"
+import { dict as ja } from "../../src/cli/cmd/tui/i18n/ja"
+import { dict as ru } from "../../src/cli/cmd/tui/i18n/ru"
+import { dict as zh } from "../../src/cli/cmd/tui/i18n/zh"
+import { dict as zht } from "../../src/cli/cmd/tui/i18n/zht"
 
 describe("skillDescription", () => {
   const t = (key: string) => {
@@ -32,5 +39,12 @@ describe("skillDescription", () => {
 
   test("user override: same name as builtin but not bundled shows fallback", () => {
     expect(skillDescription(t, "evolve", "User custom evolve", false)).toBe("User custom evolve")
+  })
+
+  test("codex CLI skills have descriptions in every TUI locale", () => {
+    for (const dict of [en, es, fr, ja, ru, zh, zht]) {
+      expect(dict["tui.skill.codex.description"]).toBeTruthy()
+      expect(dict["tui.skill.claude-code.description"]).toBeTruthy()
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Add TUI-facing translated descriptions for `codex` and `claude-code` builtin skills across all 7 locale override dictionaries (en, es, fr, ja, ru, zh, zht)
- Add test asserting both keys are present in every TUI override dictionary

## Changes
- `packages/opencode/src/cli/cmd/tui/i18n/{en,es,fr,ja,ru,zh,zht}.ts` — new `tui.skill.codex.description` and `tui.skill.claude-code.description` keys
- `packages/opencode/test/skill/skill-description.test.ts` — new locale coverage test