### PR TITLE
fix(log): isolate writers and flush safely on exit

### DIFF
--- a/docs/compose/spec/log-safety.md
+++ b/docs/compose/spec/log-safety.md
@@ -16,17 +16,17 @@ The CLI main context and TUI worker initialize logging independently but can tar
 
 ## [S2] File Ownership And Retention
 
-Each logger initialization owns a unique active filename containing the timestamp, process role, PID, and a random instance identifier. Active files are distinguishable from completed and rotated files and are never selected by cleanup. Reinitializing the same module closes its previous stream first.
+Each logger initialization owns a unique active filename containing the timestamp, process role, PID, and a random instance identifier. Active files are distinguishable from completed and rotated files and are never selected by cleanup. Initialization, writes, rotation, and shutdown share one ordered lifecycle queue, so concurrent initialization closes the prior stream before replacing its state.
 
-Writes and rotations execute through one ordered queue. With rotation enabled, queued records that individually fit within the threshold rotate before an active file would exceed 50 MiB. Archived files are reduced to at most 10 and at most 200 MiB in total, and cleanup errors do not interrupt logging. Explicitly disabling rotation continues to permit one active file to exceed 50 MiB.
+With rotation enabled, queued records that individually fit within the threshold rotate before an active file would exceed 50 MiB. Archived files are reduced to at most 10 and at most 200 MiB in total, and cleanup errors do not interrupt logging. A failed archive move uses a copy/remove fallback; if finalization still fails, the file sink closes instead of reopening the same oversized file with a reset counter. Explicitly disabling rotation continues to permit one active file to exceed 50 MiB.
 
 ## [S3] Failure And Shutdown Behavior
 
-Stream failures are consumed by the logger and reported directly to stderr at most once per initialization; they must not create unhandled promise rejections or recursively call the logger. `flush()` waits for queued writes. `shutdown()` flushes, closes the stream, and marks its file completed. CLI fatal exit and TUI worker shutdown await the appropriate operation before termination.
+Stream failures are consumed by the logger and reported directly to stderr at most once per initialization; they must not create unhandled promise rejections or recursively call the logger. `flush()` waits for queued writes. `shutdown()` runs after earlier queued rotations, closes the final stream, and marks its file completed. CLI hard exits use `Log.exit()`, normal TUI exits return through the top-level shutdown, and the TUI worker closes its log before bounded teardown can be terminated by the host.
 
 ## [S5] Testing Boundaries
 
-Tests use real temporary files and streams. They cover unique ownership across repeated initialization, ordered concurrent writes, size rotation, retention by count and total bytes, active-file preservation, disabled rotation, write failure without unhandled rejection, and flush/shutdown persistence.
+Tests use real temporary files and streams. They cover unique ownership across repeated and concurrent initialization, same-PID worker recovery, ordered concurrent writes, size rotation, shutdown queued behind a rotation, retention by count and total bytes, active-file preservation, disabled rotation, write failure without unhandled rejection, and flush/shutdown persistence. An isolated dev CLI run verifies that a post-initialization command error exits nonzero with no active log and one completed log.
 
 ## [S6] Out Of Scope
 
@@ -34,6 +34,6 @@ This change does not introduce per-record truncation, modify MCP/ACP/voice loggi
 
 ## Tasks
 
-- [ ] T1: Implement unique active-file ownership and serialized write/rotation/cleanup — acceptance: concurrent contexts cannot target or clean each other's active files, and file/count/total limits hold (covers: S2)
-- [ ] T2: Add failure-safe flush and shutdown lifecycle — acceptance: write failures do not reject globally and fatal/worker shutdown paths await pending writes (covers: S3; depends: T1)
+- [ ] T1: Implement unique active-file ownership and a serialized lifecycle queue — acceptance: concurrent initialization cannot target, leak, or clean another live active file, and file/count/total limits hold (covers: S2)
+- [ ] T2: Add failure-safe flush, shutdown, and command exit lifecycle — acceptance: write/finalization failures do not reject globally or resume unsafe file writes, and CLI/TUI/worker exit paths close pending logs before termination (covers: S3; depends: T1)
 - [ ] T3: Add and run focused tests and package typecheck — acceptance: all S5 cases pass from packages/opencode and typecheck succeeds (covers: S5; depends: T1, T2)

--- a/docs/compose/spec/log-safety.md
+++ b/docs/compose/spec/log-safety.md
@@ -1,0 +1,39 @@
+---
+feature: log-safety
+status: in-progress
+updated: 2026-07-24
+branch: fix/log-safety
+commits:
+---
+
+# Log Safety
+
+## Report
+
+## [S1] Problem
+
+The CLI main context and TUI worker initialize logging independently but can target the same file. Rotation and cleanup can therefore rename, truncate, or delete a file another context still writes. Log writes also discard asynchronous failures and fatal exits do not flush.
+
+## [S2] File Ownership And Retention
+
+Each logger initialization owns a unique active filename containing the timestamp, process role, PID, and a random instance identifier. Active files are distinguishable from completed and rotated files and are never selected by cleanup. Reinitializing the same module closes its previous stream first.
+
+Writes and rotations execute through one ordered queue. With rotation enabled, queued records that individually fit within the threshold rotate before an active file would exceed 50 MiB. Archived files are reduced to at most 10 and at most 200 MiB in total, and cleanup errors do not interrupt logging. Explicitly disabling rotation continues to permit one active file to exceed 50 MiB.
+
+## [S3] Failure And Shutdown Behavior
+
+Stream failures are consumed by the logger and reported directly to stderr at most once per initialization; they must not create unhandled promise rejections or recursively call the logger. `flush()` waits for queued writes. `shutdown()` flushes, closes the stream, and marks its file completed. CLI fatal exit and TUI worker shutdown await the appropriate operation before termination.
+
+## [S5] Testing Boundaries
+
+Tests use real temporary files and streams. They cover unique ownership across repeated initialization, ordered concurrent writes, size rotation, retention by count and total bytes, active-file preservation, disabled rotation, write failure without unhandled rejection, and flush/shutdown persistence.
+
+## [S6] Out Of Scope
+
+This change does not introduce per-record truncation, modify MCP/ACP/voice logging, add time-based retention, compress archives, change session/database retention, or remove the explicit rotation-disable option.
+
+## Tasks
+
+- [ ] T1: Implement unique active-file ownership and serialized write/rotation/cleanup — acceptance: concurrent contexts cannot target or clean each other's active files, and file/count/total limits hold (covers: S2)
+- [ ] T2: Add failure-safe flush and shutdown lifecycle — acceptance: write failures do not reject globally and fatal/worker shutdown paths await pending writes (covers: S3; depends: T1)
+- [ ] T3: Add and run focused tests and package typecheck — acceptance: all S5 cases pass from packages/opencode and typecheck succeeds (covers: S5; depends: T1, T2)

--- a/docs/compose/spec/log-safety.md
+++ b/docs/compose/spec/log-safety.md
@@ -3,7 +3,7 @@ feature: log-safety
 status: delivered
 updated: 2026-07-24
 branch: fix/log-safety
-commits: e27a610c081744624d0449744911ffcfd3e26b6c..b86149850ba6cef736a96d31eb7198a04b5ecee0
+commits: e27a610c081744624d0449744911ffcfd3e26b6c..ca726ac3
 ---
 
 # Log Safety
