### PR TITLE
fix(tool/tool_script): discourage overuse and stop escaping return values

### DIFF
--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -169,7 +169,7 @@ export const ToolScriptTool = Tool.define(
             return {
               title: "code too large",
               metadata: { status: "code_error", toolCalls: 0 },
-              output: `<tool_script status="code_error">\n<error>\ncode exceeds ${MAX_CODE_BYTES} bytes\n</error>\n</tool_script>`,
+              output: `<tool_script status="code_error">\n<error_message>\ncode exceeds ${MAX_CODE_BYTES} bytes\n</error_message>\n</tool_script>`,
             }
           }
 
@@ -205,7 +205,7 @@ export const ToolScriptTool = Tool.define(
             return {
               title: "transpile error",
               metadata: { status: "code_error", toolCalls: 0 },
-              output: `<tool_script status="code_error">\n<error>\n${transpiled.error}\n</error>\n</tool_script>`,
+              output: `<tool_script status="code_error">\n<error_message>\n${transpiled.error}\n</error_message>\n</tool_script>`,
             }
           }
 
@@ -329,7 +329,7 @@ export const ToolScriptTool = Tool.define(
             return {
               title: status,
               metadata: { status, toolCalls: trace.length },
-              output: `<tool_script status="${status}">\n<error>\n${message}\n</error>\n${logBlock}${traceBlock}</tool_script>`,
+              output: `<tool_script status="${status}">\n<error_message>\n${message}\n</error_message>\n${logBlock}${traceBlock}</tool_script>`,
             }
           }
 
@@ -343,18 +343,19 @@ export const ToolScriptTool = Tool.define(
               : typeof returned === "string"
                 ? returned
                 : JSON.stringify(returned, null, 2)
-          if (Buffer.byteLength(returnedText, "utf8") > MAX_RESULT_BYTES) {
+          const returnedBytes = Buffer.byteLength(returnedText, "utf8")
+          if (returnedBytes > MAX_RESULT_BYTES) {
             return {
               title: "result too large",
               metadata: { status: "budget_exceeded", toolCalls: trace.length },
-              output: `<tool_script status="budget_exceeded">\n<error>\nreturned value is ${returnedText.length} bytes (max ${MAX_RESULT_BYTES}). Aggregate or slice the data before returning.\n</error>\n${logBlock}${traceBlock}</tool_script>`,
+              output: `<tool_script status="budget_exceeded">\n<error_message>\nreturned value is ${returnedBytes} bytes (max ${MAX_RESULT_BYTES}). Aggregate or slice the data before returning.\n</error_message>\n${logBlock}${traceBlock}</tool_script>`,
             }
           }
 
           return {
             title: `${trace.length} tool calls`,
             metadata: { status: "completed", toolCalls: trace.length },
-            output: `<tool_script status="completed">\n<result>\n${returnedText}\n</result>\n${logBlock}${traceBlock}</tool_script>`,
+            output: `<tool_script status="completed">\n<return_value>\n${returnedText}\n</return_value>\n${logBlock}${traceBlock}</tool_script>`,
           }
         }).pipe(Effect.orDie),
     }

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -169,7 +169,7 @@ export const ToolScriptTool = Tool.define(
             return {
               title: "code too large",
               metadata: { status: "code_error", toolCalls: 0 },
-              output: `status: code_error\ncode exceeds ${MAX_CODE_BYTES} bytes`,
+              output: `<tool_script status="code_error">\n<error>\ncode exceeds ${MAX_CODE_BYTES} bytes\n</error>\n</tool_script>`,
             }
           }
 
@@ -205,7 +205,7 @@ export const ToolScriptTool = Tool.define(
             return {
               title: "transpile error",
               metadata: { status: "code_error", toolCalls: 0 },
-              output: `status: code_error\n${transpiled.error}`,
+              output: `<tool_script status="code_error">\n<error>\n${transpiled.error}\n</error>\n</tool_script>`,
             }
           }
 
