### PR TITLE
fix(worktree,bash): propagate the repo's git identity into worktrees and bash commits — never invent one

### DIFF
--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -16,18 +16,6 @@ const cfg = [
   "core.quotepath=false",
 ] as const
 
-// Single source of truth for the agent's fallback git identity, used only when
-// neither the repo's nor the global config supplies one. Without it `git commit`
-// autodetects `user@hostname` (e.g. `MI <mi@host.local>`), leaking the machine
-// hostname and wrong authorship into pushed commits. Two independent layers
-// consume this: the worktree-creation local-config pin (src/worktree/index.ts)
-// and the bash env floor (src/tool/bash.ts). Keep it here so a rename can never
-// land in one layer and silently drift in the other.
-export const FALLBACK_IDENTITY = {
-  name: "MiMo",
-  email: "mimo@xiaomi.com",
-} as const
-
 const out = (result: { text(): string }) => result.text().trim()
 const nuls = (text: string) => text.split("\0").filter(Boolean)
 const fail = (err: unknown) =>

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -16,6 +16,18 @@ const cfg = [
   "core.quotepath=false",
 ] as const
 
+// Single source of truth for the agent's fallback git identity, used only when
+// neither the repo's nor the global config supplies one. Without it `git commit`
+// autodetects `user@hostname` (e.g. `MI <mi@host.local>`), leaking the machine
+// hostname and wrong authorship into pushed commits. Two independent layers
+// consume this: the worktree-creation local-config pin (src/worktree/index.ts)
+// and the bash env floor (src/tool/bash.ts). Keep it here so a rename can never
+// land in one layer and silently drift in the other.
+export const FALLBACK_IDENTITY = {
+  name: "MiMo",
+  email: "mimo@xiaomi.com",
+} as const
+
 const out = (result: { text(): string }) => result.text().trim()
 const nuls = (text: string) => text.split("\0").filter(Boolean)
 const fail = (err: unknown) =>

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -459,8 +459,8 @@ export const BashTool = Tool.define(
     // machine hostname + wrong authorship into pushed commits. We inject
     // GIT_AUTHOR_*/COMMITTER_* env as a FLOOR (below repo/worktree local config,
     // which still wins). Resolved once per worktree and memoized.
-    const AGENT_NAME = "mimocode-agent[bot]"
-    const AGENT_EMAIL = "mimocode-agent[bot]@users.noreply.github.com"
+    const AGENT_NAME = "MiMo Code"
+    const AGENT_EMAIL = "mimo@xiaomi.com"
     const gitIdentityCache = new Map<string, { name: string; email: string }>()
     const resolveGitIdentity = Effect.fn("BashTool.resolveGitIdentity")(function* () {
       const worktree = Instance.worktree
@@ -468,9 +468,9 @@ export const BashTool = Tool.define(
       if (cached) return cached
       // Non-git projects set worktree to "/"; never read git config at root.
       if (worktree === "/") {
-        const bot = { name: AGENT_NAME, email: AGENT_EMAIL }
-        gitIdentityCache.set(worktree, bot)
-        return bot
+        const fallback = { name: AGENT_NAME, email: AGENT_EMAIL }
+        gitIdentityCache.set(worktree, fallback)
+        return fallback
       }
       const name = (yield* gitSvc.run(["config", "user.name"], { cwd: worktree })).text().trim()
       const email = (yield* gitSvc.run(["config", "user.email"], { cwd: worktree })).text().trim()

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -456,11 +456,25 @@ export const BashTool = Tool.define(
     // commit in an ad-hoc dir via this bash tool, bypassing Worktree.setup()'s
     // per-worktree local-config fix. Without an identity, `git commit`
     // autodetects `user@hostname` (e.g. `MI <mi@host.local>`), leaking the
-    // machine hostname + wrong authorship into pushed commits. We inject
-    // GIT_AUTHOR_*/COMMITTER_* env as a FLOOR (below repo/worktree local config,
-    // which still wins). Resolved once per worktree and memoized.
-    const AGENT_NAME = "MiMo"
-    const AGENT_EMAIL = "mimo@xiaomi.com"
+    // machine hostname + wrong authorship into pushed commits.
+    //
+    // Behavioral contract of this floor and its cache:
+    //   - Its ONLY job is to guarantee a commit never falls back to
+    //     `user@hostname`. It is not a general identity-configuration feature.
+    //   - It is delivered as GIT_AUTHOR_*/GIT_COMMITTER_* ENV, and git gives env
+    //     vars precedence OVER `user.name`/`user.email` config. So the value
+    //     seeded here outranks the repo's own config for commits made through
+    //     this tool. We seed it FROM that config, so the two normally agree.
+    //   - Because the resolved value is memoized per worktree path for the
+    //     lifetime of the process, a `git config user.name ...` performed
+    //     mid-session is NOT picked up until the process restarts.
+    //   - Operator-set GIT_AUTHOR_*/GIT_COMMITTER_* still win: shellEnv only
+    //     fills the vars that are absent from process.env (see below).
+    //
+    // resolveGitIdentity and gitIdentityCache live in this outer setup block,
+    // not inside shellEnv, precisely so the cache persists across every bash
+    // invocation instead of being rebuilt (and re-spawning two `git config`
+    // subprocesses) on each call.
     const gitIdentityCache = new Map<string, { name: string; email: string }>()
     const resolveGitIdentity = Effect.fn("BashTool.resolveGitIdentity")(function* () {
       const worktree = Instance.worktree
@@ -468,13 +482,16 @@ export const BashTool = Tool.define(
       if (cached) return cached
       // Non-git projects set worktree to "/"; never read git config at root.
       if (worktree === "/") {
-        const fallback = { name: AGENT_NAME, email: AGENT_EMAIL }
+        const fallback = { name: Git.FALLBACK_IDENTITY.name, email: Git.FALLBACK_IDENTITY.email }
         gitIdentityCache.set(worktree, fallback)
         return fallback
       }
       const name = (yield* gitSvc.run(["config", "user.name"], { cwd: worktree })).text().trim()
       const email = (yield* gitSvc.run(["config", "user.email"], { cwd: worktree })).text().trim()
-      const identity = { name: name || AGENT_NAME, email: email || AGENT_EMAIL }
+      const identity = {
+        name: name || Git.FALLBACK_IDENTITY.name,
+        email: email || Git.FALLBACK_IDENTITY.email,
+      }
       gitIdentityCache.set(worktree, identity)
       return identity
     })
@@ -562,8 +579,10 @@ export const BashTool = Tool.define(
         // back to the ANSI code page (GBK on zh-CN), producing mojibake. Force
         // UTF-8 for child Python processes on Windows.
         ...(process.platform === "win32" ? { PYTHONIOENCODING: "utf-8" } : {}),
-        // Git authorship floor: below process.env (operator override wins) but
-        // above plugin extra.env (a plugin can still override).
+        // Git authorship floor. Placed after process.env so the spread order
+        // reads naturally, but it can never clobber an operator value: gitFloor
+        // only ever holds keys that were absent from process.env. A plugin's
+        // extra.env comes last and so can still override the floor.
         ...gitFloor,
         ...extra.env,
       }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -454,17 +454,21 @@ export const BashTool = Tool.define(
 
     // Layer-2 floor for git authorship: an agent may create a worktree/clone or
     // commit in an ad-hoc dir via this bash tool, bypassing Worktree.setup()'s
-    // per-worktree local-config fix. Without an identity, `git commit`
-    // autodetects `user@hostname` (e.g. `MI <mi@host.local>`), leaking the
-    // machine hostname + wrong authorship into pushed commits.
+    // per-worktree local-config fix. Propagate the project repo's own identity so
+    // those commits are attributed the same way a commit in the project repo is.
     //
     // Behavioral contract of this floor and its cache:
-    //   - Its ONLY job is to guarantee a commit never falls back to
-    //     `user@hostname`. It is not a general identity-configuration feature.
+    //   - It only ever PROPAGATES an identity the repo itself already resolves.
+    //     It never invents one: when the repo has no identity — or there is no
+    //     repo at all — nothing is injected and git resolves authorship itself
+    //     (config, then `EMAIL`, then its own `user@hostname` autodetect, then
+    //     its own error). A hardcoded substitute would misattribute the commit
+    //     AND pre-empt resolution paths `git config` cannot see.
     //   - It is delivered as GIT_AUTHOR_*/GIT_COMMITTER_* ENV, and git gives env
-    //     vars precedence OVER `user.name`/`user.email` config. So the value
-    //     seeded here outranks the repo's own config for commits made through
-    //     this tool. We seed it FROM that config, so the two normally agree.
+    //     vars precedence OVER `user.name`/`user.email` config — including the
+    //     config of some OTHER repo the command happens to run in. That is
+    //     exactly why an unresolved field must inject nothing rather than a
+    //     placeholder: a placeholder would outrank that repo's correct config.
     //   - Because the resolved value is memoized per worktree path for the
     //     lifetime of the process, a `git config user.name ...` performed
     //     mid-session is NOT picked up until the process restarts.
@@ -475,23 +479,28 @@ export const BashTool = Tool.define(
     // not inside shellEnv, precisely so the cache persists across every bash
     // invocation instead of being rebuilt (and re-spawning two `git config`
     // subprocesses) on each call.
-    const gitIdentityCache = new Map<string, { name: string; email: string }>()
+    const gitIdentityCache = new Map<string, { name?: string; email?: string }>()
     const resolveGitIdentity = Effect.fn("BashTool.resolveGitIdentity")(function* () {
       const worktree = Instance.worktree
       const cached = gitIdentityCache.get(worktree)
       if (cached) return cached
-      // Non-git projects set worktree to "/"; never read git config at root.
+      // Non-git projects set worktree to "/". There is no project repo whose
+      // identity we could propagate, and whatever repo a git command does run in
+      // has its own config — which injected env would override. Inject nothing.
       if (worktree === "/") {
-        const fallback = { name: Git.FALLBACK_IDENTITY.name, email: Git.FALLBACK_IDENTITY.email }
-        gitIdentityCache.set(worktree, fallback)
-        return fallback
+        const none: { name?: string; email?: string } = {}
+        gitIdentityCache.set(worktree, none)
+        return none
       }
       const name = (yield* gitSvc.run(["config", "user.name"], { cwd: worktree })).text().trim()
       const email = (yield* gitSvc.run(["config", "user.email"], { cwd: worktree })).text().trim()
-      const identity = {
-        name: name || Git.FALLBACK_IDENTITY.name,
-        email: email || Git.FALLBACK_IDENTITY.email,
-      }
+      if (!name || !email)
+        log.warn("git identity not fully resolved from repo config; leaving authorship to git", {
+          worktree,
+          name: name ? "resolved" : "unset",
+          email: email ? "resolved" : "unset",
+        })
+      const identity = { ...(name ? { name } : {}), ...(email ? { email } : {}) }
       gitIdentityCache.set(worktree, identity)
       return identity
     })
@@ -567,12 +576,13 @@ export const BashTool = Tool.define(
       )
       const identity = yield* resolveGitIdentity()
       // Only fill vars the operator hasn't already set, so an explicit
-      // GIT_AUTHOR_* in the environment still wins over our floor.
+      // GIT_AUTHOR_* in the environment still wins over our floor — and only
+      // fields the repo itself resolved, so an unresolved field is left for git.
       const gitFloor: Record<string, string> = {}
-      if (!process.env["GIT_AUTHOR_NAME"]) gitFloor["GIT_AUTHOR_NAME"] = identity.name
-      if (!process.env["GIT_AUTHOR_EMAIL"]) gitFloor["GIT_AUTHOR_EMAIL"] = identity.email
-      if (!process.env["GIT_COMMITTER_NAME"]) gitFloor["GIT_COMMITTER_NAME"] = identity.name
-      if (!process.env["GIT_COMMITTER_EMAIL"]) gitFloor["GIT_COMMITTER_EMAIL"] = identity.email
+      if (identity.name && !process.env["GIT_AUTHOR_NAME"]) gitFloor["GIT_AUTHOR_NAME"] = identity.name
+      if (identity.email && !process.env["GIT_AUTHOR_EMAIL"]) gitFloor["GIT_AUTHOR_EMAIL"] = identity.email
+      if (identity.name && !process.env["GIT_COMMITTER_NAME"]) gitFloor["GIT_COMMITTER_NAME"] = identity.name
+      if (identity.email && !process.env["GIT_COMMITTER_EMAIL"]) gitFloor["GIT_COMMITTER_EMAIL"] = identity.email
       return {
         ...process.env,
         // Python ignores the console code page when stdout is a pipe and falls

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -459,7 +459,7 @@ export const BashTool = Tool.define(
     // machine hostname + wrong authorship into pushed commits. We inject
     // GIT_AUTHOR_*/COMMITTER_* env as a FLOOR (below repo/worktree local config,
     // which still wins). Resolved once per worktree and memoized.
-    const AGENT_NAME = "MiMo Code"
+    const AGENT_NAME = "MiMo"
     const AGENT_EMAIL = "mimo@xiaomi.com"
     const gitIdentityCache = new Map<string, { name: string; email: string }>()
     const resolveGitIdentity = Effect.fn("BashTool.resolveGitIdentity")(function* () {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -19,6 +19,7 @@ import { SessionCwd } from "./session-cwd"
 import { BashArity } from "@/permission/arity"
 import * as Truncate from "./truncate"
 import { Plugin } from "@/plugin"
+import { Git } from "@/git"
 import { Effect, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
@@ -449,6 +450,34 @@ export const BashTool = Tool.define(
     const fs = yield* AppFileSystem.Service
     const trunc = yield* Truncate.Service
     const plugin = yield* Plugin.Service
+    const gitSvc = yield* Git.Service
+
+    // Layer-2 floor for git authorship: an agent may create a worktree/clone or
+    // commit in an ad-hoc dir via this bash tool, bypassing Worktree.setup()'s
+    // per-worktree local-config fix. Without an identity, `git commit`
+    // autodetects `user@hostname` (e.g. `MI <mi@host.local>`), leaking the
+    // machine hostname + wrong authorship into pushed commits. We inject
+    // GIT_AUTHOR_*/COMMITTER_* env as a FLOOR (below repo/worktree local config,
+    // which still wins). Resolved once per worktree and memoized.
+    const AGENT_NAME = "mimocode-agent[bot]"
+    const AGENT_EMAIL = "mimocode-agent[bot]@users.noreply.github.com"
+    const gitIdentityCache = new Map<string, { name: string; email: string }>()
+    const resolveGitIdentity = Effect.fn("BashTool.resolveGitIdentity")(function* () {
+      const worktree = Instance.worktree
+      const cached = gitIdentityCache.get(worktree)
+      if (cached) return cached
+      // Non-git projects set worktree to "/"; never read git config at root.
+      if (worktree === "/") {
+        const bot = { name: AGENT_NAME, email: AGENT_EMAIL }
+        gitIdentityCache.set(worktree, bot)
+        return bot
+      }
+      const name = (yield* gitSvc.run(["config", "user.name"], { cwd: worktree })).text().trim()
+      const email = (yield* gitSvc.run(["config", "user.email"], { cwd: worktree })).text().trim()
+      const identity = { name: name || AGENT_NAME, email: email || AGENT_EMAIL }
+      gitIdentityCache.set(worktree, identity)
+      return identity
+    })
 
     const cygpath = Effect.fn("BashTool.cygpath")(function* (shell: string, text: string) {
       const lines = yield* spawner
@@ -519,12 +548,23 @@ export const BashTool = Tool.define(
         { cwd, sessionID: ctx.sessionID, callID: ctx.callID },
         { env: {} },
       )
+      const identity = yield* resolveGitIdentity()
+      // Only fill vars the operator hasn't already set, so an explicit
+      // GIT_AUTHOR_* in the environment still wins over our floor.
+      const gitFloor: Record<string, string> = {}
+      if (!process.env["GIT_AUTHOR_NAME"]) gitFloor["GIT_AUTHOR_NAME"] = identity.name
+      if (!process.env["GIT_AUTHOR_EMAIL"]) gitFloor["GIT_AUTHOR_EMAIL"] = identity.email
+      if (!process.env["GIT_COMMITTER_NAME"]) gitFloor["GIT_COMMITTER_NAME"] = identity.name
+      if (!process.env["GIT_COMMITTER_EMAIL"]) gitFloor["GIT_COMMITTER_EMAIL"] = identity.email
       return {
         ...process.env,
         // Python ignores the console code page when stdout is a pipe and falls
         // back to the ANSI code page (GBK on zh-CN), producing mojibake. Force
         // UTF-8 for child Python processes on Windows.
         ...(process.platform === "win32" ? { PYTHONIOENCODING: "utf-8" } : {}),
+        // Git authorship floor: below process.env (operator override wins) but
+        // above plugin extra.env (a plugin can still override).
+        ...gitFloor,
         ...extra.env,
       }
     })

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -276,6 +276,22 @@ export const layer: Layer.Layer<
               message: `Worktree HEAD is not attached to ${expected} (got ${head || "detached HEAD"})`,
             })
           }
+
+          // A separate worktree checkout shares the object/ref store but has its
+          // own config, so it does NOT inherit the parent repo's LOCAL identity.
+          // If global identity is also empty, `git commit` here would autodetect
+          // `user@hostname` (e.g. `MI <mi@host.local>`), leaking the machine
+          // hostname + wrong authorship into pushed commits. Resolve the parent's
+          // identity (walks local->global->system) and pin it into the new
+          // worktree's own local config; fall back to a stable mimocode identity
+          // so the worktree is NEVER left without one. Reading an unset key exits
+          // non-zero / empty, which the `git()` runner returns as empty text.
+          const parentName = (yield* git(["config", "user.name"], { cwd: ctx.worktree })).text.trim()
+          const parentEmail = (yield* git(["config", "user.email"], { cwd: ctx.worktree })).text.trim()
+          const name = parentName || "mimocode"
+          const email = parentEmail || "mimocode@users.noreply.github.com"
+          yield* git(["config", "user.name", name], { cwd: info.directory })
+          yield* git(["config", "user.email", email], { cwd: info.directory })
         }),
       )
 

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -288,8 +288,8 @@ export const layer: Layer.Layer<
           // non-zero / empty, which the `git()` runner returns as empty text.
           const parentName = (yield* git(["config", "user.name"], { cwd: ctx.worktree })).text.trim()
           const parentEmail = (yield* git(["config", "user.email"], { cwd: ctx.worktree })).text.trim()
-          const name = parentName || "mimocode"
-          const email = parentEmail || "mimocode@users.noreply.github.com"
+          const name = parentName || "mimocode-agent[bot]"
+          const email = parentEmail || "mimocode-agent[bot]@users.noreply.github.com"
           yield* git(["config", "user.name", name], { cwd: info.directory })
           yield* git(["config", "user.email", email], { cwd: info.directory })
         }),

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -279,20 +279,30 @@ export const layer: Layer.Layer<
 
           // A separate worktree checkout shares the object/ref store but has its
           // own config, so it does NOT inherit the parent repo's LOCAL identity.
-          // If global identity is also empty, `git commit` here would autodetect
-          // `user@hostname` (e.g. `MI <mi@host.local>`), leaking the machine
-          // hostname + wrong authorship into pushed commits. Resolve the parent's
-          // identity (walks local->global->system) and pin it into the new
-          // worktree's own local config; fall back to Git.FALLBACK_IDENTITY (the
-          // one shared source of truth, also used by the bash env floor) so the
-          // worktree is NEVER left without one. Reading an unset key exits
-          // non-zero / empty, which the `git()` runner returns as empty text.
+          // Copy the parent's resolved identity (`git config` walks
+          // local->global->system) into the new worktree's own local config, so a
+          // commit made here is attributed exactly as a commit in the parent repo
+          // would be. Reading an unset key exits non-zero / empty, which the
+          // `git()` runner returns as empty text.
+          //
+          // When the parent has no identity we pin NOTHING, deliberately. A
+          // hardcoded substitute would attribute the user's commits to an address
+          // they never chose, and `git config` cannot see the rest of git's own
+          // resolution chain anyway (`EMAIL`, then git's `user@hostname`
+          // autodetect), so substituting here would pre-empt a value git could
+          // still resolve. Abstaining leaves the worktree resolving authorship
+          // exactly as the parent repo does, and leaves the fallback to git.
           const parentName = (yield* git(["config", "user.name"], { cwd: ctx.worktree })).text.trim()
           const parentEmail = (yield* git(["config", "user.email"], { cwd: ctx.worktree })).text.trim()
-          const name = parentName || Git.FALLBACK_IDENTITY.name
-          const email = parentEmail || Git.FALLBACK_IDENTITY.email
-          yield* git(["config", "user.name", name], { cwd: info.directory })
-          yield* git(["config", "user.email", email], { cwd: info.directory })
+          if (parentName) yield* git(["config", "user.name", parentName], { cwd: info.directory })
+          if (parentEmail) yield* git(["config", "user.email", parentEmail], { cwd: info.directory })
+          if (!parentName || !parentEmail)
+            log.warn("worktree created without a fully pinned git identity; git resolves authorship itself", {
+              directory: info.directory,
+              parent: ctx.worktree,
+              name: parentName ? "inherited" : "unset",
+              email: parentEmail ? "inherited" : "unset",
+            })
         }),
       )
 

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -283,13 +283,14 @@ export const layer: Layer.Layer<
           // `user@hostname` (e.g. `MI <mi@host.local>`), leaking the machine
           // hostname + wrong authorship into pushed commits. Resolve the parent's
           // identity (walks local->global->system) and pin it into the new
-          // worktree's own local config; fall back to a stable mimocode identity
-          // so the worktree is NEVER left without one. Reading an unset key exits
+          // worktree's own local config; fall back to Git.FALLBACK_IDENTITY (the
+          // one shared source of truth, also used by the bash env floor) so the
+          // worktree is NEVER left without one. Reading an unset key exits
           // non-zero / empty, which the `git()` runner returns as empty text.
           const parentName = (yield* git(["config", "user.name"], { cwd: ctx.worktree })).text.trim()
           const parentEmail = (yield* git(["config", "user.email"], { cwd: ctx.worktree })).text.trim()
-          const name = parentName || "MiMo"
-          const email = parentEmail || "mimo@xiaomi.com"
+          const name = parentName || Git.FALLBACK_IDENTITY.name
+          const email = parentEmail || Git.FALLBACK_IDENTITY.email
           yield* git(["config", "user.name", name], { cwd: info.directory })
           yield* git(["config", "user.email", email], { cwd: info.directory })
         }),

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -288,8 +288,8 @@ export const layer: Layer.Layer<
           // non-zero / empty, which the `git()` runner returns as empty text.
           const parentName = (yield* git(["config", "user.name"], { cwd: ctx.worktree })).text.trim()
           const parentEmail = (yield* git(["config", "user.email"], { cwd: ctx.worktree })).text.trim()
-          const name = parentName || "mimocode-agent[bot]"
-          const email = parentEmail || "mimocode-agent[bot]@users.noreply.github.com"
+          const name = parentName || "MiMo Code"
+          const email = parentEmail || "mimo@xiaomi.com"
           yield* git(["config", "user.name", name], { cwd: info.directory })
           yield* git(["config", "user.email", email], { cwd: info.directory })
         }),

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -288,7 +288,7 @@ export const layer: Layer.Layer<
           // non-zero / empty, which the `git()` runner returns as empty text.
           const parentName = (yield* git(["config", "user.name"], { cwd: ctx.worktree })).text.trim()
           const parentEmail = (yield* git(["config", "user.email"], { cwd: ctx.worktree })).text.trim()
