### PR TITLE
fix(rebuild): make manual /rebuild perform an on-the-spot rebuild with writer-freshness + waiting UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,29 @@ const table = sqliteTable("session", {
 })
 ```
 
+### Reading a nullable column
+
+Two independent absences meet in one expression, and only one of them is
+`undefined`. `.get()` yields `undefined` when no row matches — Drizzle normalises
+the driver's `null` there — while a nullable column's SQL `NULL` arrives as
+`null`. So `row?.some_column` is `T | null | undefined`.
+
+When a caller only asks "is there a value", flatten to `undefined`, and write the
+flattening as an annotation rather than an `as` cast:
+
+```ts
+// Good — the compiler enforces it; deleting the `?? undefined` is a type error
+const boundary: MessageID | undefined = row?.last_checkpoint_message_id ?? undefined
+
+// Bad — the cast removes `null` from the union without converting anything,
+// so the declared type is untrue at runtime
+return row?.last_checkpoint_message_id as MessageID | undefined
+```
+
+Discriminate a possibly-absent value with truthiness or `== null`, never with
+`=== undefined` / `!== undefined`. Because `null !== undefined` is `true`, such a
+guard typechecks, reads correctly in review, and does nothing.
+
 ## Testing
 
 - Avoid mocks as much as possible

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/footer.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/footer.ts
@@ -1,0 +1,22 @@
+import { Locale } from "@/util"
+
+/**
+ * Cell budget for the ephemeral status message in the prompt footer. Sized so
+ * the message plus the spinner still leaves room for `esc interrupt` and the
+ * context counter on an 80-column terminal.
+ */
+export const STATUS_MESSAGE_MAX = 48
+
+/**
+ * The footer packs the spinner + status message onto the same row as the context
+ * counter (`52.4K/960K (5%)`). A long server-supplied status string wrapped over
+ * several lines and squeezed that row until the counter rendered clipped
+ * (`52.4K/96`). Clamp the message — and flatten any newlines — so a status
+ * string can never cost the counter its cells.
+ */
+export function clampStatusMessage(message: string | undefined) {
+  if (!message) return undefined
+  const flat = message.replace(/\s+/g, " ").trim()
+  if (!flat) return undefined
+  return Locale.truncate(flat, STATUS_MESSAGE_MAX)
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -18,6 +18,7 @@ import { useKeybind } from "@tui/context/keybind"
 import { usePromptHistory, type PromptInfo } from "./history"
 import { assign, expandPlaceholders } from "./part"
 import { usePromptStash } from "./stash"
+import { clampStatusMessage } from "./footer"
 import { DialogStash } from "../dialog-stash"
 import { type AutocompleteRef, Autocomplete } from "./autocomplete"
 import { useCommandDialog } from "../dialog-command"
@@ -1897,11 +1898,13 @@ export function Prompt(props: PromptProps) {
                 {(() => {
                   const busyMessage = createMemo(() => {
                     const s = status()
-                    return s.type === "busy" ? s.message : undefined
+                    return s.type === "busy" ? clampStatusMessage(s.message) : undefined
                   })
                   return (
                     <Show when={busyMessage()}>
-                      <text fg={theme.textMuted}>{busyMessage()}</text>
+                      <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
+                        {busyMessage()}
+                      </text>
                     </Show>
                   )
                 })()}
@@ -1992,7 +1995,10 @@ export function Prompt(props: PromptProps) {
                   <box gap={2} flexDirection="row">
                     <Show when={usage()}>
                       {(item) => (
-                        <text fg={theme.textMuted} wrapMode="none">
+                        // flexShrink=0: the context counter is the one number the
+                        // footer must never clip (`52.4K/96` instead of
+                        // `52.4K/960K`); the hints beside it can give way first.
+                        <text fg={theme.textMuted} wrapMode="none" flexShrink={0}>
                           {[item().context, item().cost].filter(Boolean).join(" · ")}
                         </text>
                       )}

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -155,6 +155,21 @@ export function bucketMessages<M extends { agentID?: string | null }>(
   return out
 }
 
+/**
+ * A `session.status` event is authoritative for the WHOLE status object.
+ *
+ * Solid's store setter merges plain objects into the existing node
+ * (`mergeStoreNode` only writes `Object.keys(next)`), so writing a bare
+ * `{ type: "busy" }` — which is what the runner emits at the start of every turn
+ * (session/run-state.ts:74) — inherits the `message` of whatever status was
+ * written before it. That latched `/rebuild` outcome text
+ * (session/prompt.ts:4173) into the following turn's spinner. `reconcile()`
+ * drops the fields the new status omits, so each status stands alone.
+ */
+export function nextSessionStatus(status: SessionStatus) {
+  return reconcile(status)
+}
+
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
   init: () => {
@@ -452,7 +467,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }
 
         case "session.status": {
-          setStore("session_status", event.properties.sessionID, event.properties.status)
+          setStore("session_status", event.properties.sessionID, nextSessionStatus(event.properties.status))
           break
         }
 

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -560,6 +560,10 @@ export const dict: Record<string, string> = {
   // Session badges
   "tui.session.badge.auto": "Auto",
 
+  // Context rebuild boundary marker (inserted by /rebuild)
+  "tui.session.rebuild_boundary.label": "context rebuilt",
+  "tui.session.rebuild_boundary.detail": "earlier messages summarized",
+
   // Workspace trust
   "trust.title": "Accessing workspace:",
   "trust.safety_check": "Quick safety check: Is this a project you created or one you trust? (Like your own code, a well-known open source project, or work from your team). If not, take a moment to review what's in this folder first.",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -581,6 +581,10 @@ export const dict = {
   // Session badges
   "tui.session.badge.auto": "自动",
 
+  // Context rebuild boundary marker (inserted by /rebuild)
+  "tui.session.rebuild_boundary.label": "上下文已重建",
+  "tui.session.rebuild_boundary.detail": "较早消息已摘要",
+
   // Workspace trust
   "trust.title": "访问工作区：",
   "trust.safety_check": "安全确认：这是你自己创建或信任的项目吗？（如你自己的代码、知名开源项目或团队内部项目）。如果不是，请先检查此目录下的内容。",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -550,6 +550,10 @@ export const dict = {
   // Session badges
   "tui.session.badge.auto": "自動",
 
+  // Context rebuild boundary marker (inserted by /rebuild)
+  "tui.session.rebuild_boundary.label": "上下文已重建",
+  "tui.session.rebuild_boundary.detail": "較早訊息已摘要",
+
   // Workspace trust
   "trust.title": "存取工作區：",
   "trust.safety_check": "安全確認：這是你自己建立或信任的專案嗎？（如你自己的程式碼、知名開源專案或團隊內部專案）。如果不是，請先檢查此目錄下的內容。",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1536,7 +1536,16 @@ function UserMessage(props: {
       return parsed ? [parsed] : []
     })[0]
   })
+  // A context rebuild (`/rebuild`) inserts a single user message carrying a
+  // `checkpoint` part plus `synthetic: true` text parts (the rendered context
+  // and index). Neither renders — `checkpoint` has no PART_MAPPING entry and
+  // synthetic text is excluded from `text()` above — so the boundary used to be
+  // completely invisible in the transcript, unlike compaction which at least
+  // leaves a visible summary message behind. Surface it as a one-line marker
+  // row so the user can see that a rebuild happened and where.
+  const rebuildBoundary = createMemo(() => props.parts.some((x) => x.type === "checkpoint"))
   const { theme } = useTheme()
+  const t = useLanguage().t
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
   const color = createMemo(() => local.agent.color(props.message.agent))
@@ -1602,6 +1611,17 @@ function UserMessage(props: {
             </box>
           )
         }}
+      </Show>
+      <Show when={rebuildBoundary()}>
+        <box id={props.message.id} marginTop={props.index === 0 ? 0 : 1} paddingLeft={2} flexDirection="row" gap={1}>
+          <text fg={theme.textMuted}>
+            <span style={{ bg: theme.backgroundElement, fg: theme.primary, bold: true }}>
+              {" "}
+              ⟲ {t("tui.session.rebuild_boundary.label")}{" "}
+            </span>
+            <span style={{ fg: theme.textMuted }}> {t("tui.session.rebuild_boundary.detail")}</span>
+          </text>
+        </box>
       </Show>
       <Show when={text() && !actorNotification()}>
         <box

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1386,7 +1386,7 @@ const layer: Layer.Layer<
           const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
 
           provider.models = yield* Effect.promise(async () => {
-            const next = await models(provider as any, { auth: pluginAuth })
+            const next = await models(provider, { auth: pluginAuth })
             return Object.fromEntries(
               Object.entries(next).map(([id, model]) => [
                 id,

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -1419,16 +1419,36 @@ export const layer: Layer.Layer<
             .get(),
         ),
       )
-      // `?? undefined` is load-bearing, not cosmetic. The session row always
-      // exists, so `row` is non-null and the column is SQL NULL until a writer
-      // sets the watermark — i.e. this expression is `null`, while the declared
-      // signature (:489) promises `MessageID | undefined`. The `as` cast below
-      // silences the type checker without converting anything, so the declared
-      // type was simply untrue at runtime. Every historical caller happened to
-      // test truthiness (`!boundary` at prompt.ts:413, `watermarkBefore ?` at
-      // :1131, `boundaryID ?` in nudgedSinceBoundary) and so never noticed; the
-      // first caller to write `!== undefined` got a silent no-op instead.
-      return (row?.last_checkpoint_message_id ?? undefined) as MessageID | undefined
+      // Two independent absences meet in this one expression, and only one of
+      // them is `undefined`:
+      //
+      //   row is undefined      -> no such session row. Drizzle normalises the
+      //                            driver's null to undefined here (measured:
+      //                            bun:sqlite's .get() returns null, Drizzle
+      //                            returns undefined), so this half is honest.
+      //   column is null        -> the session exists but no writer has set the
+      //                            watermark yet. SQL NULL, faithfully mapped to
+      //                            JS null, because the column is nullable
+      //                            (session.sql.ts: text().$type<MessageID>()
+      //                            with no .notNull()).
+      //
+      // So `row?.last_checkpoint_message_id` is `MessageID | null | undefined`.
+      // Callers only ever ask "is there a boundary to rebuild from", for which
+      // the last two are the same answer, so flattening to `undefined` is right
+      // — it also matches Drizzle's own row-level convention.
+      //
+      // The flattening is written as an ANNOTATION rather than an `as` cast on
+      // purpose. A cast would let the union be narrowed by assertion, which is
+      // how this went wrong before: the previous version claimed
+      // `as MessageID | undefined` while returning `null`, and a caller that
+      // then wrote `boundary !== undefined` got a condition that is always true
+      // — a guard that typechecks, reads correctly, and does nothing. Every
+      // other caller happened to test truthiness (`!boundary` at prompt.ts:413,
+      // `watermarkBefore ?` at :1131, `boundaryID ?` in nudgedSinceBoundary) and
+      // so never noticed. With an annotation, dropping the `?? undefined` is a
+      // compile error instead of a silent lie.
+      const boundary: MessageID | undefined = row?.last_checkpoint_message_id ?? undefined
+      return boundary
     })
 
     const isWriterRunning = Effect.fn("SessionCheckpoint.isWriterRunning")(function* (sessionID: SessionID) {

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -1419,7 +1419,16 @@ export const layer: Layer.Layer<
             .get(),
         ),
       )
-      return row?.last_checkpoint_message_id as MessageID | undefined
+      // `?? undefined` is load-bearing, not cosmetic. The session row always
+      // exists, so `row` is non-null and the column is SQL NULL until a writer
+      // sets the watermark — i.e. this expression is `null`, while the declared
+      // signature (:489) promises `MessageID | undefined`. The `as` cast below
+      // silences the type checker without converting anything, so the declared
+      // type was simply untrue at runtime. Every historical caller happened to
+      // test truthiness (`!boundary` at prompt.ts:413, `watermarkBefore ?` at
+      // :1131, `boundaryID ?` in nudgedSinceBoundary) and so never noticed; the
+      // first caller to write `!== undefined` got a silent no-op instead.
+      return (row?.last_checkpoint_message_id ?? undefined) as MessageID | undefined
     })
 
     const isWriterRunning = Effect.fn("SessionCheckpoint.isWriterRunning")(function* (sessionID: SessionID) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4135,19 +4135,27 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         yield* goal.set(input.sessionID, condition)
       }
 
-      // /rebuild — manually rebuild the conversation context now, from the
-      // latest checkpoint. Reuses the SAME rebuildFromCheckpoint step as the
-      // automatic overflow path (identical logic + boundary conditions), so a
-      // user-triggered rebuild behaves exactly like an auto one: it inserts a
-      // checkpoint boundary at the watermark (recent messages after it are kept
-      // verbatim; earlier ones collapse to the checkpoint summary on the next
-      // turn). If no usable checkpoint exists yet, tell the user rather than
-      // silently doing nothing — the first checkpoint has to be produced by
-      // normal turns before there is anything to rebuild from.
+      // /rebuild — manually rebuild the conversation context ON THE SPOT,
+      // from the latest checkpoint. Implements the 3-case checkpoint-freshness
+      // semantics:
+      //   1. Usable checkpoint exists, no writer running → rebuild immediately.
+      //   2. No usable checkpoint → start a writer and wait for it, then rebuild.
+      //   3. Checkpoint exists + writer in-flight → wait (with timeout), rebuild
+      //      with the fresher checkpoint if it arrives, else fall back to existing.
+      // The busy status is set BEFORE any work so the TUI spinner lights up
+      // immediately; the Runner's onIdle callback clears it after the runLoop
+      // completes. For the no-checkpoint case (no work to do), we return a
+      // synthetic message without entering the runLoop, and clear idle in a
+      // finally block.
       if (input.command === Command.Default.REBUILD) {
         const msgs = yield* sessions.messages({ sessionID: input.sessionID, agentID: "main" })
         const lastUser = msgs.findLast((m) => m.info.role === "user")
         const model = yield* lastModel(input.sessionID)
+
+        // Set busy status so the TUI shows a spinner while we wait on the
+        // writer (cases 2/3) or assemble context (case 1).
+        yield* status.set(input.sessionID, { type: "busy" }).pipe(Effect.catch(() => Effect.void))
+
         const inserted = yield* rebuildFromCheckpoint({
           sessionID: input.sessionID,
           msgs,
@@ -4155,6 +4163,32 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           agent: agentName,
           model: { providerID: model.providerID, id: model.modelID },
         }).pipe(Effect.catch(() => Effect.succeed(false)))
+
+        if (!inserted) {
+          // No checkpoint available — tell the user rather than silently doing
+          // nothing. Return a synthetic message WITHOUT entering the runLoop
+          // (noReply: true) so no model response is generated. Clear idle
+          // status since the Runner won't handle it in this path.
+          const result = yield* prompt({
+            sessionID: input.sessionID,
+            messageID: input.messageID,
+            agent: agentName,
+            parts: [
+              {
+                type: "text",
+                text: "No checkpoint is available to rebuild from yet — continue the conversation and a checkpoint will be written automatically.",
+                synthetic: true,
+              },
+            ],
+            noReply: true,
+          })
+          yield* status.set(input.sessionID, { type: "idle" }).pipe(Effect.catch(() => Effect.void))
+          return result
+        }
+
+        // Checkpoint was inserted — enter the runLoop (no noReply) so the
+        // model sees the rebuilt context boundary and produces a response.
+        // The Runner's onIdle callback clears busy status automatically.
         return yield* prompt({
           sessionID: input.sessionID,
           messageID: input.messageID,
@@ -4162,13 +4196,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           parts: [
             {
               type: "text",
-              text: inserted
-                ? "Context rebuilt from the latest checkpoint. Recent messages are preserved; earlier context is now summarized."
-                : "No checkpoint is available to rebuild from yet — continue the conversation and a checkpoint will be written automatically.",
+              text: "Context rebuilt from the latest checkpoint. Recent messages are preserved; earlier context is now summarized.",
               synthetic: true,
             },
           ],
-          noReply: true,
         })
       }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -429,6 +429,111 @@ export const layer = Layer.effect(
       return inserted
     })
 
+    // Upper bound on how long a rebuild may block waiting for a checkpoint
+    // writer it started itself. `waitForWriter` takes NO timeout argument — its
+    // own 5-min bound is hardcoded at checkpoint.ts:986 — so the bound is
+    // applied by wrapping the call below.
+    //
+    // MANUAL: 5 min, matching waitForWriter's internal bound (i.e. unchanged
+    // behaviour). A human just typed /rebuild and is watching a spinner.
+    //
+    // AUTO: 3 min. The auto path fires mid-turn WITHOUT being asked, so the
+    // stall is unsolicited and must not be as generous as the manual one.
+    // 180s is exactly the top of the 60-180s band the writer documents for
+    // itself (checkpoint.ts:981), so it admits every writer that behaves as
+    // designed while refusing to hold an unrequested turn for the extra two
+    // minutes a watching human would tolerate. Abandoning the wait does not
+    // cancel the writer — it keeps running detached — so a bound that is too
+    // tight costs one degraded turn, not the checkpoint itself.
+    const MANUAL_WRITER_WAIT_MS = 300_000
+    const AUTO_WRITER_WAIT_MS = 180_000
+
+    /**
+     * Outcome of a rebuild attempt that is allowed to WRITE a checkpoint first.
+     *
+     * - "rebuilt"       a boundary was inserted; context is freed.
+     * - "no-checkpoint" there was no checkpoint AND the writer failed / never
+     *                   ran / the wait bound expired. This is the ONLY state in
+     *                   which a caller may fall back to compaction.
+     * - "insert-failed" a checkpoint DOES exist but the boundary insert still
+     *                   refused (degraded, e.g. renderRebuildContext empty).
+     *                   Callers must report this honestly and must NOT compact.
+     */
+    type RebuildAttempt = "rebuilt" | "no-checkpoint" | "insert-failed"
+
+    // The single place that decides whether a rebuild may degrade to
+    // compaction. Every caller — both auto context-overflow sites and the
+    // manual /rebuild command — goes through here, so the fallback condition
+    // is ONE condition rather than several lookalikes that can drift apart.
+    //
+    // Ordering matters: we try the on-disk checkpoint FIRST and only start a
+    // writer when there is no checkpoint at all. When a checkpoint already
+    // exists this deliberately does not block on an in-flight writer that is
+    // producing a fresher one — that separate, unchanged policy is documented
+    // on rebuildFromCheckpoint above and is NOT the justification for waiting
+    // here. Waiting here is justified only by the no-checkpoint case, where the
+    // alternative is `compaction.create`, which inserts a bare boundary marker
+    // and therefore drops all pre-boundary history with no summary at all.
+    const rebuildEnsuringCheckpoint = Effect.fn("SessionPrompt.rebuildEnsuringCheckpoint")(function* (input: {
+      sessionID: SessionID
+      msgs: MessageV2.WithParts[]
+      agentID?: string
+      agent: string
+      model: { providerID: string; id: string }
+      /** Upper bound on the writer wait; see {AUTO,MANUAL}_WRITER_WAIT_MS. */
+      writerWaitMs: number
+      /** Run once, immediately before the wait begins, to explain the stall. */
+      onWaitingForWriter?: Effect.Effect<void>
+    }) {
+      // 1. Whatever is already on disk.
+      if (yield* rebuildFromCheckpoint(input).pipe(Effect.catch(() => Effect.succeed(false))))
+        return "rebuilt" as const
+
+      // 2. Distinguish "nothing to rebuild from" (may compact) from "checkpoint
+      //    present but the insert failed" (must not compact).
+      const hasCP = yield* checkpoint
+        .hasCheckpoint(input.sessionID)
+        .pipe(Effect.catch(() => Effect.succeed(false)))
+      if (hasCP) return "insert-failed" as const
+
+      // 3. No checkpoint → produce one on the spot. Reentrancy: the
+      //    isWriterRunning probe skips a redundant request, and
+      //    tryStartCheckpointWriter is itself safe under concurrency — it
+      //    returns "queued" instead of forking a second writer — so this can
+      //    never start two writers for one session even when reached from
+      //    successive runLoop iterations.
+      const writerRunning = yield* checkpoint
+        .isWriterRunning(input.sessionID)
+        .pipe(Effect.catch(() => Effect.succeed(false)))
+      if (!writerRunning) {
+        // promptOps is declared in TryStartCheckpointWriterInput but never read
+        // by the writer (it spawns as a subagent via spawnRef), so a stub
+        // suffices.
+        yield* checkpoint
+          .tryStartCheckpointWriter({
+            sessionID: input.sessionID,
+            model: { providerID: input.model.providerID, modelID: input.model.id },
+            promptOps: {} as never,
+          })
+          .pipe(Effect.catch(() => Effect.succeed<"started" | "queued" | "skipped">("skipped")))
+      }
+
+      if (input.onWaitingForWriter) yield* input.onWaitingForWriter
+
+      const writerOutcome = yield* checkpoint
+        .waitForWriter(input.sessionID)
+        .pipe(
+          Effect.timeout(input.writerWaitMs),
+          Effect.catch(() => Effect.succeed<"success" | "failure" | "no-writer">("failure")),
+        )
+      if (writerOutcome !== "success") return "no-checkpoint" as const
+
+      // 4. Writer wrote a checkpoint — rebuild from it.
+      if (yield* rebuildFromCheckpoint(input).pipe(Effect.catch(() => Effect.succeed(false))))
+        return "rebuilt" as const
+      return "insert-failed" as const
+    })
+
     const resolvePromptParts = Effect.fn("SessionPrompt.resolvePromptParts")(function* (template: string) {
       const ctx = yield* InstanceState.context
       const parts: PromptInput["parts"] = [{ type: "text", text: template }]
@@ -3340,34 +3445,54 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             // Main-agent overflow: insert a checkpoint boundary marker (never
             // deletes DB messages) so the next iteration rebuilds from the
-            // freshest checkpoint. Shared with the manual `/rebuild` command via
-            // rebuildFromCheckpoint so logic/boundary conditions can't drift.
-            // Falls back to compaction only when no boundary can be produced.
-            const inserted = yield* rebuildFromCheckpoint({
+            // freshest checkpoint. When NO checkpoint exists yet this now starts
+            // a writer and waits for it (bounded) rather than degrading
+            // immediately — the same on-the-spot behaviour the manual /rebuild
+            // command has, via the shared rebuildEnsuringCheckpoint helper so
+            // logic/boundary conditions can't drift.
+            const attempt: RebuildAttempt = yield* rebuildEnsuringCheckpoint({
               sessionID,
               msgs,
               agentID: lastUser.agentID,
               agent: lastUser.agent,
               model: { providerID: model.providerID, id: model.id },
+              writerWaitMs: AUTO_WRITER_WAIT_MS,
+              // The turn is mid-flight, so explain the stall: without this the
+              // TUI would sit on a bare spinner for minutes with no reason.
+              onWaitingForWriter: status
+                .set(sessionID, { type: "busy", message: "Writing checkpoint\u2026" })
+                .pipe(Effect.catch(() => Effect.void)),
             })
-            if (inserted) {
+            if (attempt === "rebuilt") {
               skipOverflowCheck = true
               continue
             }
 
-            // F39: no checkpoint — fall back to compaction (LLM-driven lossy summary).
-            // Better than mechanical trim: preserves semantic content via summary.
-            yield* compaction
-              .create({
-                sessionID,
-                agent: lastUser.agent,
-                model: { providerID: model.providerID, modelID: model.id },
-                auto: true,
-                agentID: lastUser.agentID,
-              })
-              .pipe(Effect.ignore)
-            skipOverflowCheck = true
-            continue
+            if (attempt === "no-checkpoint") {
+              // THE single compaction fallback: no checkpoint existed AND the
+              // writer failed / never ran / the bound expired. Note this is a
+              // bare boundary insert, not an LLM summary — everything before it
+              // is dropped unsummarized (compaction.ts:499, message-v2.ts:1037)
+              // — which is exactly why we tried to write a checkpoint first.
+              yield* compaction
+                .create({
+                  sessionID,
+                  agent: lastUser.agent,
+                  model: { providerID: model.providerID, modelID: model.id },
+                  auto: true,
+                  agentID: lastUser.agentID,
+                })
+                .pipe(Effect.ignore)
+              skipOverflowCheck = true
+              continue
+            }
+
+            // "insert-failed": a checkpoint DOES exist, so compaction is not
+            // permitted here — it would amputate history we hold a usable
+            // checkpoint for. Nothing freed context, so do NOT `continue` into
+            // an identical overflow check; fall through and let the model call
+            // proceed. The provider-signalled overflow handler below is the
+            // backstop if the request is actually rejected.
           }
           skipOverflowCheck = false
 
@@ -3917,30 +4042,36 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }
 
               // Main-agent provider-signalled overflow: prefer rebuild over
-              // compaction. Shared with the manual `/rebuild` command via
-              // rebuildFromCheckpoint (does not block on the writer; uses the
-              // on-disk checkpoint). Fall back to compaction only when no
-              // boundary can be produced.
-              const inserted2 = yield* rebuildFromCheckpoint({
+              // compaction, via the same shared rebuildEnsuringCheckpoint helper
+              // the token-threshold path and manual /rebuild use — so the
+              // compaction fallback stays ONE condition, not three lookalikes.
+              const attempt2: RebuildAttempt = yield* rebuildEnsuringCheckpoint({
                 sessionID,
                 msgs,
                 agentID: lastUser.agentID,
                 agent: lastUser.agent,
                 model: { providerID: model.providerID, id: model.id },
+                writerWaitMs: AUTO_WRITER_WAIT_MS,
+                onWaitingForWriter: status
+                  .set(sessionID, { type: "busy", message: "Writing checkpoint\u2026" })
+                  .pipe(Effect.catch(() => Effect.void)),
               })
-              if (inserted2) return "continue" as const
+              if (attempt2 === "rebuilt") return "continue" as const
 
-              // F39: no checkpoint — fall back to compaction (LLM-driven lossy summary).
-              yield* compaction
-                .create({
-                  sessionID,
-                  agent: lastUser.agent,
-                  model: { providerID: model.providerID, modelID: model.id },
-                  auto: true,
-                  overflow: true,
-                  agentID: lastUser.agentID,
-                })
-                .pipe(Effect.ignore)
+              if (attempt2 === "no-checkpoint") {
+                // THE single compaction fallback (see the token-threshold site).
+                yield* compaction
+                  .create({
+                    sessionID,
+                    agent: lastUser.agent,
+                    model: { providerID: model.providerID, modelID: model.id },
+                    auto: true,
+                    overflow: true,
+                    agentID: lastUser.agentID,
+                  })
+                  .pipe(Effect.ignore)
+              }
+              // "insert-failed" → a checkpoint exists; must not compact.
             }
             return "continue" as const
           }).pipe(Effect.ensuring(instruction.clear(handle.message.id)))
@@ -4142,6 +4273,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       //   2. No usable checkpoint → start a writer and wait for it, then rebuild.
       //   3. Checkpoint exists + writer in-flight → wait (with timeout), rebuild
       //      with the fresher checkpoint if it arrives, else fall back to existing.
+      // Cases 1-3 live in the shared rebuildEnsuringCheckpoint helper, which the
+      // auto context-overflow paths use too, so the manual and automatic
+      // behaviours cannot drift and there is exactly ONE compaction fallback
+      // condition (no checkpoint AND the writer failed) in this file.
       //
       // Manual /rebuild mirrors the AUTO rebuild/compaction path exactly: it
       // inserts the legitimate rebuild BOUNDARY (a role:"user" message carrying
@@ -4153,9 +4288,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       // question, so after inserting the boundary it simply returns to idle
       // (no model turn, no auto-reply).
       //
-      // The outcome ("context rebuilt" / "no checkpoint available yet") is
-      // surfaced to the user through the SessionStatus / Bus status channel —
-      // the same busy-status mechanism that drives "Rebuilding context…" /
+      // The outcome ("context rebuilt" / "compacted instead because the writer
+      // failed" / "checkpoint written but rebuild failed") is surfaced to the
+      // user through the SessionStatus / Bus status channel — the same
+      // busy-status mechanism that drives "Rebuilding context…" /
       // "Writing checkpoint…" — NOT through a persisted synthetic user message.
       // The busy status is set BEFORE any work so the TUI spinner lights up
       // immediately; because the runLoop is never entered, its onIdle won't
@@ -4173,8 +4309,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           yield* status.set(input.sessionID, { type: "busy", message }).pipe(Effect.catch(() => Effect.void))
           yield* status.set(input.sessionID, { type: "idle" }).pipe(Effect.catch(() => Effect.void))
         })
-        const noCheckpointMsg =
-          "No checkpoint is available to rebuild from yet — continue the conversation and a checkpoint will be written automatically."
+        const compactedInsteadMsg =
+          "No checkpoint could be written (the checkpoint writer failed), so the context was compacted instead — earlier messages were dropped rather than rebuilt from a checkpoint."
+        const rebuildFailedMsg =
+          "A checkpoint was written but the context could not be rebuilt from it. Context is unchanged and nothing was compacted — retry /rebuild, or report this if it repeats."
         const rebuiltMsg =
           "Context rebuilt from the latest checkpoint. Recent messages are preserved; earlier context is now summarized."
 
@@ -4184,65 +4322,57 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           Effect.catch(() => Effect.void),
         )
 
-        // Case 2: no usable checkpoint → actively spawn a writer and wait for
-        // it to finish, THEN rebuild from the freshly-written checkpoint.
-        // This is the user-decided semantics: /rebuild on a cold session
-        // produces the first checkpoint on the spot rather than deferring.
-        const hasCP = yield* checkpoint
-          .hasCheckpoint(input.sessionID)
-          .pipe(Effect.catch(() => Effect.succeed(false)))
-        if (!hasCP) {
-          const writerRunning = yield* checkpoint
-            .isWriterRunning(input.sessionID)
-            .pipe(Effect.catch(() => Effect.succeed(false)))
-          if (!writerRunning) {
-            // No checkpoint and no writer — start one. promptOps is declared
-            // in TryStartCheckpointWriterInput but never read by the writer
-            // (it spawns as a subagent via spawnRef), so a stub suffices.
-            yield* checkpoint
-              .tryStartCheckpointWriter({
-                sessionID: input.sessionID,
-                model: { providerID: model.providerID, modelID: model.modelID },
-                promptOps: {} as never,
-              })
-              .pipe(Effect.catch(() => Effect.succeed<"started" | "queued" | "skipped">("skipped")))
-          }
-          // Wait for the writer to finish. waitForWriter has its own 5-min
-          // safety bound (checkpoint.ts:985). On "success" the checkpoint file
-          // is on disk and the watermark is advanced; on "failure" or
-          // "no-writer" we fall through and let rebuildFromCheckpoint try
-          // whatever exists (or surface the no-checkpoint outcome).
-          yield* status
-            .set(input.sessionID, { type: "busy", message: "Writing checkpoint\u2026" })
-            .pipe(Effect.catch(() => Effect.void))
-          const writerOutcome = yield* checkpoint
-            .waitForWriter(input.sessionID)
-            .pipe(Effect.catch(() => Effect.succeed<"success" | "failure" | "no-writer">("failure")))
-          if (writerOutcome !== "success") {
-            // Writer failed or wasn't running — surface the outcome on the
-            // status channel and return to idle. No boundary was inserted and
-            // NO synthetic user turn is fabricated.
-            yield* settle(noCheckpointMsg)
-            return lastUser ?? msgs[msgs.length - 1]!
-          }
-          // Writer succeeded — fall through to rebuildFromCheckpoint which
-          // will now find the freshly-written checkpoint and insert the
-          // boundary.
-        }
-
-        const inserted = yield* rebuildFromCheckpoint({
+        // Cases 1-3 all run through the shared rebuildEnsuringCheckpoint helper:
+        // it rebuilds from an existing checkpoint, or — on a cold session — spawns
+        // a writer, waits for it (bounded), and rebuilds from the fresh
+        // checkpoint. That is the user-decided semantics: /rebuild on a cold
+        // session produces the first checkpoint on the spot rather than deferring.
+        const attempt: RebuildAttempt = yield* rebuildEnsuringCheckpoint({
           sessionID: input.sessionID,
           msgs,
           agentID: lastUser?.info.agentID ?? "main",
           agent: agentName,
           model: { providerID: model.providerID, id: model.modelID },
-        }).pipe(Effect.catch(() => Effect.succeed(false)))
+          writerWaitMs: MANUAL_WRITER_WAIT_MS,
+          onWaitingForWriter: status
+            .set(input.sessionID, { type: "busy", message: "Writing checkpoint\u2026" })
+            .pipe(Effect.catch(() => Effect.void)),
+        }).pipe(Effect.catch(() => Effect.succeed("insert-failed" as const)))
 
-        if (!inserted) {
-          // Defensive: writer succeeded but boundary insertion still failed
-          // (e.g. renderRebuildContext returned empty — degraded state).
-          // Surface the no-checkpoint outcome and return to idle.
-          yield* settle(noCheckpointMsg)
+        if (attempt === "no-checkpoint") {
+          // No checkpoint AND the writer genuinely failed / never ran / the bound
+          // expired — the ONE fallback condition, shared with the auto overflow
+          // paths. An earlier revision of this branch deliberately did NOT
+          // compact here, reasoning that /rebuild means "rebuild from a
+          // checkpoint" so substituting a lossy summary would misreport what
+          // happened. The user overruled that tradeoff: if the writer genuinely
+          // failed, a truncating compaction beats doing nothing. We keep the
+          // report honest by naming the substitution on the status channel
+          // instead of silently swapping the mechanism, and — per the branch's
+          // existing noReply decision (3244ca732) — fabricate neither an
+          // assistant reply nor a synthetic user turn.
+          yield* compaction
+            .create({
+              sessionID: input.sessionID,
+              agent: agentName,
+              model: { providerID: model.providerID, modelID: model.modelID },
+              // Not user-requested: the user asked for a rebuild, the system
+              // chose this degradation.
+              auto: true,
+              agentID: lastUser?.info.agentID ?? "main",
+            })
+            .pipe(Effect.ignore)
+          yield* settle(compactedInsteadMsg)
+          return lastUser ?? msgs[msgs.length - 1]!
+        }
+
+        if (attempt === "insert-failed") {
+          // A checkpoint EXISTS but the boundary insert refused (e.g.
+          // renderRebuildContext returned empty — degraded state). NOT a
+          // fallback case: compacting would drop history that a usable
+          // checkpoint was available for. Report the degraded state accurately
+          // and return to idle.
+          yield* settle(rebuildFailedMsg)
           return lastUser ?? msgs[msgs.length - 1]!
         }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -451,15 +451,23 @@ export const layer = Layer.effect(
     /**
      * Outcome of a rebuild attempt that is allowed to WRITE a checkpoint first.
      *
+     * Named for what the attempt DID, not for the state it started in: reading a
+     * call site, `writer-failed` has to say that a writer was started and awaited
+     * and only then gave up. An earlier name (`no-checkpoint`) described the entry
+     * condition instead, which made `if (attempt === "no-checkpoint") compact()`
+     * read as "no checkpoint, so compact immediately" — the writer attempt is
+     * invisible at the call site, and that is exactly how it was misread.
+     *
      * - "rebuilt"       a boundary was inserted; context is freed.
-     * - "no-checkpoint" there was no checkpoint AND the writer failed / never
-     *                   ran / the wait bound expired. This is the ONLY state in
-     *                   which a caller may fall back to compaction.
+     * - "writer-failed" there was no checkpoint, so a writer WAS STARTED AND
+     *                   AWAITED here (bounded by `writerWaitMs`), and it then
+     *                   failed / never ran / the bound expired. This is the ONLY
+     *                   state in which a caller may fall back to compaction.
      * - "insert-failed" a checkpoint DOES exist but the boundary insert still
      *                   refused (degraded, e.g. renderRebuildContext empty).
      *                   Callers must report this honestly and must NOT compact.
      */
-    type RebuildAttempt = "rebuilt" | "no-checkpoint" | "insert-failed"
+    type RebuildAttempt = "rebuilt" | "writer-failed" | "insert-failed"
 
     // The single place that decides whether a rebuild may degrade to
     // compaction. Every caller — both auto context-overflow sites and the
@@ -491,10 +499,25 @@ export const layer = Layer.effect(
 
       // 2. Distinguish "nothing to rebuild from" (may compact) from "checkpoint
       //    present but the insert failed" (must not compact).
+      //
+      //    `hasCheckpoint` alone is NOT that distinction: it is a bare
+      //    `Bun.file(...).exists()` (checkpoint.ts:1021), and
+      //    `tryStartCheckpointWriter` scaffolds an EMPTY TEMPLATE at
+      //    checkpoint.ts:650 *before* spawning the writer. Since
+      //    `prune.fireCheckpoints` (prune.ts:289) runs immediately before the
+      //    overflow check, "template on disk, watermark not yet written" is a
+      //    NORMAL arrival state — and keying on the bare check classified it as
+      //    `insert-failed`, which skipped the start-and-wait below entirely and
+      //    silently defeated this whole helper. A usable checkpoint therefore
+      //    requires the boundary too, which is exactly what
+      //    `rebuildFromCheckpoint` needs (it reads `lastBoundary` at :411).
       const hasCP = yield* checkpoint
         .hasCheckpoint(input.sessionID)
         .pipe(Effect.catch(() => Effect.succeed(false)))
-      if (hasCP) return "insert-failed" as const
+      const boundary = hasCP
+        ? yield* checkpoint.lastBoundary(input.sessionID).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        : undefined
+      if (hasCP && boundary !== undefined) return "insert-failed" as const
 
       // 3. No checkpoint → produce one on the spot. Reentrancy: the
       //    isWriterRunning probe skips a redundant request, and
@@ -526,7 +549,7 @@ export const layer = Layer.effect(
           Effect.timeout(input.writerWaitMs),
           Effect.catch(() => Effect.succeed<"success" | "failure" | "no-writer">("failure")),
         )
-      if (writerOutcome !== "success") return "no-checkpoint" as const
+      if (writerOutcome !== "success") return "writer-failed" as const
 
       // 4. Writer wrote a checkpoint — rebuild from it.
       if (yield* rebuildFromCheckpoint(input).pipe(Effect.catch(() => Effect.succeed(false))))
@@ -3468,7 +3491,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               continue
             }
 
-            if (attempt === "no-checkpoint") {
+            // A writer was started and awaited above (AUTO_WRITER_WAIT_MS) and
+            // still produced nothing — the ONE condition that may compact.
+            if (attempt === "writer-failed") {
               // THE single compaction fallback: no checkpoint existed AND the
               // writer failed / never ran / the bound expired. Note this is a
               // bare boundary insert, not an LLM summary — everything before it
@@ -4058,7 +4083,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               })
               if (attempt2 === "rebuilt") return "continue" as const
 
-              if (attempt2 === "no-checkpoint") {
+              // Same as above: the writer ran and failed — not "no checkpoint".
+              if (attempt2 === "writer-failed") {
                 // THE single compaction fallback (see the token-threshold site).
                 yield* compaction
                   .create({
@@ -4339,7 +4365,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             .pipe(Effect.catch(() => Effect.void)),
         }).pipe(Effect.catch(() => Effect.succeed("insert-failed" as const)))
 
-        if (attempt === "no-checkpoint") {
+        // A writer was started and awaited above (MANUAL_WRITER_WAIT_MS) and
+        // still produced nothing — only then may /rebuild degrade to compaction.
+        if (attempt === "writer-failed") {
           // No checkpoint AND the writer genuinely failed / never ran / the bound
           // expired — the ONE fallback condition, shared with the auto overflow
           // paths. An earlier revision of this branch deliberately did NOT

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4156,6 +4156,61 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         // writer (cases 2/3) or assemble context (case 1).
         yield* status.set(input.sessionID, { type: "busy" }).pipe(Effect.catch(() => Effect.void))
 
+        // Case 2: no usable checkpoint → actively spawn a writer and wait for
+        // it to finish, THEN rebuild from the freshly-written checkpoint.
+        // This is the user-decided semantics: /rebuild on a cold session
+        // produces the first checkpoint on the spot rather than deferring.
+        const hasCP = yield* checkpoint
+          .hasCheckpoint(input.sessionID)
+          .pipe(Effect.catch(() => Effect.succeed(false)))
+        if (!hasCP) {
+          const writerRunning = yield* checkpoint
+            .isWriterRunning(input.sessionID)
+            .pipe(Effect.catch(() => Effect.succeed(false)))
+          if (!writerRunning) {
+            // No checkpoint and no writer — start one. promptOps is declared
+            // in TryStartCheckpointWriterInput but never read by the writer
+            // (it spawns as a subagent via spawnRef), so a stub suffices.
+            yield* checkpoint
+              .tryStartCheckpointWriter({
+                sessionID: input.sessionID,
+                model: { providerID: model.providerID, modelID: model.modelID },
+                promptOps: {} as never,
+              })
+              .pipe(Effect.catch(() => Effect.succeed<"started" | "queued" | "skipped">("skipped")))
+          }
+          // Wait for the writer to finish. waitForWriter has its own 5-min
+          // safety bound (checkpoint.ts:985). On "success" the checkpoint file
+          // is on disk and the watermark is advanced; on "failure" or
+          // "no-writer" we fall through and let rebuildFromCheckpoint try
+          // whatever exists (or show the no-checkpoint message).
+          const writerOutcome = yield* checkpoint
+            .waitForWriter(input.sessionID)
+            .pipe(Effect.catch(() => Effect.succeed<"success" | "failure" | "no-writer">("failure")))
+          if (writerOutcome !== "success") {
+            // Writer failed or wasn't running — tell the user. noReply since
+            // there's nothing for the model to respond to.
+            const result = yield* prompt({
+              sessionID: input.sessionID,
+              messageID: input.messageID,
+              agent: agentName,
+              parts: [
+                {
+                  type: "text",
+                  text: "No checkpoint is available to rebuild from yet — continue the conversation and a checkpoint will be written automatically.",
+                  synthetic: true,
+                },
+              ],
+              noReply: true,
+            })
+            yield* status.set(input.sessionID, { type: "idle" }).pipe(Effect.catch(() => Effect.void))
+            return result
+          }
+          // Writer succeeded — fall through to rebuildFromCheckpoint which
+          // will now find the freshly-written checkpoint and insert the
+          // boundary.
+        }
+
         const inserted = yield* rebuildFromCheckpoint({
           sessionID: input.sessionID,
           msgs,
@@ -4165,10 +4220,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         }).pipe(Effect.catch(() => Effect.succeed(false)))
 
         if (!inserted) {
-          // No checkpoint available — tell the user rather than silently doing
-          // nothing. Return a synthetic message WITHOUT entering the runLoop
-          // (noReply: true) so no model response is generated. Clear idle
-          // status since the Runner won't handle it in this path.
+          // Defensive: writer succeeded but boundary insertion still failed
+          // (e.g. renderRebuildContext returned empty — degraded state).
+          // Fall back to the no-checkpoint message.
           const result = yield* prompt({
             sessionID: input.sessionID,
             messageID: input.messageID,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4154,7 +4154,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
         // Set busy status so the TUI shows a spinner while we wait on the
         // writer (cases 2/3) or assemble context (case 1).
-        yield* status.set(input.sessionID, { type: "busy" }).pipe(Effect.catch(() => Effect.void))
+        yield* status.set(input.sessionID, { type: "busy", message: "Rebuilding context\u2026" }).pipe(
+          Effect.catch(() => Effect.void),
+        )
 
         // Case 2: no usable checkpoint → actively spawn a writer and wait for
         // it to finish, THEN rebuild from the freshly-written checkpoint.
@@ -4184,6 +4186,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           // is on disk and the watermark is advanced; on "failure" or
           // "no-writer" we fall through and let rebuildFromCheckpoint try
           // whatever exists (or show the no-checkpoint message).
+          yield* status
+            .set(input.sessionID, { type: "busy", message: "Writing checkpoint\u2026" })
+            .pipe(Effect.catch(() => Effect.void))
           const writerOutcome = yield* checkpoint
             .waitForWriter(input.sessionID)
             .pipe(Effect.catch(() => Effect.succeed<"success" | "failure" | "no-writer">("failure")))

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4142,15 +4142,41 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       //   2. No usable checkpoint → start a writer and wait for it, then rebuild.
       //   3. Checkpoint exists + writer in-flight → wait (with timeout), rebuild
       //      with the fresher checkpoint if it arrives, else fall back to existing.
+      //
+      // Manual /rebuild mirrors the AUTO rebuild/compaction path exactly: it
+      // inserts the legitimate rebuild BOUNDARY (a role:"user" message carrying
+      // a `checkpoint` part, via rebuildFromCheckpoint → insertRebuildBoundary)
+      // and then lets the session settle — WITHOUT fabricating a second,
+      // standalone user turn. The auto path (~prompt.ts:3205/3778) `continue`s
+      // the runLoop because it has a PENDING user message to answer; a manual
+      // /rebuild is a user-initiated maintenance action with NO pending
+      // question, so after inserting the boundary it simply returns to idle
+      // (no model turn, no auto-reply).
+      //
+      // The outcome ("context rebuilt" / "no checkpoint available yet") is
+      // surfaced to the user through the SessionStatus / Bus status channel —
+      // the same busy-status mechanism that drives "Rebuilding context…" /
+      // "Writing checkpoint…" — NOT through a persisted synthetic user message.
       // The busy status is set BEFORE any work so the TUI spinner lights up
-      // immediately; the Runner's onIdle callback clears it after the runLoop
-      // completes. For the no-checkpoint case (no work to do), we return a
-      // synthetic message without entering the runLoop, and clear idle in a
-      // finally block.
+      // immediately; because the runLoop is never entered, its onIdle won't
+      // clear busy status, so every return path clears idle explicitly.
       if (input.command === Command.Default.REBUILD) {
         const msgs = yield* sessions.messages({ sessionID: input.sessionID, agentID: "main" })
         const lastUser = msgs.findLast((m) => m.info.role === "user")
         const model = yield* lastModel(input.sessionID)
+
+        // Emit the terminal outcome on the status channel, then return to idle.
+        // Returns the message the handler should hand back (never a fabricated
+        // user turn): the freshly-inserted boundary on success, else the
+        // existing last user message so callers still receive a WithParts.
+        const settle = Effect.fn("SessionPrompt.rebuild.settle")(function* (message: string) {
+          yield* status.set(input.sessionID, { type: "busy", message }).pipe(Effect.catch(() => Effect.void))
+          yield* status.set(input.sessionID, { type: "idle" }).pipe(Effect.catch(() => Effect.void))
+        })
+        const noCheckpointMsg =
+          "No checkpoint is available to rebuild from yet — continue the conversation and a checkpoint will be written automatically."
+        const rebuiltMsg =
+          "Context rebuilt from the latest checkpoint. Recent messages are preserved; earlier context is now summarized."
 
         // Set busy status so the TUI shows a spinner while we wait on the
         // writer (cases 2/3) or assemble context (case 1).
@@ -4185,7 +4211,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           // safety bound (checkpoint.ts:985). On "success" the checkpoint file
           // is on disk and the watermark is advanced; on "failure" or
           // "no-writer" we fall through and let rebuildFromCheckpoint try
-          // whatever exists (or show the no-checkpoint message).
+          // whatever exists (or surface the no-checkpoint outcome).
           yield* status
             .set(input.sessionID, { type: "busy", message: "Writing checkpoint\u2026" })
             .pipe(Effect.catch(() => Effect.void))
@@ -4193,23 +4219,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             .waitForWriter(input.sessionID)
             .pipe(Effect.catch(() => Effect.succeed<"success" | "failure" | "no-writer">("failure")))
           if (writerOutcome !== "success") {
-            // Writer failed or wasn't running — tell the user. noReply since
-            // there's nothing for the model to respond to.
-            const result = yield* prompt({
-              sessionID: input.sessionID,
-              messageID: input.messageID,
-              agent: agentName,
-              parts: [
-                {
-                  type: "text",
-                  text: "No checkpoint is available to rebuild from yet — continue the conversation and a checkpoint will be written automatically.",
-                  synthetic: true,
-                },
-              ],
-              noReply: true,
-            })
-            yield* status.set(input.sessionID, { type: "idle" }).pipe(Effect.catch(() => Effect.void))
-            return result
+            // Writer failed or wasn't running — surface the outcome on the
+            // status channel and return to idle. No boundary was inserted and
+            // NO synthetic user turn is fabricated.
+            yield* settle(noCheckpointMsg)
+            return lastUser ?? msgs[msgs.length - 1]!
           }
           // Writer succeeded — fall through to rebuildFromCheckpoint which
           // will now find the freshly-written checkpoint and insert the
@@ -4227,49 +4241,24 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         if (!inserted) {
           // Defensive: writer succeeded but boundary insertion still failed
           // (e.g. renderRebuildContext returned empty — degraded state).
-          // Fall back to the no-checkpoint message.
-          const result = yield* prompt({
-            sessionID: input.sessionID,
-            messageID: input.messageID,
-            agent: agentName,
-            parts: [
-              {
-                type: "text",
-                text: "No checkpoint is available to rebuild from yet — continue the conversation and a checkpoint will be written automatically.",
-                synthetic: true,
-              },
-            ],
-            noReply: true,
-          })
-          yield* status.set(input.sessionID, { type: "idle" }).pipe(Effect.catch(() => Effect.void))
-          return result
+          // Surface the no-checkpoint outcome and return to idle.
+          yield* settle(noCheckpointMsg)
+          return lastUser ?? msgs[msgs.length - 1]!
         }
 
-        // Checkpoint was inserted. A MANUAL /rebuild is a user action whose
-        // whole intent is to free/rebuild the context — the user asked no
-        // question, so the model must NOT produce a reply. Return the synthetic
-        // note via noReply:true so the boundary is recorded and the waiting UI
-        // shown, but the runLoop is never entered (no spurious "reply to
-        // nothing" turn). The AUTO-triggered rebuild path (runLoop, prompt.ts
-        // ~3188/3761) is unaffected: it rebuilds mid-turn and `continue`s to
-        // answer the pending user message, which is correct there.
-        // Because the runLoop doesn't run, its onIdle won't clear busy status,
-        // so clear it explicitly here (mirrors the no-checkpoint paths above).
-        const result = yield* prompt({
-          sessionID: input.sessionID,
-          messageID: input.messageID,
-          agent: agentName,
-          parts: [
-            {
-              type: "text",
-              text: "Context rebuilt from the latest checkpoint. Recent messages are preserved; earlier context is now summarized.",
-              synthetic: true,
-            },
-          ],
-          noReply: true,
-        })
-        yield* status.set(input.sessionID, { type: "idle" }).pipe(Effect.catch(() => Effect.void))
-        return result
+        // Boundary inserted (Step A — the shared, correct mechanism). A MANUAL
+        // /rebuild is a user action whose whole intent is to free/rebuild the
+        // context: the user asked no question, so the model must NOT reply and
+        // NO second user turn is fabricated. We surface the "context rebuilt"
+        // outcome on the status channel and return the boundary message itself
+        // (the newest role:"user" message carrying a checkpoint part), then go
+        // idle. The runLoop is never entered — mirroring the transparent
+        // boundary insertion the auto/compaction paths perform, minus their
+        // pending-message `continue`.
+        yield* settle(rebuiltMsg)
+        const after = yield* sessions.messages({ sessionID: input.sessionID, agentID: "main" })
+        const boundaryMessage = after.findLast((m) => m.parts.some((p) => p.type === "checkpoint"))
+        return boundaryMessage ?? lastUser ?? after[after.length - 1]!
       }
 
       const raw = input.arguments.match(argsRegex) ?? []

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4245,10 +4245,17 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           return result
         }
 
-        // Checkpoint was inserted — enter the runLoop (no noReply) so the
-        // model sees the rebuilt context boundary and produces a response.
-        // The Runner's onIdle callback clears busy status automatically.
-        return yield* prompt({
+        // Checkpoint was inserted. A MANUAL /rebuild is a user action whose
+        // whole intent is to free/rebuild the context — the user asked no
+        // question, so the model must NOT produce a reply. Return the synthetic
+        // note via noReply:true so the boundary is recorded and the waiting UI
+        // shown, but the runLoop is never entered (no spurious "reply to
+        // nothing" turn). The AUTO-triggered rebuild path (runLoop, prompt.ts
+        // ~3188/3761) is unaffected: it rebuilds mid-turn and `continue`s to
+        // answer the pending user message, which is correct there.
+        // Because the runLoop doesn't run, its onIdle won't clear busy status,
+        // so clear it explicitly here (mirrors the no-checkpoint paths above).
+        const result = yield* prompt({
           sessionID: input.sessionID,
           messageID: input.messageID,
           agent: agentName,
@@ -4259,7 +4266,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               synthetic: true,
             },
           ],
+          noReply: true,
         })
+        yield* status.set(input.sessionID, { type: "idle" }).pipe(Effect.catch(() => Effect.void))
+        return result
       }
 
       const raw = input.arguments.match(argsRegex) ?? []

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -517,7 +517,15 @@ export const layer = Layer.effect(
       const boundary = hasCP
         ? yield* checkpoint.lastBoundary(input.sessionID).pipe(Effect.catch(() => Effect.succeed(undefined)))
         : undefined
-      if (hasCP && boundary !== undefined) return "insert-failed" as const
+      //    Predicate note: this MUST be the same truthiness test that
+      //    `rebuildFromCheckpoint` applies to the same value (`if (!boundary)`
+      //    at :413), NOT `boundary !== undefined`. `lastBoundary` reads a
+      //    nullable column and returned JS `null` for an unset watermark
+      //    (checkpoint.ts:1422 — its declared `MessageID | undefined` was an
+      //    unchecked cast), so `!== undefined` was true for EVERY session with a
+      //    file on disk and this guard degenerated into the bare
+      //    `hasCheckpoint` check it was written to replace.
+      if (hasCP && boundary) return "insert-failed" as const
 
       // 3. No checkpoint → produce one on the spot. Reentrancy: the
       //    isWriterRunning probe skips a redundant request, and

--- a/packages/opencode/test/cli/cmd/tui/prompt-footer-status.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-footer-status.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "bun:test"
+import { clampStatusMessage, STATUS_MESSAGE_MAX } from "../../../../src/cli/cmd/tui/component/prompt/footer"
+
+describe("clampStatusMessage", () => {
+  test("an over-long status cannot outgrow the footer budget", () => {
+    const long =
+      "Context rebuilt from the latest checkpoint. Recent messages are preserved; earlier context is now summarized."
+    expect(long.length).toBeGreaterThan(STATUS_MESSAGE_MAX)
+    const out = clampStatusMessage(long)!
+    expect(out.length).toBe(STATUS_MESSAGE_MAX)
+    expect(out.endsWith("\u2026")).toBe(true)
+    expect(long.startsWith(out.slice(0, -1))).toBe(true)
+  })
+
+  test("short statuses pass through untouched", () => {
+    expect(clampStatusMessage("Rebuilding context\u2026")).toBe("Rebuilding context\u2026")
+    expect(clampStatusMessage("Writing checkpoint\u2026")).toBe("Writing checkpoint\u2026")
+  })
+
+  test("newlines are flattened so the status can never claim extra rows", () => {
+    expect(clampStatusMessage("Rebuilding\ncontext\u2026")).toBe("Rebuilding context\u2026")
+    expect(clampStatusMessage("  Rebuilding   context\u2026  ")).toBe("Rebuilding context\u2026")
+  })
+
+  test("empty and missing statuses render nothing", () => {
+    expect(clampStatusMessage(undefined)).toBeUndefined()
+    expect(clampStatusMessage("")).toBeUndefined()
+    expect(clampStatusMessage("   \n  ")).toBeUndefined()
+  })
+
+  test("the budget leaves room for the spinner, interrupt hint and context counter on 80 columns", () => {
+    // "⠋ " + message + "esc interrupt" + "52.4K/960K (5%)"
+    expect(STATUS_MESSAGE_MAX + 2 + "esc interrupt".length + "52.4K/960K (5%)".length).toBeLessThanOrEqual(80)
+  })
+})

--- a/packages/opencode/test/cli/cmd/tui/rebuild-boundary-marker.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/rebuild-boundary-marker.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { dict as en } from "../../../../src/cli/cmd/tui/i18n/en"
+import { dict as zh } from "../../../../src/cli/cmd/tui/i18n/zh"
+import { dict as zht } from "../../../../src/cli/cmd/tui/i18n/zht"
+
+// A `/rebuild` inserts one user message carrying a `checkpoint` part plus
+// synthetic text parts. The TUI renders it as a one-line marker row in
+// UserMessage (routes/session/index.tsx) so the boundary is visible in the
+// transcript. The label copy is localized; the marker row would render an empty
+// badge if these keys ever went missing, so pin them here.
+const KEYS = ["tui.session.rebuild_boundary.label", "tui.session.rebuild_boundary.detail"] as const
+
+describe("rebuild boundary marker copy", () => {
+  test("english copy names the rebuild and what happened to earlier messages", () => {
+    expect(en["tui.session.rebuild_boundary.label"]).toBe("context rebuilt")
+    expect(en["tui.session.rebuild_boundary.detail"]).toBe("earlier messages summarized")
+  })
+
+  test("localized dictionaries define the marker copy", () => {
+    for (const key of KEYS) {
+      for (const [name, dict] of Object.entries({ en, zh, zht })) {
+        expect(dict[key], `${name} is missing ${key}`).toBeTruthy()
+      }
+      // Untranslated keys silently fall back to English via the `base` merge in
+      // context/language.tsx, so an English string here means a missed
+      // translation rather than a crash — assert it is actually translated.
+      expect(zh[key]).not.toBe(en[key])
+      expect(zht[key]).not.toBe(en[key])
+    }
+  })
+})

--- a/packages/opencode/test/cli/tui/session-status-store.test.ts
+++ b/packages/opencode/test/cli/tui/session-status-store.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from "bun:test"
+import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
+import { nextSessionStatus } from "../../../src/cli/cmd/tui/context/sync"
+
+// The TUI stores every `session.status` event in a solid store keyed by session.
+// Solid MERGES plain objects into the existing node, so a status that omits a
+// field used to inherit it from the previous status — that is how the /rebuild
+// outcome sentence latched into the following turn's spinner.
+function harness() {
+  return createRoot((dispose) => {
+    const [store, setStore] = createStore<{ session_status: Record<string, unknown> }>({ session_status: {} })
+    return {
+      store,
+      apply: (sessionID: string, status: Parameters<typeof nextSessionStatus>[0]) =>
+        setStore("session_status", sessionID, nextSessionStatus(status)),
+      dispose,
+    }
+  })
+}
+
+describe("nextSessionStatus", () => {
+  const REBUILT =
+    "Context rebuilt from the latest checkpoint. Recent messages are preserved; earlier context is now summarized."
+
+  test("a following turn's bare busy status does not inherit the rebuild message", () => {
+    const h = harness()
+    h.apply("ses_1", { type: "busy", message: REBUILT })
+    expect(h.store.session_status["ses_1"]).toEqual({ type: "busy", message: REBUILT })
+
+    // /rebuild settles to idle immediately after emitting its outcome.
+    h.apply("ses_1", { type: "idle" })
+    expect(h.store.session_status["ses_1"]).toEqual({ type: "idle" })
+
+    // The next turn: the runner emits a bare busy (session/run-state.ts:74).
+    h.apply("ses_1", { type: "busy" })
+    expect((h.store.session_status["ses_1"] as { message?: string }).message).toBeUndefined()
+    h.dispose()
+  })
+
+  test("idle clears a busy message", () => {
+    const h = harness()
+    h.apply("ses_2", { type: "busy", message: "Writing checkpoint\u2026" })
+    h.apply("ses_2", { type: "idle" })
+    expect(h.store.session_status["ses_2"]).toEqual({ type: "idle" })
+    h.dispose()
+  })
+
+  test("busy replaces an earlier busy message instead of keeping it", () => {
+    const h = harness()
+    h.apply("ses_3", { type: "busy", message: "Rebuilding context\u2026" })
+    h.apply("ses_3", { type: "busy", message: "Writing checkpoint\u2026" })
+    expect(h.store.session_status["ses_3"]).toEqual({ type: "busy", message: "Writing checkpoint\u2026" })
+    h.dispose()
+  })
+
+  test("retry fields do not survive into the next status", () => {
+    const h = harness()
+    h.apply("ses_4", { type: "retry", attempt: 2, message: "boom", next: 1000 })
+    h.apply("ses_4", { type: "busy" })
+    expect(h.store.session_status["ses_4"]).toEqual({ type: "busy" })
+    h.dispose()
+  })
+
+  test("first status for an unseen session is stored as-is", () => {
+    const h = harness()
+    h.apply("ses_5", { type: "busy", message: "Rebuilding context\u2026" })
+    expect(h.store.session_status["ses_5"]).toEqual({ type: "busy", message: "Rebuilding context\u2026" })
+    h.dispose()
+  })
+})

--- a/packages/opencode/test/command/rebuild.test.ts
+++ b/packages/opencode/test/command/rebuild.test.ts
@@ -7,23 +7,40 @@ describe("/rebuild command", () => {
     expect(Command.Default.REBUILD).toBe("rebuild")
   })
 
-  test("prompt.ts wires a /rebuild special-case that reuses the shared rebuildFromCheckpoint helper", async () => {
+  test("prompt.ts wires a /rebuild special-case that reuses the shared rebuild helpers", async () => {
     // Source-level guard (mirrors the repo's other prompt.ts wiring guards).
     // The /rebuild command must (a) exist as a special-case in SessionPrompt.command,
-    // (b) call the SAME rebuildFromCheckpoint helper the automatic overflow path
-    // uses (so logic/boundary conditions can't drift), and (c) report both the
-    // success and no-checkpoint outcomes to the user rather than silently no-op.
+    // (b) call the SAME helpers the automatic overflow path uses (so logic/boundary
+    // conditions can't drift), and (c) report its outcomes to the user rather than
+    // silently no-op.
+    //
+    // DELIBERATE UPDATE: (b) used to require a direct rebuildFromCheckpoint( call
+    // inside the REBUILD block, and (c) used to require the string
+    //   "No checkpoint is available to rebuild from yet — continue the
+    //    conversation and a checkpoint will be written automatically."
+    // Both statements are now wrong, not merely reshaped:
+    //   - the manual block calls rebuildEnsuringCheckpoint, which wraps
+    //     rebuildFromCheckpoint and adds the start-a-writer-and-wait step the auto
+    //     overflow path now shares;
+    //   - that no-checkpoint string was deleted because the exit it could still
+    //     reach is "a checkpoint WAS written but the rebuild failed", where
+    //     advising the user to keep talking so a checkpoint gets written is false.
+    // The outcomes are still asserted, against the messages that now exist.
     const promptSrc = await Bun.file(
       path.join(import.meta.dir, "..", "..", "src", "session", "prompt.ts"),
     ).text()
 
     // (a) special-case dispatch on the rebuild command
     expect(promptSrc).toContain("input.command === Command.Default.REBUILD")
-    // (b) reuses the shared helper (defined once, called by both auto + manual)
+    // (b) reuses the shared helpers (each defined once, called by auto + manual)
     expect(promptSrc).toContain("const rebuildFromCheckpoint = Effect.fn")
-    expect(promptSrc).toMatch(/if\s*\(input\.command === Command\.Default\.REBUILD\)[\s\S]*?rebuildFromCheckpoint\(/)
-    // (c) both outcomes surfaced to the user
+    expect(promptSrc).toContain("const rebuildEnsuringCheckpoint = Effect.fn")
+    expect(promptSrc).toMatch(
+      /if\s*\(input\.command === Command\.Default\.REBUILD\)[\s\S]*?rebuildEnsuringCheckpoint\(/,
+    )
+    // (c) all three outcomes surfaced to the user
     expect(promptSrc).toContain("Context rebuilt from the latest checkpoint")
-    expect(promptSrc).toContain("No checkpoint is available to rebuild from yet")
+    expect(promptSrc).toContain("the context was compacted instead")
+    expect(promptSrc).toContain("could not be rebuilt from it")
   })
 })

--- a/packages/opencode/test/session/auto-overflow-writer-first.test.ts
+++ b/packages/opencode/test/session/auto-overflow-writer-first.test.ts
@@ -1,0 +1,414 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Deferred, Effect, Layer } from "effect"
+import * as fs from "fs/promises"
+import path from "path"
+import { GlobalBus } from "../../src/bus/global"
+import { Database, desc, eq } from "../../src/storage"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { MessageTable, SessionTable } from "../../src/session/session.sql"
+import { checkpointPath } from "../../src/session/checkpoint-paths"
+import { spawnRef } from "../../src/actor/spawn-ref"
+import type { AgentOutcome } from "../../src/actor/spawn"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { tmpdir } from "../fixture/fixture"
+import { Log } from "../../src/util"
+
+void Log.init({ print: false })
+
+const ref = {
+  providerID: ProviderID.make("alibaba"),
+  modelID: ModelID.make("qwen-plus"),
+}
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+function run<A, E>(fx: Effect.Effect<A, E, SessionPrompt.Service | Session.Service>) {
+  return Effect.runPromise(
+    fx.pipe(Effect.scoped, Effect.provide(Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer))),
+  )
+}
+
+function chat(text: string): ReadableStream<Uint8Array> {
+  const payload =
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [{ delta: { role: "assistant" } }],
+      })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [{ delta: { content: text } }],
+      })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [{ delta: {}, finish_reason: "stop" }],
+      })}`,
+      "data: [DONE]",
+    ].join("\n\n") + "\n\n"
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(ctrl) {
+      ctrl.enqueue(encoder.encode(payload))
+      ctrl.close()
+    },
+  })
+}
+
+function startLLM(reply: string) {
+  let calls = 0
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url)
+      if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
+      calls++
+      return new Response(chat(reply), { status: 200, headers: { "Content-Type": "text/event-stream" } })
+    },
+  })
+  return {
+    origin: server.url.origin,
+    get calls() {
+      return calls
+    },
+    stop: () => server.stop(true),
+  }
+}
+
+type SpawnImpl = NonNullable<typeof spawnRef.current>
+
+function withSpawnRef<T>(impl: SpawnImpl | undefined, body: () => Promise<T>): Promise<T> {
+  const prev = spawnRef.current
+  spawnRef.current = impl
+  return body().finally(() => {
+    spawnRef.current = prev
+  })
+}
+
+/**
+ * Writer stub that behaves like a REAL writer: it does not finish instantly.
+ * It resolves `delayMs` later, and only then writes real checkpoint content and
+ * advances the watermark.
+ *
+ * The delay is load-bearing for what this file proves. prune.fireCheckpoints
+ * runs immediately BEFORE the overflow check (prune.ts:289) and already calls
+ * tryStartCheckpointWriter, which scaffolds an empty template file
+ * (checkpoint.ts:650). So at the moment the overflow check runs, the realistic
+ * state is: checkpoint FILE exists, watermark NOT yet set, writer in flight —
+ * which is what rebuildFromCheckpoint reports as "nothing usable". An
+ * instant-success stub would have already advanced the watermark by then, so the
+ * old code would have rebuilt too and the test would prove nothing.
+ */
+function writerThatWritesCheckpointAfter(marker: string, delayMs: number): SpawnImpl {
+  let counter = 0
+  return {
+    spawn: (input) =>
+      Effect.gen(function* () {
+        counter += 1
+        const parent = (input.parentSessionID ?? input.sessionID) as SessionID
+        const outcome = yield* Deferred.make<AgentOutcome>()
+        yield* Effect.forkDetach(
+          Effect.gen(function* () {
+            yield* Effect.sleep(delayMs)
+            const cpFile = checkpointPath(parent)
+            yield* Effect.promise(() => fs.mkdir(path.dirname(cpFile), { recursive: true }))
+            yield* Effect.promise(() =>
+              fs.writeFile(cpFile, `# Session checkpoint\n\n## §1 Active intent\n${marker}\n`),
+            )
+            const last = yield* Effect.sync(() =>
+              Database.use((db) =>
+                db
+                  .select({ id: MessageTable.id })
+                  .from(MessageTable)
+                  .where(eq(MessageTable.session_id, parent))
+                  .orderBy(desc(MessageTable.id))
+                  .limit(1)
+                  .get(),
+              ),
+            )
+            if (last?.id) {
+              yield* Effect.sync(() =>
+                Database.use((db) =>
+                  db
+                    .update(SessionTable)
+                    .set({ last_checkpoint_message_id: last.id })
+                    .where(eq(SessionTable.id, parent))
+                    .run(),
+                ),
+              )
+            }
+            yield* Deferred.succeed(outcome, { status: "success" as const })
+          }),
+        )
+        return { actorID: `${input.agentType}-${counter}`, sessionID: input.sessionID, outcome }
+      }),
+    cancel: () => Effect.void,
+    getForkContext: () => Effect.succeed(undefined),
+  } as SpawnImpl
+}
+
+function writerThatFails(): SpawnImpl {
+  let counter = 0
+  return {
+    spawn: (input) =>
+      Effect.gen(function* () {
+        counter += 1
+        const outcome = yield* Deferred.make<AgentOutcome>()
+        yield* Deferred.succeed(outcome, { status: "failure" as const, error: "writer blew up" })
+        return { actorID: `${input.agentType}-${counter}`, sessionID: input.sessionID, outcome }
+      }),
+    cancel: () => Effect.void,
+    getForkContext: () => Effect.succeed(undefined),
+  } as SpawnImpl
+}
+
+// Shrink the usable window so a seeded token count trips
+// SessionOverflow.isOverflow deterministically. reserves() = compaction.reserved
+// (100) + a 20_000 output reservation (this model publishes no limit.input), so
+// max_context must exceed ~20_100 to be honoured at all. It must ALSO leave
+// usable > 13_000, or SessionPrune.resolveThresholds refuses the window
+// ("too small for checkpoints"). 40_000 satisfies both: usable = 40_000 -
+// 20_100 = 19_900, against the seeded 50_000 tokens.
+function mimocodeConfig(baseURL: string) {
+  return JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    enabled_providers: ["alibaba"],
+    provider: { alibaba: { options: { apiKey: "test-key", baseURL: `${baseURL}/v1` } } },
+    agent: { build: { model: "alibaba/qwen-plus" } },
+    compaction: { reserved: 100, max_context: 40000 },
+  })
+}
+
+async function seedUserMessage(sessionID: SessionID, text: string) {
+  const msg = await Effect.runPromise(
+    Session.Service.use((s) =>
+      s.updateMessage({
+        id: MessageID.ascending(),
+        role: "user",
+        sessionID,
+        // F49+F50: the main agent's messages carry agentID "main", and the
+        // runLoop reads its slice with agentID "main" — seeds must match or
+        // they are invisible to the overflow check.
+        agentID: "main",
+        agent: "build",
+        model: ref,
+        time: { created: Date.now() },
+      }),
+    ).pipe(Effect.provide(Session.defaultLayer)),
+  )
+  await Effect.runPromise(
+    Session.Service.use((s) =>
+      s.updatePart({ id: PartID.ascending(), messageID: msg.id, sessionID, type: "text", text }),
+    ).pipe(Effect.provide(Session.defaultLayer)),
+  )
+  return msg
+}
+
+/**
+ * Seed a COMPLETED assistant turn reporting a token count far above the usable
+ * window. The runLoop reads exactly this message as `lastFinished` and feeds its
+ * tokens to the overflow check, so this is what makes the next prompt overflow.
+ */
+async function seedFinishedAssistant(sessionID: SessionID, parentID: MessageID, totalTokens: number) {
+  const msg = await Effect.runPromise(
+    Session.Service.use((s) =>
+      s.updateMessage({
+        id: MessageID.ascending(),
+        role: "assistant",
+        sessionID,
+        parentID,
+        agentID: "main",
+        agent: "build",
+        mode: "build",
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        path: { cwd: "/tmp", root: "/tmp" },
+        cost: 0,
+        finish: "stop",
+        tokens: { total: totalTokens, input: totalTokens, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        time: { created: Date.now(), completed: Date.now() },
+      }),
+    ).pipe(Effect.provide(Session.defaultLayer)),
+  )
+  await Effect.runPromise(
+    Session.Service.use((s) =>
+      s.updatePart({
+        id: PartID.ascending(),
+        messageID: msg.id,
+        sessionID,
+        type: "text",
+        text: "a very long prior answer",
+      }),
+    ).pipe(Effect.provide(Session.defaultLayer)),
+  )
+  return msg
+}
+
+// These tests drive the REAL main-agent context-overflow path inside
+// SessionPrompt's runLoop (prompt.ts, the `overflowCheck(...) ||
+// maxThresholdCrossed(...)` branch) against a scripted LLM stub, and assert on
+// what the session ends up containing: a `checkpoint` boundary part (rebuild) vs
+// a `compaction` boundary part (degradation).
+//
+// The behaviour under test is the fix for the auto/manual asymmetry: both paths
+// share rebuildFromCheckpoint, which only checks hasCheckpoint and returns
+// false. Manual /rebuild handled `false` by writing a checkpoint on the spot and
+// waiting; the auto path used to give up and call compaction.create. Now both go
+// through rebuildEnsuringCheckpoint, and compaction is reachable from exactly
+// ONE condition: no checkpoint AND the writer failed / never ran / the wait bound
+// expired.
+//
+// Why this matters more than it looks: compaction.create is NOT an LLM
+// summarizer (measured p50 0.240ms). It inserts a bare `compaction` marker that
+// MessageV2.filterCompacted breaks at, so every pre-boundary message is dropped
+// with no summary at all. Degrading is therefore a real loss, not a cheaper
+// summary.
+describe("Auto context overflow: write a checkpoint before degrading to compaction", () => {
+  test(
+    "no checkpoint + writer succeeds → inserts a checkpoint boundary and does NOT compact",
+    async () => {
+      const llm = startLLM("post-rebuild-reply")
+      const writer = writerThatWritesCheckpointAfter("AUTO_OVERFLOW_FRESH_CHECKPOINT", 400)
+      const seen: Array<string | undefined> = []
+      const onEvent = (e: {
+        payload?: { type?: string; properties?: { status?: { type?: string; message?: string } } }
+      }) => {
+        if (e?.payload?.type === "session.status" && e.payload.properties?.status?.type === "busy") {
+          seen.push(e.payload.properties.status.message)
+        }
+      }
+      GlobalBus.on("event", onEvent)
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
+        })
+
+        await withSpawnRef(writer, () =>
+          Instance.provide({
+            directory: tmp.path,
+            fn: () =>
+              run(
+                Effect.gen(function* () {
+                  const prompt = yield* SessionPrompt.Service
+                  const sessions = yield* Session.Service
+                  const info = yield* sessions.create({ title: "auto-overflow-rebuild" })
+
+                  // Cold session (no checkpoint file) whose last completed
+                  // assistant turn already blew the usable window.
+                  const first = yield* Effect.promise(() => seedUserMessage(info.id, "earlier question"))
+                  yield* Effect.promise(() => seedFinishedAssistant(info.id, first.id, 50_000))
+
+                  yield* prompt.prompt({
+                    sessionID: info.id,
+                    parts: [{ type: "text", text: "next question that overflows" }],
+                    agent: "build",
+                  })
+
+                  const after = yield* sessions.messages({ sessionID: info.id })
+
+                  // The overflow was resolved by a REBUILD: a checkpoint
+                  // boundary landed…
+                  const checkpoints = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                  expect(checkpoints.length).toBe(1)
+                  expect(checkpoints[0]!.info.role).toBe("user")
+
+                  // …and NOT by degrading to compaction. This is the assertion
+                  // that fails before the fix: the old code called
+                  // compaction.create the moment rebuildFromCheckpoint said no.
+                  const compactions = after.filter((m) => m.parts.some((p) => p.type === "compaction"))
+                  expect(compactions.length).toBe(0)
+
+                  // A writer actually settled: the checkpoint watermark is now
+                  // set. Before the fix nothing waited for it, so at the moment
+                  // the overflow check ran the watermark was still unset — which
+                  // is exactly why rebuildFromCheckpoint returned false and the
+                  // old code compacted.
+                  const watermark = yield* Effect.sync(() =>
+                    Database.use((db) =>
+                      db
+                        .select({ id: SessionTable.last_checkpoint_message_id })
+                        .from(SessionTable)
+                        .where(eq(SessionTable.id, info.id))
+                        .get(),
+                    ),
+                  )
+                  expect(watermark?.id).toBeTruthy()
+
+                  // The boundary is the message the watermark points at or later
+                  // — i.e. the rebuild used the checkpoint, not a guess.
+                  expect(checkpoints[0]!.parts.some((p) => p.type === "checkpoint")).toBe(true)
+                }),
+              ),
+          }),
+        )
+      } finally {
+        GlobalBus.off("event", onEvent)
+        await llm.stop()
+      }
+
+      // A multi-minute mid-turn wait must be explained, not look frozen.
+      expect(seen).toContain("Writing checkpoint\u2026")
+    },
+    { timeout: 60_000 },
+  )
+
+  test(
+    "no checkpoint + writer genuinely fails → STILL falls back to compaction",
+    async () => {
+      const llm = startLLM("post-compaction-reply")
+      // Writer spawns and reports failure — the genuine-failure case, which is
+      // the ONLY condition allowed to reach compaction.
+      const writer = writerThatFails()
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
+        })
+
+        await withSpawnRef(writer, () =>
+          Instance.provide({
+            directory: tmp.path,
+            fn: () =>
+              run(
+                Effect.gen(function* () {
+                  const prompt = yield* SessionPrompt.Service
+                  const sessions = yield* Session.Service
+                  const info = yield* sessions.create({ title: "auto-overflow-compaction" })
+
+                  const first = yield* Effect.promise(() => seedUserMessage(info.id, "earlier question"))
+                  yield* Effect.promise(() => seedFinishedAssistant(info.id, first.id, 50_000))
+
+                  yield* prompt.prompt({
+                    sessionID: info.id,
+                    parts: [{ type: "text", text: "next question that overflows" }],
+                    agent: "build",
+                  })
+
+                  const after = yield* sessions.messages({ sessionID: info.id })
+
+                  // Writer failed and no checkpoint existed → degrade.
+                  const compactions = after.filter((m) => m.parts.some((p) => p.type === "compaction"))
+                  expect(compactions.length).toBe(1)
+
+                  // No checkpoint boundary, because no checkpoint was written.
+                  const checkpoints = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                  expect(checkpoints.length).toBe(0)
+                }),
+              ),
+          }),
+        )
+      } finally {
+        await llm.stop()
+      }
+    },
+    { timeout: 60_000 },
+  )
+})

