### PR TITLE
chore: rename build:dev to build:local + add root shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "packageManager": "bun@1.3.14",
   "scripts": {
     "dev": "bun run --cwd packages/opencode script/dev.ts",
+    "build:local": "bun run --cwd packages/opencode build:local",
     "dev:desktop": "bun --cwd packages/desktop dev",
     "dev:web": "bun --cwd packages/app dev",
     "dev:console": "ulimit -n 10240 2>/dev/null; bun run --cwd packages/console/app dev",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -14,7 +14,7 @@
     "test": "bun test --timeout 30000",
     "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "build": "bun run script/build.ts",
-    "build:dev": "MIMOCODE_CHANNEL=prod bun run script/build.ts --single",
+    "build:local": "MIMOCODE_CHANNEL=local MIMOCODE_VERSION=local bun run script/build.ts --single",
     "fix-node-pty": "bun run script/fix-node-pty.ts",
     "upgrade-opentui": "bun run script/upgrade-opentui.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",


### PR DESCRIPTION
## Summary
- Rename `packages/opencode/package.json` script `build:dev` → `build:local`, and switch its env from stale `MIMOCODE_CHANNEL=prod` to `MIMOCODE_CHANNEL=local MIMOCODE_VERSION=local`.
- Add a root-level `build:local` that delegates to the opencode package, mirroring the existing `dev` / `dev:*` shortcut convention (so `bun run build:local` from the repo root just works).

## Why
- The old `MIMOCODE_CHANNEL=prod` value was an early-stage default and no longer serves any purpose — nothing in the tree consumes it.
- With channel/version pinned to `local`, `InstallationLocal` (see `packages/opencode/src/installation/version.ts`) becomes `true`, which:
  - Bypasses the marker-skip guard in `src/skill/builtin/extract.ts` and `src/skill/compose/extract.ts` — bundled builtin/compose skills are **re-extracted on every startup**, so edits to bundled skill sources are picked up immediately after a rebuild without needing a version bump or a manual cache purge.
  - Pins the version segment of the extraction directory to `local` (`~/.local/share/mimocode/{builtin_skills,compose}/local/`), instead of the previous `0.0.0-<channel>-<sha>` that changed with every commit and left orphan directories behind.

## Non-impact on correctness
- Only affects local dev builds. Release builds (`bun run build`, CI, package publishing) are untouched — they still compute channel/version from `packages/script/src/index.ts` as before.
- No callers of `build:dev` exist anywhere in the tree (verified via full-repo grep across `*.md`/`*.yml`/`*.sh`/`*.ts`/`*.json`/`*.toml`/`*.mdx`/`*.ps1`/`*.nix`). CI, install scripts, and nix configs don't reference it.
- Typecheck passes (`bun turbo typecheck`, 12/12 packages green).

## Files touched
- `package.json` — add root-level `build:local` shortcut.
- `packages/opencode/package.json` — rename script and update env vars.