### PR TITLE
docs(skill): document CJK/East-Asian font handling for office skills

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
@@ -251,7 +251,7 @@ def ref(paragraph, name):
 | Image renders huge | Only `width` or `height` supplied ≥ page width | Compute `Cm(15)` (roughly page-content width) and let the other axis auto-scale. |
 | File opens with "content had problems" | Manually inserted XML with unbalanced tags | Reopen the exploded directory, run `xmllint --noout word/document.xml`, fix the offending element. |
 | "Missing font" warning on open (Cambria, Calibri, CJK fonts) | `python-docx` default template embeds font references in theme XML that may not be installed | Patch the theme after `Document()` — see recipe below. |
-| Chinese / non-ASCII text renders as `??` in some viewers | Font run has no East-Asian font | Set both `rFonts.ascii` and `rFonts.eastAsia`: `run.font.name = "Calibri"; run._element.rPr.rFonts.set(qn("w:eastAsia"), "Microsoft YaHei")` |
+| Chinese / non-ASCII text renders as `??` in some viewers | Font run has no East-Asian font | Set both the ASCII and East-Asian typefaces: `run.font.name = "Calibri"; run._element.get_or_add_rPr().get_or_add_rFonts().set(qn("w:eastAsia"), "Microsoft YaHei")` — the `get_or_add_*` form is safe when the run has no `rPr`/`rFonts` yet; setting only `run.font.name` leaves CJK on the default font. Use a CJK-capable font for the `w:eastAsia` value. |
 
 ## Recipes
 

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/compose.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/compose.md
@@ -160,6 +160,13 @@ c.setFont("STSong-Light", 14)
 c.drawString(50, 700, "简体中文示例")
 ```
 
+For a **Platypus** document (the multi-page report flow above), the CID font
+must also be set on the styles, not just the canvas — otherwise `Paragraph` /
+`Table` flowables fall back to Helvetica and CJK becomes black boxes. After
+`registerFont(UnicodeCIDFont("STSong-Light"))`, set `fontName="STSong-Light"`
+on each `ParagraphStyle` carrying CJK text and add `("FONTNAME", (0,0), (-1,-1),
+"STSong-Light")` to the `TableStyle` of any table with CJK cells.
+
 ## 5. Subscripts / superscripts / inline markup
 
 Built-in Helvetica has no glyphs for Unicode subscripts (`H₂O`, `x²`). They

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
@@ -367,9 +367,15 @@ isn't, inform the user and offer to spawn a vision subagent instead.
   display size (see `create.md` → *Images*).
 - **Fonts not embedded** — `python-pptx` does not embed fonts. If the deck
   is opened on a machine without the chosen font, PowerPoint substitutes,
-  and layout drifts. Either use system-safe fonts (Calibri, Arial, Segoe UI,
-  Times New Roman, Consolas) or ship the .pptx alongside a font install
-  step.
+  and layout drifts. For **Latin** text, prefer system-safe fonts (Calibri,
+  Arial, Segoe UI, Times New Roman, Consolas) or ship the .pptx alongside a
+  font install step.
+- **CJK text needs the East-Asian font slot** — `run.font.name` only sets the
+  Latin typeface (`a:latin`); Chinese / Japanese / Korean glyphs come from the
+  East-Asian slot (`a:ea`), which python-pptx does not expose. Leave it unset
+  and CJK renders as tofu boxes or an inconsistent substitute. Set `a:latin` +
+  `a:ea` + `a:cs` to a CJK-capable font on every run that contains CJK text
+  (recipe in `create.md` → *CJK / East-Asian text*).
 
 ## What is out of scope
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/create.md
@@ -99,6 +99,36 @@ Notes on text:
   tf.auto_size = MSO_AUTO_SIZE.NONE
   ```
 
