### PR TITLE
docs(mimocode): harden provider configuration guidance

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mimocode-docs
-description: Use when the user asks what MiMoCode can do, how a feature works (memory, checkpoints, agents, subagents, tasks, compose, voice, dream/distill, goal), how to configure arbitrary custom or OpenAI-compatible endpoints with a user-specified base URL (base-url/baseURL), API key (api-key/apiKey), and model name or model ID (model-name), how to configure models, providers, authentication, or other settings in the user home/global config, where config/data lives, which config key controls a behavior, what CLI or slash commands exist, or how to enable/disable/tune something — the self-documenting reference for MiMoCode itself.
+description: "Use whenever the user asks about MiMoCode itself: features, TUI or CLI commands, configuration, file locations, providers, models, authentication, or custom OpenAI-compatible or Anthropic-compatible API endpoints. Especially trigger when a prompt supplies or asks to configure a base URL/baseURL, API key/apiKey, model name or ID, provider, Anthropic Messages API, or global/project mimocode.json/jsonc. Use this skill to inspect existing config safely, make minimal changes, and verify them without guessing schema fields or model capabilities."
 ---
 
 # MiMoCode
@@ -17,7 +17,7 @@ MiMoCode (CLI binary `mimo`) is an agentic coding tool with a terminal UI, built
 |---------|-----------|-----------------|
 | **Agents / modes** | `build` (default, full tools), `plan` (read-only analysis), `compose` (specs-driven orchestration), plus custom modes you define | `Tab` cycles primary agents; add your own via `.mimocode/agent/<name>.md` (see @reference/guide.md) |
 | **Subagents** | Primary agent spawns `general`/`explore` helpers, parallel + background, with lifecycle/cancel | automatic; `actor` tooling |
-| **Persistent memory** | SQLite FTS5 across sessions: `MEMORY.md`, `checkpoint.md`, `notes.md`, `tasks/<id>/progress.md` | auto-injected on resume |
+| **Persistent memory** | Markdown-backed memory with indexed search across `MEMORY.md`, `checkpoint.md`, `notes.md`, and `tasks/<id>/progress.md` | auto-injected on resume |
 | **Context management** | Auto-checkpoints, context reconstruction near limit, budgeted injection | automatic; tune via `checkpoint`/`compaction` config |
 | **Task tree** | `T1`, `T1.1`… tree, integrated with checkpoints | `task` tooling |
 | **Goal / stop condition** | Judge model verifies a stop condition before the agent halts | `/goal` |
@@ -26,7 +26,7 @@ MiMoCode (CLI binary `mimo`) is an agentic coding tool with a terminal UI, built
 | **Dream** | Consolidates recent traces into project memory | `/dream` |
 | **Distill** | Packages repeated manual workflows into skills/subagents/commands | `/distill` |
 | **Scheduled prompts** | Cron/loop: inject a prompt on a schedule or repeating loop (UTC, 5-field) | `cron` tool · `/loop` · `/loops` |
-| **Dynamic workflows** | JS scripts that orchestrate many subagents deterministically (fan-out, pipelines, nesting); built-ins `compose`, `deep-research` & `fact-check` | `.mimocode/workflows/*.js` + `workflow` tool |
+| **Dynamic workflows** | JS scripts that orchestrate many subagents deterministically (fan-out, pipelines, nesting); built-ins include `compose`, `deep-research`, `fact-check`, and `research-experiment` | `.mimocode/workflows/*.js` + `workflow` tool |
 | **Skills / self-extension** | Add tools, hooks, skills under `.mimocode/` | see the `evolve` skill |
 | **MCP** | Local & remote Model Context Protocol servers | `mcp` config + `mimo mcp` |
 
@@ -34,7 +34,7 @@ MiMoCode (CLI binary `mimo`) is an agentic coding tool with a terminal UI, built
 
 Config file (JSON or JSONC), discovered by walking up from cwd:
 - **Project**: `.mimocode/mimocode.json` (or `.jsonc`)
-- **Global**: `~/.config/mimocode/mimocode.json`
+- **Global**: `~/.config/mimocode/mimocode.jsonc` (preferred for new files) or `mimocode.json`
 
 Add `"$schema": "https://mimo.xiaomi.com/mimocode/config.json"` for editor validation. All top-level keys are optional; project config merges over global.
 
