### PR TITLE
feat(skill): add Grok Build CLI guide

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/grok-build/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/grok-build/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: grok-build
+description: Reference and workflow guidance for the Grok Build CLI (`grok`), including interactive and headless runs, authentication, sessions, worktrees, permissions, sandboxing, MCP servers, plugins, inspection, updates, and automation output. Invoke only when the user explicitly requests the `grok-build` skill, explicitly asks to use Grok Build CLI, or an already-selected workflow requires Grok Build; do not invoke for general coding, generic shell tasks, or other agent CLIs.
+---
+
+# Grok Build CLI
+
+Operate Grok Build from a terminal while keeping execution mode, permissions, sandboxing, session state, and output handling explicit.
+
+## Start with Local Evidence
+
+1. Confirm that the CLI is available:
+
+   ```bash
+   command -v grok
+   grok version
+   ```
+
+2. Inspect the installed command before giving version-sensitive advice:
+
+   ```bash
+   grok --help
+   grok <subcommand> --help
+   ```
+
+3. Inspect the configuration discovered for the target workspace when behavior depends on rules, skills, plugins, hooks, or MCP servers:
+
+   ```bash
+   grok --cwd /path/to/repo inspect
+   grok --cwd /path/to/repo inspect --json
+   ```
+
+4. Treat current official documentation and installed help as authoritative when they differ from this bundled reference.
+
+## Choose an Execution Mode
+
+- Run `grok` with no arguments for the interactive TUI.
+- Run `grok "<initial prompt>"` to open the TUI with an initial task.
+- Run `grok -p "<prompt>"` for one non-interactive turn that prints a result and exits.
+- Run `grok agent stdio` for an ACP client that communicates over stdin/stdout.
+- Run `grok dashboard` to open the Agent Dashboard.
+
+Prefer headless mode for scripts, CI, bots, and agent orchestration. Prefer ACP only when the caller implements the ACP JSON-RPC lifecycle and consumes `session/update` chunks.
+
+## Authenticate
+
+Use an interactive login on a developer machine:
+
+```bash
+grok login
+```
+
+Use device-code authentication in headless or remote environments:
+
+```bash
+grok login --device-auth
+```
+
+Use a locally cached login or provide `XAI_API_KEY` only to the process that needs it. Never print, persist, or commit credentials. Use `grok logout` to clear cached credentials.
+
+## Run Headlessly
+
+Use an explicit working directory and output format:
+
+```bash
+grok --no-auto-update \
+  --cwd /path/to/repo \
+  --sandbox workspace \
+  -p "Inspect the repository and explain the failing test." \
+  --output-format json
+```
+
+Choose output according to the consumer:
+
+- Use `plain` for humans.
+- Use `json` for one final machine-readable object.
+- Use `streaming-json` for newline-delimited incremental events.
+- Add `--json-schema '<schema>'` when the installed CLI supports constrained structured output.
+
+Pass `--no-auto-update` in scripts and CI to suppress background update checks. Do not parse interactive TUI rendering in automation.
+
+## Control Permissions and Isolation
+
+Treat permissions and sandboxing as separate controls:
+
+- Use permission rules to decide whether a tool call may run.
+- Use a sandbox profile to limit what an approved call may access.
+- Prefer `--sandbox workspace` for normal repository changes.
+- Prefer `--sandbox read-only` for review and auditing.
+- Prefer `--sandbox strict` for an untrusted repository, then add narrow permission rules.
+- Use `--allow <RULE>` and `--deny <RULE>` for per-run policy; remember that deny rules win.
+- Use `--always-approve` only when the environment and command scope justify unattended execution. Pair it with a suitable sandbox and explicit deny rules.
+
+Do not describe `--always-approve` as equivalent to sandboxing. The sandbox is off by default unless configured or selected.
+
+## Manage Sessions and Worktrees
+
+Continue or resume intentionally:
+
+```bash
+grok -c
+grok --resume <session-id>
+grok --resume
+```
+
+Use `--session-id <UUID>` for a new named session, not to resume an existing one. Add `--fork-session` when branching from a resumed session.
+
+Use a worktree when concurrent work could collide:
+
+```bash
+grok --worktree --ref main "Fix the flaky test"
+grok --worktree=feature-name "Implement the feature"
+```
+
+Preview removal with `grok worktree rm --dry-run <id>` before deleting a worktree. Do not assume deleting a session removes its worktree.
+
+## Diagnose Before Editing Configuration
+
+Use built-in inspection and diagnostics first:
+
+```bash
+grok inspect --json
+grok mcp list --json
+grok mcp doctor
+grok plugin list
+grok models
+```
+
+Prefer `grok mcp add`, `grok mcp remove`, and plugin subcommands over manually editing configuration when the CLI supports the requested operation. Keep secrets in environment variables rather than command history or committed configuration.
+
+## Read the Bundled References
+
+- Read [references/cli-reference.md](references/cli-reference.md) for the subcommand and common flag index.
+- Read [references/workflows.md](references/workflows.md) for headless execution, sessions, worktrees, permissions, sandboxing, and MCP examples.
+
+Verify destructive commands such as session deletion, plugin removal, MCP removal, memory clearing, and worktree removal with the user or the governing workflow before running them.