--- a/packages/opencode/test/session/auto-overflow-writer-first.test.ts
+++ b/packages/opencode/test/session/auto-overflow-writer-first.test.ts
@@ -411,4 +411,100 @@ describe("Auto context overflow: write a checkpoint before degrading to compacti
     },
     { timeout: 60_000 },
   )
+
+  // The arrival state this guards is NORMAL, not degraded, which is what makes
+  // it easy to misclassify. `prune.fireCheckpoints` (prune.ts:289) runs
+  // immediately BEFORE the overflow check, and `tryStartCheckpointWriter`
+  // scaffolds an EMPTY TEMPLATE (checkpoint.ts:650) *before* spawning the
+  // writer. So by the time the overflow check runs, "checkpoint file on disk,
+  // watermark not yet written" is the ordinary case.
+  //
+  // Two successive bugs lived here, and the second one hid inside the fix for
+  // the first:
+  //
+  //  1. The discriminator keyed on bare `hasCheckpoint` — literally
+  //     `Bun.file(...).exists()` (checkpoint.ts:1021) — so the scaffolded
+  //     template counted as a usable checkpoint and the state was reported as
+  //     `insert-failed`.
+  //  2. Re-keying it on `lastBoundary` was right in substance but was written as
+  //     `boundary !== undefined`, and `lastBoundary` returned JS `null` for an
+  //     unset watermark (a nullable column behind an unchecked
+  //     `as MessageID | undefined` cast, checkpoint.ts:1422). `null !== undefined`
+  //     is true, so the new guard was a NO-OP and behaved exactly like (1).
+  //
+  // Both bugs present identically and silently: `insert-failed` is the one
+  // outcome that neither rebuilds nor compacts (prompt.ts:3515-3521 deliberately
+  // falls through to the model call), so the overflow is simply left unresolved
+  // — zero checkpoints AND zero compactions, no error anywhere. That signature
+  // is why this needs a test rather than a code reading: the sibling test above
+  // passes with either bug in place, because it seeds no file at all.
+  test(
+    "a scaffolded-but-empty checkpoint file still starts and awaits the writer",
+    async () => {
+      const llm = startLLM("post-rebuild-reply")
+      const writer = writerThatWritesCheckpointAfter("SCAFFOLD_THEN_REAL_CHECKPOINT", 400)
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
+        })
+
+        await withSpawnRef(writer, () =>
+          Instance.provide({
+            directory: tmp.path,
+            fn: () =>
+              run(
+                Effect.gen(function* () {
+                  const prompt = yield* SessionPrompt.Service
+                  const sessions = yield* Session.Service
+                  const info = yield* sessions.create({ title: "auto-overflow-scaffolded" })
+
+                  const first = yield* Effect.promise(() => seedUserMessage(info.id, "earlier question"))
+                  yield* Effect.promise(() => seedFinishedAssistant(info.id, first.id, 50_000))
+
+                  // Exactly what tryStartCheckpointWriter leaves behind before
+                  // the writer has produced anything: the file exists, the
+                  // watermark does not.
+                  const file = checkpointPath(info.id)
+                  yield* Effect.promise(() => fs.mkdir(path.dirname(file), { recursive: true }))
+                  yield* Effect.promise(() => Bun.write(file, "# Session checkpoint\n"))
+
+                  yield* prompt.prompt({
+                    sessionID: info.id,
+                    parts: [{ type: "text", text: "next question that overflows" }],
+                    agent: "build",
+                  })
+
+                  const after = yield* sessions.messages({ sessionID: info.id })
+
+                  const checkpoints = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                  const compactions = after.filter((m) => m.parts.some((p) => p.type === "compaction"))
+                  // A writer was started and awaited, and the rebuild used its
+                  // output. Both numbers matter: 0/0 is the silent-fallthrough
+                  // signature of the bug, and 0/1 would mean it degraded.
+                  expect(checkpoints.length).toBe(1)
+                  expect(compactions.length).toBe(0)
+
+                  // The scaffolded file must NOT have been mistaken for a usable
+                  // checkpoint: a watermark exists only because a writer settled.
+                  const watermark = yield* Effect.sync(() =>
+                    Database.use((db) =>
+                      db
+                        .select({ id: SessionTable.last_checkpoint_message_id })
+                        .from(SessionTable)
+                        .where(eq(SessionTable.id, info.id))
+                        .get(),
+                    ),
+                  )
+                  expect(watermark?.id).toBeTruthy()
+                }),
+              ),
+          }),
+        )
+      } finally {
+        await llm.stop()
+      }
+    },
+    { timeout: 60_000 },
+  )
 })

