### PR TITLE
fix(provider): lower DEFAULT_CONTEXT_WINDOW fallback from 1M to 200K

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -31,7 +31,7 @@ import * as ProviderTransform from "./transform"
 import { ModelID, ProviderID } from "./schema"
 
 const log = Log.create({ service: "provider" })
-const DEFAULT_CONTEXT_WINDOW = 1_000_000
+const DEFAULT_CONTEXT_WINDOW = 200_000
 // Reserved built-in model tiers: always resolve, falling back to the default
 // model when not configured in `model_groups` (zero-config never errors).
 const BUILTIN_TIERS = new Set(["ultra", "standard", "lite"])

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2124,7 +2124,7 @@ test("closest checks multiple query terms in order", async () => {
   })
 })
 
-test("model limit defaults to DEFAULT_CONTEXT_WINDOW (1M) when not specified (F41)", async () => {
+test("model limit defaults to DEFAULT_CONTEXT_WINDOW (200K) when not specified (F41)", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -2155,7 +2155,7 @@ test("model limit defaults to DEFAULT_CONTEXT_WINDOW (1M) when not specified (F4
     fn: async () => {
       const providers = await list()
       const model = providers[ProviderID.make("no-limit")].models["model"]
-      expect(model.limit.context).toBe(1_000_000)
+      expect(model.limit.context).toBe(200_000)
       expect(model.limit.output).toBe(0)
     },
   })


### PR DESCRIPTION
## Summary
- When a model has no `limit.context` (not in config, not in models.dev), the fallback was `1_000_000`. This effectively disables auto-compaction for most models: `isOverflow` never fires, sessions grow past what upstream providers handle, producing repeated empty completions (`InvalidOutputError: empty output`) and unrecoverable sessions.
- Lower the fallback to `200_000`. Models with genuinely larger windows (e.g. 1M-context models) should declare `limit.context` explicitly in config or models.dev metadata.

## Context
Upstream opencode uses `?? 0` for missing context (which disables overflow checks entirely); the 1M default is a MiMo fork addition. 200K keeps the warn-and-default behavior but with a conservative value that lets compaction engage before providers start failing.

## Test plan
- [x] `bun test test/provider/provider.test.ts -t "F41"` (updated assertion)
- [x] `bun typecheck` in packages/opencode