@@ -313,8 +313,8 @@ export const ToolScriptTool = Tool.define(
           const traceLines = trace.map(
             (t) => `- ${t.name} → ${t.status}${t.error ? ` (${t.error.slice(0, 200)})` : ""} [${t.durationMs}ms]`,
           )
-          const logBlock = logs.length ? `\n\nLogs:\n${logs.join("\n")}` : ""
-          const traceBlock = trace.length ? `\n\nTool calls (${trace.length}):\n${traceLines.join("\n")}` : ""
+          const logBlock = logs.length ? `<logs>\n${logs.join("\n")}\n</logs>\n` : ""
+          const traceBlock = trace.length ? `<trace count="${trace.length}">\n${traceLines.join("\n")}\n</trace>\n` : ""
 
           if (outcome._tag === "Failure") {
             const message = outcome.failure instanceof Error ? outcome.failure.message : String(outcome.failure)
@@ -329,23 +329,32 @@ export const ToolScriptTool = Tool.define(
             return {
               title: status,
               metadata: { status, toolCalls: trace.length },
-              output: `status: ${status}\n${message}${logBlock}${traceBlock}`,
+              output: `<tool_script status="${status}">\n<error>\n${message}\n</error>\n${logBlock}${traceBlock}</tool_script>`,
             }
           }
 
-          const json = JSON.stringify(outcome.success, null, 2) ?? "undefined"
-          if (Buffer.byteLength(json, "utf8") > MAX_RESULT_BYTES) {
+          // XML-wrap the return value verbatim: no JSON.stringify → no \n / \" escaping
+          // pollution. Strings pass through as-is; non-strings are rendered with
+          // JSON.stringify (indented) so the shape is still readable.
+          const returned = outcome.success
+          const returnedText =
+            returned === undefined
+              ? "undefined"
+              : typeof returned === "string"
+                ? returned
+                : JSON.stringify(returned, null, 2)
+          if (Buffer.byteLength(returnedText, "utf8") > MAX_RESULT_BYTES) {
             return {
               title: "result too large",
               metadata: { status: "budget_exceeded", toolCalls: trace.length },
-              output: `status: budget_exceeded\nreturned value is ${json.length} bytes (max ${MAX_RESULT_BYTES}). Aggregate or slice the data before returning.${logBlock}${traceBlock}`,
+              output: `<tool_script status="budget_exceeded">\n<error>\nreturned value is ${returnedText.length} bytes (max ${MAX_RESULT_BYTES}). Aggregate or slice the data before returning.\n</error>\n${logBlock}${traceBlock}</tool_script>`,
             }
           }
 
           return {
             title: `${trace.length} tool calls`,
             metadata: { status: "completed", toolCalls: trace.length },
-            output: `status: completed\n\nResult:\n${json}${logBlock}${traceBlock}`,
+            output: `<tool_script status="completed">\n<result>\n${returnedText}\n</result>\n${logBlock}${traceBlock}</tool_script>`,
           }
         }).pipe(Effect.orDie),
     }

--- a/packages/opencode/src/tool/tool-script.txt
+++ b/packages/opencode/src/tool/tool-script.txt
@@ -42,7 +42,7 @@ const hits = JSON.parse(await files.readText("/tmp/scan-results.json"))
 
 ## Output format
 
-The tool result comes back as XML-wrapped fields (status, result, logs, trace) — the `return` value is embedded verbatim inside a `<result>` block, not JSON-escaped, so newlines and quotes stay readable.
+The tool result comes back wrapped as `<tool_script status="...">` with three child blocks — `<return_value>`, `<logs>`, `<trace>` — plus `<error_message>` on failure paths. The `return` value is embedded verbatim inside `<return_value>` (not JSON-escaped), so newlines and quotes stay readable. `<return_value>` / `<error_message>` use distinctive names so common words in the returned content (e.g. the literal token "result" or "error") won't be confused for tag boundaries.
 
 ## Example (correct use)
 

