### PR TITLE
feat: add 1C:Enterprise (BSL/SDBL) syntax highlighting

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -286,5 +286,26 @@ export default {
         ],
       },
     },
+    // 1C:Enterprise (BSL) - source modules (.bsl, .os)
+    {
+      filetype: "bsl",
+      aliases: ["os"],
+      wasm: "https://github.com/zheltov86/tree-sitter-bsl/releases/download/v0.1.7-wasm/tree-sitter-bsl.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/alkoleft/tree-sitter-bsl/develop/grammars/bsl/queries/highlights.scm",
+        ],
+      },
+    },
+    // 1C:Enterprise query language (SDBL) - query modules (.sdbl)
+    {
+      filetype: "sdbl",
+      wasm: "https://github.com/zheltov86/tree-sitter-bsl/releases/download/v0.1.7-wasm/tree-sitter-sdbl.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/alkoleft/tree-sitter-bsl/develop/grammars/sdbl/queries/highlights.scm",
+        ],
+      },
+    },
   ],
 }


### PR DESCRIPTION
## Summary

Adds Tree-sitter parser configurations for 1C:Enterprise language syntax highlighting in the TUI editor.

## Changes

- **BSL grammar** (.bsl, .os files) — 1C source modules
- **SDBL grammar** (.sdbl files) — 1C query language

## Implementation

- Uses [tree-sitter-bsl](https://github.com/alkoleft/tree-sitter-bsl) v0.1.7 grammar
- Pre-built WASM files hosted at [zheltov86/tree-sitter-bsl](https://github.com/zheltov86/tree-sitter-bsl/releases/tag/v0.1.7-wasm)
- Highlights queries from upstream alkoleft/tree-sitter-bsl

## Files changed

- \packages/opencode/parsers-config.ts\ — added parser entries for BSL and SDBL

## Testing

1. Build MiMoCode from source
2. Open a \.bsl\ or \.os\ file
3. Verify syntax highlighting works for keywords, functions, strings, numbers, comments

## Notes

This is a community contribution. The WASM files were built from the upstream grammar and hosted separately since upstream doesn't publish pre-built WASM assets.

If accepted, consider requesting upstream (alkoleft/tree-sitter-bsl) to include WASM in their releases for easier maintenance.