### PR TITLE
docs(pptx-skill): clarify preview script paths and CLI-only scope

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
@@ -46,6 +46,8 @@ curl -fsSL https://bun.sh/install | bash
 # Windows: powershell -c "irm bun.sh/install.ps1|iex"
 ```
 
+Only if the user explicitly refuses `uv` / `bun`, substitute `pip` (in a venv you manage yourself) for `uv`, and `npm`/`pnpm` + `npx tsx` for `bun` — everything else in this skill stays the same.
+
 ### Python (uv)
 
 Python dependencies are managed by `uv`. Do not use `pip` directly.
@@ -170,15 +172,29 @@ of each file for its full CLI options.
 
 A live preview server is available for real-time slide feedback.
 **Not started by default.** When multi-slide work begins, ask the user
-if they want live preview enabled. If yes:
+if they want live preview enabled.
+
+**Only offer this in a pure command-line environment.** This server is
+for the MiMoCode CLI. If you are running inside a host that embeds
+MiMoCode via the SDK — a web UI, a desktop app, an IDE plugin, etc. —
+that host almost certainly has its own native preview / file-open
+mechanism; use it instead and do NOT start this server.
+
+If yes, and this is a CLI environment:
 
 ```bash
+# `scripts/preview.ts` lives in this skill's bundle directory, not in
+# your cwd. Prefix it with the absolute path shown in this skill's
+# location header (the folder that contains SKILL.md) — refer to it
+# as <SKILL_DIR> below. The .pptx path can also sit anywhere; if it
+# is not under your cwd, pass an absolute path too.
+
 # Start (spawns background server, prints URL, exits immediately)
-bun run scripts/preview.ts output.pptx
-bun run scripts/preview.ts output.pptx --port 5000
+bun run <SKILL_DIR>/scripts/preview.ts /path/to/output.pptx
+bun run <SKILL_DIR>/scripts/preview.ts /path/to/output.pptx --port 5000
 
 # Stop
