### PR TITLE
feat(provider): replay unsigned Anthropic reasoning

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -89,6 +89,12 @@ export const Flag = {
   MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT: number("MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT") ?? 3,
   MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT: number("MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT") ?? 2,
   MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT: number("MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT") ?? 2,
+  // Defaults to false. When enabled, unsigned historical reasoning sent through
+  // the Anthropic Messages format receives an empty placeholder signature so it
+  // follows the same native thinking-block serialization path as signed content.
+  get MIMOCODE_FORCE_ANTHROPIC_REASONING_CONTENT() {
+    return truthy("MIMOCODE_FORCE_ANTHROPIC_REASONING_CONTENT")
+  },
   // Empty/no-op tool-call loop guard: number of soft nudges (remind → replan)
   // before the harness hard-halts the turn. N consecutive empty steps beyond
   // this many recovery attempts terminates the turn. Mirrors TEXT_NGRAM_MAX_RECOVERY.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -468,6 +468,41 @@ function normalizeContentArray(msgs: ModelMessage[]): ModelMessage[] {
   })
 }
 
+function record(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  return value as Record<string, unknown>
+}
+
+// Anthropic's SDK discards historical reasoning without a signature or redacted
+// data. The opt-in compatibility mode supplies an empty placeholder signature,
+// making unsigned reasoning follow the same native thinking-block serializer
+// branch as signed reasoning. Compatible endpoints may intentionally accept it;
+// the official Anthropic API can still reject an unverifiable signature.
+function forceAnthropicReasoningContent(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
+  if (!Flag.MIMOCODE_FORCE_ANTHROPIC_REASONING_CONTENT) return msgs
+  if (!["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) return msgs
+
+  return msgs.map((msg) => {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) return msg
+    return {
+      ...msg,
+      content: msg.content.map((part) => {
+        if (part.type !== "reasoning") return part
+        const metadata = record(part.providerOptions?.anthropic ?? part.providerOptions?.[model.providerID])
+        if (typeof metadata?.signature === "string" || typeof metadata?.redactedData === "string") return part
+        const key = part.providerOptions?.anthropic ? "anthropic" : model.providerID
+        return {
+          ...part,
+          providerOptions: {
+            ...part.providerOptions,
+            [key]: { ...metadata, signature: "" },
+          },
+        }
+      }),
+    }
+  })
+}
+
 function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
   return msgs.map((msg) => {
     if (msg.role !== "user" || !Array.isArray(msg.content)) return msg
@@ -774,6 +809,7 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
   msgs = unsupportedParts(msgs, model)
   msgs = limitImages(msgs, model)
   msgs = normalizeMessages(msgs, model, options)
+  msgs = forceAnthropicReasoningContent(msgs, model)
   // SAFE prefill guard: never let the request end with an assistant (prefill)
   // message a provider (e.g. Bedrock) would reject, without deleting a completed
   // reply. Drops only empty residue; appends a continuation user turn otherwise.

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1086,6 +1086,149 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
   })
 })
 
+describe("ProviderTransform.message - forced Anthropic reasoning content", () => {
+  const flag = "MIMOCODE_FORCE_ANTHROPIC_REASONING_CONTENT"
+  const model = {
+    id: ModelID.make("anthropic/claude-sonnet-4"),
+    providerID: ProviderID.make("anthropic"),
+    api: {
+      id: "claude-sonnet-4",
+      url: "https://api.anthropic.com",
+      npm: "@ai-sdk/anthropic",
+    },
+    name: "Claude Sonnet 4",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: true },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: true,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 200_000, output: 8_192 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2025-05-22",
+  } as Provider.Model
+
+  test("is disabled by default", () => {
+    const previous = process.env[flag]
+    delete process.env[flag]
+    try {
+      const result = ProviderTransform.message(
+        [
+          {
+            role: "assistant",
+            content: [{ type: "reasoning", text: "unsigned thinking" }],
+          },
+          { role: "user", content: "next" },
+        ],
+        model,
+        {},
+      )
+
+      expect(result[0].content).toEqual([{ type: "reasoning", text: "unsigned thinking" }])
+    } finally {
+      if (previous === undefined) delete process.env[flag]
+      else process.env[flag] = previous
+    }
+  })
+
+  test("replays unsigned Anthropic reasoning through the signed thinking path when enabled", () => {
+    const previous = process.env[flag]
+    process.env[flag] = "true"
+    try {
+      const result = ProviderTransform.message(
+        [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "reasoning",
+                text: "unsigned thinking",
+              },
+              { type: "text", text: "final answer" },
+            ],
+          },
+          { role: "user", content: "next" },
+        ],
+        model,
+        {},
+      )
+
+      expect(result[0].content).toEqual([
+        {
+          type: "reasoning",
+          text: "unsigned thinking",
+          providerOptions: { anthropic: { signature: "" } },
+        },
+        { type: "text", text: "final answer" },
+      ])
+    } finally {
+      if (previous === undefined) delete process.env[flag]
+      else process.env[flag] = previous
+    }
+  })
+
+  test("preserves signed Anthropic reasoning when enabled", () => {
+    const previous = process.env[flag]
+    process.env[flag] = "true"
+    try {
+      const reasoning = {
+        type: "reasoning" as const,
+        text: "signed thinking",
+        providerOptions: { anthropic: { signature: "signature" } },
+      }
+      const result = ProviderTransform.message(
+        [
+          { role: "assistant", content: [reasoning] },
+          { role: "user", content: "next" },
+        ],
+        model,
+        {},
+      )
+
+      expect(result[0].content).toEqual([reasoning])
+    } finally {
+      if (previous === undefined) delete process.env[flag]
+      else process.env[flag] = previous
+    }
+  })
+
+  test("does not affect non-Anthropic reasoning when enabled", () => {
+    const previous = process.env[flag]
+    process.env[flag] = "true"
+    try {
+      const reasoning = {
+        type: "reasoning" as const,
+        text: "OpenAI reasoning",
+      }
+      const result = ProviderTransform.message(
+        [
+          { role: "assistant", content: [reasoning] },
+          { role: "user", content: "next" },
+        ],
+        {
+          ...model,
+          id: ModelID.make("openai/gpt-5"),
+          providerID: ProviderID.make("openai"),
+          api: { id: "gpt-5", url: "https://api.openai.com", npm: "@ai-sdk/openai" },
+        },
+        {},
+      )
+
+      expect(result[0].content).toEqual([reasoning])
+    } finally {
+      if (previous === undefined) delete process.env[flag]
+      else process.env[flag] = previous
+    }
+  })
+
+})
+
 describe("ProviderTransform.message - empty image handling", () => {
   const mockModel = {
     id: "anthropic/claude-3-5-sonnet",


### PR DESCRIPTION
## Summary

- add the opt-in `MIMOCODE_FORCE_ANTHROPIC_REASONING_CONTENT` flag
- attach an empty placeholder signature to unsigned historical reasoning so it follows Anthropic's native thinking-block serializer path
- preserve signed/redacted reasoning and leave non-Anthropic providers unchanged

## Testing

- `bun test test/session/message-v2.test.ts test/provider/transform.test.ts --timeout 30000` (249 passed)
- `bun run typecheck`
- push hook: repository-wide `bun turbo typecheck` (12/12 packages passed)
- `bunx oxlint packages/opencode/src/flag/flag.ts packages/opencode/src/provider/transform.ts packages/opencode/test/provider/transform.test.ts`

## Notes

The flag is off by default. It is intended for Anthropic-compatible endpoints that accept an empty placeholder signature; the official Anthropic API may reject an unverifiable signature.
