### PR TITLE
fix(agent): confine dream/distill writes to memory and .mimocode

### DIFF
--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -6,7 +6,7 @@ import { Global } from "@/global"
 import type * as Tool from "./tool"
 import { Instance } from "../project/instance"
 import { ProjectID } from "../project/schema"
-import { assertMemoryWriteAllowed } from "./memory-path-guard"
+import { assertMemoryWriteAllowed, assertAgentWriteSandbox } from "./memory-path-guard"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 
 type Kind = "file" | "directory"
@@ -106,6 +106,25 @@ export const assertWriteAllowed = Effect.fn("Tool.assertWriteAllowed")(function*
       return ProjectID.global
     }
   })()
+
+  // Hard write-sandbox for system agents (dream/distill): confine writes to the
+  // memory tree or <worktree>/.mimocode. Runs before the memory guard so a
+  // sandboxed agent writing an arbitrary source path is rejected up front.
+  const worktree = (() => {
+    try {
+      return Instance.worktree
+    } catch {
+      return undefined
+    }
+  })()
+  if (worktree) {
+    assertAgentWriteSandbox({
+      target,
+      agentName: ctx.agent,
+      memoryRoot: path.join(Global.Path.data, "memory"),
+      worktree,
+    })
+  }
 
   assertMemoryWriteAllowed({
     target,

--- a/packages/opencode/src/tool/memory-path-guard.ts
+++ b/packages/opencode/src/tool/memory-path-guard.ts
@@ -4,6 +4,53 @@ import type { SessionID } from "../session/schema"
 
 const VALID_SCOPES = ["global", "projects", "sessions"] as const
 
+/** Agents confined to a write sandbox: they may only mutate files under the
+ *  memory tree or the project's `.mimocode/` dir. Matches their stated purpose
+ *  (dream: consolidate memory; distill: package skills/agents/commands under
+ *  .mimocode). Everything else — source files, arbitrary worktree paths — is
+ *  denied at the write gate, independent of their `write`/`edit` permission. */
+const WRITE_SANDBOXED_AGENTS: ReadonlySet<string> = new Set(["dream", "distill"])
+
+/**
+ * Hard write-boundary for sandboxed system agents (dream/distill). Throws if
+ * `agentName` is sandboxed and `target` is neither under the memory tree nor
+ * under `<worktree>/.mimocode/`. Pure — does not touch the filesystem.
+ *
+ * This is enforced in the single write gate (assertWriteAllowed), so it cannot
+ * be bypassed by a widened `write`/`edit` permission or a new write tool: those
+ * tools all funnel through the gate. `bash` is NOT covered here (a separate,
+ * prompt-level discipline), matching the "trust the model, permission layer is
+ * a backstop" stance — this closes the biggest tool-mediated gap: arbitrary
+ * source-file writes via write/edit/apply_patch/notebook_edit.
+ */
+export function assertAgentWriteSandbox(input: {
+  target: string
+  agentName: string
+  memoryRoot: string
+  worktree: string
+}): void {
+  if (!WRITE_SANDBOXED_AGENTS.has(input.agentName)) return
+
+  const underMemory = pathContains(input.memoryRoot, input.target)
+  const dotDir = path.join(input.worktree, ".mimocode")
+  const underDotDir = pathContains(dotDir, input.target)
+  if (underMemory || underDotDir) return
+
+  throw new Error(
+    `Agent '${input.agentName}' may only write under the memory tree or ${dotDir}.\n` +
+      `  memory: ${input.memoryRoot}\n` +
+      `  config: ${dotDir}\n` +
+      `You attempted: ${input.target}.`,
+  )
+}
+
+/** True when `child` is `root` itself or nested under it. Normalizes a trailing
+ *  separator so `/a/memory` does not match `/a/memory-other`. */
+function pathContains(root: string, child: string): boolean {
+  const normalizedRoot = root.endsWith(path.sep) ? root.slice(0, -1) : root
+  return child === normalizedRoot || child.startsWith(normalizedRoot + path.sep)
+}
+
 const TASK_ID_RE = /^T\d+(\.\d+)*$/
 
 /**

--- a/packages/opencode/src/tool/memory-path-guard.ts
+++ b/packages/opencode/src/tool/memory-path-guard.ts
@@ -31,14 +31,20 @@ export function assertAgentWriteSandbox(input: {
 }): void {
   if (!WRITE_SANDBOXED_AGENTS.has(input.agentName)) return
 
-  const underMemory = pathContains(input.memoryRoot, input.target)
-  const dotDir = path.join(input.worktree, ".mimocode")
-  const underDotDir = pathContains(dotDir, input.target)
-  if (underMemory || underDotDir) return
+  // Resolve here rather than trusting the caller: write.ts/edit.ts pass an
+  // absolute file_path THROUGH unnormalized, so a target like
+  // `<worktree>/.mimocode/../src/x.ts` would string-prefix-match `.mimocode`
+  // yet land in src/. path.resolve folds `..` before comparison, closing that
+  // escape. (apply_patch already resolves; this makes the guard robust for all
+  // callers.) The roots are resolved too so the comparison is apples-to-apples.
+  const target = path.resolve(input.target)
+  const memoryRoot = path.resolve(input.memoryRoot)
+  const dotDir = path.resolve(input.worktree, ".mimocode")
+  if (pathContains(memoryRoot, target) || pathContains(dotDir, target)) return
 
   throw new Error(
     `Agent '${input.agentName}' may only write under the memory tree or ${dotDir}.\n` +
-      `  memory: ${input.memoryRoot}\n` +
+      `  memory: ${memoryRoot}\n` +
       `  config: ${dotDir}\n` +
       `You attempted: ${input.target}.`,
   )

--- a/packages/opencode/test/tool/memory-path-guard.test.ts
+++ b/packages/opencode/test/tool/memory-path-guard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import * as path from "path"
-import { assertMemoryWriteAllowed } from "../../src/tool/memory-path-guard"
+import { assertMemoryWriteAllowed, assertAgentWriteSandbox } from "../../src/tool/memory-path-guard"
 import { ProjectID } from "../../src/project/schema"
 import { SessionID } from "../../src/session/schema"
 import {
@@ -591,4 +591,76 @@ describe("assertMemoryWriteAllowed", () => {
       expect(tail).toBe(path.join("sessions", "sid", "checkpoint.md"))
     })
   })
+})
+
+describe("assertAgentWriteSandbox", () => {
+  const WORKTREE = "/repo"
+
+  test("non-sandboxed agent may write anywhere", () => {
+    expect(() =>
+      assertAgentWriteSandbox({
+        target: "/repo/src/index.ts",
+        agentName: "build",
+        memoryRoot: MEMORY_ROOT,
+        worktree: WORKTREE,
+      }),
+    ).not.toThrow()
+  })
+
+  for (const agent of ["dream", "distill"] as const) {
+    test(`${agent} may write under the memory tree`, () => {
+      expect(() =>
+        assertAgentWriteSandbox({
+          target: path.join(MEMORY_ROOT, "projects", "p", "MEMORY.md"),
+          agentName: agent,
+          memoryRoot: MEMORY_ROOT,
+          worktree: WORKTREE,
+        }),
+      ).not.toThrow()
+    })
+
+    test(`${agent} may write under <worktree>/.mimocode`, () => {
+      expect(() =>
+        assertAgentWriteSandbox({
+          target: path.join(WORKTREE, ".mimocode", "skills", "foo", "SKILL.md"),
+          agentName: agent,
+          memoryRoot: MEMORY_ROOT,
+          worktree: WORKTREE,
+        }),
+      ).not.toThrow()
+    })
+
+    test(`${agent} may NOT write a source file in the worktree`, () => {
+      expect(() =>
+        assertAgentWriteSandbox({
+          target: path.join(WORKTREE, "src", "index.ts"),
+          agentName: agent,
+          memoryRoot: MEMORY_ROOT,
+          worktree: WORKTREE,
+        }),
+      ).toThrow(/may only write/)
+    })
+
+    test(`${agent} may NOT write an arbitrary external path`, () => {
+      expect(() =>
+        assertAgentWriteSandbox({
+          target: "/etc/passwd",
+          agentName: agent,
+          memoryRoot: MEMORY_ROOT,
+          worktree: WORKTREE,
+        }),
+      ).toThrow(/may only write/)
+    })
+
+    test(`${agent} sibling of memory root does not match by prefix`, () => {
+      expect(() =>
+        assertAgentWriteSandbox({
+          target: MEMORY_ROOT + "-evil/x.md",
+          agentName: agent,
+          memoryRoot: MEMORY_ROOT,
+          worktree: WORKTREE,
+        }),
+      ).toThrow(/may only write/)
+    })
+  }
 })

--- a/packages/opencode/test/tool/memory-path-guard.test.ts
+++ b/packages/opencode/test/tool/memory-path-guard.test.ts
@@ -652,6 +652,39 @@ describe("assertAgentWriteSandbox", () => {
       ).toThrow(/may only write/)
     })
 
+    test(`${agent} may NOT escape .mimocode via .. into a source file`, () => {
+      expect(() =>
+        assertAgentWriteSandbox({
+          target: path.join(WORKTREE, ".mimocode", "..", "src", "index.ts"),
+          agentName: agent,
+          memoryRoot: MEMORY_ROOT,
+          worktree: WORKTREE,
+        }),
+      ).toThrow(/may only write/)
+    })
+
+    test(`${agent} may NOT escape the memory tree via ..`, () => {
+      expect(() =>
+        assertAgentWriteSandbox({
+          target: path.join(MEMORY_ROOT, "..", "secret.txt"),
+          agentName: agent,
+          memoryRoot: MEMORY_ROOT,
+          worktree: WORKTREE,
+        }),
+      ).toThrow(/may only write/)
+    })
+
+    test(`${agent} unnormalized-but-in-bounds path still passes`, () => {
+      expect(() =>
+        assertAgentWriteSandbox({
+          target: path.join(WORKTREE, ".mimocode", "skills", "..", "agent", "x.md"),
+          agentName: agent,
+          memoryRoot: MEMORY_ROOT,
+          worktree: WORKTREE,
+        }),
+      ).not.toThrow()
+    })
+
     test(`${agent} sibling of memory root does not match by prefix`, () => {
       expect(() =>
         assertAgentWriteSandbox({


### PR DESCRIPTION
dream/distill had write/edit permission over the entire worktree, letting them mutate source files despite their prompts stating they only touch memory / .mimocode. Add assertAgentWriteSandbox in the single write gate (assertWriteAllowed) so those agents can only write under the memory tree or <worktree>/.mimocode; every write tool funnels through the gate, so a widened permission cannot bypass it. bash is left to prompt discipline (a shell command cannot be statically bounded).
