### PR TITLE
chore: bump version to 0.1.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
     "packages/app": {
       "name": "@mimo-ai/app",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@mimo-ai/sdk": "workspace:*",
@@ -81,7 +81,7 @@
     },
     "packages/console/app": {
       "name": "@mimo-ai/console-app",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -115,7 +115,7 @@
     },
     "packages/console/core": {
       "name": "@mimo-ai/console-core",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -142,7 +142,7 @@
     },
     "packages/console/function": {
       "name": "@mimo-ai/console-function",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.48",
@@ -166,7 +166,7 @@
     },
     "packages/console/mail": {
       "name": "@mimo-ai/console-mail",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -190,7 +190,7 @@
     },
     "packages/desktop": {
       "name": "@mimo-ai/desktop",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -233,7 +233,7 @@
     },
     "packages/enterprise": {
       "name": "@mimo-ai/enterprise",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@mimo-ai/shared": "workspace:*",
         "@mimo-ai/ui": "workspace:*",
@@ -262,7 +262,7 @@
     },
     "packages/function": {
       "name": "@mimo-ai/function",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -278,7 +278,7 @@
     },
     "packages/opencode": {
       "name": "@mimo-ai/cli",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "bin": {
         "mimo": "./bin/mimo",
       },
@@ -433,7 +433,7 @@
     },
     "packages/plugin": {
       "name": "@mimo-ai/plugin",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@mimo-ai/sdk": "workspace:*",
         "effect": "catalog:",
@@ -468,7 +468,7 @@
     },
     "packages/sdk/js": {
       "name": "@mimo-ai/sdk",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -483,7 +483,7 @@
     },
     "packages/shared": {
       "name": "@mimo-ai/shared",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -507,7 +507,7 @@
     },
     "packages/slack": {
       "name": "@mimo-ai/slack",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@mimo-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -542,7 +542,7 @@
     },
     "packages/ui": {
       "name": "@mimo-ai/ui",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@mimo-ai/sdk": "workspace:*",
@@ -591,7 +591,7 @@
     },
     "packages/web": {
       "name": "@mimo-ai/web",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/app",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/console-app",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@mimo-ai/console-core",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/console-function",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/console-mail",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mimo-ai/desktop",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/enterprise",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/function",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "name": "@mimo-ai/cli",
   "type": "module",
   "license": "MIT",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@mimo-ai/plugin",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Plugin SDK for extending MiMoCode",
   "keywords": ["mimo", "mimocode", "ai", "plugin", "coding-assistant"],
   "type": "module",

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@mimo-ai/sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "TypeScript SDK for the MiMoCode API",
   "keywords": ["mimo", "mimocode", "ai", "sdk", "coding-assistant"],
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "name": "@mimo-ai/shared",
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/slack",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mimo-ai/ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "license": "MIT",
   "exports": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@mimo-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump all workspace packages + bun.lock to 0.1.9 for the 0.1.9 release.