### PR TITLE
fix(tui): add force-switch mode hotkey bypassing the mid-session lock

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -685,6 +685,18 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
     },
     {
+      title: t("tui.command.agent.force.title"),
+      value: "agent.force",
+      keybind: "agent_force",
+      category: "agent",
+      slash: {
+        name: "force-agent",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogAgent force />)
+      },
+    },
+    {
       title: t("tui.command.modalities.title"),
       value: "model.modalities",
       category: "agent",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -2,10 +2,12 @@ import { createMemo } from "solid-js"
 import { useLocal } from "@tui/context/local"
 import { DialogSelect } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
+import { useLanguage } from "@tui/context/language"
 
 export function DialogAgent(props: { force?: boolean }) {
   const local = useLocal()
   const dialog = useDialog()
+  const { t } = useLanguage()
 
   const options = createMemo(() =>
     local.agent.list().map((item) => {
@@ -19,13 +21,11 @@ export function DialogAgent(props: { force?: boolean }) {
 
   return (
     <DialogSelect
-      title={props.force ? "Force switch mode" : "Select agent"}
-      hint={props.force ? "Bypasses the mid-session lock — switch to any available mode" : undefined}
+      title={props.force ? t("tui.dialog.agent.force.title") : "Select agent"}
+      hint={props.force ? t("tui.dialog.agent.force.hint") : undefined}
       current={local.agent.current()?.name}
       options={options()}
       onSelect={(option) => {
-        // force-switch bypasses the mid-session lock so any available primary
-        // agent is reachable; the normal picker respects it.
         if (props.force) local.agent.forceSwitch(option.value)
         else local.agent.userSwitch(option.value)
         dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -3,7 +3,7 @@ import { useLocal } from "@tui/context/local"
 import { DialogSelect } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
 
-export function DialogAgent() {
+export function DialogAgent(props: { force?: boolean }) {
   const local = useLocal()
   const dialog = useDialog()
 
@@ -19,11 +19,15 @@ export function DialogAgent() {
 
   return (
     <DialogSelect
-      title="Select agent"
+      title={props.force ? "Force switch mode" : "Select agent"}
+      hint={props.force ? "Bypasses the mid-session lock — switch to any available mode" : undefined}
       current={local.agent.current()?.name}
       options={options()}
       onSelect={(option) => {
-        local.agent.userSwitch(option.value)
+        // force-switch bypasses the mid-session lock so any available primary
+        // agent is reachable; the normal picker respects it.
+        if (props.force) local.agent.forceSwitch(option.value)
+        else local.agent.userSwitch(option.value)
         dialog.clear()
       }}
     />

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -112,11 +112,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
           this.set(name)
         },
-        // Force-switch bypasses the mid-session `canSwitchTo` lock so any primary
-        // agent (notably Orchestrator, which is never in FREE_SWITCH_GROUP) can be
-        // reached from an in-progress session. Still validates the name via set()
-        // — the orchestrator-entry effect in app.tsx keys off agentStore.current,
-        // so setting it here drives the dir-switch just like a fresh entry.
+        // bypasses the mid-session canSwitchTo lock; set() still validates the name
         forceSwitch(name: string) {
           this.set(name)
         },

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -112,6 +112,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
           this.set(name)
         },
+        // Force-switch bypasses the mid-session `canSwitchTo` lock so any primary
+        // agent (notably Orchestrator, which is never in FREE_SWITCH_GROUP) can be
+        // reached from an in-progress session. Still validates the name via set()
+        // — the orchestrator-entry effect in app.tsx keys off agentStore.current,
+        // so setting it here drives the dir-switch just like a fresh entry.
+        forceSwitch(name: string) {
+          this.set(name)
+        },
         move(direction: 1 | -1) {
           const current = this.current()
           if (!current) return

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -297,6 +297,8 @@ export const dict: Record<string, string> = {
   "tui.command.worktree.list.title": "Worktrees",
   "tui.command.theme.switch.title": "Switch theme",
   "tui.command.image.switch.title": "Switch background image",
+  "tui.dialog.agent.force.title": "Force switch mode",
+  "tui.dialog.agent.force.hint": "Bypasses the mid-session lock — switch to any available mode",
   "tui.dialog.image.title": "Background images",
   "tui.dialog.image.import.option": "Choose new image…",
   "tui.dialog.image.import.title": "Import background image",

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -265,6 +265,7 @@ export const dict: Record<string, string> = {
   "tui.command.model.cycle_favorite.title": "Favorite cycle",
   "tui.command.model.cycle_favorite_reverse.title": "Favorite cycle reverse",
   "tui.command.agent.list.title": "Switch agent",
+  "tui.command.agent.force.title": "Force switch mode (bypass mid-session lock)",
   "tui.command.modalities.title": "Configure input modalities",
   "tui.modalities.title": "Input modalities — {{model}}",
   "tui.modalities.saved": "Input modalities updated: {{modalities}}",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -318,6 +318,8 @@ export const dict = {
   "tui.command.worktree.list.title": "工作树",
   "tui.command.theme.switch.title": "切换主题",
   "tui.command.image.switch.title": "切换背景图片",
+  "tui.dialog.agent.force.title": "强制切换模式",
+  "tui.dialog.agent.force.hint": "绕过会话中锁定 — 可切换到任意可用模式",
   "tui.dialog.image.title": "背景图片",
   "tui.dialog.image.import.option": "选择新图片…",
   "tui.dialog.image.import.title": "导入背景图片",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -286,6 +286,7 @@ export const dict = {
   "tui.command.model.cycle_favorite.title": "循环切换收藏模型",
   "tui.command.model.cycle_favorite_reverse.title": "反向循环切换收藏模型",
   "tui.command.agent.list.title": "切换智能体",
+  "tui.command.agent.force.title": "强制切换模式（绕过会话中锁定）",
   "tui.command.modalities.title": "配置输入模态",
   "tui.modalities.title": "输入模态 — {{model}}",
   "tui.modalities.saved": "输入模态已更新：{{modalities}}",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -286,6 +286,7 @@ export const dict = {
   "tui.command.model.cycle_favorite.title": "循環切換收藏模型",
   "tui.command.model.cycle_favorite_reverse.title": "反向循環切換收藏模型",
   "tui.command.agent.list.title": "切換智慧代理",
+  "tui.command.agent.force.title": "強制切換模式（繞過工作階段中鎖定）",
   "tui.command.modalities.title": "設定輸入模態",
   "tui.modalities.title": "輸入模態 — {{model}}",
   "tui.modalities.saved": "輸入模態已更新：{{modalities}}",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -318,6 +318,8 @@ export const dict = {
   "tui.command.worktree.list.title": "工作樹",
   "tui.command.theme.switch.title": "切換主題",
   "tui.command.image.switch.title": "切換背景圖片",
+  "tui.dialog.agent.force.title": "強制切換模式",
+  "tui.dialog.agent.force.hint": "繞過工作階段中鎖定 — 可切換到任意可用模式",
   "tui.dialog.image.title": "背景圖片",
   "tui.dialog.image.import.option": "選擇新圖片…",
   "tui.dialog.image.import.title": "匯入背景圖片",

--- a/packages/opencode/src/config/keybinds.ts
+++ b/packages/opencode/src/config/keybinds.ts
@@ -60,6 +60,7 @@ const KeybindsSchema = Schema.Struct({
   model_cycle_favorite_reverse: keybind("none", "Previous favorite model"),
   command_list: keybind("ctrl+p", "List available commands"),
   agent_list: keybind("<leader>a", "List agents"),
+  agent_force: keybind("<leader>o", "Force switch mode (bypass mid-session lock)"),
   agent_cycle: keybind("tab", "Next agent"),
   agent_cycle_reverse: keybind("shift+tab", "Previous agent"),
   variant_cycle: keybind("ctrl+t", "Cycle model variants"),

--- a/packages/opencode/test/agent/fixtures/list-agents-probe.ts
+++ b/packages/opencode/test/agent/fixtures/list-agents-probe.ts
@@ -1,0 +1,22 @@
+// Probe helper spawned as a SUBPROCESS by orchestrator.test.ts to observe the
+// orchestrator registration under a specific MIMOCODE_EXPERIMENTAL_ORCHESTRATOR
+// value. It cannot be a normal in-suite test because test/preload.ts force-sets
+// the flag ON for the whole suite (and Flag is read once at import time), so the
+// flag-OFF case is only observable in a fresh process that does NOT load the
+// preload. Prints `NAMES=<json array of agent names>` to stdout.
+import { Effect } from "effect"
+import { provideInstance, tmpdir } from "../../fixture/fixture"
+import { Instance } from "../../../src/project/instance"
+import { Agent } from "../../../src/agent/agent"
+
+function load(dir: string, fn: (svc: Agent.Interface) => Effect.Effect<any>) {
+  return Effect.runPromise(provideInstance(dir)(Agent.Service.use(fn)).pipe(Effect.provide(Agent.defaultLayer)))
+}
+
+const tmp = await tmpdir()
+const names = (await Instance.provide({
+  directory: tmp.path,
+  fn: async () => (await load(tmp.path, (svc) => svc.list())).map((a: any) => a.name),
+})) as string[]
+process.stdout.write("NAMES=" + JSON.stringify(names) + "\n")
+await Instance.disposeAll()

--- a/packages/opencode/test/agent/orchestrator.test.ts
+++ b/packages/opencode/test/agent/orchestrator.test.ts
@@ -2,7 +2,7 @@ import { afterEach, test, expect } from "bun:test"
 import { Effect } from "effect"
 import path from "path"
 import os from "os"
-import { mkdtempSync } from "fs"
+import { mkdtempSync, rmSync } from "fs"
 import { provideInstance } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Agent } from "../../src/agent/agent"
@@ -19,30 +19,34 @@ function load<A>(dir: string, fn: (svc: Agent.Interface) => Effect.Effect<A>) {
 // Returns the list of agent names Agent.list() produced under `flag`.
 function listAgentNames(flag: boolean): string[] {
   const root = mkdtempSync(path.join(os.tmpdir(), "orch-gate-"))
-  const env: Record<string, string> = {
-    ...(process.env as Record<string, string>),
-    XDG_DATA_HOME: path.join(root, "share"),
-    XDG_CACHE_HOME: path.join(root, "cache"),
-    XDG_CONFIG_HOME: path.join(root, "config"),
-    XDG_STATE_HOME: path.join(root, "state"),
-    HOME: path.join(root, "home"),
-    MIMOCODE_DB: ":memory:",
-    MIMOCODE_DISABLE_DEFAULT_PLUGINS: "true",
-    MIMOCODE_TEST_TMPDIR_ROOT: path.join(root, "tmp"),
+  try {
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      XDG_DATA_HOME: path.join(root, "share"),
+      XDG_CACHE_HOME: path.join(root, "cache"),
+      XDG_CONFIG_HOME: path.join(root, "config"),
+      XDG_STATE_HOME: path.join(root, "state"),
+      HOME: path.join(root, "home"),
+      MIMOCODE_DB: ":memory:",
+      MIMOCODE_DISABLE_DEFAULT_PLUGINS: "true",
+      MIMOCODE_TEST_TMPDIR_ROOT: path.join(root, "tmp"),
+    }
+    delete env.MIMOCODE_EXPERIMENTAL
+    delete env.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR
+    if (flag) env.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR = "true"
+    const result = Bun.spawnSync({
+      cmd: [process.execPath, path.join(import.meta.dir, "fixtures", "list-agents-probe.ts")],
+      cwd: process.cwd(),
+      env,
+    })
+    const out = result.stdout.toString() + result.stderr.toString()
+    expect(result.exitCode, `probe failed:\n${out}`).toBe(0)
+    const m = out.match(/NAMES=(\[.*\])/)
+    expect(m, `probe produced no NAMES line:\n${out}`).not.toBeNull()
+    return JSON.parse(m![1]) as string[]
+  } finally {
+    rmSync(root, { recursive: true, force: true })
   }
-  delete env.MIMOCODE_EXPERIMENTAL
-  delete env.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR
-  if (flag) env.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR = "true"
-  const result = Bun.spawnSync({
-    cmd: [process.execPath, path.join(import.meta.dir, "fixtures", "list-agents-probe.ts")],
-    cwd: process.cwd(),
-    env,
-  })
-  const out = result.stdout.toString() + result.stderr.toString()
-  expect(result.exitCode, `probe failed:\n${out}`).toBe(0)
-  const m = out.match(/NAMES=(\[.*\])/)
-  expect(m, `probe produced no NAMES line:\n${out}`).not.toBeNull()
-  return JSON.parse(m![1]) as string[]
 }
 
 afterEach(async () => {

--- a/packages/opencode/test/agent/orchestrator.test.ts
+++ b/packages/opencode/test/agent/orchestrator.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, test, expect } from "bun:test"
 import { Effect } from "effect"
+import path from "path"
+import os from "os"
+import { mkdtempSync } from "fs"
 import { provideInstance } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Agent } from "../../src/agent/agent"
@@ -10,9 +13,55 @@ function load<A>(dir: string, fn: (svc: Agent.Interface) => Effect.Effect<A>) {
   return Effect.runPromise(provideInstance(dir)(Agent.Service.use(fn)).pipe(Effect.provide(Agent.defaultLayer)))
 }
 
+// Spawn the agent-list probe in a FRESH process (no test/preload.ts, which
+// force-sets MIMOCODE_EXPERIMENTAL_ORCHESTRATOR=true for the suite). `Flag` reads
+// the env once at import time, so the flag-OFF path is only observable here.
+// Returns the list of agent names Agent.list() produced under `flag`.
+function listAgentNames(flag: boolean): string[] {
+  const root = mkdtempSync(path.join(os.tmpdir(), "orch-gate-"))
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    XDG_DATA_HOME: path.join(root, "share"),
+    XDG_CACHE_HOME: path.join(root, "cache"),
+    XDG_CONFIG_HOME: path.join(root, "config"),
+    XDG_STATE_HOME: path.join(root, "state"),
+    HOME: path.join(root, "home"),
+    MIMOCODE_DB: ":memory:",
+    MIMOCODE_DISABLE_DEFAULT_PLUGINS: "true",
+    MIMOCODE_TEST_TMPDIR_ROOT: path.join(root, "tmp"),
+  }
+  delete env.MIMOCODE_EXPERIMENTAL
+  delete env.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR
+  if (flag) env.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR = "true"
+  const result = Bun.spawnSync({
+    cmd: [process.execPath, path.join(import.meta.dir, "fixtures", "list-agents-probe.ts")],
+    cwd: process.cwd(),
+    env,
+  })
+  const out = result.stdout.toString() + result.stderr.toString()
+  expect(result.exitCode, `probe failed:\n${out}`).toBe(0)
+  const m = out.match(/NAMES=(\[.*\])/)
+  expect(m, `probe produced no NAMES line:\n${out}`).not.toBeNull()
+  return JSON.parse(m![1]) as string[]
+}
+
 afterEach(async () => {
   await Instance.disposeAll()
 })
+
+test("agent list gating: Orchestrator absent when the flag is OFF, present when ON", () => {
+  // Flag OFF: registration ternary in agent/agent.ts omits orchestrator, so the
+  // TUI picker (agents()) and force-switch dialog (list()) — both fed from
+  // Agent.list() via sync.data.agent — never surface it, and forceSwitch()
+  // validates the name against agents() so it cannot reach it either.
+  const off = listAgentNames(false)
+  expect(off).not.toContain("orchestrator")
+  expect(off).toContain("build")
+  expect(off).toContain("plan")
+  // Flag ON: orchestrator is registered and therefore selectable.
+  const on = listAgentNames(true)
+  expect(on).toContain("orchestrator")
+}, 60000)
 
 test("orchestrator agent is a native, full-capability primary (no tool restriction)", async () => {
   await using tmp = await tmpdir()


### PR DESCRIPTION
## Problem

In the TUI's agent/mode picker (`Select agent`), the mid-session lock restricts switching to `FREE_SWITCH_GROUP = ["build", "plan"]` once a session has messages. There was no way to deliberately switch into any other primary mode mid-session, even when the user knows what they're doing.

## Root cause

- The agent picker `DialogAgent` (`component/dialog-agent.tsx`) selects via `local.agent.userSwitch(name)`.
- `userSwitch` is gated by `canSwitchTo()` in `context/local.tsx`: once `sessionHasMessages` is true, switching is restricted to `FREE_SWITCH_GROUP = ["build", "plan"]`. Any other primary mode hits the lock and shows a "cannot switch mode mid-session" toast.
- The switch mechanism itself is sound: setting `agentStore.current` triggers the mode-entry effect in `app.tsx` (dir-switch + `sync.bootstrap()` for Orchestrator). Only the lock was blocking a deliberate switch.

## Fix

- **`context/local.tsx`**: add `agent.forceSwitch(name)` that bypasses `canSwitchTo` and calls `set()` directly (which still validates the name against the available agents). The mode-entry effect keys off `agentStore.current`, so the switch fires exactly like a fresh entry.
- **`component/dialog-agent.tsx`**: add a `force?` prop — in force mode the picker uses `forceSwitch` and shows a distinct, generic title + hint ("Force switch mode" / "Bypasses the mid-session lock — switch to any available mode"). The normal picker still uses `userSwitch` (lock respected).
- **`app.tsx`**: register an `agent.force` command (slash `/force-agent`) bound to the new keybind, opening `<DialogAgent force />`.
- **`config/keybinds.ts`**: add `agent_force` = `<leader>o` (previously unused), described generically as "Force switch mode (bypass mid-session lock)".
- i18n titles (en / zh / zht) use generic "Force switch mode (bypass mid-session lock)" phrasing — no mode is singled out.

This is a **generic force-switch**: it bypasses the mid-session lock to switch to any *available* mode. It does not special-case or name any particular mode.

## Orchestrator visibility is flag-gated (unchanged)

Orchestrator is one of several modes and is registered behind `Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR` in `agent/agent.ts`. When the flag is **OFF**, orchestrator is not added to the agent set → absent from `Agent.list()` → absent from `sync.data.agent` → therefore absent from the picker, the Tab-cycle, and the new force-switch (which validates against the available agents). When the flag is **ON**, it appears and is selectable. Force-switch does not expose it when the flag is off.

## Verify

- `bun typecheck` → 12/12 successful (EXIT 0).
- `bun test test/agent/orchestrator.test.ts test/agent/agent.test.ts test/keybind.test.ts` → all pass.
- Added a subprocess-based regression test (`test/agent/orchestrator.test.ts` + `test/agent/fixtures/list-agents-probe.ts`): Orchestrator is **absent** from `Agent.list()` when `MIMOCODE_EXPERIMENTAL_ORCHESTRATOR` is OFF and **present** when ON. (A subprocess is required because `test/preload.ts` force-enables the flag for the suite and `Flag` is read once at import.)
- Live TUI: in a session with messages, `<leader>o` (or `/force-agent`) opens the force picker and switches to the selected available mode; normal Tab-cycle and `<leader>a` picker remain locked to build/plan mid-session as before.