-bun run scripts/preview.ts --stop output.pptx
+bun run <SKILL_DIR>/scripts/preview.ts --stop /path/to/output.pptx
 ```
 
 If the server is already running, `preview.ts` detects this via PID file

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
@@ -186,8 +186,7 @@ If yes, and this is a CLI environment:
 # `scripts/preview.ts` lives in this skill's bundle directory, not in
 # your cwd. Prefix it with the absolute path shown in this skill's
 # location header (the folder that contains SKILL.md) — refer to it
-# as <SKILL_DIR> below. The .pptx path can also sit anywhere; if it
-# is not under your cwd, pass an absolute path too.
+# as <SKILL_DIR> below.
 
 # Start (spawns background server, prints URL, exits immediately)
 bun run <SKILL_DIR>/scripts/preview.ts /path/to/output.pptx

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview.ts
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview.ts
@@ -80,7 +80,6 @@ const source = positionals[0]
 if (!source) {
   console.error("Usage: bun run <SKILL_DIR>/scripts/preview.ts /path/to/file.pptx [--port N]")
   console.error("       bun run <SKILL_DIR>/scripts/preview.ts --stop /path/to/file.pptx")
-  console.error("(<SKILL_DIR> is the absolute path of this skill's bundle — the folder containing SKILL.md, NOT your cwd.)")
   process.exit(2)
 }
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview.ts
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview.ts
@@ -6,12 +6,21 @@
  * file, prints the URL, and exits immediately. Detects already-running
  * instances. Supports --stop to kill a running server.
  *
- * Usage:
- *   bun run scripts/preview.ts output.pptx              # start, default port 4200
- *   bun run scripts/preview.ts output.pptx --port 5000  # start on custom port
- *   bun run scripts/preview.ts --stop output.pptx       # stop running server
+ * SCOPE: for the MiMoCode CLI only. If MiMoCode is embedded via SDK in
+ * a GUI host (web app, desktop app, IDE plugin, …), use that host's
+ * native preview instead of this server.
+ *
+ * PATHS: this script sits in the skill's bundle directory, not
+ * necessarily in your cwd. Invoke with the absolute path to it
+ * (<SKILL_DIR>/scripts/preview.ts) and pass the .pptx by absolute
+ * path too if it doesn't live under your cwd.
+ *
+ * Usage (substitute <SKILL_DIR> with this skill's bundle dir):
+ *   bun run <SKILL_DIR>/scripts/preview.ts /path/to/output.pptx              # start, default port 4200
+ *   bun run <SKILL_DIR>/scripts/preview.ts /path/to/output.pptx --port 5000  # start on custom port
+ *   bun run <SKILL_DIR>/scripts/preview.ts --stop /path/to/output.pptx       # stop running server
  */
-import { resolve, dirname, basename } from "node:path"
+import { resolve, dirname } from "node:path"
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs"
 import { parseArgs } from "node:util"
 
@@ -51,7 +60,7 @@ function readPid(pidFile: string): { pid: number; port: number } | null {
 if (values.stop) {
   const source = positionals[0]
   if (!source) {
-    console.error("Usage: bun run preview.ts --stop <file.pptx>")
+    console.error("Usage: bun run <SKILL_DIR>/scripts/preview.ts --stop /path/to/file.pptx")
     process.exit(2)
   }
   const pidFile = pidFileFor(resolve(source))
@@ -70,8 +79,10 @@ if (values.stop) {
 // --- Start mode ---
 const source = positionals[0]
 if (!source) {
-  console.error("Usage: bun run preview.ts <file.pptx> [--port N]")
-  console.error("       bun run preview.ts --stop <file.pptx>")
+  console.error("Usage: bun run <SKILL_DIR>/scripts/preview.ts /path/to/file.pptx [--port N]")
+  console.error("       bun run <SKILL_DIR>/scripts/preview.ts --stop /path/to/file.pptx")
+  console.error("(<SKILL_DIR> = absolute path of this skill's bundle — the folder containing")
+  console.error(" SKILL.md, NOT your cwd. Pass the .pptx by absolute path unless it's under cwd.)")
   process.exit(2)
 }
 
@@ -116,4 +127,4 @@ console.log(`PPTX Preview Server started (pid ${child.pid})`)
 console.log(`  Watching: ${pptxPath}`)
 console.log(`  URL:      http://localhost:${port}`)
 console.log(`  Log:      ${logFile}`)
-console.log(`\n  Stop with: bun run scripts/preview.ts --stop ${basename(pptxPath)}`)
+console.log(`\n  Stop with: bun run ${import.meta.path} --stop ${pptxPath}`)

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview.ts
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview.ts
@@ -12,8 +12,7 @@
  *
  * PATHS: this script sits in the skill's bundle directory, not
  * necessarily in your cwd. Invoke with the absolute path to it
