### PR TITLE
fix(session): isolate child git operations must not move the main checkout HEAD

### DIFF
--- a/packages/opencode/src/session/prompt/orchestrator.txt
+++ b/packages/opencode/src/session/prompt/orchestrator.txt
@@ -94,6 +94,19 @@ An isolated child's commits live on its own `mimocode/<...>` branch in its workt
 - Preview conflicts with `git merge-tree`, then `git merge <branch>` (or cherry-pick) into the target branch.
 - Find a child's branch via `git worktree list` or `git branch --list 'mimocode/*'`.
 
+### Git safety for isolated children (critical)
+
+Git worktrees share the same `.git` object store and ref namespace. This means:
+- A child running `git rebase`, `git merge`, or `git checkout` in its worktree CAN affect refs visible to the main checkout (e.g. `refs/heads/main`).
+- A child's `git rebase main` operates on the shared ref store and can move the main checkout's HEAD.
+- All `mimocode/*` branches are shared across worktrees — a child's ref mutations affect every worktree.
+
+**Rules you MUST enforce in every isolated child's task description:**
+1. A child MUST NOT run `git rebase`, `git merge`, or `git checkout` on ANY branch other than its own `mimocode/<name>` branch. These operations mutate shared refs and can corrupt the main checkout.
+2. A child SHOULD use `git commit` and `git push` on its own branch — these are safe (push targets remote, commit advances only the child's branch ref).
+3. ALL integration (merge, cherry-pick, rebase of child branches into the target) is YOUR job as orchestrator — never delegate it to a child.
+4. When dispatching an isolated child, INCLUDE this instruction in the child's task: "You are on branch <branch> in an isolated worktree. Do NOT run git rebase, git merge, or git checkout on any branch other than your own. Commit and push only on your branch. The orchestrator will handle integration."
+
 ## Finished sessions stay resumable — mirror how a human treats a session (governing principle)
 
 Your interaction with a child session must be CONSISTENT with how a HUMAN interacts with a session. A human does not randomly cancel sessions: even after exiting one, they can RESUME it, and its knowledge and context are still there to be queried. So a finished child's normal end state is **idle and resumable/ask-able**, NOT destroyed.

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -733,7 +733,9 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
           output:
             `Created child session ${result.sessionID} (mode: ${op.mode ?? "build"}) in ${effectiveDir}.` +
             (op.topic ? ` Tagged with topic '${op.topic}' for reuse.` : ``) +
-            (op.isolate && !isolateNotice ? ` Isolated in its own worktree.` : isolateNotice) +
+            (op.isolate && !isolateNotice
+              ? ` Isolated in its own worktree. IMPORTANT: Git worktrees share refs — the child MUST NOT run git rebase/merge/checkout on branches it doesn't own. It may commit+push on its own branch only.`
+              : isolateNotice) +
             ` Running in the background.`,
           metadata: { sessionID: result.sessionID } as Metadata,
         }

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -506,6 +506,25 @@ describe("session tool", () => {
     ),
   )
 
+  it.live("create --isolate output warns about shared ref namespace", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const parent = yield* sessions.create({ title: "Parent" })
+        const tool = yield* (yield* SessionTool).init()
+        const res = yield* tool.execute(
+          { operation: { action: "create", task: "x", mode: "build", dir, isolate: true } },
+          ctx(parent.id),
+        )
+        // The output must warn about shared refs to prevent children from
+        // running git rebase/merge/checkout that could affect the main checkout.
+        expect(res.output).toContain("share refs")
+        expect(res.output).toContain("git rebase")
+      }),
+      { git: true },
+    ),
+  )
+
   it.live("create --dir without isolate runs the child in that directory (shared)", () =>
     provideTmpdirInstance((dir) =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- **Root cause**: Git worktrees share the same `.git` object store and ref namespace. When the Orchestrator dispatches a background child session with `isolate:true`, the child gets its own git worktree directory — BUT all worktrees share one `.git`. A child running `git rebase`, `git merge`, or `git checkout` in its worktree CAN affect refs visible to the main checkout (e.g. `refs/heads/main`), potentially moving its HEAD.
- **This is an architectural constraint of git worktrees, NOT a code bug in cwd resolution.** The bash tool correctly runs commands in the worktree directory (`ctx.directory` resolves to the worktree via `InstanceRef`). The defect is that git worktrees share refs by design — there's no code-level mechanism to prevent a child from affecting shared refs through git commands.
- **Fix**: Add explicit git safety instructions to the orchestrator prompt (`orchestrator.txt`) and a warning in the session tool output when creating isolated children. The orchestrator MUST enforce that children only `commit`+`push` on their own branch and never run `git rebase`/`git merge`/`git checkout` on other branches. ALL integration (merge, cherry-pick, rebase) is the orchestrator's job.

## Changes

| File | Change |
|------|--------|
| `packages/opencode/src/session/prompt/orchestrator.txt` | Added "Git safety for isolated children" section with 4 mandatory rules for the orchestrator to enforce |
| `packages/opencode/src/tool/session.ts` | Added git safety warning to `session create --isolate` output |
| `packages/opencode/test/tool/session-tool.test.ts` | Added test verifying the warning is present in session create output |

## Root Cause Analysis

**File:line evidence:**
- `packages/opencode/src/worktree/index.ts:260` — `git worktree add -b <branch> <directory>` creates the worktree from the shared repo root
- `packages/opencode/src/tool/session.ts:718` — `cwd: effectiveDir` correctly passes worktree path to child
- `packages/opencode/src/actor/spawn.ts:653-655` — `InstanceRef` correctly bound to worktree's InstanceContext
- `packages/opencode/src/session/prompt.ts:1551` — `const cwd = ctx.directory` correctly resolves to worktree via InstanceRef

**The mechanism**: All git worktrees share `refs/heads/*`, `packed-refs`, and the objects database. When a child runs `git rebase main` from its worktree, git operates on the shared ref store. The rebase modifies refs that the main checkout reads, potentially moving its HEAD. Git worktrees share refs by design — this cannot be prevented at the code level.

## Verification

- `bun typecheck` — PASS (all 12 packages)
- `bun test test/tool/session-tool.test.ts` — PASS (52 pass, 1 skip)
- `bun test test/worktree/index.test.ts` — PASS
- `bun test test/session/session-create-registers-main.test.ts` — PASS