### PR TITLE
fix(tui): restore recent model on startup

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -16,13 +16,7 @@ import * as Model from "../util/model"
 import { useLanguage } from "@tui/context/language"
 import { createFreeApiSunsetSignal, freeApiModelNameKey, isFreeApiModel } from "@tui/util/free-api-sunset"
 
-export function parseModel(model: string) {
-  const [providerID, ...rest] = model.split("/")
-  return {
-    providerID: providerID,
-    modelID: rest.join("/"),
-  }
-}
+export { parse as parseModel } from "../util/model"
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
@@ -207,33 +201,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
       const args = useArgs()
       const fallbackModel = createMemo(() => {
-        if (args.model) {
-          const { providerID, modelID } = parseModel(args.model)
-          if (isModelValid({ providerID, modelID })) {
-            return {
-              providerID,
-              modelID,
-            }
-          }
-        }
+        const initial = Model.initial(sync.data.provider, {
+          argument: args.model,
+          ready: modelStore.ready,
+          recent: modelStore.recent,
+          configured: sync.data.config.model,
+        })
+        if (initial || !modelStore.ready) return initial
 
-        if (sync.data.config.model) {
-          const { providerID, modelID } = parseModel(sync.data.config.model)
-          if (isModelValid({ providerID, modelID })) {
-            return {
-              providerID,
-              modelID,
-            }
-          }
-        }
-
-        for (const item of modelStore.recent) {
-          if (isModelValid(item)) {
-            return item
-          }
-        }
-
-        // No args/config/recent match: prefer the free mimo-auto channel so a
+        // No args/recent/config match: prefer the free mimo-auto channel so a
         // clean install defaults to a usable free model rather than whatever
         // provider happens to sit first (e.g. paid xiaomi/ultraspeed).
         const mimo = sync.data.provider.find((p) => p.id === "mimo")

--- a/packages/opencode/src/cli/cmd/tui/util/model.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/model.ts
@@ -1,5 +1,10 @@
 import type { Provider } from "@mimo-ai/sdk/v2"
 
+type Selection = {
+  providerID: string
+  modelID: string
+}
+
 export function index(list: Provider[] | undefined) {
   return new Map((list ?? []).map((item) => [item.id, item] as const))
 }
@@ -20,4 +25,27 @@ export function name(
   modelID: string,
 ) {
   return get(list, providerID, modelID)?.name ?? modelID
+}
+
+export function parse(value: string) {
+  const [providerID, ...modelID] = value.split("/")
+  return { providerID, modelID: modelID.join("/") }
+}
+
+export function initial(
+  list: Provider[] | undefined,
+  input: {
+    argument?: string
+    ready: boolean
+    recent: Selection[]
+    configured?: string
+  },
+) {
+  // An explicit CLI choice is available immediately. Wait for persisted state
+  // before choosing between the last TUI choice and the configured default.
+  return [
+    ...(input.argument ? [parse(input.argument)] : []),
+    ...(input.ready ? input.recent : []),
+    ...(input.ready && input.configured ? [parse(input.configured)] : []),
+  ].find((item) => get(list, item.providerID, item.modelID))
 }

--- a/packages/opencode/test/cli/tui/model.test.ts
+++ b/packages/opencode/test/cli/tui/model.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import type { Provider } from "@mimo-ai/sdk/v2"
+import { initial } from "../../../src/cli/cmd/tui/util/model"
+
+const providers = [
+  {
+    id: "openai",
+    models: {
+      "gpt-5.6-sol": {},
+    },
+  },
+  {
+    id: "ppio",
+    models: {
+      "deepseek-v3": {},
+    },
+  },
+] as unknown as Provider[]
+
+describe("initial model", () => {
+  test("restores the most recent model before the configured default", () => {
+    expect(
+      initial(providers, {
+        ready: true,
+        recent: [{ providerID: "openai", modelID: "gpt-5.6-sol" }],
+        configured: "ppio/deepseek-v3",
+      }),
+    ).toEqual({ providerID: "openai", modelID: "gpt-5.6-sol" })
+  })
+
+  test("keeps an explicit model argument highest priority", () => {
+    expect(
+      initial(providers, {
+        argument: "ppio/deepseek-v3",
+        ready: false,
+        recent: [{ providerID: "openai", modelID: "gpt-5.6-sol" }],
+        configured: "openai/gpt-5.6-sol",
+      }),
+    ).toEqual({ providerID: "ppio", modelID: "deepseek-v3" })
+  })
+
+  test("skips unavailable recent models", () => {
+    expect(
+      initial(providers, {
+        ready: true,
+        recent: [{ providerID: "openai", modelID: "removed-model" }],
+        configured: "ppio/deepseek-v3",
+      }),
+    ).toEqual({ providerID: "ppio", modelID: "deepseek-v3" })
+  })
+
+  test("waits for recent state before using the configured default", () => {
+    expect(
+      initial(providers, {
+        ready: false,
+        recent: [],
+        configured: "ppio/deepseek-v3",
+      }),
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- restore the most recent valid TUI model before falling back to `config.model`
- wait for persisted recent-model state to load before selecting configured or generic fallbacks
- keep an explicit `--model` argument as the highest-priority startup selection
- add regression coverage for priority, unavailable recents, and async state loading

## Testing

- `bun test test/cli/tui/model.test.ts test/plugin/codex.test.ts`
- `bun typecheck` (from `packages/opencode`)
- pre-push repository `bun turbo typecheck`