--- a/packages/opencode/src/tool/tool-script.txt
+++ b/packages/opencode/src/tool/tool-script.txt
@@ -1,11 +1,31 @@
-Execute a TypeScript script that orchestrates existing tools programmatically. Use this for BATCH tool operations: loops, concurrency, filtering, and aggregation over many tool calls — the intermediate results stay OUT of the conversation context; only what you `return` comes back.
+Execute a TypeScript script that orchestrates existing tools programmatically.
+
+## USE THIS TOOL SPARINGLY
+
+Prefer direct tool calls almost always. `tool_script` exists for ONE narrow purpose: HIDING large or numerous intermediate tool results from the conversation context, keeping only a small aggregated value. If the intermediate results are useful to see, do NOT use this tool — direct calls give the user (and you) the native per-call TUI rendering, which is lost when calls are wrapped here.
+
+### Do NOT use tool_script when
+- A single tool call would do — call the tool directly.
+- Fewer than ~5 same-tool calls — call them directly (in parallel if independent). The per-call output is more readable than an aggregated dump.
+- You want to see each step's output — direct calls preserve titles, outputs, and per-tool renderers.
+- The next step's decision depends on judging the previous step's output — stay in the normal loop.
+- Side-effects need per-step review (writes, deletes, network mutations) — do them one at a time.
+
+### Only use tool_script when ALL of these hold
+- You will make many similar tool calls (typically 10+) and DO NOT need the intermediate outputs in context.
+- You can express the final answer as a small aggregate (a count, a filtered list of paths, a sorted top-N).
+- The reduction (filter/sort/count) is mechanical and deterministic — no semantic judgment per item.
+
+Typical fit: "scan 40 files for a pattern and return the top 10 matches" — 40 reads collapsed into a list of 10.
+
+## Contract
 
 The `code` argument is the BODY of an async function (TypeScript or JavaScript):
-- Call tools via the `tools` object, e.g. `await tools.glob({ pattern: "src/**/*.ts" })`
-- Every tool returns `Promise<ToolResult>` where `ToolResult = { title: string; output: string; metadata: Record<string, unknown> }` — `output` is the same text you would see when calling the tool directly (may be truncated for very large outputs; check `metadata.truncated`).
+- Call tools via the `tools` object: `await tools.glob({ pattern: "src/**/*.ts" })`.
+- Every tool returns `Promise<ToolResult>` where `ToolResult = { title: string; output: string; metadata: Record<string, unknown> }`. `output` is the same text the tool prints when called directly (may be truncated for very large outputs; check `metadata.truncated`).
 - Use `Promise.all` / `Promise.allSettled` for concurrency (max 8 in flight; excess queue automatically).
-- `console.log(...)` output is captured and returned alongside the result (capped) — use it for debugging, not as the primary channel.
-- `return` a SMALL, aggregated value (object/array/string). Returning huge raw data defeats the purpose.
+- `console.log(...)` output is captured and returned alongside the result (capped). Use it for debugging, not as the primary output channel.
+- `return` a SMALL, aggregated value. Returning large raw data defeats the point — the tool will hide the intermediate results but if your return value is huge, the context is polluted anyway.
 
 Limits per execution: 50 tool calls, 8 concurrent, 60s of pure compute time (time spent waiting on tool calls is NOT charged), result capped at 256KB. Exceeding a limit fails the execution with a structured error.
 
@@ -20,18 +40,14 @@ const hits = JSON.parse(await files.readText("/tmp/scan-results.json"))
 
 `tools.*` outputs are the AGENT-FACING text (e.g. `read` prefixes lines with `N: ` line numbers and may truncate). That is fine for scanning/matching, but for exact bytes (parsing JSON, byte-accurate content) use `files.readText` instead — raw content, no line numbers, no truncation. `files.readText` covers the project worktree and the OS temp dir; `files.writeText` is limited to the OS temp dir — project file writes must go through `tools.write` / `tools.edit` so permissions apply.
 
-When to use tool_script:
-- Same tool called many times (read 30 files, grep 10 patterns)
-- Results need deterministic filtering/aggregation/sorting/counting before you see them
-- Large intermediate outputs you don't need to read verbatim
+## Output format
 
-When NOT to use tool_script:
-- A single tool call — call the tool directly
-- Each step needs semantic judgment on the previous result — stay in the normal loop
-- You need to visually inspect results (images, screenshots)
-- High-risk side effects better done one at a time with your review between steps
+The tool result comes back as XML-wrapped fields (status, result, logs, trace) — the `return` value is embedded verbatim inside a `<result>` block, not JSON-escaped, so newlines and quotes stay readable.
 