--- a/packages/opencode/test/session/prompt-rebuild-reset.test.ts
+++ b/packages/opencode/test/session/prompt-rebuild-reset.test.ts
@@ -54,21 +54,30 @@ describe("F1 — prune resetThresholds clears sticky maxCrossed", () => {
       Effect.gen(function* () {
         // Source-level regression guard (F1). The site-1 main rebuild path now
         // delegates the boundary insert + threshold reset to the shared
-        // rebuildFromCheckpoint helper (reused by the /rebuild command), then
-        // sets skipOverflowCheck and continues. Assert BOTH halves of the
-        // invariant: (a) the shared helper resets thresholds after a successful
-        // insert; (b) site-1 sets skipOverflowCheck=true then continue after
-        // calling rebuildFromCheckpoint — so the loop can't immediately
-        // re-trigger overflow on the same crossed thresholds.
+        // rebuildFromCheckpoint helper, which is itself wrapped by
+        // rebuildEnsuringCheckpoint (the start-a-writer-and-wait step reused by
+        // the /rebuild command). Assert BOTH halves of the invariant: (a) the
+        // shared helper resets thresholds after a successful insert; (b) site-1
+        // sets skipOverflowCheck=true then continue on a successful rebuild — so
+        // the loop can't immediately re-trigger overflow on the same crossed
+        // thresholds.
+        //
+        // DELIBERATE UPDATE: (b)'s pattern used to be
+        //   const inserted = yield* rebuildFromCheckpoint(…)
+        //   if (inserted) { skipOverflowCheck = true; continue }
+        // Site-1 now calls rebuildEnsuringCheckpoint and branches on a
+        // discriminated outcome instead of a boolean, so the old regex matched a
+        // code shape that no longer exists. The INVARIANT is unchanged and still
+        // asserted; only the shape it is expressed in moved.
         const promptSrc = yield* Effect.promise(() =>
           Bun.file(`${import.meta.dir}/../../src/session/prompt.ts`).text(),
         )
         expect(promptSrc).not.toContain("Do NOT reset thresholds here")
         // (a) shared helper resets thresholds on a successful insert.
         expect(promptSrc).toMatch(/if\s*\(inserted\)\s+yield\*\s+prune\.resetThresholds\(input\.sessionID\)/)
-        // (b) site-1 guards on the helper result, then skips + continues.
+        // (b) site-1 guards on the helper's outcome, then skips + continues.
         expect(promptSrc).toMatch(
-          /const\s+inserted\s*=\s*yield\*\s+rebuildFromCheckpoint\([\s\S]*?\)\s*\n\s*if\s*\(inserted\)\s*\{\s*\n\s*skipOverflowCheck\s*=\s*true\s*\n\s*continue/,
+          /const\s+attempt:\s*RebuildAttempt\s*=\s*yield\*\s+rebuildEnsuringCheckpoint\([\s\S]*?\)\s*\n\s*if\s*\(attempt\s*===\s*"rebuilt"\)\s*\{\s*\n\s*skipOverflowCheck\s*=\s*true\s*\n\s*continue/,
         )
       }),
     ),

--- a/packages/opencode/test/session/rebuild-boundary-model-context.test.ts
+++ b/packages/opencode/test/session/rebuild-boundary-model-context.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test"
+import { MessageV2 } from "../../src/session/message-v2"
+import type { Provider } from "../../src/provider"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { SessionID, MessageID, PartID } from "../../src/session/schema"
+
+// Pins the AI-facing semantics of the two context-boundary mechanisms so a
+// future "let's make rebuild look like compaction" refactor cannot silently
+// change what the model receives:
+//
+//   compaction — boundary user message carries only a `compaction` part, which
+//     becomes the bare label "Summary of previous conversation:"
+//     (message-v2.ts). The actual summary text lives in a SEPARATE
+//     `summary: true` assistant message written by processCompaction
+//     (compaction.ts), and that assistant turn is NOT filtered out.
+//
+//   rebuild — boundary user message carries a `checkpoint` part (label
+//     "Summary of previous conversation from checkpoint files:") PLUS the
+//     rendered checkpoint index / rebuild context as `synthetic: true` text
+//     parts. Synthetic text is excluded from the TUI transcript but IS sent to
+//     the model: the user-part filter is `!part.ignored`, not `!part.synthetic`.
+//
+// Net: both boundaries put a real summary into the model context. Rebuild's
+// arrives inline on the boundary user turn; compaction's arrives on the
+// following assistant turn.
+
+const sessionID = SessionID.make("session")
+const providerID = ProviderID.make("test")
+
+const model: Provider.Model = {
+  id: ModelID.make("test-model"),
+  providerID,
+  api: { id: "test-model", url: "https://example.com", npm: "@ai-sdk/openai" },
+  name: "Test Model",
+  capabilities: {
+    temperature: true,
+    reasoning: false,
+    attachment: false,
+    toolcall: true,
+    input: { text: true, audio: false, image: false, video: false, pdf: false },
+    output: { text: true, audio: false, image: false, video: false, pdf: false },
+    interleaved: false,
+  },
+  cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+  limit: { context: 0, input: 0, output: 0 },
+  status: "active",
+  options: {},
+  headers: {},
+  release_date: "2026-01-01",
+}
+
+function userInfo(id: string): MessageV2.User {
+  return {
+    id,
+    sessionID,
+    role: "user",
+    time: { created: 0 },
+    agent: "user",
+    model: { providerID, modelID: ModelID.make("test") },
+    tools: {},
+    mode: "",
+  } as unknown as MessageV2.User
+}
+
+function summaryAssistantInfo(id: string, parentID: string): MessageV2.Assistant {
+  return {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: 0 },
+    parentID,
+    modelID: model.api.id,
+    providerID: model.providerID,
+    mode: "compaction",
+    agent: "compaction",
+    summary: true,
+    path: { cwd: "/", root: "/" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  } as unknown as MessageV2.Assistant
+}
+
+function basePart(messageID: string, id: string) {
+  return {
+    id: PartID.make(id),
+    sessionID,
+    messageID: MessageID.make(messageID),
+  }
+}
+
+const INDEX_TEXT = "## Checkpoint\n\nDirectory: /tmp/cp/\n"
+const REBUILD_TEXT = "## Rebuild context\n\nprior turns summarized here\n"
+const COMPACTION_SUMMARY_TEXT = "The user asked for X; we did Y."
+
+describe("context boundaries: what reaches the model", () => {
+  test("rebuild boundary sends the checkpoint label AND the synthetic rebuild content", async () => {
+    const boundaryID = "m-rebuild-boundary"
+    const messages = await MessageV2.toModelMessages(
+      [
+        {
+          info: userInfo(boundaryID),
+          parts: [
+            {
+              ...basePart(boundaryID, "p1"),
+              type: "checkpoint",
+              checkpointDir: "",
+              checkpointNumber: 0,
+              coveredUpTo: MessageID.make("m-old"),
+            },
+            { ...basePart(boundaryID, "p2"), type: "text", synthetic: true, text: INDEX_TEXT },
+            { ...basePart(boundaryID, "p3"), type: "text", synthetic: true, text: REBUILD_TEXT },
+          ] as MessageV2.Part[],
+        },
+      ],
+      model,
+    )
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].role).toBe("user")
+    const rendered = JSON.stringify(messages[0].content)
+    expect(rendered).toContain("Summary of previous conversation from checkpoint files:")
+    // `synthetic: true` hides these from the transcript, never from the model.
+    expect(rendered).toContain("## Checkpoint")
+    expect(rendered).toContain("prior turns summarized here")
+  })
+
+  test("compaction boundary sends a bare label; the summary rides on the assistant turn", async () => {
+    const boundaryID = "m-compaction-boundary"
+    const summaryID = "m-compaction-summary"
+    const messages = await MessageV2.toModelMessages(
+      [
+        {
+          info: userInfo(boundaryID),
+          parts: [{ ...basePart(boundaryID, "p1"), type: "compaction", auto: false }] as MessageV2.Part[],
+        },
+        {
+          info: summaryAssistantInfo(summaryID, boundaryID),
+          parts: [
+            { ...basePart(summaryID, "p2"), type: "text", text: COMPACTION_SUMMARY_TEXT },
+          ] as MessageV2.Part[],
+        },
+      ],
+      model,
+    )
+
+    expect(messages).toHaveLength(2)
+    expect(messages[0].role).toBe("user")
+    expect(JSON.stringify(messages[0].content)).toContain("Summary of previous conversation:")
+    // `summary: true` is NOT a filter — the compaction summary is a real
+    // assistant turn in the model context.
+    expect(messages[1].role).toBe("assistant")
+    expect(JSON.stringify(messages[1].content)).toContain(COMPACTION_SUMMARY_TEXT)
+  })
+
+  test("filterCompacted keeps the compaction summary assistant message after the boundary", () => {
+    const boundaryID = "m-compaction-boundary"
+    const summaryID = "m-compaction-summary"
+    // stream() yields newest-first; filterCompacted stops at the boundary and reverses.
+    const window = MessageV2.filterCompacted([
+      {
+        info: summaryAssistantInfo(summaryID, boundaryID),
+        parts: [{ ...basePart(summaryID, "p2"), type: "text", text: COMPACTION_SUMMARY_TEXT }] as MessageV2.Part[],
+      },
+      {
+        info: userInfo(boundaryID),
+        parts: [{ ...basePart(boundaryID, "p1"), type: "compaction", auto: false }] as MessageV2.Part[],
+      },
+      {
+        info: userInfo("m-ancient"),
+        parts: [{ ...basePart("m-ancient", "p0"), type: "text", text: "dropped" }] as MessageV2.Part[],
+      },
+    ])
+
+    expect(window.map((m) => String(m.info.id))).toEqual([boundaryID, summaryID])
+  })
+})

--- a/packages/opencode/test/session/rebuild-on-the-spot.test.ts
+++ b/packages/opencode/test/session/rebuild-on-the-spot.test.ts
@@ -200,11 +200,30 @@ async function seedUserMessage(sessionID: SessionID, text: string) {
 // status events published on the Bus. They intentionally avoid grepping
 // prompt.ts source text (which verifies nothing and breaks on refactors) per
 // AGENTS.md: "Test actual implementation, do not duplicate logic into tests".
+//
+// The core invariant they enforce is the real fix for #1752: a manual
+// /rebuild inserts the legitimate rebuild BOUNDARY (a role:"user" message
+// carrying a `checkpoint` part) and NOTHING ELSE — it must NOT fabricate a
+// second, standalone "Context rebuilt…" user turn (the band-aid the earlier
+// noReply approach left persisted), and it must NOT produce an assistant
+// reply. Exactly ONE new message (the boundary) lands, mirroring the
+// transparent boundary insertion the auto/compaction paths perform. The
+// outcome is surfaced on the SessionStatus / Bus status channel, not as a
+// persisted user message.
 describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.command", () => {
   test(
-    "case 1: checkpoint on disk + no writer → handler inserts a boundary and enters the runLoop",
+    "case 1: checkpoint on disk + no writer → inserts EXACTLY the boundary (no fabricated user turn, no reply)",
     async () => {
       const llm = startLLM("rebuilt-reply-from-model")
+      const seen: Array<string | undefined> = []
+      const onEvent = (e: {
+        payload?: { type?: string; properties?: { status?: { type?: string; message?: string } } }
+      }) => {
+        if (e?.payload?.type === "session.status" && e.payload.properties?.status?.type === "busy") {
+          seen.push(e.payload.properties.status.message)
+        }
+      }
+      GlobalBus.on("event", onEvent)
       try {
         await using tmp = await tmpdir({
           git: true,
@@ -249,7 +268,7 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
                 )
 
                 const before = yield* sessions.messages({ sessionID: info.id })
-                const userCountBefore = before.filter((m) => m.info.role === "user").length
+                const countBefore = before.length
 
                 // Drive the real handler.
                 const result = yield* prompt.command({
@@ -259,49 +278,60 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
                   agent: "build",
                 })
 
-                // A MANUAL /rebuild must NOT enter the runLoop: it inserts the
-                // boundary and returns the synthetic note WITHOUT producing a
-                // model reply (the user asked no question). So the returned
-                // message is the synthetic rebuild note (role "user", not an
-                // assistant turn), and the LLM was never called — no spurious
-                // "reply to nothing" turn.
+                // A MANUAL /rebuild must NOT enter the runLoop: the user asked
+                // no question, so the LLM was never called.
                 expect(result.info.role).not.toBe("assistant")
-                expect(
-                  result.parts.some(
-                    (p) => p.type === "text" && p.text.includes("Context rebuilt from the latest checkpoint"),
-                  ),
-                ).toBe(true)
-                expect(
-                  result.parts.some((p) => p.type === "text" && p.text.includes("rebuilt-reply-from-model")),
-                ).toBe(false)
                 expect(llm.calls).toBe(0)
 
-                // And no assistant reply carrying the scripted text landed in the DB.
-                const replied = (yield* sessions.messages({ sessionID: info.id })).some((m) =>
+                const after = yield* sessions.messages({ sessionID: info.id })
+
+                // EXACTLY ONE new message landed — the rebuild boundary — and
+                // nothing else. This is the crux of the #1752 fix: no fabricated
+                // second "Context rebuilt…" user turn.
+                expect(after.length).toBe(countBefore + 1)
+
+                // That one new message IS the boundary: role "user" carrying a
+                // `checkpoint` part (the shared, correct mechanism).
+                const boundaries = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                expect(boundaries.length).toBe(1)
+                expect(boundaries[0]!.info.role).toBe("user")
+
+                // The handler returns the boundary message itself, not a
+                // fabricated note.
+                expect(result.parts.some((p) => p.type === "checkpoint")).toBe(true)
+
+                // No fabricated standalone "Context rebuilt…" user turn is
+                // persisted anywhere (the band-aid the old path left behind).
+                const fabricated = after.some(
+                  (m) =>
+                    !m.parts.some((p) => p.type === "checkpoint") &&
+                    m.parts.some(
+                      (p) => p.type === "text" && p.text.includes("Context rebuilt from the latest checkpoint"),
+                    ),
+                )
+                expect(fabricated).toBe(false)
+
+                // No assistant reply carrying the scripted text landed in the DB.
+                const replied = after.some((m) =>
                   m.parts.some((p) => p.type === "text" && p.text.includes("rebuilt-reply-from-model")),
                 )
                 expect(replied).toBe(false)
 
-                // A checkpoint boundary message was actually inserted into the DB.
-                const after = yield* sessions.messages({ sessionID: info.id })
-                const boundaries = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
-                expect(boundaries.length).toBe(1)
-
-                // The rebuild-success synthetic prose is present on the boundary run.
-                const rebuiltNote = after.some((m) =>
-                  m.parts.some(
-                    (p) => p.type === "text" && p.text.includes("Context rebuilt from the latest checkpoint"),
-                  ),
-                )
-                expect(rebuiltNote).toBe(true)
-
                 // Original conversation preserved (3 seeded users still there).
+                const userCountBefore = before.filter((m) => m.info.role === "user").length
                 const userCountAfter = after.filter((m) => m.info.role === "user").length
                 expect(userCountAfter).toBeGreaterThanOrEqual(userCountBefore)
+
+                // Outcome surfaced on the status channel (not a persisted user
+                // message): the terminal "context rebuilt" message was emitted.
+                expect(
+                  seen.some((m) => m?.includes("Context rebuilt from the latest checkpoint")),
+                ).toBe(true)
               }),
             ),
         })
       } finally {
+        GlobalBus.off("event", onEvent)
         await llm.stop()
       }
     },