-          const name = parentName || "MiMo Code"
+          const name = parentName || "MiMo"
           const email = parentEmail || "mimo@xiaomi.com"
           yield* git(["config", "user.name", name], { cwd: info.directory })
           yield* git(["config", "user.email", email], { cwd: info.directory })

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -15,6 +15,7 @@ import { SessionID, MessageID } from "../../src/session/schema"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { Plugin } from "../../src/plugin"
+import { Git } from "../../src/git"
 
 const runtime = ManagedRuntime.make(
   Layer.mergeAll(
@@ -23,6 +24,7 @@ const runtime = ManagedRuntime.make(
     Plugin.defaultLayer,
     Truncate.defaultLayer,
     Agent.defaultLayer,
+    Git.defaultLayer,
   ),
 )
 
@@ -187,6 +189,112 @@ describe("tool.bash", () => {
         expect(result.metadata.output).toContain("test")
       },
     })
+  })
+})
+
+describe("tool.bash git identity floor", () => {
+  const savedEnv = () => ({
+    GIT_AUTHOR_NAME: process.env["GIT_AUTHOR_NAME"],
+    GIT_AUTHOR_EMAIL: process.env["GIT_AUTHOR_EMAIL"],
+    GIT_COMMITTER_NAME: process.env["GIT_COMMITTER_NAME"],
+    GIT_COMMITTER_EMAIL: process.env["GIT_COMMITTER_EMAIL"],
+  })
+  const restoreEnv = (saved: ReturnType<typeof savedEnv>) => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  }
+  const printGitEnv =
+    process.platform === "win32"
+      ? "echo GIT_AUTHOR_NAME=$env:GIT_AUTHOR_NAME; echo GIT_AUTHOR_EMAIL=$env:GIT_AUTHOR_EMAIL; echo GIT_COMMITTER_NAME=$env:GIT_COMMITTER_NAME; echo GIT_COMMITTER_EMAIL=$env:GIT_COMMITTER_EMAIL"
+      : "echo GIT_AUTHOR_NAME=$GIT_AUTHOR_NAME; echo GIT_AUTHOR_EMAIL=$GIT_AUTHOR_EMAIL; echo GIT_COMMITTER_NAME=$GIT_COMMITTER_NAME; echo GIT_COMMITTER_EMAIL=$GIT_COMMITTER_EMAIL"
+
+  each("injects the 4 GIT_* vars inherited from the repo config", async () => {
+    const saved = savedEnv()
+    restoreEnv({
+      GIT_AUTHOR_NAME: undefined,
+      GIT_AUTHOR_EMAIL: undefined,
+      GIT_COMMITTER_NAME: undefined,
+      GIT_COMMITTER_EMAIL: undefined,
+    })
+    try {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const bash = await initBash()
+          const result = await Effect.runPromise(
+            bash.execute({ command: printGitEnv, description: "print git env" }, ctx),
+          )
+          // The tmpdir git fixture sets user.name=Test / user.email=test@mimocode.test.
+          expect(result.metadata.output).toContain("GIT_AUTHOR_NAME=Test")
+          expect(result.metadata.output).toContain("GIT_AUTHOR_EMAIL=test@mimocode.test")
+          expect(result.metadata.output).toContain("GIT_COMMITTER_NAME=Test")
+          expect(result.metadata.output).toContain("GIT_COMMITTER_EMAIL=test@mimocode.test")
+        },
+      })
+    } finally {
+      restoreEnv(saved)
+    }
+  })
+
+  each("falls back to the stable bot identity for a non-git project (worktree=/)", async () => {
+    const saved = savedEnv()
+    restoreEnv({
+      GIT_AUTHOR_NAME: undefined,
+      GIT_AUTHOR_EMAIL: undefined,
+      GIT_COMMITTER_NAME: undefined,
+      GIT_COMMITTER_EMAIL: undefined,
+    })
+    try {
+      // outsideGit -> a truly non-git project -> Instance.worktree === "/".
+      await using tmp = await tmpdir({ outsideGit: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          expect(Instance.worktree).toBe("/")
+          const bash = await initBash()
+          const result = await Effect.runPromise(
+            bash.execute({ command: printGitEnv, description: "print git env" }, ctx),
+          )
+          expect(result.metadata.output).toContain("GIT_AUTHOR_NAME=mimocode-agent[bot]")
+          expect(result.metadata.output).toContain("GIT_AUTHOR_EMAIL=mimocode-agent[bot]@users.noreply.github.com")
+          expect(result.metadata.output).toContain("GIT_COMMITTER_NAME=mimocode-agent[bot]")
+          expect(result.metadata.output).toContain("GIT_COMMITTER_EMAIL=mimocode-agent[bot]@users.noreply.github.com")
+        },
+      })
+    } finally {
+      restoreEnv(saved)
+    }
+  })
+
+  each("does not override an operator-set GIT_AUTHOR_NAME", async () => {
+    const saved = savedEnv()
+    restoreEnv({
+      GIT_AUTHOR_NAME: "Operator",
+      GIT_AUTHOR_EMAIL: undefined,
+      GIT_COMMITTER_NAME: undefined,
+      GIT_COMMITTER_EMAIL: undefined,
+    })
+    try {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const bash = await initBash()
+          const result = await Effect.runPromise(
+            bash.execute({ command: printGitEnv, description: "print git env" }, ctx),
+          )
+          // process.env value wins over the floor.
+          expect(result.metadata.output).toContain("GIT_AUTHOR_NAME=Operator")
+          // Unset ones still get the floor.
+          expect(result.metadata.output).toContain("GIT_COMMITTER_NAME=Test")
+        },
+      })
+    } finally {
+      restoreEnv(saved)
+    }
   })
 })
 

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -239,7 +239,7 @@ describe("tool.bash git identity floor", () => {
     }
   })
 
