### PR TITLE
chore: ignore Playwright CLI artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ experiment/last-outcome.json
 temp/
 __pycache__
 Thumbs.db
+.playwright-cli/


### PR DESCRIPTION
## Summary

- Ignore .playwright-cli/ runtime artifacts generated by local browser automation.

## Testing

- bun turbo typecheck (pre-push hook)