### PR TITLE
fix(session): contain checkpoint writer recovery

### DIFF
--- a/docs/compose/spec/checkpoint-writer-safety.md
+++ b/docs/compose/spec/checkpoint-writer-safety.md
@@ -1,0 +1,97 @@
+---
+feature: checkpoint-writer-safety
+status: in-progress
+updated: 2026-07-22
+branch: investigate/checkpoint-writer-sandbox
+commits:
+---
+
+# Checkpoint Writer Safety
+
+## Report
+
+## [S1] Problem
+
+The checkpoint writer is a system-spawned actor whose successful work is expressed through memory-file edits followed by an intentionally empty stop. The generic invalid-output continuation treats that empty stop as a missing user-facing answer and injects a prompt telling the writer to answer the user or call another tool. Because the writer receives full parent context, that retry can make it resume the parent's development task instead of terminating.
+
+The writer also receives general file-editing tools. Those tools call the unified write gate, but the current system-agent sandbox covers only `dream` and `distill`. The memory-specific guard precisely restricts checkpoint-writer paths only after a target is recognized as part of the memory tree; it permits non-memory targets to pass through. A drifted checkpoint writer can therefore edit source files with `write`, `edit`, or `apply_patch`.
+
+The observed incident used both gaps: a generic empty-output retry reactivated a completed checkpoint writer, and the missing hard path boundary allowed it to patch project source. Prompt instructions and tool allowlists alone are insufficient because either can drift or be widened later.
+
+## [S2] Design
+
+### [S2.1] Checkpoint Writer Write Boundary
+
+The unified write gate must enforce a checkpoint-writer-specific sandbox before applying the existing precise memory allowlist:
+
+- `checkpoint-writer` may target only files under the resolved memory root.
+- Within the memory root, `assertMemoryWriteAllowed` remains authoritative for canonical `MEMORY.md`, `checkpoint.md`, `notes.md`, permitted spillovers, and permitted task narratives.
+- `checkpoint-writer` must not write project source, repository configuration, any worktree path, or `.mimocode/`.
+- `dream` and `distill` retain their existing memory-root or worktree `.mimocode/` sandbox.
+- Primary and ordinary agents retain their existing source-write behavior.
+- Every file-mutating tool that uses `assertWriteAllowed`, including `write`, `edit`, `apply_patch`, and `notebook_edit`, receives the same boundary. `apply_patch` must enforce it for add, update, delete, and both sides of move operations.
+
+Removing `apply_patch` from the checkpoint writer's tool whitelist is not a substitute for this boundary.
+
+### [S2.2] Role-Specific Invalid-Output Policies
+
+Invalid-output continuation must select a policy from the execution role rather than sharing one user-facing prompt across all agents:
+
+- A primary turn (`agentID === "main"`) retains the existing user-facing retry that asks for a final answer or a valid tool call.
+- An ordinary actor/subagent receives an actor-facing retry that asks it to return a usable result to its parent or continue the necessary tool work. It must not claim that it is answering the user directly.
+- `checkpoint-writer` receives the checkpoint-specific policy in [S2.3].
+- Existing system agents must declare an explicit policy. The declared policy keys and `SYSTEM_SPAWNED_AGENT_TYPES` must remain synchronized by a regression test so a future system agent cannot silently inherit a default user-facing retry.
+- `dream` and `distill` require a non-empty summary and use a system/actor-facing retry rather than the primary-user wording.
+
+Policy selection must be centralized near the invalid-output continuation. Do not scatter independent agent-name checks across the three run-loop classification sites.
+
+### [S2.3] Checkpoint-Specific Retry
+
+An empty or think-only checkpoint-writer stop remains retryable, but it must never receive the generic primary-agent reminder. The synthetic checkpoint reminder must:
+
+- restate that the actor is the checkpoint writer;
+- forbid answering or continuing the parent session's task;
+- restrict further work to the authorized checkpoint and memory paths already supplied to the writer;
+- tell the writer to finish any incomplete authorized edits; and
+- tell the writer to return exactly `CHECKPOINT_COMPLETE` without further tool calls when the authorized edits are already complete.
+
+The fixed marker is ordinary non-empty assistant text, so existing classification terminates naturally without a checkpoint-specific classifier branch. Existing bounded invalid-output retry limits remain in force. This design intentionally does not add a checkpoint content hash, write ledger, or dedicated commit tool: a capable model gets one correctly scoped recovery instruction, while the hard write boundary makes drift non-destructive.
+
+### [S2.4] Actor Error Outcomes
+
+If `SessionPrompt.prompt` returns a terminal assistant carrying `assistant.error`, `Actor.runAgentLoop` must fail instead of converting the result into a successful actor outcome with no text. This applies to all actors/subagents and does not change direct primary-session behavior.
+
+For checkpoint writers, exhausting invalid-output recovery therefore produces a failed actor outcome. The checkpoint settlement watcher must leave `last_checkpoint_message_id` unchanged, preserving the existing invariant that an uncheckpointed delta is re-covered by a later writer.
+
+### [S2.5] Regression Contract
+
+Tests must cover the real boundaries rather than prompt text alone:
+
+- checkpoint-writer source and `.mimocode/` writes fail through the unified gate;
+- valid checkpoint and project-memory writes continue to pass;
+- unauthorized memory-tree paths continue to fail;
+- `apply_patch` cannot mutate source as checkpoint-writer;
+- primary, ordinary actor, and checkpoint-writer empty outputs receive their respective prompts;
+- the checkpoint reminder contains no instruction to answer the user and converges when the model returns `CHECKPOINT_COMPLETE`;
+- actor terminal assistant errors produce failure outcomes;
+- primary invalid-output recovery and existing dream/distill sandbox behavior do not regress; and
+- every system-spawned agent has an explicit invalid-output policy.
+
+## [S3] Out of Scope
+
+- Modifying Compose skills, `compose.txt`, the Compose workflow, or PR descriptions.
+- Changing the checkpoint writer's full-context or child-session architecture.
+- Removing file-editing tools from the checkpoint writer solely as a safety mechanism.
+- Introducing a dedicated checkpoint commit tool, transactional multi-file writes, checkpoint hashes, or tool-history success ledgers.
+- Changing checkpoint content schemas, spillover formats, memory paths, or watermark selection.
+- Sandboxing direct shell filesystem writes for agents that are allowed to use shell tools; checkpoint-writer does not currently receive a shell tool.
+- Detecting symlink or hardlink escapes deliberately placed inside the application-managed memory tree; this boundary protects normal resolved paths and `..` traversal, not adversarial filesystem topology controlled by the user.
+- Modifying or repairing historical database records.
+
+## Tasks
+
+- [ ] T1: Enforce the checkpoint-writer memory-only sandbox in the unified write gate - acceptance: checkpoint-writer source and `.mimocode/` targets are rejected while valid memory targets, dream/distill behavior, and normal-agent source writes pass (covers: S2.1, S2.5)
+- [ ] T2: Add centralized role-specific invalid-output policy selection and checkpoint completion-marker retry - acceptance: primary, ordinary actor, checkpoint-writer, dream, and distill receive their specified prompts, the checkpoint path converges on `CHECKPOINT_COMPLETE`, and system-agent policy coverage is exhaustive (covers: S2.2, S2.3, S2.5)
+- [ ] T3: Propagate terminal assistant errors as actor failures - acceptance: an actor whose prompt terminates with `assistant.error` resolves failure, while successful text and structured actor results remain successful (covers: S2.4, S2.5)
+- [ ] T4: Add apply-patch and checkpoint outcome regressions - acceptance: checkpoint-writer `apply_patch` cannot mutate source, valid checkpoint and project-memory mutations succeed, exhausted checkpoint recovery resolves actor failure, failed writer settlement leaves the watermark unchanged, and primary recovery remains unchanged (covers: S2.1, S2.3, S2.4, S2.5; depends: T1, T2, T3)
+- [ ] T5: Run focused tests and package typecheck, then obtain independent review - acceptance: all focused suites and `bun typecheck` pass from `packages/opencode`, and review confirms write-boundary, retry-policy, actor-outcome, and scope compliance (covers: S2.1, S2.2, S2.3, S2.4, S2.5; depends: T4)