@@ -309,12 +339,21 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
   )
 
   test(
-    "case 2: no checkpoint → handler spawns a writer, waits for it, then rebuilds from the fresh checkpoint",
+    "case 2: no checkpoint → spawns a writer, waits, then inserts EXACTLY the fresh boundary (no fabricated turn, no reply)",
     async () => {
       const llm = startLLM("case2-model-reply")
       // The writer stub writes a real checkpoint on spawn and reports success,
       // exercising the handler's spawn→wait→rebuild path for real.
       const writer = writerThatWritesCheckpoint("CASE2_FRESH_CHECKPOINT_BODY")
+      const seen: Array<string | undefined> = []
+      const onEvent = (e: {
+        payload?: { type?: string; properties?: { status?: { type?: string; message?: string } } }
+      }) => {
+        if (e?.payload?.type === "session.status" && e.payload.properties?.status?.type === "busy") {
+          seen.push(e.payload.properties.status.message)
+        }
+      }
+      GlobalBus.on("event", onEvent)
       try {
         await using tmp = await tmpdir({
           git: true,
@@ -333,6 +372,9 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
                   yield* Effect.promise(() => seedUserMessage(info.id, "cold session, no checkpoint yet"))
                   yield* Effect.promise(() => seedUserMessage(info.id, "second turn on the cold session"))
 
+                  const before = yield* sessions.messages({ sessionID: info.id })
+                  const countBefore = before.length
+
                   // Cold session: no checkpoint file exists up front.
                   const result = yield* prompt.command({
                     sessionID: info.id,
@@ -341,36 +383,47 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
                     agent: "build",
                   })
 
-                  // The writer wrote a checkpoint and the handler rebuilt from
-                  // it, but a MANUAL /rebuild must NOT reply: it returns the
-                  // synthetic rebuild note via noReply and never enters the
-                  // runLoop, so the LLM is not called.
-                  expect(
-                    result.parts.some(
-                      (p) => p.type === "text" && p.text.includes("Context rebuilt from the latest checkpoint"),
-                    ),
-                  ).toBe(true)
-                  expect(
-                    result.parts.some((p) => p.type === "text" && p.text.includes("case2-model-reply")),
-                  ).toBe(false)
+                  // A MANUAL /rebuild must NOT reply: the LLM is not called.
+                  expect(result.info.role).not.toBe("assistant")
                   expect(llm.calls).toBe(0)
 
-                  // A rebuild boundary was inserted from the freshly-written checkpoint.
-                  const msgs = yield* sessions.messages({ sessionID: info.id })
-                  const boundaries = msgs.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                  const after = yield* sessions.messages({ sessionID: info.id })
+
+                  // EXACTLY ONE new message: the boundary rebuilt from the
+                  // freshly-written checkpoint. No fabricated "Context rebuilt…"
+                  // user turn.
+                  expect(after.length).toBe(countBefore + 1)
+
+                  const boundaries = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
                   expect(boundaries.length).toBe(1)
-                  expect(
-                    msgs.some((m) =>
+                  expect(boundaries[0]!.info.role).toBe("user")
+                  expect(result.parts.some((p) => p.type === "checkpoint")).toBe(true)
+
+                  const fabricated = after.some(
+                    (m) =>
+                      !m.parts.some((p) => p.type === "checkpoint") &&
                       m.parts.some(
                         (p) => p.type === "text" && p.text.includes("Context rebuilt from the latest checkpoint"),
                       ),
-                    ),
+                  )
+                  expect(fabricated).toBe(false)
+
+                  const replied = after.some((m) =>
+                    m.parts.some((p) => p.type === "text" && p.text.includes("case2-model-reply")),
+                  )
+                  expect(replied).toBe(false)
+
+                  // Outcome surfaced on the status channel, not a persisted user
+                  // message.
+                  expect(
+                    seen.some((m) => m?.includes("Context rebuilt from the latest checkpoint")),
                   ).toBe(true)
                 }),
               ),
           }),
         )
       } finally {
+        GlobalBus.off("event", onEvent)
         await llm.stop()
       }
     },
