### PR TITLE
OCP M1: dual-scan .opencode project dirs

### DIFF
--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -24,17 +24,21 @@ export const files = Effect.fn("ConfigPaths.projectFiles")(function* (
 
 export const directories = Effect.fn("ConfigPaths.directories")(function* (directory: string, worktree?: string) {
   const afs = yield* AppFileSystem.Service
+  // OCP M1 dual-scan: keep `.mimocode` first so native config wins on conflict,
+  // then also discover OpenCode project dirs (`.opencode`) for unchanged plugins.
+  // See https://github.com/oakimov/opencode-plugin-compat/blob/main/patches/mimo-m1.md
+  const projectTargets = [".mimocode", ".opencode"]
   return unique([
     Global.Path.config,
     ...(!Flag.MIMOCODE_DISABLE_PROJECT_CONFIG
       ? yield* afs.up({
-          targets: [".mimocode"],
+          targets: projectTargets,
           start: directory,
           stop: worktree,
         })
       : []),
     ...(yield* afs.up({
-      targets: [".mimocode"],
+      targets: projectTargets,
       start: Global.Path.home,
       stop: Global.Path.home,
     })),


### PR DESCRIPTION
## Summary
- Dual-scan `.opencode` after `.mimocode` in `ConfigPaths.directories` (project + home walks).
- Native `.mimocode` stays first so MiMo config wins on conflict.
- Part of OpenCode Plugin Compat (OCP) M1 Layer B / T2 — see https://github.com/oakimov/opencode-plugin-compat/blob/main/patches/mimo-m1.md

## Test plan
- [ ] Project with only `.mimocode` — unchanged behavior
- [ ] Project with `.mimocode` + `.opencode` — both discovered; mimocode wins on name collision
- [ ] Project with only `.opencode` — discovered
- [ ] `MIMOCODE_DISABLE_PROJECT_CONFIG=1` — project walk still skipped