--- a/packages/opencode/src/skill/builtin/.bundle/grok-build/agents/openai.yaml
+++ b/packages/opencode/src/skill/builtin/.bundle/grok-build/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Grok Build CLI"
+  short_description: "Operate Grok Build from the command line"
+  default_prompt: "Use $grok-build to run a Grok Build CLI workflow safely."
+
+policy:
+  allow_implicit_invocation: false

--- a/packages/opencode/src/skill/builtin/.bundle/grok-build/references/cli-reference.md
+++ b/packages/opencode/src/skill/builtin/.bundle/grok-build/references/cli-reference.md
@@ -1,0 +1,76 @@
+# Grok Build CLI Reference
+
+Use this index for command selection. Run `grok --help` or `grok <subcommand> --help` for the complete options supported by the installed version.
+
+Official source: <https://docs.x.ai/build/cli/reference>
+
+## Subcommands
+
+| Command | Purpose |
+| --- | --- |
+| `grok login` | Sign in; add `--device-auth` for headless or remote device-code authentication. |
+| `grok logout` | Sign out and clear cached credentials. |
+| `grok inspect [--json]` | Show discovered rules, skills, plugins, hooks, and MCP servers. |
+| `grok models` | List available models. |
+| `grok mcp <list\|add\|remove\|doctor>` | Manage and diagnose MCP servers. |
+| `grok plugin <list\|install\|uninstall\|update\|enable\|disable\|details\|validate>` | Manage plugins. |
+| `grok plugin marketplace <list\|add\|remove\|update>` | Manage plugin marketplace sources. |
+| `grok sessions <list\|search\|delete>` | List, search, or permanently delete sessions. |
+| `grok export <session-id> [output]` | Export a session transcript as Markdown. |
+| `grok import [targets...]` | Import sessions from Claude Code. |
+| `grok memory clear [--workspace\|--global\|--all]` | Clear cross-session memory files. |
+| `grok worktree <list\|show\|rm\|gc>` | Manage session worktrees. |
+| `grok dashboard` | Open the Agent Dashboard. |
+| `grok agent stdio` | Run as an ACP agent over stdin/stdout. |
+| `grok wrap <command...>` | Run a local PTY command that forwards OSC 52 clipboard writes. |
+| `grok update` | Check for or install updates; inspect `--check`, `--version`, `--alpha`, and `--stable`. |
+| `grok version` | Print version information. |
+| `grok completions <shell>` | Generate shell completions. |
+| `grok setup` | Fetch and install managed configuration. |
+
+Treat `sessions delete`, `memory clear`, `worktree rm`, MCP removal, plugin uninstall, and marketplace removal as destructive or externally visible operations.
+
+## Common Flags
+
+| Flag | Purpose |
+| --- | --- |
+| `--cwd <PATH>` | Set the working directory. |
+| `-r, --resume [<ID>]` | Resume a session by ID, or the most recent when omitted. |
+| `-c, --continue` | Continue the most recent session for the current directory. |
+| `-s, --session-id <UUID>` | Assign a UUID to a new session. |
+| `--fork-session` | Fork a resumed session into a new session ID. |
+| `-w, --worktree [<NAME>]` | Start in a new git worktree. |
+| `--ref <REF>` | Select the branch, tag, or commit used as the worktree base. |
+| `-m, --model <MODEL>` | Select a model ID. |
+| `--effort <LEVEL>` | Set reasoning effort. |
+| `--always-approve`, `--yolo` | Auto-approve tool execution; deny rules and hooks still apply. |
+| `--allow <RULE>`, `--deny <RULE>` | Add per-run permission rules. |
+| `--sandbox <PROFILE>` | Select a sandbox profile. |
+| `--rules <TEXT>` | Append rules to the system prompt. |
+| `--system-prompt-override <TEXT>` | Replace the system prompt. |
+| `--tools <LIST>` | Allow selected built-in tools. |
+| `--disallowed-tools <LIST>` | Remove selected built-in tools. |
+| `--max-turns <N>` | Limit agent turns. |
+| `--no-plan` | Disable plan mode. |
+| `--no-subagents` | Disable subagents. |
+| `--no-memory` | Disable cross-session memory for the run. |
+| `--disable-web-search` | Disable web search and web fetch. |
+| `--experimental-memory` | Enable cross-session memory. |
+| `--oauth` | Use OAuth when welcome-screen authentication begins. |
+
+Overlapping Claude Code compatibility aliases include `--allowedTools`, `--disallowedTools`, `--append-system-prompt`, `--system-prompt`, and `--dangerously-skip-permissions`. Prefer the native Grok flag names in new workflows.
+
+## Headless Flags
+
+Official source: <https://docs.x.ai/build/cli/headless-scripting>
+
+| Flag | Purpose |
+| --- | --- |
+| `-p, --single <PROMPT>` | Send one prompt, print the response, and exit. |
+| `--output-format plain` | Emit human-readable output. |
+| `--output-format json` | Emit one final JSON object. |
+| `--output-format streaming-json` | Emit newline-delimited incremental events. |
+| `--no-alt-screen` | Run inline without taking over the alternate screen. |
+| `--no-auto-update` | Suppress background update checks in scripts and CI. |
+
+The installed CLI may expose additional flags, such as structured-output schema options. Verify them with local help before relying on them.