@@ -46,45 +46,16 @@ Add `"$schema": "https://mimo.xiaomi.com/mimocode/config.json"` for editor valid
 }
 ```
 
-For the full key reference (model, provider, mcp, permission, agent, checkpoint, compaction, memory, dream, distill, voice, workflow, experimental, command, keybinds, and more) see @reference/config.md. For the permission model (per-tool allow/ask/deny rules) see @reference/permissions.md.
+## Reference routing
 
-### User-supplied base URL, API key, and model name
+Read only the reference needed for the request, but read it before changing files:
 
-When the user supplies all three values, configure them directly instead of limiting them to a known provider catalog. For an OpenAI-compatible endpoint, add a custom provider and make it the selected model:
-
-```jsonc
-{
-  "$schema": "https://mimo.xiaomi.com/mimocode/config.json",
-  "model": "custom/MODEL_NAME",
-  "provider": {
-    "custom": {
-      "name": "Custom",
-      "npm": "@ai-sdk/openai-compatible",
-      "only_configured_models": true,
-      "models": {
-        "MODEL_NAME": {
-          "name": "MODEL_NAME"
-        }
-      },
-      "options": {
-        "baseURL": "BASE_URL",
-        "apiKey": "API_KEY"
-      }
-    }
-  }
-}
-```
-
-- Use the exact camel-case keys `baseURL` and `apiKey`; `base_url`, `base-url`, and `api_key` are not config keys.
-- The `models` map key is the model ID sent to the upstream API. Preserve the user's model name exactly, including `/` when present. The nested `name` is only its display label.
-- The top-level selection must be `<provider-id>/<model-id>`. Model IDs may contain `/`; MiMoCode splits only the first segment as the provider ID.
-- If the user supplies a provider ID, use it. Otherwise reuse a matching custom provider or choose an unused short lowercase ID such as `custom`; update every reference consistently.
-- Treat the base URL as opaque and preserve it exactly; do not add or remove `/v1` or another path unless the user asks.
-- `@ai-sdk/openai-compatible` is the default adapter for an arbitrary endpoint. If the endpoint is not OpenAI-compatible, use its provider-specific `npm` adapter when one exists and explain that a base URL, key, and model name alone cannot change the wire protocol.
-- A supplied `apiKey` may be stored in `options.apiKey`, which the provider runtime reads directly. Do not print the key in the response or expose it in command output; when creating a config containing a secret, restrict its file mode to the user where the platform supports it.
-- For a user-wide/home request, edit `~/.config/mimocode/mimocode.json`; for a project-only request, edit `.mimocode/mimocode.json`. Preserve unrelated providers, models, and settings.
-
-See @reference/config.md for the same shape plus field semantics and verification steps.
+- Models, providers, API keys, base URLs, or OpenAI-/Anthropic-compatible endpoints: @reference/providers.md
+- Other config keys and on-disk locations: @reference/config.md
+- Task-oriented usage and setup: @reference/guide.md
+- CLI and slash commands: @reference/commands.md
+- Permission rules: @reference/permissions.md
+- Dynamic workflows: @reference/workflows.md
 
 ## How-To Guide
 
@@ -94,6 +65,7 @@ For task-oriented walkthroughs — signing in & choosing a model, making memory 
 - **`compose`** — deterministic spec→ship pipeline (brainstorm → design → implement/TDD → verify → review → merge), auto-parallelized across per-task worktrees. Pass `args.task`.
 - **`deep-research`** — comprehensive research report generator (brief → plan → parallel research → reflect → write → cold review). Pass `args: { dir, question, today, depth?, context? }`. Convergent/resumable.
 - **`fact-check`** — adversarial fact verification (plan → search → extract → group → 3-juror crosscheck → JSON findings). Pass the question as `args`.
+- **`research-experiment`** — autonomous metric-improvement loop with baseline, guarded iterations, audit, and report. It requires an eval command, metric extraction rule, and editable-file scope.
 
 ## Where Things Live On Disk
 
@@ -106,12 +78,14 @@ Base dirs follow `MIMOCODE_HOME` (if set, absolute) else XDG. Data typically liv
 ## Helping the User Configure
 
 When asked to change a behavior:
-1. Identify the config key from @reference/config.md.
-2. Read the existing `.mimocode/mimocode.json` (project) or global config if present — don't clobber it.
-3. Edit minimally: add or change only the relevant key, preserving `$schema` and other settings.
-4. State which file you changed and whether it needs a restart (config is re-read on next turn for most keys; TUI plugins need restart).
+1. Read the routed reference and identify the exact schema fields. Do not infer fields from another tool's config format.
+2. Determine scope from the request. Treat model/provider setup as global unless the user says it is project-only; use project config for explicitly repo-local behavior.
+3. Inspect only the exact config candidates. Never recursively search the user's home directory. Prefer an existing higher-precedence `.jsonc` file and preserve comments, `$schema`, unrelated providers, and other settings.
+4. Keep secrets out of tool output and the final response. When inspecting a config, redact values for keys such as `apiKey`, `token`, `secret`, and `password`; never dump the whole unredacted file merely to find its shape.
+5. Edit minimally. If the request says configure, use, or make default, also set the top-level `model`; if it only says add, leave the current selection unchanged.
+6. Validate the parsed configuration with the narrowest relevant command and report the file changed, selected provider/model, and whether a new session or re-selection is needed. Never include the credential in the summary.
 
-Don't invent config keys. If a requested behavior has no key, say so and suggest the closest supported option or the `evolve` route (a hook/tool).
+Don't invent config keys, model limits, context windows, output limits, modalities, reasoning support, or tool-call capabilities. Add optional model metadata only when the user supplied it or a current authoritative source verifies it. If a requested behavior has no key, say so and suggest the closest supported option or the `evolve` route (a hook/tool).
 
 ## Answering Feature Questions
 

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/config.md
@@ -5,7 +5,7 @@
 Config is JSON or JSONC. MiMoCode discovers it by walking up from the cwd to the worktree root, then falls back to global.
 
 - Project: `.mimocode/mimocode.json` or `.mimocode/mimocode.jsonc`
-- Global: `~/.config/mimocode/mimocode.json` (XDG config dir)
+- Global: `~/.config/mimocode/mimocode.jsonc` or `mimocode.json` (XDG config dir). New installs seed `mimocode.jsonc`.
 - Extra config dirs are also searched via `$MIMOCODE_CONFIG_DIR`.
 
 Project config merges **over** global. Always include `"$schema": "https://mimo.xiaomi.com/mimocode/config.json"` for validation.
@@ -17,7 +17,7 @@ Base directories resolve from `MIMOCODE_HOME` if set (must be absolute → `<hom
 | Kind | Default location | Holds |
 |------|------------------|-------|
 | data | `~/.local/share/mimocode/` | memory, logs, `builtin_skills/<version>/`, bin |
