### PR TITLE
feat(tool): add tool_script — programmatic tool orchestration in a QuickJS sandbox

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -50,6 +50,7 @@ import type { TaskTool } from "@/tool/task"
 import type { QuestionTool } from "@/tool/question"
 import type { SkillTool } from "@/tool/skill"
 import type { WorkflowTool } from "@/tool/workflow"
+import type { ToolScriptTool } from "@/tool/tool-script"
 import { useKeyboard, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import { useSDK } from "@tui/context/sdk"
 import { useCommandDialog } from "@tui/component/dialog-command"
@@ -1965,6 +1966,9 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
         <Match when={props.part.tool === "workflow"}>
           <Workflow {...toolprops} />
         </Match>
+        <Match when={props.part.tool === "tool_script"}>
+          <ToolScript {...toolprops} />
+        </Match>
         <Match when={props.part.tool === "plan_exit"}>
           <PlanExit {...toolprops} />
         </Match>
@@ -2061,6 +2065,65 @@ function WorkItemTask(props: ToolProps<typeof TaskTool>) {
     <InlineTool icon="#" pending="Updating tasks..." complete={true} part={props.part}>
       task {summary()}
     </InlineTool>
+  )
+}
+
+// Renderer for the `tool_script` batch-orchestration tool. Default view is a
+// single InlineTool line — spinner + live aggregated call counts while running
+// (published through ctx.metadata), one muted summary line when done. Clicking
+// swaps to the full BlockTool with code, result, logs and per-call trace.
+function ToolScript(props: ToolProps<typeof ToolScriptTool>) {
+  const { theme } = useTheme()
+  const [expanded, setExpanded] = createSignal(false)
+  const isRunning = createMemo(() => props.part.state.status === "running")
+  const meta = createMemo(() =>
+    props.part.state.status === "pending" ? ({} as Record<string, any>) : (props.part.state.metadata ?? {}),
+  )
+  const counts = createMemo(() => {
+    const c = meta().counts as Record<string, { n: number; errors: number }> | undefined
+    if (!c) return ""
+    return Object.entries(c)
+      .sort((a, b) => b[1].n - a[1].n)
+      .map(([name, v]) => `${name}×${v.n}${v.errors ? `(${v.errors}!)` : ""}`)
+      .join(" ")
+  })
+  const status = createMemo(() => meta().status as string | undefined)
+  const callCount = createMemo(() => (meta().toolCalls as number | undefined) ?? 0)
+  const failed = createMemo(() => status() !== undefined && status() !== "completed" && !isRunning())
+  const summary = createMemo(() => {
+    const c = counts()
+    const base = `${callCount()} calls${c ? ` · ${c}` : ""}`
+    if (isRunning()) return base
+    return failed() ? `${status()} · ${base}` : base
+  })
+
+  return (
+    <Show
+      when={expanded()}
+      fallback={
+        <InlineTool
+          icon="»"
+          iconColor={failed() ? theme.error : undefined}
+          pending="Writing script..."
+          complete={!isRunning()}
+          spinner={isRunning()}
+          part={props.part}
+          onClick={() => setExpanded(true)}
+        >
+          tool_script {summary()}
+        </InlineTool>
+      }
+    >
+      <BlockTool title={`# tool_script · ${summary()}`} part={props.part} onClick={() => setExpanded(false)}>
+        <box gap={1}>
+          <text fg={theme.textMuted}>{((props.input.code as string | undefined) ?? "").trim()}</text>
+          <Show when={props.output}>
+            <text fg={failed() ? theme.error : theme.text}>{props.output}</text>
+          </Show>
+          <text fg={theme.textMuted}>Click to collapse</text>
+        </box>
+      </BlockTool>
+    </Show>
   )
 }
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -67,6 +67,8 @@ import { shellWrap } from "./shell-wrap"
 import * as BashInteractive from "./bash-interactive"
 import { resolveInvocationStyle } from "./invocation-style"
 import { BuiltinWorkflow } from "@/workflow/builtin"
+import { ToolScriptTool, renderToolScriptDeclarations } from "./tool-script"
+import { toolScriptRegistry } from "./tool-script-ref"
 
 const log = Log.create({ service: "tool.registry" })
 
