### PR TITLE
feat: enable direct messaging to subagents from TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -63,6 +63,9 @@ export type PromptProps = {
     normal?: string[]
     shell?: string[]
   }
+  /** When set, overrides the default session.prompt submit flow. The function
+   *  receives the trimmed input text and should return true on success. */
+  onCustomSubmit?: (text: string) => Promise<boolean>
 }
 
 export type PromptRef = {
@@ -1018,6 +1021,23 @@ export function Prompt(props: PromptProps) {
     if (props.disabled) return false
     if (autocomplete?.visible) return false
     if (!store.prompt.input) return false
+
+    // Custom submit path (e.g. subagent inbox send). Skip model/workspace checks.
+    if (props.onCustomSubmit) {
+      const trimmed = store.prompt.input.trim()
+      if (!trimmed) return false
+      const ok = await props.onCustomSubmit(trimmed)
+      if (ok) {
+        history.append({ ...store.prompt, mode: store.mode })
+        input.extmarks.clear()
+        setStore("prompt", { input: "", parts: [] })
+        setStore("extmarkToPartIndex", new Map())
+        props.onSubmit?.()
+        input.clear()
+      }
+      return ok
+    }
+
     const agent = local.agent.current()
     if (!agent) return false
     const trimmed = store.prompt.input.trim()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1026,16 +1026,20 @@ export function Prompt(props: PromptProps) {
     if (props.onCustomSubmit) {
       const trimmed = store.prompt.input.trim()
       if (!trimmed) return false
-      const ok = await props.onCustomSubmit(trimmed)
-      if (ok) {
-        history.append({ ...store.prompt, mode: store.mode })
-        input.extmarks.clear()
-        setStore("prompt", { input: "", parts: [] })
-        setStore("extmarkToPartIndex", new Map())
-        props.onSubmit?.()
-        input.clear()
+      submitLock = true
+      try {
+        const ok = await props.onCustomSubmit(trimmed)
+        if (ok) {
+          input.extmarks.clear()
+          setStore("prompt", { input: "", parts: [] })
+          setStore("extmarkToPartIndex", new Map())
+          props.onSubmit?.()
+          input.clear()
+        }
+        return ok
+      } finally {
+        submitLock = false
       }
-      return ok
     }
 
     const agent = local.agent.current()

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -180,6 +180,17 @@ export function Session() {
       permissions().length === 0 &&
       questions().length === 0,
   )
+  const subagentInputVisible = createMemo(() => {
+    if (currentAgentID() === "main") return false
+    if (permissions().length > 0 || questions().length > 0) return false
+    const actorID = currentAgentID()
+    const actor = actors().find((a) => a.actor_id === actorID)
+    if (!actor) return false
+    // Allow input for running/pending subagents. "unknown" status maps to
+    // idle-without-outcome (persistent peers that finished a turn but remain
+    // alive), which should also accept input.
+    return actor.status === "running" || actor.status === "pending" || actor.status === "unknown"
+  })
   const disabled = createMemo(() => permissions().length > 0 || questions().length > 0)
 
   const pending = createMemo(() => {
@@ -1399,6 +1410,44 @@ export function Session() {
                     right={<TuiPluginRuntime.Slot name="session_prompt_right" session_id={route.sessionID} />}
                   />
                 </TuiPluginRuntime.Slot>
+              </Show>
+              <Show when={subagentInputVisible()}>
+                <Prompt
+                  visible={true}
+                  disabled={disabled()}
+                  onSubmit={() => {
+                    toBottom()
+                  }}
+                  sessionID={route.sessionID}
+                  onCustomSubmit={async (text) => {
+                    try {
+                      const res = await sdk.fetch(
+                        `${sdk.url}/session/${route.sessionID}/inbox/send`,
+                        {
+                          method: "POST",
+                          headers: { "Content-Type": "application/json" },
+                          body: JSON.stringify({
+                            actorID: currentAgentID(),
+                            content: text,
+                            type: "text",
+                          }),
+                        },
+                      )
+                      if (!res.ok) {
+                        const err = await res.text()
+                        toast.show({ message: `Send failed: ${err}`, variant: "error" })
+                        return false
+                      }
+                      return true
+                    } catch (err) {
+                      toast.show({
+                        message: err instanceof Error ? err.message : "Failed to send message",
+                        variant: "error",
+                      })
+                      return false
+                    }
+                  }}
+                />
               </Show>
             </box>
           </Show>

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -28,6 +28,8 @@ import { Provider } from "@/provider"
 import { forkQuery } from "@/tool/session"
 import { spawnRef } from "@/actor/spawn-ref"
 import { inboxServiceRef } from "@/inbox/inbox-ref"
+import { InboxReceiverNotFound } from "@/inbox/inbox"
+import { NotFoundError } from "@/storage"
 import { errors } from "../../error"
 import { lazy } from "@/util/lazy"
 import { Bus } from "@/bus"
@@ -1439,7 +1441,11 @@ export const SessionRoutes = lazy(() =>
               senderActorID: "main",
               content: body.content,
               type: body.type ?? "text",
-            })
+            }).pipe(
+              Effect.catchTag("InboxReceiverNotFound", (err) =>
+                Effect.fail(new NotFoundError({ message: `Actor not found: ${err.receiverActorID}` })),
+              ),
+            )
           }),
         )
         return c.json(result)

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -27,6 +27,7 @@ import { ModelID, ProviderID } from "@/provider/schema"
 import { Provider } from "@/provider"
 import { forkQuery } from "@/tool/session"
 import { spawnRef } from "@/actor/spawn-ref"
+import { inboxServiceRef } from "@/inbox/inbox-ref"
 import { errors } from "../../error"
 import { lazy } from "@/util/lazy"
 import { Bus } from "@/bus"
@@ -1384,6 +1385,64 @@ export const SessionRoutes = lazy(() =>
           }),
         )
         return c.json(actors)
