### PR TITLE
fix(codex): cap imported GPT context at 300K

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -370,12 +370,13 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         if (auth.type !== "oauth") return {}
 
         // Zero out costs for Codex (included with ChatGPT subscription)
-        for (const model of Object.values(provider.models)) {
+        for (const [modelID, model] of Object.entries(provider.models)) {
           model.cost = {
             input: 0,
             output: 0,
             cache: { read: 0, write: 0 },
           }
+          if (modelID.startsWith("gpt-")) model.limit.context = 300_000
         }
 
         return {

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -36,8 +36,9 @@ describe("plugin.codex", () => {
       const hooks = await CodexAuthPlugin(fakeInput)
       const provider = {
         models: {
-          "gpt-5.6-sol": { api: { id: "gpt-5.6-sol" }, cost: {} },
-          "gpt-4o": { api: { id: "gpt-4o" }, cost: {} },
+          "gpt-5.6-sol": { api: { id: "gpt-5.6-sol" }, cost: {}, limit: { context: 1_000_000 } },
+          "gpt-4o": { api: { id: "gpt-4o" }, cost: {}, limit: { context: 128_000 } },
+          o3: { api: { id: "o3" }, cost: {}, limit: { context: 200_000 } },
         },
       }
 
@@ -46,7 +47,8 @@ describe("plugin.codex", () => {
         provider as never,
       )
 
-      expect(Object.keys(provider.models)).toEqual(["gpt-5.6-sol", "gpt-4o"])
+      expect(Object.keys(provider.models)).toEqual(["gpt-5.6-sol", "gpt-4o", "o3"])
+      expect(Object.values(provider.models).map((model) => model.limit.context)).toEqual([300_000, 300_000, 200_000])
     })
 
     test("forwards request cancellation while refreshing an expired token", async () => {


### PR DESCRIPTION
## Summary

- set Codex OAuth-imported `gpt-*` models to a 300K context window
- preserve catalog context limits for non-GPT models
- add coverage for both GPT and non-GPT models

## Testing

- `bun test test/plugin/codex.test.ts`
- `bun typecheck`
