### PR TITLE
fix: treat GPT reasoning-only steps as terminal

### DIFF
--- a/packages/opencode/src/session/classify.ts
+++ b/packages/opencode/src/session/classify.ts
@@ -111,7 +111,13 @@ export function classifyAssistantStep(input: {
     )
   )
     return assistant.finish === "other" ? { type: "final", degraded: true } : { type: "final" }
-  if (input.parts.some((part) => part.type === "reasoning" && part.text.trim().length > 0))
+  if (input.parts.some((part) => part.type === "reasoning" && part.text.trim().length > 0)) {
+    // GPT reasoning models may legitimately end a step with reasoning and no
+    // separate text part. Match upstream termination semantics for that family
+    // without weakening think-only recovery for other reasoning models.
+    if (/(^|\/)gpt-\d/i.test(assistant.modelID))
+      return assistant.finish === "other" ? { type: "final", degraded: true } : { type: "final" }
     return { type: "think-only" }
+  }
   return { type: "invalid", reason: "empty output" }
 }

--- a/packages/opencode/test/lib/scripted-llm-server.ts
+++ b/packages/opencode/test/lib/scripted-llm-server.ts
@@ -70,6 +70,16 @@ export function reasoningStopResponse(reasoning: string): string[] {
   ]
 }
 
