### PR TITLE
fix(mcp): negotiate per-turn lifecycle notifications

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -69,6 +69,118 @@ export const Failed = NamedError.create(
 
 type MCPClient = Client
 
+export const TURN_LIFECYCLE_CAPABILITY = "com.xiaomi.mimo/turn-lifecycle"
+export const TURN_LIFECYCLE_NOTIFICATION = `notifications/${TURN_LIFECYCLE_CAPABILITY}`
+export const TURN_LIFECYCLE_NOTIFICATION_TIMEOUT = 1_000
+
+interface PendingTurnLifecycleNotification {
+  readonly promise: Promise<void>
+  readonly waiters: Set<() => void>
+}
+
+const pendingTurnLifecycleNotifications = new WeakMap<MCPClient, PendingTurnLifecycleNotification>()
+
+export interface TurnContext {
+  [key: string]: unknown
+  sessionId: string
+  turnId: string
+  actorId?: string
+}
+
+export type TurnStatus = "completed" | "cancelled" | "error"
+
+function supportsTurnLifecycle(client: MCPClient) {
+  const capability = client.getServerCapabilities()?.experimental?.[TURN_LIFECYCLE_CAPABILITY]
+  return typeof capability === "object" && capability !== null && "version" in capability && capability.version === 1
+}
+
+function startTurnLifecycleNotification(client: MCPClient, context: TurnContext, status: TurnStatus) {
+  if (pendingTurnLifecycleNotifications.has(client)) return undefined
+  const promise = Promise.resolve().then(() =>
+    client.notification({
+      method: TURN_LIFECYCLE_NOTIFICATION,
+      params: { ...context, status },
+    } as Parameters<MCPClient["notification"]>[0]),
+  )
+  const notification: PendingTurnLifecycleNotification = { promise, waiters: new Set() }
+  pendingTurnLifecycleNotifications.set(client, notification)
+  const clear = () => {
+    if (pendingTurnLifecycleNotifications.get(client) === notification) {
+      pendingTurnLifecycleNotifications.delete(client)
+    }
+    const waiters = [...notification.waiters]
+    notification.waiters.clear()
+    for (const waiter of waiters) waiter()
+  }
+  void promise.then(clear, clear)
+  return notification
+}
+
+function waitForTurnLifecycleNotification(client: MCPClient, notification: PendingTurnLifecycleNotification) {
+  return Effect.tryPromise({
+    try: (signal) =>
+      new Promise<void>((resolve, reject) => {
+        let done = false
+        const cleanup = () => {
+          notification.waiters.delete(onSettled)
+          signal.removeEventListener("abort", onAbort)
+        }
+        const finish = (complete: () => void) => {
+          if (done) return
+          done = true
+          cleanup()
+          complete()
+        }
+        const onSettled = () => finish(resolve)
+        const onAbort = () =>
+          finish(() => reject(signal.reason instanceof Error ? signal.reason : new Error("Lifecycle wait aborted")))
+
+        notification.waiters.add(onSettled)
+        signal.addEventListener("abort", onAbort, { once: true })
+
+        if (signal.aborted) onAbort()
+        else if (pendingTurnLifecycleNotifications.get(client) !== notification) onSettled()
+      }),
+    catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+  })
+}
+
+function sendTurnLifecycleNotification(client: MCPClient, context: TurnContext, status: TurnStatus) {
+  return Effect.gen(function* () {
+    while (true) {
+      const pending = pendingTurnLifecycleNotifications.get(client)
+      if (pending) {
+        yield* waitForTurnLifecycleNotification(client, pending)
+        continue
+      }
+
+      const notification = startTurnLifecycleNotification(client, context, status)
+      if (!notification) continue
+      return yield* Effect.tryPromise({
+        try: () => notification.promise,
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      })
+    }
+  })
+}
+
+export function notifyTurnLifecycle(clients: Record<string, MCPClient>, context: TurnContext, status: TurnStatus) {
+  return Effect.forEach(
+    Object.entries(clients),
+    ([clientName, client]) => {
+      if (!supportsTurnLifecycle(client)) return Effect.void
+      return sendTurnLifecycleNotification(client, context, status).pipe(
+        Effect.timeout(TURN_LIFECYCLE_NOTIFICATION_TIMEOUT),
+        Effect.tapError((error) =>
+          Effect.sync(() => log.warn("failed to notify MCP turn lifecycle", { clientName, status, error })),
+        ),
+        Effect.ignore,
+      )
+    },
+    { concurrency: "unbounded", discard: true },
+  )
+}
+
 export const Status = z
   .discriminatedUnion("status", [
     z
@@ -137,7 +249,7 @@ function isMcpConfigured(entry: McpEntry): entry is ConfigMCP.Info {
 const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, "_")
 
 // Convert MCP tool definition to AI SDK Tool type
-function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Tool {
+function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number, context?: TurnContext): Tool {
   const inputSchema = mcpTool.inputSchema
 
   // Spread first, then override type to ensure it's always "object"
@@ -152,10 +264,13 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
     description: mcpTool.description ?? "",
     inputSchema: jsonSchema(schema),
     execute: async (args: unknown) => {
+      const metadata =
+        context && supportsTurnLifecycle(client) ? { _meta: { [TURN_LIFECYCLE_CAPABILITY]: context } } : {}
       return client.callTool(
         {
           name: mcpTool.name,
           arguments: (args || {}) as Record<string, unknown>,
+          ...metadata,
         },
         CallToolResultSchema,
         {
@@ -228,7 +343,7 @@ interface State {
 export interface Interface {
   readonly status: () => Effect.Effect<Record<string, Status>>
   readonly clients: () => Effect.Effect<Record<string, MCPClient>>
-  readonly tools: () => Effect.Effect<Record<string, Tool>>
+  readonly tools: (context?: TurnContext) => Effect.Effect<Record<string, Tool>>
   readonly prompts: () => Effect.Effect<Record<string, PromptInfo & { client: string }>>
   readonly resources: () => Effect.Effect<Record<string, ResourceInfo & { client: string }>>
   readonly add: (name: string, mcp: ConfigMCP.Info) => Effect.Effect<{ status: Record<string, Status> | Status }>
@@ -637,7 +752,7 @@ export const layer = Layer.effect(
       s.status[name] = { status: "disabled" }
     })
 
-    const tools = Effect.fn("MCP.tools")(function* () {
+    const tools = Effect.fn("MCP.tools")(function* (context?: TurnContext) {
       const result: Record<string, Tool> = {}
       const s = yield* InstanceState.get(state)
 
@@ -664,7 +779,12 @@ export const layer = Layer.effect(
 
             const timeout = entry?.timeout ?? defaultTimeout
             for (const mcpTool of listed) {
-              result[sanitize(clientName) + "_" + sanitize(mcpTool.name)] = convertMcpTool(mcpTool, client, timeout)
+              result[sanitize(clientName) + "_" + sanitize(mcpTool.name)] = convertMcpTool(
+                mcpTool,
+                client,
+                timeout,
+                context,
+              )
             }
           }),
         { concurrency: "unbounded" },

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -71,7 +71,16 @@ type MCPClient = Client
 
 export const TURN_LIFECYCLE_CAPABILITY = "com.xiaomi.mimo/turn-lifecycle"
 export const TURN_LIFECYCLE_NOTIFICATION = `notifications/${TURN_LIFECYCLE_CAPABILITY}`
+export const TURN_LIFECYCLE_VERSION = 1
 export const TURN_LIFECYCLE_NOTIFICATION_TIMEOUT = 1_000
+
+const turnLifecycleClientOptions = {
+  capabilities: {
+    experimental: {
+      [TURN_LIFECYCLE_CAPABILITY]: { version: TURN_LIFECYCLE_VERSION },
+    },
+  },
+}
 
 interface PendingTurnLifecycleNotification {
   readonly promise: Promise<void>
@@ -91,7 +100,12 @@ export type TurnStatus = "completed" | "cancelled" | "error"
 
 function supportsTurnLifecycle(client: MCPClient) {
   const capability = client.getServerCapabilities()?.experimental?.[TURN_LIFECYCLE_CAPABILITY]
-  return typeof capability === "object" && capability !== null && "version" in capability && capability.version === 1
+  return (
+    typeof capability === "object" &&
+    capability !== null &&
+    "version" in capability &&
+    capability.version === TURN_LIFECYCLE_VERSION
+  )
 }
 
 function startTurnLifecycleNotification(client: MCPClient, context: TurnContext, status: TurnStatus) {
@@ -263,7 +277,7 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
   return dynamicTool({
     description: mcpTool.description ?? "",
     inputSchema: jsonSchema(schema),
-    execute: async (args: unknown) => {
+    execute: async (args: unknown, options) => {
       const metadata =
         context && supportsTurnLifecycle(client) ? { _meta: { [TURN_LIFECYCLE_CAPABILITY]: context } } : {}
       return client.callTool(
@@ -275,6 +289,7 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
         CallToolResultSchema,
         {
           resetTimeoutOnProgress: true,
+          signal: options.abortSignal,
           timeout,
         },
       )
@@ -375,6 +390,8 @@ export const layer = Layer.effect(
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const auth = yield* McpAuth.Service
     const bus = yield* Bus.Service
+    const createClient = () =>
+      new Client({ name: "mimocode", version: InstallationVersion }, turnLifecycleClientOptions)
 
     type Transport = StdioClientTransport | StreamableHTTPClientTransport | SSEClientTransport
 
@@ -388,7 +405,7 @@ export const layer = Layer.effect(
         (t) =>
           Effect.tryPromise({
             try: () => {
-              const client = new Client({ name: "mimocode", version: InstallationVersion })
+              const client = createClient()
               return withTimeout(client.connect(t), timeout).then(() => client)
             },
             catch: (e) => (e instanceof Error ? e : new Error(String(e))),
@@ -897,7 +914,7 @@ export const layer = Layer.effect(
 
       return yield* Effect.tryPromise({
         try: () => {
-          const client = new Client({ name: "mimocode", version: InstallationVersion })
+          const client = createClient()
           return client
             .connect(transport)
             .then(() => ({ authorizationUrl: "", oauthState, client }) satisfies AuthResult)

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -73,6 +73,9 @@ export const TURN_LIFECYCLE_CAPABILITY = "com.xiaomi.mimo/turn-lifecycle"
 export const TURN_LIFECYCLE_NOTIFICATION = `notifications/${TURN_LIFECYCLE_CAPABILITY}`
 export const TURN_LIFECYCLE_VERSION = 1
 export const TURN_LIFECYCLE_NOTIFICATION_TIMEOUT = 1_000
+// A send that has already outlived the per-turn budget can never be useful to wait
+// on again, so later turns abandon it instead of queueing behind it forever.
+export const TURN_LIFECYCLE_STUCK_TIMEOUT = TURN_LIFECYCLE_NOTIFICATION_TIMEOUT
 
 const turnLifecycleClientOptions = {
   capabilities: {
@@ -85,6 +88,7 @@ const turnLifecycleClientOptions = {
 interface PendingTurnLifecycleNotification {
   readonly promise: Promise<void>
   readonly waiters: Set<() => void>
+  readonly startedAt: number
 }
 
 const pendingTurnLifecycleNotifications = new WeakMap<MCPClient, PendingTurnLifecycleNotification>()
@@ -116,7 +120,7 @@ function startTurnLifecycleNotification(client: MCPClient, context: TurnContext,
       params: { ...context, status },
     } as Parameters<MCPClient["notification"]>[0]),
   )
-  const notification: PendingTurnLifecycleNotification = { promise, waiters: new Set() }
+  const notification: PendingTurnLifecycleNotification = { promise, waiters: new Set(), startedAt: Date.now() }
   pendingTurnLifecycleNotifications.set(client, notification)
   const clear = () => {
     if (pendingTurnLifecycleNotifications.get(client) === notification) {
@@ -126,8 +130,29 @@ function startTurnLifecycleNotification(client: MCPClient, context: TurnContext,
     notification.waiters.clear()
     for (const waiter of waiters) waiter()
   }
+  // Attached at creation so an orphaned send's eventual rejection is always swallowed.
   void promise.then(clear, clear)
   return notification
+}
+
+// A send that outlives the per-turn budget is treated as stuck: drop it from the
+// pending map so the next turn sends immediately instead of paying the timeout
+// forever. The orphaned promise is never awaited again; its settlement still runs
+// `clear`, which no-ops because the map entry has been replaced.
+function releaseStuckTurnLifecycleNotification(
+  client: MCPClient,
+  notification: PendingTurnLifecycleNotification,
+  clientName: string,
+) {
+  if (pendingTurnLifecycleNotifications.get(client) !== notification) return
+  pendingTurnLifecycleNotifications.delete(client)
+  log.warn("abandoning stuck MCP turn lifecycle notification", {
+    clientName,
+    elapsed: Date.now() - notification.startedAt,
+  })
+  const waiters = [...notification.waiters]
+  notification.waiters.clear()
+  for (const waiter of waiters) waiter()
 }
 
 function waitForTurnLifecycleNotification(client: MCPClient, notification: PendingTurnLifecycleNotification) {
@@ -159,11 +184,20 @@ function waitForTurnLifecycleNotification(client: MCPClient, notification: Pendi
   })
 }
 
-function sendTurnLifecycleNotification(client: MCPClient, context: TurnContext, status: TurnStatus) {
+function sendTurnLifecycleNotification(
+  client: MCPClient,
+  context: TurnContext,
+  status: TurnStatus,
+  clientName: string,
+) {
   return Effect.gen(function* () {
     while (true) {
       const pending = pendingTurnLifecycleNotifications.get(client)
       if (pending) {
+        if (Date.now() - pending.startedAt >= TURN_LIFECYCLE_STUCK_TIMEOUT) {
+          releaseStuckTurnLifecycleNotification(client, pending, clientName)
+          continue
+        }
         yield* waitForTurnLifecycleNotification(client, pending)
         continue
       }
@@ -183,7 +217,7 @@ export function notifyTurnLifecycle(clients: Record<string, MCPClient>, context:
     Object.entries(clients),
     ([clientName, client]) => {
       if (!supportsTurnLifecycle(client)) return Effect.void
-      return sendTurnLifecycleNotification(client, context, status).pipe(
+      return sendTurnLifecycleNotification(client, context, status, clientName).pipe(
         Effect.timeout(TURN_LIFECYCLE_NOTIFICATION_TIMEOUT),
         Effect.tapError((error) =>
           Effect.sync(() => log.warn("failed to notify MCP turn lifecycle", { clientName, status, error })),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1018,8 +1018,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         agent: input.agent.name,
         actorID: input.agentID,
         taskId: input.task_id,
-        turnID: input.mcpContext.turnId,
-        turnActorID: input.mcpContext.actorId,
         messages: input.messages,
         metadata: (val) =>
           input.processor.updateToolCall(options.toolCallId, (match) => {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -937,6 +937,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       messages: MessageV2.WithParts[]
       agentID?: string
       task_id?: string
+      mcpContext: MCP.TurnContext
     }) {
       using _ = log.time("resolveTools")
       const tools: Record<string, AITool> = {}
@@ -1017,6 +1018,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         agent: input.agent.name,
         actorID: input.agentID,
         taskId: input.task_id,
+        turnID: input.mcpContext.turnId,
+        turnActorID: input.mcpContext.actorId,
         messages: input.messages,
         metadata: (val) =>
           input.processor.updateToolCall(options.toolCallId, (match) => {
@@ -1157,7 +1160,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       }
 
       const localToolNames = new Set(Object.keys(tools))
-      const mcpTools = Object.entries(yield* mcp.tools())
+      const mcpTools = Object.entries(yield* mcp.tools(input.mcpContext))
       const agentToolAllowlist = input.agent.toolAllowlist ? new Set(input.agent.toolAllowlist) : undefined
       const disabledMcpTools = Permission.disabled(
         mcpTools.map(([key]) => key),
@@ -2338,6 +2341,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         // into the same loop.
         let hardHalt = false
         const resolvedAgentID = agentID ?? "main"
+        const mcpContext: MCP.TurnContext = {
+          sessionId: sessionID,
+          turnId: ulid(),
+          actorId: resolvedAgentID,
+        }
         // Tracks plugin-driven cancellation (session.pre OR any session.userQuery.pre)
         // so session.post reports outcome="cancelled" instead of "error".
         let cancelled = false
@@ -2377,20 +2385,36 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 : finalAsst
                   ? sessionErrorText(finalAsst.error)
                   : undefined
-            yield* plugin.trigger(
-              "session.post",
-              {
-                sessionID,
-                agentID: resolvedAgentID,
-                task_id,
-                outcome,
-                error,
-                finalText: finalAsst ? assistantFinalText(finalAsst, finalParts) : undefined,
-                assistantMessageID: finalAsst?.id,
-                trajectory: serializeTrajectoryMessages(sliceMsgs),
-                systemPrompt: lastSystemPrompt,
-              },
-              {},
+            const interrupted = Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)
+            const lifecycleStatus: MCP.TurnStatus =
+              cancelled || interrupted ? "cancelled" : failed || finalIsError ? "error" : "completed"
+            yield* Effect.all(
+              [
+                plugin
+                  .trigger(
+                    "session.post",
+                    {
+                      sessionID,
+                      agentID: resolvedAgentID,
+                      task_id,
+                      outcome,
+                      error,
+                      finalText: finalAsst ? assistantFinalText(finalAsst, finalParts) : undefined,
+                      assistantMessageID: finalAsst?.id,
+                      trajectory: serializeTrajectoryMessages(sliceMsgs),
+                      systemPrompt: lastSystemPrompt,
+                    },
+                    {},
+                  )
+                  .pipe(Effect.ignore),
+                mcp
+                  .clients()
+                  .pipe(
+                    Effect.flatMap((clients) => MCP.notifyTurnLifecycle(clients, mcpContext, lifecycleStatus)),
+                    Effect.ignore,
+                  ),
+              ],
+              { concurrency: "unbounded", discard: true },
             )
           }).pipe(Effect.ignore)
 
@@ -3422,6 +3446,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               messages: msgs,
               agentID: lastUser.agentID,
               task_id,
+              mcpContext,
             })
             const tools = resolvedTools.tools
             const activeTools = resolvedTools.activeTools

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -20,6 +20,8 @@ export type Context<M extends Metadata = Metadata> = {
   agent: string
   actorID?: string
   taskId?: string
+  turnID?: string
+  turnActorID?: string
   abort: AbortSignal
   callID?: string
   extra?: { [key: string]: unknown }

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -20,8 +20,6 @@ export type Context<M extends Metadata = Metadata> = {
   agent: string
   actorID?: string
   taskId?: string
-  turnID?: string
-  turnActorID?: string
   abort: AbortSignal
   callID?: string
   extra?: { [key: string]: unknown }

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -18,6 +18,9 @@ interface MockClientState {
   notificationHandlers: Map<unknown, (...args: any[]) => any>
   serverCapabilities: Record<string, unknown>
   toolCalls: Array<Record<string, unknown>>
+  toolCallSignals: Array<AbortSignal | undefined>
+  toolCallHangs: boolean
+  toolCallAbortCount: number
   notifications: Array<Record<string, unknown>>
   notificationCalls: number
   notificationInFlight: number
@@ -34,6 +37,7 @@ let connectShouldHang = false
 let connectError = "Mock transport cannot connect"
 // Tracks how many Client instances were created (detects leaks)
 let clientCreateCount = 0
+const clientOptions: unknown[] = []
 // Tracks how many times transport.close() is called across all mock transports
 let transportCloseCount = 0
 
@@ -54,6 +58,9 @@ function getOrCreateClientState(name?: string): MockClientState {
       notificationHandlers: new Map(),
       serverCapabilities: {},
       toolCalls: [],
+      toolCallSignals: [],
+      toolCallHangs: false,
+      toolCallAbortCount: 0,
       notifications: [],
       notificationCalls: 0,
       notificationInFlight: 0,
@@ -131,8 +138,9 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
     _state!: MockClientState
     transport: any
 
-    constructor(_opts: any) {
+    constructor(_opts: any, options?: unknown) {
       clientCreateCount++
+      clientOptions.push(options)
     }
 
     async connect(transport: { start: () => Promise<void> }) {
@@ -150,8 +158,27 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       return this._state?.serverCapabilities
     }
 
-    async callTool(params: Record<string, unknown>) {
+    async callTool(
+      params: Record<string, unknown>,
+      _schema?: unknown,
+      options?: { signal?: AbortSignal },
+    ) {
       this._state?.toolCalls.push(params)
+      this._state?.toolCallSignals.push(options?.signal)
+      if (this._state?.toolCallHangs) {
+        await new Promise<void>((_resolve, reject) => {
+          const signal = options?.signal
+          const onAbort = () => {
+            signal?.removeEventListener("abort", onAbort)
+            if (this._state) this._state.toolCallAbortCount++
+            reject(signal?.reason instanceof Error ? signal.reason : new Error("tool call aborted"))
+          }
+          signal?.addEventListener("abort", onAbort, { once: true })
+          if (signal?.aborted) onAbort()
+          // Deliberately no resolver: this request must settle only through
+          // the propagated cancellation signal.
+        })
+      }
       return { content: [{ type: "text", text: "ok" }] }
     }
 
@@ -209,6 +236,7 @@ beforeEach(() => {
   connectShouldHang = false
   connectError = "Mock transport cannot connect"
   clientCreateCount = 0
+  clientOptions.length = 0
   transportCloseCount = 0
 })
 
@@ -280,6 +308,29 @@ test(
 )
 
 test(
+  "client advertises the exact lifecycle v1 capability during initialization",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "lifecycle-server"
+      yield* mcp.add("lifecycle-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      expect(clientOptions).toEqual([
+        {
+          capabilities: {
+            experimental: {
+              "com.xiaomi.mimo/turn-lifecycle": { version: 1 },
+            },
+          },
+        },
+      ])
+    }),
+  ),
+)
+
+test(
   "turn metadata is omitted unless the server advertises lifecycle v1",
   withInstance({}, (mcp) =>
     Effect.gen(function* () {
@@ -343,6 +394,55 @@ test(
           name: "test_tool",
           arguments: { index: 2 },
           _meta: { "com.xiaomi.mimo/turn-lifecycle": context },
+        },
+      ])
+    }),
+  ),
+)
+
+test(
+  "cancelling tool execution aborts the in-flight MCP request before terminal notification",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "lifecycle-server"
+      const serverState = getOrCreateClientState("lifecycle-server")
+      serverState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      serverState.toolCallHangs = true
+      yield* mcp.add("lifecycle-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      const context = { sessionId: "ses_1", turnId: "turn_1", actorId: "main" }
+      const tools = yield* mcp.tools(context)
+      const execute = tools["lifecycle-server_test_tool"]?.execute
+      expect(execute).toBeDefined()
+      const controller = new AbortController()
+      const execution = Promise.resolve(
+        execute?.({}, { toolCallId: "call_1", messages: [], abortSignal: controller.signal }),
+      )
+
+      expect(serverState.toolCallSignals).toEqual([controller.signal])
+      expect(serverState.notifications).toEqual([])
+      controller.abort(new Error("turn cancelled"))
+      yield* Effect.promise(() =>
+        execution.then(
+          () => Promise.reject(new Error("cancelled MCP call unexpectedly resolved")),
+          (error) => {
+            expect(error).toBeInstanceOf(Error)
+            expect((error as Error).message).toBe("turn cancelled")
+          },
+        ),
+      )
+      expect(serverState.toolCallAbortCount).toBe(1)
+
+      yield* MCP.notifyTurnLifecycle(yield* mcp.clients(), context, "cancelled")
+      expect(serverState.notifications).toEqual([
+        {
+          method: "notifications/com.xiaomi.mimo/turn-lifecycle",
+          params: { ...context, status: "cancelled" },
         },
       ])
     }),

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, mock, beforeEach } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Fiber } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
 
 // --- Mock infrastructure ---
@@ -16,6 +16,15 @@ interface MockClientState {
   resources: Array<{ name: string; uri: string; description?: string }>
   closed: boolean
   notificationHandlers: Map<unknown, (...args: any[]) => any>
+  serverCapabilities: Record<string, unknown>
+  toolCalls: Array<Record<string, unknown>>
+  notifications: Array<Record<string, unknown>>
+  notificationCalls: number
+  notificationInFlight: number
+  notificationMaxInFlight: number
+  notificationResolvers: Array<() => void>
+  notificationError?: string
+  notificationHangs?: boolean
 }
 
 const clientStates = new Map<string, MockClientState>()
@@ -43,6 +52,13 @@ function getOrCreateClientState(name?: string): MockClientState {
       resources: [],
       closed: false,
       notificationHandlers: new Map(),
+      serverCapabilities: {},
+      toolCalls: [],
+      notifications: [],
+      notificationCalls: 0,
+      notificationInFlight: 0,
+      notificationMaxInFlight: 0,
+      notificationResolvers: [],
     }
     clientStates.set(key, state)
   }
@@ -128,6 +144,34 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
 
     setNotificationHandler(schema: unknown, handler: (...args: any[]) => any) {
       this._state?.notificationHandlers.set(schema, handler)
+    }
+
+    getServerCapabilities() {
+      return this._state?.serverCapabilities
+    }
+
+    async callTool(params: Record<string, unknown>) {
+      this._state?.toolCalls.push(params)
+      return { content: [{ type: "text", text: "ok" }] }
+    }
+
+    async notification(notification: Record<string, unknown>) {
+      if (!this._state) return
+      this._state.notificationCalls++
+      this._state.notificationInFlight++
+      this._state.notificationMaxInFlight = Math.max(
+        this._state.notificationMaxInFlight,
+        this._state.notificationInFlight,
+      )
+      try {
+        if (this._state.notificationError) throw new Error(this._state.notificationError)
+        if (this._state.notificationHangs) {
+          await new Promise<void>((resolve) => this._state.notificationResolvers.push(resolve))
+        }
+        this._state.notifications.push(notification)
+      } finally {
+        this._state.notificationInFlight--
+      }
     }
 
     async listTools() {
@@ -231,6 +275,331 @@ test(
       expect(Object.keys(toolsA).length).toBeGreaterThan(0)
       expect(Object.keys(toolsB).length).toBeGreaterThan(0)
       expect(serverState.listToolsCalls).toBe(1)
+    }),
+  ),
+)
+
+test(
+  "turn metadata is omitted unless the server advertises lifecycle v1",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "legacy-server"
+      const serverState = getOrCreateClientState("legacy-server")
+      yield* mcp.add("legacy-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      const tools = yield* mcp.tools({ sessionId: "ses_1", turnId: "turn_1", actorId: "main" })
+      const execute = tools["legacy-server_test_tool"]?.execute
+      expect(execute).toBeDefined()
+      yield* Effect.promise(() =>
+        Promise.resolve(
+          execute?.({}, { toolCallId: "call_1", messages: [], abortSignal: new AbortController().signal }),
+        ),
+      )
+
+      expect(serverState.toolCalls).toEqual([{ name: "test_tool", arguments: {} }])
+    }),
+  ),
+)
+
+test(
+  "turn metadata is stable across calls to a lifecycle-aware server",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "lifecycle-server"
+      const serverState = getOrCreateClientState("lifecycle-server")
+      serverState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      yield* mcp.add("lifecycle-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      const context = { sessionId: "ses_1", turnId: "turn_1", actorId: "main" }
+      const tools = yield* mcp.tools(context)
+      const execute = tools["lifecycle-server_test_tool"]?.execute
+      expect(execute).toBeDefined()
+      yield* Effect.promise(() =>
+        Promise.all([
+          Promise.resolve(
+            execute?.({ index: 1 }, { toolCallId: "call_1", messages: [], abortSignal: new AbortController().signal }),
+          ),
+          Promise.resolve(
+            execute?.({ index: 2 }, { toolCallId: "call_2", messages: [], abortSignal: new AbortController().signal }),
+          ),
+        ]),
+      )
+
+      expect(serverState.toolCalls).toEqual([
+        {
+          name: "test_tool",
+          arguments: { index: 1 },
+          _meta: { "com.xiaomi.mimo/turn-lifecycle": context },
+        },
+        {
+          name: "test_tool",
+          arguments: { index: 2 },
+          _meta: { "com.xiaomi.mimo/turn-lifecycle": context },
+        },
+      ])
+    }),
+  ),
+)
+
+test(
+  "turn lifecycle notifications carry each terminal status only for v1 servers",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "lifecycle-server"
+      const serverState = getOrCreateClientState("lifecycle-server")
+      serverState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      yield* mcp.add("lifecycle-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      const context = { sessionId: "ses_1", turnId: "turn_1", actorId: "main" }
+      const clients = yield* mcp.clients()
+      yield* MCP.notifyTurnLifecycle(clients, context, "completed")
+      yield* MCP.notifyTurnLifecycle(clients, context, "cancelled")
+      yield* MCP.notifyTurnLifecycle(clients, context, "error")
+
+      expect(serverState.notifications).toEqual(
+        ["completed", "cancelled", "error"].map((status) => ({
+          method: "notifications/com.xiaomi.mimo/turn-lifecycle",
+          params: { ...context, status },
+        })),
+      )
+    }),
+  ),
+)
+
+test(
+  "turn lifecycle ignores unsupported and non-numeric capability versions",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "legacy-server"
+      const serverState = getOrCreateClientState("legacy-server")
+      serverState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: "1" } },
+      }
+      yield* mcp.add("legacy-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      yield* MCP.notifyTurnLifecycle(yield* mcp.clients(), { sessionId: "ses_1", turnId: "turn_1" }, "completed")
+
+      expect(serverState.notifications).toEqual([])
+    }),
+  ),
+)
+
+test(
+  "turn lifecycle notification failures are best effort and do not block other servers",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "failing-server"
+      const failingState = getOrCreateClientState("failing-server")
+      failingState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      failingState.notificationError = "closed"
+      yield* mcp.add("failing-server", { type: "local", command: ["echo", "test"] })
+
+      lastCreatedClientName = "healthy-server"
+      const healthyState = getOrCreateClientState("healthy-server")
+      healthyState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      yield* mcp.add("healthy-server", { type: "local", command: ["echo", "test"] })
+
+      yield* MCP.notifyTurnLifecycle(yield* mcp.clients(), { sessionId: "ses_1", turnId: "turn_1" }, "completed")
+
+      expect(failingState.notifications).toEqual([])
+      expect(healthyState.notifications).toHaveLength(1)
+    }),
+  ),
+)
+
+test(
+  "turn lifecycle serializes overlapping healthy notifications without dropping turns",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "lifecycle-server"
+      const serverState = getOrCreateClientState("lifecycle-server")
+      serverState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      serverState.notificationHangs = true
+      yield* mcp.add("lifecycle-server", { type: "local", command: ["echo", "test"] })
+
+      const clients = yield* mcp.clients()
+      const first = yield* MCP.notifyTurnLifecycle(clients, { sessionId: "ses_1", turnId: "turn_1" }, "completed").pipe(
+        Effect.forkChild,
+      )
+      yield* Effect.sleep(25)
+      expect(serverState.notificationCalls).toBe(1)
+
+      const second = yield* MCP.notifyTurnLifecycle(
+        clients,
+        { sessionId: "ses_2", turnId: "turn_2" },
+        "completed",
+      ).pipe(Effect.forkChild)
+      yield* Effect.sleep(25)
+      expect(serverState.notificationCalls).toBe(1)
+      expect(serverState.notificationInFlight).toBe(1)
+
+      serverState.notificationHangs = false
+      serverState.notificationResolvers.shift()?.()
+      yield* Fiber.join(first)
+      yield* Fiber.join(second)
+
+      expect(serverState.notificationCalls).toBe(2)
+      expect(serverState.notificationMaxInFlight).toBe(1)
+      expect(serverState.notifications.map((notification) => notification.params)).toEqual([
+        { sessionId: "ses_1", turnId: "turn_1", status: "completed" },
+        { sessionId: "ses_2", turnId: "turn_2", status: "completed" },
+      ])
+    }),
+  ),
+)
+
+test(
+  "turn lifecycle times out hanging waiters without retaining or starting their sends",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "hanging-server"
+      const hangingState = getOrCreateClientState("hanging-server")
+      hangingState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      hangingState.notificationHangs = true
+      yield* mcp.add("hanging-server", { type: "local", command: ["echo", "test"] })
+
+      lastCreatedClientName = "healthy-server"
+      const healthyState = getOrCreateClientState("healthy-server")
+      healthyState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      yield* mcp.add("healthy-server", { type: "local", command: ["echo", "test"] })
+
+      const started = Date.now()
+      const clients = yield* mcp.clients()
+      const first = yield* MCP.notifyTurnLifecycle(clients, { sessionId: "ses_1", turnId: "turn_1" }, "completed").pipe(
+        Effect.forkChild,
+      )
+
+      yield* Effect.sleep(50)
+      expect(healthyState.notifications).toHaveLength(1)
+      const second = yield* MCP.notifyTurnLifecycle(
+        clients,
+        { sessionId: "ses_1", turnId: "turn_2" },
+        "completed",
+      ).pipe(Effect.forkChild)
+      const third = yield* MCP.notifyTurnLifecycle(clients, { sessionId: "ses_1", turnId: "turn_3" }, "completed").pipe(
+        Effect.forkChild,
+      )
+      yield* Fiber.join(first)
+      yield* Fiber.join(second)
+      yield* Fiber.join(third)
+      expect(Date.now() - started).toBeLessThan(2_000)
+
+      expect(hangingState.notificationCalls).toBe(1)
+      expect(hangingState.notificationInFlight).toBe(1)
+      expect(hangingState.notificationMaxInFlight).toBe(1)
+      expect(healthyState.notifications).toHaveLength(3)
+
+      hangingState.notificationHangs = false
+      hangingState.notificationResolvers.shift()?.()
+      yield* Effect.sleep(25)
+      expect(hangingState.notificationCalls).toBe(1)
+      expect(hangingState.notifications.map((notification) => notification.params)).toEqual([
+        { sessionId: "ses_1", turnId: "turn_1", status: "completed" },
+      ])
+
+      yield* MCP.notifyTurnLifecycle(clients, { sessionId: "ses_1", turnId: "turn_4" }, "completed")
+
+      expect(hangingState.notificationCalls).toBe(2)
+      expect(hangingState.notificationInFlight).toBe(0)
+      expect(hangingState.notificationMaxInFlight).toBe(1)
+      expect(hangingState.notifications.map((notification) => notification.params)).toEqual([
+        { sessionId: "ses_1", turnId: "turn_1", status: "completed" },
+        { sessionId: "ses_1", turnId: "turn_4", status: "completed" },
+      ])
+      expect(healthyState.notifications).toHaveLength(4)
+    }),
+  ),
+)
+
+test(
+  "turn lifecycle resumes after a notification rejects",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "lifecycle-server"
+      const serverState = getOrCreateClientState("lifecycle-server")
+      serverState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      serverState.notificationError = "closed"
+      yield* mcp.add("lifecycle-server", { type: "local", command: ["echo", "test"] })
+
+      const clients = yield* mcp.clients()
+      yield* MCP.notifyTurnLifecycle(clients, { sessionId: "ses_1", turnId: "turn_1" }, "completed")
+      serverState.notificationError = undefined
+      yield* MCP.notifyTurnLifecycle(clients, { sessionId: "ses_1", turnId: "turn_2" }, "completed")
+
+      expect(serverState.notificationCalls).toBe(2)
+      expect(serverState.notificationMaxInFlight).toBe(1)
+      expect(serverState.notifications.map((notification) => notification.params)).toEqual([
+        { sessionId: "ses_1", turnId: "turn_2", status: "completed" },
+      ])
+    }),
+  ),
+)
+
+test(
+  "replacement clients are not blocked by an old pending notification",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "replacement-old"
+      const oldState = getOrCreateClientState("replacement-old")
+      oldState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      oldState.notificationHangs = true
+      yield* mcp.add("replace-server", { type: "local", command: ["echo", "test"] })
+
+      const oldNotification = yield* MCP.notifyTurnLifecycle(
+        yield* mcp.clients(),
+        { sessionId: "ses_1", turnId: "turn_1" },
+        "completed",
+      ).pipe(Effect.forkChild)
+      yield* Effect.sleep(25)
+      expect(oldState.notificationCalls).toBe(1)
+
+      lastCreatedClientName = "replacement-new"
+      const newState = getOrCreateClientState("replacement-new")
+      newState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      yield* mcp.add("replace-server", { type: "local", command: ["echo", "test"] })
+      yield* MCP.notifyTurnLifecycle(yield* mcp.clients(), { sessionId: "ses_2", turnId: "turn_2" }, "completed")
+
+      expect(oldState.notificationCalls).toBe(1)
+      expect(newState.notificationCalls).toBe(1)
+      expect(newState.notifications.map((notification) => notification.params)).toEqual([
+        { sessionId: "ses_2", turnId: "turn_2", status: "completed" },
+      ])
+
+      oldState.notificationHangs = false
+      oldState.notificationResolvers.shift()?.()
+      yield* Fiber.join(oldNotification)
     }),
   ),
 )

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -705,6 +705,63 @@ test(
 )
 
 // ========================================================================
+test(
+  "turn lifecycle abandons a permanently stuck send so a later turn still notifies promptly",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "stuck-server"
+      const stuckState = getOrCreateClientState("stuck-server")
+      stuckState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      stuckState.notificationHangs = true
+      yield* mcp.add("stuck-server", { type: "local", command: ["echo", "test"] })
+
+      const clients = yield* mcp.clients()
+
+      // turn_1's send never settles — its resolver is deliberately never called, so it
+      // stays orphaned in the pending map for the rest of the test.
+      yield* MCP.notifyTurnLifecycle(clients, { sessionId: "ses_1", turnId: "turn_1" }, "completed")
+      expect(stuckState.notificationCalls).toBe(1)
+      expect(stuckState.notifications).toEqual([])
+
+      // The transport recovers, but the orphaned send is still parked in the pending map.
+      stuckState.notificationHangs = false
+      yield* Effect.sleep(50)
+
+      const started = Date.now()
+      yield* MCP.notifyTurnLifecycle(clients, { sessionId: "ses_1", turnId: "turn_2" }, "completed")
+      const elapsed = Date.now() - started
+
+      // Before the fix this turn queued behind the orphan, burned the whole 1s budget
+      // and was dropped (notificationCalls would still be 1) — and so would every turn
+      // after it. Now the stuck entry is released and the send happens immediately.
+      expect(stuckState.notificationCalls).toBe(2)
+      expect(elapsed).toBeLessThan(MCP.TURN_LIFECYCLE_NOTIFICATION_TIMEOUT / 2)
+      expect(stuckState.notifications.map((notification) => notification.params)).toEqual([
+        { sessionId: "ses_1", turnId: "turn_2", status: "completed" },
+      ])
+      // Only the abandoned send is still counted in flight; overlapping it is the
+      // accepted cost of not blocking later turns forever.
+      expect(stuckState.notificationInFlight).toBe(1)
+      expect(stuckState.notificationMaxInFlight).toBe(2)
+
+      // A further turn is also prompt, and healthy sends stay serialized behind
+      // each other rather than piling up.
+      const secondStarted = Date.now()
+      yield* MCP.notifyTurnLifecycle(clients, { sessionId: "ses_1", turnId: "turn_3" }, "completed")
+      expect(Date.now() - secondStarted).toBeLessThan(MCP.TURN_LIFECYCLE_NOTIFICATION_TIMEOUT / 2)
+      expect(stuckState.notificationCalls).toBe(3)
+      expect(stuckState.notificationInFlight).toBe(1)
+      expect(stuckState.notificationMaxInFlight).toBe(2)
+      expect(stuckState.notifications.map((notification) => notification.params)).toEqual([
+        { sessionId: "ses_1", turnId: "turn_2", status: "completed" },
+        { sessionId: "ses_1", turnId: "turn_3", status: "completed" },
+      ])
+    }),
+  ),
+)
+
 // Test: tool change notifications refresh the cache
 // ========================================================================
 

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -352,6 +352,8 @@ const mcpIt = testEffect(
 const lifecycleContexts: MCP.TurnContext[] = []
 const lifecycleNotifications: Array<Record<string, any>> = []
 let lifecycleNotificationHangs = false
+let lifecycleToolStarted: Deferred.Deferred<void> | undefined
+let lifecycleToolGate: Deferred.Deferred<void> | undefined
 const lifecycleClient = {
   getServerCapabilities: () => ({
     experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
@@ -374,6 +376,8 @@ const lifecycleMcpIt = testEffect(
           }),
           execute: async () => {
             if (context) lifecycleContexts.push(context)
+            if (lifecycleToolStarted) Effect.runSync(Deferred.succeed(lifecycleToolStarted, undefined))
+            if (lifecycleToolGate) await Effect.runPromise(Deferred.await(lifecycleToolGate))
             return { content: [{ type: "text", text: "ok" }] }
           },
         }),
@@ -1399,6 +1403,56 @@ lifecycleMcpIt.live("MCP calls in one outer run share one turn and emit one term
           params: { ...lifecycleContexts[0], status: "completed" },
         },
       ])
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+lifecycleMcpIt.live("MCP lifecycle waits for an in-flight tool call before notifying", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      lifecycleContexts.length = 0
+      lifecycleNotifications.length = 0
+      lifecycleNotificationHangs = false
+      const started = yield* Deferred.make<void>()
+      const gate = yield* Deferred.make<void>()
+      lifecycleToolStarted = started
+      lifecycleToolGate = gate
+      yield* Effect.addFinalizer(() =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(gate, undefined)
+          lifecycleToolStarted = undefined
+          lifecycleToolGate = undefined
+        }),
+      )
+
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "Lifecycle settling",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "call the lifecycle tool" }],
+      })
+      yield* llm.tool("mcp_lifecycle", { index: 1 })
+      yield* llm.text("done")
+
+      const run = yield* prompt.loop({ sessionID: session.id }).pipe(Effect.forkChild)
+      yield* Deferred.await(started)
+      expect(lifecycleNotifications).toEqual([])
+
+      yield* Deferred.succeed(gate, undefined)
+      yield* Fiber.join(run)
+      expect(lifecycleNotifications).toHaveLength(1)
+      expect(lifecycleNotifications[0]?.params).toMatchObject({
+        sessionId: session.id,
+        turnId: lifecycleContexts[0]?.turnId,
+        status: "completed",
+      })
     }),
     { git: true, config: providerCfg },
   ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1383,6 +1383,7 @@ lifecycleMcpIt.live("MCP calls in one outer run share one turn and emit one term
       yield* prompt.prompt({
         sessionID: session.id,
         agent: "build",
+        model: ref,
         noReply: true,
         parts: [{ type: "text", text: "call the lifecycle tool twice" }],
       })
@@ -1435,6 +1436,7 @@ lifecycleMcpIt.live("MCP lifecycle waits for an in-flight tool call before notif
       yield* prompt.prompt({
         sessionID: session.id,
         agent: "build",
+        model: ref,
         noReply: true,
         parts: [{ type: "text", text: "call the lifecycle tool" }],
       })

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -140,13 +140,16 @@ function wireTool(tools: Array<Record<string, unknown>>, name: string) {
   return tools.find((item) => wireToolName(item) === name)
 }
 
-function mcpLayer(tools: () => Record<string, AITool> = () => ({})) {
+function mcpLayer(
+  tools: (context?: MCP.TurnContext) => Record<string, AITool> = () => ({}),
+  clients: () => Record<string, any> = () => ({}),
+) {
   return Layer.succeed(
     MCP.Service,
     MCP.Service.of({
       status: () => Effect.succeed({}),
-      clients: () => Effect.succeed({}),
-      tools: () => Effect.sync(tools),
+      clients: () => Effect.sync(clients),
+      tools: (context) => Effect.sync(() => tools(context)),
       prompts: () => Effect.succeed({}),
       resources: () => Effect.succeed({}),
       add: () => Effect.succeed({ status: { status: "disabled" as const } }),
@@ -344,6 +347,39 @@ const mcpIt = testEffect(
         execute: async () => mcpSuccessResult,
       }),
     })),
+  ),
+)
+const lifecycleContexts: MCP.TurnContext[] = []
+const lifecycleNotifications: Array<Record<string, any>> = []
+let lifecycleNotificationHangs = false
+const lifecycleClient = {
+  getServerCapabilities: () => ({
+    experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+  }),
+  notification: async (notification: Record<string, any>) => {
+    if (lifecycleNotificationHangs) return new Promise<void>(() => {})
+    lifecycleNotifications.push(notification)
+  },
+}
+const lifecycleMcpIt = testEffect(
+  makeHttp(
+    mcpLayer(
+      (context) => ({
+        mcp_lifecycle: dynamicTool({
+          description: "Record lifecycle context",
+          inputSchema: jsonSchema({
+            type: "object",
+            properties: { index: { type: "number" } },
+            required: ["index"],
+          }),
+          execute: async () => {
+            if (context) lifecycleContexts.push(context)
+            return { content: [{ type: "text", text: "ok" }] }
+          },
+        }),
+      }),
+      () => ({ lifecycle: lifecycleClient }),
+    ),
   ),
 )
 const unix = process.platform !== "win32" ? it.live : it.live.skip
@@ -1326,6 +1362,127 @@ it.live(
       { git: true, config: providerCfg },
     ),
   30_000,
+)
+
+lifecycleMcpIt.live("MCP calls in one outer run share one turn and emit one terminal notification", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      lifecycleContexts.length = 0
+      lifecycleNotifications.length = 0
+      lifecycleNotificationHangs = false
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "Lifecycle",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "call the lifecycle tool twice" }],
+      })
+      yield* llm.tool("mcp_lifecycle", { index: 1 })
+      yield* llm.tool("mcp_lifecycle", { index: 2 })
+      yield* llm.text("done")
+
+      yield* prompt.loop({ sessionID: session.id })
+
+      expect(lifecycleContexts).toHaveLength(2)
+      expect(lifecycleContexts[0]?.sessionId).toBe(session.id)
+      expect(lifecycleContexts[0]?.actorId).toBe("main")
+      expect(lifecycleContexts[0]?.turnId).toBeTruthy()
+      expect(lifecycleContexts[1]).toEqual(lifecycleContexts[0])
+      expect(lifecycleNotifications).toEqual([
+        {
+          method: "notifications/com.xiaomi.mimo/turn-lifecycle",
+          params: { ...lifecycleContexts[0], status: "completed" },
+        },
+      ])
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+lifecycleMcpIt.live(
+  "MCP lifecycle emits one cancelled notification when the outer run is interrupted",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        lifecycleContexts.length = 0
+        lifecycleNotifications.length = 0
+        lifecycleNotificationHangs = false
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({ title: "Lifecycle cancellation" })
+        yield* user(session.id, "wait")
+        yield* llm.hang
+
+        const fiber = yield* prompt.loop({ sessionID: session.id }).pipe(Effect.forkChild)
+        yield* llm.wait(1)
+        yield* prompt.cancel(session.id)
+        yield* Fiber.await(fiber)
+
+        expect(lifecycleNotifications).toHaveLength(1)
+        expect(lifecycleNotifications[0]).toMatchObject({
+          method: "notifications/com.xiaomi.mimo/turn-lifecycle",
+          params: { sessionId: session.id, actorId: "main", status: "cancelled" },
+        })
+        expect(lifecycleNotifications[0]?.params?.turnId).toBeTruthy()
+      }),
+      { git: true, config: providerCfg },
+    ),
+  3_000,
+)
+
+lifecycleMcpIt.live("MCP lifecycle emits one error notification when the outer run fails", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      lifecycleContexts.length = 0
+      lifecycleNotifications.length = 0
+      lifecycleNotificationHangs = false
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({ title: "Lifecycle error" })
+      yield* user(session.id, "fail")
+      yield* llm.error(400, { error: { message: "test failure" } })
+
+      yield* prompt.loop({ sessionID: session.id }).pipe(Effect.exit)
+
+      expect(lifecycleNotifications).toHaveLength(1)
+      expect(lifecycleNotifications[0]).toMatchObject({
+        method: "notifications/com.xiaomi.mimo/turn-lifecycle",
+        params: { sessionId: session.id, actorId: "main", status: "error" },
+      })
+      expect(lifecycleNotifications[0]?.params?.turnId).toBeTruthy()
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+lifecycleMcpIt.live(
+  "MCP lifecycle timeout lets the outer run finalizer complete when a notification hangs",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        lifecycleContexts.length = 0
+        lifecycleNotifications.length = 0
+        lifecycleNotificationHangs = true
+        yield* Effect.addFinalizer(() => Effect.sync(() => void (lifecycleNotificationHangs = false)))
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({ title: "Lifecycle timeout" })
+        yield* user(session.id, "finish despite a hanging notification")
+        yield* llm.text("done")
+
+        const result = yield* prompt.loop({ sessionID: session.id })
+
+        expect(result.info.role).toBe("assistant")
+        expect(lifecycleNotifications).toEqual([])
+      }),
+      { git: true, config: providerCfg },
+    ),
+  5_000,
 )
 
 it.live("glob tool keeps instance context during prompt runs", () =>


### PR DESCRIPTION
## Summary

- negotiate a provider-neutral MCP turn lifecycle capability
- propagate one stable turn context through direct tool calls
- serialize terminal notifications and recover cleanly from timeout, abort, or rejection
- keep all behavior capability-gated with no browser- or Codex-specific branches

## Review follow-ups

- **Dropped the dead turn context fields.** `Tool.Context.turnID` / `turnActorID` were
  residue of the MCP-in-`tool_script` path that `main` removed in `8c29041a8`
  (request-scoped tool discovery). Nothing reads them at this head, so both the
  declaration and its population in `SessionPrompt` are deleted rather than left as
  latent surface.
- **A stuck lifecycle send no longer taxes later turns.** A `client.notification()`
  that never settled kept its pending-map entry forever, so every subsequent turn for
  that client queued behind it, waited out the full 1s timeout and was dropped — a
  permanent, invisible per-turn stall with no signal. Each pending send now records
  `startedAt`, and a send that has outlived the per-turn budget is released (with a
  `log.warn`) so the next turn sends immediately. The orphaned promise is never awaited
  again and its eventual rejection is still swallowed, so no unhandled rejection
  escapes. Serialization for healthy sends is unchanged.

## Verification

- `test/mcp/lifecycle.test.ts`: 31/31 pass (30 pre-existing + 1 new regression test
  proving a turn after a permanently hung send is still attempted promptly)
- prompt-effect MCP lifecycle cases: 4/4 pass
- `bun typecheck`: exit 0, 12/12 tasks
- oxlint and Prettier checks passed

## Independent re-verification (follow-up pass, no code change)

Both review follow-ups above were re-checked from scratch against this head; no further
change was needed, so this branch is unchanged at `7b487037b`.

- **Finding 1, the boundary question re-traced.** The user-facing tool contract is
  `packages/plugin/src/tool.ts:4-21` (`ToolContext`: sessionID, messageID, agent, directory,
  worktree, abort, metadata, ask) — `turnID`/`turnActorID` were never declared on it. They were
  nonetheless *runtime*-visible to plugin tools, because `src/tool/registry.ts:184` spreads
  `...toolCtx` into `pluginCtx` before calling `def.execute` at `:189`. Reachable only through an
  `as any` cast against an undeclared field, that is incidental spread leakage rather than an API
  surface — documenting it would have enshrined an accident — so deletion remains the right call.
- **Finding 2, revert probe.** Restoring only the pre-fix `src/mcp/index.ts` (3 insertions,
  37 deletions) while keeping the new test reproduces the bug exactly:
  `expect(stuckState.notificationCalls).toBe(2)` → `Expected: 2 / Received: 1` at
  `test/mcp/lifecycle.test.ts:739` — the turn after the hung send is never attempted. Restoring the
  fix returns 1 pass / 12 expects.
- **Invariants confirmed intact:** the pending map is still a `WeakMap` keyed by client instance
  (`src/mcp/index.ts:94`) with identity checks before every delete (`:126`, `:147`), and all four
  healthy-path `notificationMaxInFlight === 1` assertions are unchanged and passing.
- **Measured here:** `test/mcp/` 51 pass / 0 fail (172 expects, 6 files) · `test/mcp/lifecycle.test.ts`
  31 pass / 0 fail (102 expects) · `bun typecheck` exit 0, 12/12.
- **Reviewer caution:** the four `.live` prompt-effect `MCP lifecycle` cases have hard-coded 3s/5s
  budgets and flake on a loaded machine. Across four runs at load 23-27 the failing member varied
  ({cancelled, hangs} → {cancelled} → {cancelled}), and with the fix *reverted* a different member
  failed ({hangs}) — a non-deterministic set, i.e. scheduler starvation, not a regression.
- **Known residual (bounded, by design):** release is age-checked at the start of the next send
  rather than eagerly on the timeout path, to avoid racing the outer
  `Effect.timeout(TURN_LIFECYCLE_NOTIFICATION_TIMEOUT)` at the same duration. A turn arriving inside
  the first 1s after a hung send can therefore still pay one timeout and be dropped; every later turn
  releases the orphan and sends immediately. The cumulative head-of-line block is gone; what remains
  is ordinary single-notification best-effort loss.
