### PR TITLE
fix(skill): simplify Claude Code trigger description

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/claude-code/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/claude-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-code
-description: "Operate Claude Code CLI (v2.1+) via the terminal only when the user explicitly requests Claude Code or names this skill. Do not invoke it automatically for general coding, review, test, git, or multi-step codebase tasks. Covers print mode (-p), interactive tmux sessions, and background (--bg) orchestration."
+description: "Operate Claude Code CLI (v2.1+) via the terminal only when the user explicitly requests Claude Code or names this skill. Covers print mode (-p), interactive tmux sessions, and background (--bg) orchestration."
 version: 2.0.0
 license: MIT
 platforms: [linux, macos, windows]

--- a/packages/opencode/test/skill/builtin.test.ts
+++ b/packages/opencode/test/skill/builtin.test.ts
@@ -16,7 +16,6 @@ describe("builtin skills", () => {
     ).text()
 
     expect(skill).toContain("only when the user explicitly requests Claude Code or names this skill")
-    expect(skill).toContain("Do not invoke it automatically for general coding")
     expect(skill).not.toContain("even if the user doesn't say 'Claude Code'")
   })
 


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes redundant negative wording from the Claude Code skill description while preserving the explicit-invocation requirement. Updates the metadata test to assert only the remaining guidance.

### How did you verify your code works?

- `bun test test/skill/builtin.test.ts test/skill/bundle-discovery.test.ts`
- `bun typecheck`

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