@@ -14,7 +14,7 @@ commits: e27a610c081744624d0449744911ffcfd3e26b6c..b86149850ba6cef736a96d31eb719
 
 CLI hard exits now use `Log.exit()`, normal TUI exits return through the top-level shutdown, and the worker closes its log before potentially long teardown work. This guarantees pending records are handled before the process or worker terminates.
 
-**Verification** — `bun test test/util/log.test.ts test/effect/app-runtime-logger.test.ts test/effect/runner-warn-log.test.ts` passed with 20 tests and 52 expectations. `bun typecheck` passed. Targeted oxlint completed with zero errors and only pre-existing warnings. An isolated `bun dev run` error-path check exited with code 1 and produced zero active logs and one completed log. `git diff --check` passed, and the final independent review found no critical issues.
+**Verification** — `bun test test/util/log.test.ts test/effect/app-runtime-logger.test.ts test/effect/runner-warn-log.test.ts` passed with 20 tests and 52 expectations under the CI-equivalent `main` role; the focused log suite also passed all 12 tests under both `main` and `worker` roles. `bun typecheck` passed. Targeted oxlint completed with zero errors and only pre-existing warnings. An isolated `bun dev run` error-path check exited with code 1 and produced zero active logs and one completed log. `git diff --check` passed, and the final independent reviews found no critical issues.
 
 **Journey log**
 

--- a/docs/compose/spec/log-safety.md
+++ b/docs/compose/spec/log-safety.md
@@ -1,14 +1,28 @@
 ---
 feature: log-safety
-status: in-progress
+status: delivered
 updated: 2026-07-24
 branch: fix/log-safety
-commits:
+commits: e27a610c081744624d0449744911ffcfd3e26b6c..b86149850ba6cef736a96d31eb7198a04b5ecee0
 ---
 
 # Log Safety
 
 ## Report
+
+**What was built** — Logger instances now own unique active files and serialize initialization, writes, rotation, and shutdown through one lifecycle queue. Cleanup preserves live files, recovers stale process and worker files, enforces archive count and size budgets, and stops file writes safely when finalization cannot complete.
+
+CLI hard exits now use `Log.exit()`, normal TUI exits return through the top-level shutdown, and the worker closes its log before potentially long teardown work. This guarantees pending records are handled before the process or worker terminates.
+
+**Verification** — `bun test test/util/log.test.ts test/effect/app-runtime-logger.test.ts test/effect/runner-warn-log.test.ts` passed with 20 tests and 52 expectations. `bun typecheck` passed. Targeted oxlint completed with zero errors and only pre-existing warnings. An isolated `bun dev run` error-path check exited with code 1 and produced zero active logs and one completed log. `git diff --check` passed, and the final independent review found no critical issues.
+
+**Journey log**
+
+- The first review exposed that a write queue alone is insufficient; lifecycle mutations must use the same queue.
+- Capturing a stream before queued rotation can make shutdown close the wrong resource; shutdown now resolves the current stream only when its queued operation runs.
+- Bun main and worker contexts share a PID, so stale worker recovery also needs the process role.
+- TUI worker logging must close before the 30-second drain because the host may terminate the worker after 5 seconds.
+- Isolated dev CLI driving verified the real exit path without touching user configuration or session data.
 
 ## [S1] Problem
 
@@ -34,6 +48,6 @@ This change does not introduce per-record truncation, modify MCP/ACP/voice loggi
 
 ## Tasks
 
-- [ ] T1: Implement unique active-file ownership and a serialized lifecycle queue — acceptance: concurrent initialization cannot target, leak, or clean another live active file, and file/count/total limits hold (covers: S2)
-- [ ] T2: Add failure-safe flush, shutdown, and command exit lifecycle — acceptance: write/finalization failures do not reject globally or resume unsafe file writes, and CLI/TUI/worker exit paths close pending logs before termination (covers: S3; depends: T1)
-- [ ] T3: Add and run focused tests and package typecheck — acceptance: all S5 cases pass from packages/opencode and typecheck succeeds (covers: S5; depends: T1, T2)
+- [x] T1: Implement unique active-file ownership and a serialized lifecycle queue — acceptance: concurrent initialization cannot target, leak, or clean another live active file, and file/count/total limits hold (covers: S2)
+- [x] T2: Add failure-safe flush, shutdown, and command exit lifecycle — acceptance: write/finalization failures do not reject globally or resume unsafe file writes, and CLI/TUI/worker exit paths close pending logs before termination (covers: S3; depends: T1)
+- [x] T3: Add and run focused tests and package typecheck — acceptance: all S5 cases pass from packages/opencode and typecheck succeeds (covers: S5; depends: T1, T2)

--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -7,7 +7,7 @@ import { Agent } from "../../agent/agent"
 import { Provider } from "../../provider"
 import path from "path"
 import fs from "fs/promises"
-import { Filesystem } from "../../util"
+import { Filesystem, Log } from "../../util"
 import matter from "gray-matter"
 import { Instance } from "../../project/instance"
 import { EOL } from "os"
