### PR TITLE
feat(skills): per-OS CJK font guidance in office skills (docx/pptx/xlsx)

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
@@ -315,9 +315,14 @@ shade_paragraph(p, "FFF4CE")
 `Document()` ships with a theme referencing Cambria, Calibri, and CJK fallback fonts (MS Gothic, MS Mincho) that may not exist on the target system. Viewers warn about them even when every run has an explicit font. Patch the theme right after creation:
 
 ```python
+import platform
+
 from lxml import etree
 
 doc = Document()
+
+# Per-OS CJK face (table below); copy-paste safe on any platform.
+CJK_FONT = {"Windows": "Microsoft YaHei", "Darwin": "PingFang SC"}.get(platform.system(), "Noto Sans CJK SC")
 
 # --- patch theme font definitions ---
 theme_rel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
@@ -329,7 +334,7 @@ for latin in theme_xml.xpath("//a:majorFont/a:latin | //a:minorFont/a:latin", na
     latin.set("typeface", "Times New Roman")       # or your preferred Latin font
 for font in theme_xml.xpath("//a:majorFont/a:font | //a:minorFont/a:font", namespaces=ns):
     if font.get("script", "") in ("Hans", "Hant", "Jpan", "Hang"):
-        font.set("typeface", "Microsoft YaHei")    # current OS's CJK face — see table below
+        font.set("typeface", CJK_FONT)
 
 theme_part._blob = etree.tostring(theme_xml, xml_declaration=True, encoding="UTF-8", standalone=True)
 
@@ -339,13 +344,15 @@ for style in doc.styles:
         style.font.name = "Courier New"
 ```
 
-Call this once, immediately after `Document()`, before adding content. Choose fonts that exist on the machine where the file will be viewed — don't invent names. For Chinese text, prefer the standard CJK face of the current OS (check the platform from your environment):
+Call this once, immediately after `Document()`, before adding content. Choose fonts that exist on the machine where the file will be **viewed** — don't invent names. In the common interactive case the file is viewed on the machine that generated it, so use the current OS's standard CJK face (check the platform from your environment):
 
 | OS | CJK font (for `w:eastAsia` and theme script slots) |
 |----|-----------------------------------------------------|
 | Windows | `Microsoft YaHei` (微软雅黑) |
 | macOS | `PingFang SC` (苹方) |
 | Linux | `Noto Sans CJK SC` |
+
+If the deliverable targets viewers on a **different or unknown OS** (e.g. generated on a headless Linux server, opened by Windows recipients), prefer a portable name instead — `Microsoft YaHei` or `SimSun` ship with every Windows, and other platforms substitute a reasonable CJK face. Note the failure modes differ: leaving the East-Asian slot **unset** (or using a Latin-only face) causes `??`/tofu; a CJK-capable name that's merely absent on the viewer's machine only causes font substitution — so any CJK name is correct, the choice affects fidelity.
 
 For Japanese/Korean, use the platform's JP/KR system face instead (e.g. Yu Gothic / Malgun Gothic on Windows, Hiragino Sans / Apple SD Gothic Neo on macOS).
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/create.md
@@ -251,7 +251,7 @@ def ref(paragraph, name):
 | Image renders huge | Only `width` or `height` supplied ≥ page width | Compute `Cm(15)` (roughly page-content width) and let the other axis auto-scale. |
 | File opens with "content had problems" | Manually inserted XML with unbalanced tags | Reopen the exploded directory, run `xmllint --noout word/document.xml`, fix the offending element. |
 | "Missing font" warning on open (Cambria, Calibri, CJK fonts) | `python-docx` default template embeds font references in theme XML that may not be installed | Patch the theme after `Document()` — see recipe below. |