-Example:
+## Example (correct use)
+
+Scan every TypeScript file for TODO comments; return the top 20 files by TODO count. 40+ reads collapsed into a 20-item list:
+
 ```
 const files = await tools.glob({ pattern: "src/**/*.ts" })
 const paths = files.output.split("\n").filter(p => p.trim() && !p.startsWith("("))

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -155,7 +155,7 @@ describe("tool_script", () => {
 
   test("console.log is captured into Logs block", async () => {
     const result = await runToolScript(`console.log("hello", { a: 1 }); return 1`, [])
-    expect(result.output).toContain("Logs:")
+    expect(result.output).toContain("<logs>")
     expect(result.output).toContain('hello {"a":1}')
   })
 


### PR DESCRIPTION
## Two problems

### 1. Description over-recommended the tool

The old description opened with *"Use this for BATCH tool operations"* and buried the "when NOT to use" list mid-document. Combined with a small-scale example (glob → read a handful of files → filter), it read as endorsing `tool_script` for routine multi-step work — including cases where 2 or 3 direct tool calls in parallel would have been strictly better (each call gets its own TUI title/output/metadata panel and its own agent-facing result; wrapping in `tool_script` collapses that into one aggregated string).

Rewritten:

- Opens with **"USE THIS TOOL SPARINGLY"**.
- Front-loads the "Do NOT use" list (single call, < ~5 same-tool calls, need to see per-step output, decision depends on prior step, side-effects needing per-step review).
- Quantifies the threshold: `~10+` similar calls where intermediate outputs don't need to be seen.
- Replaces the example with a 40-files → top-20 aggregation that actually demonstrates the hiding-intermediate-results value.

### 2. Return values were double-escaped

The old output packed the return value through `JSON.stringify(v, null, 2)` and inlined it into a plain-text envelope:

```
status: completed

Result:
"line1\nline2"
```

For string returns, this meant the model (and the TUI) saw literal `\n` byte sequences instead of real newlines — every user-facing "newline" in the return value was rendered as the two characters `\` and `n`.

Wrap the tool result in `<tool_script status="...">` XML blocks with `<return_value>`, `<logs>`, `<trace>` children (`<error_message>` on failure paths):

```
<tool_script status="completed">
<return_value>
line1
line2
</return_value>
<trace count="1">
- read → success [12ms]
</trace>
</tool_script>
```

- **Strings pass through verbatim** — newlines and quotes stay readable.
- **Non-strings** still go through `JSON.stringify(v, null, 2)` since JSON is their natural representation; the shape stays inspectable and the JSON output is embedded in `<return_value>` without a second layer of escaping.
- Error / budget-exceeded / timeout / cancelled / code-error paths all follow the same shape (`<error_message>` instead of `<return_value>`), so a downstream parser sees one consistent structure.
- `<return_value>` and `<error_message>` use distinctive names so common words in the returned content (the literal token `result` or `error`) don't blur the tag boundary. `<logs>` and `<trace>` keep their names — those closing forms are rare enough in real content that ambiguity is negligible.

### Follow-up (this PR): tag rename + accurate byte-length reporting

Two tweaks on top of the initial XML output:

- **Tag rename**: `<result>` → `<return_value>`, `<error>` → `<error_message>` (see rationale above). Outer `<tool_script>` wrapper stays — it's unlikely to collide with returned content.
- **Byte-length accuracy**: `budget_exceeded` message now reports `Buffer.byteLength(returnedText, "utf8")` instead of JS string `.length`, matching the gate above. Non-ASCII returns no longer under-report their size.

## Compatibility

The TUI renderer (`session/index.tsx:2133/2277`) reads `part.state.output` as a plain string and renders it as fenced text — so it treats XML as text and displays it faithfully. No renderer changes are needed; a follow-up PR could split `<return_value>` / `<logs>` / `<trace>` into separate collapsible panels but that's out of scope here.

## Tests

Only one assertion needed updating (`"Logs:"` → `"<logs>"`); every other test assertion was a substring match that survives the new format (`echo:a`, `caught:`, `→ error`, `[\n  2,\n  4,\n  6\n]` indentation, etc.).

`bun test test/tool/tool-script.test.ts` → **23 pass · 0 fail**. `bun typecheck` → **EXIT 0**.