@@ -113,9 +113,9 @@ const AgentCreateCommand = cmd({
         const model = args.model ? Provider.parseModel(args.model) : undefined
         const generated = await AppRuntime.runPromise(
           Agent.Service.use((svc) => svc.generate({ description, model })),
-        ).catch((error) => {
+        ).catch(async (error) => {
           spinner.stop(`LLM failed to generate agent: ${error.message}`, 1)
-          if (isFullyNonInteractive) process.exit(1)
+          if (isFullyNonInteractive) await Log.exit(1)
           throw new UI.CancelledError()
         })
         spinner.stop(`Agent ${generated.identifier} generated`)
@@ -197,7 +197,7 @@ const AgentCreateCommand = cmd({
         if (await Filesystem.exists(filePath)) {
           if (isFullyNonInteractive) {
             console.error(`Error: Agent file already exists: ${filePath}`)
-            process.exit(1)
+            await Log.exit(1)
           }
           prompts.log.error(`Agent file already exists: ${filePath}`)
           throw new UI.CancelledError()

--- a/packages/opencode/src/cli/cmd/db.ts
+++ b/packages/opencode/src/cli/cmd/db.ts
@@ -8,6 +8,7 @@ import { cmd } from "./cmd"
 import { JsonMigration } from "../../storage"
 import { EOL } from "os"
 import { errorMessage } from "../../util/error"
+import { Log } from "../../util"
 
 const QueryCommand = cmd({
   command: "$0 [query]",
@@ -42,7 +43,7 @@ const QueryCommand = cmd({
         }
       } catch (err) {
         UI.error(errorMessage(err))
-        process.exit(1)
+        await Log.exit(1)
       }
       db.close()
       return
@@ -103,7 +104,7 @@ const MigrateCommand = cmd({
     } catch (err) {
       if (tty) process.stderr.write("\x1b[?25h")
       UI.error(`Migration failed: ${errorMessage(err)}`)
-      process.exit(1)
+      await Log.exit(1)
     } finally {
       sqlite.close()
     }

--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -9,6 +9,7 @@ import { MessageID, PartID } from "../../../session/schema"
 import { ToolRegistry } from "../../../tool"
 import { Instance } from "../../../project/instance"
 import { Permission } from "../../../permission"
+import { Log } from "../../../util"
 import { iife } from "../../../util/iife"
 import { bootstrap } from "../../bootstrap"
 import { cmd } from "../cmd"
@@ -40,7 +41,7 @@ export const AgentCommand = cmd({
         process.stderr.write(
           `Agent ${agentName} not found, run '${basename(process.execPath)} agent list' to get an agent list` + EOL,
         )
-        process.exit(1)
+        await Log.exit(1)
       }
       const availableTools = await getAvailableTools(agent)
       const resolvedTools = await resolveTools(agent, availableTools)
@@ -49,11 +50,12 @@ export const AgentCommand = cmd({
         const tool = availableTools.find((item) => item.id === toolID)
         if (!tool) {
           process.stderr.write(`Tool ${toolID} not found for agent ${agentName}` + EOL)
-          process.exit(1)
+          await Log.exit(1)
+          throw new Error("Log.exit returned unexpectedly")
         }
         if (resolvedTools[toolID] === false) {
           process.stderr.write(`Tool ${toolID} is disabled for agent ${agentName}` + EOL)
-          process.exit(1)
+          await Log.exit(1)
         }
         const params = parseToolParams(args.params as string | undefined)
         const ctx = await createToolContext(agent)

--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -8,6 +8,7 @@ import { UI } from "../ui"
 import * as prompts from "@clack/prompts"
 import { EOL } from "os"
 import { AppRuntime } from "@/effect/app-runtime"
+import { Log } from "../../util"
 
 function redact(kind: string, id: string, value: string) {
   return value.trim() ? `[redacted:${kind}:${id}]` : value
@@ -299,7 +300,7 @@ export const ExportCommand = cmd({
         process.stdout.write(EOL)
       } catch {
         UI.error(`Session not found: ${sessionID!}`)
-        process.exit(1)
+        await Log.exit(1)
       }
     })
   },

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -32,7 +32,7 @@ import { SessionPrompt } from "@/session/prompt"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Git } from "@/git"
 import { setTimeout as sleep } from "node:timers/promises"
-import { Process } from "@/util"
+import { Log, Process } from "@/util"
 import { Effect } from "effect"
 
 type GitHubAuthor = {
@@ -444,7 +444,7 @@ export const GithubRunCommand = cmd({
       const context = isMock ? (JSON.parse(args.event!) as Context) : github.context
       if (!SUPPORTED_EVENTS.includes(context.eventName as (typeof SUPPORTED_EVENTS)[number])) {
         core.setFailed(`Unsupported event type: ${context.eventName}`)
-        process.exit(1)
+        await Log.exit(1)
       }
 
       // Determine event category for routing
@@ -708,7 +708,7 @@ export const GithubRunCommand = cmd({
           await revokeAppToken()
         }
       }
-      process.exit(exitCode)
+      await Log.exit(exitCode)
 
       function normalizeModel() {
         const value = process.env["MODEL"]

--- a/packages/opencode/src/cli/cmd/pr.ts
+++ b/packages/opencode/src/cli/cmd/pr.ts
@@ -3,7 +3,7 @@ import { cmd } from "./cmd"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Git } from "@/git"
 import { Instance } from "@/project/instance"
-import { Process } from "@/util"
+import { Log, Process } from "@/util"
 
 export const PrCommand = cmd({
   command: "pr <number>",
@@ -21,7 +21,7 @@ export const PrCommand = cmd({
         const project = Instance.project
         if (project.vcs !== "git") {
           UI.error("Could not find git repository. Please run this command from a git repository.")
-          process.exit(1)
+          await Log.exit(1)
         }
 
         const prNumber = args.number
@@ -38,7 +38,7 @@ export const PrCommand = cmd({
 
         if (result.code !== 0) {
           UI.error(`Failed to checkout PR #${prNumber}. Make sure you have gh CLI installed and authenticated.`)
-          process.exit(1)
+          await Log.exit(1)
         }
 
         // Fetch PR info for fork handling and session link detection

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -15,7 +15,7 @@ import { Plugin } from "../../plugin"
 import { t } from "../i18n"
 import { Instance } from "../../project/instance"
 import type { Hooks } from "@mimo-ai/plugin"
-import { Process } from "../../util"
+import { Log, Process } from "../../util"
 import { PROVIDER_PRIORITY } from "../../util/provider-priority"
 import { text } from "node:stream/consumers"
 import { Effect } from "effect"
@@ -39,7 +39,7 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string, 
       prompts.log.error(
         `Unknown method "${methodName}" for ${provider}. Available: ${plugin.auth.methods.map((x) => x.label).join(", ")}`,
       )
-      process.exit(1)
+      await Log.exit(1)
     }
     index = match
   } else if (plugin.auth.methods.length > 1) {
@@ -543,7 +543,8 @@ export const ProvidersLoginCommand = cmd({
           const match = byID ?? byName
           if (!match) {
             prompts.log.error(`Unknown provider "${input}"`)
-            process.exit(1)
+            await Log.exit(1)
+            throw new Error("Log.exit returned unexpectedly")
           }
           provider = match.value
         } else {

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -300,7 +300,7 @@ export const RunCommand = cmd({
       .map((arg) => (arg.includes(" ") ? `"${arg.replace(/"/g, '\\"')}"` : arg))
       .join(" ")
 
-    const directory = (() => {
+    const directory = await (async () => {
       if (!args.dir) return undefined
       if (args.attach) return args.dir
       try {
@@ -308,7 +308,8 @@ export const RunCommand = cmd({
         return process.cwd()
       } catch {
         UI.error("Failed to change directory to " + args.dir)
-        process.exit(1)
+        await Log.exit(1)
+        throw new Error("Log.exit returned unexpectedly")
       }
     })()
 
@@ -320,7 +321,7 @@ export const RunCommand = cmd({
         const resolvedPath = path.resolve(process.cwd(), filePath)
         if (!(await Filesystem.exists(resolvedPath))) {
           UI.error(`File not found: ${filePath}`)
-          process.exit(1)
+          await Log.exit(1)
         }
 
         const mime = (await Filesystem.isDir(resolvedPath)) ? "application/x-directory" : "text/plain"
@@ -338,12 +339,12 @@ export const RunCommand = cmd({
 
     if (message.trim().length === 0 && !args.command) {
       UI.error("You must provide a message or a command")
-      process.exit(1)
+      await Log.exit(1)
     }
 
     if (args.fork && !args.continue && !args.session) {
       UI.error("--fork requires --continue or --session")
-      process.exit(1)
+      await Log.exit(1)
     }
 
     const rules: Permission.Ruleset = [
@@ -633,7 +634,8 @@ export const RunCommand = cmd({
       const sessionID = await session(sdk)
       if (!sessionID) {
         UI.error("Session not found")
-        process.exit(1)
+        await Log.exit(1)
+        throw new Error("Log.exit returned unexpectedly")
       }
       await share(sdk, sessionID)
 
@@ -651,9 +653,9 @@ export const RunCommand = cmd({
         },
       })
 
-      loop(tracker).catch((e) => {
+      loop(tracker).catch(async (e) => {
         console.error(e)
-        process.exit(1)
+        await Log.exit(1)
       })
 
       if (args.command) {

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -2,6 +2,7 @@ import { Server } from "../../server/server"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
+import { Log } from "../../util"
 
 export const ServeCommand = cmd({
   command: "serve",
@@ -14,7 +15,7 @@ export const ServeCommand = cmd({
     if (!isLoopback && !Flag.MIMOCODE_SERVER_PASSWORD && !opts.noAuth) {
       console.error("ERROR: Binding to non-loopback address without MIMOCODE_SERVER_PASSWORD is not allowed.")
       console.error("Set MIMOCODE_SERVER_PASSWORD or pass --no-auth to override (DANGEROUS).")
-      process.exit(1)
+      await Log.exit(1)
     }
 
     if (!Flag.MIMOCODE_SERVER_PASSWORD) {

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -5,7 +5,7 @@ import { ClaudeImport } from "../../session/claude-import"
 import { SessionID } from "../../session/schema"
 import { bootstrap } from "../bootstrap"
 import { UI } from "../ui"
-import { Locale } from "../../util"
+import { Locale, Log } from "../../util"
 import { Flag } from "../../flag/flag"
 import { Filesystem } from "../../util"
 import { Process } from "../../util"
@@ -85,7 +85,7 @@ export const SessionDeleteCommand = cmd({
         await AppRuntime.runPromise(Session.Service.use((svc) => svc.get(sessionID)))
       } catch {
         UI.error(`Session not found: ${args.sessionID}`)
-        process.exit(1)
+        await Log.exit(1)
       }
       await AppRuntime.runPromise(Session.Service.use((svc) => svc.remove(sessionID)))
       UI.println(UI.Style.TEXT_SUCCESS_BOLD + `Session ${args.sessionID} deleted` + UI.Style.TEXT_NORMAL)

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -241,7 +241,6 @@ export const TuiThreadCommand = cmd({
         if (trustLevel !== "trusted") {
           const accepted = await promptWorkspaceTrust(cwd, trustLevel)
           if (!accepted) {
-            process.exit(0)
             return
           }
           if (trustLevel === "untrusted") await markTrusted(cwd)
@@ -254,7 +253,6 @@ export const TuiThreadCommand = cmd({
         if (process.stdin.isTTY) {
           const accepted = await promptDangerousPermissions()
           if (!accepted) {
-            process.exit(0)
             return
           }
         }
@@ -368,7 +366,6 @@ export const TuiThreadCommand = cmd({
     } finally {
       unguard?.()
     }
-    process.exit(0)
   },
 })
 // scratch

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -89,6 +89,7 @@ export const rpc = {
   },
   async shutdown() {
     Log.Default.info("worker shutting down")
+    await Log.flush()
 
     // Give in-flight background checkpoint writers a bounded chance to finish
     // before we tear down instances. A checkpoint writer can run for minutes on
@@ -105,6 +106,7 @@ export const rpc = {
 
     await Instance.disposeAll()
     if (server) await server.stop(true)
+    await Log.shutdown()
   },
 }
 

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -89,7 +89,7 @@ export const rpc = {
   },
   async shutdown() {
     Log.Default.info("worker shutting down")
-    await Log.flush()
+    await Log.shutdown()
 
     // Give in-flight background checkpoint writers a bounded chance to finish
     // before we tear down instances. A checkpoint writer can run for minutes on
@@ -106,7 +106,6 @@ export const rpc = {
 
     await Instance.disposeAll()
     if (server) await server.stop(true)
-    await Log.shutdown()
   },
 }
 

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -4,6 +4,7 @@ import { UI } from "../ui"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
+import { Log } from "../../util"
 import open from "open"
 import { networkInterfaces } from "os"
 
@@ -45,7 +46,7 @@ export const WebCommand = cmd({
       UI.println(
         UI.Style.TEXT_DANGER_BOLD + "Set MIMOCODE_SERVER_PASSWORD or pass --no-auth to override (DANGEROUS).",
       )
-      process.exit(1)
+      await Log.exit(1)
     }
 
     if (!Flag.MIMOCODE_SERVER_PASSWORD) {

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -58,6 +58,7 @@ process.on("uncaughtException", (e) => {
 })
 
 const args = hideBin(process.argv)
+const CLI_EXIT = Symbol("CLI_EXIT")
 
 function show(out: string) {
   const text = out.trimStart()
@@ -215,7 +216,8 @@ const cli = yargs(args)
       cli.showHelp(show)
     }
     if (err) throw err
-    process.exit(1)
+    void Log.exit(1)
+    throw CLI_EXIT
   })
   .strict()
 
@@ -230,40 +232,42 @@ try {
     await cli.parse()
   }
 } catch (e) {
-  let data: Record<string, any> = {}
-  if (e instanceof NamedError) {
-    const obj = e.toObject()
-    Object.assign(data, {
-      ...obj.data,
-    })
-  }
+  if (e !== CLI_EXIT) {
+    let data: Record<string, any> = {}
+    if (e instanceof NamedError) {
+      const obj = e.toObject()
+      Object.assign(data, {
+        ...obj.data,
+      })
+    }
 
-  if (e instanceof Error) {
-    Object.assign(data, {
-      name: e.name,
-      message: e.message,
-      cause: e.cause?.toString(),
-      stack: e.stack,
-    })
-  }
+    if (e instanceof Error) {
+      Object.assign(data, {
+        name: e.name,
+        message: e.message,
+        cause: e.cause?.toString(),
+        stack: e.stack,
+      })
+    }
 
-  if (e instanceof ResolveMessage) {
-    Object.assign(data, {
-      name: e.name,
-      message: e.message,
-      code: e.code,
-      specifier: e.specifier,
-      referrer: e.referrer,
-      position: e.position,
-      importKind: e.importKind,
-    })
-  }
-  Log.Default.error("fatal", data)
-  const formatted = FormatError(e)
-  if (formatted) UI.error(formatted)
-  if (formatted === undefined) {
-    UI.error("Unexpected error, check log file at " + Log.file() + " for more details" + EOL)
-    process.stderr.write(errorMessage(e) + EOL)
+    if (e instanceof ResolveMessage) {
+      Object.assign(data, {
+        name: e.name,
+        message: e.message,
+        code: e.code,
+        specifier: e.specifier,
+        referrer: e.referrer,
+        position: e.position,
+        importKind: e.importKind,
+      })
+    }
+    Log.Default.error("fatal", data)
+    const formatted = FormatError(e)
+    if (formatted) UI.error(formatted)
+    if (formatted === undefined) {
+      UI.error("Unexpected error, check log file at " + Log.file() + " for more details" + EOL)
+      process.stderr.write(errorMessage(e) + EOL)
+    }
   }
   process.exitCode = 1
 } finally {

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -271,5 +271,6 @@ try {
   // Most notably, some docker-container-based MCP servers don't handle such signals unless
   // run using `docker run --init`.
   // Explicitly exit to avoid any hanging subprocesses.
+  await Log.shutdown()
   process.exit()
 }

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -72,24 +72,25 @@ function stamp() {
 }
 
 export async function init(options: Options) {
-  await shutdown()
-  if (options.level) level = options.level
-  rotation = options.rotate ?? !Flag.MIMOCODE_DISABLE_LOG_ROTATION
-  failureReported = false
-  await cleanup(Global.Path.log)
-  if (options.print) {
-    logpath = ""
-    return
-  }
-  const role = (process.env.MIMOCODE_PROCESS_ROLE ?? "main").replace(/[^a-zA-Z0-9._-]/g, "-")
-  logpath = path.join(
-    Global.Path.log,
-    `${options.dev ? "dev" : stamp()}-${role}-${process.pid}-${crypto.randomUUID().slice(0, 8)}.active.log`,
-  )
-  stream = createWriteStream(logpath, { flags: "a" })
-  stream.on("error", report)
-  written = 0
-  sequence = 0
+  await enqueue(async () => {
+    await closeCurrent()
+    if (options.level) level = options.level
+    rotation = options.rotate ?? !Flag.MIMOCODE_DISABLE_LOG_ROTATION
+    failureReported = false
+    const role = (process.env.MIMOCODE_PROCESS_ROLE ?? "main").replace(/[^a-zA-Z0-9._-]/g, "-")
+    await cleanup(Global.Path.log, { pid: process.pid, role })
+    if (options.print) {
+      logpath = ""
+      return
+    }
+    logpath = path.join(
+      Global.Path.log,
+      `${options.dev ? "dev" : stamp()}-${role}-${process.pid}-${crypto.randomUUID().slice(0, 8)}.active.log`,
+    )
+    await open(logpath)
+    written = 0
+    sequence = 0
+  })
 }
 
 function report(error: unknown) {
@@ -102,11 +103,12 @@ function report(error: unknown) {
 }
 
 function write(msg: string) {
-  if (!stream) {
-    process.stderr.write(msg)
-    return
-  }
-  pending = pending.then(() => append(msg)).catch(report)
+  void enqueue(() => append(msg))
+}
+
+function enqueue(operation: () => void | Promise<void>) {
+  pending = pending.then(operation).catch(report)
+  return pending
 }
 
 async function append(msg: string) {
@@ -127,11 +129,56 @@ async function rotate() {
   const previous = stream
   if (!previous) return
   await close(previous)
-  await fs.rename(logpath, logpath.replace(/\.active\.log$/, `.log.${stamp()}-${sequence++}`)).catch(report)
-  stream = createWriteStream(logpath, { flags: "a" })
-  stream.on("error", report)
+  stream = undefined
+  const archived = logpath.replace(/\.active\.log$/, `.log.${stamp()}-${sequence++}`)
+  if (!(await move(logpath, archived))) {
+    written = 0
+    return
+  }
+  await open(logpath)
   written = 0
   await cleanup(Global.Path.log)
+}
+
+async function open(targetPath: string) {
+  const target = createWriteStream(targetPath, { flags: "a" })
+  stream = target
+  target.on("error", report)
+  const opened = await new Promise<boolean>((resolve) => {
+    target.once("open", () => resolve(true))
+    target.once("error", () => resolve(false))
+  })
+  if (!opened && stream === target) stream = undefined
+}
+
+async function move(source: string, target: string) {
+  const renamed = await fs.rename(source, target).then(
+    () => true,
+    () => false,
+  )
+  if (renamed) return true
+  const copied = await fs.copyFile(source, target).then<"copied", "missing" | "failed">(
+    () => "copied",
+    (error) => {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return "missing"
+      report(error)
+      return "failed"
+    },
+  )
+  if (copied === "missing") return true
+  if (copied === "failed") return false
+  const removed = await fs.unlink(source).then(
+    () => true,
+    () => false,
+  )
+  if (removed) return true
+  return fs.truncate(source, 0).then(
+    () => true,
+    (error) => {
+      report(error)
+      return false
+    },
+  )
 }
 
 function close(target: ReturnType<typeof createWriteStream>) {
@@ -147,24 +194,23 @@ export async function flush() {
 }
 
 export async function shutdown() {
+  await enqueue(closeCurrent)
+}
+
+async function closeCurrent() {
   const target = stream
-  if (!target) return flush()
-  pending = pending
-    .then(async () => {
-      await close(target)
-      if (stream !== target) return
-      stream = undefined
-      const completed = logpath.replace(/\.active\.log$/, ".log")
-      await fs.rename(logpath, completed).then(
-        () => {
-          logpath = completed
-        },
-        () => {},
-      )
-      await cleanup(Global.Path.log)
-    })
-    .catch(report)
-  await pending
+  if (!target) return
+  await close(target)
+  stream = undefined
+  written = 0
+  const completed = logpath.replace(/\.active\.log$/, ".log")
+  if (await move(logpath, completed)) logpath = completed
+  await cleanup(Global.Path.log)
+}
+
+export async function exit(code?: number): Promise<never> {
+  await shutdown()
+  process.exit(code)
 }
 
 function alive(pid: number) {
@@ -176,14 +222,17 @@ function alive(pid: number) {
   }
 }
 
-async function cleanup(dir: string) {
+async function cleanup(dir: string, takeover?: { pid: number; role: string }) {
   const entries = await fs.readdir(dir).catch(() => [] as string[])
   const stats = await Promise.all(
     entries.map(async (name) => {
       if (!name.includes(".log")) return null
       if (name.endsWith(".active.log")) {
         const owner = name.match(/-(\d+)-[0-9a-f]{8}\.active\.log$/)?.[1]
-        if (!owner || alive(Number(owner))) return null
+        if (!owner) return null
+        const pid = Number(owner)
+        const sameContext = takeover && pid === takeover.pid && name.includes(`-${takeover.role}-${takeover.pid}-`)
+        if (!sameContext && alive(pid)) return null
         const completed = name.replace(/\.active\.log$/, ".log")
         const renamed = await fs.rename(path.join(dir, name), path.join(dir, completed)).then(
           () => completed,

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -63,73 +63,142 @@ export function file() {
 let stream: ReturnType<typeof createWriteStream> | undefined
 let written = 0
 let rotation = true
-let write = (msg: any) => {
-  process.stderr.write(msg)
-  return msg.length
-}
+let sequence = 0
+let pending = Promise.resolve()
+let failureReported = false
 
 function stamp() {
-  return new Date().toISOString().split(".")[0].replace(/:/g, "")
+  return new Date().toISOString().replace(/[:.]/g, "")
 }
 
 export async function init(options: Options) {
+  await shutdown()
   if (options.level) level = options.level
   rotation = options.rotate ?? !Flag.MIMOCODE_DISABLE_LOG_ROTATION
-  void cleanup(Global.Path.log)
-  if (options.print) return
-  logpath = path.join(Global.Path.log, options.dev ? "dev.log" : stamp() + ".log")
-  if (options.dev) {
-    // Preserve previous dev.log as dev.log.<timestamp> for hang/incident
-    // forensics. cleanup() above already prunes old archived logs.
-    const stat = await fs.stat(logpath).catch(() => null)
-    if (stat && stat.size > 0) await fs.rename(logpath, `${logpath}.${stamp()}`).catch(() => {})
-  } else {
-    await fs.truncate(logpath).catch(() => {})
+  failureReported = false
+  await cleanup(Global.Path.log)
+  if (options.print) {
+    logpath = ""
+    return
   }
+  const role = (process.env.MIMOCODE_PROCESS_ROLE ?? "main").replace(/[^a-zA-Z0-9._-]/g, "-")
+  logpath = path.join(
+    Global.Path.log,
+    `${options.dev ? "dev" : stamp()}-${role}-${process.pid}-${crypto.randomUUID().slice(0, 8)}.active.log`,
+  )
   stream = createWriteStream(logpath, { flags: "a" })
+  stream.on("error", report)
   written = 0
-  write = async (msg: any) => {
-    written += Buffer.byteLength(msg)
-    if (rotation && written >= MAX_FILE_SIZE) {
-      written = 0
-      await rotate()
-    }
-    return new Promise((resolve, reject) => {
-      stream!.write(msg, (err) => {
-        if (err) reject(err)
-        else resolve(msg.length)
-      })
-    })
-  }
+  sequence = 0
 }
 
-// Archive the active file as <logpath>.<timestamp> and start a fresh one at the
-// same path, so file() stays stable. The renamed file is then subject to
-// cleanup's total-size budget.
+function report(error: unknown) {
+  if (failureReported) return
+  failureReported = true
+  const message = error instanceof Error ? error.message : String(error)
+  try {
+    process.stderr.write(`mimocode log write failed: ${message}\n`)
+  } catch {}
+}
+
+function write(msg: string) {
+  if (!stream) {
+    process.stderr.write(msg)
+    return
+  }
+  pending = pending.then(() => append(msg)).catch(report)
+}
+
+async function append(msg: string) {
+  const size = Buffer.byteLength(msg)
+  if (rotation && written > 0 && written + size > MAX_FILE_SIZE) await rotate()
+  const target = stream
+  if (!target) {
+    process.stderr.write(msg)
+    return
+  }
+  await new Promise<void>((resolve, reject) => {
+    target.write(msg, (error) => (error ? reject(error) : resolve()))
+  })
+  written += size
+}
+
 async function rotate() {
   const previous = stream
-  await fs.rename(logpath, `${logpath}.${stamp()}`).catch(() => {})
+  if (!previous) return
+  await close(previous)
+  await fs.rename(logpath, logpath.replace(/\.active\.log$/, `.log.${stamp()}-${sequence++}`)).catch(report)
   stream = createWriteStream(logpath, { flags: "a" })
-  if (previous) previous.end()
-  void cleanup(Global.Path.log)
+  stream.on("error", report)
+  written = 0
+  await cleanup(Global.Path.log)
+}
+
+function close(target: ReturnType<typeof createWriteStream>) {
+  return new Promise<void>((resolve) => {
+    if (target.closed) return resolve()
+    target.once("close", resolve)
+    target.end()
+  })
+}
+
+export async function flush() {
+  await pending
+}
+
+export async function shutdown() {
+  const target = stream
+  if (!target) return flush()
+  pending = pending
+    .then(async () => {
+      await close(target)
+      if (stream !== target) return
+      stream = undefined
+      const completed = logpath.replace(/\.active\.log$/, ".log")
+      await fs.rename(logpath, completed).then(
+        () => {
+          logpath = completed
+        },
+        () => {},
+      )
+      await cleanup(Global.Path.log)
+    })
+    .catch(report)
+  await pending
+}
+
+function alive(pid: number) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return !(error instanceof Error && "code" in error && error.code === "ESRCH")
+  }
 }
 
 async function cleanup(dir: string) {
   const entries = await fs.readdir(dir).catch(() => [] as string[])
   const stats = await Promise.all(
-    entries
-      // Match session logs (<iso>.log), dev rotations (dev.log.<stamp>) and
-      // size rotations (<name>.log.<stamp>). Skip the active file so it is
-      // never deleted out from under the open write stream.
-      .filter((name) => name.includes(".log") && path.join(dir, name) !== logpath)
-      .map(async (name) => {
-        const stat = await fs.stat(path.join(dir, name)).catch(() => null)
-        return stat?.isFile() ? { name, size: stat.size } : null
-      }),
+    entries.map(async (name) => {
+      if (!name.includes(".log")) return null
+      if (name.endsWith(".active.log")) {
+        const owner = name.match(/-(\d+)-[0-9a-f]{8}\.active\.log$/)?.[1]
+        if (!owner || alive(Number(owner))) return null
+        const completed = name.replace(/\.active\.log$/, ".log")
+        const renamed = await fs.rename(path.join(dir, name), path.join(dir, completed)).then(
+          () => completed,
+          () => null,
+        )
+        if (!renamed) return null
+        name = renamed
+      }
+      const stat = await fs.stat(path.join(dir, name)).catch(() => null)
+      return stat?.isFile() ? { name, size: stat.size, modified: stat.mtimeMs } : null
+    }),
   )
-  // Sort oldest first by name; filenames are timestamp-encoded so lexical order
-  // is chronological within each family.
-  const files = stats.flatMap((f) => (f ? [f] : [])).sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+  const files = stats
+    .flatMap((item) => (item ? [item] : []))
+    .sort((a, b) => a.modified - b.modified || a.name.localeCompare(b.name))
 
   let total = files.reduce((sum, f) => sum + f.size, 0)
   let remaining = files.length

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -38,6 +38,17 @@ test("reinitialization gives each logger context a unique active file", async ()
   expect(await fs.readFile(main.replace(/\.active\.log$/, ".log"), "utf8")).toContain("from main")
 })
 
+test("concurrent initialization serializes ownership without leaking active files", async () => {
+  await using tmp = await tmpdir()
+  Global.Path.log = tmp.path
+
+  await Promise.all([Log.init({ print: false }), Log.init({ print: false })])
+
+  const files = await fs.readdir(tmp.path)
+  expect(files.filter((file) => file.endsWith(".active.log"))).toHaveLength(1)
+  expect(files.filter((file) => !file.endsWith(".active.log"))).toHaveLength(1)
+})
+
 test("cleanup preserves active files and keeps the newest ten archives", async () => {
   await using tmp = await tmpdir()
   Global.Path.log = tmp.path
@@ -82,6 +93,21 @@ test("cleanup recovers an active file left by an exited process", async () => {
     ),
   ).toBe(false)
   expect(await fs.readFile(path.join(tmp.path, active.replace(/\.active\.log$/, ".log")), "utf8")).toBe("orphaned")
+})
+
+test("worker initialization recovers a stale same-process worker file", async () => {
+  await using tmp = await tmpdir()
+  Global.Path.log = tmp.path
+  process.env[MIMOCODE_PROCESS_ROLE] = "worker"
+  const active = `2000-01-01T000000-worker-${process.pid}-deadbeef.active.log`
+  await fs.writeFile(path.join(tmp.path, active), "orphaned worker")
+
+  await Log.init({ print: false })
+
+  const files = await fs.readdir(tmp.path)
+  expect(files).not.toContain(active)
+  expect(files).toContain(active.replace(/\.active\.log$/, ".log"))
+  expect(files.filter((file) => file.endsWith(".active.log"))).toHaveLength(1)
 })
 
 test("cleanup enforces the archived total-size budget", async () => {
@@ -133,6 +159,21 @@ test("rotation serializes writes before the active file exceeds 50 MiB", async (
   const sizes = await Promise.all(files.map((file) => fs.stat(path.join(tmp.path, file)).then((stat) => stat.size)))
   expect(files.some((file) => !file.endsWith(".active.log"))).toBe(true)
   expect(sizes.every((size) => size <= 50 * mb)).toBe(true)
+})
+
+test("shutdown closes the final stream when queued writes rotate", async () => {
+  await using tmp = await tmpdir()
+  Global.Path.log = tmp.path
+  await Log.init({ print: false, rotate: true })
+  const chunk = "x".repeat(256 * 1024)
+
+  Array.from({ length: 201 }).forEach(() => Log.Default.info(chunk))
+  await Log.shutdown()
+
+  const files = await fs.readdir(tmp.path)
+  expect(files.some((file) => file.endsWith(".active.log"))).toBe(false)
+  expect(files.some((file) => file.includes(".log."))).toBe(true)
+  expect(Log.file().endsWith(".log")).toBe(true)
 })
 
 test("rotation can still be disabled explicitly", async () => {

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -49,9 +49,10 @@ test("concurrent initialization serializes ownership without leaking active file
   expect(files.filter((file) => !file.endsWith(".active.log"))).toHaveLength(1)
 })
 
-test("cleanup preserves active files and keeps the newest ten archives", async () => {
+test("cleanup preserves another live context and keeps the newest ten archives", async () => {
   await using tmp = await tmpdir()
   Global.Path.log = tmp.path
+  process.env[MIMOCODE_PROCESS_ROLE] = "worker"
   const active = `1999-01-01T000000-main-${process.pid}-deadbeef.active.log`
   const archives = Array.from(
     { length: 12 },

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -3,67 +3,187 @@ import fs from "fs/promises"
 import path from "path"
 import { Global } from "../../src/global"
 import { Log } from "../../src/util"
+import { MIMOCODE_PROCESS_ROLE } from "../../src/util/mimo-process"
 import { tmpdir } from "../fixture/fixture"
 
 const log = Global.Path.log
+const role = process.env[MIMOCODE_PROCESS_ROLE]
+const mb = 1024 * 1024
 
-afterEach(() => {
+afterEach(async () => {
+  await Log.shutdown()
   Global.Path.log = log
+  if (role === undefined) delete process.env[MIMOCODE_PROCESS_ROLE]
+  else process.env[MIMOCODE_PROCESS_ROLE] = role
 })
 
-async function files(dir: string) {
-  let last = ""
-  let same = 0
-
-  for (let i = 0; i < 50; i++) {
-    const list = (await fs.readdir(dir)).sort()
-    const next = JSON.stringify(list)
-    same = next === last ? same + 1 : 0
-    if (same >= 2 && list.length === 11) return list
-    last = next
-    await Bun.sleep(10)
-  }
-
-  return (await fs.readdir(dir)).sort()
-}
-
-test("init cleanup keeps the newest timestamped logs", async () => {
+test("reinitialization gives each logger context a unique active file", async () => {
   await using tmp = await tmpdir()
   Global.Path.log = tmp.path
+  process.env[MIMOCODE_PROCESS_ROLE] = "main"
 
-  const list = Array.from({ length: 12 }, (_, i) => `2000-01-${String(i + 1).padStart(2, "0")}T000000.log`)
+  await Log.init({ print: false, dev: true })
+  const main = Log.file()
+  Log.Default.info("from main")
 
-  await Promise.all(list.map((file) => fs.writeFile(path.join(tmp.path, file), file)))
+  process.env[MIMOCODE_PROCESS_ROLE] = "worker"
+  await Log.init({ print: false, dev: true })
+  const worker = Log.file()
 
-  await Log.init({ print: false, dev: false })
-
-  const next = await files(tmp.path)
-
-  expect(next).not.toContain(list[0]!)
-  expect(next).toContain(list.at(-1)!)
+  expect(main).not.toBe(worker)
+  expect(path.basename(main)).toContain(`-main-${process.pid}-`)
+  expect(path.basename(worker)).toContain(`-worker-${process.pid}-`)
+  expect(main.endsWith(".active.log")).toBe(true)
+  expect(worker.endsWith(".active.log")).toBe(true)
+  expect(await fs.readFile(main.replace(/\.active\.log$/, ".log"), "utf8")).toContain("from main")
 })
 
-test("init cleanup prunes rotated dev.log archives", async () => {
+test("cleanup preserves active files and keeps the newest ten archives", async () => {
   await using tmp = await tmpdir()
   Global.Path.log = tmp.path
+  const active = `1999-01-01T000000-main-${process.pid}-deadbeef.active.log`
+  const archives = Array.from(
+    { length: 12 },
+    (_, i) => `2000-01-${String(i + 1).padStart(2, "0")}T000000-main-123-${String(i).padStart(8, "0")}.log`,
+  )
 
-  // dev.log rotations and size-rotation archives must also be pruned, not just
-  // bare <iso>.log session logs.
-  const list = Array.from({ length: 12 }, (_, i) => `dev.log.2000-01-${String(i + 1).padStart(2, "0")}T000000`)
-  await Promise.all(list.map((file) => fs.writeFile(path.join(tmp.path, file), file)))
+  await fs.writeFile(path.join(tmp.path, active), "active")
+  await Promise.all(
+    archives.map(async (file, i) => {
+      const target = path.join(tmp.path, file)
+      await fs.writeFile(target, file)
+      await fs.utimes(target, i + 1, i + 1)
+    }),
+  )
+  await Log.init({ print: false })
 
-  await Log.init({ print: false, dev: false })
+  const files = await fs.readdir(tmp.path)
+  expect(files).toContain(active)
+  expect(files).not.toContain(archives[0])
+  expect(files).not.toContain(archives[1])
+  expect(files).toContain(archives.at(-1)!)
+  expect(files.filter((file) => !file.endsWith(".active.log"))).toHaveLength(10)
+})
 
-  for (let i = 0; i < 50; i++) {
-    const current = await fs.readdir(tmp.path)
-    const archives = current.filter((f) => f.startsWith("dev.log."))
-    if (archives.length <= 10) break
+test("cleanup recovers an active file left by an exited process", async () => {
+  await using tmp = await tmpdir()
+  Global.Path.log = tmp.path
+  const child = Bun.spawn([process.execPath, "-e", ""])
+  await child.exited
+  const active = `2000-01-01T000000-worker-${child.pid}-deadbeef.active.log`
+  await fs.writeFile(path.join(tmp.path, active), "orphaned")
+
+  await Log.init({ print: false })
+
+  expect(
+    await fs.stat(path.join(tmp.path, active)).then(
+      () => true,
+      () => false,
+    ),
+  ).toBe(false)
+  expect(await fs.readFile(path.join(tmp.path, active.replace(/\.active\.log$/, ".log")), "utf8")).toBe("orphaned")
+})
+
+test("cleanup enforces the archived total-size budget", async () => {
+  await using tmp = await tmpdir()
+  Global.Path.log = tmp.path
+  const archives = Array.from(
+    { length: 4 },
+    (_, i) => `2000-01-0${i + 1}T000000-main-123-${String(i).padStart(8, "0")}.log`,
+  )
+
+  await Promise.all(
+    archives.map(async (file) => {
+      const target = path.join(tmp.path, file)
+      await fs.writeFile(target, "")
+      await fs.truncate(target, 80 * mb)
+    }),
+  )
+  await Log.init({ print: false })
+
+  const files = (await fs.readdir(tmp.path)).filter((file) => !file.endsWith(".active.log"))
+  const sizes = await Promise.all(files.map((file) => fs.stat(path.join(tmp.path, file)).then((stat) => stat.size)))
+  expect(sizes.reduce((sum, size) => sum + size, 0)).toBeLessThanOrEqual(200 * mb)
+})
+
+test("queued writes are ordered and flush waits for persistence", async () => {
+  await using tmp = await tmpdir()
+  Global.Path.log = tmp.path
+  await Log.init({ print: false, level: "INFO" })
+
+  Array.from({ length: 1_000 }, (_, i) => i).forEach((i) => Log.Default.info(`entry-${i}`))
+  await Log.flush()
+
+  const lines = (await fs.readFile(Log.file(), "utf8")).trim().split("\n")
+  expect(lines).toHaveLength(1_000)
+  expect(lines[0]?.endsWith("entry-0")).toBe(true)
+  expect(lines.at(-1)?.endsWith("entry-999")).toBe(true)
+})
+
+test("rotation serializes writes before the active file exceeds 50 MiB", async () => {
+  await using tmp = await tmpdir()
+  Global.Path.log = tmp.path
+  await Log.init({ print: false, rotate: true })
+  const chunk = "x".repeat(256 * 1024)
+
+  Array.from({ length: 201 }).forEach(() => Log.Default.info(chunk))
+  await Log.flush()
+
+  const files = await fs.readdir(tmp.path)
+  const sizes = await Promise.all(files.map((file) => fs.stat(path.join(tmp.path, file)).then((stat) => stat.size)))
+  expect(files.some((file) => !file.endsWith(".active.log"))).toBe(true)
+  expect(sizes.every((size) => size <= 50 * mb)).toBe(true)
+})
+
+test("rotation can still be disabled explicitly", async () => {
+  await using tmp = await tmpdir()
+  Global.Path.log = tmp.path
+  await Log.init({ print: false, rotate: false })
+  const chunk = "x".repeat(256 * 1024)
+
+  Array.from({ length: 201 }).forEach(() => Log.Default.info(chunk))
+  await Log.flush()
+
+  expect(await fs.stat(Log.file()).then((stat) => stat.size)).toBeGreaterThan(50 * mb)
+  expect(await fs.readdir(tmp.path)).toHaveLength(1)
+})
+
+test("write failures do not escape as process-level errors", async () => {
+  await using tmp = await tmpdir()
+  const failures: unknown[] = []
+  const capture = (error: unknown) => failures.push(error)
+  Global.Path.log = path.join(tmp.path, "not-a-directory")
+  await fs.writeFile(Global.Path.log, "file")
+  process.on("unhandledRejection", capture)
+  process.on("uncaughtException", capture)
+
+  try {
+    await Log.init({ print: false })
+    Log.Default.info("cannot be written")
+    await Log.flush()
     await Bun.sleep(10)
+    expect(failures).toHaveLength(0)
+  } finally {
+    process.off("unhandledRejection", capture)
+    process.off("uncaughtException", capture)
   }
+})
 
-  const final = await fs.readdir(tmp.path)
-  const archives = final.filter((f) => f.startsWith("dev.log.")).sort()
-  expect(archives.length).toBeLessThanOrEqual(10)
-  expect(archives).not.toContain(list[0]!)
-  expect(archives).toContain(list.at(-1)!)
+test("shutdown flushes and marks the active file completed", async () => {
+  await using tmp = await tmpdir()
+  Global.Path.log = tmp.path
+  await Log.init({ print: false })
+  const active = Log.file()
+  Log.Default.info("last message")
+
+  await Log.shutdown()
+
+  expect(Log.file()).toBe(active.replace(/\.active\.log$/, ".log"))
+  expect(await fs.readFile(Log.file(), "utf8")).toContain("last message")
+  expect(
+    await fs.stat(active).then(
+      () => true,
+      () => false,
+    ),
+  ).toBe(false)
 })


### PR DESCRIPTION
## Problem

The logger was safe only when a single context owned the log path. In the TUI, the main context and Bun worker initialize logging independently:

- local builds both targeted the fixed `dev.log` path
- release logs used only a second-resolution timestamp, so concurrent CLI processes could collide
- one context could rename, truncate, or clean up a file that another context still had open

This split or lost logs and could leave an unlinked inode consuming disk until process exit. Separately, asynchronous stream failures were discarded, and direct `process.exit()` calls could terminate before queued records were flushed.

## Solution

### File ownership and retention

- Each logger context now owns a unique active filename containing timestamp, process role, PID, and a random instance ID.
- Active files are distinguishable from completed and rotated files, so cleanup never removes another live writer.
- Cleanup recovers files from dead processes and stale same-PID workers by using both PID and process role.
- The existing limits remain unchanged: 50 MiB per rotating file, at most 10 archives, and at most 200 MiB of archived logs.

### Serialized lifecycle

Initialization, writes, rotation, flush, and shutdown now share one ordered queue. This closes the races between a queued rotation and shutdown, and between concurrent `Log.init()` calls.

Rotation first attempts an atomic rename, then falls back to copy-and-remove. If finalization still fails, the file sink stays closed and later records fall back to stderr instead of reopening the oversized file with a reset byte counter.

### Safe process termination

- `Log.flush()`, `Log.shutdown()`, and `Log.exit()` provide explicit lifecycle operations.
- CLI error paths use `Log.exit()` before terminating.
- Normal TUI exits return through the top-level shutdown.
- The TUI worker closes its log before checkpoint draining, because the host may terminate the worker before the longer teardown budget expires.

## Why this touches multiple command files

The substantive behavior lives in `src/util/log.ts`, the TUI lifecycle, and the entrypoint. The command-file changes are mechanical replacements of 23 direct `process.exit()` calls with `Log.exit()` so they cannot bypass the centralized shutdown contract. They do not change command-specific business logic, output, or intended exit codes.

The test file is comparatively large because it exercises real files and streams at the production 50 MiB threshold instead of introducing test-only production settings or mocks.

## Compatibility

Unchanged:

- existing logger call sites (`Log.create()`, `info`, `warn`, `error`, and `debug`)
- log levels and `--print-logs`
- the 50 MiB / 10 archive / 200 MiB retention policy
- `MIMOCODE_DISABLE_LOG_ROTATION` behavior
- command output and exit codes

Intentional filename change:

- logs no longer use a fixed `dev.log` or timestamp-only filename
- active files end in `.active.log`; clean shutdown marks them as completed `.log` files
- integrations that tail a hard-coded `dev.log` must use `Log.file()` or match the active-file suffix instead

Out of scope:

- per-record truncation
- MCP, ACP, or voice log-content changes
- session/database retention, compression, or time-based log retention

## Verification

- `MIMOCODE_PROCESS_ROLE=main bun test test/util/log.test.ts test/effect/app-runtime-logger.test.ts test/effect/runner-warn-log.test.ts` — 20 passed, 0 failed, 52 expectations
- focused log suite under both `main` and `worker` roles — 12 passed in each role
- `bun typecheck` — passed
- targeted `oxlint` — 0 errors; pre-existing warnings only
- isolated dev CLI error path — exit 1, 0 active logs, 1 completed log
- two independent reviews — no critical findings
