### PR TITLE
fix(project): preserve session time_updated during global re-parent

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -2,7 +2,7 @@ import z from "zod"
 import * as nodeFs from "fs/promises"
 import * as nodeOs from "os"
 import * as nodePath from "path"
-import { and, Database, eq } from "../storage"
+import { and, Database, eq, sql } from "../storage"
 import { ProjectTable } from "./project.sql"
 import { SessionTable } from "../session/session.sql"
 import { Log } from "../util"
@@ -348,10 +348,15 @@ export const layer: Layer.Layer<
       )
 
       if (data.id !== ProjectID.global) {
+        // Keep time_updated intact: the schema's $onUpdate hook injects
+        // time_updated=Date.now() into every UPDATE, and this lazy re-parent is
+        // bookkeeping, not user activity — without the explicit passthrough it
+        // flattens the recency of every migrated session to one timestamp,
+        // scrambling recency-ordered session lists.
         yield* db((d) =>
           d
             .update(SessionTable)
-            .set({ project_id: data.id })
+            .set({ project_id: data.id, time_updated: sql`time_updated` })
             .where(and(eq(SessionTable.project_id, ProjectID.global), eq(SessionTable.directory, data.worktree)))
             .run(),
         )

--- a/packages/opencode/test/project/migrate-global.test.ts
+++ b/packages/opencode/test/project/migrate-global.test.ts
@@ -25,8 +25,8 @@ function uid() {
   return SessionID.make(crypto.randomUUID())
 }
 
-function seed(opts: { id: SessionID; dir: string; project: ProjectID }) {
-  const now = Date.now()
+function seed(opts: { id: SessionID; dir: string; project: ProjectID; time?: number }) {
+  const now = opts.time ?? Date.now()
   Database.use((db) =>
     db
       .insert(SessionTable)
@@ -148,5 +148,32 @@ describe("migrateFromGlobal", () => {
     expect(row).toBeDefined()
     // Should remain under "global" — not stolen
     expect(row!.project_id).toBe(ProjectID.global)
+  })
+
+  test("preserves time_updated when migrating (re-parent is bookkeeping, not activity)", async () => {
+    // Regression: the schema's $onUpdate hook injects time_updated=Date.now()
+    // into every UPDATE, so the re-parent used to flatten the recency of every
+    // migrated session to one identical timestamp — scrambling recency-ordered
+    // session lists (newest conversations sank below older ones).
+    await using tmp = await tmpdir({ git: true })
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+    expect(project.id).not.toBe(ProjectID.global)
+
+    ensureGlobal()
+
+    const old = uid()
+    const older = uid()
+    const oldTime = Date.now() - 7 * 24 * 60 * 60 * 1000
+    seed({ id: old, dir: tmp.path, project: ProjectID.global, time: oldTime })
+    seed({ id: older, dir: tmp.path, project: ProjectID.global, time: oldTime - 60_000 })
+
+    await run((svc) => svc.fromDirectory(tmp.path))
+
+    const rows = Database.use((db) =>
+      db.select().from(SessionTable).where(eq(SessionTable.project_id, project.id)).all(),
+    )
+    const byId = new Map(rows.map((r) => [r.id, r]))
+    expect(byId.get(old)?.time_updated).toBe(oldTime)
+    expect(byId.get(older)?.time_updated).toBe(oldTime - 60_000)
   })
 })


### PR DESCRIPTION
The Timestamps schema's $onUpdate hook injects time_updated=Date.now() into every UPDATE on SessionTable, so the lazy global->project re-parent in Project.fromDirectory flattened the recency of every migrated session to a single identical timestamp. Recency-ordered session lists (desktop sidebar, /experimental/session) then fell back to the id tie-breaker, sinking the newest conversations below older ones.

Explicitly pass through the existing column value so the bookkeeping migration no longer counts as user activity.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