+/** Build SSE lines for reasoning-only output that exhausted the output token budget */
+export function reasoningLengthResponse(reasoning: string): string[] {
+  return [
+    sseChunk({ role: "assistant" }),
+    sseChunk({ reasoning_content: reasoning }),
+    sseChunk({}, "length"),
+    "data: [DONE]\n\n",
+  ]
+}
+
 /**
  * Build SSE lines for a step halted by the provider's content safety filter
  * (`finish_reason: "content_filter"`, mapped to unified "content-filter").

--- a/packages/opencode/test/session/classify.test.ts
+++ b/packages/opencode/test/session/classify.test.ts
@@ -226,6 +226,28 @@ describe("classifyAssistantStep", () => {
     ).toEqual({ type: "think-only" })
   })
 
+  test("GPT stop + reasoning only (no text) => final", () => {
+    expect(
+      classifyAssistantStep({
+        phase: "after-process",
+        lastUser,
+        assistant: { ...assistantInfo("m-2", { finish: "stop" }), modelID: ModelID.make("gpt-5.5") },
+        parts: [reasoningPart("m-2", "let me think...")],
+      }),
+    ).toEqual({ type: "final" })
+  })
+
+  test("namespaced GPT other + reasoning only => degraded final", () => {
+    expect(
+      classifyAssistantStep({
+        phase: "after-process",
+        lastUser,
+        assistant: { ...assistantInfo("m-2", { finish: "other" }), modelID: ModelID.make("openai/gpt-5.5") },
+        parts: [reasoningPart("m-2", "let me think...")],
+      }),
+    ).toEqual({ type: "final", degraded: true })
+  })
+
   test("stop + empty (no text/tool/reasoning) => invalid", () => {
     expect(
       classifyAssistantStep({

--- a/packages/opencode/test/session/invalid-output-continuation.test.ts
+++ b/packages/opencode/test/session/invalid-output-continuation.test.ts
@@ -21,6 +21,7 @@ import {
   startScriptedLLMServer,
   textStopResponse,
   emptyStopResponse,
+  reasoningLengthResponse,
   reasoningStopResponse,
 } from "../lib/scripted-llm-server"
 
@@ -46,6 +47,40 @@ function writeConfig(dir: string, origin: string) {
         alibaba: { options: { apiKey: "test-key", baseURL: `${origin}/v1` } },
       },
       agent: { build: { model: "alibaba/qwen-plus" } },
+    }),
+  )
+}
+
+function writeGPTConfig(dir: string, origin: string) {
+  return Bun.write(
+    path.join(dir, "mimocode.json"),
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      enabled_providers: ["test"],
+      provider: {
+        test: {
+          name: "Test",
+          id: "test",
+          env: [],
+          npm: "@ai-sdk/openai-compatible",
+          models: {
+            "gpt-5.5": {
+              id: "gpt-5.5",
+              name: "GPT-5.5",
+              attachment: false,
+              reasoning: true,
+              temperature: false,
+              tool_call: true,
+              release_date: "2026-01-01",
+              limit: { context: 100_000, output: 10_000 },
+              cost: { input: 0, output: 0 },
+              options: {},
+            },
+          },
+          options: { apiKey: "test-key", baseURL: `${origin}/v1` },
+        },
+      },
+      agent: { build: { model: "test/gpt-5.5" } },
     }),
   )
 }
@@ -106,6 +141,72 @@ describe("invalid-output continuation — integration", () => {
               expect(stub.captures.length).toBe(2)
               expect(result.info.role).toBe("assistant")
               if (result.info.role === "assistant") expect(result.info.error).toBeUndefined()
+              expect(result.parts.some((p) => p.type === "text" && p.text === "final answer")).toBe(true)
+            }),
+          ),
+      })
+    } finally {
+      await stub.stop()
+    }
+  })
+
+  test("GPT reasoning-only stop step is terminal and is not retried", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const stub = startScriptedLLMServer([
+      { lines: reasoningStopResponse("let me think about this...") },
+      { lines: textStopResponse("unexpected retry") },
+    ])
+    try {
+      await writeGPTConfig(tmp.path, stub.origin)
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const prompt = yield* SessionPrompt.Service
+              const session = yield* sessions.create({ title: "gpt-reasoning-only" })
+              const result = yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "build",
+                parts: [{ type: "text", text: "Answer my question." }],
+              })
+              expect(stub.captures.length).toBe(1)
+              expect(result.info.role).toBe("assistant")
+              if (result.info.role === "assistant") expect(result.info.error).toBeUndefined()
+              expect(result.parts.some((p) => p.type === "reasoning" && p.text.includes("let me think"))).toBe(true)
+              expect(result.parts.some((p) => p.type === "text")).toBe(false)
+            }),
+          ),
+      })
+    } finally {
+      await stub.stop()
+    }
+  })
+
+  test("GPT reasoning-only length step still auto-continues", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const stub = startScriptedLLMServer([
+      { lines: reasoningLengthResponse("token budget exhausted while thinking...") },
+      { lines: textStopResponse("final answer") },
+    ])
+    try {
+      await writeGPTConfig(tmp.path, stub.origin)
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const prompt = yield* SessionPrompt.Service
+              const session = yield* sessions.create({ title: "gpt-reasoning-length" })
+              const result = yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "build",
+                parts: [{ type: "text", text: "Answer my question." }],
+              })
+              expect(stub.captures.length).toBe(2)
+              expect(JSON.stringify(stub.captures[1].messages)).toContain("output token limit")
               expect(result.parts.some((p) => p.type === "text" && p.text === "final answer")).toBe(true)
             }),
           ),


### PR DESCRIPTION
## Summary
- GPT reasoning models may legitimately end a step with reasoning and no separate text part
- The previous classification always returned "think-only" for any step containing reasoning, triggering unwanted retries for GPT-family models
- Add a model ID check: when the assistant model matches `gpt-*` and the step has reasoning but no text, classify it as final instead of think-only

## Changes
- `src/session/classify.ts`: Add GPT model ID check before returning "think-only" classification
- `test/lib/scripted-llm-server.ts`: Add `reasoningLengthResponse` helper for testing length-limited reasoning output
- `test/session/classify.test.ts`: Add unit tests for GPT reasoning-only classification
- `test/session/invalid-output-continuation.test.ts`: Add integration tests verifying GPT reasoning-only steps are terminal and not retried

## Test plan
- [x] Unit tests for GPT reasoning-only classification
- [x] Integration tests verifying no retry on GPT reasoning-only stop
- [x] Integration tests verifying length-limited reasoning still auto-continues
- [x] Typecheck passes