### PR TITLE
fix(workflow): make workflow tool opt-in

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -219,10 +219,11 @@ export const Flag = {
   // global singleton workspace and child permission-approval routing. Enable with
   // MIMOCODE_EXPERIMENTAL_ORCHESTRATOR=true (or the umbrella MIMOCODE_EXPERIMENTAL).
   MIMOCODE_EXPERIMENTAL_ORCHESTRATOR: MIMOCODE_EXPERIMENTAL || truthy("MIMOCODE_EXPERIMENTAL_ORCHESTRATOR"),
-  // Defaults to true: dynamic workflow + built-in deep-research are on by default.
-  // Set MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL=false to opt out. The env-var name is
-  // kept for backwards compat (long-running experiments still pass it as `1`).
-  MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL: !falsy("MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL"),
+  // Defaults to OFF (opt-in): dynamic workflows and built-in workflows.
+  // Enable with MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL=true (or the umbrella
+  // MIMOCODE_EXPERIMENTAL flag).
+  MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL:
+    MIMOCODE_EXPERIMENTAL || truthy("MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL"),
   // Defaults to true: cron + self-paced loop scheduling are on by default.
   // Set MIMOCODE_EXPERIMENTAL_CRON=false to opt out. Runtime kill switch is
   // MIMOCODE_DISABLE_CRON (checked live every tick).

--- a/packages/opencode/test/flag/workflow-tool.test.ts
+++ b/packages/opencode/test/flag/workflow-tool.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+
+function read(value?: string, experimental?: string) {
+  const env = { ...process.env }
+  delete env.MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL
+  delete env.MIMOCODE_EXPERIMENTAL
+  if (value !== undefined) env.MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL = value
+  if (experimental !== undefined) env.MIMOCODE_EXPERIMENTAL = experimental
+  const result = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "-e",
+      'import { Flag } from "./src/flag/flag.ts"; process.stdout.write(String(Flag.MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL))',
+    ],
+    cwd: process.cwd(),
+    env,
+  })
+  expect(result.exitCode).toBe(0)
+  return result.stdout.toString()
+}
+
+describe("MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL", () => {
+  test("is disabled by default and accepts explicit truthy values", () => {
+    expect(read()).toBe("false")
+    expect(read("true")).toBe("true")
+    expect(read("1")).toBe("true")
+  })
+
+  test("is enabled by the umbrella experimental flag", () => {
+    expect(read(undefined, "true")).toBe("true")
+  })
+
+  test("false and zero keep the tool disabled", () => {
+    expect(read("false")).toBe("false")
+    expect(read("0")).toBe("false")
+  })
+})


### PR DESCRIPTION
## Summary

- disable the workflow tool by default
- preserve explicit and umbrella experimental opt-in behavior
- add isolated environment flag coverage

## Verification

- `bun test test/flag/workflow-tool.test.ts test/tool/describe-workflow.test.ts test/workflow/builtin.test.ts test/tool/skill.test.ts`
- `bun typecheck` from `packages/opencode`
- repository pre-push typecheck (12/12 tasks)