--- a/packages/opencode/src/skill/builtin/.bundle/grok-build/references/workflows.md
+++ b/packages/opencode/src/skill/builtin/.bundle/grok-build/references/workflows.md
@@ -1,0 +1,118 @@
+# Grok Build CLI Workflows
+
+Use these patterns as starting points, then confirm flags with the installed CLI.
+
+## Headless Automation
+
+Run one unattended analysis with workspace-scoped writes:
+
+```bash
+grok --no-auto-update \
+  --cwd /workspace/repo \
+  --sandbox workspace \
+  -p "Implement the requested change and run relevant tests." \
+  --output-format json
+```
+
+Use `streaming-json` for progress consumers. Use `json` when only the final result matters. Keep stderr separate if downstream code parses stdout.
+
+For structured output, first verify `--json-schema` with `grok --help`, then pass a compact JSON Schema directly or through the caller's safe argument mechanism.
+
+Official source: <https://docs.x.ai/build/cli/headless-scripting>
+
+## Sessions
+
+Resume the most recent session for a directory:
+
+```bash
+grok --cwd /workspace/repo --continue
+```
+
+Resume a known session:
+
+```bash
+grok --cwd /workspace/repo --resume <session-id>
+```
+
+Create a new session with a caller-supplied UUID:
+
+```bash
+grok --cwd /workspace/repo --session-id <uuid> -p "Start the task"
+```
+
+Do not use `--session-id` to resume. Use `--fork-session` with `--resume` or `--continue` to branch the conversation instead of modifying the original session.
+
+Official source: <https://docs.x.ai/build/features/sessions>
+
+## Worktree Isolation
+
+Start isolated work from a known ref:
+
+```bash
+grok --cwd /workspace/repo --worktree --ref main "Fix the flaky test"
+```
+
+List and inspect worktrees before cleanup:
+
+```bash
+grok worktree list
+grok worktree show <id>
+grok worktree rm --dry-run <id>
+```
+
+Worktrees persist after sessions end. Use `grok worktree gc` only after understanding its age and liveness criteria.
+
+Official source: <https://docs.x.ai/build/features/worktrees>
+
+## Permissions and Sandbox
+
+Use a read-only profile for repository review:
+
+```bash
+grok --cwd /workspace/repo \
+  --sandbox read-only \
+  -p "Review the repository without modifying files."
+```
+
+Use a strict profile for an untrusted tree:
+
+```bash
+grok --cwd /workspace/untrusted \
+  --sandbox strict \
+  -p "Inspect this repository and report risks."
+```
+
+Add narrow `--allow <RULE>` and `--deny <RULE>` options only after confirming the installed rule syntax with `grok --help` and current documentation. Deny rules take precedence over allow rules. Sandbox profiles control filesystem and child-process network scope after a tool call is approved; they do not replace permission decisions.
+
+Built-in profiles include `off`, `workspace`, `devbox`, `read-only`, and `strict`. The sandbox is off by default. Child-network restrictions for `read-only` and `strict` are not enforced on macOS, so do not rely on them there as a network security boundary.
+
+Official sources:
+
+- <https://docs.x.ai/build/features/permissions>
+- <https://docs.x.ai/build/features/sandbox>
+
+## MCP Servers
+
+Add a local stdio server:
+
+```bash
+grok mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /path/to/dir
+```
+
+Add a remote HTTP server:
+
+```bash
+grok mcp add --transport http linear https://mcp.linear.app/mcp
+```
+
+Diagnose before changing configuration:
+
+```bash
+grok mcp list --json
+grok mcp doctor
+grok inspect --json
+```
+
+Pass `--scope project` only when the server configuration should be written to the repository's `.grok/config.toml`. Keep static tokens in environment variables; avoid putting secret values directly in command history or committed files.
+
+Official source: <https://docs.x.ai/build/features/mcp-servers>

