### PR TITLE
fix(opencode): validate custom tool arguments

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -75,6 +75,7 @@ import { BuiltinWorkflow } from "@/workflow/builtin"
 import { ToolScriptTool, renderToolScriptDeclarations } from "./tool-script"
 import { toolScriptRegistry } from "./tool-script-ref"
 import { usesGPTToolset } from "./gpt"
+import { RecoverableError } from "./recoverable"
 
 const log = Log.create({ service: "tool.registry" })
 
@@ -173,19 +174,24 @@ export const layer = Layer.effect(
         const custom: Tool.Def[] = []
 
         function fromPlugin(id: string, def: ToolDefinition): Tool.Def {
+          const parameters = z.object(def.args)
           return {
             id,
-            parameters: z.object(def.args),
+            parameters,
             description: def.description,
             execute: (args, toolCtx) =>
               Effect.gen(function* () {
+                const parsed = yield* Effect.try({
+                  try: () => parameters.parse(args),
+                  catch: (error) => new RecoverableError(Tool.validationErrorMessage(id, error), { cause: error }),
+                })
                 const pluginCtx: PluginToolContext = {
                   ...toolCtx,
                   ask: (req) => toolCtx.ask(req),
                   directory: ctx.directory,
                   worktree: ctx.worktree,
                 }
-                const result = yield* Effect.promise(() => def.execute(args as any, pluginCtx))
+                const result = yield* Effect.promise(() => def.execute(parsed, pluginCtx))
                 const output = typeof result === "string" ? result : result.output
                 const metadata = typeof result === "string" ? {} : (result.metadata ?? {})
                 const info = yield* agent.get(toolCtx.agent)
@@ -199,7 +205,7 @@ export const layer = Layer.effect(
                     ...(out.truncated && { outputPath: out.outputPath }),
                   },
                 }
-              }),
+              }).pipe(Effect.orDie),
           }
         }
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -5,6 +5,7 @@ import { Effect, Layer } from "effect"
 import { Instance } from "../../src/project/instance"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { ToolRegistry } from "../../src/tool"
+import { MessageID, SessionID } from "../../src/session/schema"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
@@ -69,6 +70,58 @@ describe("tool.registry", () => {
         const registry = yield* ToolRegistry.Service
         const ids = yield* registry.ids()
         expect(ids).toContain("hello")
+      }),
+    ),
+  )
+
+  it.live("validates custom tool arguments invoked through exec", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const tools = path.join(dir, ".mimocode", "tools")
+        const marker = path.join(dir, "executed")
+        yield* Effect.promise(() => fs.mkdir(tools, { recursive: true }))
+        yield* Effect.promise(() =>
+          Bun.write(
+            path.join(tools, "validate.ts"),
+            [
+              "import z from 'zod'",
+              "export default {",
+              "  description: 'validated custom tool',",
+              "  args: { path: z.string() },",
+              "  execute: async () => {",
+              `    await Bun.write(${JSON.stringify(marker)}, "yes")`,
+              "    return 'executed'",
+              "  },",
+              "}",
+              "",
+            ].join("\n"),
+          ),
+        )
+
+        const registry = yield* ToolRegistry.Service
+        const script = (yield* registry.all()).find((tool) => tool.id === "exec")
+        expect(script).toBeDefined()
+        if (!script) return
+        const result = yield* script.execute(
+          {
+            code: `try { await tools.validate({ path: 123 }); return "executed" } catch (error) { return error.message }`,
+          },
+          {
+            sessionID: SessionID.make("ses_test"),
+            messageID: MessageID.make("msg_test"),
+            agent: "build",
+            abort: new AbortController().signal,
+            callID: "call_test",
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        expect(result.metadata.status).toBe("completed")
+        expect(result.output).toContain("Invalid arguments for the validate tool")
+        expect(result.output).toContain("path")
+        expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(false)
       }),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #1800

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom tools now parse their declared Zod argument schema before `execute` runs.
Invalid input uses the existing recoverable validation-error path, while parsed,
coerced, and stripped values are passed to the custom tool.

The regression invokes a real file-based custom tool through `tool_script` with
an invalid `path` value and verifies that its `execute` side effect never runs.
This is scoped to runtime argument validation; it does not change the tool
sandbox or permissions model.

### How did you verify your code works?

Rebased exactly across 105 upstream commits onto current `main` (`eef8206d`).
The patch-id is unchanged and the final diff still contains only
`registry.ts` plus its regression test.

- Bun 1.3.14 pre-push workspace typecheck: 12/12 tasks passed
- `bun test test/tool/registry.test.ts --timeout 60000`: 6/6 passed
- `bun test test/tool/tool-script.test.ts --timeout 60000`: 49/49 passed
- package typecheck: passed
- full Oxlint: zero errors; targeted changed files have zero errors and five
  pre-existing warnings in `registry.ts`
- `git diff --check`: passed

The repository GitHub workflows remain the required independent Linux/Bun
validation gate.

### Screenshots / recordings

Not applicable; this changes backend tool-dispatch validation and has no visual
surface.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