+      },
+    )
+    .post(
+      "/:sessionID/inbox/send",
+      describeRoute({
+        summary: "Send message to actor inbox",
+        description: "Send a direct message to a subagent's inbox, bypassing the main agent relay.",
+        operationId: "session.inboxSend",
+        responses: {
+          200: {
+            description: "Inbox message sent",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ inboxID: z.string() })),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: SessionID.zod,
+        }),
+      ),
+      validator(
+        "json",
+        z.object({
+          actorID: z.string(),
+          content: z.string().min(1),
+          type: z.string().optional(),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        const result = await runRequest(
+          "SessionRoutes.inboxSend",
+          c,
+          Effect.gen(function* () {
+            const inbox = inboxServiceRef.current
+            if (!inbox) {
+              return yield* Effect.fail(
+                new NamedError.Unknown({ message: "Inbox service is not running" }),
+              )
+            }
+            return yield* inbox.send({
+              receiverSessionID: sessionID,
+              receiverActorID: body.actorID,
+              senderSessionID: sessionID,
+              senderActorID: "main",
+              content: body.content,
+              type: body.type ?? "text",
+            })
+          }),
+        )
+        return c.json(result)
       },
     ),
 )

--- a/packages/opencode/test/server/session-inbox-send.test.ts
+++ b/packages/opencode/test/server/session-inbox-send.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session as SessionNs } from "../../src/session"
+import { ActorRegistry } from "../../src/actor/registry"
+import { Log } from "../../src/util"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+function runSession<A, E>(fx: Effect.Effect<A, E, SessionNs.Service>) {
+  return Effect.runPromise(fx.pipe(Effect.provide(SessionNs.defaultLayer)))
+}
+
+function runRegistry<A, E>(fx: Effect.Effect<A, E, ActorRegistry.Service>) {
+  return Effect.runPromise(fx.pipe(Effect.provide(ActorRegistry.defaultLayer)))
+}
+
+const createSession = () => runSession(SessionNs.Service.use((svc) => svc.create({})))
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+async function withoutWatcher<T>(fn: () => Promise<T>) {
+  if (process.platform !== "win32") return fn()
+  const prev = process.env.MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER
+  process.env.MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER = "true"
+  try {
+    return await fn()
+  } finally {
+    if (prev === undefined) delete process.env.MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER
+    else process.env.MIMOCODE_EXPERIMENTAL_DISABLE_FILEWATCHER = prev
+  }
+}
+
+describe("POST /:sessionID/inbox/send", () => {
+  test("returns 200 with inboxID for a registered actor", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await createSession()
+          await runRegistry(
+            ActorRegistry.Service.use((reg) =>
+              reg.register({
+                sessionID: session.id,
+                actorID: "test-actor",
+                mode: "subagent",
+                agent: "general",
+                description: "test",
+                contextMode: "none",
+                background: true,
+                lifecycle: "ephemeral",
+              }),
+            ),
+          )
+
+          const app = Server.Default().app
+          const res = await app.request(`/session/${session.id}/inbox/send`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ actorID: "test-actor", content: "hello from user" }),
+          })
+          expect(res.status).toBe(200)
+          const body = (await res.json()) as { inboxID: string }
+          expect(body.inboxID).toBeTruthy()
+          expect(typeof body.inboxID).toBe("string")
+        },
+      }),
+    )
+  })
+
+  test("defaults type to 'text' when omitted", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await createSession()
+          await runRegistry(
+            ActorRegistry.Service.use((reg) =>
+              reg.register({
+                sessionID: session.id,
+                actorID: "test-actor",
+                mode: "subagent",
+                agent: "general",
+                description: "test",
+                contextMode: "none",
+                background: true,
+                lifecycle: "ephemeral",
+              }),
+            ),
+          )
+
+          const app = Server.Default().app
+          const res = await app.request(`/session/${session.id}/inbox/send`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ actorID: "test-actor", content: "hello" }),
+          })
+          expect(res.status).toBe(200)
+        },
+      }),
+    )
+  })
+
+  test("returns 400 on empty content", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await createSession()
+          const app = Server.Default().app
+          const res = await app.request(`/session/${session.id}/inbox/send`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ actorID: "test-actor", content: "" }),
+          })
+          expect(res.status).toBe(400)
+        },
+      }),
+    )
+  })
+
+  test("returns 400 on missing actorID", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await createSession()
+          const app = Server.Default().app
+          const res = await app.request(`/session/${session.id}/inbox/send`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ content: "hello" }),
+          })
+          expect(res.status).toBe(400)
+        },
+      }),
+    )
+  })
+
+  test("returns 404 for nonexistent actor", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await createSession()
+          const app = Server.Default().app
+          const res = await app.request(`/session/${session.id}/inbox/send`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ actorID: "nonexistent", content: "hello" }),
+          })
+          expect(res.status).toBe(404)
+        },
+      }),
+    )
+  })
+
+  test("returns 400 on invalid sessionID format", async () => {
+    await withoutWatcher(async () => {
+      const app = Server.Default().app
+      const res = await app.request(`/session/not-valid/inbox/send`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ actorID: "test-actor", content: "hello" }),
+      })
+      expect(res.status).toBe(400)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `POST /:sessionID/inbox/send` server endpoint that wraps `Inbox.send()` for direct subagent messaging
- Add `onCustomSubmit` prop to `Prompt` component allowing custom submit routing (skips model/workspace checks)
- Show input bar when viewing a running, pending, or idle subagent — users can now type directly to subagents without relaying through the main agent

## Motivation
When navigating to a subagent's conversation view in the TUI, the input bar was hidden. All communication had to go through the main agent via `actor send`, adding latency. This PR enables direct messaging by:
1. Exposing the existing `Inbox.send()` infrastructure as an HTTP endpoint
2. Routing the TUI prompt's submit to that endpoint when viewing a subagent

If a sub-agent goes away from the main goal, you can provide small notch to put it back on track. If main agent miss indications, user can provide without let the agent go crazy.

## Changes

### Server (`packages/opencode/src/server/routes/instance/session.ts`)
- New `POST /:sessionID/inbox/send` endpoint accepting `{ actorID, content, type? }` and returning `{ inboxID }`
- Reuses the same `inboxServiceRef.current.send()` that the `actor send` tool uses

### TUI Prompt (`packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`)
- New `onCustomSubmit` prop on `PromptProps`: when provided, the submit function calls it instead of the default `session.prompt` path
- The custom path skips model selection, workspace checks, and slash command handling — just sends the text and clears the input

### TUI Session (`packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`)
- New `subagentInputVisible` memo: returns `true` when viewing a subagent with status `running`, `pending`, or `unknown` (idle-without-outcome)
- Renders a second `<Prompt>` with `onCustomSubmit` that POSTs to the inbox send endpoint
- `SubagentFooter` (navigation + status) remains visible above the input bar

## Testing
1. Spawn a persistent peer via `session create --topic test`
2. Navigate to the child session in the TUI
3. Verify the input bar appears alongside the subagent footer
4. Type a message and submit — verify it arrives in the subagent's inbox and triggers a turn
5. Verify the subagent's response appears in its conversation view
6. Navigate back to main — verify the main agent's input bar works normally
7. Test with ephemeral subagents — verify input is disabled after terminal

## Out of Scope
- Backend Inbox changes (already complete)
- Permission system changes (handled by PR #1700)
- SDK regeneration (using direct fetch instead)