### PR TITLE
fix: add fallback to read version from package.json

### DIFF
--- a/packages/opencode/script/dev.ts
+++ b/packages/opencode/script/dev.ts
@@ -23,7 +23,7 @@ function cleanup() {
 }
 process.on("exit", cleanup)
 
-const proc = Bun.spawn(["bun", "run", "--conditions=browser", "src/index.ts", ...process.argv.slice(2)], {
+const proc = Bun.spawn([process.execPath, "run", "--conditions=browser", "src/index.ts", ...process.argv.slice(2)], {
   cwd: pkgDir,
   stdio: ["inherit", "inherit", "inherit"],
   env: { ...process.env, MIMOCODE_HOME: process.env.MIMOCODE_HOME ?? path.resolve(pkgDir, "../../.dev-home") },

--- a/packages/opencode/src/installation/version.ts
+++ b/packages/opencode/src/installation/version.ts
@@ -3,6 +3,19 @@ declare global {
   const MIMOCODE_CHANNEL: string
 }
 
-export const InstallationVersion = typeof MIMOCODE_VERSION === "string" ? MIMOCODE_VERSION : "local"
+function getVersion(): string {
+  if (typeof MIMOCODE_VERSION === "string" && MIMOCODE_VERSION.length > 0) {
+    return MIMOCODE_VERSION
+  }
+  // Fallback: try to read from package.json (useful when build-time constant is missing)
+  try {
+    const pkg = require("../../package.json")
+    return pkg.version || "local"
+  } catch {
+    return "local"
+  }
+}
+
+export const InstallationVersion = getVersion()
 export const InstallationChannel = typeof MIMOCODE_CHANNEL === "string" ? MIMOCODE_CHANNEL : "local"
 export const InstallationLocal = InstallationChannel === "local"


### PR DESCRIPTION
Adds a fallback mechanism in installation/version.ts to read the version from package.json when the MIMOCODE_VERSION build-time constant is missing or empty.