### PR TITLE
feat(tui): enforce MiMo free API sunset

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -66,7 +66,7 @@ function createGlobalSync() {
     path: { state: "", config: "", worktree: "", directory: "", home: "" },
     project: projectCache.value,
     session_todo: {},
-    provider: { all: [], connected: [], default: {} },
+    provider: { all: [], connected: [], authenticated: [], default: {} },
     provider_auth: {},
     config: {},
     reload: undefined,

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -165,7 +165,7 @@ export function createChildStoreManager(input: {
             projectMeta: initialMeta,
             icon: initialIcon,
             provider_ready: false,
-            provider: { all: [], connected: [], default: {} },
+            provider: { all: [], connected: [], authenticated: [], default: {} },
             config: {},
             get path() {
               if (pathQuery.isLoading || !pathQuery.data)

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -12,7 +12,6 @@ import { useSDK } from "../context/sdk"
 import { useToast, type ToastContext } from "../ui/toast"
 import { DialogPrompt } from "../ui/dialog-prompt"
 import { useLanguage } from "@tui/context/language"
-import * as Model from "../util/model"
 import { PROVIDER_PRIORITY } from "@/util/provider-priority"
 import * as fuzzysort from "fuzzysort"
 
@@ -37,8 +36,6 @@ export function DialogModel(props: { providerID?: string }) {
   const connected = useConnected()
   const providers = createDialogProviderOptions()
   const t = useLanguage().t
-  const modelName = (providerID: string, modelID: string) =>
-    modelID === "mimo-auto" ? t("tui.model.mimo_auto.name") : Model.name(sync.data.provider, providerID, modelID)
 
   const showExtra = createMemo(() => connected() && !props.providerID)
 
@@ -64,7 +61,7 @@ export function DialogModel(props: { providerID?: string }) {
           {
             key: item,
             value: { providerID: provider.id, modelID: model.id },
-            title: modelName(provider.id, model.id),
+            title: local.model.name(provider.id, model.id),
             // Hide provider name for mimo-auto to avoid redundancy
             description: item.modelID === "mimo-auto" ? undefined : provider.name,
             category,
@@ -100,7 +97,7 @@ export function DialogModel(props: { providerID?: string }) {
             ? [
                 {
                   value: { providerID: "mimo", modelID: "mimo-auto" },
-                  title: modelName("mimo", "mimo-auto"),
+                  title: local.model.name("mimo", "mimo-auto"),
                   description: undefined as string | undefined,
                   category: pinnedCategory,
                   disabled: false,

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -12,8 +12,10 @@ import { useSDK } from "../context/sdk"
 import { useToast, type ToastContext } from "../ui/toast"
 import { DialogPrompt } from "../ui/dialog-prompt"
 import { useLanguage } from "@tui/context/language"
+import * as Model from "../util/model"
 import { PROVIDER_PRIORITY } from "@/util/provider-priority"
 import * as fuzzysort from "fuzzysort"
+import { createFreeApiSunsetSignal, freeApiModelNameKey, isFreeApiModel } from "@tui/util/free-api-sunset"
 
 const ADD_MODEL_SENTINEL = "__add_model__"
 
@@ -36,6 +38,11 @@ export function DialogModel(props: { providerID?: string }) {
   const connected = useConnected()
   const providers = createDialogProviderOptions()
   const t = useLanguage().t
+  const freeApiSunset = createFreeApiSunsetSignal()
+  const modelName = (providerID: string, modelID: string) =>
+    isFreeApiModel({ providerID, modelID })
+      ? t(freeApiModelNameKey(freeApiSunset()))
+      : Model.name(sync.data.provider, providerID, modelID)
 
   const showExtra = createMemo(() => connected() && !props.providerID)
 
@@ -61,7 +68,7 @@ export function DialogModel(props: { providerID?: string }) {
           {
             key: item,
             value: { providerID: provider.id, modelID: model.id },
-            title: local.model.name(provider.id, model.id),
+            title: modelName(provider.id, model.id),
             // Hide provider name for mimo-auto to avoid redundancy
             description: item.modelID === "mimo-auto" ? undefined : provider.name,
             category,
@@ -97,7 +104,7 @@ export function DialogModel(props: { providerID?: string }) {
             ? [
                 {
                   value: { providerID: "mimo", modelID: "mimo-auto" },
-                  title: local.model.name("mimo", "mimo-auto"),
+                  title: modelName("mimo", "mimo-auto"),
                   description: undefined as string | undefined,
                   category: pinnedCategory,
                   disabled: false,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -48,6 +48,11 @@ import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { DialogAgreement, FREE_AGREEMENT_KEY, FREE_MODEL_IDS } from "../dialog-agreement"
 import { useArgs } from "@tui/context/args"
 import { resolveSkillSlash } from "@tui/i18n/skill"
+import {
+  classifyPromptSubmission,
+  isModelBackedPromptSubmission,
+  shouldBlockFreeApiRequest,
+} from "@tui/util/free-api-sunset"
 
 export type PromptProps = {
   sessionID?: string
@@ -1005,6 +1010,30 @@ export function Prompt(props: PromptProps) {
   // deferred onSubmit). This lock prevents the deferred call from re-entering
   // while a dialog or async session-creation is in progress.
   let submitLock = false
+
+  function finishSubmission(mode: "normal" | "shell", sessionID?: string) {
+    history.append({
+      ...store.prompt,
+      mode,
+    })
+    input.extmarks.clear()
+    setStore("prompt", {
+      input: "",
+      parts: [],
+    })
+    setStore("extmarkToPartIndex", new Map())
+    props.onSubmit?.()
+
+    if (!props.sessionID && sessionID)
+      setTimeout(() => {
+        route.navigate({
+          type: "session",
+          sessionID,
+        })
+      }, 50)
+    input.clear()
+  }
+
   async function submit() {
     if (submitLock) return false
     setGhost("")
@@ -1018,23 +1047,57 @@ export function Prompt(props: PromptProps) {
     if (props.disabled) return false
     if (autocomplete?.visible) return false
     if (!store.prompt.input) return false
-    const agent = local.agent.current()
-    if (!agent) return false
     const trimmed = store.prompt.input.trim()
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
       void exit()
       return true
     }
+
+    // Classify without creating a session or touching prompt state. Local
+    // commands must remain available even when the selected model cannot send.
+    const marks = input.extmarks
+      .getAllForTypeId(promptPartTypeId)
+      .flatMap((extmark: { id: number; start: number; end: number }) => {
+        const partIndex = store.extmarkToPartIndex.get(extmark.id)
+        if (partIndex === undefined) return []
+        const part = store.prompt.parts[partIndex]
+        if (part?.type !== "text" || !part.text) return []
+        return [{ start: extmark.start, end: extmark.end, text: part.text }]
+      })
+    const inputText = expandPlaceholders(store.prompt.input, marks)
+    const clientSlash = inputText.startsWith("/")
+      ? command.slashes().find((slash) => slash.display === inputText.trim())
+      : undefined
+    const request = classifyPromptSubmission({
+      input: inputText,
+      mode: store.mode,
+      clientSlash: !!clientSlash,
+    })
+    const currentMode = store.mode
+
+    if (request === "client-slash") {
+      clientSlash?.onSelect?.()
+      finishSubmission(currentMode)
+      return true
+    }
+
+    const agent = local.agent.current()
+    if (!agent) return false
     const selectedModel = local.model.current()
     if (!selectedModel) {
       void promptModelWarning()
       return false
     }
 
+    if (shouldBlockFreeApiRequest(selectedModel, { request })) {
+      void DialogAlert.show(dialog, t("tui.dialog.free_api_sunset.title"), t("tui.dialog.free_api_sunset.message"))
+      return false
+    }
+
     // Free models require a one-time acknowledgment of the terms and privacy
     // policy. Gate submission until the user accepts; the flag is stored in KV.
     const isFreeModel = FREE_MODEL_IDS.has(selectedModel.modelID)
-    if (isFreeModel && !kv.get(FREE_AGREEMENT_KEY)) {
+    if (isModelBackedPromptSubmission(request) && isFreeModel && !kv.get(FREE_AGREEMENT_KEY)) {
       submitLock = true
       DialogAgreement.show(dialog, {
         onConfirm: () => {
@@ -1116,30 +1179,11 @@ export function Prompt(props: PromptProps) {
 
     const messageID = MessageID.ascending()
 
-    // Expand pasted text inline before submitting. Extmark offsets are
-    // display-width based while plainText is UTF-16, so expandPlaceholders
-    // bridges the two coordinate systems (otherwise CJK content desyncs them).
-    const marks = input.extmarks
-      .getAllForTypeId(promptPartTypeId)
-      .flatMap((extmark: { id: number; start: number; end: number }) => {
-        const partIndex = store.extmarkToPartIndex.get(extmark.id)
-        if (partIndex === undefined) return []
-        const part = store.prompt.parts[partIndex]
-        if (part?.type !== "text" || !part.text) return []
-        return [{ start: extmark.start, end: extmark.end, text: part.text }]
-      })
-    const inputText = expandPlaceholders(store.prompt.input, marks)
-
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
 
-    // Capture mode before it gets reset
-    const currentMode = store.mode
     const variant = local.model.variant.current()
 
-    const clientSlash = inputText.startsWith("/")
-      ? command.slashes().find((s) => s.display === inputText.trim())
-      : undefined
     const serverSlash = inputText.startsWith("/")
       ? iife(() => {
           const name = inputText.split("\n")[0].split(" ")[0].slice(1)
@@ -1238,27 +1282,7 @@ export function Prompt(props: PromptProps) {
           })
         })
     }
-    history.append({
-      ...store.prompt,
-      mode: currentMode,
-    })
-    input.extmarks.clear()
-    setStore("prompt", {
-      input: "",
-      parts: [],
-    })
-    setStore("extmarkToPartIndex", new Map())
-    props.onSubmit?.()
-
-    // temporary hack to make sure the message is sent
-    if (!props.sessionID)
-      setTimeout(() => {
-        route.navigate({
-          type: "session",
-          sessionID,
-        })
-      }, 50)
-    input.clear()
+    finishSubmission(currentMode, sessionID)
     return true
 
     } finally {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -49,8 +49,8 @@ import { DialogAgreement, FREE_AGREEMENT_KEY, FREE_MODEL_IDS } from "../dialog-a
 import { useArgs } from "@tui/context/args"
 import { resolveSkillSlash } from "@tui/i18n/skill"
 import {
-  classifyPromptSubmission,
-  isModelBackedPromptSubmission,
+  isFreeApiModel,
+  isFreeApiSunset,
   shouldBlockFreeApiRequest,
 } from "@tui/util/free-api-sunset"
 
@@ -1010,30 +1010,6 @@ export function Prompt(props: PromptProps) {
   // deferred onSubmit). This lock prevents the deferred call from re-entering
   // while a dialog or async session-creation is in progress.
   let submitLock = false
-
-  function finishSubmission(mode: "normal" | "shell", sessionID?: string) {
-    history.append({
-      ...store.prompt,
-      mode,
-    })
-    input.extmarks.clear()
-    setStore("prompt", {
-      input: "",
-      parts: [],
-    })
-    setStore("extmarkToPartIndex", new Map())
-    props.onSubmit?.()
-
-    if (!props.sessionID && sessionID)
-      setTimeout(() => {
-        route.navigate({
-          type: "session",
-          sessionID,
-        })
-      }, 50)
-    input.clear()
-  }
-
   async function submit() {
     if (submitLock) return false
     setGhost("")
@@ -1047,57 +1023,47 @@ export function Prompt(props: PromptProps) {
     if (props.disabled) return false
     if (autocomplete?.visible) return false
     if (!store.prompt.input) return false
+    const agent = local.agent.current()
+    if (!agent) return false
     const trimmed = store.prompt.input.trim()
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
       void exit()
       return true
     }
-
-    // Classify without creating a session or touching prompt state. Local
-    // commands must remain available even when the selected model cannot send.
-    const marks = input.extmarks
-      .getAllForTypeId(promptPartTypeId)
-      .flatMap((extmark: { id: number; start: number; end: number }) => {
-        const partIndex = store.extmarkToPartIndex.get(extmark.id)
-        if (partIndex === undefined) return []
-        const part = store.prompt.parts[partIndex]
-        if (part?.type !== "text" || !part.text) return []
-        return [{ start: extmark.start, end: extmark.end, text: part.text }]
-      })
-    const inputText = expandPlaceholders(store.prompt.input, marks)
-    const clientSlash = inputText.startsWith("/")
-      ? command.slashes().find((slash) => slash.display === inputText.trim())
-      : undefined
-    const request = classifyPromptSubmission({
-      input: inputText,
-      mode: store.mode,
-      clientSlash: !!clientSlash,
-    })
-    const currentMode = store.mode
-
-    if (request === "client-slash") {
-      clientSlash?.onSelect?.()
-      finishSubmission(currentMode)
-      return true
-    }
-
-    const agent = local.agent.current()
-    if (!agent) return false
     const selectedModel = local.model.current()
     if (!selectedModel) {
       void promptModelWarning()
       return false
     }
 
-    if (shouldBlockFreeApiRequest(selectedModel, { request })) {
-      void DialogAlert.show(dialog, t("tui.dialog.free_api_sunset.title"), t("tui.dialog.free_api_sunset.message"))
+    const clientSlashSubmission =
+      store.mode !== "shell" && trimmed.startsWith("/") && command.slashes().some((slash) => slash.display === trimmed)
+    const modelClientSlash = ["/btw", "/compact", "/summarize"].includes(trimmed)
+    const freeApiSunset = isFreeApiSunset()
+    const sunsetFreeApi = freeApiSunset && isFreeApiModel(selectedModel)
+    if (
+      shouldBlockFreeApiRequest(selectedModel, {
+        sunset: freeApiSunset,
+        localOnly: clientSlashSubmission && !modelClientSlash,
+        shell: store.mode === "shell",
+      })
+    ) {
+      void DialogAlert.show(
+        dialog,
+        t("tui.dialog.free_api_sunset.title"),
+        t("tui.dialog.free_api_sunset.message"),
+      )
       return false
     }
 
     // Free models require a one-time acknowledgment of the terms and privacy
     // policy. Gate submission until the user accepts; the flag is stored in KV.
     const isFreeModel = FREE_MODEL_IDS.has(selectedModel.modelID)
-    if (isModelBackedPromptSubmission(request) && isFreeModel && !kv.get(FREE_AGREEMENT_KEY)) {
+    if (
+      isFreeModel &&
+      !kv.get(FREE_AGREEMENT_KEY) &&
+      !(sunsetFreeApi && ((clientSlashSubmission && !modelClientSlash) || store.mode === "shell"))
+    ) {
       submitLock = true
       DialogAgreement.show(dialog, {
         onConfirm: () => {
@@ -1179,11 +1145,30 @@ export function Prompt(props: PromptProps) {
 
     const messageID = MessageID.ascending()
 
+    // Expand pasted text inline before submitting. Extmark offsets are
+    // display-width based while plainText is UTF-16, so expandPlaceholders
+    // bridges the two coordinate systems (otherwise CJK content desyncs them).
+    const marks = input.extmarks
+      .getAllForTypeId(promptPartTypeId)
+      .flatMap((extmark: { id: number; start: number; end: number }) => {
+        const partIndex = store.extmarkToPartIndex.get(extmark.id)
+        if (partIndex === undefined) return []
+        const part = store.prompt.parts[partIndex]
+        if (part?.type !== "text" || !part.text) return []
+        return [{ start: extmark.start, end: extmark.end, text: part.text }]
+      })
+    const inputText = expandPlaceholders(store.prompt.input, marks)
+
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
 
+    // Capture mode before it gets reset
+    const currentMode = store.mode
     const variant = local.model.variant.current()
 
+    const clientSlash = inputText.startsWith("/")
+      ? command.slashes().find((s) => s.display === inputText.trim())
+      : undefined
     const serverSlash = inputText.startsWith("/")
       ? iife(() => {
           const name = inputText.split("\n")[0].split(" ")[0].slice(1)
@@ -1217,7 +1202,12 @@ export function Prompt(props: PromptProps) {
           question,
           (active) =>
             sdk.client.session
-              .ask({ sessionID, question })
+              .ask({
+                sessionID,
+                question,
+                providerID: selectedModel.providerID,
+                modelID: selectedModel.modelID,
+              })
               .then((res) => {
                 if (!active()) return
                 return DialogAlert.show(dialog, "/btw", res.data?.answer ?? "(no answer)")
@@ -1282,7 +1272,27 @@ export function Prompt(props: PromptProps) {
           })
         })
     }
-    finishSubmission(currentMode, sessionID)
+    history.append({
+      ...store.prompt,
+      mode: currentMode,
+    })
+    input.extmarks.clear()
+    setStore("prompt", {
+      input: "",
+      parts: [],
+    })
+    setStore("extmarkToPartIndex", new Map())
+    props.onSubmit?.()
+
+    // temporary hack to make sure the message is sent
+    if (!props.sessionID)
+      setTimeout(() => {
+        route.navigate({
+          type: "session",
+          sessionID,
+        })
+      }, 50)
+    input.clear()
     return true
 
     } finally {

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -14,6 +14,7 @@ import { RGBA } from "@opentui/core"
 import { Filesystem } from "@/util"
 import * as Model from "../util/model"
 import { useLanguage } from "@tui/context/language"
+import { createFreeApiSunsetSignal, freeApiModelNameKey } from "@tui/util/free-api-sunset"
 
 export function parseModel(model: string) {
   const [providerID, ...rest] = model.split("/")
@@ -30,6 +31,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sdk = useSDK()
     const toast = useToast()
     const t = useLanguage().t
+    const freeApiSunset = createFreeApiSunsetSignal()
 
     function isModelValid(model: { providerID: string; modelID: string }) {
       const provider = sync.data.provider.find((x) => x.id === model.providerID)
@@ -262,8 +264,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         )
       })
 
+      function modelName(providerID: string, modelID: string) {
+        if (modelID === "mimo-auto") return t(freeApiModelNameKey(freeApiSunset()))
+        return Model.name(sync.data.provider, providerID, modelID)
+      }
+
       return {
         current: currentModel,
+        name: modelName,
         get ready() {
           return modelStore.ready
         },
@@ -286,10 +294,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const info = provider?.models[value.modelID]
           return {
             provider: provider?.name || value.providerID,
-            model:
-              value.modelID === "mimo-auto"
-                ? t("tui.model.mimo_auto.name")
-                : Model.name(sync.data.provider, value.providerID, value.modelID),
+            model: modelName(value.providerID, value.modelID),
             reasoning: info?.capabilities?.reasoning ?? false,
           }
         }),

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -14,7 +14,7 @@ import { RGBA } from "@opentui/core"
 import { Filesystem } from "@/util"
 import * as Model from "../util/model"
 import { useLanguage } from "@tui/context/language"
-import { createFreeApiSunsetSignal, freeApiModelNameKey } from "@tui/util/free-api-sunset"
+import { createFreeApiSunsetSignal, freeApiModelNameKey, isFreeApiModel } from "@tui/util/free-api-sunset"
 
 export function parseModel(model: string) {
   const [providerID, ...rest] = model.split("/")
@@ -264,14 +264,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         )
       })
 
-      function modelName(providerID: string, modelID: string) {
-        if (modelID === "mimo-auto") return t(freeApiModelNameKey(freeApiSunset()))
-        return Model.name(sync.data.provider, providerID, modelID)
-      }
-
       return {
         current: currentModel,
-        name: modelName,
         get ready() {
           return modelStore.ready
         },
@@ -294,7 +288,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const info = provider?.models[value.modelID]
           return {
             provider: provider?.name || value.providerID,
-            model: modelName(value.providerID, value.modelID),
+            model:
+              isFreeApiModel(value)
+                ? t(freeApiModelNameKey(freeApiSunset()))
+                : Model.name(sync.data.provider, value.providerID, value.modelID),
             reasoning: info?.capabilities?.reasoning ?? false,
           }
         }),

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -228,6 +228,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         all: [],
         default: {},
         connected: [],
+        authenticated: [],
       },
       console_state: emptyConsoleState,
       provider_auth: {},

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -1,8 +1,10 @@
-import { createMemo, createSignal, For, onCleanup } from "solid-js"
+import { createEffect, createMemo, createSignal, For, onCleanup } from "solid-js"
 import { DEFAULT_THEMES, useTheme } from "@tui/context/theme"
 import { useLanguage } from "@tui/context/language"
 import { useLocal } from "@tui/context/local"
+import { useSync } from "@tui/context/sync"
 import { Flag } from "@/flag/flag"
+import { createFreeApiSunsetSignal } from "@tui/util/free-api-sunset"
 
 const themeCount = Object.keys(DEFAULT_THEMES).length
 const TIP_ROTATION_MS = 10_000
@@ -12,6 +14,7 @@ const COMPOSE_LOCK_TIP = "tui.tips.compose_next"
 // Promote recently-added or critical features so users discover them.
 // Tips not listed here use the default weight of 1.
 const PRIORITY_WEIGHTS: Record<string, number> = {
+  "tui.tips.free_api_sunset": 100,
   "tui.tips.multi_skills": 60,
   "tui.tips.free_models": 50,
   "tui.tips.background": 50,
@@ -131,10 +134,21 @@ const TIP_KEYS = [
 // only when the experiment is enabled; otherwise use the variant without it so
 // we never point users at an agent that isn't reachable. The platform-specific
 // suspend tip is always appended last.
-export function buildTipKeys(orchestratorEnabled: boolean, platform: NodeJS.Platform): readonly string[] {
-  const tabAgentKey = orchestratorEnabled ? "tui.tips.tab_agent_orchestrator" : "tui.tips.tab_agent"
-  const suspendKey = platform === "win32" ? "tui.tips.suspend.win" : "tui.tips.suspend.unix"
-  return [...TIP_KEYS, tabAgentKey, suspendKey]
+export function buildTipKeys(options: {
+  orchestratorEnabled: boolean
+  platform: NodeJS.Platform
+  sunset: boolean
+  xiaomiConnected: boolean
+}): readonly string[] {
+  const tabAgentKey = options.orchestratorEnabled ? "tui.tips.tab_agent_orchestrator" : "tui.tips.tab_agent"
+  const suspendKey = options.platform === "win32" ? "tui.tips.suspend.win" : "tui.tips.suspend.unix"
+  const keys = options.sunset ? TIP_KEYS.filter((key) => key !== "tui.tips.free_models") : TIP_KEYS
+  return [
+    ...keys,
+    ...(options.sunset && !options.xiaomiConnected ? ["tui.tips.free_api_sunset"] : []),
+    tabAgentKey,
+    suspendKey,
+  ]
 }
 
 type TipPart = { text: string; highlight: boolean }
@@ -178,9 +192,22 @@ export function Tips() {
   const theme = useTheme().theme
   const lang = useLanguage()
   const local = useLocal()
-  const allKeys = buildTipKeys(Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR, process.platform)
-  const [key, setKey] = createSignal(pickWeighted(allKeys))
-  const interval = setInterval(() => setKey(pickWeighted(allKeys)), TIP_ROTATION_MS)
+  const sync = useSync()
+  const sunset = createFreeApiSunsetSignal()
+  const allKeys = createMemo(() =>
+    buildTipKeys({
+      orchestratorEnabled: Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR,
+      platform: process.platform,
+      sunset: sunset(),
+      xiaomiConnected: sync.data.provider_next.connected.includes("xiaomi"),
+    }),
+  )
+  const [key, setKey] = createSignal(pickWeighted(allKeys()))
+  createEffect(() => {
+    const keys = allKeys()
+    if (!keys.includes(key())) setKey(pickWeighted(keys))
+  })
+  const interval = setInterval(() => setKey(pickWeighted(allKeys())), TIP_ROTATION_MS)
   onCleanup(() => clearInterval(interval))
   // Display override: while the current agent is Compose, show the compose-next
   // deprecation tip in place of whatever the rotation currently holds. The

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -14,9 +14,9 @@ const COMPOSE_LOCK_TIP = "tui.tips.compose_next"
 // Promote recently-added or critical features so users discover them.
 // Tips not listed here use the default weight of 1.
 const PRIORITY_WEIGHTS: Record<string, number> = {
-  "tui.tips.free_api_sunset": 100,
   "tui.tips.multi_skills": 60,
   "tui.tips.free_models": 50,
+  "tui.tips.free_api_sunset": 50,
   "tui.tips.background": 50,
   "tui.tips.login": 40,
   "tui.tips.theme_mode": 40,
@@ -134,18 +134,17 @@ const TIP_KEYS = [
 // only when the experiment is enabled; otherwise use the variant without it so
 // we never point users at an agent that isn't reachable. The platform-specific
 // suspend tip is always appended last.
-export function buildTipKeys(options: {
-  orchestratorEnabled: boolean
-  platform: NodeJS.Platform
-  sunset: boolean
-  xiaomiConnected: boolean
-}): readonly string[] {
-  const tabAgentKey = options.orchestratorEnabled ? "tui.tips.tab_agent_orchestrator" : "tui.tips.tab_agent"
-  const suspendKey = options.platform === "win32" ? "tui.tips.suspend.win" : "tui.tips.suspend.unix"
-  const keys = options.sunset ? TIP_KEYS.filter((key) => key !== "tui.tips.free_models") : TIP_KEYS
+export function buildTipKeys(
+  orchestratorEnabled: boolean,
+  platform: NodeJS.Platform,
+  freeApiSunset = false,
+  xiaomiAuthenticated = false,
+): readonly string[] {
+  const tabAgentKey = orchestratorEnabled ? "tui.tips.tab_agent_orchestrator" : "tui.tips.tab_agent"
+  const suspendKey = platform === "win32" ? "tui.tips.suspend.win" : "tui.tips.suspend.unix"
   return [
-    ...keys,
-    ...(options.sunset && !options.xiaomiConnected ? ["tui.tips.free_api_sunset"] : []),
+    ...TIP_KEYS.filter((key) => !freeApiSunset || key !== "tui.tips.free_models"),
+    ...(freeApiSunset && !xiaomiAuthenticated ? ["tui.tips.free_api_sunset"] : []),
     tabAgentKey,
     suspendKey,
   ]
@@ -193,19 +192,19 @@ export function Tips() {
   const lang = useLanguage()
   const local = useLocal()
   const sync = useSync()
-  const sunset = createFreeApiSunsetSignal()
+  const freeApiSunset = createFreeApiSunsetSignal()
   const allKeys = createMemo(() =>
-    buildTipKeys({
-      orchestratorEnabled: Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR,
-      platform: process.platform,
-      sunset: sunset(),
-      xiaomiConnected: sync.data.provider_next.connected.includes("xiaomi"),
-    }),
+    buildTipKeys(
+      Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR,
+      process.platform,
+      freeApiSunset(),
+      sync.data.provider_next.authenticated.includes("xiaomi"),
+    ),
   )
   const [key, setKey] = createSignal(pickWeighted(allKeys()))
   createEffect(() => {
-    const keys = allKeys()
-    if (!keys.includes(key())) setKey(pickWeighted(keys))
+    if (allKeys().includes(key())) return
+    setKey(pickWeighted(allKeys()))
   })
   const interval = setInterval(() => setKey(pickWeighted(allKeys())), TIP_ROTATION_MS)
   onCleanup(() => clearInterval(interval))

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -324,6 +324,7 @@ export const dict: Record<string, string> = {
   "tui.dialog.select.placeholder": "Search",
   "tui.dialog.model.login_hint": "Tip: run /login to sign in before switching models",
   "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, limited-time free)",
+  "tui.model.mimo_auto.sunset_name": "MiMo Auto (MiMo-V2.5)",
   "tui.dialog.token_plan.title": "Subscribe to a Token Plan or wait in queue",
   "tui.dialog.token_plan.line1": "In free mode, requests are currently queued. For stable, high-quality service,",
   "tui.dialog.token_plan.subscribe": "subscribe to ",

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -319,6 +319,8 @@ export const dict: Record<string, string> = {
   "tui.dialog.agreement.title": "Terms & Privacy",
   "tui.dialog.agreement.message": "Please review and agree to continue.",
   "tui.dialog.agreement.confirm": "Agree & Continue",
+  "tui.dialog.free_api_sunset.title": "MiMoCode free API is no longer available",
+  "tui.dialog.free_api_sunset.message": "Run /login to sign in, or configure a third-party API before using MiMoCode again.",
   "tui.command.consent.revoke.title": "Revoke free-model agreement",
   "tui.consent.revoked": "Free-model agreement revoked — you'll be asked to agree again",
   "tui.dialog.select.placeholder": "Search",

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -53,6 +53,8 @@ export const dict: Record<string, string> = {
     "Run {highlight}/dark{/highlight} for dark mode or {highlight}/light{/highlight} for light mode",
   "tui.tips.doc": "Run {highlight}/doc{/highlight} to open the user documentation",
   "tui.tips.free_models": "Free models are available for a limited time — try them now!",
+  "tui.tips.free_api_sunset":
+    "The free MiMoCode API is no longer available. Run {highlight}/login{/highlight}, or configure a third-party API to continue using MiMoCode.",
   "tui.tips.multi_skills":
     "Combine multiple {highlight}/skill-name{/highlight} triggers in a single message to use several skills together",
   "tui.tips.background":

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -54,7 +54,7 @@ export const dict: Record<string, string> = {
   "tui.tips.doc": "Run {highlight}/doc{/highlight} to open the user documentation",
   "tui.tips.free_models": "Free models are available for a limited time — try them now!",
   "tui.tips.free_api_sunset":
-    "The free MiMoCode API is no longer available. Run {highlight}/login{/highlight}, or configure a third-party API to continue using MiMoCode.",
+    "The free API service has ended. Run {highlight}/login{/highlight} to sign in. Subscribe to the MiMo Token Plan or configure a third-party API to use MiMo Code.",
   "tui.tips.multi_skills":
     "Combine multiple {highlight}/skill-name{/highlight} triggers in a single message to use several skills together",
   "tui.tips.background":
@@ -321,13 +321,14 @@ export const dict: Record<string, string> = {
   "tui.dialog.agreement.title": "Terms & Privacy",
   "tui.dialog.agreement.message": "Please review and agree to continue.",
   "tui.dialog.agreement.confirm": "Agree & Continue",
-  "tui.dialog.free_api_sunset.title": "MiMoCode free API is no longer available",
-  "tui.dialog.free_api_sunset.message": "Run /login to sign in, or configure a third-party API before using MiMoCode again.",
+  "tui.dialog.free_api_sunset.title": "Free API service ended",
+  "tui.dialog.free_api_sunset.message":
+    "Run /login to sign in. Subscribe to the MiMo Token Plan or configure a third-party API to use MiMo Code.",
   "tui.command.consent.revoke.title": "Revoke free-model agreement",
   "tui.consent.revoked": "Free-model agreement revoked — you'll be asked to agree again",
   "tui.dialog.select.placeholder": "Search",
   "tui.dialog.model.login_hint": "Tip: run /login to sign in before switching models",
-  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, limited-time free)",
+  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5 free until Jul 26, 18:00 · UTC+8)",
   "tui.model.mimo_auto.sunset_name": "MiMo Auto (MiMo-V2.5)",
   "tui.dialog.token_plan.title": "Subscribe to a Token Plan or wait in queue",
   "tui.dialog.token_plan.line1": "In free mode, requests are currently queued. For stable, high-quality service,",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -389,6 +389,7 @@ export const dict = {
   "tui.dialog.select.placeholder": "Buscar",
   "tui.dialog.model.login_hint": "Consejo: ejecuta /login para iniciar sesión antes de cambiar de modelo",
   "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, gratis por tiempo limitado)",
+  "tui.model.mimo_auto.sunset_name": "MiMo Auto (MiMo-V2.5)",
   "tui.dialog.token_plan.title": "Suscríbete a un Token Plan o espera en la cola",
   "tui.dialog.token_plan.line1":
     "En el modo gratuito, las solicitudes están en cola. Para un servicio estable y de calidad,",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -384,6 +384,8 @@ export const dict = {
   "tui.dialog.agreement.title": "Términos y privacidad",
   "tui.dialog.agreement.message": "Revísalos y acepta para continuar.",
   "tui.dialog.agreement.confirm": "Aceptar y continuar",
+  "tui.dialog.free_api_sunset.title": "La API gratuita de MiMoCode ya no está disponible",
+  "tui.dialog.free_api_sunset.message": "Ejecuta /login para iniciar sesión o configura una API de terceros antes de volver a usar MiMoCode.",
   "tui.command.consent.revoke.title": "Revocar el acuerdo de modelo gratuito",
   "tui.consent.revoked": "Acuerdo de modelo gratuito revocado: se te pedirá aceptarlo de nuevo",
   "tui.dialog.select.placeholder": "Buscar",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -59,6 +59,8 @@ export const dict = {
     "Ejecuta {highlight}/dark{/highlight} para el modo oscuro o {highlight}/light{/highlight} para el modo claro",
   "tui.tips.doc": "Ejecuta {highlight}/doc{/highlight} para abrir la documentación de usuario",
   "tui.tips.free_models": "Modelos gratuitos disponibles por tiempo limitado — ¡pruébalos ahora!",
+  "tui.tips.free_api_sunset":
+    "La API gratuita de MiMoCode ya no está disponible. Ejecuta {highlight}/login{/highlight} o configura una API de terceros para seguir usando MiMoCode.",
   "tui.tips.multi_skills":
     "Combina varios {highlight}/skill-name{/highlight} en un mismo mensaje para usar varias Skills a la vez",
   "tui.tips.background":

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -60,7 +60,7 @@ export const dict = {
   "tui.tips.doc": "Ejecuta {highlight}/doc{/highlight} para abrir la documentación de usuario",
   "tui.tips.free_models": "Modelos gratuitos disponibles por tiempo limitado — ¡pruébalos ahora!",
   "tui.tips.free_api_sunset":
-    "La API gratuita de MiMoCode ya no está disponible. Ejecuta {highlight}/login{/highlight} o configura una API de terceros para seguir usando MiMoCode.",
+    "El servicio de API gratuita ha finalizado. Ejecuta {highlight}/login{/highlight} para iniciar sesión. Suscríbete a MiMo Token Plan o configura una API de terceros para usar MiMo Code.",
   "tui.tips.multi_skills":
     "Combina varios {highlight}/skill-name{/highlight} en un mismo mensaje para usar varias Skills a la vez",
   "tui.tips.background":
@@ -386,13 +386,14 @@ export const dict = {
   "tui.dialog.agreement.title": "Términos y privacidad",
   "tui.dialog.agreement.message": "Revísalos y acepta para continuar.",
   "tui.dialog.agreement.confirm": "Aceptar y continuar",
-  "tui.dialog.free_api_sunset.title": "La API gratuita de MiMoCode ya no está disponible",
-  "tui.dialog.free_api_sunset.message": "Ejecuta /login para iniciar sesión o configura una API de terceros antes de volver a usar MiMoCode.",
+  "tui.dialog.free_api_sunset.title": "El servicio de API gratuita ha finalizado",
+  "tui.dialog.free_api_sunset.message":
+    "Ejecuta /login para iniciar sesión. Suscríbete a MiMo Token Plan o configura una API de terceros para usar MiMo Code.",
   "tui.command.consent.revoke.title": "Revocar el acuerdo de modelo gratuito",
   "tui.consent.revoked": "Acuerdo de modelo gratuito revocado: se te pedirá aceptarlo de nuevo",
   "tui.dialog.select.placeholder": "Buscar",
   "tui.dialog.model.login_hint": "Consejo: ejecuta /login para iniciar sesión antes de cambiar de modelo",
-  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, gratis por tiempo limitado)",
+  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5 gratis hasta el 26 de julio, 18:00 · UTC+8)",
   "tui.model.mimo_auto.sunset_name": "MiMo Auto (MiMo-V2.5)",
   "tui.dialog.token_plan.title": "Suscríbete a un Token Plan o espera en la cola",
   "tui.dialog.token_plan.line1":

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -373,6 +373,8 @@ export const dict = {
   "tui.dialog.agreement.title": "Conditions et confidentialité",
   "tui.dialog.agreement.message": "Veuillez les lire et les accepter pour continuer.",
   "tui.dialog.agreement.confirm": "Accepter et continuer",
+  "tui.dialog.free_api_sunset.title": "L’API gratuite de MiMoCode n’est plus disponible",
+  "tui.dialog.free_api_sunset.message": "Exécutez /login pour vous connecter ou configurez une API tierce avant de réutiliser MiMoCode.",
   "tui.command.consent.revoke.title": "Révoquer l'accord du modèle gratuit",
   "tui.consent.revoked": "Accord du modèle gratuit révoqué — vous devrez l'accepter à nouveau",
   "tui.dialog.select.placeholder": "Rechercher",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -378,6 +378,7 @@ export const dict = {
   "tui.dialog.select.placeholder": "Rechercher",
   "tui.dialog.model.login_hint": "Astuce : exécutez /login pour vous connecter avant de changer de modèle",
   "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, gratuit pour une durée limitée)",
+  "tui.model.mimo_auto.sunset_name": "MiMo Auto (MiMo-V2.5)",
   "tui.dialog.token_plan.title": "Abonnez-vous à un Token Plan ou patientez dans la file",
   "tui.dialog.token_plan.line1":
     "En mode gratuit, les requêtes sont mises en file d'attente. Pour un service stable et de qualité,",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -59,6 +59,8 @@ export const dict = {
     "Exécutez {highlight}/dark{/highlight} pour le mode sombre ou {highlight}/light{/highlight} pour le mode clair",
   "tui.tips.doc": "Exécutez {highlight}/doc{/highlight} pour ouvrir la documentation utilisateur",
   "tui.tips.free_models": "Modèles gratuits disponibles pour une durée limitée — essayez-les !",
+  "tui.tips.free_api_sunset":
+    "L’API gratuite de MiMoCode n’est plus disponible. Exécutez {highlight}/login{/highlight} ou configurez une API tierce pour continuer à utiliser MiMoCode.",
   "tui.tips.multi_skills":
     "Combinez plusieurs déclencheurs {highlight}/skill-name{/highlight} dans un même message pour utiliser plusieurs Skills ensemble",
   "tui.tips.background":

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -60,7 +60,7 @@ export const dict = {
   "tui.tips.doc": "Exécutez {highlight}/doc{/highlight} pour ouvrir la documentation utilisateur",
   "tui.tips.free_models": "Modèles gratuits disponibles pour une durée limitée — essayez-les !",
   "tui.tips.free_api_sunset":
-    "L’API gratuite de MiMoCode n’est plus disponible. Exécutez {highlight}/login{/highlight} ou configurez une API tierce pour continuer à utiliser MiMoCode.",
+    "Le service API gratuit est terminé. Exécutez {highlight}/login{/highlight} pour vous connecter. Abonnez-vous au MiMo Token Plan ou configurez une API tierce pour utiliser MiMo Code.",
   "tui.tips.multi_skills":
     "Combinez plusieurs déclencheurs {highlight}/skill-name{/highlight} dans un même message pour utiliser plusieurs Skills ensemble",
   "tui.tips.background":
@@ -375,13 +375,14 @@ export const dict = {
   "tui.dialog.agreement.title": "Conditions et confidentialité",
   "tui.dialog.agreement.message": "Veuillez les lire et les accepter pour continuer.",
   "tui.dialog.agreement.confirm": "Accepter et continuer",
-  "tui.dialog.free_api_sunset.title": "L’API gratuite de MiMoCode n’est plus disponible",
-  "tui.dialog.free_api_sunset.message": "Exécutez /login pour vous connecter ou configurez une API tierce avant de réutiliser MiMoCode.",
+  "tui.dialog.free_api_sunset.title": "Le service API gratuit est terminé",
+  "tui.dialog.free_api_sunset.message":
+    "Exécutez /login pour vous connecter. Abonnez-vous au MiMo Token Plan ou configurez une API tierce pour utiliser MiMo Code.",
   "tui.command.consent.revoke.title": "Révoquer l'accord du modèle gratuit",
   "tui.consent.revoked": "Accord du modèle gratuit révoqué — vous devrez l'accepter à nouveau",
   "tui.dialog.select.placeholder": "Rechercher",
   "tui.dialog.model.login_hint": "Astuce : exécutez /login pour vous connecter avant de changer de modèle",
-  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, gratuit pour une durée limitée)",
+  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5 gratuit jusqu’au 26 juillet à 18:00 · UTC+8)",
   "tui.model.mimo_auto.sunset_name": "MiMo Auto (MiMo-V2.5)",
   "tui.dialog.token_plan.title": "Abonnez-vous à un Token Plan ou patientez dans la file",
   "tui.dialog.token_plan.line1":

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -321,6 +321,7 @@ export const dict = {
   "tui.dialog.select.placeholder": "検索",
   "tui.dialog.model.login_hint": "ヒント：モデルを切り替える前に /login でログインしてください",
   "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 期間限定無料）",
+  "tui.model.mimo_auto.sunset_name": "MiMo Auto（MiMo-V2.5）",
   "tui.dialog.token_plan.title": "Token Plan を購読するか順番待ち",
   "tui.dialog.token_plan.line1":
     "無料モードでは現在順番待ちが必要です。安定した高品質なサービスをご利用いただくには、",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -316,6 +316,8 @@ export const dict = {
   "tui.dialog.agreement.title": "利用規約とプライバシー",
   "tui.dialog.agreement.message": "内容を確認し、同意のうえで続行してください。",
   "tui.dialog.agreement.confirm": "同意して続行",
+  "tui.dialog.free_api_sunset.title": "MiMoCode 無料 API は提供を終了しました",
+  "tui.dialog.free_api_sunset.message": "/login でログインするか、サードパーティ API を設定してから MiMoCode をご利用ください。",
   "tui.command.consent.revoke.title": "無料モデルの同意を取り消す",
   "tui.consent.revoked": "無料モデルの同意を取り消しました — 次回利用時に再度同意を求めます",
   "tui.dialog.select.placeholder": "検索",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -57,6 +57,8 @@ export const dict = {
     "{highlight}/dark{/highlight} でダークモード、{highlight}/light{/highlight} でライトモードに切り替えます",
   "tui.tips.doc": "{highlight}/doc{/highlight} を実行してユーザードキュメントを開きます",
   "tui.tips.free_models": "期間限定で無料モデルを提供中。今すぐお試しください！",
+  "tui.tips.free_api_sunset":
+    "MiMoCode の無料 API は提供を終了しました。{highlight}/login{/highlight} でログインするか、サードパーティ API を設定してから MiMoCode をご利用ください。",
   "tui.tips.multi_skills":
     "1 つのメッセージ内で複数の {highlight}/skill-name{/highlight} を組み合わせて、複数の Skill を同時に使えます",
   "tui.tips.background": "{highlight}/background{/highlight} を実行してホーム背景にお好みの画像を設定できます",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -58,7 +58,7 @@ export const dict = {
   "tui.tips.doc": "{highlight}/doc{/highlight} を実行してユーザードキュメントを開きます",
   "tui.tips.free_models": "期間限定で無料モデルを提供中。今すぐお試しください！",
   "tui.tips.free_api_sunset":
-    "MiMoCode の無料 API は提供を終了しました。{highlight}/login{/highlight} でログインするか、サードパーティ API を設定してから MiMoCode をご利用ください。",
+    "無料 API サービスは終了しました。{highlight}/login{/highlight} でログインしてください。MiMo Token Plan を購読するか、サードパーティ API を設定して MiMo Code をご利用ください。",
   "tui.tips.multi_skills":
     "1 つのメッセージ内で複数の {highlight}/skill-name{/highlight} を組み合わせて、複数の Skill を同時に使えます",
   "tui.tips.background": "{highlight}/background{/highlight} を実行してホーム背景にお好みの画像を設定できます",
@@ -318,13 +318,14 @@ export const dict = {
   "tui.dialog.agreement.title": "利用規約とプライバシー",
   "tui.dialog.agreement.message": "内容を確認し、同意のうえで続行してください。",
   "tui.dialog.agreement.confirm": "同意して続行",
-  "tui.dialog.free_api_sunset.title": "MiMoCode 無料 API は提供を終了しました",
-  "tui.dialog.free_api_sunset.message": "/login でログインするか、サードパーティ API を設定してから MiMoCode をご利用ください。",
+  "tui.dialog.free_api_sunset.title": "無料 API サービスは終了しました",
+  "tui.dialog.free_api_sunset.message":
+    "/login でログインしてください。MiMo Token Plan を購読するか、サードパーティ API を設定して MiMo Code をご利用ください。",
   "tui.command.consent.revoke.title": "無料モデルの同意を取り消す",
   "tui.consent.revoked": "無料モデルの同意を取り消しました — 次回利用時に再度同意を求めます",
   "tui.dialog.select.placeholder": "検索",
   "tui.dialog.model.login_hint": "ヒント：モデルを切り替える前に /login でログインしてください",
-  "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 期間限定無料）",
+  "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 7月26日 18:00 まで無料 · UTC+8）",
   "tui.model.mimo_auto.sunset_name": "MiMo Auto（MiMo-V2.5）",
   "tui.dialog.token_plan.title": "Token Plan を購読するか順番待ち",
   "tui.dialog.token_plan.line1":

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -388,6 +388,8 @@ export const dict = {
   "tui.dialog.agreement.title": "Условия и конфиденциальность",
   "tui.dialog.agreement.message": "Ознакомьтесь и примите их, чтобы продолжить.",
   "tui.dialog.agreement.confirm": "Принять и продолжить",
+  "tui.dialog.free_api_sunset.title": "Бесплатный API MiMoCode больше недоступен",
+  "tui.dialog.free_api_sunset.message": "Выполните /login для входа или настройте сторонний API, прежде чем снова использовать MiMoCode.",
   "tui.command.consent.revoke.title": "Отозвать согласие на бесплатную модель",
   "tui.consent.revoked": "Согласие на бесплатную модель отозвано — потребуется принять снова",
   "tui.dialog.select.placeholder": "Поиск",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -393,6 +393,7 @@ export const dict = {
   "tui.dialog.select.placeholder": "Поиск",
   "tui.dialog.model.login_hint": "Подсказка: выполните /login для входа перед сменой модели",
   "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, временно бесплатно)",
+  "tui.model.mimo_auto.sunset_name": "MiMo Auto (MiMo-V2.5)",
   "tui.dialog.token_plan.title": "Оформите Token Plan или подождите в очереди",
   "tui.dialog.token_plan.line1":
     "В бесплатном режиме запросы сейчас в очереди. Для стабильного и качественного сервиса",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -58,6 +58,8 @@ export const dict = {
     "Выполните {highlight}/dark{/highlight} для тёмного режима или {highlight}/light{/highlight} для светлого",
   "tui.tips.doc": "Выполните {highlight}/doc{/highlight}, чтобы открыть пользовательскую документацию",
   "tui.tips.free_models": "Бесплатные модели доступны ограниченное время — попробуйте их сейчас!",
+  "tui.tips.free_api_sunset":
+    "Бесплатный API MiMoCode больше недоступен. Выполните {highlight}/login{/highlight} или настройте сторонний API, чтобы продолжить работу с MiMoCode.",
   "tui.tips.multi_skills":
     "Комбинируйте несколько {highlight}/skill-name{/highlight} в одном сообщении, чтобы использовать несколько Skills одновременно",
   "tui.tips.background":

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -59,7 +59,7 @@ export const dict = {
   "tui.tips.doc": "Выполните {highlight}/doc{/highlight}, чтобы открыть пользовательскую документацию",
   "tui.tips.free_models": "Бесплатные модели доступны ограниченное время — попробуйте их сейчас!",
   "tui.tips.free_api_sunset":
-    "Бесплатный API MiMoCode больше недоступен. Выполните {highlight}/login{/highlight} или настройте сторонний API, чтобы продолжить работу с MiMoCode.",
+    "Сервис бесплатного API завершён. Выполните {highlight}/login{/highlight}, чтобы войти. Оформите подписку на MiMo Token Plan или настройте сторонний API для использования MiMo Code.",
   "tui.tips.multi_skills":
     "Комбинируйте несколько {highlight}/skill-name{/highlight} в одном сообщении, чтобы использовать несколько Skills одновременно",
   "tui.tips.background":
@@ -390,13 +390,14 @@ export const dict = {
   "tui.dialog.agreement.title": "Условия и конфиденциальность",
   "tui.dialog.agreement.message": "Ознакомьтесь и примите их, чтобы продолжить.",
   "tui.dialog.agreement.confirm": "Принять и продолжить",
-  "tui.dialog.free_api_sunset.title": "Бесплатный API MiMoCode больше недоступен",
-  "tui.dialog.free_api_sunset.message": "Выполните /login для входа или настройте сторонний API, прежде чем снова использовать MiMoCode.",
+  "tui.dialog.free_api_sunset.title": "Сервис бесплатного API завершён",
+  "tui.dialog.free_api_sunset.message":
+    "Выполните /login, чтобы войти. Оформите подписку на MiMo Token Plan или настройте сторонний API для использования MiMo Code.",
   "tui.command.consent.revoke.title": "Отозвать согласие на бесплатную модель",
   "tui.consent.revoked": "Согласие на бесплатную модель отозвано — потребуется принять снова",
   "tui.dialog.select.placeholder": "Поиск",
   "tui.dialog.model.login_hint": "Подсказка: выполните /login для входа перед сменой модели",
-  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5, временно бесплатно)",
+  "tui.model.mimo_auto.name": "MiMo Auto (MiMo-V2.5 бесплатно до 26 июля, 18:00 · UTC+8)",
   "tui.model.mimo_auto.sunset_name": "MiMo Auto (MiMo-V2.5)",
   "tui.dialog.token_plan.title": "Оформите Token Plan или подождите в очереди",
   "tui.dialog.token_plan.line1":

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -340,6 +340,8 @@ export const dict = {
   "tui.dialog.agreement.title": "服务协议与隐私政策",
   "tui.dialog.agreement.message": "请阅读并同意后继续使用。",
   "tui.dialog.agreement.confirm": "同意并继续",
+  "tui.dialog.free_api_sunset.title": "MiMoCode 免费 API 已下线",
+  "tui.dialog.free_api_sunset.message": "请使用 /login 登录，或配置第三方 API 后再使用 MiMoCode。",
   "tui.command.consent.revoke.title": "撤销免费模型协议",
   "tui.consent.revoked": "已撤销免费模型协议 — 下次使用时将再次请求同意",
   "tui.dialog.select.placeholder": "搜索",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -345,6 +345,7 @@ export const dict = {
   "tui.dialog.select.placeholder": "搜索",
   "tui.dialog.model.login_hint": "提示：先 /login 登录再切换模型",
   "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 限免中）",
+  "tui.model.mimo_auto.sunset_name": "MiMo Auto（MiMo-V2.5）",
   "tui.dialog.token_plan.title": "订阅token plan或排队等待",
   "tui.dialog.token_plan.line1": "免费模式下当前需要排队等待，如果想要稳定获取高质量服务，",
   "tui.dialog.token_plan.subscribe": "欢迎订阅 ",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -56,6 +56,8 @@ export const dict = {
     "运行 {highlight}/dark{/highlight} 切换到深色模式，{highlight}/light{/highlight} 切换到浅色模式",
   "tui.tips.doc": "运行 {highlight}/doc{/highlight} 打开使用文档",
   "tui.tips.free_models": "限时提供免费模型中，立即体验！",
+  "tui.tips.free_api_sunset":
+    "MiMoCode 免费 API 已下线。请运行 {highlight}/login{/highlight} 登录，或配置第三方 API 后再使用 MiMoCode。",
   "tui.tips.multi_skills":
     "在同一条消息中输入多个 {highlight}/skill-name{/highlight} 可以同时组合使用多个 Skills",
   "tui.tips.background": "运行 {highlight}/background{/highlight} 设置自定义图片作为主页背景",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -57,7 +57,7 @@ export const dict = {
   "tui.tips.doc": "运行 {highlight}/doc{/highlight} 打开使用文档",
   "tui.tips.free_models": "限时提供免费模型中，立即体验！",
   "tui.tips.free_api_sunset":
-    "MiMoCode 免费 API 已下线。请运行 {highlight}/login{/highlight} 登录，或配置第三方 API 后再使用 MiMoCode。",
+    "免费 API 服务已终止。请使用 {highlight}/login{/highlight} 登录，欢迎订阅MiMo Token Plan或配置第三方 API 后使用 MiMo Code。",
   "tui.tips.multi_skills":
     "在同一条消息中输入多个 {highlight}/skill-name{/highlight} 可以同时组合使用多个 Skills",
   "tui.tips.background": "运行 {highlight}/background{/highlight} 设置自定义图片作为主页背景",
@@ -342,13 +342,14 @@ export const dict = {
   "tui.dialog.agreement.title": "服务协议与隐私政策",
   "tui.dialog.agreement.message": "请阅读并同意后继续使用。",
   "tui.dialog.agreement.confirm": "同意并继续",
-  "tui.dialog.free_api_sunset.title": "MiMoCode 免费 API 已下线",
-  "tui.dialog.free_api_sunset.message": "请使用 /login 登录，或配置第三方 API 后再使用 MiMoCode。",
+  "tui.dialog.free_api_sunset.title": "免费 API 服务已终止",
+  "tui.dialog.free_api_sunset.message":
+    "请使用 /login 登录，欢迎订阅MiMo Token Plan或配置第三方 API 后使用 MiMo Code。",
   "tui.command.consent.revoke.title": "撤销免费模型协议",
   "tui.consent.revoked": "已撤销免费模型协议 — 下次使用时将再次请求同意",
   "tui.dialog.select.placeholder": "搜索",
   "tui.dialog.model.login_hint": "提示：先 /login 登录再切换模型",
-  "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 限免中）",
+  "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 限免至 7 月 26 日 18:00 · UTC+8）",
   "tui.model.mimo_auto.sunset_name": "MiMo Auto（MiMo-V2.5）",
   "tui.dialog.token_plan.title": "订阅token plan或排队等待",
   "tui.dialog.token_plan.line1": "免费模式下当前需要排队等待，如果想要稳定获取高质量服务，",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -345,6 +345,7 @@ export const dict = {
   "tui.dialog.select.placeholder": "搜尋",
   "tui.dialog.model.login_hint": "提示：先 /login 登入再切換模型",
   "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 限免中）",
+  "tui.model.mimo_auto.sunset_name": "MiMo Auto（MiMo-V2.5）",
   "tui.dialog.token_plan.title": "訂閱token plan或排隊等待",
   "tui.dialog.token_plan.line1": "免費模式下目前需要排隊等待，若想穩定取得高品質服務，",
   "tui.dialog.token_plan.subscribe": "歡迎訂閱 ",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -340,6 +340,8 @@ export const dict = {
   "tui.dialog.agreement.title": "服務協議與隱私政策",
   "tui.dialog.agreement.message": "請閱讀並同意後繼續使用。",
   "tui.dialog.agreement.confirm": "同意並繼續",
+  "tui.dialog.free_api_sunset.title": "MiMoCode 免費 API 已下線",
+  "tui.dialog.free_api_sunset.message": "請使用 /login 登入，或配置第三方 API 後再使用 MiMoCode。",
   "tui.command.consent.revoke.title": "撤銷免費模型協議",
   "tui.consent.revoked": "已撤銷免費模型協議 — 下次使用時將再次請求同意",
   "tui.dialog.select.placeholder": "搜尋",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -56,6 +56,8 @@ export const dict = {
     "執行 {highlight}/dark{/highlight} 切換深色模式，{highlight}/light{/highlight} 切換淺色模式",
   "tui.tips.doc": "執行 {highlight}/doc{/highlight} 開啟使用文件",
   "tui.tips.free_models": "限時提供免費模型中，立即體驗！",
+  "tui.tips.free_api_sunset":
+    "MiMoCode 免費 API 已下線。請執行 {highlight}/login{/highlight} 登入，或設定第三方 API 後再使用 MiMoCode。",
   "tui.tips.multi_skills":
     "在同一則訊息中輸入多個 {highlight}/skill-name{/highlight} 可同時組合使用多個 Skills",
   "tui.tips.background": "執行 {highlight}/background{/highlight} 設定自訂圖片作為主頁背景",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -57,7 +57,7 @@ export const dict = {
   "tui.tips.doc": "執行 {highlight}/doc{/highlight} 開啟使用文件",
   "tui.tips.free_models": "限時提供免費模型中，立即體驗！",
   "tui.tips.free_api_sunset":
-    "MiMoCode 免費 API 已下線。請執行 {highlight}/login{/highlight} 登入，或設定第三方 API 後再使用 MiMoCode。",
+    "免費 API 服務已終止。請使用 {highlight}/login{/highlight} 登入，歡迎訂閱 MiMo Token Plan 或設定第三方 API 後使用 MiMo Code。",
   "tui.tips.multi_skills":
     "在同一則訊息中輸入多個 {highlight}/skill-name{/highlight} 可同時組合使用多個 Skills",
   "tui.tips.background": "執行 {highlight}/background{/highlight} 設定自訂圖片作為主頁背景",
@@ -342,13 +342,14 @@ export const dict = {
   "tui.dialog.agreement.title": "服務協議與隱私政策",
   "tui.dialog.agreement.message": "請閱讀並同意後繼續使用。",
   "tui.dialog.agreement.confirm": "同意並繼續",
-  "tui.dialog.free_api_sunset.title": "MiMoCode 免費 API 已下線",
-  "tui.dialog.free_api_sunset.message": "請使用 /login 登入，或配置第三方 API 後再使用 MiMoCode。",
+  "tui.dialog.free_api_sunset.title": "免費 API 服務已終止",
+  "tui.dialog.free_api_sunset.message":
+    "請使用 /login 登入，歡迎訂閱 MiMo Token Plan 或設定第三方 API 後使用 MiMo Code。",
   "tui.command.consent.revoke.title": "撤銷免費模型協議",
   "tui.consent.revoked": "已撤銷免費模型協議 — 下次使用時將再次請求同意",
   "tui.dialog.select.placeholder": "搜尋",
   "tui.dialog.model.login_hint": "提示：先 /login 登入再切換模型",
-  "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 限免中）",
+  "tui.model.mimo_auto.name": "MiMo Auto（MiMo-V2.5 限免至 7 月 26 日 18:00 · UTC+8）",
   "tui.model.mimo_auto.sunset_name": "MiMo Auto（MiMo-V2.5）",
   "tui.dialog.token_plan.title": "訂閱token plan或排隊等待",
   "tui.dialog.token_plan.line1": "免費模式下目前需要排隊等待，若想穩定取得高品質服務，",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -98,6 +98,12 @@ import { DialogGoUpsell } from "../../component/dialog-go-upsell"
 import { DialogTokenPlan } from "../../component/dialog-token-plan"
 import { SessionRetry } from "@/session/retry"
 import { getRevertDiffFiles } from "../../util/revert-diff"
+import {
+  createFreeApiSunsetSignal,
+  freeApiModelNameKey,
+  isFreeApiModel,
+  shouldBlockFreeApiRequest,
+} from "@tui/util/free-api-sunset"
 
 addDefaultParsers(parsers.parsers)
 
@@ -121,6 +127,7 @@ const context = createContext<{
   providers: () => ReadonlyMap<string, Provider>
   sync: ReturnType<typeof useSync>
   tui: ReturnType<typeof useTuiConfig>
+  freeApiSunset: () => boolean
 }>()
 
 function use() {
@@ -159,6 +166,7 @@ export function Session() {
   const kv = useKV()
   const { theme } = useTheme()
   const promptRef = usePromptRef()
+  const freeApiSunset = createFreeApiSunsetSignal()
   const session = createMemo(() => sync.session.get(route.sessionID))
   const currentAgentID = useCurrentAgentID()
   const actors = createMemo(() => sync.data.actor[route.sessionID] ?? [])
@@ -576,6 +584,14 @@ export function Session() {
           })
           return
         }
+        if (shouldBlockFreeApiRequest(selectedModel)) {
+          void DialogAlert.show(
+            dialog,
+            t("tui.dialog.free_api_sunset.title"),
+            t("tui.dialog.free_api_sunset.message"),
+          )
+          return
+        }
         void sdk.client.session.summarize({
           sessionID: route.sessionID,
           modelID: selectedModel.modelID,
@@ -593,6 +609,23 @@ export function Session() {
         name: "btw",
       },
       onSelect: async (dialog) => {
+        const selectedModel = local.model.current()
+        if (!selectedModel) {
+          toast.show({
+            variant: "warning",
+            message: "Connect a provider to ask a side question",
+            duration: 3000,
+          })
+          return
+        }
+        if (shouldBlockFreeApiRequest(selectedModel)) {
+          await DialogAlert.show(
+            dialog,
+            t("tui.dialog.free_api_sunset.title"),
+            t("tui.dialog.free_api_sunset.message"),
+          )
+          return
+        }
         // Ask a read-only side question via fork-query. Keep the prompt dialog
         // mounted in a busy/spinner state across the (multi-second) blocking
         // `ask` so the user gets immediate feedback, then swap in the answer.
@@ -602,8 +635,22 @@ export function Session() {
           dialog,
           "/btw",
           async (question, active) => {
+            if (shouldBlockFreeApiRequest(selectedModel)) {
+              if (active())
+                await DialogAlert.show(
+                  dialog,
+                  t("tui.dialog.free_api_sunset.title"),
+                  t("tui.dialog.free_api_sunset.message"),
+                )
+              return
+            }
             const res = await sdk.client.session
-              .ask({ sessionID: route.sessionID, question })
+              .ask({
+                sessionID: route.sessionID,
+                question,
+                providerID: selectedModel.providerID,
+                modelID: selectedModel.modelID,
+              })
               .catch((error) => {
                 if (active())
                   toast.show({
@@ -1234,6 +1281,7 @@ export function Session() {
         providers,
         sync,
         tui: tuiConfig,
+        freeApiSunset,
       }}
     >
       <box flexDirection="row">
@@ -1630,8 +1678,8 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const [copyHover, setCopyHover] = createSignal(false)
   const messages = createMemo(() => sync.data.message[props.message.sessionID]?.[props.message.agentID ?? "main"] ?? [])
   const model = createMemo(() =>
-    props.message.modelID === "mimo-auto"
-      ? t("tui.model.mimo_auto.name")
+    isFreeApiModel({ providerID: props.message.providerID, modelID: props.message.modelID })
+      ? t(freeApiModelNameKey(ctx.freeApiSunset()))
       : Model.name(ctx.providers(), props.message.providerID, props.message.modelID),
   )
 

--- a/packages/opencode/src/cli/cmd/tui/util/free-api-sunset.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/free-api-sunset.ts
@@ -10,12 +10,36 @@ export function isFreeApiModel(model: { providerID: string; modelID: string } | 
   return model?.providerID === "mimo" && model.modelID === "mimo-auto"
 }
 
+export type PromptSubmission = "client-slash" | "shell" | "model"
+
+export function classifyPromptSubmission(input: {
+  input: string
+  mode: "normal" | "shell"
+  clientSlash: boolean
+}): PromptSubmission {
+  if (input.mode === "shell") return "shell"
+  if (input.input.trim() === "/btw") return "model"
+  if (input.input.startsWith("/") && input.clientSlash) return "client-slash"
+  return "model"
+}
+
+export function isModelBackedPromptSubmission(request: PromptSubmission) {
+  return request === "model"
+}
+
 export function shouldBlockFreeApiRequest(
   model: { providerID: string; modelID: string } | undefined,
-  options: { sunset?: boolean; clientSlash?: boolean; shell?: boolean } = {},
+  options: {
+    now?: number
+    sunset?: boolean
+    request?: PromptSubmission
+    clientSlash?: boolean
+    shell?: boolean
+  } = {},
 ) {
-  if (!(options.sunset ?? isFreeApiSunset())) return false
+  if (!(options.sunset ?? isFreeApiSunset(options.now))) return false
   if (!isFreeApiModel(model)) return false
+  if (options.request) return isModelBackedPromptSubmission(options.request)
   return !options.clientSlash && !options.shell
 }
 

--- a/packages/opencode/src/cli/cmd/tui/util/free-api-sunset.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/free-api-sunset.ts
@@ -1,46 +1,15 @@
 import { createSignal, onCleanup } from "solid-js"
+import { FREE_API_SUNSET_AT, isFreeApiModel, isFreeApiSunset } from "@/util/free-api-sunset"
 
-export const FREE_API_SUNSET_AT = Date.parse("2026-07-26T10:00:00.000Z")
-
-export function isFreeApiSunset(now = Date.now()) {
-  return now >= FREE_API_SUNSET_AT
-}
-
-export function isFreeApiModel(model: { providerID: string; modelID: string } | undefined) {
-  return model?.providerID === "mimo" && model.modelID === "mimo-auto"
-}
-
-export type PromptSubmission = "client-slash" | "shell" | "model"
-
-export function classifyPromptSubmission(input: {
-  input: string
-  mode: "normal" | "shell"
-  clientSlash: boolean
-}): PromptSubmission {
-  if (input.mode === "shell") return "shell"
-  if (input.input.trim() === "/btw") return "model"
-  if (input.input.startsWith("/") && input.clientSlash) return "client-slash"
-  return "model"
-}
-
-export function isModelBackedPromptSubmission(request: PromptSubmission) {
-  return request === "model"
-}
+export { FREE_API_SUNSET_AT, isFreeApiModel, isFreeApiSunset }
 
 export function shouldBlockFreeApiRequest(
   model: { providerID: string; modelID: string } | undefined,
-  options: {
-    now?: number
-    sunset?: boolean
-    request?: PromptSubmission
-    clientSlash?: boolean
-    shell?: boolean
-  } = {},
+  options: { sunset?: boolean; localOnly?: boolean; shell?: boolean } = {},
 ) {
-  if (!(options.sunset ?? isFreeApiSunset(options.now))) return false
+  if (!(options.sunset ?? isFreeApiSunset())) return false
   if (!isFreeApiModel(model)) return false
-  if (options.request) return isModelBackedPromptSubmission(options.request)
-  return !options.clientSlash && !options.shell
+  return !options.localOnly && !options.shell
 }
 
 export function freeApiModelNameKey(sunset = isFreeApiSunset()) {

--- a/packages/opencode/src/cli/cmd/tui/util/free-api-sunset.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/free-api-sunset.ts
@@ -1,0 +1,41 @@
+import { createSignal, onCleanup } from "solid-js"
+
+export const FREE_API_SUNSET_AT = Date.parse("2026-07-26T10:00:00.000Z")
+
+export function isFreeApiSunset(now = Date.now()) {
+  return now >= FREE_API_SUNSET_AT
+}
+
+export function isFreeApiModel(model: { providerID: string; modelID: string } | undefined) {
+  return model?.providerID === "mimo" && model.modelID === "mimo-auto"
+}
+
+export function shouldBlockFreeApiRequest(
+  model: { providerID: string; modelID: string } | undefined,
+  options: { sunset?: boolean; clientSlash?: boolean; shell?: boolean } = {},
+) {
+  if (!(options.sunset ?? isFreeApiSunset())) return false
+  if (!isFreeApiModel(model)) return false
+  return !options.clientSlash && !options.shell
+}
+
+export function freeApiModelNameKey(sunset = isFreeApiSunset()) {
+  return sunset ? ("tui.model.mimo_auto.sunset_name" as const) : ("tui.model.mimo_auto.name" as const)
+}
+
+export function createFreeApiSunsetSignal(
+  now = Date.now(),
+  timer: {
+    set(callback: () => void, delay: number): ReturnType<typeof setTimeout>
+    clear(handle: ReturnType<typeof setTimeout>): void
+  } = {
+    set: (callback, delay) => setTimeout(callback, delay),
+    clear: (handle) => clearTimeout(handle),
+  },
+) {
+  const [sunset, setSunset] = createSignal(isFreeApiSunset(now))
+  if (sunset()) return sunset
+  const timeout = timer.set(() => setSunset(true), FREE_API_SUNSET_AT - now)
+  onCleanup(() => timer.clear(timeout))
+  return sunset
+}

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -26,6 +26,7 @@ import { InstanceState } from "@/effect"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { isRecord } from "@/util/record"
 import { withStatics } from "@/util/schema"
+import { isFreeApiModel, isFreeApiSunset } from "@/util/free-api-sunset"
 
 import * as ProviderTransform from "./transform"
 import { ModelID, ProviderID } from "./schema"
@@ -940,6 +941,7 @@ export const ListResult = Schema.Struct({
   all: Schema.Array(Info),
   default: DefaultModelIDs,
   connected: Schema.Array(Schema.String),
+  authenticated: Schema.Array(Schema.String),
 }).pipe(withStatics((s) => ({ zod: zod(s) })))
 export type ListResult = Types.DeepMutable<Schema.Schema.Type<typeof ListResult>>
 
@@ -1619,6 +1621,9 @@ const layer: Layer.Layer<
     })
 
     const getLanguage = Effect.fn("Provider.getLanguage")(function* (model: Model) {
+      if (isFreeApiSunset() && isFreeApiModel({ providerID: model.providerID, modelID: model.id })) {
+        throw new Error("MiMo free API service has ended. Sign in or configure a third-party API.")
+      }
       const s = yield* InstanceState.get(state)
       const envs = yield* env.all()
       const key = `${model.providerID}/${model.id}`

--- a/packages/opencode/src/server/routes/instance/httpapi/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/provider.ts
@@ -1,5 +1,6 @@
 import { ProviderAuth } from "@/provider"
 import { Config } from "@/config"
+import { Auth } from "@/auth"
 import { ModelsDev } from "@/provider"
 import { Provider } from "@/provider"
 import { ProviderID } from "@/provider/schema"
@@ -72,6 +73,7 @@ export const ProviderApi = HttpApi.make("provider")
 export const providerHandlers = Layer.unwrap(
   Effect.gen(function* () {
     const cfg = yield* Config.Service
+    const authStore = yield* Auth.Service
     const provider = yield* Provider.Service
     const svc = yield* ProviderAuth.Service
 
@@ -95,6 +97,7 @@ export const providerHandlers = Layer.unwrap(
         all: Object.values(providers),
         default: Provider.defaultModelIDs(providers),
         connected: Object.keys(connected),
+        authenticated: Object.keys(yield* authStore.all().pipe(Effect.orDie)),
       }
     })
 
@@ -136,6 +139,7 @@ export const providerHandlers = Layer.unwrap(
     )
   }),
 ).pipe(
+  Layer.provide(Auth.defaultLayer),
   Layer.provide(ProviderAuth.defaultLayer),
   Layer.provide(Provider.defaultLayer),
   Layer.provide(Config.defaultLayer),

--- a/packages/opencode/src/server/routes/instance/provider.ts
+++ b/packages/opencode/src/server/routes/instance/provider.ts
@@ -11,6 +11,7 @@ import { errors } from "../../error"
 import { lazy } from "@/util/lazy"
 import { Effect } from "effect"
 import { jsonRequest } from "./trace"
+import { Auth } from "@/auth"
 
 export const ProviderRoutes = lazy(() =>
   new Hono()
@@ -34,6 +35,7 @@ export const ProviderRoutes = lazy(() =>
       async (c) =>
         jsonRequest("ProviderRoutes.list", c, function* () {
           const svc = yield* Provider.Service
+          const auth = yield* Auth.Service
           const cfg = yield* Config.Service
           const config = yield* cfg.get()
           const all = yield* Effect.promise(() => ModelsDev.get())
@@ -54,6 +56,7 @@ export const ProviderRoutes = lazy(() =>
             all: Object.values(providers),
             default: Provider.defaultModelIDs(providers),
             connected: Object.keys(connected),
+            authenticated: Object.keys(yield* auth.all().pipe(Effect.orDie)),
           }
         }),
     )

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -716,12 +716,14 @@ export const SessionRoutes = lazy(() =>
         "json",
         z.object({
           question: z.string().min(1),
+          providerID: ProviderID.zod.optional(),
+          modelID: ModelID.zod.optional(),
         }),
       ),
       async (c) =>
         jsonRequest("SessionRoutes.ask", c, function* () {
           const sessionID = c.req.valid("param").sessionID
-          const question = c.req.valid("json").question
+          const body = c.req.valid("json")
           const sessions = yield* Session.Service
           const provider = yield* Provider.Service
           // Resolve the Actor through the late-bound spawnRef rather than a layer
@@ -732,7 +734,9 @@ export const SessionRoutes = lazy(() =>
             return yield* Effect.fail(
               new Error("Actor service unavailable — Actor.defaultLayer must be running to ask a side question"),
             )
-          const answer = yield* forkQuery({ sessions, provider, actor }, sessionID, question)
+          const selectedModel =
+            body.providerID && body.modelID ? { providerID: body.providerID, modelID: body.modelID } : undefined
+          const answer = yield* forkQuery({ sessions, provider, actor }, sessionID, body.question, selectedModel)
           return { answer }
         }),
     )

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -61,7 +61,7 @@ export function forkQuery(deps: {
   sessions: Session.Interface
   provider: Provider.Interface
   actor: ActorInterface
-}, targetSessionID: SessionID, question: string) {
+}, targetSessionID: SessionID, question: string, selectedModel?: { providerID: ProviderID; modelID: ModelID }) {
   return Effect.gen(function* () {
     // a. Resolve the target's persisted history and the slice to snapshot.
     // A child created via `session create` runs as a PEER actor whose actorID
@@ -96,7 +96,7 @@ export function forkQuery(deps: {
 
     // Model for the prefix + the fork's LLM call: the project default. The prefix
     // captor needs a concrete provider/model; the answer quality is the default's.
-    const model = yield* deps.provider.defaultModel()
+    const model = selectedModel ?? (yield* deps.provider.defaultModel())
     const providerID = model.providerID as ProviderID
     const modelID = model.modelID as ModelID
 

--- a/packages/opencode/src/util/free-api-sunset.ts
+++ b/packages/opencode/src/util/free-api-sunset.ts
@@ -1,0 +1,9 @@
+export const FREE_API_SUNSET_AT = Date.parse("2026-07-26T10:00:00.000Z")
+
+export function isFreeApiSunset(now = Date.now()) {
+  return now >= FREE_API_SUNSET_AT
+}
+
+export function isFreeApiModel(model: { providerID: string; modelID: string } | undefined) {
+  return model?.providerID === "mimo" && model.modelID === "mimo-auto"
+}

--- a/packages/opencode/test/cli/cmd/tui/free-api-sunset.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/free-api-sunset.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, mock, test } from "bun:test"
 import { createRoot, type Accessor } from "solid-js"
 import {
   FREE_API_SUNSET_AT,
+  classifyPromptSubmission,
   createFreeApiSunsetSignal,
   freeApiModelNameKey,
   isFreeApiModel,
   isFreeApiSunset,
+  isModelBackedPromptSubmission,
   shouldBlockFreeApiRequest,
 } from "../../../../src/cli/cmd/tui/util/free-api-sunset"
 
@@ -29,11 +31,44 @@ describe("free API sunset", () => {
 
   test("blocks model-backed requests after sunset", () => {
     const model = { providerID: "mimo", modelID: "mimo-auto" }
-    expect(shouldBlockFreeApiRequest(model, { sunset: false })).toBe(false)
-    expect(shouldBlockFreeApiRequest(model, { sunset: true })).toBe(true)
-    expect(shouldBlockFreeApiRequest(model, { sunset: true, clientSlash: true })).toBe(false)
-    expect(shouldBlockFreeApiRequest(model, { sunset: true, shell: true })).toBe(false)
-    expect(shouldBlockFreeApiRequest({ providerID: "xiaomi", modelID: "mimo-auto" }, { sunset: true })).toBe(false)
+    const request = classifyPromptSubmission({ input: "hello", mode: "normal", clientSlash: false })
+    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT - 1, request })).toBe(false)
+    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT, request })).toBe(true)
+    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT + 1, request })).toBe(true)
+    expect(
+      shouldBlockFreeApiRequest({ providerID: "xiaomi", modelID: "mimo-auto" }, { now: FREE_API_SUNSET_AT, request }),
+    ).toBe(false)
+    expect(
+      shouldBlockFreeApiRequest({ providerID: "third-party", modelID: "mimo-auto" }, { now: FREE_API_SUNSET_AT, request }),
+    ).toBe(false)
+    expect(
+      shouldBlockFreeApiRequest({ providerID: "mimo", modelID: "other" }, { now: FREE_API_SUNSET_AT, request }),
+    ).toBe(false)
+  })
+
+  test("classifies client-side slash and shell before model-backed requests", () => {
+    expect(classifyPromptSubmission({ input: "/login", mode: "normal", clientSlash: true })).toBe("client-slash")
+    expect(classifyPromptSubmission({ input: "/connect", mode: "normal", clientSlash: true })).toBe("client-slash")
+    expect(classifyPromptSubmission({ input: "/theme", mode: "normal", clientSlash: true })).toBe("client-slash")
+    expect(classifyPromptSubmission({ input: "pwd", mode: "shell", clientSlash: false })).toBe("shell")
+    expect(classifyPromptSubmission({ input: "hello", mode: "normal", clientSlash: false })).toBe("model")
+    expect(classifyPromptSubmission({ input: "/review", mode: "normal", clientSlash: false })).toBe("model")
+    expect(classifyPromptSubmission({ input: "/btw", mode: "normal", clientSlash: true })).toBe("model")
+    expect(classifyPromptSubmission({ input: "/btw question", mode: "normal", clientSlash: false })).toBe("model")
+  })
+
+  test("uses the same model-backed classification for sunset and agreement gates", () => {
+    const model = { providerID: "mimo", modelID: "mimo-auto" }
+    const clientSlash = classifyPromptSubmission({ input: "/login", mode: "normal", clientSlash: true })
+    const shell = classifyPromptSubmission({ input: "pwd", mode: "shell", clientSlash: false })
+    const btw = classifyPromptSubmission({ input: "/btw", mode: "normal", clientSlash: true })
+
+    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT, request: clientSlash })).toBe(false)
+    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT, request: shell })).toBe(false)
+    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT, request: btw })).toBe(true)
+    expect(isModelBackedPromptSubmission(clientSlash)).toBe(false)
+    expect(isModelBackedPromptSubmission(shell)).toBe(false)
+    expect(isModelBackedPromptSubmission(btw)).toBe(true)
   })
 
   test("switches the model display key at sunset", () => {

--- a/packages/opencode/test/cli/cmd/tui/free-api-sunset.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/free-api-sunset.test.ts
@@ -8,6 +8,13 @@ import {
   isFreeApiSunset,
   shouldBlockFreeApiRequest,
 } from "../../../../src/cli/cmd/tui/util/free-api-sunset"
+import { dict as en } from "../../../../src/cli/cmd/tui/i18n/en"
+import { dict as es } from "../../../../src/cli/cmd/tui/i18n/es"
+import { dict as fr } from "../../../../src/cli/cmd/tui/i18n/fr"
+import { dict as ja } from "../../../../src/cli/cmd/tui/i18n/ja"
+import { dict as ru } from "../../../../src/cli/cmd/tui/i18n/ru"
+import { dict as zh } from "../../../../src/cli/cmd/tui/i18n/zh"
+import { dict as zht } from "../../../../src/cli/cmd/tui/i18n/zht"
 
 describe("free API sunset", () => {
   test("uses the exact UTC threshold", () => {
@@ -37,8 +44,21 @@ describe("free API sunset", () => {
   })
 
   test("switches the model display key at sunset", () => {
-    expect(freeApiModelNameKey(false)).toBe("tui.model.mimo_auto.name")
-    expect(freeApiModelNameKey(true)).toBe("tui.model.mimo_auto.sunset_name")
+    expect(freeApiModelNameKey(isFreeApiSunset(FREE_API_SUNSET_AT - 1))).toBe("tui.model.mimo_auto.name")
+    expect(freeApiModelNameKey(isFreeApiSunset(FREE_API_SUNSET_AT))).toBe("tui.model.mimo_auto.sunset_name")
+    expect(freeApiModelNameKey(isFreeApiSunset(FREE_API_SUNSET_AT + 1))).toBe("tui.model.mimo_auto.sunset_name")
+  })
+
+  test("all TUI locales define the post-sunset model name", () => {
+    expect([en, es, fr, ja, ru, zh, zht].map((locale) => locale["tui.model.mimo_auto.sunset_name"])).toEqual([
+      "MiMo Auto (MiMo-V2.5)",
+      "MiMo Auto (MiMo-V2.5)",
+      "MiMo Auto (MiMo-V2.5)",
+      "MiMo Auto（MiMo-V2.5）",
+      "MiMo Auto (MiMo-V2.5)",
+      "MiMo Auto（MiMo-V2.5）",
+      "MiMo Auto（MiMo-V2.5）",
+    ])
   })
 
   test("schedules one reactive switch before the threshold", () => {

--- a/packages/opencode/test/cli/cmd/tui/free-api-sunset.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/free-api-sunset.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, mock, test } from "bun:test"
+import { createRoot, type Accessor } from "solid-js"
+import {
+  FREE_API_SUNSET_AT,
+  createFreeApiSunsetSignal,
+  freeApiModelNameKey,
+  isFreeApiModel,
+  isFreeApiSunset,
+  shouldBlockFreeApiRequest,
+} from "../../../../src/cli/cmd/tui/util/free-api-sunset"
+
+describe("free API sunset", () => {
+  test("uses the exact UTC threshold", () => {
+    expect(FREE_API_SUNSET_AT).toBe(Date.parse("2026-07-26T10:00:00.000Z"))
+  })
+
+  test("starts exactly at the configured UTC threshold", () => {
+    expect(isFreeApiSunset(FREE_API_SUNSET_AT - 1)).toBe(false)
+    expect(isFreeApiSunset(FREE_API_SUNSET_AT)).toBe(true)
+    expect(isFreeApiSunset(FREE_API_SUNSET_AT + 1)).toBe(true)
+  })
+
+  test("only identifies the anonymous MiMo free channel", () => {
+    expect(isFreeApiModel({ providerID: "mimo", modelID: "mimo-auto" })).toBe(true)
+    expect(isFreeApiModel({ providerID: "xiaomi", modelID: "mimo-auto" })).toBe(false)
+    expect(isFreeApiModel({ providerID: "third-party", modelID: "mimo-auto" })).toBe(false)
+    expect(isFreeApiModel({ providerID: "mimo", modelID: "mimo-free" })).toBe(false)
+  })
+
+  test("blocks model-backed requests after sunset", () => {
+    const model = { providerID: "mimo", modelID: "mimo-auto" }
+    expect(shouldBlockFreeApiRequest(model, { sunset: false })).toBe(false)
+    expect(shouldBlockFreeApiRequest(model, { sunset: true })).toBe(true)
+    expect(shouldBlockFreeApiRequest(model, { sunset: true, clientSlash: true })).toBe(false)
+    expect(shouldBlockFreeApiRequest(model, { sunset: true, shell: true })).toBe(false)
+    expect(shouldBlockFreeApiRequest({ providerID: "xiaomi", modelID: "mimo-auto" }, { sunset: true })).toBe(false)
+  })
+
+  test("switches the model display key at sunset", () => {
+    expect(freeApiModelNameKey(false)).toBe("tui.model.mimo_auto.name")
+    expect(freeApiModelNameKey(true)).toBe("tui.model.mimo_auto.sunset_name")
+  })
+
+  test("schedules one reactive switch before the threshold", () => {
+    const clear = mock(() => {})
+    let callback = () => {}
+    let sunset!: Accessor<boolean>
+    let dispose = () => {}
+    const timer = {
+      set(fn: () => void, delay: number) {
+        callback = fn
+        expect(delay).toBe(1)
+        return 1 as unknown as ReturnType<typeof setTimeout>
+      },
+      clear,
+    }
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose
+      sunset = createFreeApiSunsetSignal(FREE_API_SUNSET_AT - 1, timer)
+    })
+
+    expect(sunset()).toBe(false)
+    callback()
+    expect(sunset()).toBe(true)
+    dispose()
+    expect(clear).toHaveBeenCalledTimes(1)
+  })
+
+  test("is immediately true after the threshold without scheduling", () => {
+    const set = mock(() => 1 as unknown as ReturnType<typeof setTimeout>)
+    let sunset!: Accessor<boolean>
+
+    createRoot((dispose) => {
+      sunset = createFreeApiSunsetSignal(FREE_API_SUNSET_AT, { set, clear: () => {} })
+      dispose()
+    })
+
+    expect(sunset()).toBe(true)
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  test("cancels the pending switch on cleanup", () => {
+    const clear = mock(() => {})
+    const handle = 1 as unknown as ReturnType<typeof setTimeout>
+    let dispose = () => {}
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose
+      createFreeApiSunsetSignal(FREE_API_SUNSET_AT - 1, { set: () => handle, clear })
+    })
+    dispose()
+
+    expect(clear).toHaveBeenCalledTimes(1)
+    expect(clear).toHaveBeenCalledWith(handle)
+  })
+})

--- a/packages/opencode/test/cli/cmd/tui/free-api-sunset.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/free-api-sunset.test.ts
@@ -2,21 +2,12 @@ import { describe, expect, mock, test } from "bun:test"
 import { createRoot, type Accessor } from "solid-js"
 import {
   FREE_API_SUNSET_AT,
-  classifyPromptSubmission,
   createFreeApiSunsetSignal,
   freeApiModelNameKey,
   isFreeApiModel,
   isFreeApiSunset,
-  isModelBackedPromptSubmission,
   shouldBlockFreeApiRequest,
 } from "../../../../src/cli/cmd/tui/util/free-api-sunset"
-import { dict as en } from "../../../../src/cli/cmd/tui/i18n/en"
-import { dict as es } from "../../../../src/cli/cmd/tui/i18n/es"
-import { dict as fr } from "../../../../src/cli/cmd/tui/i18n/fr"
-import { dict as ja } from "../../../../src/cli/cmd/tui/i18n/ja"
-import { dict as ru } from "../../../../src/cli/cmd/tui/i18n/ru"
-import { dict as zh } from "../../../../src/cli/cmd/tui/i18n/zh"
-import { dict as zht } from "../../../../src/cli/cmd/tui/i18n/zht"
 
 describe("free API sunset", () => {
   test("uses the exact UTC threshold", () => {
@@ -38,62 +29,16 @@ describe("free API sunset", () => {
 
   test("blocks model-backed requests after sunset", () => {
     const model = { providerID: "mimo", modelID: "mimo-auto" }
-    const request = classifyPromptSubmission({ input: "hello", mode: "normal", clientSlash: false })
-    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT - 1, request })).toBe(false)
-    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT, request })).toBe(true)
-    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT + 1, request })).toBe(true)
-    expect(
-      shouldBlockFreeApiRequest({ providerID: "xiaomi", modelID: "mimo-auto" }, { now: FREE_API_SUNSET_AT, request }),
-    ).toBe(false)
-    expect(
-      shouldBlockFreeApiRequest({ providerID: "third-party", modelID: "mimo-auto" }, { now: FREE_API_SUNSET_AT, request }),
-    ).toBe(false)
-    expect(
-      shouldBlockFreeApiRequest({ providerID: "mimo", modelID: "other" }, { now: FREE_API_SUNSET_AT, request }),
-    ).toBe(false)
-  })
-
-  test("classifies client-side slash and shell before model-backed requests", () => {
-    expect(classifyPromptSubmission({ input: "/login", mode: "normal", clientSlash: true })).toBe("client-slash")
-    expect(classifyPromptSubmission({ input: "/connect", mode: "normal", clientSlash: true })).toBe("client-slash")
-    expect(classifyPromptSubmission({ input: "/theme", mode: "normal", clientSlash: true })).toBe("client-slash")
-    expect(classifyPromptSubmission({ input: "pwd", mode: "shell", clientSlash: false })).toBe("shell")
-    expect(classifyPromptSubmission({ input: "hello", mode: "normal", clientSlash: false })).toBe("model")
-    expect(classifyPromptSubmission({ input: "/review", mode: "normal", clientSlash: false })).toBe("model")
-    expect(classifyPromptSubmission({ input: "/btw", mode: "normal", clientSlash: true })).toBe("model")
-    expect(classifyPromptSubmission({ input: "/btw question", mode: "normal", clientSlash: false })).toBe("model")
-  })
-
-  test("uses the same model-backed classification for sunset and agreement gates", () => {
-    const model = { providerID: "mimo", modelID: "mimo-auto" }
-    const clientSlash = classifyPromptSubmission({ input: "/login", mode: "normal", clientSlash: true })
-    const shell = classifyPromptSubmission({ input: "pwd", mode: "shell", clientSlash: false })
-    const btw = classifyPromptSubmission({ input: "/btw", mode: "normal", clientSlash: true })
-
-    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT, request: clientSlash })).toBe(false)
-    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT, request: shell })).toBe(false)
-    expect(shouldBlockFreeApiRequest(model, { now: FREE_API_SUNSET_AT, request: btw })).toBe(true)
-    expect(isModelBackedPromptSubmission(clientSlash)).toBe(false)
-    expect(isModelBackedPromptSubmission(shell)).toBe(false)
-    expect(isModelBackedPromptSubmission(btw)).toBe(true)
+    expect(shouldBlockFreeApiRequest(model, { sunset: false })).toBe(false)
+    expect(shouldBlockFreeApiRequest(model, { sunset: true })).toBe(true)
+    expect(shouldBlockFreeApiRequest(model, { sunset: true, localOnly: true })).toBe(false)
+    expect(shouldBlockFreeApiRequest(model, { sunset: true, shell: true })).toBe(false)
+    expect(shouldBlockFreeApiRequest({ providerID: "xiaomi", modelID: "mimo-auto" }, { sunset: true })).toBe(false)
   })
 
   test("switches the model display key at sunset", () => {
-    expect(freeApiModelNameKey(isFreeApiSunset(FREE_API_SUNSET_AT - 1))).toBe("tui.model.mimo_auto.name")
-    expect(freeApiModelNameKey(isFreeApiSunset(FREE_API_SUNSET_AT))).toBe("tui.model.mimo_auto.sunset_name")
-    expect(freeApiModelNameKey(isFreeApiSunset(FREE_API_SUNSET_AT + 1))).toBe("tui.model.mimo_auto.sunset_name")
-  })
-
-  test("all TUI locales define the post-sunset model name", () => {
-    expect([en, es, fr, ja, ru, zh, zht].map((locale) => locale["tui.model.mimo_auto.sunset_name"])).toEqual([
-      "MiMo Auto (MiMo-V2.5)",
-      "MiMo Auto (MiMo-V2.5)",
-      "MiMo Auto (MiMo-V2.5)",
-      "MiMo Auto（MiMo-V2.5）",
-      "MiMo Auto (MiMo-V2.5)",
-      "MiMo Auto（MiMo-V2.5）",
-      "MiMo Auto（MiMo-V2.5）",
-    ])
+    expect(freeApiModelNameKey(false)).toBe("tui.model.mimo_auto.name")
+    expect(freeApiModelNameKey(true)).toBe("tui.model.mimo_auto.sunset_name")
   })
 
   test("schedules one reactive switch before the threshold", () => {

--- a/packages/opencode/test/cli/cmd/tui/tips-view.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/tips-view.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import { buildTipKeys } from "../../../../src/cli/cmd/tui/feature-plugins/home/tips-view"
+import { dict as en } from "../../../../src/cli/cmd/tui/i18n/en"
+import { dict as es } from "../../../../src/cli/cmd/tui/i18n/es"
+import { dict as fr } from "../../../../src/cli/cmd/tui/i18n/fr"
+import { dict as ja } from "../../../../src/cli/cmd/tui/i18n/ja"
+import { dict as ru } from "../../../../src/cli/cmd/tui/i18n/ru"
+import { dict as zh } from "../../../../src/cli/cmd/tui/i18n/zh"
+import { dict as zht } from "../../../../src/cli/cmd/tui/i18n/zht"
+import { FREE_API_SUNSET_AT, isFreeApiSunset } from "../../../../src/cli/cmd/tui/util/free-api-sunset"
 
 // buildTipKeys assembles the weighted tip pool. The Tab-cycle tip must only
 // mention the Orchestrator agent when the experiment flag is on; otherwise the
@@ -7,27 +15,75 @@ import { buildTipKeys } from "../../../../src/cli/cmd/tui/feature-plugins/home/t
 // agent.
 describe("buildTipKeys", () => {
   test("omits the Orchestrator tab tip when the flag is off", () => {
-    const keys = buildTipKeys(false, "linux")
+    const keys = buildTipKeys({ orchestratorEnabled: false, platform: "linux", sunset: false, xiaomiConnected: false })
     expect(keys).toContain("tui.tips.tab_agent")
     expect(keys).not.toContain("tui.tips.tab_agent_orchestrator")
   })
 
   test("uses the Orchestrator tab tip when the flag is on", () => {
-    const keys = buildTipKeys(true, "linux")
+    const keys = buildTipKeys({ orchestratorEnabled: true, platform: "linux", sunset: false, xiaomiConnected: false })
     expect(keys).toContain("tui.tips.tab_agent_orchestrator")
     expect(keys).not.toContain("tui.tips.tab_agent")
   })
 
-  test("includes exactly one tab-agent variant regardless of flag", () => {
-    for (const enabled of [true, false]) {
-      const tabKeys = buildTipKeys(enabled, "linux").filter((k) => k.startsWith("tui.tips.tab_agent"))
-      expect(tabKeys).toHaveLength(1)
+  test("preserves platform and Orchestrator variants before and after sunset", () => {
+    for (const sunset of [false, true]) {
+      for (const orchestratorEnabled of [false, true]) {
+        for (const platform of ["win32", "darwin", "linux"] as const) {
+          const keys = buildTipKeys({ orchestratorEnabled, platform, sunset, xiaomiConnected: true })
+          expect(keys.filter((key) => key.startsWith("tui.tips.tab_agent"))).toEqual([
+            orchestratorEnabled ? "tui.tips.tab_agent_orchestrator" : "tui.tips.tab_agent",
+          ])
+          expect(keys).toContain(platform === "win32" ? "tui.tips.suspend.win" : "tui.tips.suspend.unix")
+        }
+      }
     }
   })
 
-  test("appends the platform-specific suspend tip", () => {
-    expect(buildTipKeys(false, "win32")).toContain("tui.tips.suspend.win")
-    expect(buildTipKeys(false, "darwin")).toContain("tui.tips.suspend.unix")
-    expect(buildTipKeys(false, "linux")).toContain("tui.tips.suspend.unix")
+  test("keeps the free-model promotion before sunset", () => {
+    const keys = buildTipKeys({
+      orchestratorEnabled: false,
+      platform: "linux",
+      sunset: isFreeApiSunset(FREE_API_SUNSET_AT - 1),
+      xiaomiConnected: false,
+    })
+    expect(keys).toContain("tui.tips.free_models")
+    expect(keys).not.toContain("tui.tips.free_api_sunset")
+  })
+
+  test("replaces the free-model promotion at and after sunset for logged-out users", () => {
+    for (const now of [FREE_API_SUNSET_AT, FREE_API_SUNSET_AT + 1]) {
+      const keys = buildTipKeys({
+        orchestratorEnabled: false,
+        platform: "linux",
+        sunset: isFreeApiSunset(now),
+        xiaomiConnected: false,
+      })
+      expect(keys).not.toContain("tui.tips.free_models")
+      expect(keys).toContain("tui.tips.free_api_sunset")
+    }
+  })
+
+  test("removes both free API tips after sunset for Xiaomi users", () => {
+    const keys = buildTipKeys({ orchestratorEnabled: false, platform: "linux", sunset: true, xiaomiConnected: true })
+    expect(keys).not.toContain("tui.tips.free_models")
+    expect(keys).not.toContain("tui.tips.free_api_sunset")
+  })
+})
+
+describe("free API sunset translations", () => {
+  test("tell users to log in or configure a third-party API in all seven locales", () => {
+    for (const [dict, thirdPartyApi] of [
+      [en, "third-party API"],
+      [es, "API de terceros"],
+      [fr, "API tierce"],
+      [ja, "サードパーティ API"],
+      [ru, "сторонний API"],
+      [zh, "第三方 API"],
+      [zht, "第三方 API"],
+    ] as const) {
+      expect(dict["tui.tips.free_api_sunset"]).toContain("/login")
+      expect(dict["tui.tips.free_api_sunset"]).toContain(thirdPartyApi)
+    }
   })
 })

--- a/packages/opencode/test/cli/cmd/tui/tips-view.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/tips-view.test.ts
@@ -1,13 +1,5 @@
 import { describe, expect, test } from "bun:test"
 import { buildTipKeys } from "../../../../src/cli/cmd/tui/feature-plugins/home/tips-view"
-import { dict as en } from "../../../../src/cli/cmd/tui/i18n/en"
-import { dict as es } from "../../../../src/cli/cmd/tui/i18n/es"
-import { dict as fr } from "../../../../src/cli/cmd/tui/i18n/fr"
-import { dict as ja } from "../../../../src/cli/cmd/tui/i18n/ja"
-import { dict as ru } from "../../../../src/cli/cmd/tui/i18n/ru"
-import { dict as zh } from "../../../../src/cli/cmd/tui/i18n/zh"
-import { dict as zht } from "../../../../src/cli/cmd/tui/i18n/zht"
-import { FREE_API_SUNSET_AT, isFreeApiSunset } from "../../../../src/cli/cmd/tui/util/free-api-sunset"
 
 // buildTipKeys assembles the weighted tip pool. The Tab-cycle tip must only
 // mention the Orchestrator agent when the experiment flag is on; otherwise the
@@ -15,75 +7,44 @@ import { FREE_API_SUNSET_AT, isFreeApiSunset } from "../../../../src/cli/cmd/tui
 // agent.
 describe("buildTipKeys", () => {
   test("omits the Orchestrator tab tip when the flag is off", () => {
-    const keys = buildTipKeys({ orchestratorEnabled: false, platform: "linux", sunset: false, xiaomiConnected: false })
+    const keys = buildTipKeys(false, "linux")
     expect(keys).toContain("tui.tips.tab_agent")
     expect(keys).not.toContain("tui.tips.tab_agent_orchestrator")
   })
 
   test("uses the Orchestrator tab tip when the flag is on", () => {
-    const keys = buildTipKeys({ orchestratorEnabled: true, platform: "linux", sunset: false, xiaomiConnected: false })
+    const keys = buildTipKeys(true, "linux")
     expect(keys).toContain("tui.tips.tab_agent_orchestrator")
     expect(keys).not.toContain("tui.tips.tab_agent")
   })
 
-  test("preserves platform and Orchestrator variants before and after sunset", () => {
-    for (const sunset of [false, true]) {
-      for (const orchestratorEnabled of [false, true]) {
-        for (const platform of ["win32", "darwin", "linux"] as const) {
-          const keys = buildTipKeys({ orchestratorEnabled, platform, sunset, xiaomiConnected: true })
-          expect(keys.filter((key) => key.startsWith("tui.tips.tab_agent"))).toEqual([
-            orchestratorEnabled ? "tui.tips.tab_agent_orchestrator" : "tui.tips.tab_agent",
-          ])
-          expect(keys).toContain(platform === "win32" ? "tui.tips.suspend.win" : "tui.tips.suspend.unix")
-        }
-      }
+  test("includes exactly one tab-agent variant regardless of flag", () => {
+    for (const enabled of [true, false]) {
+      const tabKeys = buildTipKeys(enabled, "linux").filter((k) => k.startsWith("tui.tips.tab_agent"))
+      expect(tabKeys).toHaveLength(1)
     }
+  })
+
+  test("appends the platform-specific suspend tip", () => {
+    expect(buildTipKeys(false, "win32")).toContain("tui.tips.suspend.win")
+    expect(buildTipKeys(false, "darwin")).toContain("tui.tips.suspend.unix")
+    expect(buildTipKeys(false, "linux")).toContain("tui.tips.suspend.unix")
   })
 
   test("keeps the free-model promotion before sunset", () => {
-    const keys = buildTipKeys({
-      orchestratorEnabled: false,
-      platform: "linux",
-      sunset: isFreeApiSunset(FREE_API_SUNSET_AT - 1),
-      xiaomiConnected: false,
-    })
-    expect(keys).toContain("tui.tips.free_models")
-    expect(keys).not.toContain("tui.tips.free_api_sunset")
+    expect(buildTipKeys(false, "linux", false, false)).toContain("tui.tips.free_models")
+    expect(buildTipKeys(false, "linux", false, false)).not.toContain("tui.tips.free_api_sunset")
   })
 
-  test("replaces the free-model promotion at and after sunset for logged-out users", () => {
-    for (const now of [FREE_API_SUNSET_AT, FREE_API_SUNSET_AT + 1]) {
-      const keys = buildTipKeys({
-        orchestratorEnabled: false,
-        platform: "linux",
-        sunset: isFreeApiSunset(now),
-        xiaomiConnected: false,
-      })
-      expect(keys).not.toContain("tui.tips.free_models")
-      expect(keys).toContain("tui.tips.free_api_sunset")
-    }
+  test("replaces the free promotion with guidance for signed-out users after sunset", () => {
+    const keys = buildTipKeys(false, "linux", true, false)
+    expect(keys).not.toContain("tui.tips.free_models")
+    expect(keys).toContain("tui.tips.free_api_sunset")
   })
 
-  test("removes both free API tips after sunset for Xiaomi users", () => {
-    const keys = buildTipKeys({ orchestratorEnabled: false, platform: "linux", sunset: true, xiaomiConnected: true })
+  test("does not show sign-in guidance to authenticated Xiaomi users after sunset", () => {
+    const keys = buildTipKeys(false, "linux", true, true)
     expect(keys).not.toContain("tui.tips.free_models")
     expect(keys).not.toContain("tui.tips.free_api_sunset")
-  })
-})
-
-describe("free API sunset translations", () => {
-  test("tell users to log in or configure a third-party API in all seven locales", () => {
-    for (const [dict, thirdPartyApi] of [
-      [en, "third-party API"],
-      [es, "API de terceros"],
-      [fr, "API tierce"],
-      [ja, "サードパーティ API"],
-      [ru, "сторонний API"],
-      [zh, "第三方 API"],
-      [zht, "第三方 API"],
-    ] as const) {
-      expect(dict["tui.tips.free_api_sunset"]).toContain("/login")
-      expect(dict["tui.tips.free_api_sunset"]).toContain(thirdPartyApi)
-    }
   })
 })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2309,6 +2309,8 @@ export class Session2 extends HeyApiClient {
       directory?: string
       workspace?: string
       question?: string
+      providerID?: string
+      modelID?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2321,6 +2323,8 @@ export class Session2 extends HeyApiClient {
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
             { in: "body", key: "question" },
+            { in: "body", key: "providerID" },
+            { in: "body", key: "modelID" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4661,6 +4661,8 @@ export type SessionSummarizeResponse = SessionSummarizeResponses[keyof SessionSu
 export type SessionAskData = {
   body?: {
     question: string
+    providerID?: string
+    modelID?: string
   }
   path: {
     sessionID: string
@@ -5731,6 +5733,7 @@ export type ProviderListResponses = {
       [key: string]: string
     }
     connected: Array<string>
+    authenticated: Array<string>
   }
 }
 


### PR DESCRIPTION
## Summary

- sunset the anonymous `mimo/mimo-auto` API at `2026-07-26T10:00:00.000Z` (July 26, 3:00 AM PDT)
- block TUI prompt, `/btw`, `/compact`, and `/summarize` request paths while keeping login, provider configuration, and shell flows available
- add localized login, MiMo Token Plan, and third-party API guidance across seven locales
- show the free-until deadline in the MiMo Auto label before sunset and remove promotional text afterward
- expose authenticated provider state, pass the selected model to side questions, add a provider-level fallback guard, and regenerate the JS SDK

## Testing

- `bun test test/cli/cmd/tui/free-api-sunset.test.ts test/cli/cmd/tui/tips-view.test.ts`
- `bun test test/server/ask-route-fork-query.test.ts test/server/summarize-route-main-slice.test.ts`
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/app`
- `bun typecheck` in `packages/sdk/js`
- pre-push `bun turbo typecheck` (12/12 tasks passed)
- isolated TUI verification for the sunset dialog, tips, model label, `/login`, and shell execution
