### PR TITLE
fix(actor): resolve GPT subagent tools by catalog model

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -277,6 +277,7 @@ export const layer = Layer.effect(
                 glob: "allow",
                 list: "allow",
                 bash: "allow",
+                exec: "allow",
                 webfetch: "allow",
                 websearch: "allow",
                 codesearch: "allow",
@@ -391,6 +392,7 @@ export const layer = Layer.effect(
                 grep: "allow",
                 memory: "allow",
                 bash: "allow",
+                exec: "allow",
                 external_directory: {
                   [path.join(Global.Path.data, "memory")]: "allow",
                   [path.join(Global.Path.data, "memory", "*")]: "allow",
@@ -398,7 +400,18 @@ export const layer = Layer.effect(
               }),
               user,
             ),
-            toolAllowlist: ["read", "write", "edit", "glob", "grep", "memory", "bash"],
+            toolAllowlist: [
+              "read",
+              "write",
+              "edit",
+              "apply_patch",
+              "view_image",
+              "glob",
+              "grep",
+              "memory",
+              "bash",
+              "exec",
+            ],
           },
           distill: {
             name: "distill",
@@ -418,6 +431,7 @@ export const layer = Layer.effect(
                 grep: "allow",
                 memory: "allow",
                 bash: "allow",
+                exec: "allow",
                 external_directory: {
                   [path.join(Global.Path.data, "memory")]: "allow",
                   [path.join(Global.Path.data, "memory", "*")]: "allow",
@@ -425,7 +439,18 @@ export const layer = Layer.effect(
               }),
               user,
             ),
-            toolAllowlist: ["read", "write", "edit", "glob", "grep", "memory", "bash"],
+            toolAllowlist: [
+              "read",
+              "write",
+              "edit",
+              "apply_patch",
+              "view_image",
+              "glob",
+              "grep",
+              "memory",
+              "bash",
+              "exec",
+            ],
           },
         }
 

--- a/packages/opencode/src/agent/prompt/gpt-tools.txt
+++ b/packages/opencode/src/agent/prompt/gpt-tools.txt
@@ -1,0 +1,10 @@
+# GPT subagent tools
+
+The tools exposed in this turn are the source of truth. GPT-5-family agents use a model-specific tool set, so do not call legacy file tools that are absent from the tool list.
+
+- Use `exec` as the main composition surface when you need to batch independent tool calls or compactly transform their results. Run independent calls with `Promise.all` or `Promise.allSettled`, keep dependent calls sequential, and return only the evidence needed by the caller. Call one small tool directly instead of wrapping it in `exec`.
+- Code inside `exec` is the body of an async JavaScript/TypeScript function. Use only the declared `tools`, `files`, and `console` globals. Conversation-control tools are unavailable inside `exec` and must be called directly.
+- Use `apply_patch` for project text edits. Provide the complete patch in `patch_text`; do not create or modify project files through `exec` raw file helpers.
+- Use `view_image` to inspect local JPEG, PNG, GIF, or WebP files when visual analysis is needed.
+- When `read`, `grep`, or `glob` are not exposed, use `bash` with targeted `rg`, `rg --files`, and `sed -n` commands for codebase exploration. Keep every command read-only when the subagent's role is read-only.
+- `exec` never broadens permissions: its nested calls have the same model-, agent-, and permission-filtered tool set as direct calls.

--- a/packages/opencode/src/session/llm-request-prefix.ts
+++ b/packages/opencode/src/session/llm-request-prefix.ts
@@ -3,7 +3,6 @@ import { tool, jsonSchema, type Tool as AITool } from "ai"
 import z from "zod"
 import { MessageV2 } from "./message-v2"
 import type { SessionID } from "./schema"
-import { ModelID } from "../provider/schema"
 import type { Agent } from "../agent/agent"
 import type { Provider } from "../provider"
 import { LLM } from "./llm"
