### PR TITLE
fix(provider): enable reasoning effort variants for DeepSeek models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -888,7 +888,6 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   const id = model.id.toLowerCase()
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
   if (
-    id.includes("deepseek") ||
     id.includes("minimax") ||
     id.includes("glm") ||
     id.includes("mistral") ||
@@ -898,6 +897,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     id.includes("big-pickle")
   )
     return {}
+
+  // DeepSeek V4 supports reasoning_effort: "high" (default) and "max"
+  // low/medium map to high, xhigh maps to max per DeepSeek docs
+  if (id.includes("deepseek")) {
+    return {
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    }
+  }
 
   // see: https://docs.x.ai/docs/guides/reasoning#control-how-hard-the-model-thinks
   if (id.includes("grok") && id.includes("grok-3-mini")) {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2983,7 +2983,7 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
-  test("deepseek returns empty object", () => {
+  test("deepseek returns high and max variants", () => {
     const model = createMockModel({
       id: "deepseek/deepseek-chat",
       providerID: "deepseek",
@@ -2994,7 +2994,10 @@ describe("ProviderTransform.variants", () => {
       },
     })
     const result = ProviderTransform.variants(model)
-    expect(result).toEqual({})
+    expect(result).toEqual({
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    })
   })
 
   test("minimax returns empty object", () => {


### PR DESCRIPTION
Closes #1894

## What

Enable the Ctrl+T reasoning effort toggle for DeepSeek models. DeepSeek V4 supports reasoning_effort with values high and max, but it was excluded from the variant system.

## Why

Users cannot change reasoning effort for DeepSeek models at runtime. The config sets a static reasoningEffort value, but there is no UI toggle to switch between high and max.

## Changes

- Remove deepseek from the exclusion list in ProviderTransform.variants()
- Add a DeepSeek-specific case returning high and max variants per DeepSeek API docs
- Update the unit test to expect the new variant output

## Verification

- Updated test case passes (deepseek returns high and max variants)
- All other model exclusions (minimax, glm, mistral, kimi, qwen, big-pickle) remain unchanged
- Change is minimal: 2 files, 14 lines added, 3 removed