### PR TITLE
fix(session): honor toolChoice on max-mode's final step

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3646,7 +3646,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "break" as const
             }
 
-            const stepEffect = useMaxMode
+            const stepEffect = useMaxMode && !isLastStep
               ? MaxMode.runMaxStep({
                   // runMaxStep reuses the identical per-step args as handle.process,
                   // plus the orchestration handles it needs.

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -364,6 +364,25 @@ function providerCfg(url: string) {
   }
 }
 
+// Enables the "max" agent (only registered when experimental.maxMode is
+// configured) and caps it at a single step, so the very first step is also
+// the last one.
+function maxModeLastStepCfg(url: string) {
+  return {
+    ...providerCfg(url),
+    experimental: {
+      maxMode: {
+        candidates: 2,
+      },
+    },
+    agent: {
+      max: {
+        steps: 1,
+      },
+    },
+  }
+}
+
 function mediaProviderCfg(url: string) {
   const config = providerCfg(url)
   return {
@@ -1812,4 +1831,38 @@ it.live(
       { git: true, config: cfg },
     ),
   30_000,
+)
+
+// Max mode
+
+it.live("max mode's last step falls back to a single handle.process call", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Max mode last step",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* llm.text("final answer")
+
+      const result = yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "max",
+        model: ref,
+        parts: [{ type: "text", text: "hello" }],
+      })
+
+      expect(result.info.role).toBe("assistant")
+      expect(result.parts.some((part) => part.type === "text" && part.text === "final answer")).toBe(true)
+      // With steps: 1, the very first step is also the last one. If max mode
+      // still ran runMaxStep here, it would fan out to 2 candidates + 1 judge
+      // call (3 total) instead of the single handle.process call the step-cap
+      // wrap-up expects.
+      expect(yield* llm.calls).toBe(1)
+    }),
+    { git: true, config: maxModeLastStepCfg },
+  ),
+  15_000,
 )


### PR DESCRIPTION
## Summary

- On the last step of a run, the main loop sets `toolChoice: "none"` so the model is forced to wrap up with text instead of proposing more tool calls. When max-mode is active, the step was unconditionally dispatched to `MaxMode.runMaxStep` instead of `handle.process`. `runMaxStep`'s `toolChoice` field is intentionally unused, so a max-mode session could keep proposing and executing tool calls past its configured step budget.
- Gate the branch so the last step always falls back to `handle.process`, which does honor `toolChoice`, regardless of whether max-mode is otherwise enabled.
- Added a regression test that pins the "max" agent to a single step with 2 candidates and asserts only 1 LLM call (not 3) on the final step.

## Test plan

- [x] `bun typecheck` passes
- [x] New test "max mode's last step falls back to a single handle.process call" passes