### PR TITLE
feat: disable auto-dream and auto-distill by default

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -348,7 +348,7 @@ const InfoSchema = Schema.Struct({
     Schema.Struct({
       auto: Schema.optional(Schema.Boolean).annotate({
         description:
-          "Auto-trigger dream memory consolidation on new session start. Default: true.",
+          "Auto-trigger dream memory consolidation on new session start. Default: false.",
       }),
       interval_days: Schema.optional(NonNegativeInt).annotate({
         description: "Minimum days between automatic dream runs. Set to 0 to trigger on every new session. Default: 7.",
@@ -359,7 +359,7 @@ const InfoSchema = Schema.Struct({
     Schema.Struct({
       auto: Schema.optional(Schema.Boolean).annotate({
         description:
-          "Auto-trigger distill workflow packaging on new session start. Default: true.",
+          "Auto-trigger distill workflow packaging on new session start. Default: false.",
       }),
       interval_days: Schema.optional(NonNegativeInt).annotate({
         description: "Minimum days between automatic distill runs. Default: 30.",

--- a/packages/opencode/src/session/auto-dream.ts
+++ b/packages/opencode/src/session/auto-dream.ts
@@ -107,7 +107,7 @@ function shouldAutoRun(input: {
 }
 
 export function shouldAutoDream(cfg: Config.Info) {
-  const enabled = cfg.dream?.auto !== false
+  const enabled = cfg.dream?.auto === true
   if (!enabled) return Effect.succeed(false)
   const now = Date.now()
   if (now - lastDreamSpawnTime < MIN_SPAWN_GAP_MS) return Effect.succeed(false)
@@ -117,7 +117,7 @@ export function shouldAutoDream(cfg: Config.Info) {
 }
 
 export function shouldAutoDistill(cfg: Config.Info) {
-  const enabled = cfg.distill?.auto !== false
+  const enabled = cfg.distill?.auto === true
   if (!enabled) return Effect.succeed(false)
   const now = Date.now()
   if (now - lastDistillSpawnTime < MIN_SPAWN_GAP_MS) return Effect.succeed(false)


### PR DESCRIPTION
Require explicit opt-in via dream.auto / distill.auto config instead of running memory consolidation and workflow packaging automatically.