+### CJK / East-Asian text (Chinese, Japanese, Korean)
+
+`run.font.name` only sets the **Latin** typeface (`a:latin`). CJK glyphs are
+taken from the separate **East-Asian slot** (`a:ea`), which python-pptx does
+not expose. If you leave it unset, PowerPoint falls back to a default and
+Chinese / Japanese / Korean text often renders as tofu boxes (□□□) or an
+inconsistent substitute — even when `run.font.name` looks correct. For any run
+containing CJK text, set all three slots (`a:latin`, `a:ea`, `a:cs`) via XML:
+
+```python
+from pptx.oxml.ns import qn
+
+def set_cjk_font(run, font_name):
+    """Set Latin (a:latin), East-Asian (a:ea) and complex-script (a:cs) typefaces."""
+    run.font.name = font_name                      # a:latin
+    rPr = run._r.get_or_add_rPr()
+    for tag in ("a:ea", "a:cs"):
+        el = rPr.find(qn(tag))
+        if el is None:
+            el = rPr.makeelement(qn(tag), {})
+            rPr.append(el)
+        el.set("typeface", font_name)
+
+set_cjk_font(p.runs[0], "Noto Sans CJK SC")        # a CJK-capable font present on the render machine
+```
+
+Choose a font that actually ships CJK glyphs (a Noto Sans CJK / Source Han
+variant, or the platform's system CJK font). A Latin-only face such as Calibri
+will not carry CJK no matter which slot you set.
+
 ### Bulleted list
 
 ```python

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/create.md
@@ -113,13 +113,22 @@ from pptx.oxml.ns import qn
 
 def set_cjk_font(run, font_name):
     """Set Latin (a:latin), East-Asian (a:ea) and complex-script (a:cs) typefaces."""
-    run.font.name = font_name                      # a:latin
+    run.font.name = font_name                      # a:latin (python-pptx inserts it in order)
     rPr = run._r.get_or_add_rPr()
+    # a:ea / a:cs aren't exposed by python-pptx, so build them by hand. But a:rPr
+    # enforces child order (a:latin, a:ea, a:cs, a:sym, a:hlinkClick, ...); a bare
+    # append() lands after any existing a:hlinkClick/a:sym/etc. and yields invalid
+    # markup that PowerPoint "repairs" by dropping the font. Insert before the first
+    # legal successor instead (a:ea must also precede a:cs).
+    successors = {
+        "a:ea": ("a:cs", "a:sym", "a:hlinkClick", "a:hlinkMouseOver", "a:rtl", "a:extLst"),
+        "a:cs": ("a:sym", "a:hlinkClick", "a:hlinkMouseOver", "a:rtl", "a:extLst"),
+    }
     for tag in ("a:ea", "a:cs"):
         el = rPr.find(qn(tag))
         if el is None:
             el = rPr.makeelement(qn(tag), {})
-            rPr.append(el)
+            rPr.insert_element_before(el, *successors[tag])
         el.set("typeface", font_name)
 
 set_cjk_font(p.runs[0], "Noto Sans CJK SC")        # a CJK-capable font present on the render machine


### PR DESCRIPTION
## Summary
Improve the built-in office skill docs around CJK / East-Asian font handling, which currently either uses a fragile recipe or omits the guidance entirely.

- **docx** (`create.md`): the run-font recipe used `run._element.rPr.rFonts.set(...)`, which raises when the run has no `rPr`/`rFonts` yet. Switched to `run._element.get_or_add_rPr().get_or_add_rFonts()` and clarified that a CJK-capable font must be used for the `w:eastAsia` value.
- **pdf** (`compose.md`): for Platypus documents, the CID font must be set on `ParagraphStyle`/`TableStyle`, not just the canvas — otherwise flowables fall back to Helvetica and CJK renders as black boxes.
- **pptx** (`SKILL.md` + `create.md`): `run.font.name` only sets the Latin slot (`a:latin`); CJK glyphs come from the East-Asian slot (`a:ea`), which python-pptx does not expose. Added a `set_cjk_font` recipe setting `a:latin`/`a:ea`/`a:cs`, plus a troubleshooting note.

## Notes
- Docs-only change (no code paths affected).
- These edits target the base skill bundle files; translated (`.en/.fr/.ja/.ru`) variants are not updated here.

## Test plan
- [ ] docx `get_or_add_*` recipe runs without error on a fresh run and produces correct `w:eastAsia`
- [ ] pptx `set_cjk_font` renders CJK with the chosen font in PowerPoint
- [ ] pdf Platypus example renders CJK in `Paragraph`/`Table` flowables