-| config | `~/.config/mimocode/` | global `mimocode.json` |
+| config | `~/.config/mimocode/` | global `mimocode.jsonc` / `mimocode.json` |
 | cache | `~/.cache/mimocode/` | caches, downloaded bins |
 | state | `~/.local/state/mimocode/` | runtime state |
 
@@ -51,46 +51,7 @@ All optional.
 | `provider` | Custom provider configs & model overrides |
 | `enabled_providers` / `disabled_providers` | Allowlist / blocklist providers |
 
-### Custom OpenAI-compatible endpoint
-
-MiMoCode can configure a provider that is absent from the built-in model catalog. Given a base URL, API key, and model name, use this shape:
-
-```jsonc
-{
-  "$schema": "https://mimo.xiaomi.com/mimocode/config.json",
-  "model": "custom/MODEL_NAME",
-  "provider": {
-    "custom": {
-      "name": "Custom",
-      "npm": "@ai-sdk/openai-compatible",
-      "only_configured_models": true,
-      "models": {
-        "MODEL_NAME": {
-          "name": "MODEL_NAME"
-        }
-      },
-      "options": {
-        "baseURL": "BASE_URL",
-        "apiKey": "API_KEY"
-      }
-    }
-  }
-}
-```
-
-Field semantics:
-
-- `provider.custom` — `custom` is the provider ID. It may be replaced with a user-specified or unused lowercase ID, but the prefix in the top-level `model` must match it.
-- `npm` — selects the wire-protocol adapter. `@ai-sdk/openai-compatible` supports OpenAI-compatible APIs; a non-compatible service needs its own adapter.
-- `models.MODEL_NAME` — the map key is the exact upstream model ID, not merely a display name. Model IDs containing `/` are supported.
-- `options.baseURL` — the exact request base URL. The runtime gives this precedence over a catalog URL and does not require a known provider.
-- `options.apiKey` — the credential passed to the provider SDK. This is a plaintext secret in the config, so never echo it and keep the file user-readable only. As an alternative, known providers can obtain credentials from their documented environment variable or the provider login flow.
-- `only_configured_models: true` — limits the provider to the explicitly configured model instead of augmenting a known catalog.
-- `model` — selects the configured model using `<provider-id>/<model-id>`; only the first `/` separates the provider, so the model ID itself may contain `/`.
-
-Use `~/.config/mimocode/mimocode.json` for user-wide settings and `.mimocode/mimocode.json` for project-only settings. Merge into the existing JSON/JSONC rather than replacing unrelated keys. Preserve the supplied base URL and model ID exactly; do not infer or append `/v1`.
-
-After editing, verify with `mimo models` or the TUI model picker. Configuration is read on the next turn; select the configured model again or start a new session if the current session has already pinned another model.
+For custom endpoints, adapter selection, provider reuse, credential handling, and verification, read @providers.md before editing.
 
 ### Model groups
 

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/guide.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/guide.md
@@ -8,6 +8,8 @@ How-to for the features users most often ask about. For config keys see @config.
 2. **Pick a model** — set `"model": "provider/model"` in config, or switch live in the TUI model dialog. Provider API keys are auto-detected from environment variables (unless `MIMOCODE_MIMO_ONLY=1`).
 3. **List what's available** — `mimo models`, `mimo providers`.
 