@@ -378,9 +431,18 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
   )
 
   test(
-    "case 2 fallback: no checkpoint + no spawnable writer → surfaces the no-checkpoint message without a model reply",
+    "case 2 fallback: no checkpoint + no spawnable writer → surfaces the no-checkpoint outcome on the status channel, persists nothing",
     async () => {
       const llm = startLLM("should-not-be-used-as-a-reply")
+      const seen: Array<string | undefined> = []
+      const onEvent = (e: {
+        payload?: { type?: string; properties?: { status?: { type?: string; message?: string } } }
+      }) => {
+        if (e?.payload?.type === "session.status" && e.payload.properties?.status?.type === "busy") {
+          seen.push(e.payload.properties.status.message)
+        }
+      }
+      GlobalBus.on("event", onEvent)
       try {
         await using tmp = await tmpdir({
           git: true,
@@ -389,7 +451,8 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
 
         // Force NO writer: with spawnRef unset, tryStartCheckpointWriter cannot
         // spawn and waitForWriter resolves "no-writer" → the handler must fall
-        // through to the no-checkpoint outcome (noReply, no runLoop).
+        // through to the no-checkpoint outcome (status channel, no runLoop, no
+        // persisted message).
         await withSpawnRef(undefined, () =>
           Instance.provide({
             directory: tmp.path,
@@ -401,6 +464,9 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
                   const info = yield* sessions.create({ title: "rebuild-case-2-fallback" })
                   yield* Effect.promise(() => seedUserMessage(info.id, "cold session, no checkpoint yet"))
 
+                  const before = yield* sessions.messages({ sessionID: info.id })
+                  const countBefore = before.length
+
                   const result = yield* prompt.command({
                     sessionID: info.id,
                     command: Command.Default.REBUILD,
@@ -408,29 +474,40 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
                     agent: "build",
                   })
 
-                  // Handler surfaces the no-checkpoint message to the user…
-                  expect(
-                    result.parts.some(
+                  // Did NOT enter the runLoop (no reply produced).
+                  expect(result.info.role).not.toBe("assistant")
+
+                  const after = yield* sessions.messages({ sessionID: info.id })
+
+                  // NOTHING was persisted: no boundary (nothing to rebuild from)
+                  // and no fabricated "No checkpoint…" user turn. The message
+                  // count is unchanged.
+                  expect(after.length).toBe(countBefore)
+                  const boundaries = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                  expect(boundaries.length).toBe(0)
+                  const fabricated = after.some((m) =>
+                    m.parts.some(
                       (p) => p.type === "text" && p.text.includes("No checkpoint is available to rebuild from yet"),
                     ),
-                  ).toBe(true)
+                  )
+                  expect(fabricated).toBe(false)
 
-                  // …and did NOT enter the runLoop (noReply), so no assistant
-                  // reply carrying the scripted text was produced.
-                  const msgs = yield* sessions.messages({ sessionID: info.id })
-                  const modelReplied = msgs.some((m) =>
+                  // No assistant reply carrying the scripted text was produced.
+                  const modelReplied = after.some((m) =>
                     m.parts.some((p) => p.type === "text" && p.text.includes("should-not-be-used-as-a-reply")),
                   )
                   expect(modelReplied).toBe(false)
 
-                  // No rebuild boundary was inserted (nothing usable to rebuild from).
-                  const boundaries = msgs.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
-                  expect(boundaries.length).toBe(0)
+                  // The outcome IS surfaced — on the status channel.
+                  expect(
+                    seen.some((m) => m?.includes("No checkpoint is available to rebuild from yet")),
+                  ).toBe(true)
                 }),
               ),
           }),
         )
       } finally {
+        GlobalBus.off("event", onEvent)
         await llm.stop()
       }
     },

--- a/packages/opencode/test/session/rebuild-on-the-spot.test.ts
+++ b/packages/opencode/test/session/rebuild-on-the-spot.test.ts
@@ -1,51 +1,173 @@
-import { afterEach, describe, expect } from "bun:test"
-import { Effect, Layer } from "effect"
+import { afterEach, describe, expect, test } from "bun:test"
+import { Deferred, Effect, Layer } from "effect"
 import * as fs from "fs/promises"
 import path from "path"
-import { Bus } from "../../src/bus"
-import { Config } from "../../src/config"
-import { Memory } from "../../src/memory"
-import { Session } from "../../src/session"
-import { SessionCheckpoint } from "../../src/session/checkpoint"
-import { checkpointPath } from "../../src/session/checkpoint-paths"
-import { SessionStatus } from "../../src/session/status"
-import { TaskRegistry } from "../../src/task/registry"
-import { ActorRegistry } from "../../src/actor/registry"
+import { Command } from "../../src/command"
+import { GlobalBus } from "../../src/bus/global"
+import { Database, desc, eq } from "../../src/storage"
 import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { MessageTable, SessionTable } from "../../src/session/session.sql"
+import { checkpointPath } from "../../src/session/checkpoint-paths"
+import { spawnRef } from "../../src/actor/spawn-ref"
+import type { AgentOutcome } from "../../src/actor/spawn"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
-import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
-import { provideTmpdirInstance } from "../fixture/fixture"
-import { testEffect } from "../lib/effect"
+import { tmpdir } from "../fixture/fixture"
 import { Log } from "../../src/util"
 
 void Log.init({ print: false })
 
 const ref = {
-  providerID: ProviderID.make("test"),
-  modelID: ModelID.make("test-model"),
+  providerID: ProviderID.make("alibaba"),
+  modelID: ModelID.make("qwen-plus"),
 }
 
 afterEach(async () => {
   await Instance.disposeAll()
 })
 
-const it = testEffect(
-  Layer.mergeAll(
-    CrossSpawnSpawner.defaultLayer,
-    Bus.defaultLayer,
-    Config.defaultLayer,
-    Memory.defaultLayer,
-    Session.defaultLayer,
-    TaskRegistry.defaultLayer,
-    ActorRegistry.defaultLayer,
-    SessionCheckpoint.defaultLayer,
-    SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer)),
-  ),
-)
+function run<A, E>(fx: Effect.Effect<A, E, SessionPrompt.Service | Session.Service>) {
+  return Effect.runPromise(
+    fx.pipe(Effect.scoped, Effect.provide(Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer))),
+  )
+}
+
+/** OpenAI-compatible SSE for a plain text stop response. */
+function chat(text: string): ReadableStream<Uint8Array> {
+  const payload =
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [{ delta: { role: "assistant" } }],
+      })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [{ delta: { content: text } }],
+      })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [{ delta: {}, finish_reason: "stop" }],
+      })}`,
+      "data: [DONE]",
+    ].join("\n\n") + "\n\n"
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(ctrl) {
+      ctrl.enqueue(encoder.encode(payload))
+      ctrl.close()
+    },
+  })
+}
+
+/** Start a Bun HTTP mock that streams `reply` for every /chat/completions call. */
+function startLLM(reply: string) {
+  let calls = 0
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url)
+      if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
+      calls++
+      return new Response(chat(reply), { status: 200, headers: { "Content-Type": "text/event-stream" } })
+    },
+  })
+  return {
+    origin: server.url.origin,
+    get calls() {
+      return calls
+    },
+    stop: () => server.stop(true),
+  }
+}
+
+// ---- spawnRef seam control ----------------------------------------------
+// tryStartCheckpointWriter resolves the checkpoint-writer subagent through the
+// process-wide spawnRef.current seam (late-bound to break an Actor↔SessionPrompt
+// layer cycle). Because it is a module global, its value leaks across tests in
+// the same process, so each case-2 test sets it explicitly (and restores it)
+// rather than depending on ambient state.
+type SpawnImpl = NonNullable<typeof spawnRef.current>
+
+function withSpawnRef<T>(impl: SpawnImpl | undefined, body: () => Promise<T>): Promise<T> {
+  const prev = spawnRef.current
+  spawnRef.current = impl
+  return body().finally(() => {
+    spawnRef.current = prev
+  })
+}
+
+// A spawn stub emulating a successful checkpoint-writer run: on spawn it writes
+// a real (non-template) checkpoint file for the PARENT session, then resolves
+// the outcome to success. This drives the real case-2 path end-to-end
+// (hasCheckpoint=false → tryStartCheckpointWriter → waitForWriter → success →
+// rebuildFromCheckpoint) without a slow real LLM writer round-trip.
+//
+// The parent's checkpoint watermark (last_checkpoint_message_id) is what
+// rebuildFromCheckpoint's lastBoundary reads. In production the writer runs for
+// tens of seconds, so tryStartCheckpointWriter's settlement fiber advances the
+// watermark long before waitForWriter returns. This stub is near-instant, so it
+// advances the watermark itself to the session's last message — matching what a
+// real settled writer leaves behind — rather than racing the settlement fiber.
+function writerThatWritesCheckpoint(marker: string): SpawnImpl {
+  let counter = 0
+  return {
+    spawn: (input) =>
+      Effect.gen(function* () {
+        counter += 1
+        const parent = (input.parentSessionID ?? input.sessionID) as SessionID
+        const outcome = yield* Deferred.make<AgentOutcome>()
+        const cpFile = checkpointPath(parent)
+        yield* Effect.promise(() => fs.mkdir(path.dirname(cpFile), { recursive: true }))
+        yield* Effect.promise(() =>
+          fs.writeFile(cpFile, `# Session checkpoint\n\n## §1 Active intent\n${marker}\n`),
+        )
+        // Advance the watermark to the newest message, as a settled writer does.
+        const last = yield* Effect.sync(() =>
+          Database.use((db) =>
+            db
+              .select({ id: MessageTable.id })
+              .from(MessageTable)
+              .where(eq(MessageTable.session_id, parent))
+              .orderBy(desc(MessageTable.id))
+              .limit(1)
+              .get(),
+          ),
+        )
+        if (last?.id) {
+          yield* Effect.sync(() =>
+            Database.use((db) =>
+              db
+                .update(SessionTable)
+                .set({ last_checkpoint_message_id: last.id })
+                .where(eq(SessionTable.id, parent))
+                .run(),
+            ),
+          )
+        }
+        yield* Deferred.succeed(outcome, { status: "success" as const })
+        return { actorID: `${input.agentType}-${counter}`, sessionID: input.sessionID, outcome }
+      }),
+    cancel: () => Effect.void,
+    getForkContext: () => Effect.succeed(undefined),
+  } as SpawnImpl
+}
+
+function mimocodeConfig(baseURL: string) {
+  return JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    enabled_providers: ["alibaba"],
+    provider: { alibaba: { options: { apiKey: "test-key", baseURL: `${baseURL}/v1` } } },
+    agent: { build: { model: "alibaba/qwen-plus" } },
+  })
+}
 
 async function seedUserMessage(sessionID: SessionID, text: string) {
-  const ssn = await Effect.runPromise(
+  const msg = await Effect.runPromise(
     Session.Service.use((s) =>
       s.updateMessage({
         id: MessageID.ascending(),
@@ -61,135 +183,296 @@ async function seedUserMessage(sessionID: SessionID, text: string) {
     Session.Service.use((s) =>
       s.updatePart({
         id: PartID.ascending(),
-        messageID: ssn.id,
+        messageID: msg.id,
         sessionID,
         type: "text",
         text,
       }),
     ).pipe(Effect.provide(Session.defaultLayer)),
   )
-  return ssn
+  return msg
 }
 
-describe("Manual /rebuild: on-the-spot rebuild with 3-case checkpoint-freshness", () => {
-  it.live(
-    "case 1: no writer + has checkpoint → inserts boundary immediately (rebuild happens now)",
-    provideTmpdirInstance(() =>
-      Effect.gen(function* () {
-        const ssn = yield* Session.Service
-        const cp = yield* SessionCheckpoint.Service
-
-        const info = yield* ssn.create({ title: "rebuild-test" })
-        const m1 = yield* Effect.promise(() => seedUserMessage(info.id, "turn one"))
-        const m2 = yield* Effect.promise(() => seedUserMessage(info.id, "turn two"))
-        const m3 = yield* Effect.promise(() => seedUserMessage(info.id, "turn three"))
-
-        // Put a real checkpoint on disk so renderRebuildContext produces non-empty context.
-        const cpFile = checkpointPath(info.id)
-        yield* Effect.promise(() => fs.mkdir(path.dirname(cpFile), { recursive: true }))
-        yield* Effect.promise(() =>
-          fs.writeFile(cpFile, "# Session checkpoint\n\n## §1 Active intent\nTest rebuild.\n"),
-        )
-
-        // Verify no boundary exists yet.
-        const before = yield* ssn.messages({ sessionID: info.id })
-        expect(before.length).toBe(3)
-
-        // Simulate what the /rebuild handler does: insertRebuildBoundary is the core
-        // of rebuildFromCheckpoint. When a checkpoint exists and no writer is running,
-        // it should insert immediately.
-        const inserted = yield* cp.insertRebuildBoundary({
-          sessionID: info.id,
-          boundary: m3.id,
-          agent: "build",
-          model: { providerID: "test", modelID: "test-model" },
+// These tests drive the REAL /rebuild handler in SessionPrompt.command (the
+// same code path a user hits by running `/rebuild`) against a scripted LLM
+// stub, and assert on observable runtime behavior — inserted boundary
+// messages, the returned message, whether the model was called, and the busy
+// status events published on the Bus. They intentionally avoid grepping
+// prompt.ts source text (which verifies nothing and breaks on refactors) per
+// AGENTS.md: "Test actual implementation, do not duplicate logic into tests".
+describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.command", () => {
+  test(
+    "case 1: checkpoint on disk + no writer → handler inserts a boundary and enters the runLoop",
+    async () => {
+      const llm = startLLM("rebuilt-reply-from-model")
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
         })
-        expect(inserted).toBe(true)
 
-        // Boundary was inserted — a new message with a checkpoint part exists.
-        const after = yield* ssn.messages({ sessionID: info.id })
-        expect(after.length).toBe(4)
-        const boundary = after.at(-1)!
-        expect(boundary.parts.some((p) => p.type === "checkpoint")).toBe(true)
+        await Instance.provide({
+          directory: tmp.path,
+          fn: () =>
+            run(
+              Effect.gen(function* () {
+                const prompt = yield* SessionPrompt.Service
+                const sessions = yield* Session.Service
+                const info = yield* sessions.create({ title: "rebuild-case-1" })
 
-        // All original messages preserved.
-        expect(after.some((m) => m.info.id === m1.id)).toBe(true)
-        expect(after.some((m) => m.info.id === m2.id)).toBe(true)
-        expect(after.some((m) => m.info.id === m3.id)).toBe(true)
-      }),
-      { outsideGit: true },
-    ),
+                yield* Effect.promise(() => seedUserMessage(info.id, "turn one"))
+                yield* Effect.promise(() => seedUserMessage(info.id, "turn two"))
+                const boundaryMsg = yield* Effect.promise(() => seedUserMessage(info.id, "turn three"))
+
+                // Real (non-template) checkpoint on disk so renderRebuildContext
+                // produces non-empty content and the boundary can be inserted.
+                const cpFile = checkpointPath(info.id)
+                yield* Effect.promise(() => fs.mkdir(path.dirname(cpFile), { recursive: true }))
+                yield* Effect.promise(() =>
+                  fs.writeFile(
+                    cpFile,
+                    "# Session checkpoint\n\n## §1 Active intent\nRebuild the context from this checkpoint.\n",
+                  ),
+                )
+
+                // Seed the checkpoint watermark the same way a settled writer does
+                // (SessionTable.last_checkpoint_message_id) so lastBoundary resolves
+                // and the handler takes the has-checkpoint → rebuild path.
+                yield* Effect.sync(() =>
+                  Database.use((db) =>
+                    db
+                      .update(SessionTable)
+                      .set({ last_checkpoint_message_id: boundaryMsg.id })
+                      .where(eq(SessionTable.id, info.id))
+                      .run(),
+                  ),
+                )
+
+                const before = yield* sessions.messages({ sessionID: info.id })
+                const userCountBefore = before.filter((m) => m.info.role === "user").length
+
+                // Drive the real handler.
+                const result = yield* prompt.command({
+                  sessionID: info.id,
+                  command: Command.Default.REBUILD,
+                  arguments: "",
+                  agent: "build",
+                })
+
+                // The success path enters the runLoop → the model was called and
+                // an assistant reply came back (NOT the noReply no-checkpoint path).
+                expect(result.info.role).toBe("assistant")
+                expect(result.parts.some((p) => p.type === "text" && p.text.includes("rebuilt-reply-from-model"))).toBe(
+                  true,
+                )
+                expect(llm.calls).toBeGreaterThanOrEqual(1)
+
+                // A checkpoint boundary message was actually inserted into the DB.
+                const after = yield* sessions.messages({ sessionID: info.id })
+                const boundaries = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                expect(boundaries.length).toBe(1)
+
+                // The rebuild-success synthetic prose is present on the boundary run.
+                const rebuiltNote = after.some((m) =>
+                  m.parts.some(
+                    (p) => p.type === "text" && p.text.includes("Context rebuilt from the latest checkpoint"),
+                  ),
+                )
+                expect(rebuiltNote).toBe(true)
+
+                // Original conversation preserved (3 seeded users still there).
+                const userCountAfter = after.filter((m) => m.info.role === "user").length
+                expect(userCountAfter).toBeGreaterThanOrEqual(userCountBefore)
+              }),
+            ),
+        })
+      } finally {
+        await llm.stop()
+      }
+    },
+    { timeout: 30_000 },
   )
 
-  it.live(
-    "case 2: no checkpoint → handler spawns writer + waits + rebuilds (source-level guard)",
-    () =>
-      Effect.gen(function* () {
-        // Source-level guard: verify the /rebuild handler, when no checkpoint
-        // exists, actively spawns a checkpoint-writer and waits for it before
-        // attempting rebuildFromCheckpoint — the user-decided case-2 semantics.
-        const promptSrc = yield* Effect.promise(() =>
-          Bun.file(`${import.meta.dir}/../../src/session/prompt.ts`).text(),
-        )
+  test(
+    "case 2: no checkpoint → handler spawns a writer, waits for it, then rebuilds from the fresh checkpoint",
+    async () => {
+      const llm = startLLM("case2-model-reply")
+      // The writer stub writes a real checkpoint on spawn and reports success,
+      // exercising the handler's spawn→wait→rebuild path for real.
+      const writer = writerThatWritesCheckpoint("CASE2_FRESH_CHECKPOINT_BODY")
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
+        })
 
-        // The handler must check hasCheckpoint before attempting rebuild
-        expect(promptSrc).toMatch(
-          /if\s*\(input\.command\s*===\s*Command\.Default\.REBUILD\)[\s\S]*?hasCheckpoint/,
-        )
+        await withSpawnRef(writer, () =>
+          Instance.provide({
+            directory: tmp.path,
+            fn: () =>
+              run(
+                Effect.gen(function* () {
+                  const prompt = yield* SessionPrompt.Service
+                  const sessions = yield* Session.Service
+                  const info = yield* sessions.create({ title: "rebuild-case-2" })
+                  yield* Effect.promise(() => seedUserMessage(info.id, "cold session, no checkpoint yet"))
+                  yield* Effect.promise(() => seedUserMessage(info.id, "second turn on the cold session"))
 
-        // When no checkpoint exists, must call tryStartCheckpointWriter
-        expect(promptSrc).toMatch(
-          /if\s*\(input\.command\s*===\s*Command\.Default\.REBUILD\)[\s\S]*?tryStartCheckpointWriter/,
-        )
+                  // Cold session: no checkpoint file exists up front.
+                  const result = yield* prompt.command({
+                    sessionID: info.id,
+                    command: Command.Default.REBUILD,
+                    arguments: "",
+                    agent: "build",
+                  })
 
-        // Must wait for the writer via waitForWriter
-        expect(promptSrc).toMatch(
-          /if\s*\(input\.command\s*===\s*Command\.Default\.REBUILD\)[\s\S]*?waitForWriter/,
-        )
+                  // The writer wrote a checkpoint and the handler rebuilt from
+                  // it → entered the runLoop → the model produced a reply.
+                  expect(result.info.role).toBe("assistant")
+                  expect(
+                    result.parts.some((p) => p.type === "text" && p.text.includes("case2-model-reply")),
+                  ).toBe(true)
+                  expect(llm.calls).toBeGreaterThanOrEqual(1)
 
-        // After writer success, must call rebuildFromCheckpoint to insert boundary
-        expect(promptSrc).toMatch(
-          /if\s*\(input\.command\s*===\s*Command\.Default\.REBUILD\)[\s\S]*?writerOutcome.*success[\s\S]*?rebuildFromCheckpoint/,
+                  // A rebuild boundary was inserted from the freshly-written checkpoint.
+                  const msgs = yield* sessions.messages({ sessionID: info.id })
+                  const boundaries = msgs.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                  expect(boundaries.length).toBe(1)
+                  expect(
+                    msgs.some((m) =>
+                      m.parts.some(
+                        (p) => p.type === "text" && p.text.includes("Context rebuilt from the latest checkpoint"),
+                      ),
+                    ),
+                  ).toBe(true)
+                }),
+              ),
+          }),
         )
-      }),
+      } finally {
+        await llm.stop()
+      }
+    },
+    { timeout: 30_000 },
   )
 
-  it.live(
-    "busy status carries a descriptive message (source-level guard)",
-    () =>
-      Effect.gen(function* () {
-        // Source-level guard: verify the /rebuild handler sets busy status
-        // WITH a descriptive message so the user sees what's happening.
-        const promptSrc = yield* Effect.promise(() =>
-          Bun.file(`${import.meta.dir}/../../src/session/prompt.ts`).text(),
-        )
+  test(
+    "case 2 fallback: no checkpoint + no spawnable writer → surfaces the no-checkpoint message without a model reply",
+    async () => {
+      const llm = startLLM("should-not-be-used-as-a-reply")
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
+        })
 
-        // Must set busy status with "Rebuilding context…" message before work.
-        // The source has \u2026 as a literal Unicode escape in the string,
-        // so the raw source text contains the 6 chars \u2026.
-        expect(promptSrc).toMatch(
-          /status[\s\S]*?\.set\(input\.sessionID,\s*\{\s*type:\s*"busy",\s*message:\s*"Rebuilding context\\u2026"\s*\}/,
-        )
+        // Force NO writer: with spawnRef unset, tryStartCheckpointWriter cannot
+        // spawn and waitForWriter resolves "no-writer" → the handler must fall
+        // through to the no-checkpoint outcome (noReply, no runLoop).
+        await withSpawnRef(undefined, () =>
+          Instance.provide({
+            directory: tmp.path,
+            fn: () =>
+              run(
+                Effect.gen(function* () {
+                  const prompt = yield* SessionPrompt.Service
+                  const sessions = yield* Session.Service
+                  const info = yield* sessions.create({ title: "rebuild-case-2-fallback" })
+                  yield* Effect.promise(() => seedUserMessage(info.id, "cold session, no checkpoint yet"))
 
-        // Case 2 writer-wait path must set "Writing checkpoint…" message
-        expect(promptSrc).toMatch(
-          /status[\s\S]*?\.set\(input\.sessionID,\s*\{\s*type:\s*"busy",\s*message:\s*"Writing checkpoint\\u2026"\s*\}/,
-        )
+                  const result = yield* prompt.command({
+                    sessionID: info.id,
+                    command: Command.Default.REBUILD,
+                    arguments: "",
+                    agent: "build",
+                  })
 
-        // Must NOT use noReply:true on the rebuild-success path (so runLoop runs)
-        // The noReply:true should only appear in the no-checkpoint early-return path.
-        const rebuildBlock = promptSrc.slice(
-          promptSrc.indexOf("input.command === Command.Default.REBUILD"),
-        )
-        // Find the two prompt() calls in the rebuild block
-        const firstPromptIdx = rebuildBlock.indexOf("yield* prompt({")
-        const secondPromptIdx = rebuildBlock.indexOf("yield* prompt({", firstPromptIdx + 1)
+                  // Handler surfaces the no-checkpoint message to the user…
+                  expect(
+                    result.parts.some(
+                      (p) => p.type === "text" && p.text.includes("No checkpoint is available to rebuild from yet"),
+                    ),
+                  ).toBe(true)
 
-        // The second prompt (rebuild-success path) must NOT have noReply: true
-        if (secondPromptIdx >= 0) {
-          const secondPromptBlock = rebuildBlock.slice(secondPromptIdx, secondPromptIdx + 300)
-          expect(secondPromptBlock).not.toContain("noReply: true")
+                  // …and did NOT enter the runLoop (noReply), so no assistant
+                  // reply carrying the scripted text was produced.
+                  const msgs = yield* sessions.messages({ sessionID: info.id })
+                  const modelReplied = msgs.some((m) =>
+                    m.parts.some((p) => p.type === "text" && p.text.includes("should-not-be-used-as-a-reply")),
+                  )
+                  expect(modelReplied).toBe(false)
+
+                  // No rebuild boundary was inserted (nothing usable to rebuild from).
+                  const boundaries = msgs.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                  expect(boundaries.length).toBe(0)
+                }),
+              ),
+          }),
+        )
+      } finally {
+        await llm.stop()
+      }
+    },
+    { timeout: 30_000 },
+  )
+
+  test(
+    "busy status carries descriptive messages while the handler runs (observed on the Bus, not source text)",
+    async () => {
+      const llm = startLLM("busy-path-reply")
+      const writer = writerThatWritesCheckpoint("BUSY_CHECKPOINT_BODY")
+      const seen: Array<string | undefined> = []
+      // SessionStatus.set publishes on the instance Bus which also mirrors every
+      // event onto the process-wide GlobalBus. Subscribing here captures the
+      // real busy-status messages the handler emits, regardless of which Bus
+      // layer instance SessionPrompt.defaultLayer wired internally.
+      const onEvent = (e: { payload?: { type?: string; properties?: { status?: { type?: string; message?: string } } } }) => {
+        if (e?.payload?.type === "session.status" && e.payload.properties?.status?.type === "busy") {
+          seen.push(e.payload.properties.status.message)
         }
-      }),
+      }
+      GlobalBus.on("event", onEvent)
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
+        })
+
+        await withSpawnRef(writer, () =>
+          Instance.provide({
+            directory: tmp.path,
+            fn: () =>
+              run(
+                Effect.gen(function* () {
+                  const prompt = yield* SessionPrompt.Service
+                  const sessions = yield* Session.Service
+
+                  // Cold session → exercises BOTH busy messages: "Rebuilding
+                  // context…" (set first) then "Writing checkpoint…" (set while
+                  // waiting on the writer that this test provides).
+                  const info = yield* sessions.create({ title: "rebuild-busy" })
+                  yield* Effect.promise(() => seedUserMessage(info.id, "no checkpoint here either"))
+                  yield* Effect.promise(() => seedUserMessage(info.id, "second turn"))
+
+                  yield* prompt.command({
+                    sessionID: info.id,
+                    command: Command.Default.REBUILD,
+                    arguments: "",
+                    agent: "build",
+                  })
+                }),
+              ),
+          }),
+        )
+      } finally {
+        GlobalBus.off("event", onEvent)
+        await llm.stop()
+      }
+
+      // The handler set busy with the human-readable messages the TUI shows.
+      expect(seen).toContain("Rebuilding context\u2026")
+      expect(seen).toContain("Writing checkpoint\u2026")
+    },
+    { timeout: 30_000 },
   )
 })

--- a/packages/opencode/test/session/rebuild-on-the-spot.test.ts
+++ b/packages/opencode/test/session/rebuild-on-the-spot.test.ts
@@ -122,36 +122,36 @@ describe("Manual /rebuild: on-the-spot rebuild with 3-case checkpoint-freshness"
   )
 
   it.live(
-    "case 2: no checkpoint → insertRebuildBoundary returns false (nothing to rebuild from)",
-    provideTmpdirInstance(() =>
+    "case 2: no checkpoint → handler spawns writer + waits + rebuilds (source-level guard)",
+    () =>
       Effect.gen(function* () {
-        const ssn = yield* Session.Service
-        const cp = yield* SessionCheckpoint.Service
+        // Source-level guard: verify the /rebuild handler, when no checkpoint
+        // exists, actively spawns a checkpoint-writer and waits for it before
+        // attempting rebuildFromCheckpoint — the user-decided case-2 semantics.
+        const promptSrc = yield* Effect.promise(() =>
+          Bun.file(`${import.meta.dir}/../../src/session/prompt.ts`).text(),
+        )
 
-        const info = yield* ssn.create({ title: "rebuild-no-cp" })
-        yield* Effect.promise(() => seedUserMessage(info.id, "turn one"))
-        yield* Effect.promise(() => seedUserMessage(info.id, "turn two"))
-        const m3 = yield* Effect.promise(() => seedUserMessage(info.id, "turn three"))
+        // The handler must check hasCheckpoint before attempting rebuild
+        expect(promptSrc).toMatch(
+          /if\s*\(input\.command\s*===\s*Command\.Default\.REBUILD\)[\s\S]*?hasCheckpoint/,
+        )
 
-        // No checkpoint file on disk — renderRebuildContext is empty.
-        const hasCP = yield* cp.hasCheckpoint(info.id).pipe(Effect.catch(() => Effect.succeed(false)))
-        expect(hasCP).toBe(false)
+        // When no checkpoint exists, must call tryStartCheckpointWriter
+        expect(promptSrc).toMatch(
+          /if\s*\(input\.command\s*===\s*Command\.Default\.REBUILD\)[\s\S]*?tryStartCheckpointWriter/,
+        )
 
-        // insertRebuildBoundary should return false (no context to insert).
-        const inserted = yield* cp.insertRebuildBoundary({
-          sessionID: info.id,
-          boundary: m3.id,
-          agent: "build",
-          model: { providerID: "test", modelID: "test-model" },
-        }).pipe(Effect.catch(() => Effect.succeed(false)))
-        expect(inserted).toBe(false)
+        // Must wait for the writer via waitForWriter
+        expect(promptSrc).toMatch(
+          /if\s*\(input\.command\s*===\s*Command\.Default\.REBUILD\)[\s\S]*?waitForWriter/,
+        )
 
-        // No boundary message added.
-        const after = yield* ssn.messages({ sessionID: info.id })
-        expect(after.length).toBe(3)
+        // After writer success, must call rebuildFromCheckpoint to insert boundary
+        expect(promptSrc).toMatch(
+          /if\s*\(input\.command\s*===\s*Command\.Default\.REBUILD\)[\s\S]*?writerOutcome.*success[\s\S]*?rebuildFromCheckpoint/,
+        )
       }),
-      { outsideGit: true, config: { checkpoint: { push_caps: { recent_user: 0 } } } },
-    ),
   )
 
   it.live(

--- a/packages/opencode/test/session/rebuild-on-the-spot.test.ts
+++ b/packages/opencode/test/session/rebuild-on-the-spot.test.ts
@@ -155,18 +155,25 @@ describe("Manual /rebuild: on-the-spot rebuild with 3-case checkpoint-freshness"
   )
 
   it.live(
-    "busy status is set before rebuild work and cleared after (source-level guard)",
+    "busy status carries a descriptive message (source-level guard)",
     () =>
       Effect.gen(function* () {
         // Source-level guard: verify the /rebuild handler sets busy status
-        // BEFORE calling rebuildFromCheckpoint and clears it when done.
+        // WITH a descriptive message so the user sees what's happening.
         const promptSrc = yield* Effect.promise(() =>
           Bun.file(`${import.meta.dir}/../../src/session/prompt.ts`).text(),
         )
 
-        // Must set busy status before rebuildFromCheckpoint
+        // Must set busy status with "Rebuilding context…" message before work.
+        // The source has \u2026 as a literal Unicode escape in the string,
+        // so the raw source text contains the 6 chars \u2026.
         expect(promptSrc).toMatch(
-          /if\s*\(input\.command\s*===\s*Command\.Default\.REBUILD\)[\s\S]*?status\.set\(input\.sessionID,\s*\{\s*type:\s*"busy"\s*\}/,
+          /status[\s\S]*?\.set\(input\.sessionID,\s*\{\s*type:\s*"busy",\s*message:\s*"Rebuilding context\\u2026"\s*\}/,
+        )
+
+        // Case 2 writer-wait path must set "Writing checkpoint…" message
+        expect(promptSrc).toMatch(
+          /status[\s\S]*?\.set\(input\.sessionID,\s*\{\s*type:\s*"busy",\s*message:\s*"Writing checkpoint\\u2026"\s*\}/,
         )
 
         // Must NOT use noReply:true on the rebuild-success path (so runLoop runs)

--- a/packages/opencode/test/session/rebuild-on-the-spot.test.ts
+++ b/packages/opencode/test/session/rebuild-on-the-spot.test.ts
@@ -259,13 +259,28 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
                   agent: "build",
                 })
 
-                // The success path enters the runLoop → the model was called and
-                // an assistant reply came back (NOT the noReply no-checkpoint path).
-                expect(result.info.role).toBe("assistant")
-                expect(result.parts.some((p) => p.type === "text" && p.text.includes("rebuilt-reply-from-model"))).toBe(
-                  true,
+                // A MANUAL /rebuild must NOT enter the runLoop: it inserts the
+                // boundary and returns the synthetic note WITHOUT producing a
+                // model reply (the user asked no question). So the returned
+                // message is the synthetic rebuild note (role "user", not an
+                // assistant turn), and the LLM was never called — no spurious
+                // "reply to nothing" turn.
+                expect(result.info.role).not.toBe("assistant")
+                expect(
+                  result.parts.some(
+                    (p) => p.type === "text" && p.text.includes("Context rebuilt from the latest checkpoint"),
+                  ),
+                ).toBe(true)
+                expect(
+                  result.parts.some((p) => p.type === "text" && p.text.includes("rebuilt-reply-from-model")),
+                ).toBe(false)
+                expect(llm.calls).toBe(0)
+
+                // And no assistant reply carrying the scripted text landed in the DB.
+                const replied = (yield* sessions.messages({ sessionID: info.id })).some((m) =>
+                  m.parts.some((p) => p.type === "text" && p.text.includes("rebuilt-reply-from-model")),
                 )
-                expect(llm.calls).toBeGreaterThanOrEqual(1)
+                expect(replied).toBe(false)
 
                 // A checkpoint boundary message was actually inserted into the DB.
                 const after = yield* sessions.messages({ sessionID: info.id })
@@ -327,12 +342,18 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
                   })
 
                   // The writer wrote a checkpoint and the handler rebuilt from
-                  // it → entered the runLoop → the model produced a reply.
-                  expect(result.info.role).toBe("assistant")
+                  // it, but a MANUAL /rebuild must NOT reply: it returns the
+                  // synthetic rebuild note via noReply and never enters the
+                  // runLoop, so the LLM is not called.
+                  expect(
+                    result.parts.some(
+                      (p) => p.type === "text" && p.text.includes("Context rebuilt from the latest checkpoint"),
+                    ),
+                  ).toBe(true)
                   expect(
                     result.parts.some((p) => p.type === "text" && p.text.includes("case2-model-reply")),
-                  ).toBe(true)
-                  expect(llm.calls).toBeGreaterThanOrEqual(1)
+                  ).toBe(false)
+                  expect(llm.calls).toBe(0)
 
                   // A rebuild boundary was inserted from the freshly-written checkpoint.
                   const msgs = yield* sessions.messages({ sessionID: info.id })

--- a/packages/opencode/test/session/rebuild-on-the-spot.test.ts
+++ b/packages/opencode/test/session/rebuild-on-the-spot.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import * as fs from "fs/promises"
+import path from "path"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config"
+import { Memory } from "../../src/memory"
+import { Session } from "../../src/session"
+import { SessionCheckpoint } from "../../src/session/checkpoint"
+import { checkpointPath } from "../../src/session/checkpoint-paths"
+import { SessionStatus } from "../../src/session/status"
+import { TaskRegistry } from "../../src/task/registry"
+import { ActorRegistry } from "../../src/actor/registry"
+import { Instance } from "../../src/project/instance"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { Log } from "../../src/util"
+
+void Log.init({ print: false })
+
+const ref = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("test-model"),
+}
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const it = testEffect(
+  Layer.mergeAll(
+    CrossSpawnSpawner.defaultLayer,
+    Bus.defaultLayer,
+    Config.defaultLayer,
+    Memory.defaultLayer,
+    Session.defaultLayer,
+    TaskRegistry.defaultLayer,
+    ActorRegistry.defaultLayer,
+    SessionCheckpoint.defaultLayer,
+    SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer)),
+  ),
+)
+
+async function seedUserMessage(sessionID: SessionID, text: string) {
+  const ssn = await Effect.runPromise(
+    Session.Service.use((s) =>
+      s.updateMessage({
+        id: MessageID.ascending(),
+        role: "user",
+        sessionID,
+        agent: "build",
+        model: ref,
+        time: { created: Date.now() },
+      }),
+    ).pipe(Effect.provide(Session.defaultLayer)),
+  )
+  await Effect.runPromise(
+    Session.Service.use((s) =>
+      s.updatePart({
+        id: PartID.ascending(),
+        messageID: ssn.id,
+        sessionID,
+        type: "text",
+        text,
+      }),
+    ).pipe(Effect.provide(Session.defaultLayer)),
+  )
+  return ssn
+}
+
+describe("Manual /rebuild: on-the-spot rebuild with 3-case checkpoint-freshness", () => {
+  it.live(
+    "case 1: no writer + has checkpoint → inserts boundary immediately (rebuild happens now)",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const ssn = yield* Session.Service
+        const cp = yield* SessionCheckpoint.Service
+
+        const info = yield* ssn.create({ title: "rebuild-test" })
+        const m1 = yield* Effect.promise(() => seedUserMessage(info.id, "turn one"))
+        const m2 = yield* Effect.promise(() => seedUserMessage(info.id, "turn two"))
+        const m3 = yield* Effect.promise(() => seedUserMessage(info.id, "turn three"))
+
+        // Put a real checkpoint on disk so renderRebuildContext produces non-empty context.
+        const cpFile = checkpointPath(info.id)
+        yield* Effect.promise(() => fs.mkdir(path.dirname(cpFile), { recursive: true }))
+        yield* Effect.promise(() =>
+          fs.writeFile(cpFile, "# Session checkpoint\n\n## §1 Active intent\nTest rebuild.\n"),
+        )
+
+        // Verify no boundary exists yet.
+        const before = yield* ssn.messages({ sessionID: info.id })
+        expect(before.length).toBe(3)
+
+        // Simulate what the /rebuild handler does: insertRebuildBoundary is the core
+        // of rebuildFromCheckpoint. When a checkpoint exists and no writer is running,
+        // it should insert immediately.
+        const inserted = yield* cp.insertRebuildBoundary({
+          sessionID: info.id,
+          boundary: m3.id,
+          agent: "build",
+          model: { providerID: "test", modelID: "test-model" },
+        })
+        expect(inserted).toBe(true)
+
+        // Boundary was inserted — a new message with a checkpoint part exists.
+        const after = yield* ssn.messages({ sessionID: info.id })
+        expect(after.length).toBe(4)
+        const boundary = after.at(-1)!
+        expect(boundary.parts.some((p) => p.type === "checkpoint")).toBe(true)
+
+        // All original messages preserved.
+        expect(after.some((m) => m.info.id === m1.id)).toBe(true)
+        expect(after.some((m) => m.info.id === m2.id)).toBe(true)
+        expect(after.some((m) => m.info.id === m3.id)).toBe(true)
+      }),
+      { outsideGit: true },
+    ),
+  )
+
+  it.live(
+    "case 2: no checkpoint → insertRebuildBoundary returns false (nothing to rebuild from)",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const ssn = yield* Session.Service
+        const cp = yield* SessionCheckpoint.Service
+
+        const info = yield* ssn.create({ title: "rebuild-no-cp" })
+        yield* Effect.promise(() => seedUserMessage(info.id, "turn one"))
+        yield* Effect.promise(() => seedUserMessage(info.id, "turn two"))
+        const m3 = yield* Effect.promise(() => seedUserMessage(info.id, "turn three"))
+
+        // No checkpoint file on disk — renderRebuildContext is empty.
+        const hasCP = yield* cp.hasCheckpoint(info.id).pipe(Effect.catch(() => Effect.succeed(false)))
+        expect(hasCP).toBe(false)
+
+        // insertRebuildBoundary should return false (no context to insert).
+        const inserted = yield* cp.insertRebuildBoundary({
+          sessionID: info.id,
+          boundary: m3.id,
+          agent: "build",
+          model: { providerID: "test", modelID: "test-model" },
+        }).pipe(Effect.catch(() => Effect.succeed(false)))
+        expect(inserted).toBe(false)
+
+        // No boundary message added.
+        const after = yield* ssn.messages({ sessionID: info.id })
+        expect(after.length).toBe(3)
+      }),
+      { outsideGit: true, config: { checkpoint: { push_caps: { recent_user: 0 } } } },
+    ),
+  )
+
+  it.live(
+    "busy status is set before rebuild work and cleared after (source-level guard)",
+    () =>
+      Effect.gen(function* () {
+        // Source-level guard: verify the /rebuild handler sets busy status
+        // BEFORE calling rebuildFromCheckpoint and clears it when done.
+        const promptSrc = yield* Effect.promise(() =>
+          Bun.file(`${import.meta.dir}/../../src/session/prompt.ts`).text(),
+        )
+
+        // Must set busy status before rebuildFromCheckpoint
+        expect(promptSrc).toMatch(
+          /if\s*\(input\.command\s*===\s*Command\.Default\.REBUILD\)[\s\S]*?status\.set\(input\.sessionID,\s*\{\s*type:\s*"busy"\s*\}/,
+        )
+
+        // Must NOT use noReply:true on the rebuild-success path (so runLoop runs)
+        // The noReply:true should only appear in the no-checkpoint early-return path.
+        const rebuildBlock = promptSrc.slice(
+          promptSrc.indexOf("input.command === Command.Default.REBUILD"),
+        )
+        // Find the two prompt() calls in the rebuild block
+        const firstPromptIdx = rebuildBlock.indexOf("yield* prompt({")
+        const secondPromptIdx = rebuildBlock.indexOf("yield* prompt({", firstPromptIdx + 1)
+
+        // The second prompt (rebuild-success path) must NOT have noReply: true
+        if (secondPromptIdx >= 0) {
+          const secondPromptBlock = rebuildBlock.slice(secondPromptIdx, secondPromptIdx + 300)
+          expect(secondPromptBlock).not.toContain("noReply: true")
+        }
+      }),
+  )
+})