- * (<SKILL_DIR>/scripts/preview.ts) and pass the .pptx by absolute
- * path too if it doesn't live under your cwd.
+ * (<SKILL_DIR>/scripts/preview.ts).
  *
  * Usage (substitute <SKILL_DIR> with this skill's bundle dir):
  *   bun run <SKILL_DIR>/scripts/preview.ts /path/to/output.pptx              # start, default port 4200
@@ -81,8 +80,7 @@ const source = positionals[0]
 if (!source) {
   console.error("Usage: bun run <SKILL_DIR>/scripts/preview.ts /path/to/file.pptx [--port N]")
   console.error("       bun run <SKILL_DIR>/scripts/preview.ts --stop /path/to/file.pptx")
-  console.error("(<SKILL_DIR> = absolute path of this skill's bundle — the folder containing")
-  console.error(" SKILL.md, NOT your cwd. Pass the .pptx by absolute path unless it's under cwd.)")
+  console.error("(<SKILL_DIR> is the absolute path of this skill's bundle — the folder containing SKILL.md, NOT your cwd.)")
   process.exit(2)
 }
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview_server.ts
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview_server.ts
@@ -10,8 +10,9 @@
  * SCOPE: for the MiMoCode CLI only. GUI hosts embedding MiMoCode via
  * the SDK should use their own native preview mechanism instead.
  *
- * PATHS: this script sits in the skill's bundle directory. Invoke via
- * the absolute path (<SKILL_DIR>/scripts/preview_server.ts).
+ * PATHS: this script sits in the skill's bundle directory, not
+ * necessarily in your cwd. Invoke via the absolute path
+ * (<SKILL_DIR>/scripts/preview_server.ts).
  *
  * Usage:
  *   bun run <SKILL_DIR>/scripts/preview_server.ts /path/to/output.pptx --port 4200

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview_server.ts
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview_server.ts
@@ -7,8 +7,15 @@
  *
  * Not meant to be run directly — use preview.ts to start/stop.
  *
+ * SCOPE: for the MiMoCode CLI only. GUI hosts embedding MiMoCode via
+ * the SDK should use their own native preview mechanism instead.
+ *
+ * PATHS: this script sits in the skill's bundle directory. Invoke via
+ * the absolute path (<SKILL_DIR>/scripts/preview_server.ts) and pass
+ * the .pptx by absolute path unless it lives under your cwd.
+ *
  * Usage:
- *   bun run scripts/preview_server.ts output.pptx --port 4200
+ *   bun run <SKILL_DIR>/scripts/preview_server.ts /path/to/output.pptx --port 4200
  */
 import { watch } from "node:fs"
 import { resolve, basename, dirname } from "node:path"
@@ -23,7 +30,7 @@ const { values, positionals } = parseArgs({
 
 const source = positionals[0]
 if (!source) {
-  console.error("Usage: bun run preview_server.ts <file.pptx> [--port N]")
+  console.error("Usage: bun run <SKILL_DIR>/scripts/preview_server.ts /path/to/file.pptx [--port N]")
   process.exit(2)
 }
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview_server.ts
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/preview_server.ts
@@ -11,8 +11,7 @@
  * the SDK should use their own native preview mechanism instead.
  *
  * PATHS: this script sits in the skill's bundle directory. Invoke via
- * the absolute path (<SKILL_DIR>/scripts/preview_server.ts) and pass
- * the .pptx by absolute path unless it lives under your cwd.
+ * the absolute path (<SKILL_DIR>/scripts/preview_server.ts).
  *
  * Usage:
  *   bun run <SKILL_DIR>/scripts/preview_server.ts /path/to/output.pptx --port 4200


### PR DESCRIPTION
## Summary

Small cleanup of the pptx-official skill's live-preview instructions and the two `preview*.ts` scripts.

- Preview commands in `SKILL.md` and the script header comments now reference `<SKILL_DIR>/scripts/preview.ts` (the skill bundle directory) and use `/path/to/output.pptx` as the placeholder, instead of bare `scripts/preview.ts output.pptx`. The old wording quietly assumed the caller's cwd was the skill directory, which isn't reliable when the skill runs from arbitrary projects.
- `preview.ts`'s `Stop with:` hint used `basename(pptxPath)`, so the suggested command failed as soon as the user's cwd changed. It now prints the absolute script path (`import.meta.path`) plus the absolute pptx path.
- Added a short note that the preview server is intended for the MiMoCode CLI only; SDK-embedded GUI hosts should use their own native preview / file-open mechanism instead.
- Added a one-line pointer in the setup section for users who explicitly refuse `uv` / `bun` (fall back to `pip` in a self-managed venv, or `npm` / `pnpm` + `npx tsx`). The rest of the skill still uses `uv run` / `bun run` as the default.
- Follow-up commit drops leftover "under cwd" prose (the `/path/to/...` placeholder already conveys the shape) and unfolds a visually-wrapped multi-line `console.error` hint into single-line output.

## Test plan

- Ran `bun run …/scripts/preview.ts` with no args → new usage strings render as expected.
- Ran `bun run …/scripts/preview.ts /tmp/x.pptx` → `Stop with:` line prints absolute script path + absolute pptx path (verified copy-pasteable from any cwd).
- Docs-only and string-only changes; no runtime behavior changed.
