### PR TITLE
chore(xai): bump @ai-sdk/xai 3.0.102 + sync grok transform + add OAuth login

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -308,7 +308,7 @@
         "@ai-sdk/provider-utils": "4.0.23",
         "@ai-sdk/togetherai": "2.0.41",
         "@ai-sdk/vercel": "2.0.39",
-        "@ai-sdk/xai": "3.0.82",
+        "@ai-sdk/xai": "3.0.102",
         "@aws-sdk/credential-providers": "3.993.0",
         "@clack/prompts": "1.0.0-alpha.1",
         "@effect/opentelemetry": "catalog:",
@@ -763,7 +763,7 @@
 
     "@ai-sdk/vercel": ["@ai-sdk/vercel@2.0.39", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.37", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8eu3ljJpkCTP4ppcyYB+NcBrkcBoSOFthCSgk5VnjaxnDaOJFaxnPwfddM7wx3RwMk2CiK1O61Px/LlqNc7QkQ=="],
 
-    "@ai-sdk/xai": ["@ai-sdk/xai@3.0.82", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.41", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-A0VFMufnVf4wODcT3SPQUUzvYXiIO1VhFuXj9r6z/vP4rlo+QRDPw3WSTchcz93ROQWSfBE3I6Szqz342OHi5w=="],
+    "@ai-sdk/xai": ["@ai-sdk/xai@3.0.102", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.56", "@ai-sdk/provider": "3.0.13", "@ai-sdk/provider-utils": "4.0.35" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NeQyOR7OCqDMgaLS4uNX/ep/HrwUzzFYLzXQSRoqLy2jsnqxAJhsgltRwAwf+ADjyPBIAKEOestWnIQA+LrLrQ=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -5207,6 +5207,12 @@
 
     "@ai-sdk/vercel/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
+    "@ai-sdk/xai/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.56", "", { "dependencies": { "@ai-sdk/provider": "3.0.13", "@ai-sdk/provider-utils": "4.0.35" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-cQrN6OUn/jvsY3OdsU6Wn+ss7vp1iwIcakZKSlSRMnYqShBfyT7Qht+eqmgxs7w9ttrw6FAG6o11AiBs+iEsTA=="],
+
+    "@ai-sdk/xai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.13", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw=="],
+
+    "@ai-sdk/xai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.35", "", { "dependencies": { "@ai-sdk/provider": "3.0.13", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bjYld/2KGPLt78kpqbya+fD4LYS7BqVQJyUjE3qAHrYB0FR2Q90BaWEVIBZaguTWXf/A8L6uG1zO1v9TxVlGWg=="],
+
     "@astrojs/check/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "@astrojs/cloudflare/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
@@ -5693,6 +5699,8 @@
 
     "ai-gateway-provider/@ai-sdk/google-vertex": ["@ai-sdk/google-vertex@4.0.112", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.71", "@ai-sdk/google": "3.0.64", "@ai-sdk/openai-compatible": "2.0.41", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "google-auth-library": "^10.5.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-cSfHCkM+9ZrFtQWIN1WlV93JPD+isGSdFxKj7u1L9m2aLVZajlXdcE41GL9hMt7ld7bZYE4NnZ+4VLxBAHE+Eg=="],
 
+    "ai-gateway-provider/@ai-sdk/xai": ["@ai-sdk/xai@3.0.82", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.41", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-A0VFMufnVf4wODcT3SPQUUzvYXiIO1VhFuXj9r6z/vP4rlo+QRDPw3WSTchcz93ROQWSfBE3I6Szqz342OHi5w=="],
+
     "ai-gateway-provider/@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.5.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-r1fJL1Cb3gQDa2MpWH/sfx1BsEW0uzlRriJM6eihaKqbtKDmZoBisF32VcVaQYassighX7NGCkF68EsrZA43uQ=="],
 
     "ajv-keywords/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
@@ -6112,6 +6120,8 @@
     "@ai-sdk/togetherai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@ai-sdk/vercel/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@ai-sdk/xai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@astrojs/check/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -108,7 +108,7 @@
     "@ai-sdk/provider-utils": "4.0.23",
     "@ai-sdk/togetherai": "2.0.41",
     "@ai-sdk/vercel": "2.0.39",
-    "@ai-sdk/xai": "3.0.82",
+    "@ai-sdk/xai": "3.0.102",
     "@aws-sdk/credential-providers": "3.993.0",
     "@clack/prompts": "1.0.0-alpha.1",
     "@effect/opentelemetry": "catalog:",

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -18,6 +18,7 @@ import { Log } from "../util"
 import { createOpencodeClient } from "@mimo-ai/sdk"
 import { Flag } from "../flag/flag"
 import { CodexAuthPlugin } from "./codex"
+import { XaiAuthPlugin } from "./xai"
 import { MimoAuthPlugin, AnthropicProxyPlugin } from "./mimo"
 import { Session } from "../session"
 import type { SessionID } from "../session/schema"
@@ -142,6 +143,7 @@ const INTERNAL_PLUGINS: PluginInstance[] = [
   MimoAuthPlugin,
   AnthropicProxyPlugin,
   CodexAuthPlugin,
+  XaiAuthPlugin,
   CopilotAuthPlugin,
   // gitlab/poe auth are external npm packages typed against the published
   // upstream plugin package, which carries a duplicate (nominal) copy of the

--- a/packages/opencode/src/plugin/xai.ts
+++ b/packages/opencode/src/plugin/xai.ts
@@ -1,0 +1,670 @@
+import type { Hooks, PluginInput } from "@mimo-ai/plugin"
+import { OAUTH_DUMMY_KEY } from "../auth"
+import { createServer } from "http"
+import { InstallationVersion } from "../installation/version"
+import { Log } from "../util"
+
+const log = Log.create({ service: "plugin.xai" })
+
+// Public Grok-CLI OAuth client. xAI's auth server rejects loopback OAuth from
+// non-allowlisted clients, so we reuse the Grok-CLI client_id that xAI ships
+// for desktop OAuth flows. Source of truth: hermes-agent PR #26534.
+const CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+const AUTHORIZE_URL = "https://auth.x.ai/oauth2/authorize"
+const TOKEN_URL = "https://auth.x.ai/oauth2/token"
+// RFC 8628 device authorization grant. Confirmed exposed by xAI's
+// /.well-known/openid-configuration as `device_authorization_endpoint`
+// with the matching `urn:ietf:params:oauth:grant-type:device_code` grant
+// in `grant_types_supported`. This is the headless / VPS path: no
+// loopback callback server, no SSH port forwarding, no inbound firewall
+// holes — the user opens the URL on any device with a browser, types
+// the short user_code, and the CLI long-polls the token endpoint.
+const DEVICE_AUTHORIZATION_URL = "https://auth.x.ai/oauth2/device/code"
+const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+const SCOPE = "openid profile email offline_access grok-cli:access api:access"
+
+// Bounds for the device-code poll loop. xAI returns `interval` (seconds)
+// but we floor it to avoid hammering and we add the spec's slow_down
+// increment when xAI explicitly asks us to back off.
+const DEVICE_CODE_DEFAULT_INTERVAL_MS = 5_000
+const DEVICE_CODE_MIN_INTERVAL_MS = 1_000
+const DEVICE_CODE_SLOW_DOWN_INCREMENT_MS = 5_000
+const DEVICE_CODE_DEFAULT_EXPIRES_MS = 5 * 60 * 1000
+const OAUTH_POLLING_SAFETY_MARGIN_MS = 3_000
+
+// xAI rejects redirect_uris that don't match what was registered for the
+// Grok-CLI client. The host:port pair is part of the registration, so we have
+// to bind the loopback server to this exact port.
+const OAUTH_HOST = "127.0.0.1"
+const OAUTH_PORT = 56121
+const OAUTH_REDIRECT_PATH = "/callback"
+const REDIRECT_URI = `http://${OAUTH_HOST}:${OAUTH_PORT}${OAUTH_REDIRECT_PATH}`
+
+// Refresh the access token a little before it actually expires so a single
+// long-running tool call doesn't have to recover from a mid-flight 401.
+const ACCESS_TOKEN_REFRESH_SKEW_MS = 120_000
+
+interface XaiAuthPluginOptions {
+  authorizeUrl?: string
+  tokenUrl?: string
+  deviceAuthorizationUrl?: string
+}
+
+interface PkceCodes {
+  verifier: string
+  challenge: string
+}
+
+async function generatePKCE(): Promise<PkceCodes> {
+  const verifier = generateRandomString(64)
+  const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier))
+  return { verifier, challenge: base64UrlEncode(hash) }
+}
+
+function generateRandomString(length: number): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+  return Array.from(crypto.getRandomValues(new Uint8Array(length)))
+    .map((b) => chars[b % chars.length])
+    .join("")
+}
+
+function base64UrlEncode(buffer: ArrayBuffer): string {
+  const binary = String.fromCharCode(...new Uint8Array(buffer))
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+function generateState(): string {
+  return base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)).buffer)
+}
+
+interface TokenResponse {
+  access_token: string
+  refresh_token: string
+  id_token?: string
+  token_type?: string
+  expires_in?: number
+  scope?: string
+}
+
+function authHeaders() {
+  return {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json",
+    "User-Agent": `mimocode/${InstallationVersion}`,
+  }
+}
+
+// Parse the `exp` claim out of a JWT access_token without verifying the
+// signature. We only use this to decide whether to proactively refresh, never
+// to make trust decisions, so unsigned decode is safe. Returns false for
+// opaque tokens (no JWT shape), which conservatively skips the proactive
+// refresh and lets the 401-on-call path drive the refresh instead.
+export function accessTokenIsExpiring(
+  token: string | undefined,
+  skewMs: number = ACCESS_TOKEN_REFRESH_SKEW_MS,
+): boolean {
+  if (!token || typeof token !== "string") return false
+  const parts = token.split(".")
+  if (parts.length < 2) return false
+  try {
+    let payload = parts[1].replace(/-/g, "+").replace(/_/g, "/")
+    while (payload.length % 4 !== 0) payload += "="
+    const claims = JSON.parse(Buffer.from(payload, "base64").toString("utf8"))
+    if (typeof claims?.exp !== "number") return false
+    return claims.exp * 1000 <= Date.now() + Math.max(0, skewMs)
+  } catch {
+    return false
+  }
+}
+
+export function buildAuthorizeUrl(
+  pkce: PkceCodes,
+  state: string,
+  nonce: string,
+  options: XaiAuthPluginOptions = {},
+): string {
+  // `plan=generic` opts the consent screen into xAI's generic OAuth plan tier;
+  // without it, accounts.x.ai rejects loopback OAuth from non-allowlisted
+  // clients. `referrer=opencode` lets xAI attribute opencode-originated
+  // logins in their OAuth server logs (best-effort attribution while we
+  // continue to reuse the Grok-CLI client_id).
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: CLIENT_ID,
+    redirect_uri: REDIRECT_URI,
+    scope: SCOPE,
+    code_challenge: pkce.challenge,
+    code_challenge_method: "S256",
+    state,
+    nonce,
+    plan: "generic",
+    referrer: "opencode",
+  })
+  return `${options.authorizeUrl ?? AUTHORIZE_URL}?${params.toString()}`
+}
+
+async function exchangeCodeForTokens(
+  code: string,
+  pkce: PkceCodes,
+  options: XaiAuthPluginOptions = {},
+): Promise<TokenResponse> {
+  const response = await fetch(options.tokenUrl ?? TOKEN_URL, {
+    method: "POST",
+    headers: authHeaders(),
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID,
+      code_verifier: pkce.verifier,
+    }).toString(),
+  })
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "")
+    throw new Error(`xAI token exchange failed (${response.status})${detail ? `: ${detail}` : ""}`)
+  }
+  return response.json() as Promise<TokenResponse>
+}
+
+async function refreshAccessToken(refreshToken: string, options: XaiAuthPluginOptions = {}): Promise<TokenResponse> {
+  const response = await fetch(options.tokenUrl ?? TOKEN_URL, {
+    method: "POST",
+    headers: authHeaders(),
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: CLIENT_ID,
+    }).toString(),
+  })
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "")
+    throw new Error(`xAI token refresh failed (${response.status})${detail ? `: ${detail}` : ""}`)
+  }
+  return response.json() as Promise<TokenResponse>
+}
+
+export interface DeviceCodeResponse {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete?: string
+  expires_in?: number
+  interval?: number
+}
+
+interface DeviceTokenErrorBody {
+  error?: string
+  error_description?: string
+}
+
+export async function requestDeviceCode(options: XaiAuthPluginOptions = {}): Promise<DeviceCodeResponse> {
+  const response = await fetch(options.deviceAuthorizationUrl ?? DEVICE_AUTHORIZATION_URL, {
+    method: "POST",
+    headers: authHeaders(),
+    body: new URLSearchParams({
+      client_id: CLIENT_ID,
+      scope: SCOPE,
+    }).toString(),
+  })
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "")
+    throw new Error(`xAI device code request failed (${response.status})${detail ? `: ${detail}` : ""}`)
+  }
+  const json = (await response.json()) as DeviceCodeResponse
+  if (!json.device_code || !json.user_code || !json.verification_uri) {
+    throw new Error("xAI device code response is missing device_code / user_code / verification_uri")
+  }
+  return json
+}
+
+// Default sleep used between device-code polls. Test-injectable so we can
+// exercise authorization_pending / slow_down branches without real waits.
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+// Normalize a server-supplied seconds value to milliseconds, falling back to
+// the supplied default when the input is missing, non-positive, or not a
+// finite number. Defends the polling loop against garbage like `NaN`, `"NaN"`,
+// `null`, or `-5` from a misbehaving device-code endpoint — without this,
+// a NaN interval would slip through `?? default` (NaN is typeof number),
+// reach `setTimeout(_, NaN)` which is treated as 0, and busy-loop until the
+// hard deadline. Matches the defensive normalization Codex uses for the same
+// field (`parseInt(deviceData.interval) || 5`).
+function positiveSecondsToMs(value: unknown, defaultMs: number): number {
+  const seconds = Number(value)
+  return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : defaultMs
+}
+
+export async function pollDeviceCodeToken(
+  device: DeviceCodeResponse,
+  options: XaiAuthPluginOptions & { sleep?: (ms: number) => Promise<void>; now?: () => number } = {},
+): Promise<TokenResponse> {
+  const sleep = options.sleep ?? defaultSleep
+  const now = options.now ?? (() => Date.now())
+  const expiresInMs = positiveSecondsToMs(device.expires_in, DEVICE_CODE_DEFAULT_EXPIRES_MS)
+  const deadline = now() + expiresInMs
+  let intervalMs = Math.max(
+    positiveSecondsToMs(device.interval, DEVICE_CODE_DEFAULT_INTERVAL_MS),
+    DEVICE_CODE_MIN_INTERVAL_MS,
+  )
+
+  while (now() < deadline) {
+    const response = await fetch(options.tokenUrl ?? TOKEN_URL, {
+      method: "POST",
+      headers: authHeaders(),
+      body: new URLSearchParams({
+        grant_type: DEVICE_CODE_GRANT_TYPE,
+        client_id: CLIENT_ID,
+        device_code: device.device_code,
+      }).toString(),
+    })
+    if (response.ok) return (await response.json()) as TokenResponse
+
+    const body = (await response.json().catch(() => ({}))) as DeviceTokenErrorBody
+    const remaining = Math.max(0, deadline - now())
+    // RFC 8628 §3.5: authorization_pending = keep polling at the same
+    // interval; slow_down = bump the interval by ≥5s and keep polling.
+    // Anything else is terminal.
+    if (body.error === "authorization_pending") {
+      await sleep(Math.min(intervalMs + OAUTH_POLLING_SAFETY_MARGIN_MS, remaining))
+      continue
+    }
+    if (body.error === "slow_down") {
+      intervalMs += DEVICE_CODE_SLOW_DOWN_INCREMENT_MS
+      await sleep(Math.min(intervalMs + OAUTH_POLLING_SAFETY_MARGIN_MS, remaining))
+      continue
+    }
+    if (body.error === "access_denied" || body.error === "authorization_denied") {
+      throw new Error("xAI device authorization was denied")
+    }
+    if (body.error === "expired_token") {
+      throw new Error("xAI device code expired - please re-run login")
+    }
+    const detail = body.error_description ?? body.error ?? ""
+    throw new Error(`xAI device token exchange failed (${response.status})${detail ? `: ${detail}` : ""}`)
+  }
+  throw new Error("xAI device authorization timed out")
+}
+
+// CORS allowlist for the loopback callback. The redirect_uri itself is
+// already bound to 127.0.0.1 and gated by PKCE+state, so we only accept
+// xAI's own auth origins for additional defense-in-depth on the OPTIONS
+// preflight.
+const CORS_ALLOWED_ORIGINS = new Set(["https://accounts.x.ai", "https://auth.x.ai"])
+
+interface PendingOAuth {
+  pkce: PkceCodes
+  state: string
+  resolve: (tokens: TokenResponse) => void
+  reject: (error: Error) => void
+}
+
+let oauthServer: ReturnType<typeof createServer> | undefined
+let pendingOAuth: PendingOAuth | undefined
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;")
+}
+
+const HTML_SUCCESS = `<!doctype html>
+<html>
+  <head>
+    <title>MiMoCode - xAI Authorization Successful</title>
+    <style>
+      body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #131010; color: #f1ecec; }
+      .container { text-align: center; padding: 2rem; }
+      h1 { color: #f1ecec; margin-bottom: 1rem; }
+      p { color: #b7b1b1; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Authorization Successful</h1>
+      <p>You can close this window and return to MiMoCode.</p>
+    </div>
+    <script>setTimeout(() => window.close(), 2000)</script>
+  </body>
+</html>`
+
+const HTML_ERROR = (error: string) => `<!doctype html>
+<html>
+  <head>
+    <title>MiMoCode - xAI Authorization Failed</title>
+    <style>
+      body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #131010; color: #f1ecec; }
+      .container { text-align: center; padding: 2rem; }
+      h1 { color: #fc533a; margin-bottom: 1rem; }
+      p { color: #b7b1b1; }
+      .error { color: #ff917b; font-family: monospace; margin-top: 1rem; padding: 1rem; background: #3c140d; border-radius: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Authorization Failed</h1>
+      <p>An error occurred during authorization.</p>
+      <div class="error">${escapeHtml(error)}</div>
+    </div>
+  </body>
+</html>`
+
+async function startOAuthServer(): Promise<{ port: number; redirectUri: string }> {
+  if (oauthServer) return { port: OAUTH_PORT, redirectUri: REDIRECT_URI }
+
+  const server = createServer((req, res) => {
+    const reqUrl = req.url || "/"
+    const url = new URL(reqUrl, `http://${OAUTH_HOST}:${OAUTH_PORT}`)
+
+    const origin = req.headers["origin"]
+    const allowOrigin = typeof origin === "string" && CORS_ALLOWED_ORIGINS.has(origin) ? origin : ""
+    if (allowOrigin) {
+      res.setHeader("Access-Control-Allow-Origin", allowOrigin)
+      res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS")
+      res.setHeader("Access-Control-Allow-Headers", "Content-Type")
+      res.setHeader("Access-Control-Allow-Private-Network", "true")
+      res.setHeader("Vary", "Origin")
+    }
+
+    if (req.method === "OPTIONS") {
+      res.writeHead(204)
+      res.end()
+      return
+    }
+
+    if (url.pathname === OAUTH_REDIRECT_PATH) {
+      const code = url.searchParams.get("code")
+      const state = url.searchParams.get("state")
+      const error = url.searchParams.get("error")
+      const errorDescription = url.searchParams.get("error_description")
+
+      if (error) {
+        const errorMsg = errorDescription || error
+        pendingOAuth?.reject(new Error(errorMsg))
+        pendingOAuth = undefined
+        res.writeHead(200, { "Content-Type": "text/html" })
+        res.end(HTML_ERROR(errorMsg))
+        return
+      }
+
+      if (!code) {
+        const errorMsg = "Missing authorization code"
+        pendingOAuth?.reject(new Error(errorMsg))
+        pendingOAuth = undefined
+        res.writeHead(400, { "Content-Type": "text/html" })
+        res.end(HTML_ERROR(errorMsg))
+        return
+      }
+
+      if (!pendingOAuth || state !== pendingOAuth.state) {
+        const errorMsg = "Invalid state - potential CSRF attack"
+        pendingOAuth?.reject(new Error(errorMsg))
+        pendingOAuth = undefined
+        res.writeHead(400, { "Content-Type": "text/html" })
+        res.end(HTML_ERROR(errorMsg))
+        return
+      }
+
+      const current = pendingOAuth
+      pendingOAuth = undefined
+
+      exchangeCodeForTokens(code, current.pkce)
+        .then((tokens) => current.resolve(tokens))
+        .catch((err) => current.reject(err))
+
+      res.writeHead(200, { "Content-Type": "text/html" })
+      res.end(HTML_SUCCESS)
+      return
+    }
+
+    if (url.pathname === "/cancel") {
+      pendingOAuth?.reject(new Error("Login cancelled"))
+      pendingOAuth = undefined
+      res.writeHead(200)
+      res.end("Login cancelled")
+      return
+    }
+
+    res.writeHead(404)
+    res.end("Not found")
+  })
+
+  // listen() failures (e.g. EADDRINUSE because Grok-CLI is bound to the same
+  // pinned port) must clear `oauthServer` and remove our error listener,
+  // otherwise the next startOAuthServer() short-circuits on the truthy check
+  // and returns a redirect_uri pointing at nothing.
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error) => {
+      oauthServer = undefined
+      reject(err)
+    }
+    server.once("error", onError)
+    server.listen(OAUTH_PORT, OAUTH_HOST, () => {
+      server.removeListener("error", onError)
+      log.info("xai oauth server started", { port: OAUTH_PORT })
+      resolve()
+    })
+    oauthServer = server
+  })
+
+  return { port: OAUTH_PORT, redirectUri: REDIRECT_URI }
+}
+
+function stopOAuthServer() {
+  if (oauthServer) {
+    oauthServer.close(() => {
+      log.info("xai oauth server stopped")
+    })
+    oauthServer = undefined
+  }
+}
+
+function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResponse> {
+  // A previous in-flight authorize() that the user abandoned (or that is
+  // being superseded by a fresh attempt) still owns `pendingOAuth`. Reject
+  // it eagerly so its caller stops waiting on a state value that can never
+  // match the next callback.
+  if (pendingOAuth) {
+    pendingOAuth.reject(new Error("Superseded by a newer xAI authorize request"))
+    pendingOAuth = undefined
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => {
+        if (pendingOAuth) {
+          pendingOAuth = undefined
+          reject(new Error("OAuth callback timeout - authorization took too long"))
+        }
+      },
+      5 * 60 * 1000,
+    )
+
+    pendingOAuth = {
+      pkce,
+      state,
+      resolve: (tokens) => {
+        clearTimeout(timeout)
+        resolve(tokens)
+      },
+      reject: (error) => {
+        clearTimeout(timeout)
+        reject(error)
+      },
+    }
+  })
+}
+
+interface RefreshResult {
+  access: string
+  refresh: string
+  expires: number
+}
+
+export async function XaiAuthPlugin(input: PluginInput, options: XaiAuthPluginOptions = {}): Promise<Hooks> {
+  return {
+    auth: {
+      provider: "xai",
+      async loader(getAuth) {
+        const auth = await getAuth()
+        if (auth.type !== "oauth") return {}
+
+        // Single-flight refresh: collapse concurrent fetches from this loaded
+        // provider onto one HTTP call so we don't replay a rotating refresh_token.
+        let refreshPromise: Promise<RefreshResult> | undefined
+
+        return {
+          // Dummy bearer keeps the AI SDK from bailing on "missing apiKey"; the
+          // real OAuth token is injected by the fetch override below.
+          // We intentionally do NOT set baseURL — @ai-sdk/xai already defaults
+          // to https://api.x.ai/v1 and overriding here would silently route
+          // around a user-configured gateway.
+          apiKey: OAUTH_DUMMY_KEY,
+          async fetch(requestInput: RequestInfo | URL, init?: RequestInit) {
+            let currentAuth = await getAuth()
+            // Auth can flip from oauth to api mid-session (user re-runs
+            // /connect with a pasted key). When that happens, pass the
+            // request through untouched so the AI SDK's own apiKey-based
+            // Authorization header reaches xAI unmodified.
+            if (currentAuth.type !== "oauth") return fetch(requestInput, init)
+
+            // Refresh either when the stored expires timestamp is within the
+            // skew window, or — for JWT access tokens — when the JWT exp
+            // claim itself is. The stored expires field is best-effort
+            // (xAI doesn't always return expires_in) so the JWT check is the
+            // load-bearing one for tokens that lack a fresh stored deadline.
+            const expiresSoon =
+              !currentAuth.expires ||
+              currentAuth.expires - Date.now() <= ACCESS_TOKEN_REFRESH_SKEW_MS ||
+              accessTokenIsExpiring(currentAuth.access)
+            if (expiresSoon) {
+              if (!refreshPromise) {
+                const refreshToken = currentAuth.refresh
+                refreshPromise = refreshAccessToken(refreshToken, options)
+                  .then(async (tokens) => {
+                    const refreshedExpires = Date.now() + (tokens.expires_in ?? 3600) * 1000
+                    const refreshedRefresh = tokens.refresh_token || refreshToken
+                    // Persist the rotated pair as best-effort. xAI has already consumed the
+                    // old refresh_token by the time we get here; an auth.set failure leaves
+                    // the on-disk state stale but the in-memory result is still valid for
+                    // this turn. The next live refresh against the stale disk state will
+                    // 4xx and force re-login — a known cross-process limitation.
+                    await input.client.auth
+                      .set({
+                        path: { id: "xai" },
+                        body: {
+                          type: "oauth",
+                          access: tokens.access_token,
+                          refresh: refreshedRefresh,
+                          expires: refreshedExpires,
+                        },
+                      })
+                      .catch(() => {})
+                    return { access: tokens.access_token, refresh: refreshedRefresh, expires: refreshedExpires }
+                  })
+                  .finally(() => {
+                    refreshPromise = undefined
+                  })
+              }
+              const refreshed = await refreshPromise
+              currentAuth = { ...currentAuth, ...refreshed }
+            }
+
+            // Copy the caller's headers into a fresh Headers (case-insensitive)
+            // so we never mutate the RequestInit the AI SDK may reuse on retry.
+            // Headers.set overwrites case-insensitively, which kills the dummy
+            // bearer the AI SDK injected from apiKey in a single line.
+            const headers = new Headers(requestInput instanceof Request ? requestInput.headers : undefined)
+            if (init?.headers) {
+              const entries =
+                init.headers instanceof Headers
+                  ? init.headers.entries()
+                  : Array.isArray(init.headers)
+                    ? init.headers
+                    : Object.entries(init.headers as Record<string, string | undefined>)
+              for (const [key, value] of entries) {
+                if (value !== undefined) headers.set(key, String(value))
+              }
+            }
+            headers.set("authorization", `Bearer ${currentAuth.access}`)
+            headers.set("User-Agent", `mimocode/${InstallationVersion}`)
+
+            return fetch(requestInput, { ...init, headers })
+          },
+        }
+      },
+      methods: [
+        {
+          label: "xAI Grok OAuth (SuperGrok Subscription)",
+          type: "oauth",
+          authorize: async () => {
+            await startOAuthServer()
+            const pkce = await generatePKCE()
+            const state = generateState()
+            const nonce = generateState()
+            const authUrl = buildAuthorizeUrl(pkce, state, nonce, options)
+
+            const callbackPromise = waitForOAuthCallback(pkce, state)
+
+            return {
+              url: authUrl,
+              instructions: "Complete authorization in your browser. This window will close automatically.",
+              method: "auto" as const,
+              callback: async () => {
+                try {
+                  const tokens = await callbackPromise
+                  return {
+                    type: "success" as const,
+                    refresh: tokens.refresh_token,
+                    access: tokens.access_token,
+                    expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                  }
+                } catch (err) {
+                  return { type: "failed" as const }
+                } finally {
+                  stopOAuthServer()
+                }
+              },
+            }
+          },
+        },
+        {
+          // RFC 8628 device-code flow. The CLI prints a verification URL
+          // and a short user_code that the user enters in a browser on
+          // any device. No loopback callback server runs on the CLI host,
+          // so this works on VPS / SSH / Docker / CI / WSL / any
+          // environment where 127.0.0.1:56121 isn't reachable from the
+          // user's browser. Defends the only attack surface (the polling
+          // loop) with the standard authorization_pending / slow_down
+          // backoff and a hard deadline from xAI's `expires_in`.
+          label: "xAI Grok OAuth (Headless / Remote / VPS)",
+          type: "oauth",
+          authorize: async () => {
+            const device = await requestDeviceCode(options)
+            const browserUrl = device.verification_uri_complete ?? device.verification_uri
+            return {
+              url: browserUrl,
+              instructions: `Open ${device.verification_uri} on any device and enter code: ${device.user_code}`,
+              method: "auto" as const,
+              callback: async () => {
+                try {
+                  const tokens = await pollDeviceCodeToken(device, options)
+                  return {
+                    type: "success" as const,
+                    refresh: tokens.refresh_token,
+                    access: tokens.access_token,
+                    expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                  }
+                } catch (err) {
+                  return { type: "failed" as const }
+                }
+              },
+            }
+          },
+        },
+        {
+          label: "Manually enter API Key",
+          type: "api",
+        },
+      ],
+    },
+  }
+}

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1268,7 +1268,9 @@ export function options(input: {
   if (
     input.model.providerID === "openai" ||
     input.model.api.npm === "@ai-sdk/openai" ||
-    input.model.api.npm === "@ai-sdk/github-copilot"
+    input.model.api.npm === "@ai-sdk/github-copilot" ||
+    input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle" ||
+    input.model.api.npm === "@ai-sdk/xai"
   ) {
     result["store"] = false
   }
@@ -1304,7 +1306,7 @@ export function options(input: {
     }
   }
 
-  if (input.model.providerID === "openai" || input.providerOptions?.setCacheKey) {
+  if (input.model.providerID === "openai" || input.model.api.npm === "@ai-sdk/xai" || input.providerOptions?.setCacheKey) {
     result["promptCacheKey"] = input.sessionID
   }
 
@@ -1405,7 +1407,8 @@ export function smallOptions(model: Provider.Model) {
   if (
     model.providerID === "openai" ||
     model.api.npm === "@ai-sdk/openai" ||
-    model.api.npm === "@ai-sdk/github-copilot"
+    model.api.npm === "@ai-sdk/github-copilot" ||
+    model.api.npm === "@ai-sdk/xai"
   ) {
     // Match the main-model path: request encrypted reasoning so store:false
     // stays round-trippable if a small-model call ever runs a tool loop.


### PR DESCRIPTION
## Summary

Complete Grok/xAI sync with upstream opencode: SDK version bump, transform handling alignment, **and** OAuth login plugin. Supersedes the closed OAuth-plugin PR #1817 (was a standalone misread).

## Changes

### 1. SDK version bump
`@ai-sdk/xai` 3.0.82 → 3.0.102 (matches upstream `anomalyco/opencode`)

### 2. Transform touch-points synced

| Touch-point | Upstream block | Action |
|---|---|---|
| `reasoningEfforts` (grok reasoning config) | `case "@ai-sdk/xai":` in effort mapping | Already present |
| `store: false` (providerOptions) | `input.model.api.npm === "@ai-sdk/xai"` | Ported |
| `promptCacheKey` (providerOptions) | `input.model.api.npm === "@ai-sdk/xai" \|\|` | Ported |
| `smallOptions` | `model.api.npm === "@ai-sdk/xai"` in store:false block | Ported |
| `reasoningBudget` | `case "@ai-sdk/xai":` → `return` (no-op) | N/A — repo lacks `budgetVariants`/`reasoningToggle` system |

### 3. Grok OAuth login plugin

Ported from **official `anomalyco/opencode` origin/dev** (`plugin/xai.ts`), reconciled with this fork's plugin API:

- `@opencode-ai/plugin` → `@mimo-ai/plugin`
- `@opencode-ai/core/installation/version` → `../installation/version`
- `OauthCallbackPage` module → inline HTML templates (matches `plugin/codex.ts` pattern)
- `OAUTH_DUMMY_KEY` imported from `../auth`
- User-Agent: `mimocode/${InstallationVersion}`
- `Log.create({ service: "plugin.xai" })`
- Registered in `INTERNAL_PLUGINS` array alongside `CodexAuthPlugin`

Three auth methods:
1. **Browser OAuth** — loopback callback on `127.0.0.1:56121`, PKCE + state CSRF protection
2. **Device-code OAuth** (RFC 8628) — headless/VPS/SSH/Docker; user enters short code on any device
3. **Manual API key entry**

Token flow: `auth.loader` injects OAuth Bearer token via fetch override, handles proactive JWT expiry + refresh with single-flight dedup, persists rotated refresh tokens via `input.client.auth.set()`.

## Verification

- `bun install` clean
- `turbo typecheck` — 12/12 packages pass
- `bun test test/provider/` — 381/381 tests pass (0 failures)