-| Chinese / non-ASCII text renders as `??` in some viewers | Font run has no East-Asian font | Set both the ASCII and East-Asian typefaces: `run.font.name = "Calibri"; run._element.get_or_add_rPr().get_or_add_rFonts().set(qn("w:eastAsia"), "Microsoft YaHei")` — the `get_or_add_*` form is safe when the run has no `rPr`/`rFonts` yet; setting only `run.font.name` leaves CJK on the default font. Use a CJK-capable font for the `w:eastAsia` value. |
+| Chinese / non-ASCII text renders as `??` in some viewers | Font run has no East-Asian font | Set both the ASCII and East-Asian typefaces: `run.font.name = "Calibri"; run._element.get_or_add_rPr().get_or_add_rFonts().set(qn("w:eastAsia"), "Microsoft YaHei")` — the `get_or_add_*` form is safe when the run has no `rPr`/`rFonts` yet; setting only `run.font.name` leaves CJK on the default font. Use a CJK-capable font for the `w:eastAsia` value (per-OS table in the theme-patch section below). |
 
 ## Recipes
 
@@ -329,7 +329,7 @@ for latin in theme_xml.xpath("//a:majorFont/a:latin | //a:minorFont/a:latin", na
     latin.set("typeface", "Times New Roman")       # or your preferred Latin font
 for font in theme_xml.xpath("//a:majorFont/a:font | //a:minorFont/a:font", namespaces=ns):
     if font.get("script", "") in ("Hans", "Hant", "Jpan", "Hang"):
-        font.set("typeface", "SimSun")             # or your preferred CJK font
+        font.set("typeface", "Microsoft YaHei")    # current OS's CJK face — see table below
 
 theme_part._blob = etree.tostring(theme_xml, xml_declaration=True, encoding="UTF-8", standalone=True)
 
@@ -339,7 +339,15 @@ for style in doc.styles:
         style.font.name = "Courier New"
 ```
 
-Call this once, immediately after `Document()`, before adding content. Choose fonts you know exist on your target audience's systems. For CJK documents the most portable choices are SimSun / 宋体 (Chinese), MS Mincho (Japanese), or Malgun Gothic (Korean).
+Call this once, immediately after `Document()`, before adding content. Choose fonts that exist on the machine where the file will be viewed — don't invent names. For Chinese text, prefer the standard CJK face of the current OS (check the platform from your environment):
+
+| OS | CJK font (for `w:eastAsia` and theme script slots) |
+|----|-----------------------------------------------------|
+| Windows | `Microsoft YaHei` (微软雅黑) |
+| macOS | `PingFang SC` (苹方) |
+| Linux | `Noto Sans CJK SC` |
+
+For Japanese/Korean, use the platform's JP/KR system face instead (e.g. Yu Gothic / Malgun Gothic on Windows, Hiragino Sans / Apple SD Gothic Neo on macOS).
 
 ## Testing your generator
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/create.md
@@ -135,10 +135,14 @@ set_cjk_font(p.runs[0], "Noto Sans CJK SC")        # a CJK-capable font present 
 ```
 
 Choose a font that actually ships CJK glyphs and exists on the machine where
-the deck will be viewed — prefer the standard CJK face of the current OS
-(check the platform from your environment): `Microsoft YaHei` on Windows,
-`PingFang SC` on macOS, `Noto Sans CJK SC` on Linux. A Latin-only face such as
-Calibri will not carry CJK no matter which slot you set.
+the deck will be viewed. In the common interactive case that's the machine
+generating it — use the current OS's standard CJK face (check the platform
+from your environment): `Microsoft YaHei` on Windows, `PingFang SC` on macOS,
+`Noto Sans CJK SC` on Linux. If the deck targets viewers on a different or
+unknown OS, prefer a portable name (`Microsoft YaHei` — every Windows ships
+it; other platforms substitute). A wrong-but-CJK name only causes font
+substitution; a Latin-only face such as Calibri causes tofu no matter which
+slot you set.
 
 ### Bulleted list
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/create.md
@@ -134,9 +134,11 @@ def set_cjk_font(run, font_name):
 set_cjk_font(p.runs[0], "Noto Sans CJK SC")        # a CJK-capable font present on the render machine
 ```
 
-Choose a font that actually ships CJK glyphs (a Noto Sans CJK / Source Han
-variant, or the platform's system CJK font). A Latin-only face such as Calibri
-will not carry CJK no matter which slot you set.
+Choose a font that actually ships CJK glyphs and exists on the machine where
+the deck will be viewed — prefer the standard CJK face of the current OS
+(check the platform from your environment): `Microsoft YaHei` on Windows,
+`PingFang SC` on macOS, `Noto Sans CJK SC` on Linux. A Latin-only face such as
+Calibri will not carry CJK no matter which slot you set.
 
 ### Bulleted list
 

--- a/packages/opencode/src/skill/builtin/.bundle/xlsx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/xlsx-official/create.md
@@ -154,6 +154,14 @@ for cell in ws[1]:                              # header row
 Colors are 8-character ARGB strings (`"FFF2F2F2"`) or 6-character RGB
 (`"F2F2F2"`) — openpyxl accepts both. Alpha is almost always `FF`.
 
+For cells containing CJK (Chinese/Japanese/Korean) text, set a CJK-capable
+font name — openpyxl's `Font(name=...)` is the single face for the whole cell,
+and a Latin-only face such as Calibri leaves CJK rendering to inconsistent
+viewer substitution. Prefer the standard CJK face of the OS the file will be
+viewed on (check the platform from your environment): `Microsoft YaHei` on
+Windows, `PingFang SC` on macOS, `Noto Sans CJK SC` on Linux — e.g.
+`Font(name="Microsoft YaHei", size=11)`.
+
 ### Named styles (reusable)
 
 ```python

