### PR TITLE
fix(tool_script): serialization contract, sandbox jail, MCP dispatch,and opt-in gating

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -146,6 +146,13 @@ export const Flag = {
   MIMOCODE_SERVER_USERNAME: process.env["MIMOCODE_SERVER_USERNAME"],
   MIMOCODE_ENABLE_QUESTION_TOOL: truthy("MIMOCODE_ENABLE_QUESTION_TOOL"),
 
+  // Defaults to false (tool_script hidden). Set MIMOCODE_ENABLE_TOOL_SCRIPT=true
+  // (or 1, or the umbrella MIMOCODE_EXPERIMENTAL) to register the tool_script
+  // sandbox tool. Getter so tests can flip the env var at runtime.
+  get MIMOCODE_ENABLE_TOOL_SCRIPT() {
+    return MIMOCODE_EXPERIMENTAL || truthy("MIMOCODE_ENABLE_TOOL_SCRIPT")
+  },
+
   // Defaults to false. Set MIMOCODE_ENABLE_TRY_BEST_HANDOFF=true (or 1) to
   // enable try-best loop detection, automatic turn pausing, and handoff UI.
   MIMOCODE_ENABLE_TRY_BEST_HANDOFF: truthy("MIMOCODE_ENABLE_TRY_BEST_HANDOFF"),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -65,6 +65,7 @@ import { builtinSkillRoot, matchDocumentSkills } from "@/skill/builtin/extract"
 import { ToolRegistry } from "../tool"
 import { MCP } from "../mcp"
 import { normalizeToolResult } from "../mcp/tool-result"
+import { toolScriptMcp } from "../tool/tool-script-ref"
 import { LSP } from "../lsp"
 import { Flag } from "../flag/flag"
 import { ulid } from "ulid"
@@ -303,6 +304,12 @@ export const layer = Layer.effect(
     const llm = yield* LLM.Service
     const actorRegistry = yield* ActorRegistry.Service
     const inbox = yield* Inbox.Service
+
+    // Late-bound ref (see tool-script-ref.ts): tool_script dispatches MCP tools
+    // through the same live client set the agent sees. Populated here (not in
+    // ToolRegistry) because MCP's layer lives in this graph — the registry
+    // providing MCP.defaultLayer itself would duplicate client connections.
+    toolScriptMcp.current = () => mcp.tools()
 
     // Track sessions that have already shown the "loaded instructions" toast so we
     // surface it once per primary session rather than on every run-loop turn.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -69,7 +69,7 @@ import * as BashInteractive from "./bash-interactive"
 import { resolveInvocationStyle } from "./invocation-style"
 import { BuiltinWorkflow } from "@/workflow/builtin"
 import { ToolScriptTool, renderToolScriptDeclarations } from "./tool-script"
-import { toolScriptRegistry } from "./tool-script-ref"
+import { toolScriptRegistry, toolScriptMcp } from "./tool-script-ref"
 
 const log = Log.create({ service: "tool.registry" })
 
@@ -282,7 +282,7 @@ export const layer = Layer.effect(
             tool.memory,
             tool.history,
             tool.task,
-            tool.toolscript,
+            ...(Flag.MIMOCODE_ENABLE_TOOL_SCRIPT ? [tool.toolscript] : []),
             ...(Flag.MIMOCODE_EXPERIMENTAL_CRON ? [tool.cron] : []),
             ...(Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR ? [tool.session] : []),
             ...(Flag.MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL ? [tool.workflow] : []),
@@ -332,7 +332,10 @@ export const layer = Layer.effect(
     })
 
     const describeToolScript = Effect.fn("ToolRegistry.describeToolScript")(function* () {
-      return renderToolScriptDeclarations(yield* all())
+      // MCP declarations ride along when SessionPrompt has populated the ref
+      // (interactive sessions); registry-only contexts render builtins only.
+      const mcp = toolScriptMcp.current ? yield* toolScriptMcp.current() : {}
+      return renderToolScriptDeclarations(yield* all(), mcp)
     })
 
     const describeTask = Effect.fn("ToolRegistry.describeTask")(function* (agent: Agent.Info) {

--- a/packages/opencode/src/tool/tool-script-ref.ts
+++ b/packages/opencode/src/tool/tool-script-ref.ts
@@ -6,14 +6,29 @@
 // the registry layer populates this module-local reference on initialisation and
 // the tool reads it at call time.
 import type { Effect } from "effect"
+import type { Tool as AiTool } from "ai"
 import type * as Tool from "./tool"
 
 export const toolScriptRegistry: {
   current: (() => Effect.Effect<Tool.Def[]>) | undefined
 } = { current: undefined }
 
+// MCP tools live outside ToolRegistry (SessionPrompt assembles them straight
+// from MCP.Service), so tool_script reaches them through this second ref,
+// populated by the SessionPrompt layer. Reusing the ref pattern keeps MCP's
+// layer out of the registry graph — providing MCP.defaultLayer to the registry
+// would spin up a SECOND set of MCP client connections.
+export const toolScriptMcp: {
+  current: (() => Effect.Effect<Record<string, AiTool>>) | undefined
+} = { current: undefined }
+
 // Agent control-flow tools make no sense inside a script (they steer the
 // conversation, not data) — excluded from both the declared API and dispatch.
+// bash is excluded as a policy choice, not control-flow: it is the universal
+// escape hatch (network, deletes, arbitrary side effects), and burying up to
+// 50 shell commands inside one opaque script defeats per-command review even
+// though each still triggers Permission.ask. Batch shell work belongs in ONE
+// reviewable bash call running a script, not a tool_script loop.
 export const TOOL_SCRIPT_EXCLUDED = new Set([
   "tool_script",
   "invalid",
@@ -27,4 +42,5 @@ export const TOOL_SCRIPT_EXCLUDED = new Set([
   "session",
   "workflow",
   "change_directory",
+  "bash",
 ])

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -1,19 +1,27 @@
 import z from "zod"
 import os from "os"
+import fs from "fs"
 import path from "path"
 import { Effect } from "effect"
+import { asSchema, type Tool as AiTool } from "ai"
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import { EffectBridge, InstanceState } from "@/effect"
 import { Log, Filesystem } from "@/util"
+import { Agent } from "@/agent/agent"
+import { normalizeToolResult } from "../mcp/tool-result"
 import { evalScript, type HostFn } from "../workflow/sandbox"
-import { toolScriptRegistry, TOOL_SCRIPT_EXCLUDED } from "./tool-script-ref"
+import { toolScriptRegistry, toolScriptMcp, TOOL_SCRIPT_EXCLUDED } from "./tool-script-ref"
 import DESCRIPTION from "./tool-script.txt"
 import * as Tool from "./tool"
+import * as Truncate from "./truncate"
 
 const log = Log.create({ service: "tool.tool_script" })
 
-const MAX_TOOL_CALLS = 50
+const MAX_TOOL_CALLS_DEFAULT = 50
+const MAX_TOOL_CALLS_CEILING = 500
 const MAX_CONCURRENT = 8
-const ACTIVE_DEADLINE_MS = 60_000
+const ACTIVE_DEADLINE_S_DEFAULT = 60
+const ACTIVE_DEADLINE_S_CEILING = 600
 const WALL_DEADLINE_MS = 30 * 60 * 1000
 const MAX_RESULT_BYTES = 256 * 1024
 const MAX_LOG_BYTES = 64 * 1024
@@ -58,7 +66,7 @@ function schemaToTs(schema: any): string {
 }
 
 /** Render the `tools` API declaration block appended to the tool description. */
-export function renderToolScriptDeclarations(defs: Tool.Def[]): string {
+export function renderToolScriptDeclarations(defs: Tool.Def[], mcp: Record<string, AiTool> = {}): string {
   const lines = defs
     .filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id))
     .map((def) => {
@@ -66,11 +74,17 @@ export function renderToolScriptDeclarations(defs: Tool.Def[]): string {
       const input = schemaToTs(z.toJSONSchema(def.parameters))
       return `  /** ${summary.trim().slice(0, 200)} */\n  ${def.id}(input: ${input}): Promise<ToolResult>`
     })
+  const mcpLines = Object.entries(mcp).map(([id, tool]) => {
+    const summary = (tool.description ?? "").split("\n").find((l) => l.trim()) ?? ""
+    const input = schemaToTs(asSchema(tool.inputSchema).jsonSchema)
+    return `  /** [MCP] ${summary.trim().slice(0, 200)} */\n  ${id}(input: ${input}): Promise<ToolResult>`
+  })
   return [
     "```ts",
     "type ToolResult = { title: string; output: string; metadata: Record<string, unknown> }",
     "declare const tools: {",
     ...lines,
+    ...mcpLines,
     "}",
     "// Raw file IO for machine-to-machine data (pipelines across executions).",
     "declare const files: {",
@@ -94,9 +108,116 @@ const tools = new Proxy({}, {
       throw e instanceof Error ? e : new Error(String(e));
     }),
 });
+// Explicit JSON-safe serializer. JSON.stringify (and the sandbox marshal
+// fallback) silently degrades non-JSON values — circular refs became
+// "[object Object]", NaN became null with no signal, Error lost its message.
+// strict mode (return values): unserializable → throw with a $.path; lossy
+// conversions → recorded warnings. lenient mode (console.log): never throws,
+// inlines markers like [Circular] instead.
+function __serialize(root, lenient) {
+  const warnings = [];
+  const seen = new Set();
+  const segs = [];
+  const at = () => "$" + segs.join("");
+  const warn = (m) => { if (warnings.length < 20) warnings.push(m); };
+  const errMsg = (e) => (e && e.message ? e.message : String(e));
+  const walk = (v) => {
+    if (v === null) return null;
+    const t = typeof v;
+    if (t === "string" || t === "boolean") return v;
+    if (t === "number") {
+      if (Number.isFinite(v)) return v;
+      const label = Number.isNaN(v) ? "NaN" : v > 0 ? "Infinity" : "-Infinity";
+      if (lenient) return label;
+      warn(label + " at " + at() + " serialized as null");
+      return null;
+    }
+    if (t === "bigint") {
+      if (lenient) return String(v) + "n";
+      throw new Error("return value is not JSON-serializable: BigInt at " + at() + " — convert with Number() or String() before returning");
+    }
+    if (t === "undefined") return undefined;
+    if (t === "function") {
+      if (lenient) return "[function]";
+      warn("function at " + at() + " dropped (not JSON-serializable)");
+      return undefined;
+    }
+    if (t === "symbol") {
+      if (lenient) return String(v);
+      warn("symbol at " + at() + " dropped (not JSON-serializable)");
+      return undefined;
+    }
+    if (v instanceof Error) {
+      if (!lenient) warn("Error at " + at() + " serialized as {name, message, stack}");
+      return { name: v.name, message: v.message, stack: v.stack };
+    }
+    if (v instanceof Promise) {
+      if (lenient) return "[Promise]";
+      warn("unawaited Promise at " + at() + " serialized as null — did you forget an await?");
+      return null;
+    }
+    if (seen.has(v)) {
+      if (lenient) return "[Circular]";
+      throw new Error("return value is not JSON-serializable: circular reference at " + at());
+    }
+    if (v instanceof RegExp) {
+      if (!lenient) warn("RegExp at " + at() + " serialized as its string form");
+      return String(v);
+    }
+    let obj = v;
+    if (v instanceof Map) {
+      if (!lenient) warn("Map at " + at() + " serialized as an entries array");
+      obj = Array.from(v.entries());
+    } else if (v instanceof Set) {
+      if (!lenient) warn("Set at " + at() + " serialized as a values array");
+      obj = Array.from(v.values());
+    } else if (typeof v.toJSON === "function") {
+      let j;
+      try { j = v.toJSON(); } catch (e) {
+        if (lenient) return "[toJSON threw: " + errMsg(e) + "]";
+        throw new Error("toJSON at " + at() + " threw: " + errMsg(e));
+      }
+      if (j !== v) return walk(j);
+    }
+    seen.add(v);
+    try {
+      if (Array.isArray(obj)) {
+        const out = [];
+        for (let i = 0; i < obj.length; i++) {
+          segs.push("[" + i + "]");
+          const w = walk(obj[i]);
+          out.push(w === undefined ? null : w);
+          segs.pop();
+        }
+        return out;
+      }
+      const out = {};
+      for (const key of Object.keys(obj)) {
+        segs.push("." + key);
+        let pv;
+        try { pv = obj[key]; } catch (e) {
+          if (lenient) { out[key] = "[getter threw: " + errMsg(e) + "]"; segs.pop(); continue; }
+          throw new Error("return value is not JSON-serializable: getter at " + at() + " threw: " + errMsg(e));
+        }
+        const w = walk(pv);
+        if (w !== undefined) out[key] = w;
+        segs.pop();
+      }
+      return out;
+    } finally { seen.delete(v); }
+  };
+  return { value: walk(root), warnings };
+}
 const __fmt = (x) => {
   if (typeof x === "string") return x;
-  try { return JSON.stringify(x); } catch { return String(x); }
+  if (x instanceof Error) {
+    const head = x.name + ": " + x.message;
+    return x.stack ? head + "\\n" + x.stack : head;
+  }
+  try {
+    const v = __serialize(x, true).value;
+    return v === undefined ? "undefined" : JSON.stringify(v);
+  } catch { return String(x); }
 };
 const console = {
   log: (...a) => __log(a.map(__fmt).join(" ")),
@@ -116,12 +237,30 @@ const files = {
 
 /** Jail for the `files` raw-IO primitives. Read: worktree + OS tmp. Write: OS
  * tmp ONLY — project writes must go through tools.write/edit so Permission.ask
- * applies (enforced here, not just advised in the prompt). Lexical containment
- * (same posture as workflow's resolveInWorkspace) — blocks `..` traversal and
- * out-of-jail absolutes; symlink resolution deferred. */
+ * applies (enforced here, not just advised in the prompt). Containment is
+ * checked on REALPATHS: macOS /tmp and /var are symlinks into /private, so a
+ * lexical check rejects the literal "/tmp/x" even though it lives inside the
+ * canonical os.tmpdir() jail. For not-yet-existing targets (writes) the
+ * deepest existing ancestor is canonicalized and the remainder re-appended. */
+function realpathBestEffort(p: string): string {
+  let cur = p
+  let suffix = ""
+  while (true) {
+    try {
+      return path.join(fs.realpathSync.native(cur), suffix)
+    } catch {
+      suffix = suffix ? path.join(path.basename(cur), suffix) : path.basename(cur)
+      const parent = path.dirname(cur)
+      if (parent === cur) return p
+      cur = parent
+    }
+  }
+}
+
 function resolveJailed(roots: string[], p: string, kind: "read" | "write"): string {
-  const abs = path.resolve(roots[0], p)
-  if (roots.some((root) => abs === root || Filesystem.contains(root, abs))) return abs
+  const canonRoots = roots.map(realpathBestEffort)
+  const abs = realpathBestEffort(path.resolve(canonRoots[0], p))
+  if (canonRoots.some((root) => abs === root || Filesystem.contains(root, abs))) return abs
   throw new Error(
     kind === "write"
       ? `files.writeText is limited to the OS temp dir — write project files via tools.write/tools.edit: ${JSON.stringify(p)}`
@@ -154,6 +293,8 @@ function makeSemaphore(max: number) {
 export const ToolScriptTool = Tool.define(
   "tool_script",
   Effect.gen(function* () {
+    const truncate = yield* Truncate.Service
+    const agents = yield* Agent.Service
     return {
       description: DESCRIPTION,
       parameters: z.object({
@@ -162,9 +303,29 @@ export const ToolScriptTool = Tool.define(
           .describe(
             "TypeScript (or JavaScript) source for the body of an async function. Call tools via the global `tools` object; `return` the final aggregated value.",
           ),
+        max_tool_calls: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_TOOL_CALLS_CEILING)
+          .optional()
+          .describe(
+            `Tool call budget for this execution (default ${MAX_TOOL_CALLS_DEFAULT}, max ${MAX_TOOL_CALLS_CEILING}). Raise it only when the work genuinely needs more calls.`,
+          ),
+        timeout_seconds: z
+          .number()
+          .int()
+          .min(1)
+          .max(ACTIVE_DEADLINE_S_CEILING)
+          .optional()
+          .describe(
+            `Compute-time budget in seconds (default ${ACTIVE_DEADLINE_S_DEFAULT}, max ${ACTIVE_DEADLINE_S_CEILING}). Counts only active script compute — time parked on tool calls is not charged.`,
+          ),
       }),
-      execute: (params: { code: string }, ctx: Tool.Context) =>
+      execute: (params: { code: string; max_tool_calls?: number; timeout_seconds?: number }, ctx: Tool.Context) =>
         Effect.gen(function* () {
+          const maxToolCalls = params.max_tool_calls ?? MAX_TOOL_CALLS_DEFAULT
+          const activeDeadlineMs = (params.timeout_seconds ?? ACTIVE_DEADLINE_S_DEFAULT) * 1000
           if (Buffer.byteLength(params.code, "utf8") > MAX_CODE_BYTES) {
             return {
               title: "code too large",
@@ -177,11 +338,20 @@ export const ToolScriptTool = Tool.define(
           if (!getDefs) throw new Error("tool_script registry unavailable")
           const defs = (yield* getDefs()).filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id))
           const byId = new Map(defs.map((def) => [def.id, def]))
+          // MCP tools (late-bound ref, populated by SessionPrompt). Builtin ids
+          // win on collision — an MCP server must not shadow `read`/`grep`.
+          const mcpTools = toolScriptMcp.current ? yield* toolScriptMcp.current() : {}
+          const mcpById = new Map(Object.entries(mcpTools).filter(([id]) => !byId.has(id)))
+          const agentInfo = yield* agents.get(ctx.agent)
           // Non-git projects report worktree === "/" (see Instance.containsPath) —
           // "/" as a jail root would allow EVERYTHING. Fall back to the project
           // directory in that case. Relative guest paths resolve against roots[0].
+          // "/tmp" is allowed alongside os.tmpdir(): on macOS they are DIFFERENT
+          // directories (/private/tmp vs /private/var/folders/...), and the tool
+          // description's staging example uses "/tmp/..." — both must work.
           const ins = yield* InstanceState.context
-          const jailRoots = [ins.worktree === "/" ? ins.directory : ins.worktree, os.tmpdir()]
+          const tmpRoots = [os.tmpdir(), ...(process.platform === "win32" ? [] : ["/tmp"])]
+          const jailRoots = [ins.worktree === "/" ? ins.directory : ins.worktree, ...tmpRoots]
 
           // Snapshot the Effect context BEFORE crossing into Promise-land: the
           // quickjs hook boundary loses Instance/Workspace context otherwise.
@@ -191,16 +361,28 @@ export const ToolScriptTool = Tool.define(
           // (top-level `return`/`await`), which is invalid at module top level —
           // Bun.Transpiler would reject it. The wrapped form transpiles to a plain
           // JS async-arrow expression the guest body can invoke.
+          // Bun surfaces syntax errors as BuildMessage (single) or AggregateError
+          // (several), each carrying a position. Report line/column relative to
+          // the CALLER's code (the wrapper adds one line above), plus the source
+          // line text — a bare "Parse error" is undebuggable in a 100-line script.
+          const formatBuildError = (err: unknown): string => {
+            const messages = err instanceof AggregateError ? err.errors : [err]
+            const rendered = messages
+              .map((m: any) => {
+                const pos = m?.position
+                if (!pos || typeof pos.line !== "number") return String(m?.message ?? m)
+                return `line ${pos.line - 1}, column ${pos.column}: ${m.message}\n  ${pos.lineText ?? ""}`
+              })
+              .join("\n")
+            const importHint = /^\s*(import|export)\s/m.test(params.code)
+              ? "\nnote: import/export are NOT supported — the code runs as a sandboxed function body. Use the provided `tools` / `files` globals instead of Node modules."
+              : ""
+            return `TypeScript transpile failed:\n${rendered}${importHint}`
+          }
           const transpiled = yield* Effect.try({
             try: () => new Bun.Transpiler({ loader: "ts" }).transformSync(`globalThis.__main = async () => {\n${params.code}\n}`),
             catch: (err) => err,
-          }).pipe(
-            Effect.catch((err) =>
-              Effect.succeed({
-                error: `TypeScript transpile failed: ${err instanceof Error ? err.message : String(err)}`,
-              }),
-            ),
-          )
+          }).pipe(Effect.catch((err) => Effect.succeed({ error: formatBuildError(err) })))
           if (typeof transpiled === "object") {
             return {
               title: "transpile error",
@@ -232,23 +414,57 @@ export const ToolScriptTool = Tool.define(
           const callTool: HostFn = (name: unknown, args: unknown) => {
             const id = String(name)
             const def = byId.get(id)
-            if (!def) return Promise.reject(new Error(`unknown tool: ${id}`))
+            const mcpDef = def ? undefined : mcpById.get(id)
+            if (!def && !mcpDef) return Promise.reject(new Error(`unknown tool: ${id}`))
             calls++
-            if (calls > MAX_TOOL_CALLS)
-              return Promise.reject(new Error(`tool call budget exceeded (${MAX_TOOL_CALLS} per execution)`))
+            if (calls > maxToolCalls)
+              return Promise.reject(new Error(`tool call budget exceeded (${maxToolCalls} per execution)`))
             const seq = calls
             const start = Date.now()
+            const subCtx = {
+              ...ctx,
+              callID: `${ctx.callID ?? "tool_script"}:${seq}`,
+              // Sub-call metadata would clobber the outer tool_script call's
+              // title in the UI — swallow it; the trace covers observability.
+              metadata: () => Effect.void,
+            }
+            // MCP path: same permission gate as the direct SessionPrompt MCP
+            // wrapper (ask per tool name), then normalizeToolResult folds the
+            // content blocks to text. Non-text blocks (images, audio, blobs)
+            // cannot cross the sandbox string boundary — note them so the
+            // script (and the model reading the aggregate) knows data was
+            // dropped rather than absent.
+            const executeMcp = (tool: AiTool) =>
+              Effect.gen(function* () {
+                yield* ctx.ask({ permission: id, metadata: {}, patterns: ["*"], always: ["*"] })
+                const result = (yield* Effect.promise(() =>
+                  Promise.resolve(
+                    tool.execute!(args ?? {}, {
+                      toolCallId: subCtx.callID,
+                      messages: [],
+                      abortSignal: ctx.abort,
+                    }),
+                  ),
+                )) as CallToolResult
+                const normalized = normalizeToolResult(result)
+                if (normalized.isError) return yield* Effect.fail(new Error(normalized.output || "MCP tool execution failed"))
+                const dropped = normalized.attachments.length
+                  ? `\n[note: ${normalized.attachments.length} non-text attachment(s) dropped — binary content cannot cross the tool_script sandbox]`
+                  : ""
+                const truncated = yield* truncate.output(normalized.output + dropped, {}, agentInfo)
+                return {
+                  title: id,
+                  output: truncated.content,
+                  metadata: {
+                    ...normalized.metadata,
+                    truncated: truncated.truncated,
+                    ...(truncated.truncated && { outputPath: truncated.outputPath }),
+                  },
+                } satisfies Tool.ExecuteResult
+              })
             return withSlot(() =>
               bridge
-                .promise(
-                  def.execute(args, {
-                    ...ctx,
-                    callID: `${ctx.callID ?? "tool_script"}:${seq}`,
-                    // Sub-call metadata would clobber the outer tool_script call's
-                    // title in the UI — swallow it; the trace covers observability.
-                    metadata: () => Effect.void,
-                  }),
-                )
+                .promise(def ? def.execute(args, subCtx) : executeMcp(mcpDef!))
                 .then(
                   (result) => {
                     trace.push({ name: id, status: "success", durationMs: Date.now() - start })
@@ -283,10 +499,21 @@ export const ToolScriptTool = Tool.define(
             const file = Bun.file(abs)
             if (!(await file.exists())) return null
             if (file.size > MAX_FILE_BYTES) throw new Error(`file exceeds ${MAX_FILE_BYTES} bytes: ${String(p)}`)
-            return file.text()
+            // Non-UTF-8 content cannot survive the string boundary into the guest
+            // (Bun's .text() folds invalid sequences to U+FFFD and NULs previously
+            // truncated at the C-string marshal). Fail loud instead of silently
+            // returning corrupted/empty data.
+            const bytes = await file.bytes()
+            try {
+              return new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+            } catch {
+              throw new Error(
+                `file is not valid UTF-8 text (binary content cannot cross the sandbox string boundary): ${String(p)}`,
+              )
+            }
           }
           const writeText: HostFn = async (p: unknown, content: unknown) => {
-            const abs = resolveJailed([os.tmpdir()], String(p), "write")
+            const abs = resolveJailed(tmpRoots, String(p), "write")
             const text = String(content)
             if (Buffer.byteLength(text, "utf8") > MAX_FILE_BYTES)
               throw new Error(`content exceeds ${MAX_FILE_BYTES} bytes`)
@@ -296,7 +523,19 @@ export const ToolScriptTool = Tool.define(
 
           const outcome = yield* Effect.tryPromise({
             try: () =>
-              evalScript(GUEST_PRELUDE + "\n" + transpiled + "\nreturn await globalThis.__main()", {
+              // The return value is serialized IN THE GUEST via __serialize (strict):
+              // unserializable values (circular refs, BigInt, throwing getters) throw
+              // with a $.path instead of silently degrading to "[object Object]",
+              // and lossy conversions (NaN→null, Map→array, Error→plain object) are
+              // reported as warnings. The envelope crosses the boundary as plain JSON.
+              evalScript(
+                GUEST_PRELUDE +
+                  "\n" +
+                  transpiled +
+                  `\nconst __ret = await globalThis.__main();
+const __out = __serialize(__ret, false);
+return { __undef: __out.value === undefined, json: __out.value === undefined ? "" : JSON.stringify(__out.value), warnings: __out.warnings };`,
+                {
                 __callTool: callTool,
                 __log: logHook,
                 __readText: readText,
@@ -304,7 +543,7 @@ export const ToolScriptTool = Tool.define(
               }, {
                 deterministic: false,
                 deadlineMs: WALL_DEADLINE_MS,
-                activeDeadlineMs: ACTIVE_DEADLINE_MS,
+                activeDeadlineMs,
                 interrupt: () => ctx.abort.aborted,
               }),
             catch: (err) => (err instanceof Error ? err : new Error(String(err))),
@@ -325,37 +564,43 @@ export const ToolScriptTool = Tool.define(
                 : message.includes("budget exceeded")
                   ? "budget_exceeded"
                   : "code_error"
-            log.warn("tool_script failed", { status, message: message.slice(0, 500) })
+            // The raw interrupt error ({"name":"InternalError","message":"interrupted"})
+            // reads like an engine fault — explain which budget was exhausted.
+            const explained =
+              status === "timeout"
+                ? `execution exceeded its time budget (${activeDeadlineMs / 1000}s of active compute, ${WALL_DEADLINE_MS / 60000}min wall clock — time parked on tool calls is not charged against the compute budget; raise via timeout_seconds, max ${ACTIVE_DEADLINE_S_CEILING}). Original error: ${message}`
+                : message
+            log.warn("tool_script failed", { status, message: explained.slice(0, 500) })
             return {
               title: status,
               metadata: { status, toolCalls: trace.length },
-              output: `<tool_script status="${status}">\n<error_message>\n${message}\n</error_message>\n${logBlock}${traceBlock}</tool_script>`,
+              output: `<tool_script status="${status}">\n<error_message>\n${explained}\n</error_message>\n${logBlock}${traceBlock}</tool_script>`,
             }
           }
 
           // XML-wrap the return value verbatim: no JSON.stringify → no \n / \" escaping
-          // pollution. Strings pass through as-is; non-strings are rendered with
-          // JSON.stringify (indented) so the shape is still readable.
-          const returned = outcome.success
+          // pollution. Strings pass through as-is; non-strings arrive as guest-side
+          // strict-serialized JSON (see __serialize) and are re-indented for readability.
+          const envelope = outcome.success as { __undef: boolean; json: string; warnings: string[] }
+          const parsed = envelope.__undef ? undefined : (JSON.parse(envelope.json) as unknown)
           const returnedText =
-            returned === undefined
-              ? "undefined"
-              : typeof returned === "string"
-                ? returned
-                : JSON.stringify(returned, null, 2)
+            parsed === undefined ? "undefined" : typeof parsed === "string" ? parsed : JSON.stringify(parsed, null, 2)
+          const warningsBlock = envelope.warnings.length
+            ? `<warnings>\n${envelope.warnings.map((w) => `- ${w}`).join("\n")}\n</warnings>\n`
+            : ""
           const returnedBytes = Buffer.byteLength(returnedText, "utf8")
           if (returnedBytes > MAX_RESULT_BYTES) {
             return {
               title: "result too large",
               metadata: { status: "budget_exceeded", toolCalls: trace.length },
-              output: `<tool_script status="budget_exceeded">\n<error_message>\nreturned value is ${returnedBytes} bytes (max ${MAX_RESULT_BYTES}). Aggregate or slice the data before returning.\n</error_message>\n${logBlock}${traceBlock}</tool_script>`,
+              output: `<tool_script status="budget_exceeded">\n<error_message>\nreturned value is ${returnedBytes} bytes (max ${MAX_RESULT_BYTES}). Aggregate or slice the data before returning.\n</error_message>\n${warningsBlock}${logBlock}${traceBlock}</tool_script>`,
             }
           }
 
           return {
             title: `${trace.length} tool calls`,
             metadata: { status: "completed", toolCalls: trace.length },
-            output: `<tool_script status="completed">\n<return_value>\n${returnedText}\n</return_value>\n${logBlock}${traceBlock}</tool_script>`,
+            output: `<tool_script status="completed">\n<return_value>\n${returnedText}\n</return_value>\n${warningsBlock}${logBlock}${traceBlock}</tool_script>`,
           }
         }).pipe(Effect.orDie),
     }

--- a/packages/opencode/src/tool/tool-script.txt
+++ b/packages/opencode/src/tool/tool-script.txt
@@ -5,9 +5,7 @@ Execute a TypeScript script that orchestrates existing tools programmatically.
 Prefer direct tool calls almost always. `tool_script` exists for ONE narrow purpose: HIDING large or numerous intermediate tool results from the conversation context, keeping only a small aggregated value. If the intermediate results are useful to see, do NOT use this tool — direct calls give the user (and you) the native per-call TUI rendering, which is lost when calls are wrapped here.
 
 ### Do NOT use tool_script when
-- A single tool call would do — call the tool directly.
-- Fewer than ~5 same-tool calls — call them directly (in parallel if independent). The per-call output is more readable than an aggregated dump.
-- You want to see each step's output — direct calls preserve titles, outputs, and per-tool renderers.
+- Fewer than ~5 same-tool calls would do — call them directly (in parallel if independent).
 - The next step's decision depends on judging the previous step's output — stay in the normal loop.
 - Side-effects need per-step review (writes, deletes, network mutations) — do them one at a time.
 
@@ -21,13 +19,21 @@ Typical fit: "scan 40 files for a pattern and return the top 10 matches" — 40 
 ## Contract
 
 The `code` argument is the BODY of an async function (TypeScript or JavaScript):
-- Call tools via the `tools` object: `await tools.glob({ pattern: "src/**/*.ts" })`.
-- Every tool returns `Promise<ToolResult>` where `ToolResult = { title: string; output: string; metadata: Record<string, unknown> }`. `output` is the same text the tool prints when called directly (may be truncated for very large outputs; check `metadata.truncated`).
+- Call tools via the `tools` object: `await tools.glob({ pattern: "src/**/*.ts" })`. MCP tools are included under their full name: `await tools.myserver_search({ query: "..." })`.
+- Every tool returns `Promise<ToolResult>` where `ToolResult = { title: string; output: string; metadata: Record<string, unknown> }`. `output` is the same text the tool prints when called directly (may be truncated for very large outputs; check `metadata.truncated`). MCP results are folded to text; non-text content (images, audio) is dropped with a note.
+- `bash` is NOT available here — batch shell work belongs in a single reviewable bash call running a script.
 - Use `Promise.all` / `Promise.allSettled` for concurrency (max 8 in flight; excess queue automatically).
-- `console.log(...)` output is captured and returned alongside the result (capped). Use it for debugging, not as the primary output channel.
-- `return` a SMALL, aggregated value. Returning large raw data defeats the point — the tool will hide the intermediate results but if your return value is huge, the context is polluted anyway.
+- `console.log(...)` output is captured and returned alongside the result (capped at 64KB). Use it for debugging, not as the primary output channel.
+- `return` a SMALL, aggregated value.
 
-Limits per execution: 50 tool calls, 8 concurrent, 60s of pure compute time (time spent waiting on tool calls is NOT charged), result capped at 256KB. Exceeding a limit fails the execution with a structured error.
+### Environment (minimal sandbox — NOT Node, NOT a browser)
+- Available: JS language built-ins (`JSON`, `Math`, `Date`, `Promise`, `RegExp`, ...), a minimal `URL`, plus the injected `tools`, `files`, `console`.
+- NOT available: `import`/`export`/`require` (code is a function body — a top-level import is a syntax error), `setTimeout`/`setInterval`, `fetch`, `crypto`, `Buffer`, `TextEncoder`, `structuredClone`, `process`. Anything needing a module, a timer, or a shell belongs in the normal agent loop.
+
+### Return value serialization
+The returned value must be JSON-serializable. Circular references, BigInt, and throwing getters FAIL the execution with the offending path (e.g. `$.items[3].self`) — they do not silently degrade. Lossy-but-accepted conversions are applied and reported in a `<warnings>` block: `NaN`/`Infinity` → null, `Map` → entries array, `Set` → values array, `Error` → `{name, message, stack}`, `RegExp` → string, unawaited `Promise` → null, functions/symbols → dropped.
+
+Limits per execution: 50 tool calls (default — raise via `max_tool_calls`, hard cap 500), 8 concurrent, 60s of pure compute time (default — raise via `timeout_seconds`, hard cap 600; time spent waiting on tool calls is NOT charged), result capped at 256KB, logs capped at 64KB. Exceeding a limit fails the execution with a structured error.
 
 Permissions are enforced per tool call exactly as if you had called the tool directly — calls may pause awaiting user approval; a user rejection rejects that call's promise (catchable).
 
@@ -38,11 +44,11 @@ await files.writeText("/tmp/scan-results.json", JSON.stringify(hits))
 const hits = JSON.parse(await files.readText("/tmp/scan-results.json"))
 ```
 
-`tools.*` outputs are the AGENT-FACING text (e.g. `read` prefixes lines with `N: ` line numbers and may truncate). That is fine for scanning/matching, but for exact bytes (parsing JSON, byte-accurate content) use `files.readText` instead — raw content, no line numbers, no truncation. `files.readText` covers the project worktree and the OS temp dir; `files.writeText` is limited to the OS temp dir — project file writes must go through `tools.write` / `tools.edit` so permissions apply.
+`tools.*` outputs are the AGENT-FACING text (e.g. `read` prefixes lines with `N: ` line numbers and may truncate). That is fine for scanning/matching, but for exact bytes (parsing JSON, byte-accurate content) use `files.readText` instead — raw content, no line numbers, no truncation. `files.readText` covers the project worktree and the OS temp dir; `files.writeText` is limited to the OS temp dir — project file writes must go through `tools.write` / `tools.edit` so permissions apply. Both are TEXT-only: reading a file that is not valid UTF-8 throws (binary content cannot cross the sandbox string boundary).
 
 ## Output format
 
-The tool result comes back wrapped as `<tool_script status="...">` with three child blocks — `<return_value>`, `<logs>`, `<trace>` — plus `<error_message>` on failure paths. The `return` value is embedded verbatim inside `<return_value>` (not JSON-escaped), so newlines and quotes stay readable. `<return_value>` / `<error_message>` use distinctive names so common words in the returned content (e.g. the literal token "result" or "error") won't be confused for tag boundaries.
+The tool result comes back wrapped as `<tool_script status="...">` with child blocks — `<return_value>`, `<warnings>` (lossy serialization notes, when any), `<logs>`, `<trace>` — plus `<error_message>` on failure paths. The `return` value is embedded verbatim inside `<return_value>` (not JSON-escaped), so newlines and quotes stay readable.
 
 ## Example (correct use)
 

--- a/packages/opencode/src/workflow/sandbox.ts
+++ b/packages/opencode/src/workflow/sandbox.ts
@@ -43,6 +43,18 @@ export type SandboxOptions = {
 
 const DEFAULT_DEADLINE_MS = 12 * 60 * 60 * 1000
 const DEFAULT_MEMORY = 64 * 1024 * 1024
+
+/** Guest rejection values dump as {name, message, stack} objects — render them
+ * like a normal Error string instead of leaking a JSON blob into the message. */
+function formatGuestError(err: unknown): string {
+  if (typeof err === "string") return err
+  if (err && typeof err === "object" && "message" in err) {
+    const e = err as { name?: string; message: string; stack?: string }
+    const head = e.name && e.name !== "Error" ? `${e.name}: ${e.message}` : String(e.message)
+    return e.stack ? `${head}\n${e.stack.trimEnd()}` : head
+  }
+  return JSON.stringify(err)
+}
 /** Fallback seed when no caller-supplied seed is set. Stable so the existing
  * single-shot tests stay deterministic. The runtime always passes seed=hash(runID)
  * so production paths never see this default. */
@@ -195,7 +207,7 @@ export async function evalScript(body: string, hooks: Record<string, HostFn>, op
     if (evalRes.error) {
       const err = vm.dump(evalRes.error)
       evalRes.error.dispose()
-      throw new Error(`workflow script error: ${typeof err === "string" ? err : JSON.stringify(err)}`)
+      throw new Error(`workflow script error: ${formatGuestError(err)}`)
     }
     const promiseHandle = track(evalRes.value)
     // Concurrent pump: a BACKSTOP that drains guest microtasks while we await
@@ -248,7 +260,7 @@ export async function evalScript(body: string, hooks: Record<string, HostFn>, op
       if (resolved.error) {
         const err = vm.dump(resolved.error)
         resolved.error.dispose()
-        throw new Error(`workflow script rejected: ${typeof err === "string" ? err : JSON.stringify(err)}`)
+        throw new Error(`workflow script rejected: ${formatGuestError(err)}`)
       }
       const valueHandle = track(resolved.value)
       return vm.dump(valueHandle)
@@ -320,7 +332,10 @@ function injectHooks(
 /** Marshal a host JS value INTO the guest (by copy via JSON for structured data). */
 function marshalIn(vm: QuickJSContext, value: unknown): QuickJSHandle {
   if (value === undefined || value === null) return vm.undefined
-  if (typeof value === "string") return vm.newString(value)
+  // newString truncates at the first NUL byte (C-string boundary). Route
+  // NUL-containing strings through the JSON path below, where \0 is escaped
+  // as the 6-char sequence \u0000 and restored by the guest's JSON.parse.
+  if (typeof value === "string" && !value.includes("\0")) return vm.newString(value)
   if (typeof value === "number") return vm.newNumber(value)
   if (typeof value === "boolean") return value ? vm.true : vm.false
   const json = vm.newString(JSON.stringify(value))

--- a/packages/opencode/test/flag/tool-script-flag.test.ts
+++ b/packages/opencode/test/flag/tool-script-flag.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+
+function read(env: Record<string, string | undefined>) {
+  const merged = { ...process.env }
+  delete merged.MIMOCODE_ENABLE_TOOL_SCRIPT
+  delete merged.MIMOCODE_EXPERIMENTAL
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete merged[k]
+    else merged[k] = v
+  }
+  const result = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "-e",
+      'import { Flag } from "./src/flag/flag.ts"; process.stdout.write(String(Flag.MIMOCODE_ENABLE_TOOL_SCRIPT))',
+    ],
+    cwd: process.cwd(),
+    env: merged,
+  })
+  expect(result.exitCode).toBe(0)
+  return result.stdout.toString()
+}
+
+describe("MIMOCODE_ENABLE_TOOL_SCRIPT", () => {
+  test("is disabled by default and accepts explicit truthy values", () => {
+    expect(read({})).toBe("false")
+    expect(read({ MIMOCODE_ENABLE_TOOL_SCRIPT: "true" })).toBe("true")
+    expect(read({ MIMOCODE_ENABLE_TOOL_SCRIPT: "1" })).toBe("true")
+  })
+
+  test("false and zero keep it disabled", () => {
+    expect(read({ MIMOCODE_ENABLE_TOOL_SCRIPT: "false" })).toBe("false")
+    expect(read({ MIMOCODE_ENABLE_TOOL_SCRIPT: "0" })).toBe("false")
+  })
+
+  test("umbrella MIMOCODE_EXPERIMENTAL enables it", () => {
+    expect(read({ MIMOCODE_EXPERIMENTAL: "true" })).toBe("true")
+  })
+})

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -5,10 +5,11 @@ import os from "os"
 import fs from "fs/promises"
 import path from "path"
 import { evalScript } from "../../src/workflow/sandbox"
+import { jsonSchema } from "ai"
 import { Agent } from "../../src/agent/agent"
 import { Truncate, Tool } from "../../src/tool"
 import { ToolScriptTool, renderToolScriptDeclarations } from "../../src/tool/tool-script"
-import { toolScriptRegistry, TOOL_SCRIPT_EXCLUDED } from "../../src/tool/tool-script-ref"
+import { toolScriptRegistry, toolScriptMcp, TOOL_SCRIPT_EXCLUDED } from "../../src/tool/tool-script-ref"
 import { Instance } from "../../src/project/instance"
 
 describe("sandbox non-deterministic mode", () => {
@@ -85,9 +86,16 @@ function fakeDef(id: string, execute: (args: any) => Promise<string>): Tool.Def 
   }
 }
 
-async function runToolScript(code: string, defs: Tool.Def[], abort?: AbortSignal) {
+async function runToolScript(
+  code: string,
+  defs: Tool.Def[],
+  abort?: AbortSignal,
+  opts?: { mcp?: Record<string, any>; ask?: () => Effect.Effect<void>; maxToolCalls?: number; timeoutSeconds?: number },
+) {
   const prev = toolScriptRegistry.current
+  const prevMcp = toolScriptMcp.current
   toolScriptRegistry.current = () => Effect.succeed(defs)
+  toolScriptMcp.current = opts?.mcp ? () => Effect.succeed(opts.mcp!) : undefined
   try {
     return await Instance.provide({
       directory: tmp,
@@ -96,7 +104,11 @@ async function runToolScript(code: string, defs: Tool.Def[], abort?: AbortSignal
         const def = await Effect.runPromise(Tool.init(info))
         return runtime.runPromise(
           def.execute(
-            { code },
+            {
+              code,
+              ...(opts?.maxToolCalls !== undefined && { max_tool_calls: opts.maxToolCalls }),
+              ...(opts?.timeoutSeconds !== undefined && { timeout_seconds: opts.timeoutSeconds }),
+            },
             {
               sessionID: "ses_test" as any,
               messageID: "msg_test" as any,
@@ -105,7 +117,7 @@ async function runToolScript(code: string, defs: Tool.Def[], abort?: AbortSignal
               callID: "call_test",
               messages: [],
               metadata: () => Effect.void,
-              ask: () => Effect.void,
+              ask: opts?.ask ?? (() => Effect.void),
             },
           ),
         )
@@ -113,6 +125,7 @@ async function runToolScript(code: string, defs: Tool.Def[], abort?: AbortSignal
     })
   } finally {
     toolScriptRegistry.current = prev
+    toolScriptMcp.current = prevMcp
   }
 }
 
@@ -198,6 +211,43 @@ describe("tool_script", () => {
     expect(result.metadata.status).toBe("budget_exceeded")
   })
 
+  test("max_tool_calls raises the call budget", async () => {
+    const defs = [fakeDef("ping", async () => "pong")]
+    const result = await runToolScript(
+      `
+      for (let i = 0; i < 60; i++) await tools.ping({})
+      return "done"
+      `,
+      defs,
+      undefined,
+      { maxToolCalls: 80 },
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.metadata.toolCalls).toBe(60)
+  })
+
+  test("max_tool_calls lowers the call budget and the error names the limit", async () => {
+    const defs = [fakeDef("ping", async () => "pong")]
+    const result = await runToolScript(
+      `
+      for (let i = 0; i < 10; i++) await tools.ping({})
+      return "done"
+      `,
+      defs,
+      undefined,
+      { maxToolCalls: 5 },
+    )
+    expect(result.metadata.status).toBe("budget_exceeded")
+    expect(result.output).toContain("tool call budget exceeded (5 per execution)")
+  })
+
+  test("timeout_seconds bounds compute time and the error names the budget", async () => {
+    const result = await runToolScript(`while (true) {}`, [], undefined, { timeoutSeconds: 1 })
+    expect(result.metadata.status).toBe("timeout")
+    expect(result.output).toContain("1s of active compute")
+    expect(result.output).toContain("timeout_seconds")
+  }, 15_000)
+
   test("syntax error → code_error", async () => {
     const result = await runToolScript(`const = broken (`, [])
     expect(result.metadata.status).toBe("code_error")
@@ -220,6 +270,16 @@ describe("tool_script", () => {
       defs,
     )
     expect(result.output).toContain("unknown tool: task")
+  })
+
+  test("bash is excluded from the sandbox", async () => {
+    const defs = [fakeDef("bash", async () => "should never run")]
+    const result = await runToolScript(
+      `try { await tools.bash({ value: "ls" }) } catch (e) { return e.message }`,
+      defs,
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("unknown tool: bash")
   })
 
   test("concurrency is capped at 8", async () => {
@@ -313,6 +373,218 @@ describe("tool_script", () => {
     expect(result.metadata.status).toBe("completed")
     expect(result.output).toContain("1: not a line number")
   })
+
+  test("circular reference in return value fails loud with the offending path", async () => {
+    const result = await runToolScript(`const a = { items: [{}] }; a.items[0].self = a; return a`, [])
+    expect(result.metadata.status).toBe("code_error")
+    expect(result.output).toContain("circular reference at $.items[0].self")
+  })
+
+  test("BigInt fails loud with path and conversion hint (top-level and nested)", async () => {
+    const top = await runToolScript(`return 123n`, [])
+    expect(top.metadata.status).toBe("code_error")
+    expect(top.output).toContain("BigInt at $")
+    const nested = await runToolScript(`return { x: { y: 123n } }`, [])
+    expect(nested.metadata.status).toBe("code_error")
+    expect(nested.output).toContain("BigInt at $.x.y")
+  })
+
+  test("throwing getter fails loud with path", async () => {
+    const result = await runToolScript(`return { get x() { throw new Error("boom") } }`, [])
+    expect(result.metadata.status).toBe("code_error")
+    expect(result.output).toContain("getter at $.x threw: boom")
+  })
+
+  test("lossy conversions succeed with warnings: NaN, Map, Set, Error, RegExp", async () => {
+    const result = await runToolScript(
+      `return { n: NaN, m: new Map([["k", 1]]), s: new Set([2]), e: new Error("msg"), r: /x/g }`,
+      [],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("<warnings>")
+    expect(result.output).toContain("NaN at $.n serialized as null")
+    expect(result.output).toContain('"m": [')
+    expect(result.output).toContain('"message": "msg"')
+    expect(result.output).toContain('"r": "/x/g"')
+  })
+
+  test("clean JSON return has no warnings block", async () => {
+    const result = await runToolScript(`return { a: 1, b: "x", c: [true, null] }`, [])
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).not.toContain("<warnings>")
+  })
+
+  test("console.log renders circular objects and Errors usefully", async () => {
+    const result = await runToolScript(
+      `const a = {}; a.self = a; console.log(a); console.log(new Error("oops")); return "done"`,
+      [],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain('{"self":"[Circular]"}')
+    expect(result.output).toContain("oops")
+  })
+
+  test("string return passes through verbatim (no JSON escaping)", async () => {
+    const result = await runToolScript(`return "line1\\nline2 with \\"quotes\\""`, [])
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain('line1\nline2 with "quotes"')
+  })
+
+  test("syntax error reports line, column, and source line", async () => {
+    const result = await runToolScript(`const ok = 1\nconst = broken (`, [])
+    expect(result.metadata.status).toBe("code_error")
+    expect(result.output).toContain("line 2, column 7")
+    expect(result.output).toContain("const = broken (")
+  })
+
+  test("top-level import gets an explicit not-supported note", async () => {
+    const result = await runToolScript(`import * as x from "node:fs"\nreturn 1`, [])
+    expect(result.metadata.status).toBe("code_error")
+    expect(result.output).toContain("import/export are NOT supported")
+  })
+
+  test("files: literal /tmp paths work (macOS symlink jail)", async () => {
+    const marker = path.join("/tmp", `ts-jail-${Date.now()}.json`)
+    const result = await runToolScript(
+      `
+      await files.writeText("${marker}", "via-tmp")
+      return await files.readText("${marker}")
+      `,
+      [],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("via-tmp")
+    await fs.rm(marker, { force: true })
+  })
+
+  test("files.readText rejects binary (non-UTF-8) files instead of returning empty", async () => {
+    const bin = path.join(os.tmpdir(), `ts-bin-${Date.now()}.dat`)
+    await fs.writeFile(bin, new Uint8Array([0x00, 0xff, 0xfe, 0x41, 0x80]))
+    const result = await runToolScript(
+      `try { await files.readText("${bin}"); return "no-error" } catch (e) { return "caught: " + e.message }`,
+      [],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("caught:")
+    expect(result.output).toContain("not valid UTF-8")
+    await fs.rm(bin, { force: true })
+  })
+
+  test("strings containing NUL survive the host→guest marshal boundary", async () => {
+    const nulFile = path.join(os.tmpdir(), `ts-nul-${Date.now()}.txt`)
+    // Valid UTF-8 containing a NUL byte — legal text, previously truncated at \0.
+    await fs.writeFile(nulFile, "before\0after")
+    const result = await runToolScript(
+      `const v = await files.readText("${nulFile}"); return { len: v.length, tail: v.slice(7) }`,
+      [],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain('"len": 12')
+    expect(result.output).toContain('"tail": "after"')
+    await fs.rm(nulFile, { force: true })
+  })
+})
+
+describe("tool_script MCP dispatch", () => {
+  function fakeMcpTool(execute: (args: any) => Promise<any>) {
+    return {
+      description: "fake mcp tool",
+      inputSchema: jsonSchema({ type: "object", properties: { q: { type: "string" } } }),
+      execute,
+    }
+  }
+
+  test("MCP tool is callable; result content folds to text output", async () => {
+    const seen: any[] = []
+    const mcp = {
+      srv_search: fakeMcpTool(async (args) => {
+        seen.push(args)
+        return { content: [{ type: "text", text: "hit-1" }, { type: "text", text: "hit-2" }] }
+      }),
+    }
+    const result = await runToolScript(
+      `const r = await tools.srv_search({ q: "x" }); return r.output`,
+      [],
+      undefined,
+      { mcp },
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("hit-1")
+    expect(result.output).toContain("hit-2")
+    expect(seen).toEqual([{ q: "x" }])
+  })
+
+  test("MCP call goes through permission ask", async () => {
+    const asked: string[] = []
+    const mcp = {
+      srv_go: fakeMcpTool(async () => ({ content: [{ type: "text", text: "ok" }] })),
+    }
+    const result = await runToolScript(`return (await tools.srv_go({})).output`, [], undefined, {
+      mcp,
+      ask: () => {
+        asked.push("srv_go")
+        return Effect.void
+      },
+    })
+    expect(result.metadata.status).toBe("completed")
+    expect(asked).toContain("srv_go")
+  })
+
+  test("MCP isError result rejects catchably", async () => {
+    const mcp = {
+      srv_fail: fakeMcpTool(async () => ({
+        isError: true,
+        content: [{ type: "text", text: "server exploded" }],
+      })),
+    }
+    const result = await runToolScript(
+      `try { await tools.srv_fail({}) } catch (e) { return "caught: " + e.message }`,
+      [],
+      undefined,
+      { mcp },
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("caught: srv_fail: server exploded")
+  })
+
+  test("non-text MCP content is dropped with a note", async () => {
+    const mcp = {
+      srv_img: fakeMcpTool(async () => ({
+        content: [
+          { type: "text", text: "caption" },
+          { type: "image", mimeType: "image/png", data: "aGVsbG8=" },
+        ],
+      })),
+    }
+    const result = await runToolScript(`return (await tools.srv_img({})).output`, [], undefined, { mcp })
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("caption")
+    expect(result.output).toContain("non-text attachment(s) dropped")
+  })
+
+  test("builtin tool id wins over a colliding MCP tool id", async () => {
+    const defs = [fakeDef("echo", async (args) => `builtin:${args.value}`)]
+    const mcp = {
+      echo: fakeMcpTool(async () => ({ content: [{ type: "text", text: "mcp-should-not-run" }] })),
+    }
+    const result = await runToolScript(`return (await tools.echo({ value: "v" })).output`, defs, undefined, { mcp })
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("builtin:v")
+    expect(result.output).not.toContain("mcp-should-not-run")
+  })
+
+  test("MCP calls count against the shared 50-call budget", async () => {
+    const mcp = {
+      srv_ping: fakeMcpTool(async () => ({ content: [{ type: "text", text: "pong" }] })),
+    }
+    const result = await runToolScript(
+      `for (let i = 0; i < 60; i++) await tools.srv_ping({}); return "done"`,
+      [],
+      undefined,
+      { mcp },
+    )
+    expect(result.metadata.status).toBe("budget_exceeded")
+  })
 })
 
 describe("renderToolScriptDeclarations", () => {
@@ -329,9 +601,22 @@ describe("renderToolScriptDeclarations", () => {
     expect(text).toContain("declare const tools")
   })
 
-  test("exclusion list covers agent control-flow tools", () => {
-    for (const id of ["task", "question", "actor", "skill", "plan_enter", "plan_exit", "tool_script"]) {
+  test("exclusion list covers agent control-flow tools and bash", () => {
+    for (const id of ["task", "question", "actor", "skill", "plan_enter", "plan_exit", "tool_script", "bash"]) {
       expect(TOOL_SCRIPT_EXCLUDED.has(id)).toBe(true)
     }
+  })
+
+  test("MCP tools are rendered into the declaration block", () => {
+    const mcp = {
+      srv_search: {
+        description: "Search the thing",
+        inputSchema: jsonSchema({ type: "object", properties: { q: { type: "string" } }, required: ["q"] }),
+        execute: async () => ({ content: [] }),
+      },
+    }
+    const text = renderToolScriptDeclarations([fakeDef("read", async () => "x")], mcp as any)
+    expect(text).toContain("srv_search(input: { q: string })")
+    expect(text).toContain("[MCP] Search the thing")
   })
 })


### PR DESCRIPTION
Fixes tool_script audit plus follow-up capability work:

Serialization (A-class):
- Guest-side __serialize replaces the JSON.stringify/String() fallback. Strict mode for return values: circular refs, BigInt, and throwing getters fail loud with the offending path ($.items[0].self) instead of silently degrading to "[object Object]". Lossy conversions (NaN→null, Map/Set→arrays, Error→{name,message,stack}, RegExp→string) succeed with a <warnings> block. Lenient mode for console.log inlines [Circular]/stack markers so debugging output stays useful.
- marshalIn routes NUL-containing strings through the JSON path (newString truncates at the first NUL byte).

files.* and jail (B1/E1):
- resolveJailed canonicalizes roots and targets via realpath, fixing the macOS /tmp symlink rejection; /tmp is allowed alongside os.tmpdir().
- files.readText decodes with TextDecoder(fatal) and rejects non-UTF-8 content instead of silently returning an empty string.

Error reporting (B4/D1/D2):
- Transpile errors carry line/column/source-line (caller-relative) and an explicit "import/export not supported" hint.
- Timeout errors name the compute budget instead of the raw InternalError:interrupted message; guest rejections render as Error+stack, not JSON blobs.

Capabilities:
- MCP tools are dispatchable inside the sandbox via a late-bound ref populated by SessionPrompt (same permission ask as direct MCP calls, normalizeToolResult folding, builtin ids win on collision, non-text content dropped with a note).
- bash is excluded: batch shell work belongs in one reviewable bash call, not 50 opaque sandboxed invocations.
- New max_tool_calls (default 50, cap 500) and timeout_seconds (default 60, cap 600) parameters.
- New MIMOCODE_ENABLE_TOOL_SCRIPT flag: the tool is now opt-in (default off), also enabled by the MIMOCODE_EXPERIMENTAL umbrella.

Docs trimmed of redundant guidance and updated with the sandbox globals list, serialization contract, and new limits. Tests: 23 → 46 + 3 flag tests.
