### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@mimo-ai/app",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@mimo-ai/sdk": "workspace:*",
@@ -83,7 +83,7 @@
     },
     "packages/console/app": {
       "name": "@mimo-ai/console-app",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -117,7 +117,7 @@
     },
     "packages/console/core": {
       "name": "@mimo-ai/console-core",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -144,7 +144,7 @@
     },
     "packages/console/function": {
       "name": "@mimo-ai/console-function",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.48",
@@ -168,7 +168,7 @@
     },
     "packages/console/mail": {
       "name": "@mimo-ai/console-mail",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -192,7 +192,7 @@
     },
     "packages/desktop": {
       "name": "@mimo-ai/desktop",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -236,7 +236,7 @@
     },
     "packages/enterprise": {
       "name": "@mimo-ai/enterprise",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@mimo-ai/shared": "workspace:*",
         "@mimo-ai/ui": "workspace:*",
@@ -265,7 +265,7 @@
     },
     "packages/function": {
       "name": "@mimo-ai/function",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -281,7 +281,7 @@
     },
     "packages/opencode": {
       "name": "@mimo-ai/cli",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "bin": {
         "mimo": "./bin/mimo",
       },
@@ -436,7 +436,7 @@
     },
     "packages/plugin": {
       "name": "@mimo-ai/plugin",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@mimo-ai/sdk": "workspace:*",
         "effect": "catalog:",
@@ -471,7 +471,7 @@
     },
     "packages/sdk/js": {
       "name": "@mimo-ai/sdk",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -486,7 +486,7 @@
     },
     "packages/shared": {
       "name": "@mimo-ai/shared",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -510,7 +510,7 @@
     },
     "packages/slack": {
       "name": "@mimo-ai/slack",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@mimo-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -545,7 +545,7 @@
     },
     "packages/ui": {
       "name": "@mimo-ai/ui",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@mimo-ai/sdk": "workspace:*",
@@ -594,7 +594,7 @@
     },
     "packages/web": {
       "name": "@mimo-ai/web",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/app",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/console-app",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@mimo-ai/console-core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/console-function",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/console-mail",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mimo-ai/desktop",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/enterprise",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/function",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "name": "@mimo-ai/cli",
   "type": "module",
   "license": "MIT",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@mimo-ai/plugin",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Plugin SDK for extending MiMoCode",
   "keywords": ["mimo", "mimocode", "ai", "plugin", "coding-assistant"],
   "type": "module",

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@mimo-ai/sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TypeScript SDK for the MiMoCode API",
   "keywords": ["mimo", "mimocode", "ai", "sdk", "coding-assistant"],
   "type": "module",

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -119,6 +119,17 @@ export type EventActorStuck = {
   }
 }
 
+export type EventActorStalled = {
+  type: "actor.stalled"
+  properties: {
+    sessionID: string
+    actorID: string
+    description: string
+    lastTurnTime: number
+    stalledDuration: number
+  }
+}
+
 export type EventWriterCachePerf = {
   type: "writer.cache_perf"
   properties: {
@@ -717,6 +728,36 @@ export type EventBashInteractiveReplied = {
   }
 }
 
+export type SessionStatus =
+  | {
+      type: "idle"
+    }
+  | {
+      type: "retry"
+      attempt: number
+      message: string
+      next: number
+    }
+  | {
+      type: "busy"
+      message?: string
+    }
+
+export type EventSessionStatus = {
+  type: "session.status"
+  properties: {
+    sessionID: string
+    status: SessionStatus
+  }
+}
+
+export type EventSessionIdle = {
+  type: "session.idle"
+  properties: {
+    sessionID: string
+  }
+}
+
 export type EventVcsBranchUpdated = {
   type: "vcs.branch.updated"
   properties: {
@@ -780,36 +821,6 @@ export type EventTodoUpdated = {
   properties: {
     sessionID: string
     todos: Array<Todo>
-  }
-}
-
-export type SessionStatus =
-  | {
-      type: "idle"
-    }
-  | {
-      type: "retry"
-      attempt: number
-      message: string
-      next: number
-    }
-  | {
-      type: "busy"
-      message?: string
-    }
-
-export type EventSessionStatus = {
-  type: "session.status"
-  properties: {
-    sessionID: string
-    status: SessionStatus
-  }
-}
-
-export type EventSessionIdle = {
-  type: "session.idle"
-  properties: {
-    sessionID: string
   }
 }
 
@@ -1521,6 +1532,7 @@ export type GlobalEvent = {
     | EventActorRegistered
     | EventActorStatus
     | EventActorStuck
+    | EventActorStalled
     | EventWriterCachePerf
     | EventInboxArrived
     | EventTaskCreated
@@ -1559,6 +1571,8 @@ export type GlobalEvent = {
     | EventSessionCwd
     | EventBashInteractiveAsked
     | EventBashInteractiveReplied
+    | EventSessionStatus
+    | EventSessionIdle
     | EventVcsBranchUpdated
     | EventMcpToolsChanged
     | EventMcpBrowserOpenFailed
@@ -1566,8 +1580,6 @@ export type GlobalEvent = {
     | EventWorktreeReady
     | EventWorktreeFailed
     | EventTodoUpdated
-    | EventSessionStatus
-    | EventSessionIdle
     | EventSessionGoal
     | EventSessionCompacted
     | EventPtyCreated
@@ -1917,15 +1929,9 @@ export type Config = {
    */
   $schema?: string
   logLevel?: LogLevel
-  /**
-   * Environment variables to inject into the mimocode process and its child processes (e.g. the bash tool). A variable already set in the real environment takes precedence — config values only apply when the variable is not already set. Supports {env:VAR} and {file:path} substitution.
-   */
-  env?: {
-    [key: string]: string
-  }
   server?: ServerConfig
   /**
-   * Command configuration, see https://opencode.ai/docs/commands
+   * Command configuration, see https://mimo.xiaomi.com/mimocode/commands
    */
   command?: {
     [key: string]: {
@@ -2038,7 +2044,7 @@ export type Config = {
     [key: string]: AgentConfig | undefined
   }
   /**
-   * Agent configuration, see https://opencode.ai/docs/agents
+   * Agent configuration, see https://mimo.xiaomi.com/mimocode/agents
    */
   agent?: {
     plan?: AgentConfig
@@ -2720,6 +2726,7 @@ export type Event =
   | EventActorRegistered
   | EventActorStatus
   | EventActorStuck
+  | EventActorStalled
   | EventWriterCachePerf
   | EventInboxArrived
   | EventTaskCreated
@@ -2758,6 +2765,8 @@ export type Event =
   | EventSessionCwd
   | EventBashInteractiveAsked
   | EventBashInteractiveReplied
+  | EventSessionStatus
+  | EventSessionIdle
   | EventVcsBranchUpdated
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
@@ -2765,8 +2774,6 @@ export type Event =
   | EventWorktreeReady
   | EventWorktreeFailed
   | EventTodoUpdated
-  | EventSessionStatus
-  | EventSessionIdle
   | EventSessionGoal
   | EventSessionCompacted
   | EventPtyCreated

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "name": "@mimo-ai/shared",
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/slack",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/ui",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "license": "MIT",
   "exports": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@mimo-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump all package versions from 0.1.5 to 0.1.6 (publish script output)
- Update SDK generated types (new `EventActorStalled` type, reorder `SessionStatus`/`EventSessionStatus`/`EventSessionIdle`)
- Update bun.lock to reflect version changes