### PR TITLE
docs(agents): use `bun ci` for dependency install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - The default branch in this repo is `main`.
 - CI triggers on both `main` and `dev` branches.
 - Prefer automation: execute requested actions without confirmation unless blocked by missing info or safety/irreversibility.
+- Install deps with `bun ci` (= `bun install --frozen-lockfile`) — install per `bun.lock`, don't mutate the lockfile. ⛔ Do NOT use `bun install`/`npm install`.
 
 ## Core Focus (as of 2025-06-18)
 


### PR DESCRIPTION
## Summary
- Add an AGENTS.md guideline: install dependencies with `bun ci` (= `bun install --frozen-lockfile`) so installs honor `bun.lock` and never mutate it; avoid `bun install`/`npm install`.

## Why
Keeps lockfile-driven installs reproducible and prevents accidental `bun.lock` churn during routine installs.