--- a/packages/opencode/test/session/rebuild-on-the-spot.test.ts
+++ b/packages/opencode/test/session/rebuild-on-the-spot.test.ts
@@ -216,10 +216,13 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
     async () => {
       const llm = startLLM("rebuilt-reply-from-model")
       const seen: Array<string | undefined> = []
+      const lifecycle: Array<string | undefined> = []
       const onEvent = (e: {
         payload?: { type?: string; properties?: { status?: { type?: string; message?: string } } }
       }) => {
-        if (e?.payload?.type === "session.status" && e.payload.properties?.status?.type === "busy") {
+        if (e?.payload?.type !== "session.status") return
+        lifecycle.push(e.payload.properties?.status?.type)
+        if (e.payload.properties?.status?.type === "busy") {
           seen.push(e.payload.properties.status.message)
         }
       }
@@ -327,6 +330,10 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
                 expect(
                   seen.some((m) => m?.includes("Context rebuilt from the latest checkpoint")),
                 ).toBe(true)
+
+                // …and the status is CLEARED again: /rebuild must settle to idle
+                // so the outcome text cannot leak into the following turn.
+                expect(lifecycle.at(-1)).toBe("idle")
               }),
             ),
         })

--- a/packages/opencode/test/session/rebuild-on-the-spot.test.ts
+++ b/packages/opencode/test/session/rebuild-on-the-spot.test.ts
@@ -437,8 +437,26 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
     { timeout: 30_000 },
   )
 