@@ -150,6 +152,7 @@ export const layer = Layer.effect(
     const crontool = yield* CronTool
     const sessiontool = yield* SessionTool
     const workflowtool = yield* WorkflowTool
+    const toolscript = yield* ToolScriptTool
     const agent = yield* Agent.Service
 
     const state = yield* InstanceState.make<State>(
@@ -246,6 +249,7 @@ export const layer = Layer.effect(
           cron: Tool.init(crontool),
           session: Tool.init(sessiontool),
           workflow: Tool.init(workflowtool),
+          toolscript: Tool.init(toolscript),
         })
 
         return {
@@ -273,6 +277,7 @@ export const layer = Layer.effect(
             tool.memory,
             tool.history,
             tool.task,
+            tool.toolscript,
             ...(Flag.MIMOCODE_EXPERIMENTAL_CRON ? [tool.cron] : []),
             ...(Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR ? [tool.session] : []),
             ...(Flag.MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL ? [tool.workflow] : []),
@@ -289,6 +294,10 @@ export const layer = Layer.effect(
       const builtins = s.builtin.filter((t) => !customIds.has(t.id))
       return [...builtins, ...s.custom] as Tool.Def[]
     })
+
+    // Late-bound ref (see tool-script-ref.ts): tool_script dispatches guest RPC
+    // calls through the same def list the agent sees, without a module cycle.
+    toolScriptRegistry.current = all
 
     const ids: Interface["ids"] = Effect.fn("ToolRegistry.ids")(function* () {
       return (yield* all()).map((tool) => tool.id)
@@ -315,6 +324,10 @@ export const layer = Layer.effect(
 
     const describeWorkflow = Effect.fn("ToolRegistry.describeWorkflow")(function* () {
       return renderWorkflowCatalog()
+    })
+
+    const describeToolScript = Effect.fn("ToolRegistry.describeToolScript")(function* () {
+      return renderToolScriptDeclarations(yield* all())
     })
 
     const describeTask = Effect.fn("ToolRegistry.describeTask")(function* (agent: Agent.Info) {
@@ -392,6 +405,7 @@ export const layer = Layer.effect(
               tool.id === ActorTool.id ? yield* describeTask(input.agent) : undefined,
               tool.id === SkillTool.id ? yield* describeSkill(input.agent) : undefined,
               tool.id === WorkflowTool.id ? yield* describeWorkflow() : undefined,
+              tool.id === ToolScriptTool.id ? yield* describeToolScript() : undefined,
             ]
               .filter(Boolean)
               .join("\n"),

--- a/packages/opencode/src/tool/tool-script-ref.ts
+++ b/packages/opencode/src/tool/tool-script-ref.ts
@@ -1,0 +1,30 @@
+// Late-bound reference to the tool set executable from inside tool_script.
+//
+// tool_script needs the full ToolRegistry def list to dispatch guest RPC calls,
+// but the registry itself constructs tool_script (registry → tool_script →
+// registry would be a module cycle). Mirroring workflowRef (workflow/runtime-ref.ts):
+// the registry layer populates this module-local reference on initialisation and
+// the tool reads it at call time.
+import type { Effect } from "effect"
+import type * as Tool from "./tool"
+
+export const toolScriptRegistry: {
+  current: (() => Effect.Effect<Tool.Def[]>) | undefined
+} = { current: undefined }
+
+// Agent control-flow tools make no sense inside a script (they steer the
+// conversation, not data) — excluded from both the declared API and dispatch.
+export const TOOL_SCRIPT_EXCLUDED = new Set([
+  "tool_script",
+  "invalid",
+  "question",
+  "task",
+  "actor",
+  "skill",
+  "plan_enter",
+  "plan_exit",
+  "cron",
+  "session",
+  "workflow",
+  "change_directory",
+])

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -1,0 +1,353 @@
+import z from "zod"
+import os from "os"
+import path from "path"
+import { Effect } from "effect"
+import { EffectBridge, InstanceState } from "@/effect"
+import { Log, Filesystem } from "@/util"
+import { evalScript, type HostFn } from "../workflow/sandbox"
+import { toolScriptRegistry, TOOL_SCRIPT_EXCLUDED } from "./tool-script-ref"
+import DESCRIPTION from "./tool-script.txt"
+import * as Tool from "./tool"
+
+const log = Log.create({ service: "tool.tool_script" })
+
+const MAX_TOOL_CALLS = 50
+const MAX_CONCURRENT = 8
+const ACTIVE_DEADLINE_MS = 60_000
+const WALL_DEADLINE_MS = 30 * 60 * 1000
+const MAX_RESULT_BYTES = 256 * 1024
+const MAX_LOG_BYTES = 64 * 1024
+const MAX_CODE_BYTES = 128 * 1024
+const MAX_FILE_BYTES = 10 * 1024 * 1024
+
+/** JSON Schema (zod v4 toJSONSchema output) → compact TS type text. Best-effort:
+ * anything unrecognized renders as `unknown`, which is safe for declarations. */
+function schemaToTs(schema: any): string {
+  if (!schema || typeof schema !== "object") return "unknown"
+  if (schema.const !== undefined) return JSON.stringify(schema.const)
+  if (schema.enum) return schema.enum.map((v: unknown) => JSON.stringify(v)).join(" | ")
+  const variants = schema.anyOf ?? schema.oneOf
+  if (variants) return variants.map(schemaToTs).join(" | ")
+  switch (schema.type) {
+    case "string":
+      return "string"
+    case "number":
+    case "integer":
+      return "number"
+    case "boolean":
+      return "boolean"
+    case "null":
+      return "null"
+    case "array":
+      return `Array<${schemaToTs(schema.items)}>`
+    case "object": {
+      if (!schema.properties) {
+        if (schema.additionalProperties && typeof schema.additionalProperties === "object")
+          return `Record<string, ${schemaToTs(schema.additionalProperties)}>`
+        return "Record<string, unknown>"
+      }
+      const required = new Set<string>(schema.required ?? [])
+      const fields = Object.entries(schema.properties).map(
+        ([key, value]) => `${key}${required.has(key) ? "" : "?"}: ${schemaToTs(value)}`,
+      )
+      return `{ ${fields.join("; ")} }`
+    }
+    default:
+      return "unknown"
+  }
+}
+
+/** Render the `tools` API declaration block appended to the tool description. */
+export function renderToolScriptDeclarations(defs: Tool.Def[]): string {
+  const lines = defs
+    .filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id))
+    .map((def) => {
+      const summary = def.description.split("\n").find((l) => l.trim()) ?? ""
+      const input = schemaToTs(z.toJSONSchema(def.parameters))
+      return `  /** ${summary.trim().slice(0, 200)} */\n  ${def.id}(input: ${input}): Promise<ToolResult>`
+    })
+  return [
+    "```ts",
+    "type ToolResult = { title: string; output: string; metadata: Record<string, unknown> }",
+    "declare const tools: {",
+    ...lines,
+    "}",
+    "// Raw file IO for machine-to-machine data (pipelines across executions).",
+    "declare const files: {",
+    "  /** Raw file contents — no line numbers, no truncation. null if missing. Paths: worktree or OS tmp. */",
+    "  readText(path: string): Promise<string | null>",
+    "  /** Write raw text; parent dirs auto-created. OS tmp dir ONLY — project writes go through tools.write/edit. */",
+    "  writeText(path: string, content: string): Promise<void>",
+    "}",
+    "```",
+  ].join("\n")
+}
+
+/** Guest-side prelude: `tools` proxy → __callTool RPC, console → __log capture.
+ * Prepended AFTER transpilation so it stays plain JS. The catch-rethrow exists
+ * because the sandbox promise bridge rejects with a plain STRING (not Error) —
+ * wrapping restores `e.message` / `e instanceof Error` for guest catch blocks. */
+const GUEST_PRELUDE = `
+const tools = new Proxy({}, {
+  get: (_t, name) => (args) =>
+    __callTool(String(name), args === undefined ? {} : args).catch((e) => {
+      throw e instanceof Error ? e : new Error(String(e));
+    }),
+});
+const __fmt = (x) => {
+  if (typeof x === "string") return x;
+  try { return JSON.stringify(x); } catch { return String(x); }
+};
+const console = {
+  log: (...a) => __log(a.map(__fmt).join(" ")),
+  error: (...a) => __log("[error] " + a.map(__fmt).join(" ")),
+  warn: (...a) => __log("[warn] " + a.map(__fmt).join(" ")),
+};
+const __wrapErr = (e) => {
+  throw e instanceof Error ? e : new Error(String(e));
+};
+// marshalIn maps host null to guest undefined; normalize back so the declared
+// "string | null" contract holds for === null checks.
+const files = {
+  readText: (p) => __readText(p).then((v) => (v === undefined ? null : v), __wrapErr),
+  writeText: (p, c) => __writeText(p, c).catch(__wrapErr),
+};
+`
+
+/** Jail for the `files` raw-IO primitives. Read: worktree + OS tmp. Write: OS
+ * tmp ONLY — project writes must go through tools.write/edit so Permission.ask
+ * applies (enforced here, not just advised in the prompt). Lexical containment
+ * (same posture as workflow's resolveInWorkspace) — blocks `..` traversal and
+ * out-of-jail absolutes; symlink resolution deferred. */
+function resolveJailed(roots: string[], p: string, kind: "read" | "write"): string {
+  const abs = path.resolve(roots[0], p)
+  if (roots.some((root) => abs === root || Filesystem.contains(root, abs))) return abs
+  throw new Error(
+    kind === "write"
+      ? `files.writeText is limited to the OS temp dir — write project files via tools.write/tools.edit: ${JSON.stringify(p)}`
+      : `path outside allowed roots (worktree, tmp): ${JSON.stringify(p)}`,
+  )
+}
+
+type TraceEntry = {
+  name: string
+  status: "success" | "error"
+  durationMs: number
+  error?: string
+}
+
+function makeSemaphore(max: number) {
+  let active = 0
+  const queue: Array<() => void> = []
+  return async <T>(fn: () => Promise<T>): Promise<T> => {
+    if (active >= max) await new Promise<void>((resolve) => queue.push(resolve))
+    active++
+    try {
+      return await fn()
+    } finally {
+      active--
+      queue.shift()?.()
+    }
+  }
+}
+
+export const ToolScriptTool = Tool.define(
+  "tool_script",
+  Effect.gen(function* () {
+    return {
+      description: DESCRIPTION,
+      parameters: z.object({
+        code: z
+          .string()
+          .describe(
+            "TypeScript (or JavaScript) source for the body of an async function. Call tools via the global `tools` object; `return` the final aggregated value.",
+          ),
+      }),
+      execute: (params: { code: string }, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          if (Buffer.byteLength(params.code, "utf8") > MAX_CODE_BYTES) {
+            return {
+              title: "code too large",
+              metadata: { status: "code_error", toolCalls: 0 },
+              output: `status: code_error\ncode exceeds ${MAX_CODE_BYTES} bytes`,
+            }
+          }
+
+          const getDefs = toolScriptRegistry.current
+          if (!getDefs) throw new Error("tool_script registry unavailable")
+          const defs = (yield* getDefs()).filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id))
+          const byId = new Map(defs.map((def) => [def.id, def]))
+          // Non-git projects report worktree === "/" (see Instance.containsPath) —
+          // "/" as a jail root would allow EVERYTHING. Fall back to the project
+          // directory in that case. Relative guest paths resolve against roots[0].
+          const ins = yield* InstanceState.context
+          const jailRoots = [ins.worktree === "/" ? ins.directory : ins.worktree, os.tmpdir()]
+
+          // Snapshot the Effect context BEFORE crossing into Promise-land: the
+          // quickjs hook boundary loses Instance/Workspace context otherwise.
+          const bridge = yield* EffectBridge.make()
+
+          // Wrap before transpiling: the code is the BODY of an async function
+          // (top-level `return`/`await`), which is invalid at module top level —
+          // Bun.Transpiler would reject it. The wrapped form transpiles to a plain
+          // JS async-arrow expression the guest body can invoke.
+          const transpiled = yield* Effect.try({
+            try: () => new Bun.Transpiler({ loader: "ts" }).transformSync(`globalThis.__main = async () => {\n${params.code}\n}`),
+            catch: (err) => err,
+          }).pipe(
+            Effect.catch((err) =>
+              Effect.succeed({
+                error: `TypeScript transpile failed: ${err instanceof Error ? err.message : String(err)}`,
+              }),
+            ),
+          )
+          if (typeof transpiled === "object") {
+            return {
+              title: "transpile error",
+              metadata: { status: "code_error", toolCalls: 0 },
+              output: `status: code_error\n${transpiled.error}`,
+            }
+          }
+
+          const trace: TraceEntry[] = []
+          const logs: string[] = []
+          let logBytes = 0
+          let calls = 0
+          const withSlot = makeSemaphore(MAX_CONCURRENT)
+
+          // Live progress for the TUI: after each settled call, publish the
+          // aggregated per-tool counts through the OUTER part's metadata (each
+          // ctx.metadata fires a part delta the ToolScript view renders
+          // reactively). Fire-and-forget — progress must never fail a call.
+          const publishProgress = () => {
+            const counts: Record<string, { n: number; errors: number }> = {}
+            for (const t of trace) {
+              const c = (counts[t.name] ??= { n: 0, errors: 0 })
+              c.n++
+              if (t.status === "error") c.errors++
+            }
+            bridge.promise(ctx.metadata({ metadata: { running: true, toolCalls: trace.length, counts } })).catch(() => {})
+          }
+
+          const callTool: HostFn = (name: unknown, args: unknown) => {
+            const id = String(name)
+            const def = byId.get(id)
+            if (!def) return Promise.reject(new Error(`unknown tool: ${id}`))
+            calls++
+            if (calls > MAX_TOOL_CALLS)
+              return Promise.reject(new Error(`tool call budget exceeded (${MAX_TOOL_CALLS} per execution)`))
+            const seq = calls
+            const start = Date.now()
+            return withSlot(() =>
+              bridge
+                .promise(
+                  def.execute(args, {
+                    ...ctx,
+                    callID: `${ctx.callID ?? "tool_script"}:${seq}`,
+                    // Sub-call metadata would clobber the outer tool_script call's
+                    // title in the UI — swallow it; the trace covers observability.
+                    metadata: () => Effect.void,
+                  }),
+                )
+                .then(
+                  (result) => {
+                    trace.push({ name: id, status: "success", durationMs: Date.now() - start })
+                    publishProgress()
+                    return { title: result.title, output: result.output, metadata: result.metadata }
+                  },
+                  (err) => {
+                    const message = err instanceof Error ? err.message : String(err)
+                    trace.push({ name: id, status: "error", durationMs: Date.now() - start, error: message })
+                    publishProgress()
+                    throw new Error(`${id}: ${message}`)
+                  },
+                ),
+            )
+          }
+
+          const logHook: HostFn = (message: unknown) => {
+            const text = String(message)
+            if (logBytes >= MAX_LOG_BYTES) return undefined
+            logBytes += Buffer.byteLength(text, "utf8")
+            logs.push(logBytes >= MAX_LOG_BYTES ? text.slice(0, 200) + " …(log budget exhausted)" : text)
+            return undefined
+          }
+
+          // Raw file IO (`files.*`): machine-to-machine data channel, bypassing the
+          // agent-facing read/write formatting (line numbers, truncation). Reads are
+          // jailed to worktree + OS tmp; writes to OS tmp ONLY (project writes must
+          // carry permissions → tools.write/edit). Read side also caps size so a
+          // giant file can't blow the guest memory limit.
+          const readText: HostFn = async (p: unknown) => {
+            const abs = resolveJailed(jailRoots, String(p), "read")
+            const file = Bun.file(abs)
+            if (!(await file.exists())) return null
+            if (file.size > MAX_FILE_BYTES) throw new Error(`file exceeds ${MAX_FILE_BYTES} bytes: ${String(p)}`)
+            return file.text()
+          }
+          const writeText: HostFn = async (p: unknown, content: unknown) => {
+            const abs = resolveJailed([os.tmpdir()], String(p), "write")
+            const text = String(content)
+            if (Buffer.byteLength(text, "utf8") > MAX_FILE_BYTES)
+              throw new Error(`content exceeds ${MAX_FILE_BYTES} bytes`)
+            await Filesystem.write(abs, text)
+            return undefined
+          }
+
+          const outcome = yield* Effect.tryPromise({
+            try: () =>
+              evalScript(GUEST_PRELUDE + "\n" + transpiled + "\nreturn await globalThis.__main()", {
+                __callTool: callTool,
+                __log: logHook,
+                __readText: readText,
+                __writeText: writeText,
+              }, {
+                deterministic: false,
+                deadlineMs: WALL_DEADLINE_MS,
+                activeDeadlineMs: ACTIVE_DEADLINE_MS,
+                interrupt: () => ctx.abort.aborted,
+              }),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          }).pipe(Effect.result)
+
+          const traceLines = trace.map(
+            (t) => `- ${t.name} → ${t.status}${t.error ? ` (${t.error.slice(0, 200)})` : ""} [${t.durationMs}ms]`,
+          )
+          const logBlock = logs.length ? `\n\nLogs:\n${logs.join("\n")}` : ""
+          const traceBlock = trace.length ? `\n\nTool calls (${trace.length}):\n${traceLines.join("\n")}` : ""
+
+          if (outcome._tag === "Failure") {
+            const message = outcome.failure instanceof Error ? outcome.failure.message : String(outcome.failure)
+            const status = ctx.abort.aborted
+              ? "cancelled"
+              : message.includes("deadline exceeded") || message.includes("interrupted")
+                ? "timeout"
+                : message.includes("budget exceeded")
+                  ? "budget_exceeded"
+                  : "code_error"
+            log.warn("tool_script failed", { status, message: message.slice(0, 500) })
+            return {
+              title: status,
+              metadata: { status, toolCalls: trace.length },
+              output: `status: ${status}\n${message}${logBlock}${traceBlock}`,
+            }
+          }
+
+          const json = JSON.stringify(outcome.success, null, 2) ?? "undefined"
+          if (Buffer.byteLength(json, "utf8") > MAX_RESULT_BYTES) {
+            return {
+              title: "result too large",
+              metadata: { status: "budget_exceeded", toolCalls: trace.length },
+              output: `status: budget_exceeded\nreturned value is ${json.length} bytes (max ${MAX_RESULT_BYTES}). Aggregate or slice the data before returning.${logBlock}${traceBlock}`,
+            }
+          }
+
+          return {
+            title: `${trace.length} tool calls`,
+            metadata: { status: "completed", toolCalls: trace.length },
+            output: `status: completed\n\nResult:\n${json}${logBlock}${traceBlock}`,
+          }
+        }).pipe(Effect.orDie),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/tool-script.txt
+++ b/packages/opencode/src/tool/tool-script.txt
@@ -1,0 +1,46 @@
+Execute a TypeScript script that orchestrates existing tools programmatically. Use this for BATCH tool operations: loops, concurrency, filtering, and aggregation over many tool calls — the intermediate results stay OUT of the conversation context; only what you `return` comes back.
+
+The `code` argument is the BODY of an async function (TypeScript or JavaScript):
+- Call tools via the `tools` object, e.g. `await tools.glob({ pattern: "src/**/*.ts" })`
+- Every tool returns `Promise<ToolResult>` where `ToolResult = { title: string; output: string; metadata: Record<string, unknown> }` — `output` is the same text you would see when calling the tool directly (may be truncated for very large outputs; check `metadata.truncated`).
+- Use `Promise.all` / `Promise.allSettled` for concurrency (max 8 in flight; excess queue automatically).
+- `console.log(...)` output is captured and returned alongside the result (capped) — use it for debugging, not as the primary channel.
+- `return` a SMALL, aggregated value (object/array/string). Returning huge raw data defeats the purpose.
+
+Limits per execution: 50 tool calls, 8 concurrent, 60s of pure compute time (time spent waiting on tool calls is NOT charged), result capped at 256KB. Exceeding a limit fails the execution with a structured error.
+
+Permissions are enforced per tool call exactly as if you had called the tool directly — calls may pause awaiting user approval; a user rejection rejects that call's promise (catchable).
+
+State does NOT persist between executions: each tool_script call runs in a fresh sandbox — variables from a previous execution are gone. To pass data between executions, either `return` it (best for small results) or use the `files` raw-IO API to stage it in a temp file:
+```
+await files.writeText("/tmp/scan-results.json", JSON.stringify(hits))
+// ...next tool_script execution:
+const hits = JSON.parse(await files.readText("/tmp/scan-results.json"))
+```
+
+`tools.*` outputs are the AGENT-FACING text (e.g. `read` prefixes lines with `N: ` line numbers and may truncate). That is fine for scanning/matching, but for exact bytes (parsing JSON, byte-accurate content) use `files.readText` instead — raw content, no line numbers, no truncation. `files.readText` covers the project worktree and the OS temp dir; `files.writeText` is limited to the OS temp dir — project file writes must go through `tools.write` / `tools.edit` so permissions apply.
+
+When to use tool_script:
+- Same tool called many times (read 30 files, grep 10 patterns)
+- Results need deterministic filtering/aggregation/sorting/counting before you see them
+- Large intermediate outputs you don't need to read verbatim
+
+When NOT to use tool_script:
+- A single tool call — call the tool directly
+- Each step needs semantic judgment on the previous result — stay in the normal loop
+- You need to visually inspect results (images, screenshots)
+- High-risk side effects better done one at a time with your review between steps
+
+Example:
+```
+const files = await tools.glob({ pattern: "src/**/*.ts" })
+const paths = files.output.split("\n").filter(p => p.trim() && !p.startsWith("("))
+const reads = await Promise.all(paths.map(p => tools.read({ file_path: p })))
+const hits = paths
+  .map((p, i) => ({ path: p, todos: (reads[i].output.match(/TODO/g) ?? []).length }))
+  .filter(x => x.todos > 0)
+  .sort((a, b) => b.todos - a.todos)
+return { total: hits.length, top: hits.slice(0, 20) }
+```
+
+The available tools and their exact input types are declared below.

--- a/packages/opencode/src/workflow/sandbox.ts
+++ b/packages/opencode/src/workflow/sandbox.ts
@@ -1,6 +1,5 @@
 import {
   newQuickJSWASMModuleFromVariant,
-  shouldInterruptAfterDeadline,
   type QuickJSContext,
   type QuickJSDeferredPromise,
   type QuickJSHandle,
@@ -28,6 +27,18 @@ export type SandboxOptions = {
    * runtime passes a hash of runID so resume gets the same seed naturally;
    * tests / one-off callers that don't care can omit this. */
   seed?: number
+  /** Default true: strip Date/Math.random/WeakRef for resume-replay determinism
+   * (the workflow contract). Pass false for single-shot callers (tool_script)
+   * that have no replay requirement and want the standard JS environment. */
+  deterministic?: boolean
+  /** Optional ACTIVE-time budget: counts only time when NO host hook promise is
+   * pending, so a guest parked on a slow tool call is not charged. Kills runaway
+   * synchronous guest code via the interrupt handler. Wall-clock `deadlineMs`
+   * remains the overall kill-switch for hangs. */
+  activeDeadlineMs?: number
+  /** Optional cooperative cancel: polled from the interrupt handler (guest
+   * bytecode) so an aborted caller can stop a busy guest promptly. */
+  interrupt?: () => boolean
 }
 
 const DEFAULT_DEADLINE_MS = 12 * 60 * 60 * 1000
@@ -84,7 +95,35 @@ export async function evalScript(body: string, hooks: Record<string, HostFn>, op
   const QuickJS = await newQuickJSWASMModuleFromVariant(singlefileVariant)
   const rt = QuickJS.newRuntime()
   rt.setMemoryLimit(opts.memoryLimitBytes ?? DEFAULT_MEMORY)
-  rt.setInterruptHandler(shouldInterruptAfterDeadline(Date.now() + (opts.deadlineMs ?? DEFAULT_DEADLINE_MS)))
+  // Active-time accounting: charge the guest only while no host hook promise is
+  // pending. `pending` transitions drive a pause/resume clock; the interrupt
+  // handler (fires only during guest bytecode execution) compares accumulated
+  // active time against the budget. Wall-clock deadline still backstops hangs.
+  const activeBudget = opts.activeDeadlineMs
+  let pending = 0
+  let activeStart = Date.now()
+  let activeAccum = 0
+  const hostCallTracker =
+    activeBudget === undefined
+      ? undefined
+      : {
+          start: () => {
+            pending++
+            if (pending === 1) activeAccum += Date.now() - activeStart
+          },
+          end: () => {
+            pending--
+            if (pending === 0) activeStart = Date.now()
+          },
+        }
+  const wallDeadline = Date.now() + (opts.deadlineMs ?? DEFAULT_DEADLINE_MS)
+  rt.setInterruptHandler(() => {
+    if (opts.interrupt?.()) return true
+    if (Date.now() > wallDeadline) return true
+    if (activeBudget === undefined) return false
+    const active = activeAccum + (pending === 0 ? Date.now() - activeStart : 0)
+    return active > activeBudget
+  })
   const vm = rt.newContext()
 
   // Arena: every handle we create goes here and is disposed in `finally`.
@@ -99,7 +138,7 @@ export async function evalScript(body: string, hooks: Record<string, HostFn>, op
   }
 
   try {
-    injectHooks(vm, hooks, track, deferreds)
+    injectHooks(vm, hooks, track, deferreds, hostCallTracker)
     // Determinism: the guest is a bare quickjs-emscripten JS engine — no Web/Node
     // APIs exist (no crypto/performance/fetch/timers/process/Temporal/gc; all
     // already undefined). We neutralize the JS built-ins whose output or timing is
@@ -114,8 +153,11 @@ export async function evalScript(body: string, hooks: Record<string, HostFn>, op
     //     is only used by tests/one-off callers that don't pass a seed.
     //   - WeakRef / FinalizationRegistry — deleted (expose GC liveness/callback
     //     scheduling, which differs across runs and would silently diverge on replay).
-    const seed = (opts.seed ?? DEFAULT_PRNG_SEED) >>> 0
-    const strip = vm.evalCode(`
+    // Skipped entirely when deterministic === false (single-shot callers with no
+    // replay contract keep the stock JS environment: real Date, real Math.random).
+    if (opts.deterministic !== false) {
+      const seed = (opts.seed ?? DEFAULT_PRNG_SEED) >>> 0
+      const strip = vm.evalCode(`
       delete globalThis.Date;
       (function () {
         // mulberry32 — tiny seeded PRNG; deterministic for a given seed.
@@ -131,10 +173,11 @@ export async function evalScript(body: string, hooks: Record<string, HostFn>, op
       delete globalThis.WeakRef;
       delete globalThis.FinalizationRegistry;
     `)
-    if (strip.error) {
-      strip.error.dispose()
-    } else {
-      strip.value.dispose()
+      if (strip.error) {
+        strip.error.dispose()
+      } else {
+        strip.value.dispose()
+      }
     }
     const pre = vm.evalCode(PRELUDE)
     if (pre.error) {
@@ -233,6 +276,7 @@ function injectHooks(
   hooks: Record<string, HostFn>,
   track: <H extends QuickJSHandle>(h: H) => H,
   deferreds: QuickJSDeferredPromise[],
+  hostCallTracker?: { start: () => void; end: () => void },
 ): void {
   for (const [name, fn] of Object.entries(hooks)) {
     const fnHandle = vm.newFunction(name, (...argHandles) => {
@@ -241,8 +285,10 @@ function injectHooks(
       if (out instanceof Promise) {
         const promise = vm.newPromise()
         deferreds.push(promise)
+        hostCallTracker?.start()
         out.then(
           (value) => {
+            hostCallTracker?.end()
             // A late settle may arrive after the context is disposed (script
             // returned without awaiting). Bail before touching a dead context.
             if (!vm.alive) return
@@ -252,6 +298,7 @@ function injectHooks(
             vm.runtime.executePendingJobs()
           },
           (err) => {
+            hostCallTracker?.end()
             if (!vm.alive) return
             const eh = vm.newString(err instanceof Error ? err.message : String(err))
             promise.reject(eh)

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, test, afterAll } from "bun:test"
+import { Effect, Layer, ManagedRuntime } from "effect"
+import z from "zod"
+import os from "os"
+import fs from "fs/promises"
+import path from "path"
+import { evalScript } from "../../src/workflow/sandbox"
+import { Agent } from "../../src/agent/agent"
+import { Truncate, Tool } from "../../src/tool"
+import { ToolScriptTool, renderToolScriptDeclarations } from "../../src/tool/tool-script"
+import { toolScriptRegistry, TOOL_SCRIPT_EXCLUDED } from "../../src/tool/tool-script-ref"
+import { Instance } from "../../src/project/instance"
+
+describe("sandbox non-deterministic mode", () => {
+  test("deterministic:false keeps Date and Math.random", async () => {
+    const result = (await evalScript(
+      `return { hasDate: typeof Date === "function", rand: Math.random() }`,
+      {},
+      { deterministic: false },
+    )) as { hasDate: boolean; rand: number }
+    expect(result.hasDate).toBe(true)
+    expect(result.rand).toBeGreaterThanOrEqual(0)
+    expect(result.rand).toBeLessThan(1)
+  })
+
+  test("default mode still strips Date (workflow contract unchanged)", async () => {
+    const result = await evalScript(`return typeof Date`, {})
+    expect(result).toBe("undefined")
+  })
+
+  test("activeDeadlineMs kills runaway sync code", async () => {
+    await expect(evalScript(`while (true) {}`, {}, { deterministic: false, activeDeadlineMs: 200 })).rejects.toThrow()
+  })
+
+  test("activeDeadlineMs does NOT charge time parked on a host hook", async () => {
+    const hooks = {
+      slow: async () => {
+        await new Promise((r) => setTimeout(r, 300))
+        return "ok"
+      },
+    }
+    const result = await evalScript(`return await slow()`, hooks, {
+      deterministic: false,
+      activeDeadlineMs: 150,
+    })
+    expect(result).toBe("ok")
+  })
+
+  test("interrupt() stops the guest once it resumes after a host hook", async () => {
+    // interrupt is polled during guest BYTECODE execution only. A pure sync spin
+    // blocks the host event loop, so timer-driven aborts can't fire — the kill
+    // for that case is activeDeadlineMs (Date-based, above). Here abort is set
+    // while the guest is parked on a hook; the spin after resume is interrupted.
+    let stop = false
+    const hooks = {
+      pause: async () => {
+        await new Promise((r) => setTimeout(r, 50))
+        stop = true
+        return "ok"
+      },
+    }
+    await expect(
+      evalScript(`await pause(); while (true) {}`, hooks, { deterministic: false, interrupt: () => stop }),
+    ).rejects.toThrow()
+  })
+})
+
+const runtime = ManagedRuntime.make(Layer.mergeAll(Truncate.defaultLayer, Agent.defaultLayer))
+
+const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mimocode-test-toolscript-"))
+afterAll(async () => {
+  await Instance.disposeAll()
+  await fs.rm(tmp, { recursive: true, force: true })
+})
+
+function fakeDef(id: string, execute: (args: any) => Promise<string>): Tool.Def {
+  return {
+    id,
+    description: `fake ${id}`,
+    parameters: z.object({ value: z.string().optional() }),
+    execute: (args: any) =>
+      Effect.promise(() => execute(args)).pipe(
+        Effect.map((output) => ({ title: id, output, metadata: {} })),
+      ),
+  }
+}
+
+async function runToolScript(code: string, defs: Tool.Def[], abort?: AbortSignal) {
+  const prev = toolScriptRegistry.current
+  toolScriptRegistry.current = () => Effect.succeed(defs)
+  try {
+    return await Instance.provide({
+      directory: tmp,
+      fn: async () => {
+        const info = await runtime.runPromise(ToolScriptTool)
+        const def = await Effect.runPromise(Tool.init(info))
+        return runtime.runPromise(
+          def.execute(
+            { code },
+            {
+              sessionID: "ses_test" as any,
+              messageID: "msg_test" as any,
+              agent: "build",
+              abort: abort ?? new AbortController().signal,
+              callID: "call_test",
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          ),
+        )
+      },
+    })
+  } finally {
+    toolScriptRegistry.current = prev
+  }
+}
+
+describe("tool_script", () => {
+  test("executes code, calls tools, returns aggregated result", async () => {
+    const seen: string[] = []
+    const defs = [
+      fakeDef("echo", async (args) => {
+        seen.push(args.value)
+        return `echo:${args.value}`
+      }),
+    ]
+    const result = await runToolScript(
+      `
+      const items = ["a", "b", "c"]
+      const outs = await Promise.all(items.map(v => tools.echo({ value: v })))
+      return outs.map(o => o.output)
+      `,
+      defs,
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("echo:a")
+    expect(result.output).toContain("echo:c")
+    expect(seen.toSorted()).toEqual(["a", "b", "c"])
+    expect(result.metadata.toolCalls).toBe(3)
+  })
+
+  test("accepts TypeScript syntax (types stripped by transpiler)", async () => {
+    const result = await runToolScript(
+      `
+      const double = (n: number): number => n * 2
+      const xs: number[] = [1, 2, 3]
+      return xs.map(double)
+      `,
+      [],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("[\n  2,\n  4,\n  6\n]")
+  })
+
+  test("console.log is captured into Logs block", async () => {
+    const result = await runToolScript(`console.log("hello", { a: 1 }); return 1`, [])
+    expect(result.output).toContain("Logs:")
+    expect(result.output).toContain('hello {"a":1}')
+  })
+
+  test("unknown tool rejects catchably; trace records the error", async () => {
+    const result = await runToolScript(
+      `
+      try { await tools.nope({}) } catch (e) { return "caught: " + e.message }
+      `,
+      [],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("caught:")
+    expect(result.output).toContain("unknown tool: nope")
+  })
+
+  test("tool failure rejects the guest promise with tool name prefix", async () => {
+    const defs = [
+      fakeDef("boom", async () => {
+        throw new Error("kapow")
+      }),
+    ]
+    const result = await runToolScript(
+      `try { await tools.boom({}) } catch (e) { return e.message }`,
+      defs,
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("boom: kapow")
+    expect(result.output).toContain("→ error")
+  })
+
+  test("call budget exceeded → budget_exceeded status", async () => {
+    const defs = [fakeDef("ping", async () => "pong")]
+    const result = await runToolScript(
+      `
+      for (let i = 0; i < 60; i++) await tools.ping({})
+      return "done"
+      `,
+      defs,
+    )
+    expect(result.metadata.status).toBe("budget_exceeded")
+  })
+
+  test("syntax error → code_error", async () => {
+    const result = await runToolScript(`const = broken (`, [])
+    expect(result.metadata.status).toBe("code_error")
+  })
+
+  test("pre-aborted signal cancels the execution", async () => {
+    // A sync spin blocks the host event loop, so a timer-armed abort can never
+    // fire mid-spin (the 60s active budget covers that in production). An
+    // already-aborted signal exercises the interrupt path deterministically.
+    const abort = new AbortController()
+    abort.abort()
+    const result = await runToolScript(`while (true) {}`, [], abort.signal)
+    expect(result.metadata.status).toBe("cancelled")
+  }, 15_000)
+
+  test("excluded tools are not dispatchable", async () => {
+    const defs = [fakeDef("task", async () => "should never run")]
+    const result = await runToolScript(
+      `try { await tools.task({}) } catch (e) { return e.message }`,
+      defs,
+    )
+    expect(result.output).toContain("unknown tool: task")
+  })
+
+  test("concurrency is capped at 8", async () => {
+    let active = 0
+    let peak = 0
+    const defs = [
+      fakeDef("work", async () => {
+        active++
+        peak = Math.max(peak, active)
+        await new Promise((r) => setTimeout(r, 20))
+        active--
+        return "ok"
+      }),
+    ]
+    const result = await runToolScript(
+      `
+      await Promise.all(Array.from({ length: 20 }, () => tools.work({})))
+      return "done"
+      `,
+      defs,
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(peak).toBeLessThanOrEqual(8)
+    expect(peak).toBeGreaterThan(1)
+  })
+
+  test("Date works inside tool_script guest", async () => {
+    const result = await runToolScript(`return typeof Date.now()`, [])
+    expect(result.output).toContain("number")
+  })
+
+  test("files.writeText → files.readText round-trips raw bytes via tmp", async () => {
+    const marker = `ts-${Date.now()}`
+    const write = await runToolScript(
+      `
+      await files.writeText("${path.join(os.tmpdir(), marker)}.json", JSON.stringify({ a: [1, 2], s: "x: 1" }))
+      return "written"
+      `,
+      [],
+    )
+    expect(write.metadata.status).toBe("completed")
+    const read = await runToolScript(
+      `
+      const data = JSON.parse(await files.readText("${path.join(os.tmpdir(), marker)}.json"))
+      return data.a.length + ":" + data.s
+      `,
+      [],
+    )
+    expect(read.metadata.status).toBe("completed")
+    expect(read.output).toContain("2:x: 1")
+    await fs.rm(path.join(os.tmpdir(), `${marker}.json`), { force: true })
+  })
+
+  test("files.readText returns null for missing file", async () => {
+    const result = await runToolScript(
+      `return (await files.readText("${path.join(os.tmpdir(), "definitely-missing-xyz.json")}")) === null`,
+      [],
+    )
+    expect(result.output).toContain("true")
+  })
+
+  test("files.readText rejects paths outside jail (catchable)", async () => {
+    const result = await runToolScript(
+      `try { await files.readText("/etc/passwd") } catch (e) { return e.message }`,
+      [],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("outside allowed roots")
+  })
+
+  test("files.writeText rejects paths outside the OS tmp dir (write is tmp-only)", async () => {
+    // NOTE: the test worktree lives INSIDE os.tmpdir() (mkdtemp), so a worktree
+    // path can't exercise the rejection here — use a clearly-outside path.
+    const result = await runToolScript(
+      `try { await files.writeText("/etc/tool-script-test.json", "data") } catch (e) { return e.message }`,
+      [],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("tools.write/tools.edit")
+  })
+
+  test("files.readText reads worktree files raw (no line numbers)", async () => {
+    await fs.writeFile(path.join(tmp, "raw-check.json"), `{"k": "1: not a line number"}`)
+    const result = await runToolScript(
+      `
+      const data = JSON.parse(await files.readText("raw-check.json"))
+      return data.k
+      `,
+      [],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("1: not a line number")
+  })
+})
+
+describe("renderToolScriptDeclarations", () => {
+  test("renders TS signatures and skips excluded tools", () => {
+    const defs = [
+      fakeDef("read", async () => "x"),
+      fakeDef("task", async () => "x"),
+      fakeDef("question", async () => "x"),
+    ]
+    const text = renderToolScriptDeclarations(defs)
+    expect(text).toContain("read(input:")
+    expect(text).not.toContain("task(input:")
+    expect(text).not.toContain("question(input:")
+    expect(text).toContain("declare const tools")
+  })
+
+  test("exclusion list covers agent control-flow tools", () => {
+    for (const id of ["task", "question", "actor", "skill", "plan_enter", "plan_exit", "tool_script"]) {
+      expect(TOOL_SCRIPT_EXCLUDED.has(id)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
Model writes a TypeScript async-function body that calls existing tools via a tools.* proxy (RPC through the real Tool.Context, so Permission.ask / approvals apply per call). Intermediate results stay in the sandbox; only the returned value enters context. Includes files.readText/writeText raw IO (read: worktree
+ tmp; write: tmp only), per-execution budgets (50 calls / 8 concurrent / 60s active compute), full per-call trace, and a collapsed-by-default TUI renderer with live call counts.