### PR TITLE
fix(tui): keep completed actor actions terminal

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/actor-tool-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/actor-tool-state.ts
@@ -1,0 +1,10 @@
+export function isActorToolRunning(input: {
+  partStatus: string
+  action?: string
+  actorStatus?: string
+}) {
+  if (input.partStatus === "running") return true
+  if (input.partStatus !== "completed") return false
+  if (input.action !== "spawn") return false
+  return input.actorStatus === "running" || input.actorStatus === "pending"
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -71,6 +71,7 @@ import { Sidebar } from "./sidebar"
 import { WorkflowTree } from "@tui/component/workflow-tree"
 import { SubagentFooter } from "./subagent-footer.tsx"
 import { DialogSubagent } from "./dialog-subagent.tsx"
+import { isActorToolRunning } from "./actor-tool-state"
 import { Flag } from "@/flag/flag"
 import { parseActorNotification } from "@/inbox/render"
 import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
@@ -3206,12 +3207,11 @@ function Task(props: ToolProps<typeof ActorTool>) {
   )
 
   const isRunning = createMemo(() => {
-    if (props.part.state.status === "running") return true
-    if (props.part.state.status === "completed") {
-      const status = actorStatus()
-      return status === "running" || status === "pending"
-    }
-    return false
+    return isActorToolRunning({
+      partStatus: props.part.state.status,
+      action: inputAction(),
+      actorStatus: actorStatus(),
+    })
   })
 
   const duration = createMemo(() => {

--- a/packages/opencode/test/cli/tui/actor-tool-state.test.ts
+++ b/packages/opencode/test/cli/tui/actor-tool-state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { isActorToolRunning } from "@/cli/cmd/tui/routes/session/actor-tool-state"
+
+describe("actor tool running state", () => {
+  test("keeps a completed spawn active while its background actor runs", () => {
+    expect(isActorToolRunning({ partStatus: "completed", action: "spawn", actorStatus: "running" })).toBe(true)
+    expect(isActorToolRunning({ partStatus: "completed", action: "spawn", actorStatus: "pending" })).toBe(true)
+  })
+
+  test("does not reactivate completed snapshot and blocking actions on a later actor turn", () => {
+    for (const action of ["run", "wait", "status", "cancel"]) {
+      expect(isActorToolRunning({ partStatus: "completed", action, actorStatus: "running" })).toBe(false)
+    }
+  })
+
+  test("uses the tool part state while an action is still executing", () => {
+    expect(isActorToolRunning({ partStatus: "running", action: "wait", actorStatus: "idle" })).toBe(true)
+    expect(isActorToolRunning({ partStatus: "running", action: "status" })).toBe(true)
+    expect(isActorToolRunning({ partStatus: "completed", action: "spawn", actorStatus: "idle" })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- keep completed `run`, `wait`, `status`, and `cancel` actor cards terminal when the same actor runs another turn
- preserve live background state tracking for completed `spawn` calls
- add focused regression coverage for actor tool running-state boundaries

## Testing

- `bun test test/cli/tui/actor-tool-state.test.ts` (3 pass, 9 assertions)
- `bun typecheck`
- `bun test test/cli/cmd/tui` (66 pass, 138 assertions)
- independent code review: pass, no remaining findings

## Known baseline issue

`bun test test/cli/tui` still hits the existing cross-suite isolation failure in `thread.test.ts`, where `src/workflow/builtin/deep-research.js` is intermittently parsed as a normal ESM module. The same aggregate failure reproduces on unchanged `main`; `thread.test.ts` passes 2/2 when run alone.
