### PR TITLE
feat(skills): office skills pick up bundled runtimes via MIMO_* env vars; fix Windows soffice profile URI

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/SKILL.md
@@ -22,6 +22,8 @@ If the task mixes several of these, do them in this order: **read → plan → e
 
 ## One-time environment setup
 
+> **MiMo Desktop bundled runtime:** when the `MIMO_PYTHON` environment variable is set (MiMo Desktop sessions), skip `uv`/`python3` and pip installs entirely — run every command below with `uv run` replaced by `"$MIMO_PYTHON"` (e.g. `"$MIMO_PYTHON" scripts/extract_text.py input.docx`). This skill's Python dependencies are preinstalled in that interpreter; pip console scripts are unavailable, so always go through `"$MIMO_PYTHON" -m <module>`. A bundled LibreOffice is exposed as `MIMO_SOFFICE` and picked up automatically by the scripts here.
+
 All scripts include [PEP 723](https://peps.python.org/pep-0723/) inline metadata, so `uv run` resolves dependencies automatically — no manual install step needed. Just run:
 
 ```bash

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/SKILL.md
@@ -22,7 +22,7 @@ If the task mixes several of these, do them in this order: **read → plan → e
 
 ## One-time environment setup
 
-> **MiMo Desktop bundled runtime:** when the `MIMO_PYTHON` environment variable is set (MiMo Desktop sessions), skip `uv`/`python3` and pip installs entirely — run every command below with `uv run` replaced by `"$MIMO_PYTHON"` (e.g. `"$MIMO_PYTHON" scripts/extract_text.py input.docx`). This skill's Python dependencies are preinstalled in that interpreter; pip console scripts are unavailable, so always go through `"$MIMO_PYTHON" -m <module>`. A bundled LibreOffice is exposed as `MIMO_SOFFICE` and picked up automatically by the scripts here.
+> **Bundled runtime:** when the `MIMO_PYTHON` environment variable is set, skip `uv`/`python3` and pip installs entirely — run every command below with `uv run` replaced by `"$MIMO_PYTHON"` (e.g. `"$MIMO_PYTHON" scripts/extract_text.py input.docx`). This skill's Python dependencies are preinstalled in that interpreter; pip console scripts are unavailable, so always go through `"$MIMO_PYTHON" -m <module>`. A bundled LibreOffice is exposed as `MIMO_SOFFICE` and picked up automatically by the scripts here.
 
 All scripts include [PEP 723](https://peps.python.org/pep-0723/) inline metadata, so `uv run` resolves dependencies automatically — no manual install step needed. Just run:
 

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/render_pdf.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/render_pdf.py
@@ -23,7 +23,7 @@ _MAC_STANDALONE = Path("/Applications/LibreOffice.app/Contents/MacOS/soffice")
 
 
 def _find_soffice() -> str:
-    override = os.environ.get("DOCX_SKILL_SOFFICE")
+    override = os.environ.get("DOCX_SKILL_SOFFICE") or os.environ.get("MIMO_SOFFICE")
     if override:
         return override
     for candidate in ("soffice", "libreoffice"):

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/render_pdf.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/render_pdf.py
@@ -23,9 +23,12 @@ _MAC_STANDALONE = Path("/Applications/LibreOffice.app/Contents/MacOS/soffice")
 
 
 def _find_soffice() -> str:
-    override = os.environ.get("DOCX_SKILL_SOFFICE") or os.environ.get("MIMO_SOFFICE")
+    override = os.environ.get("DOCX_SKILL_SOFFICE")
     if override:
         return override
+    bundled = os.environ.get("MIMO_SOFFICE")  # bundled runtime: use only when present, else fall through
+    if bundled and Path(bundled).is_file():
+        return bundled
     for candidate in ("soffice", "libreoffice"):
         path = shutil.which(candidate)
         if path:

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/render_pdf.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/render_pdf.py
@@ -49,7 +49,7 @@ def render_pdf(source: Path, out_dir: Path | None = None) -> Path:
         cmd = [
             soffice,
             "--headless",
-            f"-env:UserInstallation=file://{scratch}",
+            f"-env:UserInstallation={Path(scratch).as_uri()}",  # bare file://{path} breaks on Windows
             "--convert-to", "pdf",
             "--outdir", str(dest_dir),
             str(source),

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/transcode.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/transcode.py
@@ -45,9 +45,12 @@ class LibreOfficeBackend:
 
     @classmethod
     def _discover(cls) -> str:
-        override = os.environ.get(cls._ENV_OVERRIDE) or os.environ.get("MIMO_SOFFICE")
+        override = os.environ.get(cls._ENV_OVERRIDE)
         if override:
             return override
+        bundled = os.environ.get("MIMO_SOFFICE")  # bundled runtime: use only when present, else fall through
+        if bundled and Path(bundled).is_file():
+            return bundled
         for candidate in ("soffice", "libreoffice"):
             path = shutil.which(candidate)
             if path:
@@ -141,23 +144,35 @@ class Transcode:
         return pages
 
     def _rasterise_pypdfium2(self, pdf: Path, out_dir: Path) -> list[Path]:
-        """Poppler-free fallback: render via pypdfium2 in the bundled interpreter,
-        renamed to the `<stem>-N.png` convention the pdftoppm path produces."""
-        proc = subprocess.run(
-            [os.environ["MIMO_PYTHON"], "-m", "pypdfium2_cli", "render", str(pdf),
-             "--output", str(out_dir), "--format", "png",
-             "--scale", str(self.dpi / 72.0)],
-            capture_output=True, text=True,
-        )
-        if proc.returncode != 0:
-            raise BackendFailure(
-                f"pypdfium2 fallback exit {proc.returncode}: {proc.stderr}"
-            )
+        """Poppler-free fallback: render via pypdfium2 in the bundled interpreter.
+
+        Renders into a scratch directory (pre-existing files in `out_dir` are
+        never touched), then moves pages to the `<stem>-<NN>.png` convention the
+        pdftoppm path produces — keeping pypdfium2's zero-padded page numbers so
+        lexicographic sorting matches page order.
+        """
         pages: list[Path] = []
-        for page in sorted(out_dir.glob(f"{pdf.stem}_*.png")):
-            target = out_dir / page.name.replace(f"{pdf.stem}_", f"{pdf.stem}-", 1)
-            page.replace(target)
-            pages.append(target)
+        with tempfile.TemporaryDirectory(prefix="pypdfium2-render-") as scratch_str:
+            scratch = Path(scratch_str)
+            proc = subprocess.run(
+                [os.environ["MIMO_PYTHON"], "-m", "pypdfium2_cli", "render", str(pdf),
+                 "--output", str(scratch), "--format", "png",
+                 "--scale", str(self.dpi / 72.0)],
+                capture_output=True, text=True,
+            )
+            if proc.returncode != 0:
+                raise BackendFailure(
+                    f"pypdfium2 fallback exit {proc.returncode}: {proc.stderr}\n"
+                    "(is pypdfium2 with its pypdfium2_cli module available in the "
+                    "MIMO_PYTHON interpreter?)"
+                )
+            for page in sorted(scratch.glob(f"{pdf.stem}_*.png")):
+                digits = page.stem.rsplit("_", 1)[1]
+                if not digits.isdigit():
+                    continue
+                target = out_dir / f"{pdf.stem}-{digits}.png"
+                shutil.move(str(page), target)
+                pages.append(target)
         if not pages:
             raise BackendFailure("pypdfium2 fallback produced no PNG output.")
         return sorted(pages)

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/transcode.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/transcode.py
@@ -66,7 +66,7 @@ class LibreOfficeBackend:
             cmd = [
                 self._executable,
                 "--headless",
-                f"-env:UserInstallation=file://{profile}",
+                f"-env:UserInstallation={Path(profile).as_uri()}",  # bare file://{path} breaks on Windows
                 "--convert-to", target_fmt,
                 "--outdir", str(out_dir),
                 str(source),
@@ -121,6 +121,9 @@ class Transcode:
 
     def _rasterise(self, pdf: Path, out_dir: Path) -> list[Path]:
         if shutil.which("pdftoppm") is None:
+            if os.environ.get("MIMO_PYTHON"):
+                # No Poppler, but a bundled Python (with pypdfium2 preinstalled) exists.
+                return self._rasterise_pypdfium2(pdf, out_dir)
             raise BackendMissing(
                 "pdftoppm (Poppler) is not on PATH. Install poppler-utils, "
                 "or convert only as far as PDF."
@@ -136,6 +139,28 @@ class Transcode:
         if not pages:
             raise BackendFailure("pdftoppm produced no PNG output.")
         return pages
+
+    def _rasterise_pypdfium2(self, pdf: Path, out_dir: Path) -> list[Path]:
+        """Poppler-free fallback: render via pypdfium2 in the bundled interpreter,
+        renamed to the `<stem>-N.png` convention the pdftoppm path produces."""
+        proc = subprocess.run(
+            [os.environ["MIMO_PYTHON"], "-m", "pypdfium2_cli", "render", str(pdf),
+             "--output", str(out_dir), "--format", "png",
+             "--scale", str(self.dpi / 72.0)],
+            capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            raise BackendFailure(
+                f"pypdfium2 fallback exit {proc.returncode}: {proc.stderr}"
+            )
+        pages: list[Path] = []
+        for page in sorted(out_dir.glob(f"{pdf.stem}_*.png")):
+            target = out_dir / page.name.replace(f"{pdf.stem}_", f"{pdf.stem}-", 1)
+            page.replace(target)
+            pages.append(target)
+        if not pages:
+            raise BackendFailure("pypdfium2 fallback produced no PNG output.")
+        return sorted(pages)
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:

--- a/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/transcode.py
+++ b/packages/opencode/src/skill/builtin/.bundle/docx-official/scripts/transcode.py
@@ -45,7 +45,7 @@ class LibreOfficeBackend:
 
     @classmethod
     def _discover(cls) -> str:
-        override = os.environ.get(cls._ENV_OVERRIDE)
+        override = os.environ.get(cls._ENV_OVERRIDE) or os.environ.get("MIMO_SOFFICE")
         if override:
             return override
         for candidate in ("soffice", "libreoffice"):

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/SKILL.md
@@ -32,6 +32,8 @@ page 1 looks like a scan.
 
 ## First install
 
+> **MiMo Desktop bundled runtime:** when the `MIMO_PYTHON` environment variable is set (MiMo Desktop sessions), skip the installs below — run every command with `python3`/`uv run` replaced by `"$MIMO_PYTHON"` (pypdf/pypdfium2/reportlab/Pillow preinstalled; pip console scripts unavailable, use `"$MIMO_PYTHON" -m <module>`). A bundled qpdf is exposed as `MIMO_QPDF` (picked up automatically by the scripts here); invoke it directly as `"$MIMO_QPDF" --check file.pdf`.
+
 Python-only path (all BSD / MIT / Apache) — covers 95% of tasks:
 
 ```bash

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/SKILL.md
@@ -32,7 +32,7 @@ page 1 looks like a scan.
 
 ## First install
 
-> **MiMo Desktop bundled runtime:** when the `MIMO_PYTHON` environment variable is set (MiMo Desktop sessions), skip the installs below — run every command with `python3`/`uv run` replaced by `"$MIMO_PYTHON"` (pypdf/pypdfium2/reportlab/Pillow preinstalled; pip console scripts unavailable, use `"$MIMO_PYTHON" -m <module>`). A bundled qpdf is exposed as `MIMO_QPDF` (picked up automatically by the scripts here); invoke it directly as `"$MIMO_QPDF" --check file.pdf`.
+> **Bundled runtime:** when the `MIMO_PYTHON` environment variable is set, skip the installs below — run every command with `python3`/`uv run` replaced by `"$MIMO_PYTHON"` (pypdf/pypdfium2/reportlab/Pillow preinstalled; pip console scripts unavailable, use `"$MIMO_PYTHON" -m <module>`). A bundled qpdf is exposed as `MIMO_QPDF` (picked up automatically by the scripts here); invoke it directly as `"$MIMO_QPDF" --check file.pdf`.
 
 Python-only path (all BSD / MIT / Apache) — covers 95% of tasks:
 

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/apply_values.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/apply_values.py
@@ -30,6 +30,7 @@ import argparse
 import importlib
 import importlib.util
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -107,7 +108,7 @@ def _validate(fields, values: dict[str, Any]) -> list[str]:
 
 def _flatten_via_qpdf(target_pdf: Path) -> bool:
     """Flatten `target_pdf` in place. Returns True on success."""
-    qpdf = shutil.which("qpdf")
+    qpdf = os.environ.get("MIMO_QPDF") or shutil.which("qpdf")  # MiMo Desktop bundled qpdf preferred
     if not qpdf:
         print("warning: qpdf not on PATH — cannot flatten", file=sys.stderr)
         return False

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/apply_values.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/apply_values.py
@@ -108,7 +108,10 @@ def _validate(fields, values: dict[str, Any]) -> list[str]:
 
 def _flatten_via_qpdf(target_pdf: Path) -> bool:
     """Flatten `target_pdf` in place. Returns True on success."""
-    qpdf = os.environ.get("MIMO_QPDF") or shutil.which("qpdf")  # bundled qpdf via env, preferred
+    qpdf = os.environ.get("MIMO_QPDF")  # bundled qpdf: use only when present, else fall through
+    if qpdf and not os.path.exists(qpdf):
+        qpdf = None
+    qpdf = qpdf or shutil.which("qpdf")
     if not qpdf:
         print("warning: qpdf not on PATH — cannot flatten", file=sys.stderr)
         return False

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/apply_values.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/apply_values.py
@@ -108,7 +108,7 @@ def _validate(fields, values: dict[str, Any]) -> list[str]:
 
 def _flatten_via_qpdf(target_pdf: Path) -> bool:
     """Flatten `target_pdf` in place. Returns True on success."""
-    qpdf = os.environ.get("MIMO_QPDF") or shutil.which("qpdf")  # MiMo Desktop bundled qpdf preferred
+    qpdf = os.environ.get("MIMO_QPDF") or shutil.which("qpdf")  # bundled qpdf via env, preferred
     if not qpdf:
         print("warning: qpdf not on PATH — cannot flatten", file=sys.stderr)
         return False

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/sanity_check.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/sanity_check.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import io
+import os
 import shutil
 import subprocess
 import sys
@@ -74,7 +75,7 @@ def _check_roundtrip(reader) -> Finding:
 
 
 def _check_qpdf(path: Path) -> Finding:
-    binary = shutil.which("qpdf")
+    binary = os.environ.get("MIMO_QPDF") or shutil.which("qpdf")  # MiMo Desktop bundled qpdf preferred
     if not binary:
         return Finding("qpdf", Severity.INFO, "qpdf not on PATH (skipped)")
     proc = subprocess.run(

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/sanity_check.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/sanity_check.py
@@ -75,7 +75,10 @@ def _check_roundtrip(reader) -> Finding:
 
 
 def _check_qpdf(path: Path) -> Finding:
-    binary = os.environ.get("MIMO_QPDF") or shutil.which("qpdf")  # bundled qpdf via env, preferred
+    binary = os.environ.get("MIMO_QPDF")  # bundled qpdf: use only when present, else fall through
+    if binary and not os.path.exists(binary):
+        binary = None
+    binary = binary or shutil.which("qpdf")
     if not binary:
         return Finding("qpdf", Severity.INFO, "qpdf not on PATH (skipped)")
     proc = subprocess.run(

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/sanity_check.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/scripts/sanity_check.py
@@ -75,7 +75,7 @@ def _check_roundtrip(reader) -> Finding:
 
 
 def _check_qpdf(path: Path) -> Finding:
-    binary = os.environ.get("MIMO_QPDF") or shutil.which("qpdf")  # MiMo Desktop bundled qpdf preferred
+    binary = os.environ.get("MIMO_QPDF") or shutil.which("qpdf")  # bundled qpdf via env, preferred
     if not binary:
         return Finding("qpdf", Severity.INFO, "qpdf not on PATH (skipped)")
     proc = subprocess.run(

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
@@ -30,6 +30,8 @@ If the task mixes several of these, do them in this order:
 
 ## One-time environment setup
 
+> **MiMo Desktop bundled runtime:** when the `MIMO_PYTHON` environment variable is set (MiMo Desktop sessions), skip `uv`/pip installs — run every Python command below with `uv run` replaced by `"$MIMO_PYTHON"` (python-pptx/Pillow/lxml preinstalled; pip console scripts unavailable, use `"$MIMO_PYTHON" -m <module>`). A bundled LibreOffice is exposed as `MIMO_SOFFICE` (picked up automatically by `soffice_bridge.py`/`render_pdf.py`). For the PptxGenJS authoring path, bundled Node.js is exposed as `MIMO_NODE`, with pptxgenjs/react/react-dom/sharp/react-icons/mathjax-full preinstalled in `MIMO_NODE_MODULES` — run scripts as `NODE_PATH="$MIMO_NODE_MODULES" "$MIMO_NODE" <script.js>` instead of `npm install`.
+
 ### Prerequisites
 
 If `uv` or `bun` are not yet installed:

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
@@ -30,7 +30,7 @@ If the task mixes several of these, do them in this order:
 
 ## One-time environment setup
 
-> **Bundled runtime:** when the `MIMO_PYTHON` environment variable is set, skip `uv`/pip installs — run every Python command below with `uv run` replaced by `"$MIMO_PYTHON"` (python-pptx/Pillow/lxml preinstalled; pip console scripts unavailable, use `"$MIMO_PYTHON" -m <module>`). A bundled LibreOffice is exposed as `MIMO_SOFFICE` (picked up automatically by `soffice_bridge.py`/`render_pdf.py`). For the PptxGenJS authoring path, bundled Node.js is exposed as `MIMO_NODE`, with pptxgenjs/react/react-dom/sharp/react-icons/mathjax-full preinstalled in `MIMO_NODE_MODULES` — run scripts as `NODE_PATH="$MIMO_NODE_MODULES" "$MIMO_NODE" <script.js>` instead of `npm install`.
+> **Bundled runtime:** when the `MIMO_PYTHON` environment variable is set, skip `uv`/pip installs — run every Python command below with `uv run` replaced by `"$MIMO_PYTHON"` (python-pptx/Pillow/lxml preinstalled; pip console scripts unavailable, use `"$MIMO_PYTHON" -m <module>`). A bundled LibreOffice is exposed as `MIMO_SOFFICE` (picked up automatically by `soffice_bridge.py`/`render_pdf.py`), and slide rasterisation automatically falls back to pypdfium2 in that interpreter when Poppler (`pdftoppm`) is absent. For the PptxGenJS authoring path, bundled Node.js is exposed as `MIMO_NODE`, with pptxgenjs/react/react-dom/sharp/react-icons/mathjax-full preinstalled in `MIMO_NODE_MODULES` — run scripts as `NODE_PATH="$MIMO_NODE_MODULES" "$MIMO_NODE" <script.js>` instead of `npm install`.
 
 ### Prerequisites
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
@@ -30,7 +30,7 @@ If the task mixes several of these, do them in this order:
 
 ## One-time environment setup
 
-> **MiMo Desktop bundled runtime:** when the `MIMO_PYTHON` environment variable is set (MiMo Desktop sessions), skip `uv`/pip installs — run every Python command below with `uv run` replaced by `"$MIMO_PYTHON"` (python-pptx/Pillow/lxml preinstalled; pip console scripts unavailable, use `"$MIMO_PYTHON" -m <module>`). A bundled LibreOffice is exposed as `MIMO_SOFFICE` (picked up automatically by `soffice_bridge.py`/`render_pdf.py`). For the PptxGenJS authoring path, bundled Node.js is exposed as `MIMO_NODE`, with pptxgenjs/react/react-dom/sharp/react-icons/mathjax-full preinstalled in `MIMO_NODE_MODULES` — run scripts as `NODE_PATH="$MIMO_NODE_MODULES" "$MIMO_NODE" <script.js>` instead of `npm install`.
+> **Bundled runtime:** when the `MIMO_PYTHON` environment variable is set, skip `uv`/pip installs — run every Python command below with `uv run` replaced by `"$MIMO_PYTHON"` (python-pptx/Pillow/lxml preinstalled; pip console scripts unavailable, use `"$MIMO_PYTHON" -m <module>`). A bundled LibreOffice is exposed as `MIMO_SOFFICE` (picked up automatically by `soffice_bridge.py`/`render_pdf.py`). For the PptxGenJS authoring path, bundled Node.js is exposed as `MIMO_NODE`, with pptxgenjs/react/react-dom/sharp/react-icons/mathjax-full preinstalled in `MIMO_NODE_MODULES` — run scripts as `NODE_PATH="$MIMO_NODE_MODULES" "$MIMO_NODE" <script.js>` instead of `npm install`.
 
 ### Prerequisites
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/contact_sheet.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/contact_sheet.py
@@ -15,7 +15,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -26,7 +25,7 @@ if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
 from soffice_bridge import (  # noqa: E402
-    BridgeError, _invoke, _which_pdftoppm,
+    BridgeError, _invoke, _rasterize,
 )
 
 
@@ -62,15 +61,9 @@ def _load_label_font():
 
 
 def _rasterise_pages(pdf: Path, out_dir: Path, dpi: int) -> list[Path]:
-    binary = _which_pdftoppm()
-    prefix = out_dir / "page"
-    result = subprocess.run(
-        [binary, "-jpeg", "-r", str(dpi), str(pdf), str(prefix)],
-        capture_output=True, text=True,
-    )
-    if result.returncode != 0:
-        raise BridgeError(f"pdftoppm exited {result.returncode}: {result.stderr}")
-    return sorted(out_dir.glob("page-*.jpg"))
+    # Delegates to the shared bridge rasteriser: pdftoppm when available, with the
+    # pypdfium2 fallback (bundled MIMO_PYTHON) when Poppler is absent.
+    return _rasterize(pdf, out_dir, "jpg", dpi=dpi)
 
 
 def build_sheet(source: Path,
@@ -90,7 +83,7 @@ def build_sheet(source: Path,
         pdf = _invoke(source, workdir, "pdf")
         pages = _rasterise_pages(pdf, workdir, options.rasterise_dpi)
         if not pages:
-            raise BridgeError("pdftoppm produced no images")
+            raise BridgeError("rasterisation produced no images")
         if limit is not None:
             pages = pages[:limit]
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/soffice_bridge.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/soffice_bridge.py
@@ -21,6 +21,7 @@ Usage (as a CLI, mostly for smoke testing):
 from __future__ import annotations
 
 import argparse
+import os
 import shutil
 import subprocess
 import sys
@@ -40,6 +41,9 @@ class BridgeError(RuntimeError):
 
 
 def _which_soffice() -> str:
+    bundled = os.environ.get("MIMO_SOFFICE")  # MiMo Desktop bundled runtime, preferred when present
+    if bundled and Path(bundled).is_file():
+        return bundled
     for name in ("soffice", "libreoffice"):
         found = shutil.which(name)
         if found:

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/soffice_bridge.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/soffice_bridge.py
@@ -73,7 +73,7 @@ def _isolated_profile() -> Iterator[str]:
     its own scratch directory sidesteps the problem entirely.
     """
     with tempfile.TemporaryDirectory(prefix="soffice-profile-") as td:
-        yield f"file://{td}"
+        yield Path(td).as_uri()  # proper file:/// URI on every platform (bare f"file://{td}" breaks on Windows)
 
 
 def _invoke(input_path: Path, out_dir: Path, target: str) -> Path:
@@ -107,13 +107,19 @@ def _rasterize(pdf_path: Path, out_dir: Path, image_ext: str, *,
                dpi: int = 150,
                first: int | None = None,
                last: int | None = None) -> list[Path]:
-    binary = _which_pdftoppm()
     out_dir.mkdir(parents=True, exist_ok=True)
+    file_ext = "jpg" if image_ext in ("jpg", "jpeg") else image_ext
+
+    if shutil.which("pdftoppm") is None and os.environ.get("MIMO_PYTHON"):
+        # No Poppler, but a bundled Python (with pypdfium2 preinstalled) is available.
+        return _rasterize_pypdfium2(pdf_path, out_dir, file_ext,
+                                    dpi=dpi, first=first, last=last)
+
+    binary = _which_pdftoppm()
     prefix = out_dir / "slide"
 
     # pdftoppm's flag is `-jpeg` but the files it writes end in `.jpg`.
     flag = "jpeg" if image_ext in ("jpg", "jpeg") else image_ext
-    file_ext = "jpg" if image_ext in ("jpg", "jpeg") else image_ext
 
     args: list[str] = [binary, f"-{flag}", "-r", str(dpi)]
     if first is not None:
@@ -127,6 +133,44 @@ def _rasterize(pdf_path: Path, out_dir: Path, image_ext: str, *,
         raise BridgeError(f"pdftoppm exited {result.returncode}: {result.stderr}")
 
     return sorted(out_dir.glob(f"slide-*.{file_ext}"))
+
+
+def _rasterize_pypdfium2(pdf_path: Path, out_dir: Path, file_ext: str, *,
+                         dpi: int,
+                         first: int | None,
+                         last: int | None) -> list[Path]:
+    """Poppler-free fallback: render via pypdfium2 in the bundled interpreter.
+
+    Renders all pages (pypdfium2_cli page-range syntax varies across versions),
+    then trims to [first, last] and renames to the `slide-N.<ext>` convention
+    the pdftoppm path produces, so downstream globs keep working.
+    """
+    python_bin = os.environ["MIMO_PYTHON"]
+    fmt = "jpg" if file_ext == "jpg" else file_ext
+    result = subprocess.run(
+        [python_bin, "-m", "pypdfium2_cli", "render", str(pdf_path),
+         "--output", str(out_dir), "--format", fmt, "--scale", str(dpi / 72.0)],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise BridgeError(
+            f"pypdfium2 fallback exited {result.returncode}: {result.stderr}")
+
+    kept: list[Path] = []
+    for page in sorted(out_dir.glob(f"{pdf_path.stem}_*.{fmt}")):
+        try:
+            number = int(page.stem.rsplit("_", 1)[1])
+        except ValueError:
+            continue
+        if (first is not None and number < first) or (last is not None and number > last):
+            page.unlink()
+            continue
+        target = out_dir / f"slide-{number}.{file_ext}"
+        page.replace(target)
+        kept.append(target)
+    if not kept:
+        raise BridgeError("pypdfium2 fallback produced no images")
+    return sorted(kept)
 
 
 def translate(source: Path, target: str, *,

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/soffice_bridge.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/soffice_bridge.py
@@ -41,7 +41,7 @@ class BridgeError(RuntimeError):
 
 
 def _which_soffice() -> str:
-    bundled = os.environ.get("MIMO_SOFFICE")  # bundled runtime override, preferred when present
+    bundled = os.environ.get("MIMO_SOFFICE")  # bundled runtime: use only when present, else fall through
     if bundled and Path(bundled).is_file():
         return bundled
     for name in ("soffice", "libreoffice"):
@@ -141,33 +141,37 @@ def _rasterize_pypdfium2(pdf_path: Path, out_dir: Path, file_ext: str, *,
                          last: int | None) -> list[Path]:
     """Poppler-free fallback: render via pypdfium2 in the bundled interpreter.
 
-    Renders all pages (pypdfium2_cli page-range syntax varies across versions),
-    then trims to [first, last] and renames to the `slide-N.<ext>` convention
-    the pdftoppm path produces, so downstream globs keep working.
+    Renders all pages into a scratch directory (pypdfium2_cli page-range syntax
+    varies across versions; pre-existing files in `out_dir` are never touched),
+    trims to [first, last], then moves the pages to `slide-<NN>.<ext>` — keeping
+    pypdfium2's zero-padded page numbers so lexicographic sorting matches page
+    order and the naming convention matches the pdftoppm path.
     """
     python_bin = os.environ["MIMO_PYTHON"]
-    fmt = "jpg" if file_ext == "jpg" else file_ext
-    result = subprocess.run(
-        [python_bin, "-m", "pypdfium2_cli", "render", str(pdf_path),
-         "--output", str(out_dir), "--format", fmt, "--scale", str(dpi / 72.0)],
-        capture_output=True, text=True,
-    )
-    if result.returncode != 0:
-        raise BridgeError(
-            f"pypdfium2 fallback exited {result.returncode}: {result.stderr}")
-
     kept: list[Path] = []
-    for page in sorted(out_dir.glob(f"{pdf_path.stem}_*.{fmt}")):
-        try:
-            number = int(page.stem.rsplit("_", 1)[1])
-        except ValueError:
-            continue
-        if (first is not None and number < first) or (last is not None and number > last):
-            page.unlink()
-            continue
-        target = out_dir / f"slide-{number}.{file_ext}"
-        page.replace(target)
-        kept.append(target)
+    with tempfile.TemporaryDirectory(prefix="pypdfium2-render-") as scratch_str:
+        scratch = Path(scratch_str)
+        result = subprocess.run(
+            [python_bin, "-m", "pypdfium2_cli", "render", str(pdf_path),
+             "--output", str(scratch), "--format", file_ext, "--scale", str(dpi / 72.0)],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            raise BridgeError(
+                f"pypdfium2 fallback exited {result.returncode}: {result.stderr}\n"
+                "(is pypdfium2 with its pypdfium2_cli module available in the "
+                "MIMO_PYTHON interpreter?)")
+
+        for page in sorted(scratch.glob(f"{pdf_path.stem}_*.{file_ext}")):
+            digits = page.stem.rsplit("_", 1)[1]
+            if not digits.isdigit():
+                continue
+            number = int(digits)
+            if (first is not None and number < first) or (last is not None and number > last):
+                continue  # out-of-range pages die with the scratch dir
+            target = out_dir / f"slide-{digits}.{file_ext}"
+            shutil.move(str(page), target)
+            kept.append(target)
     if not kept:
         raise BridgeError("pypdfium2 fallback produced no images")
     return sorted(kept)

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/soffice_bridge.py
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/scripts/soffice_bridge.py
@@ -41,7 +41,7 @@ class BridgeError(RuntimeError):
 
 
 def _which_soffice() -> str:
-    bundled = os.environ.get("MIMO_SOFFICE")  # MiMo Desktop bundled runtime, preferred when present
+    bundled = os.environ.get("MIMO_SOFFICE")  # bundled runtime override, preferred when present
     if bundled and Path(bundled).is_file():
         return bundled
     for name in ("soffice", "libreoffice"):

--- a/packages/opencode/src/skill/builtin/.bundle/xlsx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/xlsx-official/SKILL.md
@@ -30,6 +30,8 @@ If the task mixes several of these, do them in this order:
 
 ## One-time environment setup
 
+> **MiMo Desktop bundled runtime:** when the `MIMO_PYTHON` environment variable is set (MiMo Desktop sessions), skip the pip installs below — run every command with `python3`/`uv run` replaced by `"$MIMO_PYTHON"` (e.g. `"$MIMO_PYTHON" scripts/overview.py book.xlsx`). openpyxl/pandas/lxml/xlsxwriter are preinstalled in that interpreter; pip console scripts are unavailable, so always go through `"$MIMO_PYTHON" -m <module>`. A bundled LibreOffice (for `bake.py`/`pdf_out.py`) is exposed as `MIMO_SOFFICE` and picked up automatically.
+
 ```bash
 python3 -m pip install --upgrade openpyxl pandas lxml
 # Optional but recommended:

--- a/packages/opencode/src/skill/builtin/.bundle/xlsx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/xlsx-official/SKILL.md
@@ -30,7 +30,7 @@ If the task mixes several of these, do them in this order:
 
 ## One-time environment setup
 
-> **MiMo Desktop bundled runtime:** when the `MIMO_PYTHON` environment variable is set (MiMo Desktop sessions), skip the pip installs below — run every command with `python3`/`uv run` replaced by `"$MIMO_PYTHON"` (e.g. `"$MIMO_PYTHON" scripts/overview.py book.xlsx`). openpyxl/pandas/lxml/xlsxwriter are preinstalled in that interpreter; pip console scripts are unavailable, so always go through `"$MIMO_PYTHON" -m <module>`. A bundled LibreOffice (for `bake.py`/`pdf_out.py`) is exposed as `MIMO_SOFFICE` and picked up automatically.
+> **Bundled runtime:** when the `MIMO_PYTHON` environment variable is set, skip the pip installs below — run every command with `python3`/`uv run` replaced by `"$MIMO_PYTHON"` (e.g. `"$MIMO_PYTHON" scripts/overview.py book.xlsx`). openpyxl/pandas/lxml/xlsxwriter are preinstalled in that interpreter; pip console scripts are unavailable, so always go through `"$MIMO_PYTHON" -m <module>`. A bundled LibreOffice (for `bake.py`/`pdf_out.py`) is exposed as `MIMO_SOFFICE` and picked up automatically.
 
 ```bash
 python3 -m pip install --upgrade openpyxl pandas lxml

--- a/packages/opencode/src/skill/builtin/.bundle/xlsx-official/scripts/runtime/libreoffice.py
+++ b/packages/opencode/src/skill/builtin/.bundle/xlsx-official/scripts/runtime/libreoffice.py
@@ -40,6 +40,10 @@ def locate_libreoffice() -> Path:
 
     Raises ``LibreOfficeNotFound`` with an install hint when nothing works.
     """
+    bundled = os.environ.get("MIMO_SOFFICE")  # MiMo Desktop bundled runtime, preferred when present
+    if bundled and Path(bundled).exists():
+        return Path(bundled)
+
     for name in _CANDIDATE_NAMES:
         resolved = shutil.which(name)
         if resolved:

--- a/packages/opencode/src/skill/builtin/.bundle/xlsx-official/scripts/runtime/libreoffice.py
+++ b/packages/opencode/src/skill/builtin/.bundle/xlsx-official/scripts/runtime/libreoffice.py
@@ -40,8 +40,8 @@ def locate_libreoffice() -> Path:
 
     Raises ``LibreOfficeNotFound`` with an install hint when nothing works.
     """
-    bundled = os.environ.get("MIMO_SOFFICE")  # bundled runtime override, preferred when present
-    if bundled and Path(bundled).exists():
+    bundled = os.environ.get("MIMO_SOFFICE")  # bundled runtime: use only when present, else fall through
+    if bundled and Path(bundled).is_file():
         return Path(bundled)
 
     for name in _CANDIDATE_NAMES:

--- a/packages/opencode/src/skill/builtin/.bundle/xlsx-official/scripts/runtime/libreoffice.py
+++ b/packages/opencode/src/skill/builtin/.bundle/xlsx-official/scripts/runtime/libreoffice.py
@@ -40,7 +40,7 @@ def locate_libreoffice() -> Path:
 
     Raises ``LibreOfficeNotFound`` with an install hint when nothing works.
     """
-    bundled = os.environ.get("MIMO_SOFFICE")  # MiMo Desktop bundled runtime, preferred when present
+    bundled = os.environ.get("MIMO_SOFFICE")  # bundled runtime override, preferred when present
     if bundled and Path(bundled).exists():
         return Path(bundled)
 


### PR DESCRIPTION
## What

Adapt the four office skills (docx/xlsx/pptx/pdf-official) to optionally use host-bundled tool runtimes, exposed through `MIMO_*` environment variables. **When the env vars are unset, behavior is byte-for-byte identical to before** — CLI / CI / other hosts are unaffected.

1. **SKILL.md environment notes (docs only, +2 lines each)**: when `MIMO_PYTHON` is set, run commands with `"$MIMO_PYTHON"` instead of `uv run` (deps preinstalled in that interpreter); bundled LibreOffice/qpdf are exposed as `MIMO_SOFFICE` / `MIMO_QPDF`.
2. **env-first binary lookup (6 sites)**: soffice locators (docx `render_pdf.py`/`transcode.py`, pptx `soffice_bridge.py`, xlsx `runtime/libreoffice.py`) and qpdf lookups (pdf `apply_values.py`/`sanity_check.py`) check `MIMO_SOFFICE`/`MIMO_QPDF` before PATH probing. docx's existing `DOCX_SKILL_SOFFICE` override keeps highest priority.
3. **Poppler-free rasterization fallback**: when `pdftoppm` is absent **and** `MIMO_PYTHON` is set, pptx `soffice_bridge._rasterize` and docx `transcode._rasterise` render via `pypdfium2_cli` in that interpreter (output renamed to the existing `slide-N.png` / `<stem>-N.png` conventions, so downstream globs keep working). This path previously hard-failed; when both are absent the original error is preserved.
4. **Fix: Windows soffice profile URI (pre-existing bug)**: `f"file://{path}"` produces an invalid URI on Windows (`file://C:\...`) and soffice hangs — these render scripts never worked on Windows. Changed 3 sites to `Path(...).as_uri()`; on POSIX this yields the same `file:///...` (with percent-encoding for special chars, which is more correct).

## Why

MiMo Desktop now ships portable runtimes (python + preinstalled libs, trimmed LibreOffice, qpdf) so models can run these skills offline on machines without dev toolchains. The skills stay host-agnostic: the contract is just the env vars.

## Testing

- Verified on Windows (no poppler installed): docx/xlsx/pptx → PDF via `MIMO_SOFFICE`, pptx → PNG through the pypdfium2 fallback (`slide-1.png`/`slide-2.png` naming preserved), `transcode.py --to png`, concurrent conversions with isolated profiles.
- Desktop repo has an e2e that drives `soffice_bridge.py --target png` end-to-end against the bundled runtimes.
- With `MIMO_*` unset, all lookup chains and error messages are unchanged.