### PR TITLE
docs: use `bun ci` for install instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ https://github.com/anomalyco/models.dev
 - Install dependencies and start the dev server from the repo root:
 
   ```bash
-  bun install
+  bun ci   # = bun install --frozen-lockfile
   bun dev
   ```
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ confirmation. Only use it where you fully trust the workspace.
 ## Development
 
 ```bash
-bun install              # Install dependencies
+bun ci                   # Install dependencies (= bun install --frozen-lockfile)
 bun run dev              # Run in development mode
 bun turbo typecheck      # Type check
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -373,7 +373,7 @@ MIMOCODE_DANGEROUSLY_SKIP_PERMISSIONS=1 mimo
 ## 开发
 
 ```bash
-bun install              # 安装依赖
+bun ci                   # 安装依赖(= bun install --frozen-lockfile)
 bun run dev              # 开发模式运行
 bun turbo typecheck      # 类型检查
 ```

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -5,7 +5,7 @@ The OpenCode Desktop app, built with Electron.
 ## Development
 
 ```bash
-bun install
+bun ci
 bun dev
 ```
 

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -3,7 +3,7 @@
 To install dependencies:
 
 ```bash
-bun install
+bun ci
 ```
 
 To run:

--- a/sdks/vscode/README.md
+++ b/sdks/vscode/README.md
@@ -20,7 +20,7 @@ This is an early release. If you encounter issues or have feedback, please creat
 ## Development
 
 1. `code sdks/vscode` - Open the `sdks/vscode` directory in VS Code. **Do not open from repo root.**
-2. `bun install` - Run inside the `sdks/vscode` directory.
+2. `bun ci` - Run inside the `sdks/vscode` directory.
 3. Press `F5` to start debugging - This launches a new VS Code window with the extension loaded.
 
 #### Making Changes


### PR DESCRIPTION
Swap `bun install` → `bun ci` in the setup/install docs (README, README.zh, CONTRIBUTING, packages/opencode, packages/desktop, sdks/vscode).

`bun ci` is an alias for `bun install --frozen-lockfile` (available since bun **v1.2.19**, PR #20590). It installs the exact versions from `bun.lock` and does not rewrite the lockfile, so setup installs are reproducible and don't produce incidental `bun.lock` churn.

Docs only — no code changes.

> Note on semantics: `bun ci` errors if `package.json` is out of sync with `bun.lock` (by design). It's meant for "install exactly what's committed". Contributors who **add/change dependencies** should still use `bun install` to update the lockfile.