--- a/packages/opencode/test/skill/builtin.test.ts
+++ b/packages/opencode/test/skill/builtin.test.ts
@@ -25,6 +25,16 @@ describe("builtin skills", () => {
     expect(isBuiltinSkillInstalled("codex", () => null)).toBe(false)
   })
 
+  test("keeps Grok Build explicitly invoked", async () => {
+    const root = path.join(import.meta.dir, "../../src/skill/builtin/.bundle/grok-build")
+    const skill = await Bun.file(path.join(root, "SKILL.md")).text()
+    const metadata = await Bun.file(path.join(root, "agents/openai.yaml")).text()
+
+    expect(skill).toContain("Invoke only when the user explicitly requests the `grok-build` skill")
+    expect(skill).toContain("do not invoke for general coding")
+    expect(metadata).toContain("allow_implicit_invocation: false")
+  })
+
   test("does not gate unrelated builtin skills", () => {
     expect(isBuiltinSkillInstalled("pdf-official", () => null)).toBe(true)
   })

--- a/packages/opencode/test/skill/bundle-discovery.test.ts
+++ b/packages/opencode/test/skill/bundle-discovery.test.ts
@@ -23,6 +23,7 @@ describe("bundled skill discovery", () => {
           const names = new Set(list.map((item) => item.name))
 
           expect(names.has("data-analytics")).toBe(true)
+          expect(names.has("grok-build")).toBe(true)
           expect(names.has("product-design")).toBe(true)
           expect(names.has("sales")).toBe(true)
           expect(


### PR DESCRIPTION
## Summary

- add a bundled `grok-build` skill based on the official xAI CLI reference
- document interactive, headless, session, worktree, sandbox, permission, and MCP workflows
- disable implicit invocation and add regression coverage for discovery and trigger policy

## Testing

- `uv run --no-project --with pyyaml python /Users/mi/.codex/skills/.system/skill-creator/scripts/quick_validate.py src/skill/builtin/.bundle/grok-build`
- `bun test test/skill/bundle-discovery.test.ts test/skill/builtin.test.ts`
- `bun turbo typecheck` (push hook)