+  // DELIBERATE REWRITE — this test previously encoded the OPPOSITE behaviour.
+  //
+  // It used to be titled "case 2 fallback: no checkpoint + no spawnable writer →
+  // surfaces the no-checkpoint outcome on the status channel, persists nothing"
+  // and asserted `after.length === countBefore` — i.e. that a manual /rebuild
+  // whose writer could not run must NOT compact. That encoded a deliberate
+  // tradeoff: /rebuild means "rebuild from a checkpoint", so substituting a
+  // lossy summary would misreport what happened.
+  //
+  // The user overruled that tradeoff: when there is no checkpoint AND the writer
+  // genuinely fails, a truncating compaction beats doing nothing. That is now the
+  // single compaction fallback condition, shared with the auto overflow paths.
+  // The test is rewritten rather than edited quietly, because the assertion it
+  // used to make is now a statement of the wrong behaviour.
+  //
+  // What is PRESERVED from the old test, and still asserted below: the handler
+  // must not enter the runLoop, must not produce an assistant reply, and must not
+  // fabricate a synthetic user turn — only the boundary marker may be persisted.
   test(
-    "case 2 fallback: no checkpoint + no spawnable writer → surfaces the no-checkpoint outcome on the status channel, persists nothing",
+    "case 2 fallback: no checkpoint + no spawnable writer → compacts instead, and says so on the status channel",
     async () => {
       const llm = startLLM("should-not-be-used-as-a-reply")
       const seen: Array<string | undefined> = []
@@ -457,9 +475,8 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
         })
 
         // Force NO writer: with spawnRef unset, tryStartCheckpointWriter cannot
-        // spawn and waitForWriter resolves "no-writer" → the handler must fall
-        // through to the no-checkpoint outcome (status channel, no runLoop, no
-        // persisted message).
+        // spawn and waitForWriter resolves "no-writer" → the genuine
+        // writer-failure case, the ONLY one allowed to reach compaction.
         await withSpawnRef(undefined, () =>
           Instance.provide({
             directory: tmp.path,
@@ -486,29 +503,32 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
 
                   const after = yield* sessions.messages({ sessionID: info.id })
 
-                  // NOTHING was persisted: no boundary (nothing to rebuild from)
-                  // and no fabricated "No checkpoint…" user turn. The message
-                  // count is unchanged.
-                  expect(after.length).toBe(countBefore)
+                  // The writer could not run and no checkpoint existed, so the
+                  // context was compacted: exactly ONE new message, carrying a
+                  // `compaction` part.
+                  expect(after.length).toBe(countBefore + 1)
+                  const compactions = after.filter((m) => m.parts.some((p) => p.type === "compaction"))
+                  expect(compactions.length).toBe(1)
+
+                  // No rebuild boundary — there was nothing to rebuild from.
                   const boundaries = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
                   expect(boundaries.length).toBe(0)
+
+                  // Still no fabricated user turn carrying the outcome text.
                   const fabricated = after.some((m) =>
-                    m.parts.some(
-                      (p) => p.type === "text" && p.text.includes("No checkpoint is available to rebuild from yet"),
-                    ),
+                    m.parts.some((p) => p.type === "text" && p.text.includes("the context was compacted instead")),
                   )
                   expect(fabricated).toBe(false)
 
-                  // No assistant reply carrying the scripted text was produced.
+                  // Still no assistant reply.
                   const modelReplied = after.some((m) =>
                     m.parts.some((p) => p.type === "text" && p.text.includes("should-not-be-used-as-a-reply")),
                   )
                   expect(modelReplied).toBe(false)
 
-                  // The outcome IS surfaced — on the status channel.
-                  expect(
-                    seen.some((m) => m?.includes("No checkpoint is available to rebuild from yet")),
-                  ).toBe(true)
+                  // The substitution is NAMED on the status channel rather than
+                  // silently swapping the mechanism the user asked for.
+                  expect(seen.some((m) => m?.includes("the context was compacted instead"))).toBe(true)
                 }),
               ),
           }),


### PR DESCRIPTION
## Summary

- **Bug**: Manual `/rebuild` only inserted a DB boundary marker and returned — the actual context rebuild was deferred to the NEXT user message, with zero frontend feedback (no spinner, no text).
- **Root cause**: The handler called `rebuildFromCheckpoint()` (which inserts a boundary) then `prompt({noReply:true})` which short-circuited before the runLoop ever set busy status.
- **Fix**: 
  1. Set `session.status` busy BEFORE rebuild work so the TUI spinner lights up immediately, with a descriptive message: **"Rebuilding context…"** (all cases) and **"Writing checkpoint…"** (case 2 writer-wait phase).
  2. Remove `noReply:true` on the rebuild-success path so the runLoop actually runs — the model sees the rebuilt context and produces a response; the Runner's `onIdle` clears busy status automatically.
  3. Keep `noReply:true` only for the no-checkpoint case with explicit idle clear.
  4. **Case 2 (no checkpoint)**: Actively spawns a checkpoint-writer via `tryStartCheckpointWriter()`, waits for it via `waitForWriter()` (5-min safety bound), then rebuilds from the freshly-written checkpoint.

## 3-Case Checkpoint-Freshness Semantics (via `renderRebuildContext`)

| Case | Condition | Behavior | Timeout |
|------|-----------|----------|---------|
| 1 | Checkpoint exists, no writer | Immediate rebuild | N/A |
| 2 | No checkpoint, no writer | Spawn writer + wait + rebuild | `FIRST_CHECKPOINT_WAIT_MS` (5 min) |
| 3 | Checkpoint exists, writer in-flight | Wait for fresher checkpoint | `REBUILD_WAIT_MS` (30 sec), fallback on timeout |

## Files Changed

- `packages/opencode/src/session/prompt.ts:3964-4080` — `/rebuild` handler rewired with 3-case logic + busy messages
- `packages/opencode/test/session/rebuild-on-the-spot.test.ts` — 3 new tests

## Verification

- `bun typecheck` from `packages/opencode`: EXIT 0
- 3 new tests pass (case 1 immediate rebuild, case 2 source-level guard, busy message assertions)
- 7 existing rebuild tests continue to pass (no regressions)

---

## Follow-up fix — manual `/rebuild` must NOT auto-reply (b8a879d)

**Correction to item 2 above.** Live TUI testing confirmed a regression: dropping `noReply:true` on the manual `/rebuild` success path made the model emit a spurious reply (e.g. *"Ready for your next request"*) after every manual rebuild. A manual `/rebuild` is a user action whose only intent is to free/rebuild context — the user asked no question, so a model reply is a "reply to nothing". The earlier review already flagged *"Dropping noReply so the model responds after rebuild is a deliberate behavior change"* — that change was the bug.

**Trigger-source distinction (the correct behavior):**
- **Manual `/rebuild`** (user-initiated, no pending question) → rebuild, then **STOP**. No auto-reply.
- **Auto-triggered rebuild** (compaction mid-turn, pending user message) → rebuild, then **continue** answering the pending message (correct, unchanged).

The distinction is structural: the auto path lives inside the runLoop and uses `continue`/`return "continue"` (prompt.ts ~3188/3761) to keep answering the pending user turn — it never re-enters `prompt()`. Only the manual handler calls `prompt()` with the synthetic note.

**Fix (`prompt.ts` manual `/rebuild` success path):**
- Restore `noReply:true` so the boundary is inserted and the waiting UI still shows, but the runLoop is never entered — no spurious reply.
- Clear busy status explicitly (the runLoop's `onIdle` no longer fires since `loop()` doesn't run) — mirrors the existing no-checkpoint paths.
- **Unchanged**: busy-UI wiring ("Rebuilding context…" / "Writing checkpoint…"), on-the-spot rebuild, writer-freshness, and the case-2 spawn→wait→rebuild behavior.

**Tests** (`rebuild-on-the-spot.test.ts`): case 1 and case 2 now assert NO model reply after a manual `/rebuild` (`llm.calls === 0`, returned message role ≠ `assistant`) while still asserting the boundary insertion and busy-status messages.

**Verification:** `bun typecheck` EXIT 0; `rebuild-on-the-spot.test.ts` 4/4 pass; related rebuild/checkpoint tests (prompt-rebuild-loop, prompt-rebuild-reset, checkpoint-rebuild-unify, checkpoint-rebuild-nonblocking, rebuild-microcompact, command/rebuild) all pass. Rebased clean onto latest `origin/main`.


---

## Real fix — remove the fabricated second user turn (e43b1ba)

**This supersedes the `noReply` follow-up above.** The `noReply` approach was a band-aid on the wrong layer. Root-causing against the DB revealed the actual defect.

**Root cause (verified via the message table):** The manual `/rebuild` handler did TWO things:
- **Step A (correct, kept):** `rebuildFromCheckpoint()` → `insertRebuildBoundary()` inserts the legitimate rebuild boundary as a `role:"user"` message carrying a `checkpoint` part. This is the SHARED mechanism the auto pre-turn overflow (`prompt.ts` ~3205), auto mid-turn (~3778), and manual `/rebuild` paths all use.
- **Step B (the bug, removed):** a trailing `prompt({ parts:[{text:"Context rebuilt from the latest checkpoint…", synthetic:true}], noReply:true })` that fabricated a SECOND, standalone `role:"user"` turn. The auto/compaction paths NEVER create this — they just `continue`/`return "continue"` the runLoop to answer the pending user message. `noReply:true` only suppresses the model REPLY; `createUserMessage` still PERSISTS the fabricated user message. So after a manual `/rebuild` the DB showed extra `role=user` rows ("Context rebuilt from the latest checkpoint…") with ZERO assistant replies — the reply was hidden but the fabricated user turn remained.

**The correct fix:** Make manual `/rebuild` behave exactly like the auto/compaction path — insert the boundary and settle transparently, WITHOUT fabricating a second user turn:
1. **Kept** Step A (boundary insertion via the shared helper).
2. **Removed** Step B — no more `prompt({…"Context rebuilt…", noReply:true})`. The `noReply` band-aid on the `/rebuild` path is gone (still preserved for other callers such as `/goal` clear).
3. **Outcome surfaced via the status channel**, not a persisted synthetic user message: `"Context rebuilt from the latest checkpoint…"` (success) / `"No checkpoint is available to rebuild from yet…"` (no checkpoint) are emitted on the `SessionStatus` / `Bus` busy-status channel — the same channel that drives `"Rebuilding context…"`/`"Writing checkpoint…"` — then the session goes idle.
4. **Returns to idle correctly:** manual `/rebuild` is a user-initiated maintenance action with NO pending question, so after inserting the boundary it finishes to idle (no model turn, no auto-reply). The auto path `continue`s only because it HAS a pending user message mid-runLoop; the manual handler has none, so it cleanly returns the boundary message and clears busy status. No broken/busy state, no auto-reply.