--- a/docs/compose/spec/checkpoint-writer-safety.md
+++ b/docs/compose/spec/checkpoint-writer-safety.md
@@ -1,14 +1,28 @@
 ---
 feature: checkpoint-writer-safety
-status: in-progress
+status: delivered
 updated: 2026-07-22
 branch: investigate/checkpoint-writer-sandbox
-commits:
+commits: 0cb81dba827e27549bde6fba794e27509ef1bf65..25f175dd
 ---
 
 # Checkpoint Writer Safety
 
 ## Report
+
+**What was built** - The checkpoint writer is now confined to normal paths under the memory tree at the unified write gate; the existing precise memory allowlist remains authoritative inside that tree. Dream/distill retain their prior memory-or-`.mimocode/` behavior, while ordinary agents retain normal source writes. The gate now obtains its worktree from `InstanceState.context`, so InstanceRef-bound actor fibers cannot skip the sandbox.
+
+Invalid-output recovery now selects an explicit role policy. Primary turns keep the user-facing reminder, ordinary actors receive a parent-facing reminder, and checkpoint writers receive a scoped recovery instruction that either finishes authorized memory edits or returns `CHECKPOINT_COMPLETE`. System-agent policy coverage is exhaustive. Terminal assistant errors now fail actor outcomes, so exhausted checkpoint recovery leaves the watermark unchanged through the existing transactional settlement path.
+
+**Verification** - From `packages/opencode`, `bun test test/tool/memory-path-guard.test.ts test/tool/apply_patch.test.ts test/agent/ask-routing.test.ts test/session/invalid-output-continuation.test.ts test/actor/spawn.test.ts test/session/checkpoint-watermark-transactional.test.ts test/session/checkpoint-child-session.test.ts test/session/checkpoint-permission.test.ts` passed 151 tests with 286 assertions and 0 failures. `bun typecheck` passed. `git diff --check` passed. Targeted oxlint reported 0 errors; remaining warnings were existing large-file/test idioms. Independent final review approved spec compliance, correctness, and codebase consistency with no remaining findings.
+
+**Journey log**
+
+- The incident was one writer reactivated by the generic user-facing empty-output reminder, not duplicate checkpoint-writer spawns.
+- The unified memory guard was precise only after a path entered the memory tree; a separate checkpoint-writer memory-only sandbox was required for source paths.
+- `SessionPrompt.prompt` could return a terminal assistant error that Actor previously converted to success; propagating that error restores watermark transactionality.
+- A combined AppRuntime watermark E2E was process-state dependent, so stable boundary tests cover checkpoint exhaustion → actor failure and writer failure → unchanged watermark separately.
+- Symlink/hardlink topology inside the application-managed memory tree is explicitly user-owned and outside this lexical path-boundary threat model.
 
 ## [S1] Problem
 