--- a/packages/opencode/src/skill/builtin/.bundle/xlsx-official/create.md
+++ b/packages/opencode/src/skill/builtin/.bundle/xlsx-official/create.md
@@ -157,10 +157,13 @@ Colors are 8-character ARGB strings (`"FFF2F2F2"`) or 6-character RGB
 For cells containing CJK (Chinese/Japanese/Korean) text, set a CJK-capable
 font name — openpyxl's `Font(name=...)` is the single face for the whole cell,
 and a Latin-only face such as Calibri leaves CJK rendering to inconsistent
-viewer substitution. Prefer the standard CJK face of the OS the file will be
-viewed on (check the platform from your environment): `Microsoft YaHei` on
-Windows, `PingFang SC` on macOS, `Noto Sans CJK SC` on Linux — e.g.
-`Font(name="Microsoft YaHei", size=11)`.
+viewer substitution. In the common interactive case the workbook is viewed on
+the machine that generated it — use the current OS's standard CJK face (check
+the platform from your environment): `Microsoft YaHei` on Windows,
+`PingFang SC` on macOS, `Noto Sans CJK SC` on Linux — e.g.
+`Font(name="Microsoft YaHei", size=11)`. If it targets viewers on a different
+or unknown OS, prefer the portable `Microsoft YaHei` (every Windows ships it;
+other platforms substitute a reasonable CJK face).
 
 ### Named styles (reusable)
 


### PR DESCRIPTION
## Summary
- Office files generated with a made-up or Latin-only font name render CJK inconsistently across viewers. Teach docx/pptx/xlsx skills to pick the current OS's standard CJK face (Windows: `Microsoft YaHei`, macOS: `PingFang SC`, Linux: `Noto Sans CJK SC`) for the East-Asian slots.
- docx: replace the SimSun-based "portable choices" advice with a per-OS table (theme-patch section + troubleshooting row pointer); pptx: concretize the "choose a CJK-capable font" paragraph; xlsx: first CJK font note (openpyxl `Font.name` is the single face per cell).
- pdf-official already covers CJK via reportlab `STSong-Light` and is unchanged.

Context: MiMo Desktop is dropping its bundled brand font (MiSans) for generated office files in favor of OS system fonts, so the font-choice guidance moves into the shared skills where it is desktop-agnostic (CLI benefits equally). Desktop-side counterpart: mimo-desktop MR !2156 (base prompt now routes four-format generation through these skills unconditionally).

## Test plan
- [x] Doc-only change (skill markdown); no code paths affected
- [ ] Manual: generate a Chinese docx/pptx/xlsx via the skills and verify the East-Asian slot carries the current OS's font