### PR TITLE
feat(tool): align GPT tool guidance and skill search

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -337,7 +337,7 @@ export const layer = Layer.effect(
         const captureSession = yield* sessions.get(input.sessionID).pipe(Effect.catch(() => Effect.succeed(undefined)))
         if (!captureSession) return empty
         const [skills, env, instructions] = yield* Effect.all([
-          sys.skills(ag),
+          sys.skills(ag, model),
           sys.environment(model, captureSession.time.created),
           instruction.system().pipe(Effect.orDie),
         ])
@@ -3527,7 +3527,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
 
             const [skills, env, instructions] = yield* Effect.all([
-              sys.skills(agent),
+              sys.skills(agent, model),
               sys.environment(model, session.time.created),
               instruction.system().pipe(Effect.orDie),
             ])

--- a/packages/opencode/src/session/skill-search-reminder.ts
+++ b/packages/opencode/src/session/skill-search-reminder.ts
@@ -1,4 +1,5 @@
 import { Flag } from "../flag/flag"
+import { isSkillSearchDisabled } from "../skill/search"
 
 export const SKILL_SEARCH_REMINDER_MARKER = "Skill search trigger:"
 
@@ -71,9 +72,7 @@ export function skillSearchReminderForSession(input: {
     input.session.parentID ||
     input.agent.mode === "subagent" ||
     input.agent.name === "compose" ||
-    [input.model.id, input.model.api.id, input.model.name, input.model.family]
-      .filter((value) => value !== undefined)
-      .some((value) => /(^|[^a-z0-9])(claude|gpt)($|[^a-z0-9])/i.test(value))
+    isSkillSearchDisabled(input.model)
   )
     return
   return skillSearchReminderForMessages(input.messages)

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -19,6 +19,7 @@ import { sortVisionModels } from "@/provider/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
+import { isSkillSearchDisabled, type SkillSearchModel } from "@/skill/search"
 
 export function provider(model: Provider.Model) {
   if (model.api.id.includes("gpt-4") || model.api.id.includes("o1") || model.api.id.includes("o3"))
@@ -41,7 +42,7 @@ export function provider(model: Provider.Model) {
 
 export interface Interface {
   readonly environment: (model: Provider.Model, now: number) => Effect.Effect<string[]>
-  readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
+  readonly skills: (agent: Agent.Info, model?: SkillSearchModel) => Effect.Effect<string | undefined>
   readonly available: (agent?: Agent.Info) => Effect.Effect<Skill.Info[]>
   readonly all: () => Effect.Effect<Skill.Info[]>
 }
@@ -110,10 +111,18 @@ export const layer = Layer.effect(
         return base
       }),
 
-      skills: Effect.fn("SystemPrompt.skills")(function* (agent: Agent.Info) {
+      skills: Effect.fn("SystemPrompt.skills")(function* (agent: Agent.Info, model?: SkillSearchModel) {
         if (Permission.disabled(["skill"], agent.permission).has("skill")) return
 
         const list = yield* skill.available(agent)
+
+        if (model && isSkillSearchDisabled(model)) {
+          return [
+            "Skills provide specialized instructions and workflows for specific tasks.",
+            "Use the skill tool to load a skill when a task matches its description.",
+            Skill.fmt(list, { verbose: true }),
+          ].join("\n")
+        }
 
         return [
           "Skills provide specialized instructions and workflows for specific tasks.",

--- a/packages/opencode/src/skill/search.ts
+++ b/packages/opencode/src/skill/search.ts
@@ -9,6 +9,20 @@ export type SearchResult = {
   reason: string
 }
 
+export type SkillSearchModel = {
+  id?: string
+  modelID?: string
+  name?: string
+  family?: string
+  api?: { id?: string }
+}
+
+export function isSkillSearchDisabled(model: SkillSearchModel) {
+  return [model.id, model.modelID, model.api?.id, model.name, model.family]
+    .filter((value) => value !== undefined)
+    .some((value) => /(^|[^a-z0-9])(claude|gpt)($|[^a-z0-9])/i.test(value))
+}
+
 function normalize(value: string) {
   return value.toLocaleLowerCase().trim()
 }

--- a/packages/opencode/src/tool/bash.gpt.txt
+++ b/packages/opencode/src/tool/bash.gpt.txt
@@ -1,0 +1,62 @@
+Runs a shell command and returns its output, with optional timeout and interactive terminal support.
+
+Environment: OS: ${os}, Shell: ${shell}
+
+Commands run in the current working directory by default. Set the `workdir` parameter when a command belongs in another directory; do not use `cd <directory> && <command>` unless `workdir` cannot express the operation.
+
+IMPORTANT: In this GPT tool set, the dedicated `read`, `write`, and `edit` tools are unavailable. Use this tool to inspect, search, and navigate files. Use `apply_patch` to create, update, move, or delete project text files. Do not attempt to call unavailable tools.
+
+# Filesystem operations
+
+- Prefer `rg --files` to list or find files and `rg` to search file contents. If `rg` is unavailable, use commands native to the current shell.
+- Read only the relevant portion of a file when possible. On POSIX shells use commands such as `sed -n 'START,ENDp'`; use `cat` only for small files that must be read in full. On PowerShell use `Get-Content` with appropriate range or count options.
+- Use `apply_patch` for deliberate project text edits. Do not use shell redirection, `sed -i`, or an inline Python script merely to bypass `apply_patch`.
+- Shell writes are appropriate when they are the natural result of a command such as a formatter, code generator, build, or package script, or when handling generated or non-text data that `apply_patch` cannot represent.
+- Before creating a new path, verify its parent directory and the intended location. Quote paths containing spaces.
+- Before a recursive delete or move, resolve and verify the exact target. Never use a broad target such as a home directory, filesystem root, or unresolved environment variable.
+- On Windows, keep destructive filesystem operations in one shell end-to-end. Prefer native PowerShell cmdlets with `-LiteralPath`; do not enumerate targets in PowerShell and pass them to another shell for deletion or moving.
+
+# Command execution
+
+- The `command` and a concise 5-10 word `description` are required.
+- The optional `timeout` is in milliseconds and defaults to 120000 (2 minutes).
+- Set `interactive: true` only when the command requires direct user interaction, such as a password, confirmation prompt, authentication, or input that cannot be supplied non-interactively. Interactive commands do not time out while waiting for the user.
+- If output exceeds ${maxLines} lines or ${maxBytes} bytes, the response is truncated and the full output is saved to a file. Inspect that file with `rg`, a targeted line-range command, or the equivalent command for the current shell.
+- Do not add `head`, `tail`, or other output truncation solely to work around tool limits; prefer a query that selects the relevant information.
+- When commands are independent, issue multiple Bash tool calls in parallel.
+- ${chaining}
+- Use `;` only when commands must be sequential but later commands may run after an earlier failure.
+- Do not use newlines to separate commands; newlines are acceptable inside quoted strings.
+
+# Committing changes with git
+
+Only create commits when explicitly requested by the user. If unclear, ask first.
+
+Git safety protocol:
+- NEVER update git config.
+- NEVER run destructive or irreversible git commands such as force push, hard reset, or clean unless the user explicitly requests the exact operation.
+- NEVER skip hooks with flags such as `--no-verify` or `--no-gpg-sign` unless explicitly requested.
+- NEVER force push to main or master; warn the user if asked.
+- Avoid `git commit --amend`. Use it only when the user explicitly requested it, or when a successful commit made by you in this conversation was modified by a hook, remains unpushed, and needs the hook changes included.
+- If a commit failed or was rejected by a hook, fix the issue and create a new commit; do not amend.
+- Do not commit files likely to contain secrets. Warn the user if they explicitly request that.
+
+When asked to commit:
+1. Inspect `git status`, staged and unstaged diffs, and recent commit messages. Independent inspection commands should run in parallel.
+2. Review all staged changes and draft a concise message that describes why the change exists.
+3. Stage only relevant files, create the commit, then run `git status` after the commit completes to verify it.
+4. If a hook fails, fix the problem and create a new commit.
+
+Do not push unless the user explicitly asks. Never use interactive git flags such as `git rebase -i` or `git add -i`. Do not create an empty commit when there are no changes.
+
+# Creating pull requests
+
+Use `gh` through this tool for GitHub issues, pull requests, checks, and releases.
+
+When asked to create a pull request:
+1. In parallel, inspect repository status, staged and unstaged changes, remote tracking state, commits since the base branch, and the full diff from the merge base. The default base branch is `main` unless repository instructions say otherwise.
+2. Review every commit and change included in the pull request, then draft its title and summary.
+3. Create a branch if needed, push with `-u` if needed, and create the pull request with `gh pr create`. Use a heredoc or equivalent safe multiline mechanism for the body.
+4. Return the pull request URL.
+
+Do not use the task or Actor tools for commit or pull-request workflows.

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -4,6 +4,7 @@ import { createWriteStream, readFileSync } from "node:fs"
 import * as Tool from "./tool"
 import path from "path"
 import DESCRIPTION from "./bash.txt"
+import GPT_DESCRIPTION from "./bash.gpt.txt"
 import { Log } from "../util"
 import { Instance } from "../project/instance"
 import { lazy } from "@/util/lazy"
@@ -53,6 +54,21 @@ const FILES = new Set([
 ])
 const FLAGS = new Set(["-destination", "-literalpath", "-path"])
 const SWITCHES = new Set(["-confirm", "-debug", "-force", "-nonewline", "-recurse", "-verbose", "-whatif"])
+
+export function bashDescription(gpt = false) {
+  const name = Shell.name(Shell.acceptable())
+  const chaining =
+    name === "powershell"
+      ? "If the commands depend on each other and must run sequentially, avoid '&&' in this shell because Windows PowerShell 5.1 does not support it. Use PowerShell conditionals such as `cmd1; if ($?) { cmd2 }` when later commands must depend on earlier success."
+      : "If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m \"message\" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, apply_patch before Bash for git operations, or git add before git commit), run these operations sequentially instead."
+  return (gpt ? GPT_DESCRIPTION : DESCRIPTION)
+    .replaceAll("${directory}", Instance.directory)
+    .replaceAll("${os}", process.platform)
+    .replaceAll("${shell}", name)
+    .replaceAll("${chaining}", chaining)
+    .replaceAll("${maxLines}", String(Truncate.MAX_LINES))
+    .replaceAll("${maxBytes}", String(Truncate.MAX_BYTES))
+}
 
 // Irreversible file/directory removal commands. Names are matched
 // case-insensitively for PowerShell; bash is case-sensitive.
@@ -731,19 +747,10 @@ export const BashTool = Tool.define(
       Effect.sync(() => {
         const shell = Shell.acceptable()
         const name = Shell.name(shell)
-        const chain =
-          name === "powershell"
-            ? "If the commands depend on each other and must run sequentially, avoid '&&' in this shell because Windows PowerShell 5.1 does not support it. Use PowerShell conditionals such as `cmd1; if ($?) { cmd2 }` when later commands must depend on earlier success."
-            : "If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m \"message\" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, Write before Bash for git operations, or git add before git commit), run these operations sequentially instead."
         log.info("bash tool using shell", { shell })
 
         return {
-          description: DESCRIPTION.replaceAll("${directory}", Instance.directory)
-            .replaceAll("${os}", process.platform)
-            .replaceAll("${shell}", name)
-            .replaceAll("${chaining}", chain)
-            .replaceAll("${maxLines}", String(Truncate.MAX_LINES))
-            .replaceAll("${maxBytes}", String(Truncate.MAX_BYTES)),
+          description: bashDescription(),
           parameters: Parameters,
           execute: (params: z.infer<typeof Parameters>, ctx: Tool.Context) =>
             Effect.gen(function* () {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -1,7 +1,7 @@
 import { PlanEnterTool, PlanExitTool } from "./plan"
 import { Session } from "../session"
 import { QuestionTool } from "./question"
-import { BashTool } from "./bash"
+import { BashTool, bashDescription } from "./bash"
 import { EditTool } from "./edit"
 import { GlobTool } from "./glob"
 import { GrepTool } from "./grep"
@@ -56,6 +56,7 @@ import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { Bus } from "../bus"
 import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
+import { isSkillSearchDisabled } from "../skill/search"
 import { Permission } from "@/permission"
 import { ActorRegistry } from "@/actor/registry"
 import { ActorWaiter } from "@/actor/waiter"
@@ -364,7 +365,10 @@ export const layer = Layer.effect(
     })
 
     const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
+      const useGPTTools =
+        input.modelID.includes("gpt-") && !input.modelID.includes("oss") && !input.modelID.includes("gpt-4")
       let filtered = (yield* all()).filter((tool) => {
+        if (tool.id === SkillSearchTool.id) return !isSkillSearchDisabled({ modelID: input.modelID })
         if (tool.id === CodeSearchTool.id || tool.id === WebSearchTool.id) {
           if (tool.id === WebSearchTool.id) {
             return (
@@ -376,10 +380,14 @@ export const layer = Layer.effect(
           return input.providerID === ProviderID.opencode || Flag.MIMOCODE_ENABLE_EXA
         }
 
-        const useGPTTools =
-          input.modelID.includes("gpt-") && !input.modelID.includes("oss") && !input.modelID.includes("gpt-4")
         if (tool.id === ApplyPatchTool.id || tool.id === ViewImageTool.id) return useGPTTools
-        if (tool.id === EditTool.id || tool.id === WriteTool.id || tool.id === ReadTool.id) return !useGPTTools
+        if (
+          tool.id === EditTool.id ||
+          tool.id === WriteTool.id ||
+          tool.id === ReadTool.id ||
+          tool.id === NotebookEditTool.id
+        )
+          return !useGPTTools
 
         return true
       })
@@ -403,7 +411,7 @@ export const layer = Layer.effect(
         Effect.fnUntraced(function* (tool: Tool.Def) {
           using _ = log.time(tool.id)
           const output = {
-            description: tool.description,
+            description: tool.id === BashTool.id && useGPTTools ? bashDescription(true) : tool.description,
             parameters: tool.parameters,
           }
           yield* plugin.trigger("tool.definition", { toolID: tool.id }, output)

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -102,4 +102,29 @@ description: ${description}
       process.env.USERPROFILE = userProfile
     }
   })
+
+  test("does not prompt GPT or Claude models to use skill_search", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const build = await load(tmp.path, (svc) => svc.get("build"))
+        const prompts = await Effect.runPromise(
+          Effect.gen(function* () {
+            const system = yield* SystemPrompt.Service
+            return yield* Effect.all([
+              system.skills(build!, { id: "gpt-5.4" }),
+              system.skills(build!, { id: "claude-sonnet-4-6" }),
+              system.skills(build!, { id: "mimo-v2" }),
+            ])
+          }).pipe(Effect.provide(SystemPrompt.defaultLayer)),
+        )
+
+        expect(prompts[0]).not.toContain("skill_search")
+        expect(prompts[1]).not.toContain("skill_search")
+        expect(prompts[2]).toContain("skill_search")
+      },
+    })
+  })
 })

--- a/packages/opencode/test/tool/registry-invocation-style.test.ts
+++ b/packages/opencode/test/tool/registry-invocation-style.test.ts
@@ -17,6 +17,70 @@ afterEach(async () => {
 })
 
 describe("ToolRegistry.tools: invocation style resolution", () => {
+  it.live("masks skill_search for GPT and Claude models", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* ToolRegistry.Service
+        const agents = yield* Agent.Service
+        const general = yield* agents.get("general")
+        if (!general) throw new Error("no general agent")
+        const ids = (modelID: string) =>
+          reg
+            .tools({
+              providerID: ProviderID.opencode,
+              modelID: ModelID.make(modelID),
+              agent: general,
+            })
+            .pipe(Effect.map((tools) => tools.map((tool) => tool.id)))
+
+        expect(yield* ids("openai/gpt-5.4")).not.toContain("skill_search")
+        expect(yield* ids("anthropic/claude-sonnet-4-6")).not.toContain("skill_search")
+        expect(yield* ids("mimo-v2")).toContain("skill_search")
+      }),
+    ),
+  )
+
+  it.live("uses the filesystem-capable bash description for GPT models", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* ToolRegistry.Service
+        const agents = yield* Agent.Service
+        const general = yield* agents.get("general")
+        if (!general) throw new Error("no general agent")
+        const tools = yield* reg.tools({
+          providerID: ProviderID.make("openai"),
+          modelID: ModelID.make("gpt-5"),
+          agent: general,
+        })
+        const bash = tools.find((tool) => tool.id === "bash")
+        expect(bash?.description).toContain("the dedicated `read`, `write`, and `edit` tools are unavailable")
+        expect(bash?.description).toContain("Use `apply_patch`")
+        expect(bash?.description).not.toContain("DO NOT use it for file operations")
+        expect(tools.some((tool) => tool.id === "notebook_edit")).toBeFalse()
+      }),
+    ),
+  )
+
+  it.live("keeps the specialized-tool bash description for non-GPT models", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* ToolRegistry.Service
+        const agents = yield* Agent.Service
+        const general = yield* agents.get("general")
+        if (!general) throw new Error("no general agent")
+        const tools = yield* reg.tools({
+          providerID: ProviderID.opencode,
+          modelID: ModelID.make("opencode/claude-sonnet-4-6"),
+          agent: general,
+        })
+        const bash = tools.find((tool) => tool.id === "bash")
+        expect(bash?.description).toContain("DO NOT use it for file operations")
+        expect(bash?.description).not.toContain("the dedicated `read`, `write`, and `edit` tools are unavailable")
+        expect(tools.some((tool) => tool.id === "notebook_edit")).toBeTrue()
+      }),
+    ),
+  )
+
   it.live("default config keeps task in JSON mode", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {

--- a/packages/opencode/test/tool/skill-search.test.ts
+++ b/packages/opencode/test/tool/skill-search.test.ts
@@ -56,7 +56,7 @@ Build the management presentation.
           const agent = { name: "build", mode: "primary" as const, permission: [], options: {} }
           const tool = (yield* registry.tools({
             providerID: "opencode" as any,
-            modelID: "gpt-5" as any,
+            modelID: "mimo-v2" as any,
             agent,
           })).find((item) => item.id === SkillSearchTool.id)
           if (!tool) throw new Error("Skill search tool not found")
@@ -99,7 +99,7 @@ Build the management presentation.
           const agent = { name: "build", mode: "primary" as const, permission: [], options: {} }
           const tool = (yield* registry.tools({
             providerID: "opencode" as any,
-            modelID: "gpt-5" as any,
+            modelID: "mimo-v2" as any,
             agent,
           })).find((item) => item.id === SkillSearchTool.id)
           if (!tool) throw new Error("Skill search tool not found")
@@ -160,7 +160,7 @@ description: Analyze quasar telemetry and operational metrics.
           const agent = { name: "build", mode: "primary" as const, permission: [], options: {} }
           const tool = (yield* registry.tools({
             providerID: "opencode" as any,
-            modelID: "gpt-5" as any,
+            modelID: "mimo-v2" as any,
             agent,
           })).find((item) => item.id === SkillSearchTool.id)
           if (!tool) throw new Error("Skill search tool not found")


### PR DESCRIPTION
## Summary

- add a GPT-specific Bash description for filesystem inspection and `apply_patch` editing
- hide unsupported `notebook_edit` and `skill_search` tools for matching model families
- remove `skill_search` prompting and reminders for GPT and Claude models
- centralize model-family detection and cover both GPT and non-GPT tool profiles

## Test plan

- `bun test --timeout 30000 test/tool/registry-invocation-style.test.ts test/tool/skill-search.test.ts test/session/system.test.ts`
- `bun typecheck` from `packages/opencode`
- repository pre-push `bun turbo typecheck`

## Dependency

Stacked on #1864 (`feat/view-image-tool`).