@@ -90,8 +104,8 @@ Tests must cover the real boundaries rather than prompt text alone:
 
 ## Tasks
 
-- [ ] T1: Enforce the checkpoint-writer memory-only sandbox in the unified write gate - acceptance: checkpoint-writer source and `.mimocode/` targets are rejected while valid memory targets, dream/distill behavior, and normal-agent source writes pass (covers: S2.1, S2.5)
-- [ ] T2: Add centralized role-specific invalid-output policy selection and checkpoint completion-marker retry - acceptance: primary, ordinary actor, checkpoint-writer, dream, and distill receive their specified prompts, the checkpoint path converges on `CHECKPOINT_COMPLETE`, and system-agent policy coverage is exhaustive (covers: S2.2, S2.3, S2.5)
-- [ ] T3: Propagate terminal assistant errors as actor failures - acceptance: an actor whose prompt terminates with `assistant.error` resolves failure, while successful text and structured actor results remain successful (covers: S2.4, S2.5)
-- [ ] T4: Add apply-patch and checkpoint outcome regressions - acceptance: checkpoint-writer `apply_patch` cannot mutate source, valid checkpoint and project-memory mutations succeed, exhausted checkpoint recovery resolves actor failure, failed writer settlement leaves the watermark unchanged, and primary recovery remains unchanged (covers: S2.1, S2.3, S2.4, S2.5; depends: T1, T2, T3)
-- [ ] T5: Run focused tests and package typecheck, then obtain independent review - acceptance: all focused suites and `bun typecheck` pass from `packages/opencode`, and review confirms write-boundary, retry-policy, actor-outcome, and scope compliance (covers: S2.1, S2.2, S2.3, S2.4, S2.5; depends: T4)
+- [x] T1: Enforce the checkpoint-writer memory-only sandbox in the unified write gate - acceptance: checkpoint-writer source and `.mimocode/` targets are rejected while valid memory targets, dream/distill behavior, and normal-agent source writes pass (covers: S2.1, S2.5)
+- [x] T2: Add centralized role-specific invalid-output policy selection and checkpoint completion-marker retry - acceptance: primary, ordinary actor, checkpoint-writer, dream, and distill receive their specified prompts, the checkpoint path converges on `CHECKPOINT_COMPLETE`, and system-agent policy coverage is exhaustive (covers: S2.2, S2.3, S2.5)
+- [x] T3: Propagate terminal assistant errors as actor failures - acceptance: an actor whose prompt terminates with `assistant.error` resolves failure, while successful text and structured actor results remain successful (covers: S2.4, S2.5)
+- [x] T4: Add apply-patch and checkpoint outcome regressions - acceptance: checkpoint-writer `apply_patch` cannot mutate source, valid checkpoint and project-memory mutations succeed, exhausted checkpoint recovery resolves actor failure, failed writer settlement leaves the watermark unchanged, and primary recovery remains unchanged (covers: S2.1, S2.3, S2.4, S2.5; depends: T1, T2, T3)
+- [x] T5: Run focused tests and package typecheck, then obtain independent review - acceptance: all focused suites and `bun typecheck` pass from `packages/opencode`, and review confirms write-boundary, retry-policy, actor-outcome, and scope compliance (covers: S2.1, S2.2, S2.3, S2.4, S2.5; depends: T4)

