### PR TITLE
fix(session): narrow empty-step guard to only empty-args tool calls

### DIFF
--- a/packages/opencode/src/session/prompt/empty-step-detection.ts
+++ b/packages/opencode/src/session/prompt/empty-step-detection.ts
@@ -2,48 +2,39 @@ import { Flag } from "@/flag/flag"
 import type { MessageV2 } from "../message-v2"
 
 /**
- * Empty / no-op tool-call loop guard.
+ * Empty tool-call loop guard.
  *
- * Sibling to text-ngram-detection: the text-ngram ladder only inspects TEXT
- * parts, so a model that spins by re-emitting content-free tool calls (or by
- * "calling a tool" that produces no structured tool part at all) slips past it
- * with no text to match. stepSignature (prompt.ts) also misses this: it signs
- * only `part.type === "tool"` steps and returns undefined for a step with zero
- * tool parts, so an empty terminal step is dropped from repeat counting instead
- * of counted. This module fills that gap with a pure classifier + a soft→hard
- * recovery ladder mirroring TEXT_NGRAM_MAX_RECOVERY.
+ * Narrow purpose: some models (including frontier ones under certain workloads)
+ * occasionally emit a tool call with a completely empty argument object —
+ * i.e. they "called a tool" but passed nothing actionable. Re-looping just
+ * repeats the same empty call. This guard detects that specific shape and
+ * escalates via a soft→hard recovery ladder mirroring text-ngram-detection.
  *
- * This is a HARNESS backstop for a MODEL bug: a degraded model that keeps
- * emitting empty/no-op steps will never self-correct from a reminder, so after
- * a bounded number of soft nudges the harness must hard-halt the turn rather
- * than spin forever.
+ * IMPORTANT scope note: this guard does NOT try to catch "empty terminals"
+ * (steps that emit no tool call and no text). An empty terminal is a natural
+ * turn end, not a spin — the next user input drives the next turn. Treating
+ * it as a loop caused frequent false positives on legitimate quiet steps
+ * (task done, sub-agent returned, reasoning-only steps, provider-executed
+ * tool calls). Wall-clock / active deadlines and provider stream timeouts
+ * already backstop any actual "model produces nothing" pathology.
  */
 
 export const EMPTY_STEP_MAX_RECOVERY = Flag.MIMOCODE_EMPTY_STEP_MAX_RECOVERY
 
 /**
- * Is this assistant step an empty / no-op tool call?
+ * Is this assistant step an empty tool call?
  *
- * Two shapes count as empty (mirrors the task's definition):
+ * True iff the step emitted one or more client (non-providerExecuted) tool
+ * parts AND every such tool part has an empty/invalid input — no keys, or
+ * only keys whose values are null/undefined/empty-string/whitespace.
  *
- *  (a) The step emitted one or more client (non-providerExecuted) tool parts,
- *      but EVERY such tool part has an empty/invalid input — no keys, or only
- *      keys whose values are null/undefined/empty-string/whitespace. The model
- *      "called a tool" but passed nothing actionable, so the call cannot make
- *      progress and re-looping just repeats it.
+ * A step with ANY tool part that has real input is NOT empty.
+ * A step with no client tool part is NOT empty (empty terminals are allowed).
+ * A step with substantive text or reasoning alongside a bad tool call is NOT
+ * empty (the model is making some kind of progress).
  *
- *  (b) The step produced NO client tool part at all AND no substantive text and
- *      no substantive reasoning — a fully empty terminal. (This overlaps with
- *      classify's `invalid`/"empty output", but we count it here too so the
- *      hard-halt ladder can escalate on a run of them rather than only softly
- *      nudging via autoContinueInvalidOutput.)
- *
- * A step that emits at least one tool part with real input, or any substantive
- * text/reasoning, is NOT empty — the model is making some kind of progress.
- *
- * Provider-executed tool parts (e.g. server-side web search) are ignored for
- * the "has a tool part" test: they are not client actions and their presence
- * does not mean the model issued an actionable call.
+ * Provider-executed tool parts (e.g. server-side web search) are ignored:
+ * they are not client actions.
  */
 export function isEmptyStep(parts: readonly MessageV2.Part[]): boolean {
   const clientToolParts = parts.filter(
@@ -51,14 +42,13 @@ export function isEmptyStep(parts: readonly MessageV2.Part[]): boolean {
       part.type === "tool" && !part.metadata?.providerExecuted,
   )
 
-  if (clientToolParts.length > 0) {
-    // (a) Every client tool part has an empty/invalid input.
-    return clientToolParts.every((part) => isEmptyInput(part.state.input))
-  }
+  // No client tool part → not an empty tool call. Empty terminals fall through
+  // to natural turn end; this guard only targets the specific "called a tool
+  // with no args" pathology.
+  if (clientToolParts.length === 0) return false
 
-  // (b) No client tool part — empty only if there is also no substantive
-  // text and no substantive reasoning (a pure-empty terminal). A step with a
-  // real text answer or real reasoning is a legitimate (non-loop) outcome.
+  // Substantive text or reasoning alongside a bad tool call → model is making
+  // progress, don't flag.
   const hasSubstantiveText = parts.some(
     (part) => part.type === "text" && !part.synthetic && !part.ignored && part.text.trim().length > 0,
   )
@@ -67,7 +57,9 @@ export function isEmptyStep(parts: readonly MessageV2.Part[]): boolean {
     (part) => part.type === "reasoning" && part.text.trim().length > 0,
   )
   if (hasSubstantiveReasoning) return false
-  return true
+
+  // Every client tool part must have empty input.
+  return clientToolParts.every((part) => isEmptyInput(part.state.input))
 }
 
 /**
@@ -93,21 +85,15 @@ function isEmptyValue(value: unknown): boolean {
 
 export const EMPTY_STEP_RECOVERY_REMIND = [
   "<system-reminder>",
-  "NO PROGRESS: your previous step made no valid tool call and produced no answer",
-  "(the tool call had empty/invalid arguments, or there was no tool call and no text).",
-  "Stop repeating an empty step. Do exactly ONE of these now:",
-  "- Issue a valid tool call with COMPLETE, non-empty arguments, or",
-  "- Reply to the user directly with plain text.",
-  "Do NOT emit another empty or argument-less tool call.",
+  "Your previous tool call had empty or missing arguments — the tool needs real input to make progress.",
+  "Retry the call with COMPLETE arguments, or if the tool is not the right next step, answer the user in plain text.",
   "</system-reminder>",
 ].join("\n")
 
 export const EMPTY_STEP_RECOVERY_REPLAN = [
   "<system-reminder>",
-  "STILL NO PROGRESS: you are repeating empty/no-op tool calls after a reminder.",
-  "This is your final chance before the turn is halted. You MUST either:",
-  "1. Send a single valid tool call whose arguments are fully populated, or",
-  "2. Give the user a plain-text response explaining the result or the blocker.",
-  "Any further empty/argument-less tool call will terminate this turn.",
+  "Second empty tool call. Final chance before this turn is halted.",
+  "Either issue a tool call with fully-populated arguments, or give a plain-text reply.",
+  "Any further empty-argument tool call will terminate this turn.",
   "</system-reminder>",
 ].join("\n")

--- a/packages/opencode/test/session/empty-step-detection.test.ts
+++ b/packages/opencode/test/session/empty-step-detection.test.ts
@@ -59,22 +59,23 @@ describe("isEmptyStep — case (a): tool call with empty/invalid input", () => {
   })
 
   test("provider-executed tool part is ignored for the has-tool test", () => {
-    // Only a provider-executed part + no substantive output => empty terminal.
-    expect(isEmptyStep([toolPart({ q: "x" }, { providerExecuted: true })])).toBe(true)
+    // A provider-executed part is not a client action; without any real client
+    // tool call there is nothing to flag as empty (b-branch is disabled).
+    expect(isEmptyStep([toolPart({ q: "x" }, { providerExecuted: true })])).toBe(false)
   })
 })
 
-describe("isEmptyStep — case (b): empty terminal (no valid tool part, no output)", () => {
-  test("completely empty parts array is empty", () => {
-    expect(isEmptyStep([])).toBe(true)
+describe("isEmptyStep — (b) empty terminal is NOT flagged (allowed by design)", () => {
+  test("completely empty parts array is NOT empty (natural turn end)", () => {
+    expect(isEmptyStep([])).toBe(false)
   })
 
-  test("only a synthetic text part (harness reminder) is empty", () => {
-    expect(isEmptyStep([textPart("<system-reminder>...</system-reminder>", { synthetic: true })])).toBe(true)
+  test("only a synthetic text part is NOT empty (no client tool call to flag)", () => {
+    expect(isEmptyStep([textPart("<system-reminder>...</system-reminder>", { synthetic: true })])).toBe(false)
   })
 
-  test("only whitespace text is empty", () => {
-    expect(isEmptyStep([textPart("   \n  ")])).toBe(true)
+  test("only whitespace text is NOT empty", () => {
+    expect(isEmptyStep([textPart("   \n  ")])).toBe(false)
   })
 
   test("substantive text answer is NOT empty", () => {
@@ -85,7 +86,11 @@ describe("isEmptyStep — case (b): empty terminal (no valid tool part, no outpu
     expect(isEmptyStep([reasoningPart("Let me think about this...")])).toBe(false)
   })
 
-  test("ignored text does not count as substantive", () => {
-    expect(isEmptyStep([textPart("stuff", { ignored: true })])).toBe(true)
+  test("ignored text alone is NOT empty (no tool call to flag)", () => {
+    expect(isEmptyStep([textPart("stuff", { ignored: true })])).toBe(false)
+  })
+
+  test("provider-executed tool part alone is NOT empty (not a client action)", () => {
+    expect(isEmptyStep([toolPart({ q: "x" }, { providerExecuted: true })])).toBe(false)
   })
 })

--- a/packages/opencode/test/session/empty-step-guard-integration.test.ts
+++ b/packages/opencode/test/session/empty-step-guard-integration.test.ts
@@ -25,7 +25,7 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { EMPTY_STEP_MAX_RECOVERY } from "../../src/session/prompt/empty-step-detection"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
-import { startScriptedLLMServer, emptyStopResponse, textStopResponse } from "../lib/scripted-llm-server"
+import { startScriptedLLMServer, emptyStopResponse, textStopResponse, toolCallStopResponse } from "../lib/scripted-llm-server"
 
 void Log.init({ print: false })
 
@@ -54,12 +54,15 @@ function writeConfig(dir: string, origin: string) {
 }
 
 describe("empty/no-op tool-call loop guard — integration", () => {
-  test("repeated empty steps HARD-HALT the turn instead of looping forever", async () => {
+  test("repeated empty-args tool calls HARD-HALT the turn instead of looping forever", async () => {
     await using tmp = await tmpdir({ git: true })
-    // Every response is an empty stop step. The stub repeats its last entry
-    // forever, so if the guard failed to halt this would spin indefinitely
-    // (the test would hang / time out). We assert it terminates.
-    const stub = startScriptedLLMServer([{ lines: emptyStopResponse() }])
+    // Every response is a tool call with empty args ({}). The stub repeats its
+    // last entry forever, so if the guard failed to halt this would spin
+    // indefinitely. We assert it terminates. (This is the specific "frontier
+    // model emits tool call with no args" pathology the guard targets.)
+    const stub = startScriptedLLMServer([
+      { lines: toolCallStopResponse({ id: "call_1", name: "read", args: "{}" }) },
+    ])
     try {
       await writeConfig(tmp.path, stub.origin)
       await Instance.provide({
@@ -75,10 +78,8 @@ describe("empty/no-op tool-call loop guard — integration", () => {
                 agent: "build",
                 parts: [{ type: "text", text: "Do the task." }],
               })
-              // Turn terminated (did not hang) with an error on the assistant.
               expect(result.info.role).toBe("assistant")
               if (result.info.role === "assistant") expect(result.info.error).toBeDefined()
-              // Bounded: EMPTY_STEP_MAX_RECOVERY soft nudges + 1 halting step.
               expect(stub.captures.length).toBe(EMPTY_STEP_MAX_RECOVERY + 1)
             }),
           ),
@@ -88,11 +89,47 @@ describe("empty/no-op tool-call loop guard — integration", () => {
     }
   })
 
-  test("a single empty step recovers when the next step produces a real answer (no halt)", async () => {
+  test("empty terminal (no tool call, no text) is NOT halted by the empty-step guard", async () => {
+    await using tmp = await tmpdir({ git: true })
+    // Empty terminal used to be flagged (b-branch) and could hard-halt the turn
+    // after EMPTY_STEP_MAX_RECOVERY. It is now allowed by isEmptyStep — no
+    // client tool call means nothing to loop-guard. Other invalid-output
+    // handling (autoContinueInvalidOutput) may still nudge, but the guard's
+    // terminal error must not fire.
+    const stub = startScriptedLLMServer([{ lines: emptyStopResponse() }])
+    try {
+      await writeConfig(tmp.path, stub.origin)
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const prompt = yield* SessionPrompt.Service
+              const session = yield* sessions.create({ title: "empty-terminal-allowed" })
+              const result = yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "build",
+                parts: [{ type: "text", text: "Do the task." }],
+              })
+              expect(result.info.role).toBe("assistant")
+              // The empty-step guard specifically must NOT be the terminator.
+              if (result.info.role === "assistant" && result.info.error) {
+                expect(result.info.error.data?.message ?? "").not.toContain("Empty tool call loop detected")
+              }
+            }),
+          ),
+      })
+    } finally {
+      await stub.stop()
+    }
+  })
+
+  test("a single empty-args tool call recovers when the next step produces a real answer (no halt)", async () => {
     await using tmp = await tmpdir({ git: true })
     const stub = startScriptedLLMServer([
-      // step 1: empty terminal → streak 1 → REMIND nudge, continue
-      { lines: emptyStopResponse() },
+      // step 1: empty-args tool call → streak 1 → REMIND nudge, continue
+      { lines: toolCallStopResponse({ id: "call_1", name: "read", args: "{}" }) },
       // step 2: real answer → streak reset, loop exits cleanly
       { lines: textStopResponse("here is the real answer") },
     ])


### PR DESCRIPTION
## Problem

The empty-step guard (added in #1706 and iterated in a series of follow-up patches: schema-aware unwrap, `_meta` filtering, `ZodDefault`/`ZodNullable` unwrap, threshold-halt → single-empty-call retry, explicitly-terminal fix) fires in two shapes:

- **(a)** every client tool part has empty/invalid input — the specific frontier-model "called a tool with `{}` args" pathology the guard was originally motivated by; and
- **(b)** no client tool part AND no substantive text/reasoning — a fully empty terminal.

Branch (b) is the source of frequent user-visible pain: legitimate quiet endings (e.g. a step that only produced a side-effect the harness routes through a non-client path, a sub-agent that just returned, a reasoning-only step, a step with only a provider-executed tool call) get flagged, the harness injects a "NO PROGRESS" `<system-reminder>`, and the model — under pressure to say something — restates prior explanations. The user sees "MiMo suddenly repeated itself".

There is no evidence in this repo's history that branch (b) ever caught a real spin: none of the six follow-up patches to this file cite a branch-(b) incident; they are all narrowing branch (a) to reduce its own false positives.

Wall-clock / active deadlines and provider stream timeouts already backstop any actual "model produces nothing" pathology, so branch (b) is a redundant defense whose cost is high false-positive rate.

## Fix

- `isEmptyStep` returns `false` when there is no client tool part. Empty terminals fall through to natural turn end. All of branch (a) is preserved unchanged, including the accumulated hardening.
- Tighten the reminder wording: from vague "NO PROGRESS: your previous step made no valid tool call and produced no answer" to precise "Your previous tool call had empty or missing arguments". The old phrasing was the direct trigger for models to fill the void with restated prior output; the new phrasing gives them a specific, actionable correction (fix the args, or answer in text).

## Tests

- **Unit**: (b) `describe` block re-asserted with `toBe(false)` outcomes (empty parts array, whitespace-only text, ignored text, synthetic reminder, provider-executed-only, reasoning-only). (a) suite unchanged.
- **Integration**: halt test now uses `toolCallStopResponse(args: "{}")` so it exercises the actual target shape (frontier-model empty-args pathology). New regression test asserts an empty terminal is NOT halted by this guard's terminal error.

`bun test test/session/empty-step-*` → **18 pass · 0 fail**. `bun typecheck` → **EXIT 0**.

## Not in this PR

The wider "should this guard exist at all?" discussion is deferred. This PR keeps the guard, keeps its ladder, keeps its escalation budget, and keeps its terminal error path — it only narrows the detection surface to the one shape that has real motivation behind it.
