### PR TITLE
fix(tui): respect MIMOCODE_EXPERIMENTAL_ORCHESTRATOR flag in orchestrator session check

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -32,6 +32,7 @@ import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
 import { Locale } from "@/util"
 import { formatDuration } from "@/util/format"
+import { Flag } from "@/flag/flag"
 import { SessionRetry } from "@/session/retry"
 import { createColors, createFrames } from "../../ui/spinner.ts"
 import { useDialog } from "@tui/ui/dialog"
@@ -1084,7 +1085,7 @@ export function Prompt(props: PromptProps) {
     // composer must land the first message INTO that root rather than creating a
     // duplicate root session. Only applies when the composer has no bound
     // sessionID (home view) and the current agent is orchestrator.
-    if (sessionID == null && agent.name === "orchestrator") {
+    if (sessionID == null && agent.name === "orchestrator" && Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR) {
       const stashed = local.orchestrator.sessionID()
       if (stashed) {
         sessionID = stashed


### PR DESCRIPTION
Closes #1756

## Type of change

- [x] Bug fix

## What does this PR do?

当 oh-my-opencode-slim 等插件注册了名为 "orchestrator" 的 agent 但未开启 `MIMOCODE_EXPERIMENTAL_ORCHESTRATOR` flag 时，prompt 组件的 orchestrator session 检查路径会永久阻塞消息提交。

根因：`app.tsx` 中设置 `local.orchestrator.sessionID()` 的异步初始化被 Flag 守卫，但 `prompt/index.tsx` 中的同名检查没有检查 Flag —— 当 agent 名为 "orchestrator" 时无条件进入 stashed session 路径，`sessionID()` 永远为 undefined，导致死锁。

**修复**：在条件中增加 `Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR` 检查，只有内置 Orchestrator 模式激活时才走 stashed session 路径，否则创建普通 session。

## How did you verify your code works?

修改仅增加 Flag 条件判断，与 `app.tsx` 中相同 Flag 的使用一致。改动范围极小（1 行条件 + 1 行 import）。

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR