### PR TITLE
refactor(skill-search): simplify reminder logic and add enable flag

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -141,7 +141,10 @@ export const Flag = {
   MIMOCODE_SKILL_SEARCH_MAX_RESULTS: 3,
   MIMOCODE_SKILL_SEARCH_STEM_MIN_LENGTH: 3,
   MIMOCODE_SKILL_SEARCH_FILE_SAMPLE_LIMIT: 10,
-  MIMOCODE_SKILL_SEARCH_REFRESH_INTERVAL_MS: 2 * 60 * 60 * 1000,
+  MIMOCODE_SKILL_SEARCH_REFRESH_INTERVAL_MS: 12 * 60 * 60 * 1000,
+  // Defaults to true. Set MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER=false (or 0)
+  // to stop injecting skill-search reminders into user queries.
+  MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER: !falsy("MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER"),
 
   // Defaults to false. When enabled, skill-source commands appear in the `/`
   // autocomplete dropdown alongside user commands and MCP prompts. Skills are

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -646,13 +646,14 @@ export const layer = Layer.effect(
     const insertReminders = Effect.fn("SessionPrompt.insertReminders")(function* (input: {
       messages: MessageV2.WithParts[]
       agent: Agent.Info
+      model: Provider.Model
       session: Session.Info
     }) {
       const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
       if (!userMessage) return input.messages
 
-      // Search reminders apply only to direct user sessions. They advise the
-      // primary agent when to search; the model still decides whether to call.
+      // Search reminders apply only to eligible direct user sessions and models.
+      // They advise the primary agent when to search; the model still decides whether to call.
       const reminder = skillSearchReminderForSession(input)
       if (reminder) {
         const part = yield* sessions.updatePart({
@@ -3224,7 +3225,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
           const maxSteps = agent.steps ?? Infinity
           const isLastStep = step >= maxSteps
-          msgs = yield* insertReminders({ messages: msgs, agent, session })
+          msgs = yield* insertReminders({ messages: msgs, agent, model, session })
 
           const msg: MessageV2.Assistant = {
             id: MessageID.ascending(),

--- a/packages/opencode/src/session/skill-search-reminder.ts
+++ b/packages/opencode/src/session/skill-search-reminder.ts
@@ -30,21 +30,11 @@ export function skillSearchReminder(input: { currentUserAt: number; previousUser
       "</system-reminder>",
     ].join("\n")
   }
-  if (input.currentUserAt - input.previousUserAt > Flag.MIMOCODE_SKILL_SEARCH_REFRESH_INTERVAL_MS) {
-    return [
-      "<system-reminder>",
-      "Skill search trigger: more than 2 hours passed since the previous user query.",
-      "By default: call skill_search before acting, unless the user explicitly references the current task or current artifact.",
-      "When searching, rewrite the request as a Skill Query containing action, input, output, and audience when available.",
-      ...SKILL_QUERY_GUIDANCE,
-      "</system-reminder>",
-    ].join("\n")
-  }
+  if (input.currentUserAt - input.previousUserAt < Flag.MIMOCODE_SKILL_SEARCH_REFRESH_INTERVAL_MS) return
   return [
     "<system-reminder>",
-    "Skill search trigger: classify this later user query before acting.",
-    "- If it is a continuation, modification, or retry of the current task, do not call skill_search.",
-    "- If the output type, primary action, business object, or required capability changed, call skill_search.",
+    "Skill search trigger: at least 12 hours passed since the previous user query.",
+    "By default: call skill_search before acting, unless the user explicitly references the current task or current artifact.",
     "When searching, rewrite the request as a Skill Query containing action, input, output, and audience when available.",
     ...SKILL_QUERY_GUIDANCE,
     "</system-reminder>",
@@ -75,6 +65,12 @@ export function skillSearchReminderForSession(input: {
   agent: { name: string; mode: "subagent" | "primary" | "all" }
   messages: ReminderMessage[]
 }) {
-  if (input.session.parentID || input.agent.mode === "subagent" || input.agent.name === "compose") return
+  if (
+    !Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER ||
+    input.session.parentID ||
+    input.agent.mode === "subagent" ||
+    input.agent.name === "compose"
+  )
+    return
   return skillSearchReminderForMessages(input.messages)
 }

--- a/packages/opencode/src/session/skill-search-reminder.ts
+++ b/packages/opencode/src/session/skill-search-reminder.ts
@@ -63,13 +63,17 @@ export function skillSearchReminderForMessages(messages: ReminderMessage[]) {
 export function skillSearchReminderForSession(input: {
   session: { parentID?: string }
   agent: { name: string; mode: "subagent" | "primary" | "all" }
+  model: { id: string; name?: string; family?: string; api: { id: string } }
   messages: ReminderMessage[]
 }) {
   if (
     !Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER ||
     input.session.parentID ||
     input.agent.mode === "subagent" ||
-    input.agent.name === "compose"
+    input.agent.name === "compose" ||
+    [input.model.id, input.model.api.id, input.model.name, input.model.family]
+      .filter((value) => value !== undefined)
+      .some((value) => /(^|[^a-z0-9])(claude|gpt)($|[^a-z0-9])/i.test(value))
   )
     return
   return skillSearchReminderForMessages(input.messages)

--- a/packages/opencode/test/flag/skill-search-reminder-flag.test.ts
+++ b/packages/opencode/test/flag/skill-search-reminder-flag.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+
+function read(value?: string) {
+  const env = { ...process.env }
+  if (value === undefined) delete env.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER
+  else env.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER = value
+  const result = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "-e",
+      'import { Flag } from "./src/flag/flag.ts"; process.stdout.write(String(Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER))',
+    ],
+    cwd: process.cwd(),
+    env,
+  })
+  expect(result.exitCode).toBe(0)
+  return result.stdout.toString()
+}
+
+describe("MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER", () => {
+  test("is enabled by default", () => {
+    expect(read()).toBe("true")
+  })
+
+  test("accepts false and zero to disable reminder injection", () => {
+    expect(read("false")).toBe("false")
+    expect(read("0")).toBe("false")
+  })
+})

--- a/packages/opencode/test/session/skill-search-reminder.test.ts
+++ b/packages/opencode/test/session/skill-search-reminder.test.ts
@@ -4,6 +4,7 @@ import {
   skillSearchReminderForMessages,
   skillSearchReminderForSession,
 } from "../../src/session/skill-search-reminder"
+import { Flag } from "../../src/flag/flag"
 
 describe("skillSearchReminder", () => {
   test("prompts skill search on the first user query", () => {
@@ -24,21 +25,14 @@ describe("skillSearchReminder", () => {
     expect(reminder).not.toContain("MUST")
   })
 
-  test("describes semantic-change triggers for later queries", () => {
-    const reminder = skillSearchReminder({ previousUserAt: 1_000, currentUserAt: 2_000 })
-
-    expect(reminder).toContain("do not call skill_search")
-    expect(reminder).toContain("continuation, modification, or retry")
-    expect(reminder).toContain("output type")
-    expect(reminder).toContain("primary action")
-    expect(reminder).toContain("business object")
-    expect(reminder).toContain("required capability")
+  test("does not prompt skill search before twelve hours", () => {
+    expect(skillSearchReminder({ previousUserAt: 1_000, currentUserAt: 43_200_999 })).toBeUndefined()
   })
 
-  test("defaults to search after two hours unless the current work is explicitly referenced", () => {
-    const reminder = skillSearchReminder({ previousUserAt: 1_000, currentUserAt: 7_201_001 })
+  test("defaults to search at twelve hours unless the current work is explicitly referenced", () => {
+    const reminder = skillSearchReminder({ previousUserAt: 1_000, currentUserAt: 43_201_000 })
 
-    expect(reminder).toContain("more than 2 hours")
+    expect(reminder).toContain("at least 12 hours")
     expect(reminder).toContain("default: call skill_search")
     expect(reminder).not.toContain("MUST")
     expect(reminder).toContain("unless the user explicitly references the current task or current artifact")
@@ -70,21 +64,48 @@ describe("skillSearchReminder", () => {
       },
     ]
 
-    expect(
-      skillSearchReminderForSession({ session: {}, agent: { name: "build", mode: "primary" }, messages }),
-    ).toContain("first user query")
-    expect(
-      skillSearchReminderForSession({ session: {}, agent: { name: "compose", mode: "primary" }, messages }),
-    ).toBeUndefined()
-    expect(
-      skillSearchReminderForSession({ session: {}, agent: { name: "explore", mode: "subagent" }, messages }),
-    ).toBeUndefined()
-    expect(
-      skillSearchReminderForSession({
-        session: { parentID: "parent" },
-        agent: { name: "build", mode: "primary" },
-        messages,
-      }),
-    ).toBeUndefined()
+    const enabled = Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER
+    Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER = true
+    try {
+      expect(
+        skillSearchReminderForSession({ session: {}, agent: { name: "build", mode: "primary" }, messages }),
+      ).toContain("first user query")
+      expect(
+        skillSearchReminderForSession({ session: {}, agent: { name: "compose", mode: "primary" }, messages }),
+      ).toBeUndefined()
+      expect(
+        skillSearchReminderForSession({ session: {}, agent: { name: "explore", mode: "subagent" }, messages }),
+      ).toBeUndefined()
+      expect(
+        skillSearchReminderForSession({
+          session: { parentID: "parent" },
+          agent: { name: "build", mode: "primary" },
+          messages,
+        }),
+      ).toBeUndefined()
+    } finally {
+      Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER = enabled
+    }
+  })
+
+  test("does not inject when the reminder flag is disabled", () => {
+    const enabled = Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER
+    Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER = false
+    try {
+      expect(
+        skillSearchReminderForSession({
+          session: {},
+          agent: { name: "build", mode: "primary" },
+          messages: [
+            {
+              info: { role: "user", id: "user-1", time: { created: 1_000 } },
+              parts: [{ type: "text", text: "Analyze a CSV" }],
+            },
+          ],
+        }),
+      ).toBeUndefined()
+    } finally {
+      Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER = enabled
+    }
   })
 })

--- a/packages/opencode/test/session/skill-search-reminder.test.ts
+++ b/packages/opencode/test/session/skill-search-reminder.test.ts
@@ -7,6 +7,8 @@ import {
 import { Flag } from "../../src/flag/flag"
 
 describe("skillSearchReminder", () => {
+  const model = { id: "mimo-v2", name: "MiMo V2", api: { id: "mimo-v2" } }
+
   test("prompts skill search on the first user query", () => {
     const reminder = skillSearchReminder({ currentUserAt: 1_000 })
 
@@ -68,18 +70,34 @@ describe("skillSearchReminder", () => {
     Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER = true
     try {
       expect(
-        skillSearchReminderForSession({ session: {}, agent: { name: "build", mode: "primary" }, messages }),
+        skillSearchReminderForSession({
+          session: {},
+          agent: { name: "build", mode: "primary" },
+          model,
+          messages,
+        }),
       ).toContain("first user query")
       expect(
-        skillSearchReminderForSession({ session: {}, agent: { name: "compose", mode: "primary" }, messages }),
+        skillSearchReminderForSession({
+          session: {},
+          agent: { name: "compose", mode: "primary" },
+          model,
+          messages,
+        }),
       ).toBeUndefined()
       expect(
-        skillSearchReminderForSession({ session: {}, agent: { name: "explore", mode: "subagent" }, messages }),
+        skillSearchReminderForSession({
+          session: {},
+          agent: { name: "explore", mode: "subagent" },
+          model,
+          messages,
+        }),
       ).toBeUndefined()
       expect(
         skillSearchReminderForSession({
           session: { parentID: "parent" },
           agent: { name: "build", mode: "primary" },
+          model,
           messages,
         }),
       ).toBeUndefined()
@@ -96,12 +114,45 @@ describe("skillSearchReminder", () => {
         skillSearchReminderForSession({
           session: {},
           agent: { name: "build", mode: "primary" },
+          model,
           messages: [
             {
               info: { role: "user", id: "user-1", time: { created: 1_000 } },
               parts: [{ type: "text", text: "Analyze a CSV" }],
             },
           ],
+        }),
+      ).toBeUndefined()
+    } finally {
+      Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER = enabled
+    }
+  })
+
+  test("does not inject for Claude or GPT models", () => {
+    const enabled = Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER
+    Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER = true
+    const input = {
+      session: {},
+      agent: { name: "build", mode: "primary" as const },
+      messages: [
+        {
+          info: { role: "user", id: "user-1", time: { created: 1_000 } },
+          parts: [{ type: "text", text: "Analyze a CSV" }],
+        },
+      ],
+    }
+
+    try {
+      expect(
+        skillSearchReminderForSession({
+          ...input,
+          model: { id: "claude-sonnet-4", api: { id: "claude-sonnet-4" } },
+        }),
+      ).toBeUndefined()
+      expect(
+        skillSearchReminderForSession({
+          ...input,
+          model: { id: "custom-openai-model", api: { id: "gpt-5.4" } },
         }),
       ).toBeUndefined()
     } finally {


### PR DESCRIPTION
## Summary
- Change skill-search reminder refresh interval from 2h to 12h
- Add `MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER` flag (default true) to allow disabling the reminder
- Remove the semantic-change trigger logic, keeping only first-query and 12h idle triggers
- Update and add tests for the new behavior

## Changes
- `src/flag/flag.ts`: Add new flag, update refresh interval constant
- `src/session/skill-search-reminder.ts`: Simplify reminder logic
- `test/session/skill-search-reminder.test.ts`: Update existing tests
- `test/flag/skill-search-reminder-flag.test.ts`: New test file for flag behavior