-  each("falls back to the stable fallback identity for a non-git project (worktree=/)", async () => {
+  each("injects NO GIT_* vars for a non-git project (worktree=/), leaving authorship to git", async () => {
     const saved = savedEnv()
     restoreEnv({
       GIT_AUTHOR_NAME: undefined,
@@ -258,10 +258,13 @@ describe("tool.bash git identity floor", () => {
           const result = await Effect.runPromise(
             bash.execute({ command: printGitEnv, description: "print git env" }, ctx),
           )
-          expect(result.metadata.output).toContain(`GIT_AUTHOR_NAME=${Git.FALLBACK_IDENTITY.name}`)
-          expect(result.metadata.output).toContain(`GIT_AUTHOR_EMAIL=${Git.FALLBACK_IDENTITY.email}`)
-          expect(result.metadata.output).toContain(`GIT_COMMITTER_NAME=${Git.FALLBACK_IDENTITY.name}`)
-          expect(result.metadata.output).toContain(`GIT_COMMITTER_EMAIL=${Git.FALLBACK_IDENTITY.email}`)
+          // There is no project repo to inherit from, so injecting anything would
+          // override the config of whatever repo the command actually runs in
+          // (GIT_AUTHOR_*/GIT_COMMITTER_* env outrank `user.name`/`user.email`).
+          for (const key of ["GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"]) {
+            const line = result.metadata.output.split("\n").find((l) => l.trim().startsWith(`${key}=`))
+            expect(line?.trim()).toBe(`${key}=`)
+          }
         },
       })
     } finally {

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -258,10 +258,10 @@ describe("tool.bash git identity floor", () => {
           const result = await Effect.runPromise(
             bash.execute({ command: printGitEnv, description: "print git env" }, ctx),
           )
-          expect(result.metadata.output).toContain("GIT_AUTHOR_NAME=MiMo")
-          expect(result.metadata.output).toContain("GIT_AUTHOR_EMAIL=mimo@xiaomi.com")
-          expect(result.metadata.output).toContain("GIT_COMMITTER_NAME=MiMo")
-          expect(result.metadata.output).toContain("GIT_COMMITTER_EMAIL=mimo@xiaomi.com")
+          expect(result.metadata.output).toContain(`GIT_AUTHOR_NAME=${Git.FALLBACK_IDENTITY.name}`)
+          expect(result.metadata.output).toContain(`GIT_AUTHOR_EMAIL=${Git.FALLBACK_IDENTITY.email}`)
+          expect(result.metadata.output).toContain(`GIT_COMMITTER_NAME=${Git.FALLBACK_IDENTITY.name}`)
+          expect(result.metadata.output).toContain(`GIT_COMMITTER_EMAIL=${Git.FALLBACK_IDENTITY.email}`)
         },
       })
     } finally {
@@ -269,7 +269,7 @@ describe("tool.bash git identity floor", () => {
     }
   })
 
-  each("does not override an operator-set GIT_AUTHOR_NAME", async () => {
+  each("applies the floor per-variable, not all-or-nothing, when only GIT_AUTHOR_NAME is operator-set", async () => {
     const saved = savedEnv()
     restoreEnv({
       GIT_AUTHOR_NAME: "Operator",
@@ -286,10 +286,14 @@ describe("tool.bash git identity floor", () => {
           const result = await Effect.runPromise(
             bash.execute({ command: printGitEnv, description: "print git env" }, ctx),
           )
-          // process.env value wins over the floor.
+          // The one operator-set var wins over the floor.
           expect(result.metadata.output).toContain("GIT_AUTHOR_NAME=Operator")
-          // Unset ones still get the floor.
+          // The other three are absent from process.env, so each still receives
+          // the floor independently. The tmpdir git fixture sets
+          // user.name=Test / user.email=test@mimocode.test.
+          expect(result.metadata.output).toContain("GIT_AUTHOR_EMAIL=test@mimocode.test")
           expect(result.metadata.output).toContain("GIT_COMMITTER_NAME=Test")
+          expect(result.metadata.output).toContain("GIT_COMMITTER_EMAIL=test@mimocode.test")
         },
       })
     } finally {

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -258,9 +258,9 @@ describe("tool.bash git identity floor", () => {
           const result = await Effect.runPromise(
             bash.execute({ command: printGitEnv, description: "print git env" }, ctx),
           )
-          expect(result.metadata.output).toContain("GIT_AUTHOR_NAME=MiMo Code")
+          expect(result.metadata.output).toContain("GIT_AUTHOR_NAME=MiMo")
           expect(result.metadata.output).toContain("GIT_AUTHOR_EMAIL=mimo@xiaomi.com")
-          expect(result.metadata.output).toContain("GIT_COMMITTER_NAME=MiMo Code")
+          expect(result.metadata.output).toContain("GIT_COMMITTER_NAME=MiMo")
           expect(result.metadata.output).toContain("GIT_COMMITTER_EMAIL=mimo@xiaomi.com")
         },
       })

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -239,7 +239,7 @@ describe("tool.bash git identity floor", () => {
     }
   })
 
-  each("falls back to the stable bot identity for a non-git project (worktree=/)", async () => {
+  each("falls back to the stable fallback identity for a non-git project (worktree=/)", async () => {
     const saved = savedEnv()
     restoreEnv({
       GIT_AUTHOR_NAME: undefined,
@@ -258,10 +258,10 @@ describe("tool.bash git identity floor", () => {
           const result = await Effect.runPromise(
             bash.execute({ command: printGitEnv, description: "print git env" }, ctx),
           )
-          expect(result.metadata.output).toContain("GIT_AUTHOR_NAME=mimocode-agent[bot]")
-          expect(result.metadata.output).toContain("GIT_AUTHOR_EMAIL=mimocode-agent[bot]@users.noreply.github.com")
-          expect(result.metadata.output).toContain("GIT_COMMITTER_NAME=mimocode-agent[bot]")
-          expect(result.metadata.output).toContain("GIT_COMMITTER_EMAIL=mimocode-agent[bot]@users.noreply.github.com")
+          expect(result.metadata.output).toContain("GIT_AUTHOR_NAME=MiMo Code")
+          expect(result.metadata.output).toContain("GIT_AUTHOR_EMAIL=mimo@xiaomi.com")
+          expect(result.metadata.output).toContain("GIT_COMMITTER_NAME=MiMo Code")
+          expect(result.metadata.output).toContain("GIT_COMMITTER_EMAIL=mimo@xiaomi.com")
         },
       })
     } finally {

--- a/packages/opencode/test/worktree/index.test.ts
+++ b/packages/opencode/test/worktree/index.test.ts
@@ -65,8 +65,8 @@ describe("Worktree.setup git identity", () => {
           const email = (
             yield* Effect.promise(() => $`git config user.email`.cwd(info.directory).quiet().text())
           ).trim()
-          expect(name).toBe("mimocode")
-          expect(email).toBe("mimocode@users.noreply.github.com")
+          expect(name).toBe("mimocode-agent[bot]")
+          expect(email).toBe("mimocode-agent[bot]@users.noreply.github.com")
           // Sanity: identity is never left empty (the hostname-fallback trigger).
           expect(name.length).toBeGreaterThan(0)
           expect(email.length).toBeGreaterThan(0)

--- a/packages/opencode/test/worktree/index.test.ts
+++ b/packages/opencode/test/worktree/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test"
+import { $ } from "bun"
 import { Effect, Layer } from "effect"
 import { Worktree } from "../../src/worktree"
 import { testEffect } from "../lib/effect"
@@ -22,6 +23,53 @@ describe("Worktree.head / isPristine", () => {
           // Write a file -> no longer pristine.
           yield* Effect.promise(() => Bun.write(`${info.directory}/dirty.txt`, "x"))
           expect(yield* wt.isPristine(info.directory, base)).toBe(false)
+          yield* wt.remove({ directory: info.directory })
+        }),
+      { git: true },
+    ),
+  )
+})
+
+describe("Worktree.setup git identity", () => {
+  it.live("pins the parent repo identity into the new worktree's local config", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const wt = yield* Worktree.Service
+          const info = yield* wt.makeWorktreeInfo()
+          yield* wt.createFromInfo(info)
+          // The fixture sets the parent repo's local identity to Test/test@mimocode.test.
+          const name = (yield* Effect.promise(() => $`git config user.name`.cwd(info.directory).quiet().text())).trim()
+          const email = (
+            yield* Effect.promise(() => $`git config user.email`.cwd(info.directory).quiet().text())
+          ).trim()
+          expect(name).toBe("Test")
+          expect(email).toBe("test@mimocode.test")
+          yield* wt.remove({ directory: info.directory })
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("falls back to a stable mimocode identity when the parent has none", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          // Strip the parent's identity so the fallback path is exercised.
+          yield* Effect.promise(() => $`git config --unset user.name`.cwd(dir).quiet().nothrow())
+          yield* Effect.promise(() => $`git config --unset user.email`.cwd(dir).quiet().nothrow())
+          const wt = yield* Worktree.Service
+          const info = yield* wt.makeWorktreeInfo()
+          yield* wt.createFromInfo(info)
+          const name = (yield* Effect.promise(() => $`git config user.name`.cwd(info.directory).quiet().text())).trim()
+          const email = (
+            yield* Effect.promise(() => $`git config user.email`.cwd(info.directory).quiet().text())
+          ).trim()
+          expect(name).toBe("mimocode")
+          expect(email).toBe("mimocode@users.noreply.github.com")
+          // Sanity: identity is never left empty (the hostname-fallback trigger).
+          expect(name.length).toBeGreaterThan(0)
+          expect(email.length).toBeGreaterThan(0)
           yield* wt.remove({ directory: info.directory })
         }),
       { git: true },

--- a/packages/opencode/test/worktree/index.test.ts
+++ b/packages/opencode/test/worktree/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect } from "bun:test"
 import { $ } from "bun"
 import { Effect, Layer } from "effect"
 import { Worktree } from "../../src/worktree"
+import { Git } from "../../src/git"
 import { testEffect } from "../lib/effect"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
@@ -65,8 +66,8 @@ describe("Worktree.setup git identity", () => {
           const email = (
             yield* Effect.promise(() => $`git config user.email`.cwd(info.directory).quiet().text())
           ).trim()
-          expect(name).toBe("MiMo")
-          expect(email).toBe("mimo@xiaomi.com")
+          expect(name).toBe(Git.FALLBACK_IDENTITY.name)
+          expect(email).toBe(Git.FALLBACK_IDENTITY.email)
           // Sanity: identity is never left empty (the hostname-fallback trigger).
           expect(name.length).toBeGreaterThan(0)
           expect(email.length).toBeGreaterThan(0)

--- a/packages/opencode/test/worktree/index.test.ts
+++ b/packages/opencode/test/worktree/index.test.ts
@@ -65,8 +65,8 @@ describe("Worktree.setup git identity", () => {
           const email = (
             yield* Effect.promise(() => $`git config user.email`.cwd(info.directory).quiet().text())
           ).trim()
-          expect(name).toBe("mimocode-agent[bot]")
-          expect(email).toBe("mimocode-agent[bot]@users.noreply.github.com")
+          expect(name).toBe("MiMo Code")
+          expect(email).toBe("mimo@xiaomi.com")
           // Sanity: identity is never left empty (the hostname-fallback trigger).
           expect(name.length).toBeGreaterThan(0)
           expect(email.length).toBeGreaterThan(0)

--- a/packages/opencode/test/worktree/index.test.ts
+++ b/packages/opencode/test/worktree/index.test.ts
@@ -65,7 +65,7 @@ describe("Worktree.setup git identity", () => {
           const email = (
             yield* Effect.promise(() => $`git config user.email`.cwd(info.directory).quiet().text())
           ).trim()
-          expect(name).toBe("MiMo Code")
+          expect(name).toBe("MiMo")
           expect(email).toBe("mimo@xiaomi.com")
           // Sanity: identity is never left empty (the hostname-fallback trigger).
           expect(name.length).toBeGreaterThan(0)

--- a/packages/opencode/test/worktree/index.test.ts
+++ b/packages/opencode/test/worktree/index.test.ts
@@ -2,7 +2,6 @@ import { describe, expect } from "bun:test"
 import { $ } from "bun"
 import { Effect, Layer } from "effect"
 import { Worktree } from "../../src/worktree"
-import { Git } from "../../src/git"
 import { testEffect } from "../lib/effect"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
@@ -52,25 +51,61 @@ describe("Worktree.setup git identity", () => {
     ),
   )
 
-  it.live("falls back to a stable mimocode identity when the parent has none", () =>
+  it.live("pins NO identity when the parent has none, leaving the fallback to git", () =>
     provideTmpdirInstance(
       (dir) =>
         Effect.gen(function* () {
-          // Strip the parent's identity so the fallback path is exercised.
+          // Strip the parent's identity so the abstain path is exercised.
           yield* Effect.promise(() => $`git config --unset user.name`.cwd(dir).quiet().nothrow())
           yield* Effect.promise(() => $`git config --unset user.email`.cwd(dir).quiet().nothrow())
           const wt = yield* Worktree.Service
           const info = yield* wt.makeWorktreeInfo()
           yield* wt.createFromInfo(info)
-          const name = (yield* Effect.promise(() => $`git config user.name`.cwd(info.directory).quiet().text())).trim()
-          const email = (
-            yield* Effect.promise(() => $`git config user.email`.cwd(info.directory).quiet().text())
+          // --local, so a global identity on the host machine cannot mask an
+          // identity we wrongly pinned into the worktree.
+          const name = (
+            yield* Effect.promise(() =>
+              $`git config --local --get user.name`.cwd(info.directory).quiet().nothrow().text(),
+            )
           ).trim()
-          expect(name).toBe(Git.FALLBACK_IDENTITY.name)
-          expect(email).toBe(Git.FALLBACK_IDENTITY.email)
-          // Sanity: identity is never left empty (the hostname-fallback trigger).
-          expect(name.length).toBeGreaterThan(0)
-          expect(email.length).toBeGreaterThan(0)
+          const email = (
+            yield* Effect.promise(() =>
+              $`git config --local --get user.email`.cwd(info.directory).quiet().nothrow().text(),
+            )
+          ).trim()
+          expect(name).toBe("")
+          expect(email).toBe("")
+          yield* wt.remove({ directory: info.directory })
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("does not override an identity git itself would resolve from EMAIL", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => $`git config --unset user.name`.cwd(dir).quiet().nothrow())
+          yield* Effect.promise(() => $`git config --unset user.email`.cwd(dir).quiet().nothrow())
+          const wt = yield* Worktree.Service
+          const info = yield* wt.makeWorktreeInfo()
+          yield* wt.createFromInfo(info)
+          // `git config user.email` cannot see EMAIL, but `git commit` honours it.
+          // Supply the name via GIT_*_NAME so the author name never depends on
+          // GECOS autodetection, and leave both email paths to git.
+          const env: Record<string, string | undefined> = { ...process.env }
+          env["EMAIL"] = "chosen@example.test"
+          env["GIT_AUTHOR_NAME"] = "Chosen"
+          env["GIT_COMMITTER_NAME"] = "Chosen"
+          delete env["GIT_AUTHOR_EMAIL"]
+          delete env["GIT_COMMITTER_EMAIL"]
+          yield* Effect.promise(() => Bun.write(`${info.directory}/probe.txt`, "x"))
+          yield* Effect.promise(() => $`git add probe.txt`.cwd(info.directory).env(env).quiet())
+          yield* Effect.promise(() => $`git commit -m probe`.cwd(info.directory).env(env).quiet())
+          const author = (
+            yield* Effect.promise(() => $`git log -1 --format=%ae`.cwd(info.directory).env(env).quiet().text())
+          ).trim()
+          expect(author).toBe("chosen@example.test")
           yield* wt.remove({ directory: info.directory })
         }),
       { git: true },


### PR DESCRIPTION
## Summary

A linked git worktree does not inherit its parent repo's **local** config, so commits made in a mimocode-created worktree could be authored `MI <mi@MIdeMacBook-Pro.local>` — the machine hostname, in pushed history. This propagates the identity the repo itself resolves into the worktree, and injects it for bash-tool commits.

**It deliberately does NOT invent an identity when the repo has none.** An earlier revision of this PR did (a hardcoded `MiMo <mimo@xiaomi.com>` fallback); that was wrong and is removed — see the follow-up section at the bottom for the measurements that settled it. The contract now is **propagate or abstain**: copy what git can resolve, otherwise set nothing and leave git's own chain (local → global → system → `EMAIL` → autodetect → git's actionable error) fully intact.

## Root cause

A separate worktree checkout shares the object/ref store with its parent repo **but has its own config**, so it does **not** inherit the parent's LOCAL git identity. With no global identity either, `git commit` autodetects `user@hostname`. That differential — the parent repo commits correctly, its worktree does not — is the actual defect, and the only thing this PR is entitled to fix.

## Layer 1 — worktree local config (`src/worktree/index.ts` `setup()`)

After `git worktree add` + the HEAD-attach assertion, inside the existing per-repo lock:
1. Resolve the parent repo's identity via `git -C <ctx.worktree> config user.name/user.email` (walks local → global → system).
2. Pin **each resolved field** into the new worktree's own local config.
3. **If a field does not resolve, write nothing for it** and `log.warn`, so the worktree behaves exactly like its parent instead of carrying an identity nobody chose.

Covers worktrees mimocode creates in code, including commits made there later by the user's own terminal — which is precisely why an invented identity was harmful and an abstain is not.

## Layer 2 — bash-env floor (`src/tool/bash.ts` `shellEnv()`)

Layer 1 does not cover commits an agent makes through the bash tool in an ad-hoc directory, so `shellEnv()` injects `GIT_AUTHOR_NAME/EMAIL` + `GIT_COMMITTER_NAME/EMAIL` as a floor:
- Resolve the repo identity once per worktree (memoized) via the Git service at `Instance.worktree`.
- Inject **only the fields that resolved**; inject nothing at all when nothing resolved.
- The non-git case (`Instance.worktree === "/"`) now injects nothing — previously it short-circuited straight to the hardcoded identity **without consulting any config**.
- Fill only the vars absent from `process.env`, so an operator-set `GIT_AUTHOR_*` still wins — **per variable**, not all-or-nothing. Plugin `extra.env` is spread last and can still override.

⚠️ Why "inject nothing" matters and is not merely tidier: `GIT_AUTHOR_*`/`GIT_COMMITTER_*` override the config of **whatever repo the command runs in**, not just the session's repo. A placeholder floor therefore rewrote authorship in unrelated repositories reached with `cd`.

## Corrected: git precedence (env beats config)

An earlier revision of this description — and a code comment — claimed the layer-2 env floor sat *below* repo/worktree local config. **That was backwards.** Verified empirically:

```
# repo config user.name=LocalCfg, plus explicit -c user.name=DashC
GIT_AUTHOR_NAME=EnvName ... git -c user.name=DashC commit
→ author=EnvName <env@x.com>   committer=EnvName <env@x.com>
```

`GIT_AUTHOR_*`/`GIT_COMMITTER_*` env **outranks** `user.name`/`user.email` config, including an explicit `-c`. Actual precedence:

`GIT_AUTHOR_*/COMMITTER_* env` **>** worktree/repo LOCAL config **>** global **>** `EMAIL` **>** autodetect `user@hostname`.

The two layers don't conflict: layer 2 **seeds itself from** the same config resolution, so they normally agree. Layer 1 remains necessary for commits made in the worktree outside the bash tool, where no env floor is present. The comment in `shellEnv()` has been corrected to match the code and git's real behavior.

## Documented cache contract

`gitIdentityCache` is keyed by worktree path and memoized for the **process lifetime**. Its behavioral contract is written down at the definition site:

- Its only job is to stop the worktree/parent attribution differential. It is not a general identity-configuration feature, and it never substitutes an identity of its own.
- Because it is delivered as env, it takes precedence over the repo's config (see above) — including a repo reached by `cd`.
- Because the resolved value is memoized per worktree path, a `git config user.name ...` performed **mid-session is not picked up until the process restarts**.
- Operator-set `GIT_AUTHOR_*`/`GIT_COMMITTER_*` still win, per variable.

Also noted why `resolveGitIdentity`/`gitIdentityCache` live in the tool's **outer setup block** rather than inside `shellEnv` — so the cache persists across bash invocations instead of re-spawning two `git config` subprocesses per call.

## Tests (real git, no mocks)

`test/worktree/index.test.ts`:
- worktree inherits the parent repo's identity;
- worktree whose parent has **no** identity is left with an empty `--local` identity, and a commit there resolves through git's own chain (asserted via `EMAIL`).

`test/tool/bash.test.ts`:
- bash env injects the 4 `GIT_*` vars inherited from repo config;
- a non-git project (`worktree=/`) gets **no** `GIT_*` var injected;
- **per-variable precedence**: with only `GIT_AUTHOR_NAME` operator-set, that one var is preserved while the other three each still receive the floor.

⚠️ The two assertions that previously pinned the invented fallback were **replaced, not adjusted** — they encoded the defect, so quietly editing them to match new behaviour would have hidden the change.

## Reviewer note — `.text.trim()` vs `.text().trim()`

These are **two different runners**, both correct, not a silent bug:
- `worktree/index.ts` uses a file-local `git()` helper returning `{ code, text, stderr }` where `text` is a plain string from `Stream.mkString` — hence the **property** form `.text.trim()`. The same file already uses that form at `:264`, `:272`, `:425`, `:430`, `:448`.
- `bash.ts` uses `gitSvc.run(...)`, whose `Result.text` **is a method** — hence `.text().trim()`.

## Verification

- `bun typecheck` → exit 0
- `bun test test/worktree/index.test.ts test/tool/bash.test.ts --timeout 120000` → **31 pass / 0 fail** (84 `expect()` calls); pristine baseline at `ae18decb7`, identical command → **30 pass / 0 fail**
- `bun test test/git` → **7 pass / 0 fail**
- Rebased onto latest `origin/main`.

## Follow-up (`8c965e96b`): the fallback identity is removed — git decides

A review objection was raised against `Git.FALLBACK_IDENTITY` (`MiMo <mimo@xiaomi.com>`): a
hardcoded fallback attributes commits to an identity the user never chose, and git already has its
own fallback chain. **Investigated against git's actual behaviour, and the objection holds.**

Measured on `git 2.50.1`:

| probe | result |
| --- | --- |
| no identity configured anywhere, no `EMAIL` | `git commit` **exit 0**, author `MI <mi@host.local>` — **there is no fatal to rescue** |
| `EMAIL=real@person.dev`, no config | `git config user.email` prints nothing, exit 1 — **the probe is blind to `EMAIL`** |
| same, `git commit` | author `MI <real@person.dev>` — **git would have used the user's chosen address** |
| repo with LOCAL `Real Person <real@person.dev>`, commit run with the 4 injected vars | `author=MiMo <mimo@xiaomi.com>` — **env outranks that repo's own correct config** |

So the constant was not a rescue for a hard failure; it **pre-empted a resolution git could still
make**, silently, and with no log or surfaced message. Worst case: for a non-git project
(`Instance.worktree === "/"`) `bash.ts` injected the placeholder **without probing any config at
all**, so a `cd ~/anyrepo && git commit` through the bash tool overrode that repo's real identity.
Layer 1's write also lands in `<worktree>/.git/config`, so it governed every later commit there —
including ones the human makes in their own terminal.

**Both layers are now propagate-or-abstain.** They copy an identity the repo itself resolves, and
pin/inject **nothing** when it resolves none — leaving the fallback to git (config → `EMAIL` →
`user@hostname` → git's own actionable `*** Please tell me who you are.`). Unresolved fields are
`log.warn`ed rather than silently substituted, so the abstain is discoverable.

This keeps the PR's actual fix intact: the reported bug was that a linked worktree does **not**
inherit the parent's LOCAL identity, and propagation still fixes exactly that. When the parent has
no identity, the worktree now resolves authorship *exactly as the parent repo would* — mimocode
introduces no attribution differential, which is the honest contract.

### The two assertions that pinned the substitution encoded the defect

They are replaced, not quietly edited to match:
- `test/worktree/index.test.ts` — was `expect(email).toBe(Git.FALLBACK_IDENTITY.email)`; now asserts
  the worktree's `--local` identity is **empty**.
- `test/tool/bash.test.ts` — was `toContain('GIT_AUTHOR_EMAIL=' + Git.FALLBACK_IDENTITY.email)`; now
  asserts **no** `GIT_*` var is injected for a non-git project.

### New regression test + revert-probe

New: *"does not override an identity git itself would resolve from EMAIL"* — commits in a worktree
whose parent has no identity and asserts the author email comes from `EMAIL`.

Revert-probe (new tests, `src/` reverted to `ae18decb7`) → **28 pass / 3 fail**:

```
error: expect(received).toBe(expected)
Expected: "chosen@example.test"
Received: "mimo@xiaomi.com"
(fail) Worktree.setup git identity > does not override an identity git itself would resolve from EMAIL
Expected: ""              Received: "MiMo"
Expected: "GIT_AUTHOR_NAME="   Received: "GIT_AUTHOR_NAME=MiMo"
```

### Verification

- `bun typecheck` → **exit 0**
- `bun test test/worktree/index.test.ts test/tool/bash.test.ts --timeout 120000` → **31 pass / 0 fail**
  (84 `expect()`); pristine baseline of the identical command at `ae18decb7` → **30 pass / 0 fail** (85).
- `mimo@xiaomi.com` no longer appears anywhere in `packages/opencode`.