@@ -65,7 +64,7 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
 
   // Resolve tools using parent agent's permission and toolAllowlist
   const toolDefs = yield* toolRegistry.tools({
-    modelID: ModelID.make(input.model.api.id),
+    modelID: input.model.id,
     providerID: input.model.providerID,
     agent: input.agent,
   })

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -248,8 +248,7 @@ const live: Layer.Layer<
       const system: string[] = []
       system.push(
         [
-          // use agent prompt otherwise provider prompt
-          ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
+          ...SystemPrompt.agent(input.agent, input.model),
           // any custom prompt passed into this call
           ...input.system,
           // any custom prompt from last user message

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -995,7 +995,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         abort: options.abortSignal!,
         messageID: input.processor.message.id,
         callID: options.toolCallId,
-        extra: { model: input.model, bypassAgentCheck: input.bypassAgentCheck, promptOps },
+        extra: {
+          model: input.model,
+          bypassAgentCheck: input.bypassAgentCheck,
+          promptOps,
+          ...(whitelist ? { toolWhitelist: [...whitelist] } : {}),
+        },
         agent: input.agent.name,
         actorID: input.agentID,
         taskId: input.task_id,
@@ -1035,7 +1040,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
 
       for (const item of yield* registry.tools({
-        modelID: ModelID.make(input.model.api.id),
+        modelID: input.model.id,
         providerID: input.model.providerID,
         agent: input.agent,
       })) {

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -8,6 +8,7 @@ import PROMPT_BEAST from "./prompt/beast.txt"
 import PROMPT_GEMINI from "./prompt/gemini.txt"
 import PROMPT_GPT from "./prompt/gpt.txt"
 import PROMPT_KIMI from "./prompt/kimi.txt"
+import PROMPT_GPT_SUBAGENT_TOOLS from "../agent/prompt/gpt-tools.txt"
 
 import PROMPT_CODEX from "./prompt/codex.txt"
 import PROMPT_DEEPSEEK from "./prompt/deepseek.txt"
@@ -20,24 +21,28 @@ import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { isSkillSearchDisabled, type SkillSearchModel } from "@/skill/search"
+import { usesGPTToolset } from "@/tool/gpt"
 
 export function provider(model: Provider.Model) {
-  if (model.api.id.includes("gpt-4") || model.api.id.includes("o1") || model.api.id.includes("o3"))
-    return [PROMPT_BEAST]
-  if (model.api.id.includes("gpt")) {
-    if (model.api.id.includes("codex")) {
-      return [PROMPT_CODEX]
-    }
-    return [PROMPT_GPT]
+  const prompt = (id: string) => {
+    if (id.includes("gpt-4") || id.includes("o1") || id.includes("o3")) return PROMPT_BEAST
+    if (id.includes("gpt")) return id.includes("codex") ? PROMPT_CODEX : PROMPT_GPT
+    if (id.includes("gemini-")) return PROMPT_GEMINI
+    if (id.includes("claude")) return PROMPT_ANTHROPIC
+    if (id.toLowerCase().includes("trinity")) return PROMPT_TRINITY
+    if (id.toLowerCase().includes("kimi")) return PROMPT_KIMI
+    if (id.toLowerCase().includes("deepseek")) return PROMPT_DEEPSEEK
+    if (id.toLowerCase().includes("glm")) return PROMPT_GLM
+    if (id.toLowerCase().includes("minimax")) return PROMPT_MINIMAX
   }
-  if (model.api.id.includes("gemini-")) return [PROMPT_GEMINI]
-  if (model.api.id.includes("claude")) return [PROMPT_ANTHROPIC]
-  if (model.api.id.toLowerCase().includes("trinity")) return [PROMPT_TRINITY]
-  if (model.api.id.toLowerCase().includes("kimi")) return [PROMPT_KIMI]
-  if (model.api.id.toLowerCase().includes("deepseek")) return [PROMPT_DEEPSEEK]
-  if (model.api.id.toLowerCase().includes("glm")) return [PROMPT_GLM]
-  if (model.api.id.toLowerCase().includes("minimax")) return [PROMPT_MINIMAX]
-  return [PROMPT_DEFAULT]
+  return [prompt(model.id) ?? prompt(model.api.id) ?? PROMPT_DEFAULT]
+}
+
+export function agent(agent: Agent.Info, model: Provider.Model) {
+  const base = agent.prompt ? [agent.prompt] : provider(model)
+  if (agent.mode !== "subagent" || agent.toolAllowlist?.length === 0 || !usesGPTToolset(model.id)) return base
+  if (!agent.prompt && base.includes(PROMPT_GPT)) return base
+  return [...base, PROMPT_GPT_SUBAGENT_TOOLS]
 }
 
 export interface Interface {

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -1,0 +1,3 @@
+export function usesGPTToolset(modelID: string) {
+  return modelID.includes("gpt-") && !modelID.includes("oss") && !modelID.includes("gpt-4")
+}

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -73,6 +73,7 @@ import { resolveInvocationStyle } from "./invocation-style"
 import { BuiltinWorkflow } from "@/workflow/builtin"
 import { ToolScriptTool, renderToolScriptDeclarations } from "./tool-script"
 import { toolScriptRegistry, toolScriptMcp } from "./tool-script-ref"
+import { usesGPTToolset } from "./gpt"
 
 const log = Log.create({ service: "tool.registry" })
 
@@ -365,8 +366,7 @@ export const layer = Layer.effect(
       modelID: ModelID
       agent: Agent.Info
     }) {
-      const useGPTTools =
-        input.modelID.includes("gpt-") && !input.modelID.includes("oss") && !input.modelID.includes("gpt-4")
+      const useGPTTools = usesGPTToolset(input.modelID)
       let filtered = (yield* all()).filter((tool) => {
         if (tool.id === ToolScriptTool.id) return useGPTTools
         if (tool.id === CodeSearchTool.id || tool.id === WebSearchTool.id) {

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -8,7 +8,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import { EffectBridge, InstanceState } from "@/effect"
 import { Log, Filesystem } from "@/util"
 import { Agent } from "@/agent/agent"
-import { ModelID, type ProviderID } from "../provider/schema"
+import type { ModelID, ProviderID } from "../provider/schema"
 import { normalizeToolResult } from "../mcp/tool-result"
 import { evalScript, type HostFn } from "../workflow/sandbox"
 import { toolScriptRegistry, toolScriptMcp, TOOL_SCRIPT_ALIASES, TOOL_SCRIPT_EXCLUDED } from "./tool-script-ref"
@@ -347,19 +347,24 @@ export const ToolScriptTool = Tool.define(
           const getDefs = toolScriptRegistry.current
           if (!getDefs) throw new Error("exec tool registry unavailable")
           const agentInfo = yield* agents.get(ctx.agent)
-          const model = ctx.extra?.model as { providerID: ProviderID; api: { id: string } } | undefined
+          const model = ctx.extra?.model as { id: ModelID; providerID: ProviderID } | undefined
+          const whitelist = Array.isArray(ctx.extra?.toolWhitelist)
+            ? new Set(ctx.extra.toolWhitelist.filter((id): id is string => typeof id === "string"))
+            : undefined
           const defs = (
             yield* getDefs(
               model
-                ? { providerID: model.providerID, modelID: ModelID.make(model.api.id), agent: agentInfo }
+                ? { providerID: model.providerID, modelID: model.id, agent: agentInfo }
                 : undefined,
             )
-          ).filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id))
+          ).filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id) && (!whitelist || whitelist.has(def.id)))
           const byId = new Map(defs.map((def) => [def.id, def]))
           // MCP tools (late-bound ref, populated by SessionPrompt). Builtin ids
           // win on collision — an MCP server must not shadow `read`/`grep`.
           const mcpTools = toolScriptMcp.current ? yield* toolScriptMcp.current() : {}
-          const mcpById = new Map(Object.entries(mcpTools).filter(([id]) => !byId.has(id)))
+          const mcpById = new Map(
+            Object.entries(mcpTools).filter(([id]) => !byId.has(id) && (!whitelist || whitelist.has(id))),
+          )
           // Non-git projects report worktree === "/" (see Instance.containsPath) —
           // "/" as a jail root would allow EVERYTHING. Fall back to the project
           // directory in that case. Relative guest paths resolve against roots[0].

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -251,6 +251,28 @@ function providerCfg(url: string) {
   }
 }
 
+function gptProviderCfg(url: string) {
+  const config = providerCfg(url)
+  return {
+    ...config,
+    provider: {
+      ...config.provider,
+      "gpt-test": {
+        ...config.provider.test,
+        id: "gpt-test",
+        name: "GPT Test",
+        models: {
+          "gpt-5.4": {
+            ...config.provider.test.models["test-model"],
+            id: "deployment-primary",
+            name: "GPT-5.4",
+          },
+        },
+      },
+    },
+  }
+}
+
 describe("Actor.spawn peer mode", () => {
   it.live("creates a new sessionID, registers actor with mode=peer", () =>
     provideTmpdirServer(
@@ -349,6 +371,132 @@ describe("Actor.spawn peer mode", () => {
 })
 
 describe("Actor.spawn subagent mode", () => {
+  it.live("exposes GPT orchestration and read tools to read-only GPT subagents", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const parent = yield* session.create({ title: "GPT subagent tools" })
+
+        yield* llm.text("done")
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "explore",
+          task: "verify tools",
+          context: "none",
+          tools: "INHERIT",
+          background: false,
+          model: { providerID: ProviderID.make("gpt-test"), modelID: ModelID.make("gpt-5.4") },
+        })
+        yield* Deferred.await(result.outcome)
+
+        const request = (yield* llm.hits).find(
+          (hit) =>
+            Array.isArray(hit.body.tools) &&
+            hit.body.tools.some(
+              (tool) => (tool as { function?: { name?: string } }).function?.name === "view_image",
+            ),
+        )
+        const names = (request?.body.tools as Array<{ function?: { name?: string } }> | undefined)?.map(
+          (tool) => tool.function?.name,
+        )
+        expect(names).toContain("exec")
+        expect(names).toContain("view_image")
+        expect(names).not.toContain("apply_patch")
+        expect(names).not.toContain("read")
+        expect(names).not.toContain("edit")
+        expect(names).not.toContain("write")
+        expect(
+          (request?.body.messages as Array<{ role?: string; content?: string }> | undefined)
+            ?.filter((message) => message.role === "system")
+            .map((message) => message.content)
+            .join("\n"),
+        ).toContain("Use `exec` as the main composition surface")
+      }),
+      { git: true, config: gptProviderCfg },
+    ),
+    30000,
+  )
+
+  it.live("exposes the full GPT-specific tool set to general GPT subagents", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const parent = yield* session.create({ title: "General GPT subagent tools" })
+
+        yield* llm.text("done")
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "general",
+          task: "verify tools",
+          context: "none",
+          tools: "INHERIT",
+          background: false,
+          model: { providerID: ProviderID.make("gpt-test"), modelID: ModelID.make("gpt-5.4") },
+        })
+        yield* Deferred.await(result.outcome)
+
+        const request = (yield* llm.hits).find(
+          (hit) =>
+            Array.isArray(hit.body.tools) &&
+            hit.body.tools.some(
+              (tool) => (tool as { function?: { name?: string } }).function?.name === "view_image",
+            ),
+        )
+        const names = (request?.body.tools as Array<{ function?: { name?: string } }> | undefined)?.map(
+          (tool) => tool.function?.name,
+        )
+        expect(names).toContain("exec")
+        expect(names).toContain("apply_patch")
+        expect(names).toContain("view_image")
+        expect(names).not.toContain("read")
+        expect(names).not.toContain("edit")
+        expect(names).not.toContain("write")
+      }),
+      { git: true, config: gptProviderCfg },
+    ),
+    30000,
+  )
+
+  it.live("keeps the legacy tool set for non-GPT subagents", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const parent = yield* session.create({ title: "General non-GPT subagent tools" })
+
+        yield* llm.text("done")
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "general",
+          task: "verify tools",
+          context: "none",
+          tools: "INHERIT",
+          background: false,
+          model: ref,
+        })
+        yield* Deferred.await(result.outcome)
+
+        const request = (yield* llm.hits).find((hit) => Array.isArray(hit.body.tools))
+        const names = (request?.body.tools as Array<{ function?: { name?: string } }> | undefined)?.map(
+          (tool) => tool.function?.name,
+        )
+        expect(names).toContain("read")
+        expect(names).toContain("edit")
+        expect(names).toContain("write")
+        expect(names).not.toContain("exec")
+        expect(names).not.toContain("apply_patch")
+        expect(names).not.toContain("view_image")
+      }),
+      { git: true, config: providerCfg },
+    ),
+    30000,
+  )
+
   it.live("does NOT create new session, allocates <type>-<n> actorID", () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -22,6 +22,71 @@ describe("session.system", () => {
     expect(prompt).not.toContain("When possible, prefer parallelization over sequential tool calls")
   })
 
+  test("adds GPT tool guidance to prompted subagents", () => {
+    const model = ProviderTest.model({
+      id: ModelID.make("gpt-5.4"),
+      api: { id: "deployment-primary" } as never,
+    })
+    const prompt = SystemPrompt.agent(
+      {
+        name: "explore",
+        mode: "subagent",
+        prompt: "Explore files without modifying them.",
+        permission: [],
+        options: {},
+      },
+      model,
+    ).join("\n")
+    const general = SystemPrompt.agent(
+      {
+        name: "general",
+        mode: "subagent",
+        permission: [],
+        options: {},
+      },
+      model,
+    ).join("\n")
+
+    expect(prompt).toContain("Explore files without modifying them.")
+    expect(prompt).toContain("Use `exec` as the main composition surface")
+    expect(prompt).toContain("Use `apply_patch` for project text edits")
+    expect(prompt).toContain("Use `view_image`")
+    expect(prompt).toContain("`rg --files`")
+    expect(general).toContain("On GPT models, use `exec` as the main composition surface")
+  })
+
+  test("prefers the catalog model ID when the API deployment ID is opaque", () => {
+    const prompt = SystemPrompt.provider(
+      ProviderTest.model({
+        id: ModelID.make("gpt-5.4"),
+        api: { id: "deployment-primary" } as never,
+      }),
+    )[0]
+
+    expect(prompt).toContain("You are MiMoCode, an agent based on the GPT-5 family")
+  })
+
+  test("does not add GPT tool guidance to non-GPT or tool-less subagents", () => {
+    const subagent = {
+      name: "explore",
+      mode: "subagent" as const,
+      prompt: "Explore files.",
+      permission: [],
+      options: {},
+    }
+    const nonGPT = SystemPrompt.agent(
+      subagent,
+      ProviderTest.model({ id: ModelID.make("claude-sonnet-4-6"), api: { id: "claude-sonnet-4-6" } as never }),
+    ).join("\n")
+    const toolLess = SystemPrompt.agent(
+      { ...subagent, toolAllowlist: [] },
+      ProviderTest.model(),
+    ).join("\n")
+
+    expect(nonGPT).toBe("Explore files.")
+    expect(toolLess).toBe("Explore files.")
+  })
+
   test("does not inject vision capability guidance for GPT, Claude, or Gemini models", async () => {
     await using tmp = await tmpdir({ git: true })
 

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -90,7 +90,13 @@ async function runToolScript(
   code: string,
   defs: Tool.Def[],
   abort?: AbortSignal,
-  opts?: { mcp?: Record<string, any>; ask?: () => Effect.Effect<void>; maxToolCalls?: number; timeoutSeconds?: number },
+  opts?: {
+    mcp?: Record<string, any>
+    ask?: () => Effect.Effect<void>
+    maxToolCalls?: number
+    timeoutSeconds?: number
+    toolWhitelist?: string[]
+  },
 ) {
   const prev = toolScriptRegistry.current
   const prevMcp = toolScriptMcp.current
@@ -115,6 +121,7 @@ async function runToolScript(
               agent: "build",
               abort: abort ?? new AbortController().signal,
               callID: "call_test",
+              extra: opts?.toolWhitelist ? { toolWhitelist: opts.toolWhitelist } : undefined,
               messages: [],
               metadata: () => Effect.void,
               ask: opts?.ask ?? (() => Effect.void),
@@ -130,6 +137,19 @@ async function runToolScript(
 }
 
 describe("exec", () => {
+  test("cannot call tools outside the actor runtime whitelist", async () => {
+    const result = await runToolScript(
+      `return await tools.echo({ value: "blocked" })`,
+      [fakeDef("echo", async () => "unexpected")],
+      undefined,
+      { toolWhitelist: ["exec"] },
+    )
+
+    expect(result.metadata.status).toBe("code_error")
+    expect(result.output).toContain("echo")
+    expect(result.output).not.toContain("unexpected")
+  })
+
   test("executes code, calls tools, returns aggregated result", async () => {
     const seen: string[] = []
     const defs = [


### PR DESCRIPTION
## Summary

- resolve GPT-specific tool families from the catalog model ID across prompt, prefix, and nested `exec` paths
- add GPT-aware subagent guidance for `exec`, `apply_patch`, `view_image`, and `bash`/`rg`
- preserve actor runtime whitelists for nested builtin and MCP calls
- keep non-GPT and tool-less subagent behavior unchanged

## Testing

- `bun test test/actor/spawn.test.ts` — 26 passed
- `bun test test/session/system.test.ts test/session/llm-request-prefix.test.ts test/tool/tool-script.test.ts test/agent/agent.test.ts test/permission/next.test.ts` — 185 passed, 2 existing skipped
- `bun typecheck` from `packages/opencode`
- pre-push workspace typecheck — 12/12 tasks passed
- `git diff --check`
