### PR TITLE
chore(flag): default MIMOCODE_ENABLE_TRY_BEST_HANDOFF to off

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -146,9 +146,9 @@ export const Flag = {
   MIMOCODE_SERVER_USERNAME: process.env["MIMOCODE_SERVER_USERNAME"],
   MIMOCODE_ENABLE_QUESTION_TOOL: truthy("MIMOCODE_ENABLE_QUESTION_TOOL"),
 
-  // Defaults to true. Set MIMOCODE_ENABLE_TRY_BEST_HANDOFF=false (or 0) to
-  // disable try-best loop detection, automatic turn pausing, and handoff UI.
-  MIMOCODE_ENABLE_TRY_BEST_HANDOFF: !falsy("MIMOCODE_ENABLE_TRY_BEST_HANDOFF"),
+  // Defaults to false. Set MIMOCODE_ENABLE_TRY_BEST_HANDOFF=true (or 1) to
+  // enable try-best loop detection, automatic turn pausing, and handoff UI.
+  MIMOCODE_ENABLE_TRY_BEST_HANDOFF: truthy("MIMOCODE_ENABLE_TRY_BEST_HANDOFF"),
 
   // Defaults to false. The edit tool does pure exact-string matching with
   // explicit error signals. Set MIMOCODE_ENABLE_FUZZY_EDIT=true to opt into the


### PR DESCRIPTION
## Summary
- Flip `MIMOCODE_ENABLE_TRY_BEST_HANDOFF` default from **on** to **off**.
- Try-best loop detection, automatic turn pausing, and handoff UI now require explicit opt-in via `MIMOCODE_ENABLE_TRY_BEST_HANDOFF=true` (or `1`).
- Comment updated to match the new semantics.

## Test plan
- [x] `bun turbo typecheck` passes.
- [ ] Verify handoff UI is inactive by default in a fresh shell (no env var set).
- [ ] Verify `MIMOCODE_ENABLE_TRY_BEST_HANDOFF=1` re-enables the feature.