--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -273,6 +273,9 @@ export const layer = Layer.effect(
       // last text part (often a pre-tool-call preamble) is dropped to avoid
       // duplicating the result downstream. See spec §5.2.
       const info = (result as MessageV2.WithParts | undefined)?.info
+      if (info?.role === "assistant" && info.error) {
+        return yield* Effect.fail(new Error(`Actor assistant failed: ${info.error.name}`))
+      }
       const structured = info?.role === "assistant" ? info.structured : undefined
       const finalText =
         structured !== undefined

--- a/packages/opencode/src/agent/config.ts
+++ b/packages/opencode/src/agent/config.ts
@@ -4,6 +4,26 @@
  */
 export const SYSTEM_SPAWNED_AGENT_TYPES: ReadonlySet<string> = new Set(["checkpoint-writer", "dream", "distill"])
 
+export type InvalidOutputPolicy = "primary" | "actor" | "checkpoint"
+
+/** System agents must opt into an invalid-output contract instead of inheriting
+ * the user-facing primary retry when they run with agentID "main". */
+export const SYSTEM_INVALID_OUTPUT_POLICIES: Readonly<Record<string, InvalidOutputPolicy>> = {
+  "checkpoint-writer": "checkpoint",
+  dream: "actor",
+  distill: "actor",
+}
+
+export function resolveInvalidOutputPolicy(input: {
+  agentName: string
+  agentID?: string
+}): InvalidOutputPolicy {
+  const system = SYSTEM_INVALID_OUTPUT_POLICIES[input.agentName]
+  if (system) return system
+  if (!input.agentID || input.agentID === "main") return "primary"
+  return "actor"
+}
+
 /** Decide how a permission `ask` from the current turn should be routed:
  *  - system agent -> non-interactive (auto-deny, no human to answer)
  *  - orchestrator peer (background + mode:peer + has a parent) -> forward the ask

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -8,7 +8,7 @@ import { Log } from "../util"
 import { SessionRevert } from "./revert"
 import * as Session from "./session"
 import { Agent } from "../agent/agent"
-import { decideAskRouting, SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
+import { decideAskRouting, resolveInvalidOutputPolicy, SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { renderActorNotification } from "@/inbox/render"
 import { parseReturnHeader } from "@/actor/return-header"
 import { Provider } from "../provider"
@@ -2487,6 +2487,28 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           invalidContinuations++
           yield* slog.info("auto-continuing invalid output", { attempt: invalidContinuations, reason: input.reason })
+          const policy = resolveInvalidOutputPolicy({
+            agentName: input.lastUser.agent,
+            agentID: input.lastUser.agentID,
+          })
+          const reminder =
+            policy === "checkpoint"
+              ? [
+                  "Your checkpoint writer turn ended without a completion signal.",
+                  "Do not answer or continue the parent session's task. Work only on the authorized checkpoint and memory paths already provided to you.",
+                  "If any authorized edits remain, finish them now. If they are complete, call no more tools and reply exactly CHECKPOINT_COMPLETE.",
+                ]
+              : policy === "actor"
+                ? [
+                    "Your previous response contained no usable result for the parent agent (it had only reasoning, or was empty).",
+                    "Provide a final result to the parent agent now, or call a valid tool to complete the delegated task.",
+                    "Do not respond with only reasoning/thinking.",
+                  ]
+                : [
+                    "Your previous response contained no usable answer (it had only reasoning, or was empty).",
+                    "Provide a final answer to the user now, or call a valid tool to make progress on the task.",
+                    "Do not respond with only reasoning/thinking.",
+                  ]
           const msg = yield* sessions.updateMessage({
             id: MessageID.ascending(),
             role: "user" as const,
@@ -2504,13 +2526,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             sessionID: msg.sessionID,
             type: "text",
             synthetic: true,
-            text: [
-              "<system-reminder>",
-              "Your previous response contained no usable answer (it had only reasoning, or was empty).",
-              "Provide a final answer to the user now, or call a valid tool to make progress on the task.",
-              "Do not respond with only reasoning/thinking.",
-              "</system-reminder>",
-            ].join("\n"),
+            text: ["<system-reminder>", ...reminder, "</system-reminder>"].join("\n"),
           } satisfies MessageV2.TextPart)
           return true
         })

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -107,24 +107,14 @@ export const assertWriteAllowed = Effect.fn("Tool.assertWriteAllowed")(function*
     }
   })()
 
-  // Hard write-sandbox for system agents (dream/distill): confine writes to the
-  // memory tree or <worktree>/.mimocode. Runs before the memory guard so a
-  // sandboxed agent writing an arbitrary source path is rejected up front.
-  const worktree = (() => {
-    try {
-      return Instance.worktree
-    } catch {
-      return undefined
-    }
-  })()
-  if (worktree) {
-    assertAgentWriteSandbox({
-      target,
-      agentName: ctx.agent,
-      memoryRoot: path.join(Global.Path.data, "memory"),
-      worktree,
-    })
-  }
+  // System-agent write sandbox: checkpoint-writer is memory-only, while
+  // dream/distill may also write <worktree>/.mimocode.
+  assertAgentWriteSandbox({
+    target,
+    agentName: ctx.agent,
+    memoryRoot: path.join(Global.Path.data, "memory"),
+    worktree: (yield* InstanceState.context).worktree,
+  })
 
   assertMemoryWriteAllowed({
     target,

--- a/packages/opencode/src/tool/memory-path-guard.ts
+++ b/packages/opencode/src/tool/memory-path-guard.ts
@@ -4,17 +4,14 @@ import type { SessionID } from "../session/schema"
 
 const VALID_SCOPES = ["global", "projects", "sessions"] as const
 
-/** Agents confined to a write sandbox: they may only mutate files under the
- *  memory tree or the project's `.mimocode/` dir. Matches their stated purpose
- *  (dream: consolidate memory; distill: package skills/agents/commands under
- *  .mimocode). Everything else — source files, arbitrary worktree paths — is
- *  denied at the write gate, independent of their `write`/`edit` permission. */
+/** Agents that may write memory or the project's `.mimocode/` directory. The
+ *  checkpoint writer has a stricter memory-only policy below. */
 const WRITE_SANDBOXED_AGENTS: ReadonlySet<string> = new Set(["dream", "distill"])
 
 /**
- * Hard write-boundary for sandboxed system agents (dream/distill). Throws if
- * `agentName` is sandboxed and `target` is neither under the memory tree nor
- * under `<worktree>/.mimocode/`. Pure — does not touch the filesystem.
+ * Hard write-boundary for sandboxed system agents. checkpoint-writer is
+ * memory-only; dream/distill may also write under `<worktree>/.mimocode/`.
+ * Pure — does not touch the filesystem.
  *
  * This is enforced in the single write gate (assertWriteAllowed), so it cannot
  * be bypassed by a widened `write`/`edit` permission or a new write tool: those
@@ -29,8 +26,6 @@ export function assertAgentWriteSandbox(input: {
   memoryRoot: string
   worktree: string
 }): void {
-  if (!WRITE_SANDBOXED_AGENTS.has(input.agentName)) return
-
   // Resolve here rather than trusting the caller: write.ts/edit.ts pass an
   // absolute file_path THROUGH unnormalized, so a target like
   // `<worktree>/.mimocode/../src/x.ts` would string-prefix-match `.mimocode`
@@ -39,6 +34,17 @@ export function assertAgentWriteSandbox(input: {
   // callers.) The roots are resolved too so the comparison is apples-to-apples.
   const target = path.resolve(input.target)
   const memoryRoot = path.resolve(input.memoryRoot)
+  if (input.agentName === "checkpoint-writer") {
+    if (pathContains(memoryRoot, target)) return
+    throw new Error(
+      `Agent '${input.agentName}' may only write under the memory tree.\n` +
+        `  memory: ${memoryRoot}\n` +
+        `You attempted: ${input.target}.`,
+    )
+  }
+
+  if (!WRITE_SANDBOXED_AGENTS.has(input.agentName)) return
+
   const dotDir = path.resolve(input.worktree, ".mimocode")
   if (pathContains(memoryRoot, target) || pathContains(dotDir, target)) return
 

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -59,6 +59,7 @@ import { TestLLMServer } from "../lib/llm-server"
 import { reply } from "../lib/llm-server"
 import { Inbox } from "../../src/inbox"
 import { inboxServiceRef } from "../../src/inbox/inbox-ref"
+import { Flag } from "../../src/flag/flag"
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -943,6 +944,38 @@ describe("Actor.spawn structured output (P3)", () => {
           expect(outcome.structured).toBeUndefined()
           expect(outcome.finalText).toContain("plain answer")
         }
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  it.live("exhausted checkpoint-writer invalid output produces a failed actor outcome", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const parent = yield* session.create({
+          title: "invalid actor output",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        yield* llm.push(
+          ...Array.from({ length: Flag.MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT + 1 }, () => reply().stop()),
+        )
+
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "checkpoint-writer",
+          task: "return a result",
+          context: "none",
+          tools: ["read"],
+          background: false,
+          model: ref,
+        })
+
+        const outcome = yield* Deferred.await(result.outcome)
+        expect(outcome.status).toBe("failure")
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/agent/ask-routing.test.ts
+++ b/packages/opencode/test/agent/ask-routing.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, test } from "bun:test"
-import { decideAskRouting } from "../../src/agent/config"
+import {
+  decideAskRouting,
+  resolveInvalidOutputPolicy,
+  SYSTEM_INVALID_OUTPUT_POLICIES,
+  SYSTEM_SPAWNED_AGENT_TYPES,
+} from "../../src/agent/config"
+
+describe("invalid-output policy", () => {
+  test("every system-spawned agent declares a policy", () => {
+    expect(Object.keys(SYSTEM_INVALID_OUTPUT_POLICIES).sort()).toEqual([...SYSTEM_SPAWNED_AGENT_TYPES].sort())
+  })
+
+  test("system policy takes precedence over main agentID", () => {
+    expect(resolveInvalidOutputPolicy({ agentName: "checkpoint-writer", agentID: "main" })).toBe("checkpoint")
+    expect(resolveInvalidOutputPolicy({ agentName: "dream", agentID: "main" })).toBe("actor")
+  })
+
+  test("primary and ordinary actors use role-specific policies", () => {
+    expect(resolveInvalidOutputPolicy({ agentName: "build", agentID: "main" })).toBe("primary")
+    expect(resolveInvalidOutputPolicy({ agentName: "general", agentID: "general-1" })).toBe("actor")
+  })
+})
 
 describe("decideAskRouting", () => {
   test("system agent (by actor) -> non-interactive, no forward", () => {

--- a/packages/opencode/test/session/invalid-output-continuation.test.ts
+++ b/packages/opencode/test/session/invalid-output-continuation.test.ts
@@ -46,7 +46,10 @@ function writeConfig(dir: string, origin: string) {
       provider: {
         alibaba: { options: { apiKey: "test-key", baseURL: `${origin}/v1` } },
       },
-      agent: { build: { model: "alibaba/qwen-plus" } },
+      agent: {
+        build: { model: "alibaba/qwen-plus" },
+        "checkpoint-writer": { model: "alibaba/qwen-plus" },
+      },
     }),
   )
 }
@@ -142,6 +145,70 @@ describe("invalid-output continuation — integration", () => {
               expect(result.info.role).toBe("assistant")
               if (result.info.role === "assistant") expect(result.info.error).toBeUndefined()
               expect(result.parts.some((p) => p.type === "text" && p.text === "final answer")).toBe(true)
+            }),
+          ),
+      })
+    } finally {
+      await stub.stop()
+    }
+  })
+
+  test("ordinary actor gets a parent-facing invalid-output reminder", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const stub = startScriptedLLMServer([{ lines: emptyStopResponse() }, { lines: textStopResponse("actor result") }])
+    try {
+      await writeConfig(tmp.path, stub.origin)
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const prompt = yield* SessionPrompt.Service
+              const session = yield* sessions.create({ title: "invalid-actor" })
+              yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "build",
+                agentID: "general-1",
+                parts: [{ type: "text", text: "Do delegated work." }],
+              })
+              const retry = JSON.stringify(stub.captures[1].messages)
+              expect(retry).toContain("parent agent")
+              expect(retry).not.toContain("final answer to the user")
+            }),
+          ),
+      })
+    } finally {
+      await stub.stop()
+    }
+  })
+
+  test("checkpoint-writer gets a scoped retry and converges on CHECKPOINT_COMPLETE", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const stub = startScriptedLLMServer([
+      { lines: emptyStopResponse() },
+      { lines: textStopResponse("CHECKPOINT_COMPLETE") },
+    ])
+    try {
+      await writeConfig(tmp.path, stub.origin)
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const prompt = yield* SessionPrompt.Service
+              const session = yield* sessions.create({ title: "invalid-checkpoint-writer" })
+              const result = yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "checkpoint-writer",
+                parts: [{ type: "text", text: "Update the checkpoint." }],
+              })
+              const retry = JSON.stringify(stub.captures[1].messages)
+              expect(retry).toContain("checkpoint writer")
+              expect(retry).toContain("CHECKPOINT_COMPLETE")
+              expect(retry).not.toContain("final answer to the user")
+              expect(result.parts.some((part) => part.type === "text" && part.text === "CHECKPOINT_COMPLETE")).toBe(true)
             }),
           ),
       })

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -586,6 +586,92 @@ EOF`
 })
 
 describe("tool.apply_patch memory-path-guard", () => {
+  test("checkpoint-writer cannot patch a source file", async () => {
+    await using fixture = await tmpdir({ git: true })
+    const { ctx: base } = makeCtx()
+    const ctx = { ...base, agent: "checkpoint-writer" }
+    const target = path.join(fixture.path, "source.ts")
+    await fs.writeFile(target, "before\n", "utf-8")
+
+    await Instance.provide({
+      directory: fixture.path,
+      fn: async () => {
+        await expect(
+          execute(
+            {
+              patch_text: `*** Begin Patch\n*** Update File: ${target}\n@@\n-before\n+after\n*** End Patch`,
+            },
+            ctx,
+          ),
+        ).rejects.toThrow(/may only write under the memory tree/)
+        expect(await fs.readFile(target, "utf-8")).toBe("before\n")
+      },
+    })
+  })
+
+  test("checkpoint-writer cannot patch under .mimocode", async () => {
+    await using fixture = await tmpdir({ git: true })
+    const { ctx: base } = makeCtx()
+    const ctx = { ...base, agent: "checkpoint-writer" }
+    const target = path.join(fixture.path, ".mimocode", "skills", "unsafe", "SKILL.md")
+
+    await Instance.provide({
+      directory: fixture.path,
+      fn: async () => {
+        await expect(
+          execute(
+            {
+              patch_text: `*** Begin Patch\n*** Add File: ${target}\n+unsafe\n*** End Patch`,
+            },
+            ctx,
+          ),
+        ).rejects.toThrow(/may only write under the memory tree/)
+      },
+    })
+  })
+
+  test("checkpoint-writer can patch its checkpoint file", async () => {
+    await using fixture = await tmpdir({ git: true })
+    const { ctx: base, calls } = makeCtx()
+    const ctx = { ...base, agent: "checkpoint-writer" }
+    const target = path.join(Global.Path.data, "memory", "sessions", "ses_test", "checkpoint.md")
+
+    await Instance.provide({
+      directory: fixture.path,
+      fn: async () => {
+        await execute(
+          {
+            patch_text: `*** Begin Patch\n*** Add File: ${target}\n+Topic: safe checkpoint\n*** End Patch`,
+          },
+          ctx,
+        )
+        expect(await fs.readFile(target, "utf-8")).toBe("Topic: safe checkpoint\n")
+        expect(calls).toHaveLength(0)
+      },
+    })
+  })
+
+  test("checkpoint-writer can patch project MEMORY.md", async () => {
+    await using fixture = await tmpdir({ git: true })
+    const { ctx: base, calls } = makeCtx()
+    const ctx = { ...base, agent: "checkpoint-writer" }
+    const target = path.join(Global.Path.data, "memory", "projects", "p_test", "MEMORY.md")
+
+    await Instance.provide({
+      directory: fixture.path,
+      fn: async () => {
+        await execute(
+          {
+            patch_text: `*** Begin Patch\n*** Add File: ${target}\n+# Project memory\n*** End Patch`,
+          },
+          ctx,
+        )
+        expect(await fs.readFile(target, "utf-8")).toBe("# Project memory\n")
+        expect(calls).toHaveLength(0)
+      },
+    })
+  })
+
   test("rejects writing another task's memory (taskId=T3 → tasks/T5)", async () => {
     await using fixture = await tmpdir({ git: true })
     const { ctx: base } = makeCtx()

--- a/packages/opencode/test/tool/memory-path-guard.test.ts
+++ b/packages/opencode/test/tool/memory-path-guard.test.ts
@@ -607,6 +607,39 @@ describe("assertAgentWriteSandbox", () => {
     ).not.toThrow()
   })
 
+  test("checkpoint-writer may write under the memory tree", () => {
+    expect(() =>
+      assertAgentWriteSandbox({
+        target: path.join(MEMORY_ROOT, "sessions", "sid", "checkpoint.md"),
+        agentName: "checkpoint-writer",
+        memoryRoot: MEMORY_ROOT,
+        worktree: WORKTREE,
+      }),
+    ).not.toThrow()
+  })
+
+  test("checkpoint-writer may NOT write a source file", () => {
+    expect(() =>
+      assertAgentWriteSandbox({
+        target: path.join(WORKTREE, "src", "index.ts"),
+        agentName: "checkpoint-writer",
+        memoryRoot: MEMORY_ROOT,
+        worktree: WORKTREE,
+      }),
+    ).toThrow(/may only write under the memory tree/)
+  })
+
+  test("checkpoint-writer may NOT write under <worktree>/.mimocode", () => {
+    expect(() =>
+      assertAgentWriteSandbox({
+        target: path.join(WORKTREE, ".mimocode", "skills", "unsafe", "SKILL.md"),
+        agentName: "checkpoint-writer",
+        memoryRoot: MEMORY_ROOT,
+        worktree: WORKTREE,
+      }),
+    ).toThrow(/may only write under the memory tree/)
+  })
+
   for (const agent of ["dream", "distill"] as const) {
     test(`${agent} may write under the memory tree`, () => {
       expect(() =>

--- a/packages/opencode/test/workflow/runtime.test.ts
+++ b/packages/opencode/test/workflow/runtime.test.ts
@@ -875,11 +875,9 @@ describe("WorkflowRuntime replay journal", () => {
 // null contract — these tests pin both invariants: the script still sees null,
 // AND the bus carries one event per failed agent with the right reason.
 describe("WorkflowRuntime agent failure event (Gap 3)", () => {
-  it.live("a 400 client error → reason='no-deliverable'; success sibling → no event", () =>
-    // The actor outcome is status:"success" (agent finished its turn cleanly),
-    // but the failed-LLM call produced no assistant text → no finalText/structured
-    // to extract → deliverable is null → reason="no-deliverable". This matches the
-    // existing "a failing child yields null" test's mechanism (line 79).
+  it.live("a 400 client error → reason='actor-error'; success sibling → no event", () =>
+    // A terminal assistant error now fails the actor outcome instead of being
+    // misreported as a successful turn with no deliverable.
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {
         const runtime = yield* WorkflowRuntime.Service
@@ -909,7 +907,7 @@ describe("WorkflowRuntime agent failure event (Gap 3)", () => {
         // Bus is async; let the publish settle before asserting.
         yield* Effect.sleep("100 millis")
         expect(events.length).toBe(1)
-        expect(events[0].reason).toBe("no-deliverable")
+        expect(events[0].reason).toBe("actor-error")
         expect(events[0].label).toBe("fail-one")
         expect(events[0].phase).toBe("Test")
       }),


### PR DESCRIPTION
## Summary
- confine checkpoint-writer file mutations to authorized memory paths through the unified write gate
- select invalid-output recovery prompts by execution role, with a checkpoint-specific `CHECKPOINT_COMPLETE` recovery path
- propagate terminal assistant errors to actor failure so failed checkpoint writers do not advance the watermark

## Verification
- focused local suite: 151 pass, 0 fail, 286 assertions
- workflow actor-error contract test: 1 pass
- actor/checkpoint recheck: 32 pass, 0 fail
- `bun typecheck` from `packages/opencode`
- push hook full workspace typecheck: 12/12 tasks
- GitHub CI at `6b1c8d2c`: lint pass, typecheck pass, unit shards 1/4 through 4/4 all pass

## Final Review
- first CI run exposed one real cross-module expectation gap: provider 400 errors now propagate as actor failure, so Workflow correctly reports `actor-error` rather than the legacy `no-deliverable`; the test contract was updated in `6b1c8d2c`
- fresh-eyes final review used `anthropic/claude-opus-4-7` and inspected the complete PR diff plus write-tool, Actor, Workflow, and checkpoint settlement call chains
- review result: approved with no critical, high, medium, or low findings
- confirmed all current file mutators route through `assertWriteAllowed`; `apply_patch` checks the source path for every hunk and the destination for moves
- confirmed exhausted checkpoint recovery resolves actor failure and cannot advance `last_checkpoint_message_id`

## Scope
- preserves primary-agent invalid-output recovery and existing dream/distill sandbox behavior
- intentionally excludes symlink/hardlink topology inside the application-managed memory tree
- does not modify Compose skills, Compose workflow production code, or historical database records