### PR TITLE
fix(provider): scope DeepSeek variants to official API

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -934,9 +934,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   )
     return {}
 
-  // DeepSeek V4 supports reasoning_effort: "high" (default) and "max"
-  // low/medium map to high, xhigh maps to max per DeepSeek docs
   if (id.includes("deepseek")) {
+    if (model.providerID !== "deepseek" || model.api.npm !== "@ai-sdk/openai-compatible") return {}
     return {
       high: { reasoningEffort: "high" },
       max: { reasoningEffort: "max" },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3126,12 +3126,12 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
-  test("deepseek returns high and max variants", () => {
+  test("official deepseek V4 returns high and max variants", () => {
     const model = createMockModel({
-      id: "deepseek/deepseek-chat",
+      id: "deepseek/deepseek-v4-pro",
       providerID: "deepseek",
       api: {
-        id: "deepseek-chat",
+        id: "deepseek-v4-pro",
         url: "https://api.deepseek.com",
         npm: "@ai-sdk/openai-compatible",
       },
@@ -3141,6 +3141,20 @@ describe("ProviderTransform.variants", () => {
       high: { reasoningEffort: "high" },
       max: { reasoningEffort: "max" },
     })
+  })
+
+  test("deepseek variants remain disabled for non-official openai-compatible providers", () => {
+    const model = createMockModel({
+      id: "custom/deepseek-v4-pro",
+      providerID: "custom",
+      api: {
+        id: "deepseek-v4-pro",
+        url: "https://api.example.com",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({})
   })
 
   test("minimax returns empty object", () => {
@@ -3186,6 +3200,20 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@openrouter/ai-sdk-provider", () => {
+    test("deepseek variants remain disabled", () => {
+      const model = createMockModel({
+        id: "openrouter/deepseek/deepseek-v4-pro",
+        providerID: "openrouter",
+        api: {
+          id: "deepseek/deepseek-v4-pro",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result).toEqual({})
+    })
+
     test("returns empty object for non-qualifying models", () => {
       const model = createMockModel({
         id: "openrouter/test-model",


### PR DESCRIPTION
Follow-up to #1895.

## What

- Limit DeepSeek `high`/`max` reasoning-effort variants to the official `deepseek` provider using `@ai-sdk/openai-compatible`
- Keep DeepSeek variants disabled for OpenRouter and custom OpenAI-compatible endpoints
- Update the positive test to use `deepseek-v4-pro` and add provider-scope regression coverage

## Why

The merged DeepSeek ID check runs before provider-specific handling, so it also matched OpenRouter and custom endpoints. That could inject the official `reasoningEffort` option into providers that use a different request shape.

## Verification

- `bun test test/provider/transform.test.ts` (225 pass)
- `bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck` (12 tasks successful)