### PR TITLE
feat(codex): add Codex login option and remove model filtering

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-mimo-login.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-mimo-login.tsx
@@ -5,7 +5,7 @@ import { useLocal } from "@tui/context/local"
 import { useDialog } from "@tui/ui/dialog"
 import { useTheme } from "../context/theme"
 import { useLanguage } from "../context/language"
-import { createDialogProviderOptions } from "./dialog-provider"
+import { AutoMethod, createDialogProviderOptions } from "./dialog-provider"
 import { DialogSelect } from "@tui/ui/dialog-select"
 import { DialogPrompt } from "../ui/dialog-prompt"
 import { useToast } from "../ui/toast"
@@ -42,6 +42,31 @@ export function DialogMimoLogin() {
           }
           dialog.replace(() => (
             <MimoOAuthFlow url={result.data!.url} instructions={result.data!.instructions} />
+          ))
+        },
+      },
+      {
+        title: "Codex",
+        value: "codex",
+        description: "ChatGPT Pro/Plus",
+        category: "Recommended",
+        onSelect: async () => {
+          const result = await sdk.client.provider.oauth.authorize({
+            providerID: "openai",
+            method: 0,
+          })
+          if (result.error) {
+            toast.show({ message: t("tui.dialog.login.start_failed"), variant: "error" })
+            dialog.clear()
+            return
+          }
+          dialog.replace(() => (
+            <AutoMethod
+              providerID="openai"
+              index={0}
+              title="Codex"
+              authorization={result.data!}
+            />
           ))
         },
       },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -243,7 +243,7 @@ interface AutoMethodProps {
   title: string
   authorization: ProviderAuthAuthorization
 }
-function AutoMethod(props: AutoMethodProps) {
+export function AutoMethod(props: AutoMethodProps) {
   const { theme } = useTheme()
   const sdk = useSDK()
   const dialog = useDialog()

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -368,23 +368,6 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         const auth = await getAuth()
         if (auth.type !== "oauth") return {}
 
-        // Filter models to only allowed Codex models for OAuth
-        const allowedModels = new Set([
-          "gpt-5.1-codex",
-          "gpt-5.1-codex-max",
-          "gpt-5.1-codex-mini",
-          "gpt-5.2",
-          "gpt-5.2-codex",
-          "gpt-5.3-codex",
-          "gpt-5.4",
-          "gpt-5.4-mini",
-        ])
-        for (const [modelId, model] of Object.entries(provider.models)) {
-          if (modelId.includes("codex")) continue
-          if (allowedModels.has(model.api.id)) continue
-          delete provider.models[modelId]
-        }
-
         // Zero out costs for Codex (included with ChatGPT subscription)
         for (const model of Object.values(provider.models)) {
           model.cost = {
@@ -478,7 +461,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
       },
       methods: [
         {
-          label: "ChatGPT Pro/Plus (browser)",
+          label: "Codex via ChatGPT Pro/Plus (browser)",
           type: "oauth",
           authorize: async () => {
             const { redirectUri } = await startOAuthServer()
@@ -490,7 +473,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
 
             return {
               url: authUrl,
-              instructions: "Complete authorization in your browser. This window will close automatically.",
+              instructions: "Complete Codex authorization in your browser. This window will close automatically.",
               method: "auto" as const,
               callback: async () => {
                 const tokens = await callbackPromise
@@ -508,7 +491,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
           },
         },
         {
-          label: "ChatGPT Pro/Plus (headless)",
+          label: "Codex via ChatGPT Pro/Plus (headless)",
           type: "oauth",
           authorize: async () => {
             const deviceResponse = await fetch(`${ISSUER}/api/accounts/deviceauth/usercode`, {

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -1,10 +1,22 @@
 import { describe, expect, test } from "bun:test"
 import {
+  CodexAuthPlugin,
   parseJwtClaims,
   extractAccountIdFromClaims,
   extractAccountId,
   type IdTokenClaims,
 } from "../../src/plugin/codex"
+import type { PluginInput } from "@mimo-ai/plugin"
+
+const fakeInput = {
+  client: {},
+  project: {},
+  worktree: "",
+  directory: "",
+  experimental_workspace: { register() {} },
+  serverUrl: new URL("http://localhost:4096"),
+  $: undefined,
+} as unknown as PluginInput
 
 function createTestJwt(payload: object): string {
   const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")
@@ -13,6 +25,25 @@ function createTestJwt(payload: object): string {
 }
 
 describe("plugin.codex", () => {
+  describe("loader", () => {
+    test("keeps all OpenAI models for OAuth", async () => {
+      const hooks = await CodexAuthPlugin(fakeInput)
+      const provider = {
+        models: {
+          "gpt-5.6-sol": { api: { id: "gpt-5.6-sol" }, cost: {} },
+          "gpt-4o": { api: { id: "gpt-4o" }, cost: {} },
+        },
+      }
+
+      await hooks.auth!.loader!(
+        async () => ({ type: "oauth", access: "access", refresh: "refresh", expires: Date.now() + 60_000 }),
+        provider as never,
+      )
+
+      expect(Object.keys(provider.models)).toEqual(["gpt-5.6-sol", "gpt-4o"])
+    })
+  })
+
   describe("parseJwtClaims", () => {
     test("parses valid JWT with claims", () => {
       const payload = { email: "test@example.com", chatgpt_account_id: "acc-123" }


### PR DESCRIPTION
## Summary
- Add Codex login option to TUI dialog for ChatGPT Pro/Plus users
- Export `AutoMethod` component for reuse in login flow
- Remove model filtering in Codex plugin to allow all OpenAI models for OAuth
- Add test to verify all models are kept for OAuth authentication

## Changes
- `dialog-mimo-login.tsx`: Added Codex login option with OAuth flow
- `dialog-provider.tsx`: Exported `AutoMethod` component
- `codex.ts`: Removed model filtering logic, keeping all OpenAI models
- `codex.test.ts`: Added test for model preservation during OAuth

## Testing
- Verified Codex login option appears in TUI dialog
- Confirmed all OpenAI models are available for OAuth authentication
- Added unit test to prevent regression

## Related
- Resolves Codex OAuth model filtering issue
- Improves user experience for ChatGPT Pro/Plus subscribers