### PR TITLE
fix: change 'opencode mcp auth' to 'mimo mcp auth' in MCP authentication prompt

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -360,7 +360,7 @@ export const layer = Layer.effect(
                 return bus
                   .publish(TuiEvent.ToastShow, {
                     title: "MCP Authentication Required",
-                    message: `Server "${key}" requires authentication. Run: opencode mcp auth ${key}`,
+                    message: `Server "${key}" requires authentication. Run: mimo mcp auth ${key}`,
                     variant: "warning",
                     duration: 8000,
                   })


### PR DESCRIPTION
Fixed MCP authentication prompt to use correct command name 'mimo mcp auth' instead of 'opencode mcp auth'.