**Handler edit (before → after, success path):**
```ts
// BEFORE (band-aid): fabricates a second user turn, hidden by noReply
const result = yield* prompt({
  sessionID, messageID, agent: agentName,
  parts: [{ type: "text", text: "Context rebuilt from the latest checkpoint…", synthetic: true }],
  noReply: true,
})
yield* status.set(sessionID, { type: "idle" })
return result

// AFTER (real fix): surface outcome on status channel, return the boundary itself
yield* settle(rebuiltMsg) // status.set(busy, "Context rebuilt…") then status.set(idle)
const after = yield* sessions.messages({ sessionID, agentID: "main" })
const boundaryMessage = after.findLast((m) => m.parts.some((p) => p.type === "checkpoint"))
return boundaryMessage ?? lastUser ?? after[after.length - 1]!
```
(The no-checkpoint and degraded paths likewise drop `prompt({noReply:true})`, surface the outcome via `settle(noCheckpointMsg)`, and return the existing last user message — persisting nothing new.)

**Tests (`rebuild-on-the-spot.test.ts`):** now assert that after a manual `/rebuild` the message table gains **EXACTLY ONE** new message — the boundary (`role:"user"` + `checkpoint` part) — with **no** fabricated `"Context rebuilt…"` user turn and **no** assistant reply (`llm.calls === 0`, returned role ≠ `assistant`). The no-checkpoint fallback asserts the count is **unchanged** (nothing persisted). All assert the outcome is surfaced on the busy-status channel, not as a persisted user message. The busy-message test (`"Rebuilding context…"`/`"Writing checkpoint…"`) is unchanged and still passes.

**Verification:** `bun typecheck` EXIT 0 (full-repo turbo typecheck 12/12 on push); `rebuild-on-the-spot.test.ts` 4/4 pass; 29 related rebuild/checkpoint tests pass (command/rebuild, rebuild-microcompact, checkpoint-rebuild-unify, prompt-rebuild-reset, prompt-rebuild-loop, checkpoint-rebuild-nonblocking, checkpoint-rebuild-v3, checkpoint-rebuild-fallback-decision). Rebased clean onto latest `origin/main`. #1752's core value (on-the-spot rebuild + writer-freshness + busy `"Rebuilding context…"`/`"Writing checkpoint…"` UI) fully intact.


---

## UX completion — make the boundary VISIBLE in the transcript (054775d, folded in from #1940 which is now closed)

The real fix above leaves the manual `/rebuild` boundary as the only new message. But that message rendered **zero rows** in the TUI, so a user who ran `/rebuild` saw the spinner, then nothing — no way to tell it happened or where the boundary sits.

**Why nothing rendered:** the boundary is a `role:"user"` message whose parts are a `checkpoint` part plus `synthetic: true` text parts. `PART_MAPPING` (`tui/routes/session/index.tsx`) covers only `text`/`tool`/`reasoning` — there is no `checkpoint` entry — and `UserMessage` renders its text block only when a **non-synthetic** text part exists. Both conditions fail, so the whole message drew nothing.

### Why this is render-only: what each mechanism actually sends to the model

The obvious alternative was "reuse compaction's mechanism" — compaction is visible because it writes a real `summary: true` **assistant** message whose text renders through `TextPart`. Tracing `toModelMessagesEffect`/`filterCompacted` shows why copying that shape would be a downgrade, not an upgrade:

| | compaction | rebuild |
|---|---|---|
| boundary message | `role:user` + `compaction` part | `role:user` + `checkpoint` part |
| what the boundary contributes to model context | bare label `"Summary of previous conversation:"` (`message-v2.ts:709-713`) — no content | label `"Summary of previous conversation from checkpoint files:"` (`message-v2.ts:703-708`) **plus** the rendered checkpoint index + rebuild context + actor registry, carried as `synthetic: true` text parts (`checkpoint.ts:1465-1497`) |
| where the summary text lives | a **separate** `summary: true` assistant message written by `processCompaction` (`compaction.ts:337-364`), needing a second LLM call | **inline** on the boundary user turn, deterministic, no extra LLM call |
| does the summary reach the model? | **yes** — the assistant branch has no `summary` filter (`message-v2.ts:786-792`); `filterCompacted` stops *at* the boundary so the newer summary message survives (`message-v2.ts:1025-1033`) | **yes** — the user-part filter is `!part.ignored`, **not** `!part.synthetic` (`message-v2.ts:681-685`), so all of the rebuild text is sent |

Both boundaries therefore deliver a real, model-readable summary; rebuild's is arguably richer (structured index + rebuild context + actors) and cheaper (no summarizer call). The asymmetry was **purely in the render layer**: `synthetic: true` hides text from the transcript, never from the model.

So bolting a compaction-style assistant summary onto rebuild would duplicate that text in the context window and change model-facing semantics for zero comprehension gain. Only the render layer moves.

**Change:** render the `checkpoint` part as a one-line badge row in `UserMessage`, reusing the badge pattern already used for cron fires and actor notifications:

```
 ⟲ context rebuilt   earlier messages summarized
```

- i18n keys `tui.session.rebuild_boundary.{label,detail}` added for **en / zh / zht**.
- `test/cli/cmd/tui/rebuild-boundary-marker.test.ts` pins the copy and asserts zh/zht are genuinely translated (not silently falling back to English through the `base` merge in `context/language.tsx`).
- `test/session/rebuild-boundary-model-context.test.ts` (new) pins the semantics table above so a future refactor cannot silently change what the model receives: the synthetic rebuild content survives into the model messages, the compaction `summary: true` assistant turn survives into the model messages, and `filterCompacted` keeps the summary message after the boundary.

**No rebuild or compaction logic changed.**

**Verification:** `bun typecheck` EXIT 0 (12/12 turbo tasks). `test/cli/cmd/tui/` + `checkpoint-rebuild-unify` + the new model-context test: 74 pass / 0 fail. All rebuild/checkpoint/message-v2 suites: 55 pass / 0 fail. Rebased clean onto latest `origin/main` (`eaac8b7ac`).


---

## Follow-up (`eb4183825`): a finished status message latched into the next turn, and squeezed the counter

Live verification of this PR surfaced a second, render-layer defect. After `/rebuild`, the **whole following turn** showed the rebuild outcome sentence on the spinner line instead of the current activity, and because that sentence wraps to three lines it squeezed the footer until the context counter rendered clipped as `52.4K/96` instead of `52.4K/960K` — the exact number this PR is about.

**Diagnosed mechanism** (not a coalescing race, and not the server holding state):

- `settle()` (`session/prompt.ts:4173-4174`) emits `busy{message}` then `idle`. Server-side that is clean: `SessionStatus.set` publishes and then **deletes** the map entry on `idle` (`session/status.ts:77-80`). No debounce, no dedupe, no "keep last message".
- The TUI stored it with `setStore("session_status", sessionID, status)` (`cli/cmd/tui/context/sync.tsx:454`). Solid's store setter **merges** a plain object into the existing node — `updatePath` → `mergeStoreNode` only writes `Object.keys(next)` (`solid-js@1.9.10/store/dist/store.js:201-202`, `:139-145`). Keys absent from the incoming status are retained.
- So `idle` merged down to `{ type:"idle", message:"Context rebuilt…" }`. Invisible, because the spinner row is gated on `status().type !== "idle"` (`component/prompt/index.tsx:1884`) — which is why it "only cleared when the session went fully idle".
- The next turn's runner emits a **bare** `{ type: "busy" }` with no message (`session/run-state.ts:74`). Merged over the latched object it became `{ type:"busy", message:"Context rebuilt…" }`, and `busyMessage()` (`component/prompt/index.tsx:1898-1901`) rendered the stale sentence for the entire turn.

**Fix — TUI store layer, `sync.tsx`.** A `session.status` event is authoritative for the whole status object, so it is wrapped in `reconcile()` (`nextSessionStatus`), which drops the fields the new status omits. Chosen over the alternatives because the bug is **general** (any status that omits a field inherited it — `retry`'s `attempt`/`next` leaked the same way), not rebuild-specific; and because `settle()`'s emission is left intact for the non-TUI consumers (SDK `session.status`, plugin API, `run` completion) and its existing tests. The user-visible confirmation is unaffected: it is the `⟲ context rebuilt` transcript boundary row added earlier in this PR, which is persisted and verified.

**Footer hardening** (independent of clearing): the status message is clamped to a fixed cell budget with newlines flattened (`component/prompt/footer.ts`, `clampStatusMessage`, 48 cells) and rendered `wrapMode="none" flexShrink={1}`; the context counter gets `flexShrink={0}` so it is never the element that gives way.

**Tests** (each proven by reverting only the src change):

- `test/cli/tui/session-status-store.test.ts` — status lifecycle against a real Solid store: a following turn's bare `busy` does not inherit the rebuild message; `idle` clears; `busy` replaces; `retry` fields do not survive. Revert probe (`reconcile` → raw status): 3 fail, e.g. `Expected {"type":"idle"}` / `Received {"type":"idle","message":"Context rebuilt from the latest checkpoint. …"}`.
- `test/cli/cmd/tui/prompt-footer-status.test.ts` — over-long status clamped to the budget, newlines flattened, empty → nothing, and the budget arithmetic leaves room for spinner + `esc interrupt` + `52.4K/960K (5%)` on 80 columns. Revert probe (clamp removed): 2 fail, `Expected: 48 / Received: 109`.
- `test/session/rebuild-on-the-spot.test.ts` — now also asserts the terminal status is `idle`, so `/rebuild` cannot leave a busy status behind. Revert probe (drop `settle`'s `idle`): `Expected: "idle" / Received: "busy"`.

**Verification:** `bun typecheck` EXIT 0. `test/cli/tui` + `test/cli/cmd/tui` + `rebuild-on-the-spot` + `run-completion`: **214 pass / 0 fail** (pristine baseline of the same command: 204 pass / 0 fail — the +10 are the new files). Live in a real TUI on `mimo/mimo-v2.5`, the turn immediately after `/rebuild`:

```
   ∙·🛸             esc interrupt                      51.1K/960K (5%)  tab 切换模式  ctrl+p 设置
     ·˙∙·˙🛸        esc interrupt                      51.1K/960K (5%)  tab 切换模式  ctrl+p 设置
           ·˙∙·˙🛸  esc interrupt                      51.1K/960K (5%)  tab 切换模式  ctrl+p 设置
```

No stale sentence, counter intact. And with a status genuinely in flight during the rebuild itself:

```
   ·˙∙🛸           Writing checkpoint…  esc interrupt            49.0K/960K (5%)
```


---

## Auto overflow now writes a checkpoint before it degrades (closes an asymmetry with manual `/rebuild`)

**The asymmetry.** Both paths share `rebuildFromCheckpoint` (`prompt.ts:398`), which only checks `hasCheckpoint` and returns `false` — it never starts a writer. The two callers then disagreed about what `false` means:

- **Manual `/rebuild`** treated it as "make one": it called `tryStartCheckpointWriter`, waited on `waitForWriter`, and only then rebuilt.
- **Auto overflow** treated it as "give up": `if (inserted) {…}` then straight to `compaction.create`.

So in the *same* state — no checkpoint — a human who asked got one created, while an automatic mid-turn overflow silently degraded.

**Fix.** One shared helper, `rebuildEnsuringCheckpoint`, used by all three main-agent sites (token-threshold overflow, provider-signalled overflow, manual `/rebuild`). It returns a discriminated outcome so there is exactly **one** compaction fallback condition instead of three lookalikes that can drift:

| outcome | meaning | may compact? |
|---|---|---|
| `"rebuilt"` | boundary inserted, context freed | — |
| `"no-checkpoint"` | no usable checkpoint **and** the writer failed / never ran / the bound expired | **yes — the only one** |
| `"insert-failed"` | a usable checkpoint exists but the boundary insert refused | **no** — compacting would amputate history we hold a checkpoint for |

Per the narrowed rule, manual `/rebuild` now *also* compacts on `"no-checkpoint"`. That reverses this branch's earlier deliberate choice not to (the reasoning being that `/rebuild` means "rebuild from a checkpoint", so substituting a summary would misreport what happened). If the writer genuinely failed, a truncating compaction beats doing nothing. The substitution is **named** on the status channel rather than swapped in silently, and neither an assistant reply nor a synthetic user turn is fabricated (the `noReply` decision in `3244ca732` still stands). The defensive writer-succeeded-but-insert-failed exit stopped reusing the no-checkpoint text, which gave *false advice* there — it said "continue the conversation and a checkpoint will be written automatically" when the checkpoint had already been written and continuing fixes nothing — and now reports its own degraded state.

"Usable" deliberately means what `rebuildFromCheckpoint` needs — a checkpoint file **and** a watermark — not just `hasCheckpoint`. `tryStartCheckpointWriter` scaffolds an empty template file before spawning (`checkpoint.ts:650`) and `prune.fireCheckpoints` runs immediately before the overflow check (`prune.ts:289`), so a content-free template with no watermark is the *normal* state on arrival. Keying off `hasCheckpoint` alone would have skipped the wait in the exact case the change exists for.

### Measured cost — and a correction to the premise

The obvious objection is that waiting 60–180 s mid-turn freezes the conversation, and the counter-argument offered was that compaction is *also* an LLM call, so it's slow-vs-slow. **That counter-argument is wrong, and the measurement says so.**

`compaction.create` (`compaction.ts:499`) performs three local operations — one synthetic message row, one `compaction` part row, one bus event — and no model call. Measured over 20 sequential calls on a 40-message session:

```
compaction.create  n=20  total=18.10ms  mean=0.905ms  min=0.185ms  p50=0.240ms  max=12.551ms
```

(`max` is first-call warmup.) Against the writer wait, which the writer documents for itself at `checkpoint.ts:981` as "frequently take 60-180s":

| | cost | result |
|---|---|---|
| `compaction.create` | **p50 0.240 ms** | all pre-boundary history dropped, **unsummarized** |
| writer wait | 60 000–180 000 ms (documented) | structured digest + live tail preserved verbatim |

Compaction is ~250 000–750 000× cheaper. **The cost-parity justification does not hold and is withdrawn.**

The change still stands, but on **quality**, not cost. The LLM summarizer is `processCompaction`, reached only from `/compact` — never from `create`. Nothing generates the summary later either (the sole `Event.Compacted` subscriber, `cron-bridge.ts:196`, just resets a cache). Since `MessageV2.filterCompacted` (`message-v2.ts:1037`) breaks at the marker, falling back **truncates the conversation with no summary at all**. So the real trade is a bounded, explained, one-time stall versus silently amputating the entire history — worth waiting for. The in-code comment claiming this fallback was an "LLM-driven lossy summary" that "preserves semantic content via summary" was factually wrong and is corrected. (In-tree corroboration predates this PR: `checkpoint-rebuild-unify.test.ts:194` already says `create` "runs purely synthetically (no LLM)".)

### The bound: 3 min auto, 5 min manual

`waitForWriter` takes **no** timeout argument — its 5-minute bound is hardcoded at `checkpoint.ts:986` — so the bound is applied by wrapping the call site rather than by passing an argument.

- **Manual: 300 s**, matching `waitForWriter`'s internal bound, i.e. unchanged. A human just typed `/rebuild` and is watching a spinner.
- **Auto: 180 s.** It fires mid-turn *without being asked*, so the stall is unsolicited and should not be as generous. 180 s is exactly the top of the 60–180 s band the writer documents for itself, so it admits every writer behaving as designed while refusing to hold an unrequested turn for the extra two minutes a watching human would tolerate. Abandoning the wait does **not** cancel the writer — it keeps running detached — so a bound that is too tight costs one degraded turn, not the checkpoint itself.

**Reentrancy.** The `isWriterRunning` probe plus `tryStartCheckpointWriter`'s own `"queued"` result (rather than forking a second writer) mean two writers can never start for one session, even across successive runLoop iterations. On `"rebuilt"` and `"no-checkpoint"` the auto sites keep their existing `skipOverflowCheck = true; continue` shape; on `"insert-failed"` they fall through to the model call instead of continuing, since nothing freed context and the provider-signalled handler is the backstop. Auto overflow also sets `"Writing checkpoint…"` on the status channel so a multi-minute mid-turn wait is explained rather than looking frozen. The three subagent `compaction.create` sites are untouched — subagents have no checkpoints, so checkpoint-first does not apply.

### Tests

- **`test/session/auto-overflow-writer-first.test.ts`** (new) drives the real overflow branch in the runLoop and asserts on what the session contains:
  - *no checkpoint + writer succeeds → checkpoint boundary, zero compactions.* Revert probe against `eb4183825`: `expect(checkpoints.length).toBe(1)` → `Expected: 1 / Received: 0`.
  - *no checkpoint + writer genuinely fails → still compacts, zero checkpoints.* Passes before **and** after by design — it guards behaviour the change preserves, so it must not flip.
- **`test/session/rebuild-on-the-spot.test.ts` — rewritten, not tweaked.** Its "case 2 fallback" test asserted `after.length === countBefore`: that a manual `/rebuild` whose writer could not run must **not** compact. That is now the wrong behaviour, so the assertion was replaced rather than edited quietly. It now asserts one `compaction` part plus the status text naming the substitution, and still asserts everything the old test protected (no runLoop entry, no assistant reply, no fabricated user turn). Revert probe: `expect(after.length).toBe(countBefore + 1)` → `Expected: 2 / Received: 1`.
- **`prompt-rebuild-reset.test.ts`** and **`command/rebuild.test.ts`** are source-grep guards keyed to the old code *text*. Their invariants are unchanged and still asserted; only the shape moved — except the deleted `"No checkpoint is available to rebuild from yet"` string, which was not reshaped but removed as false advice.

**Verification.** `bun typecheck` EXIT 0. Scoped run (`rebuild.test.ts`, `auto-overflow-writer-first`, `prompt-rebuild-reset`, `cron-bridge.integration`, `rebuild-on-the-spot`, `checkpoint-rebuild-unify`, `checkpoint-rebuild-v3`, `overflow`): **81 pass / 0 fail** at loadavg 5.41. Pristine baseline of the identical command at `eb4183825` (7 pre-existing files; the new file does not exist there): **79 pass / 0 fail** at loadavg 4.66 — the +2 are exactly the new tests, and nothing pre-existing regressed.


---

## Scaffolded arrival state: why the guard above was still a no-op (`95a3d6ea9`)

The commit before this one re-keyed the compaction discriminator off bare
`hasCheckpoint` and onto `lastBoundary`. That was the right value to read, and it
still did nothing.

**The trap.** `hasCheckpoint` is literally `Bun.file(checkpointPath(sid)).exists()`
(`checkpoint.ts:1021`), and `tryStartCheckpointWriter` scaffolds an **empty
template** (`checkpoint.ts:650`) *before* it spawns the writer. Since
`prune.fireCheckpoints` (`prune.ts:289`) runs immediately before the overflow
check, **"checkpoint file on disk, watermark not yet written" is how a normal
rebuild arrives** — not a degraded state, the ordinary one.

**Why re-keying didn't fix it.** The new guard was written as
`boundary !== undefined`, and that predicate never excluded anything.
`lastBoundary` reads a nullable column behind an unchecked
`as MessageID | undefined` cast (`checkpoint.ts:1422`), so an unset watermark
arrives as JS **`null`** — the declared `MessageID | undefined` was simply untrue
at runtime. `null !== undefined` is `true`, so the guard fired for **every**
session with a file on disk and behaved exactly like the bare `hasCheckpoint`
check it replaced. Nobody had noticed the nullability because every pre-existing
caller happens to test truthiness (`!boundary` at `prompt.ts:413`,
`watermarkBefore ?` at `checkpoint.ts:1131`, `boundaryID ?` in
`nudgedSinceBoundary`); this was the first strict-equality caller.

**Why it was invisible.** The misclassification lands on `insert-failed`, which is
the one outcome that neither rebuilds nor compacts — `prompt.ts:3515-3521`
deliberately falls through to the model call. So the overflow was left unresolved
with **zero checkpoints and zero compactions and no error anywhere**. A
scaffolded-state seed reproduces exactly that signature:

```
[DIAG] checkpoints=0 compactions=0
[DIAG2] OVERFLOW BRANCH entered agentID=main
[DIAG2] step2 hasCP=true boundary=null      <- null, not undefined
[DIAG2] attempt=insert-failed
```

The overflow branch *was* entered and `tryStartCheckpointWriter` was never
reached; after the fix the same seed logs `boundary=undefined` -> `tryStart=started`
-> `writerOutcome=success` -> `attempt=rebuilt`.

**What closes it.** Two one-liners, either of which is sufficient (verified
independently); both kept because the first makes the declared type honest for
future callers and the second makes the two readers of this value agree:

- `checkpoint.ts:1431` — return `?? undefined`, so the value matches the signature
  declared at `:489` instead of relying on every caller to test truthiness.
- `prompt.ts:528` — `if (hasCP && boundary)`, the same truthiness test
  `rebuildFromCheckpoint` applies to the same value at `:413`.

**Regression test.** `auto-overflow-writer-first.test.ts` — "a scaffolded-but-empty
checkpoint file still starts and awaits the writer". It pre-writes the empty
template exactly as `tryStartCheckpointWriter` leaves it, then asserts one
checkpoint boundary, zero compactions, and a non-null watermark. Revert probe
against the previous commit's source, verbatim:

```
451 |                   const checkpoints = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
452 |                   const compactions = after.filter((m) => m.parts.some((p) => p.type === "compaction"))
453 |                   expect(checkpoints.length).toBe(1)
      ^
error: expect(received).toBe(expected)

Expected: 1
Received: 0
```

The sibling writer-first test cannot catch this: it seeds no checkpoint file, so
it never reaches the misclassified branch and passes with the bug in place.

**Verification.** `bun typecheck` EXIT 0 (confirmed to cover `test/` — a deliberate
type error in the test file is reported). Scoped run of
`auto-overflow-writer-first`, `rebuild-on-the-spot`, `prompt-rebuild-reset`,
`command/rebuild`: **11 pass / 0 fail**. Pristine baseline of the identical command
at `5189f1974`: **10 pass / 0 fail** — the +1 is exactly the new test, and nothing
pre-existing regressed.