### PR TITLE
feat(tui): improve slash command discovery

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -14,6 +14,7 @@ const COMPOSE_LOCK_TIP = "tui.tips.compose_next"
 // Promote recently-added or critical features so users discover them.
 // Tips not listed here use the default weight of 1.
 const PRIORITY_WEIGHTS: Record<string, number> = {
+  "tui.tips.ask_slash_commands": 70,
   "tui.tips.multi_skills": 60,
   "tui.tips.free_models": 50,
   "tui.tips.free_api_sunset": 50,
@@ -28,6 +29,7 @@ const PRIORITY_WEIGHTS: Record<string, number> = {
 }
 
 const TIP_KEYS = [
+  "tui.tips.ask_slash_commands",
   "tui.tips.multi_skills",
   "tui.tips.free_models",
   "tui.tips.background",
@@ -130,6 +132,10 @@ const TIP_KEYS = [
   "tui.tips.rename",
 ] as const
 
+export function tipWeight(key: string) {
+  return PRIORITY_WEIGHTS[key] ?? 1
+}
+
 // Build the tip key pool. The Tab-cycle tip mentions the Orchestrator agent
 // only when the experiment is enabled; otherwise use the variant without it so
 // we never point users at an agent that isn't reachable. The platform-specific
@@ -177,7 +183,7 @@ function parse(tip: string): TipPart[] {
 }
 
 function pickWeighted(keys: readonly string[]): string {
-  const weights = keys.map((k) => PRIORITY_WEIGHTS[k] ?? 1)
+  const weights = keys.map(tipWeight)
   const total = weights.reduce((a, b) => a + b, 0)
   let target = Math.random() * total
   for (let i = 0; i < keys.length; i++) {

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -57,6 +57,8 @@ export const dict: Record<string, string> = {
     "The free API service has ended. Run {highlight}/login{/highlight} to sign in. Subscribe to the MiMo Token Plan or configure a third-party API to use MiMo Code.",
   "tui.tips.multi_skills":
     "Combine multiple {highlight}/skill-name{/highlight} triggers in a single message to use several skills together",
+  "tui.tips.ask_slash_commands":
+    "Looking for a shortcut? Ask {highlight}Which slash commands can I use?{/highlight} directly in chat",
   "tui.tips.background":
     "Run {highlight}/background{/highlight} to set a custom image as your home background",
   "tui.tips.compose_next":

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -63,6 +63,8 @@ export const dict = {
     "El servicio de API gratuita ha finalizado. Ejecuta {highlight}/login{/highlight} para iniciar sesión. Suscríbete a MiMo Token Plan o configura una API de terceros para usar MiMo Code.",
   "tui.tips.multi_skills":
     "Combina varios {highlight}/skill-name{/highlight} en un mismo mensaje para usar varias Skills a la vez",
+  "tui.tips.ask_slash_commands":
+    "¿Buscas un atajo? Pregunta {highlight}¿Qué comandos slash puedo usar?{/highlight} directamente en el chat",
   "tui.tips.background":
     "Ejecuta {highlight}/background{/highlight} para usar una imagen personalizada como fondo de inicio",
   "tui.tips.compose_next":

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -63,6 +63,8 @@ export const dict = {
     "Le service API gratuit est terminé. Exécutez {highlight}/login{/highlight} pour vous connecter. Abonnez-vous au MiMo Token Plan ou configurez une API tierce pour utiliser MiMo Code.",
   "tui.tips.multi_skills":
     "Combinez plusieurs déclencheurs {highlight}/skill-name{/highlight} dans un même message pour utiliser plusieurs Skills ensemble",
+  "tui.tips.ask_slash_commands":
+    "Vous cherchez un raccourci ? Demandez {highlight}Quelles commandes slash puis-je utiliser ?{/highlight} directement dans le chat",
   "tui.tips.background":
     "Exécutez {highlight}/background{/highlight} pour définir une image personnalisée comme fond d'écran d'accueil",
   "tui.tips.compose_next":

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -61,6 +61,8 @@ export const dict = {
     "無料 API サービスは終了しました。{highlight}/login{/highlight} でログインしてください。MiMo Token Plan を購読するか、サードパーティ API を設定して MiMo Code をご利用ください。",
   "tui.tips.multi_skills":
     "1 つのメッセージ内で複数の {highlight}/skill-name{/highlight} を組み合わせて、複数の Skill を同時に使えます",
+  "tui.tips.ask_slash_commands":
+    "ショートカットを探すには、チャットで {highlight}使えるスラッシュコマンドは？{/highlight} と直接質問できます",
   "tui.tips.background": "{highlight}/background{/highlight} を実行してホーム背景にお好みの画像を設定できます",
   "tui.tips.compose_next":
     "{highlight}/compose-next{/highlight} を推奨（強力なモデル向け・Compose 代替）",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -62,6 +62,8 @@ export const dict = {
     "Сервис бесплатного API завершён. Выполните {highlight}/login{/highlight}, чтобы войти. Оформите подписку на MiMo Token Plan или настройте сторонний API для использования MiMo Code.",
   "tui.tips.multi_skills":
     "Комбинируйте несколько {highlight}/skill-name{/highlight} в одном сообщении, чтобы использовать несколько Skills одновременно",
+  "tui.tips.ask_slash_commands":
+    "Ищете команду? Спросите {highlight}Какие slash-команды я могу использовать?{/highlight} прямо в чате",
   "tui.tips.background":
     "Выполните {highlight}/background{/highlight}, чтобы установить произвольное изображение в качестве фона главной страницы",
   "tui.tips.compose_next":

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -60,6 +60,8 @@ export const dict = {
     "免费 API 服务已终止。请使用 {highlight}/login{/highlight} 登录，欢迎订阅MiMo Token Plan或配置第三方 API 后使用 MiMo Code。",
   "tui.tips.multi_skills":
     "在同一条消息中输入多个 {highlight}/skill-name{/highlight} 可以同时组合使用多个 Skills",
+  "tui.tips.ask_slash_commands":
+    "想找快捷指令？直接在聊天中问 {highlight}有哪些 slash 快捷指令？{/highlight}",
   "tui.tips.background": "运行 {highlight}/background{/highlight} 设置自定义图片作为主页背景",
   "tui.tips.compose_next":
     "推荐前沿模型使用 {highlight}/compose-next{/highlight} 代替 Compose 智能体",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -60,6 +60,8 @@ export const dict = {
     "免費 API 服務已終止。請使用 {highlight}/login{/highlight} 登入，歡迎訂閱 MiMo Token Plan 或設定第三方 API 後使用 MiMo Code。",
   "tui.tips.multi_skills":
     "在同一則訊息中輸入多個 {highlight}/skill-name{/highlight} 可同時組合使用多個 Skills",
+  "tui.tips.ask_slash_commands":
+    "想找快捷指令？直接在聊天中問 {highlight}有哪些 slash 快捷指令？{/highlight}",
   "tui.tips.background": "執行 {highlight}/background{/highlight} 設定自訂圖片作為主頁背景",
   "tui.tips.compose_next":
     "推薦前沿模型使用 {highlight}/compose-next{/highlight} 代替 Compose 智慧體",

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/commands.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/commands.md
@@ -33,20 +33,95 @@ Notable TUI flags: `--continue`/`-c` (resume last session), `--session`/`-s`, `-
 
 ## Slash commands (inside the TUI)
 
+Type `/` to see the commands available in the current context. You can also ask in chat, for example, “Which slash commands can I use?” or “How do I switch models?” MiMoCode will explain the relevant command without requiring you to remember its name.
+
+Most client commands run only when the whole input is the command. `/btw <question>` and prompt commands that accept arguments are the exceptions.
+
+### Application commands
+
+| Command | Aliases | Purpose / availability |
+|---------|---------|------------------------|
+| `/sessions` | `/resume`, `/continue` | List and continue previous sessions |
+| `/workflows` | — | Open the workflow list; shown when the workflow experiment is enabled |
+| `/new` | `/clear` | Start a new session |
+| `/models` | — | Switch models |
+| `/agents` | — | Switch agents |
+| `/modalities` | — | Configure a custom model's input modalities (image/audio/video/PDF) |
+| `/never-ask` | — | Toggle never-ask permission mode |
+| `/skip-permissions` | — | Toggle runtime auto-allow for permission asks; explicit denies still block |
+| `/mcps` | — | Show MCP server status |
+| `/variants` | — | Switch model variants; shown only when variants are available |
+| `/login` | — | Sign in to Xiaomi MiMo |
+| `/connect` | — | Connect or sign in to a model provider |
+| `/logout` | — | Sign out of Xiaomi MiMo |
+| `/org` | `/orgs`, `/switch-org` | Switch organizations; shown when more than one organization is available |
+| `/status` | — | Show system and session status |
+| `/worktree` | `/wt` | List and switch worktrees |
+| `/themes` | — | Choose a color theme |
+| `/background` | — | Choose the home-screen background |
+| `/logo` | — | Choose the home-screen logo style |
+| `/dark` | — | Switch to dark mode |
+| `/light` | — | Switch to light mode |
+| `/help` | — | Open command help |
+| `/doc` | `/docs` | Open the user documentation |
+| `/exit` | `/quit`, `/q` | Exit MiMoCode |
+| `/language` | `/lang` | Switch the TUI language |
+
+### Prompt commands
+
 | Command | Purpose |
 |---------|---------|
-| `/goal` | Set a stop condition; a judge model verifies it's truly met before the agent halts (prevents premature stops in autonomous work) |
-| `/dream` | Scan recent traces, extract durable knowledge into project memory, prune stale entries |
-| `/distill` | Detect repeated manual workflows and package high-confidence ones into skills/subagents/commands |
-| `/voice` | Toggle streaming voice input (needs `sox`; MiMo-logged-in users) |
-| `/loop` | `[interval] <prompt>` — schedule a repeating prompt (also runs once now); maps the interval to a cron job |
-| `/loops` | List scheduled cron/loop jobs; `/loops cancel <id>` stops one |
-| `/rebuild` | Rebuild the conversation context now from the latest checkpoint — frees context on demand instead of waiting for the automatic overflow trigger. Keeps recent messages verbatim; earlier context collapses to the checkpoint summary. Waits (bounded) for an in-flight checkpoint writer first |
-| `/connect` | Sign in to a provider (e.g. OpenRouter; OAuth logins include Xiaomi MiMo, Codex/ChatGPT, xAI/Grok) |
-| `/modalities` | Configure a custom model's input modalities (image/audio/video/pdf) via multi-select dialog; persists to `provider.<id>.models.<id>.modalities` in global config |
-| `/skip-permissions` | Toggle auto-allow for permission asks at runtime (instance-wide, inherited by subagents). `deny` rules still block; forced-ask operations (destructive bash etc.) auto-reject after 60s with actionable feedback instead of hanging |
-| `/compose-next` | Recommended spec→ship feature delivery skill; hidden from model auto-discovery — invoke explicitly |
-| `/<skill-name>` | Invoke any available skill directly by name. Mentioning 2+ skills in one message auto-loads them (up to 3) and injects a multi-skill orchestration plan |
+| `/editor` | Edit the current prompt in an external editor |
+| `/skills` | Browse and select available skills |
+| `/revoke-consent` | Revoke consent for the free service |
+| `/voice` | Toggle streaming voice input (requires `sox` and a MiMo login) |
+| `/voice-send` | Toggle sending transcribed voice input automatically |
+| `/voice-control` | Toggle voice control |
+
+### Session commands
+
+These commands are available while viewing a session. Some appear only when their action is possible.
+
+| Command | Aliases | Purpose / availability |
+|---------|---------|------------------------|
+| `/share` | — | Share the session; unavailable when sharing is disabled |
+| `/rename` | — | Rename the session |
+| `/timeline` | — | Open the message timeline |
+| `/fork` | — | Fork the session from an earlier message |
+| `/compact` | `/summarize` | Summarize a long session to free context |
+| `/btw <question>` | — | Ask a side question without adding it to the main conversation context |
+| `/unshare` | — | Stop sharing; shown only for a shared session |
+| `/undo` | — | Undo the latest message and its file changes |
+| `/redo` | — | Restore an undone message and its file changes |
+| `/timestamps` | `/toggle-timestamps` | Toggle message timestamps |
+| `/thinking` | `/toggle-thinking` | Toggle thinking-block visibility |
+| `/copy` | — | Copy the session transcript |
+| `/export` | — | Export the session transcript |
+
+### Built-in prompt commands
+
+These commands submit a predefined prompt to the agent and may accept trailing arguments.
+
+| Command | Purpose |
+|---------|---------|
+| `/init` | Generate or update project `AGENTS.md` guidance from the codebase |
+| `/review [target]` | Review a commit, branch, or pull request; defaults to uncommitted changes |
+| `/goal <condition>` | Set a judge-verified stop condition; `/goal clear` aborts it |
+| `/dream [focus]` | Consolidate durable knowledge from recent work into project memory |
+| `/distill [focus]` | Package repeated workflows into skills, subagents, or commands |
+| `/rebuild` | Rebuild conversation context from the latest checkpoint while keeping recent messages verbatim |
+| `/deep-research <question>` | Run deep multi-source research; the prompt-command implementation requires the workflow experiment |
+| `/loops [cancel <id>]` | List or cancel scheduled jobs; requires the cron experiment |
+
+### Skills and other dynamic commands
+
+The slash menu also includes commands discovered at runtime:
+
+- `/<skill-name>` invokes an available skill; `/loop [interval] <prompt>` schedules a repeating prompt, and `/compose-next` starts the recommended spec-to-ship workflow.
+- Project and global Markdown commands from `command/**/*.md` and `commands/**/*.md` use their relative filename as the slash name.
+- MCP prompts become slash commands and are marked `:mcp` in autocomplete.
+- A custom command or MCP prompt with the same name overrides a built-in prompt command. Skills do not override an existing command.
+- Mentioning two or more skills in one chat message can auto-load up to three skills with an orchestration plan.
 
 ## Keybindings
 

--- a/packages/opencode/test/cli/cmd/tui/tips-view.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/tips-view.test.ts
@@ -1,11 +1,25 @@
 import { describe, expect, test } from "bun:test"
-import { buildTipKeys } from "../../../../src/cli/cmd/tui/feature-plugins/home/tips-view"
+import { buildTipKeys, tipWeight } from "../../../../src/cli/cmd/tui/feature-plugins/home/tips-view"
+import { dict as en } from "../../../../src/cli/cmd/tui/i18n/en"
+import { dict as es } from "../../../../src/cli/cmd/tui/i18n/es"
+import { dict as fr } from "../../../../src/cli/cmd/tui/i18n/fr"
+import { dict as ja } from "../../../../src/cli/cmd/tui/i18n/ja"
+import { dict as ru } from "../../../../src/cli/cmd/tui/i18n/ru"
+import { dict as zh } from "../../../../src/cli/cmd/tui/i18n/zh"
+import { dict as zht } from "../../../../src/cli/cmd/tui/i18n/zht"
 
 // buildTipKeys assembles the weighted tip pool. The Tab-cycle tip must only
 // mention the Orchestrator agent when the experiment flag is on; otherwise the
 // Orchestrator-free variant is used so we never point users at an unreachable
 // agent.
 describe("buildTipKeys", () => {
+  test("promotes localized chat guidance for discovering slash commands", () => {
+    const key = "tui.tips.ask_slash_commands"
+    expect(buildTipKeys(false, "linux")).toContain(key)
+    expect(tipWeight(key)).toBeGreaterThan(tipWeight("tui.tips.multi_skills"))
+    Array.of(en, es, fr, ja, ru, zh, zht).forEach((dict) => expect(dict[key]).toBeTruthy())
+  })
+
   test("omits the Orchestrator tab tip when the flag is off", () => {
     const keys = buildTipKeys(false, "linux")
     expect(keys).toContain("tui.tips.tab_agent")


### PR DESCRIPTION
## Summary

- document application, prompt, session, built-in, and dynamic slash commands in the bundled mimocode-docs skill
- add a high-priority home tip that tells users to ask about slash commands directly in chat
- localize the tip across all seven TUI dictionaries and cover its priority and translations in tests

## Testing

- `bun test ./test/cli/cmd/tui/tips-view.test.ts`
- `bun typecheck`
- `bunx oxlint <changed TypeScript files>`
- `git diff --check`