### PR TITLE
docs(skill): pptx visual QA model selection — prefer current model, n…

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
@@ -337,24 +337,31 @@ actor({
   operation: {
     action: "run",
     subagent_type: "general",
-    model: "xiaomi/mimo-v2.5",   // recommended: vision-capable model
+    // omit `model` when your current model is vision-capable (preferred — see Model selection)
     description: "Visual QA slides",
     prompt: "Inspect the rendered slide images in qa/ for: text overflow, overlapping shapes, cut-off labels, wrong-scale icons, off-brand colors. Report each issue as 'slide N: <problem>'. Images: qa/slide-1.png through qa/slide-<N>.png."
   }
 })
 ```
 
-**Model selection (recommended, not enforced):**
+**Model selection (in priority order):**
 
-| Your current model | Recommended vision subagent model | Notes |
-|--------------------|-----------------------------------|-------|
-| `xiaomi/mimo-v2.5-pro` | `xiaomi/mimo-v2.5` | mimo-v2.5-pro is text-only; mimo-v2.5 is multimodal |
-| Any non-vision model | A vision-capable model | Query available vision models to pick one |
-| Already a vision model | Same model or any vision model | No change needed |
+1. **Prefer the user's current model.** Query the servable vision models via
+   `actor({ operation: { action: "models", vision: true } })`. If your current
+   model is in the list, **omit the `model` parameter** — the subagent inherits
+   it, and visual QA runs on the model the user chose.
+2. **Fallback: lightweight vision model, stated explicitly.** If your current
+   model is not vision-capable, pick a **lightweight** vision model from the
+   query result (haiku/flash/lite-class if present, otherwise the cheapest
+   listed) and **tell the user in your reply** which model you used for visual
+   QA and why (current model cannot inspect images).
+3. **No vision model available.** If the query returns an empty list, do not
+   guess a model id — skip the visual QA subagent, run the structural checks
+   only, and tell the user visual inspection could not be performed.
 
-Pick a vision-capable model for the subagent. If unsure what's available,
-query available vision models via
-`actor({ operation: { action: "models", vision: true } })`.
+**Never hardcode a model id.** Which models are servable varies per
+deployment and changes over time; only ids returned by the vision models
+query are guaranteed to work. A guessed id fails the subagent outright.
 
 **Exception — direct inspection in the main context:** Only load slide
 images directly (without a subagent) when the user explicitly requests


### PR DESCRIPTION
…o hardcoded id

The skill hardcoded model: "xiaomi/mimo-v2.5" for the visual QA subagent. On deployments where that id is not servable (e.g. router groups without a mimo channel) every QA request 503s and the subtask hangs on retries.

Replace with priority-ordered guidance: query `actor models --vision`; prefer the user's current model (omit `model` so the subagent inherits it); otherwise fall back to a lightweight vision model and state the substitution explicitly; if none exist, skip visual QA and say so. Never hardcode ids.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
