### PR TITLE
fix(tui): disable OSC 66 text sizing on VTE terminals

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -69,7 +69,7 @@ import { TuiConfigProvider, useTuiConfig } from "./context/tui-config"
 import { TuiConfig } from "@/cli/cmd/tui/config/tui"
 import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
-import { isPlainTerminal, isWindowsTerminal } from "./util/terminal"
+import { isPlainTerminal, isWindowsTerminal, needsTextSizingDisabled } from "./util/terminal"
 import {
   detectionFromPart,
   formatHarnessReminder,
@@ -159,6 +159,11 @@ export function tui(input: {
     }
 
     const plainTerminal = isPlainTerminal()
+    if (needsTextSizingDisabled()) {
+      process.env.OPENTUI_FORCE_EXPLICIT_WIDTH ??= "0"
+      process.env.OPENTUI_FORCE_WCWIDTH ??= "1"
+    }
+
     const renderer = await createCliRenderer(rendererConfig(input.config, plainTerminal))
     // 默认使用 dark 模式(不跟随终端背景);用户手动切换后会被 theme_mode_lock 记住并优先。
     const mode = "dark"

--- a/packages/opencode/src/cli/cmd/tui/util/terminal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/terminal.ts
@@ -25,6 +25,14 @@ export function isPlainTerminal(input?: { platform?: NodeJS.Platform; termProgra
   return isMacNativeTerminal(input)
 }
 
+export function needsTextSizingDisabled(input?: { vteVersion?: string; disableTextSizing?: string }) {
+  const disable = input?.disableTextSizing ?? process.env.MIMOCODE_DISABLE_TEXT_SIZING
+  if (disable === "false" || disable === "0") return false
+  if (disable === "true" || disable === "1") return true
+  const vteVersion = input?.vteVersion ?? process.env.VTE_VERSION
+  return vteVersion !== undefined && vteVersion !== ""
+}
+
 function parse(color: string): RGBA | null {
   if (color.startsWith("rgb:")) {
     const parts = color.substring(4).split("/")

--- a/packages/opencode/test/terminal.test.ts
+++ b/packages/opencode/test/terminal.test.ts
@@ -1,11 +1,22 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { isWindowsTerminal } from "../src/cli/cmd/tui/util/terminal"
+import {
+  isMacNativeTerminal,
+  isPlainTerminal,
+  isWindowsTerminal,
+  needsTextSizingDisabled,
+} from "../src/cli/cmd/tui/util/terminal"
 
 describe("isWindowsTerminal", () => {
   const originalWTSession = process.env.WT_SESSION
+  const originalVTEVersion = process.env.VTE_VERSION
+  const originalDisableTextSizing = process.env.MIMOCODE_DISABLE_TEXT_SIZING
+  const originalTuiPlain = process.env.MIMOCODE_TUI_PLAIN
 
   beforeEach(() => {
     delete process.env.WT_SESSION
+    delete process.env.VTE_VERSION
+    delete process.env.MIMOCODE_DISABLE_TEXT_SIZING
+    delete process.env.MIMOCODE_TUI_PLAIN
   })
 
   afterEach(() => {
@@ -13,6 +24,21 @@ describe("isWindowsTerminal", () => {
       process.env.WT_SESSION = originalWTSession
     } else {
       delete process.env.WT_SESSION
+    }
+    if (originalVTEVersion !== undefined) {
+      process.env.VTE_VERSION = originalVTEVersion
+    } else {
+      delete process.env.VTE_VERSION
+    }
+    if (originalDisableTextSizing !== undefined) {
+      process.env.MIMOCODE_DISABLE_TEXT_SIZING = originalDisableTextSizing
+    } else {
+      delete process.env.MIMOCODE_DISABLE_TEXT_SIZING
+    }
+    if (originalTuiPlain !== undefined) {
+      process.env.MIMOCODE_TUI_PLAIN = originalTuiPlain
+    } else {
+      delete process.env.MIMOCODE_TUI_PLAIN
     }
   })
 
@@ -44,5 +70,56 @@ describe("isWindowsTerminal", () => {
 
   test("returns false when input is undefined and no env var", () => {
     expect(isWindowsTerminal()).toBe(false)
+  })
+})
+
+describe("needsTextSizingDisabled", () => {
+  test("returns true for VTE terminals", () => {
+    expect(needsTextSizingDisabled({ vteVersion: "6800" })).toBe(true)
+  })
+
+  test("returns false on a non-VTE terminal with no override", () => {
+    expect(needsTextSizingDisabled({})).toBe(false)
+  })
+
+  test("treats empty VTE_VERSION as not VTE", () => {
+    expect(needsTextSizingDisabled({ vteVersion: "" })).toBe(false)
+  })
+
+  test("MIMOCODE_DISABLE_TEXT_SIZING=1/true forces the workaround", () => {
+    expect(needsTextSizingDisabled({ disableTextSizing: "1" })).toBe(true)
+    expect(needsTextSizingDisabled({ disableTextSizing: "true" })).toBe(true)
+  })
+
+  test("MIMOCODE_DISABLE_TEXT_SIZING=0/false overrides VTE auto-detection", () => {
+    expect(needsTextSizingDisabled({ vteVersion: "6800", disableTextSizing: "0" })).toBe(false)
+    expect(needsTextSizingDisabled({ vteVersion: "6800", disableTextSizing: "false" })).toBe(false)
+  })
+
+  test("unrecognized MIMOCODE_DISABLE_TEXT_SIZING falls back to VTE auto-detection", () => {
+    expect(needsTextSizingDisabled({ vteVersion: "6800", disableTextSizing: "maybe" })).toBe(true)
+    expect(needsTextSizingDisabled({ disableTextSizing: "maybe" })).toBe(false)
+  })
+})
+
+describe("isMacNativeTerminal", () => {
+  test("returns true only for Apple Terminal on macOS", () => {
+    expect(isMacNativeTerminal({ platform: "darwin", termProgram: "Apple_Terminal" })).toBe(true)
+    expect(isMacNativeTerminal({ platform: "darwin", termProgram: "iTerm.app" })).toBe(false)
+    expect(isMacNativeTerminal({ platform: "linux", termProgram: "Apple_Terminal" })).toBe(false)
+  })
+})
+
+describe("isPlainTerminal", () => {
+  test("MIMOCODE_TUI_PLAIN overrides terminal heuristics", () => {
+    expect(isPlainTerminal({ plain: "1" })).toBe(true)
+    expect(isPlainTerminal({ plain: "true" })).toBe(true)
+    expect(isPlainTerminal({ plain: "0", platform: "darwin", termProgram: "Apple_Terminal" })).toBe(false)
+    expect(isPlainTerminal({ plain: "false", platform: "darwin", termProgram: "Apple_Terminal" })).toBe(false)
+  })
+
+  test("defaults to mac-native detection when MIMOCODE_TUI_PLAIN is unset", () => {
+    expect(isPlainTerminal({ platform: "darwin", termProgram: "Apple_Terminal" })).toBe(true)
+    expect(isPlainTerminal({ platform: "linux", termProgram: "xterm" })).toBe(false)
   })
 })


### PR DESCRIPTION
﻿## Summary

Refreshes the VTE / OSC 66 text-sizing workaround from the earlier community contribution after the previous replacement PR (#1098, originally #246) became conflicting with current `main`.

## Root cause

VTE-based terminals such as MATE Terminal and GNOME Terminal do not support opentui's OSC 66 explicit-width protocol. Instead of silently ignoring the sequence, they can print it as literal text, producing repeated `]66;w=1;` garbage in the TUI.

## Changes

- Detect VTE terminals through `VTE_VERSION`, with `MIMOCODE_DISABLE_TEXT_SIZING=1/0` as an explicit user override.
- Before `createCliRenderer()`, set `OPENTUI_FORCE_EXPLICIT_WIDTH=0` and `OPENTUI_FORCE_WCWIDTH=1` when the workaround is needed.
- Keep user-provided `OPENTUI_FORCE_*` values intact via `??=`.
- Move the tests into the current `packages/opencode/test/terminal.test.ts` location used by latest `main`.

## Validation

Run from `packages/opencode`:

- `bun test test/terminal.test.ts` — 16 pass / 0 fail
- `bun typecheck` — pass
- `bunx oxlint packages/opencode/src/cli/cmd/tui/app.tsx packages/opencode/src/cli/cmd/tui/util/terminal.ts packages/opencode/test/terminal.test.ts` — 0 errors; existing warnings in `app.tsx` remain unrelated to this change

Related to #162. Refreshes #1098 / #246.