+For a custom base URL, API key, or OpenAI-/Anthropic-compatible model, read @providers.md before editing config; it covers protocol selection, adapter names, provider reuse, secret handling, and local verification.
+
 ## Memory: making MiMoCode remember
 
 Memory persists across sessions and is auto-injected on resume, so the agent doesn't relearn project context.

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/permissions.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/permissions.md
@@ -40,6 +40,8 @@ Path/command-keyed (accept the glob-map form): `read`, `edit`, `glob`, `grep`, `
 
 Simple action-only: `question`, `webfetch`, `websearch`, `codesearch`, `doom_loop`.
 
+`doom_loop` is the safety gate raised when repeated identical tool calls look like an infinite loop. Keep it at `ask` (the default) unless the surrounding automation has another reliable stop condition.
+
 Unknown keys fall through to a catch-all record, so future/custom tools can be named too.
 
 ## Common recipes

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/providers.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/providers.md
@@ -1,0 +1,120 @@
+# MiMoCode Models and Providers
+
+Read this reference whenever a request involves a provider, model, API key, base URL, authentication, or an OpenAI-/Anthropic-compatible endpoint.
+
+## Choose the target config
+
+- Use `.mimocode/mimocode.jsonc` or `.mimocode/mimocode.json` only when the user explicitly wants project-local behavior.
+- Otherwise use the global config directory (normally `~/.config/mimocode/`). Global files merge in this order: `config.json`, `mimocode.json`, then `mimocode.jsonc`; later files win. Edit the existing highest-precedence file, or create `mimocode.jsonc` when none exists.
+- Inspect these exact candidates directly. Do not recursively glob or search the entire home directory.
+- If both JSON and JSONC exist, account for the merged result before editing so a higher-precedence file cannot silently override the change.
+
+## Custom OpenAI-compatible endpoint
+
+Given a base URL, API key, and model ID, configure a provider that does not depend on the built-in catalog:
+
+```jsonc
+{
+  "$schema": "https://mimo.xiaomi.com/mimocode/config.json",
+  "model": "custom/MODEL_ID",
+  "provider": {
+    "custom": {
+      "name": "Custom",
+      "npm": "@ai-sdk/openai-compatible",
+      "only_configured_models": true,
+      "models": {
+        "MODEL_ID": {
+          "name": "MODEL_ID"
+        }
+      },
+      "options": {
+        "baseURL": "BASE_URL",
+        "apiKey": "API_KEY"
+      }
+    }
+  }
+}
+```
+
+Use the exact package and camel-case field names shown above:
+
+- `@ai-sdk/openai-compatible` is the adapter implemented and shipped by MiMoCode. Do not substitute `@ai-sdk/compatible-openai`.
+- `baseURL` and `apiKey` are valid; `base_url`, `base-url`, and `api_key` are not.
+- The key under `models` is the exact ID sent upstream. Preserve its case, punctuation, and `/` characters. `name` is only the display label.
+- The top-level selection is `<provider-id>/<model-id>`. MiMoCode treats only the first `/` as the separator, so a model ID may contain `/`.
+- Preserve the base URL exactly. Do not add, remove, or normalize `/v1` unless the user requests it.
+- A non-OpenAI wire protocol needs its provider-specific adapter. A base URL, key, and model name do not by themselves change protocol semantics.
+
+## Custom Anthropic-compatible endpoint
+
+For a service that implements Anthropic's Messages API rather than OpenAI Chat Completions or Responses, use the native Anthropic adapter:
+
+```jsonc
+{
+  "$schema": "https://mimo.xiaomi.com/mimocode/config.json",
+  "model": "custom-anthropic/MODEL_ID",
+  "provider": {
+    "custom-anthropic": {
+      "name": "Custom Anthropic",
+      "npm": "@ai-sdk/anthropic",
+      "only_configured_models": true,
+      "models": {
+        "MODEL_ID": {
+          "name": "MODEL_ID"
+        }
+      },
+      "options": {
+        "baseURL": "BASE_URL",
+        "apiKey": "API_KEY"
+      }
+    }
+  }
+}
+```
+
+MiMoCode ships `@ai-sdk/anthropic`; its SDK constructs Anthropic Messages API requests, including the Anthropic authentication/version headers and the `/messages` request path. Configure `baseURL` as the API base (commonly ending in `/v1`), not as the full `/v1/messages` endpoint, because the adapter appends `/messages`.
+
+Choose the adapter from the endpoint's documented wire protocol, not the model name:
+
+- Use `@ai-sdk/openai-compatible` for OpenAI-compatible Chat Completions/Responses, even when the upstream model ID contains `claude`.
+- Use `@ai-sdk/anthropic` when the endpoint implements Anthropic Messages semantics such as `POST /v1/messages`, `x-api-key`, and `anthropic-version`.
+- If the user explicitly states the format, follow it. If they provide only a URL, key, and Claude-like model name, do not infer the protocol from the name; inspect authoritative endpoint documentation or ask which API format it implements.
+- Do not add OpenAI-only settings to an Anthropic provider or Anthropic-only headers to an OpenAI-compatible provider unless the gateway documentation requires them.
+
+## Reuse or create a provider
+
+Provider options, including credentials and base URL, are shared by every model under that provider. Choose deliberately:
+
+- Reuse a provider and append the model when its endpoint and credential already match.
+- If the endpoint matches but the supplied credential differs, create a distinct provider ID unless the user explicitly wants to rotate the existing provider's key. Overwriting it would silently change every existing model under that provider.
+- If the desired provider ID already exists with different options, choose an unused short lowercase ID or a meaningful suffixed ID. Update `model` and allowlists consistently.
+- If `enabled_providers` is present, add the new provider ID. If `disabled_providers` contains it and the user wants to use the model, remove only that entry.
+- Set the top-level `model` when the user says configure, use, select, switch, or make default. When the user only asks to add/register a model, preserve the current selection.
+
+## Do not invent model metadata
+
+The model's display name is enough to register it. Do not guess `limit.context`, `limit.output`, `reasoning`, `tool_call`, `modalities`, cost, or other capabilities from the model name. Internal routers often expose aliases whose behavior differs from similarly named public models.
+
+Add optional metadata only when the user supplied it or a current authoritative source verifies it. If limits are important but unknown, omit them and state that they remain unspecified; MiMoCode will apply its runtime fallback and log a warning for an unknown context window.
+
+## Credential handling
+
+- Treat any API key as a secret even when the user pasted it into the prompt. Never repeat it in commentary, tool summaries, diffs, or the final response.
+- Avoid printing an unredacted config because it may contain unrelated credentials. Inspect with sensitive values masked and make the smallest possible edit.
+- Direct `options.apiKey` storage is supported when the user asks MiMoCode to persist the supplied key. Keep the config user-readable only where file modes are available.
+- If the user prefers not to store plaintext, use a config token such as `"apiKey": "{env:CUSTOM_API_KEY}"` and explain that the variable must exist in the MiMoCode process environment. Do not silently switch to an environment reference when the user asked for a ready-to-use persisted configuration.
+- If a real key was posted in a conversation or log, recommend rotating it after completing the requested setup.
+
+## Minimal edit and verification
+
+Preserve JSONC comments, `$schema`, unrelated providers, models, and settings. Avoid whole-file rewrites when a targeted insertion is possible.
+
+Do not make a paid or state-changing API request merely to verify configuration. Validate locally from the same working directory in which the user will run MiMoCode:
+
+```sh
+mimo models PROVIDER_ID
+```
+
+Confirm that the output contains exactly `PROVIDER_ID/MODEL_ID`. This proves the config parsed and the provider/model registered; it does not prove the remote credential, endpoint, or selected wire protocol works. If the current TUI session already pinned a model, reselect it or start a new session after the edit.
+
+In the final response, name the config file and selected `provider/model`, state whether it was added or made default, and report local validation. Never include the key.

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/workflows.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/workflows.md
@@ -95,6 +95,7 @@ Runnable by `name` without writing a file:
 - **`compose`** — full spec→ship pipeline (brainstorm → design → implement (TDD) → verify → review → merge). Pass `args.task`. Auto-parallelizes independent subtasks into per-task worktrees and chains each phase's structured output to the next. Re-running on existing docs reuses them and scopes the fan-out to the actual diff (incremental amend).
 - **`deep-research`** — comprehensive research report generator (brief → plan → parallel sub-agent research → reflect gap-check → single-writer cited Markdown report → cold review). Pass `args: { dir, question, today, depth?, context? }`. Convergent: file checkpoints enable resume after interruption.
 - **`fact-check`** — adversarial fact verification (plan → parallel web search → source extraction → group duplicates → 3-juror crosscheck → structured JSON findings). Pass the question as `args`. Best for verifying specific claims.
+- **`research-experiment`** — autonomous loop for improving a mechanically verifiable metric. Pass `args: { dir, goal, metric, evalCmd, editable, guardCmd?, lowerIsBetter?, maxIters?, targetValue? }` and use the same `dir` as the workflow workspace. It records a baseline, runs guarded hypothesis/implementation/evaluation iterations, audits metric gaming, and writes a traceable report. Do not use it when success cannot be reduced to one numeric metric.
 
 ### `compose` workflow vs `compose` agent
 

--- a/packages/opencode/test/skill/mimocode-docs.test.ts
+++ b/packages/opencode/test/skill/mimocode-docs.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+
+const root = path.resolve(import.meta.dir, "../../src/skill/builtin/.bundle/mimocode-docs")
+
+describe("mimocode-docs provider guidance", () => {
+  test("routes provider requests to the dedicated reference", async () => {
+    const skill = await Bun.file(path.join(root, "SKILL.md")).text()
+
+    expect(skill).toContain("@reference/providers.md")
+    expect(skill).toContain("Never recursively search the user's home directory")
+    expect(skill).toContain("Don't invent config keys, model limits")
+    expect(skill).toContain("research-experiment")
+    expect(skill).not.toContain("SQLite FTS5 across sessions")
+  })
+
+  test("documents the implemented OpenAI-compatible adapter and safe merge rules", async () => {
+    const providers = await Bun.file(path.join(root, "reference/providers.md")).text()
+
+    expect(providers).toContain('"npm": "@ai-sdk/openai-compatible"')
+    expect(providers).toContain("Do not substitute `@ai-sdk/compatible-openai`")
+    expect(providers).toContain("If the endpoint matches but the supplied credential differs, create a distinct provider ID")
+    expect(providers).toContain("Do not guess `limit.context`, `limit.output`")
+    expect(providers).toContain("mimo models PROVIDER_ID")
+  })
+
+  test("documents native Anthropic Messages API configuration", async () => {
+    const providers = await Bun.file(path.join(root, "reference/providers.md")).text()
+
+    expect(providers).toContain('"npm": "@ai-sdk/anthropic"')
+    expect(providers).toContain("the adapter appends `/messages`")
+    expect(providers).toContain("not the model name")
+    expect(providers).toContain("even when the upstream model ID contains `claude`")
+    expect(providers).toContain("`x-api-key`, and `anthropic-version`")
+  })
+
+  test("documents the effective global config precedence", async () => {
+    const providers = await Bun.file(path.join(root, "reference/providers.md")).text()
+
+    expect(providers).toContain("`config.json`, `mimocode.json`, then `mimocode.jsonc`; later files win")
+    expect(providers).toContain("create `mimocode.jsonc` when none exists")
+  })
+})


### PR DESCRIPTION
## Summary
- route provider and model configuration requests to a dedicated reference
- document safe OpenAI- and Anthropic-compatible endpoint setup, config precedence, and credential handling
- add regression coverage for the bundled MiMoCode documentation guidance

## Testing
- `bun test test/skill/mimocode-docs.test.ts`