### PR TITLE
fix(log): keep log records off the TUI terminal

### DIFF
--- a/docs/compose/spec/log-safety.md
+++ b/docs/compose/spec/log-safety.md
@@ -1,28 +1,31 @@
 ---
 feature: log-safety
 status: delivered
-updated: 2026-07-24
-branch: fix/log-safety
-commits: e27a610c081744624d0449744911ffcfd3e26b6c..ca726ac3
+updated: 2026-07-27
+branch: fix/tui-log-stderr
+commits: 014a2577..aa28c273
 ---
 
 # Log Safety
 
 ## Report
 
-**What was built** — Logger instances now own unique active files and serialize initialization, writes, rotation, and shutdown through one lifecycle queue. Cleanup preserves live files, recovers stale process and worker files, enforces archive count and size budgets, and stops file writes safely when finalization cannot complete.
+**What was built** — Logger instances own unique active files and serialize initialization, writes, rotation, and shutdown through one lifecycle queue. Cleanup preserves live files, recovers stale process and worker files, enforces archive count and size budgets, and stops file writes safely when finalization cannot complete. CLI hard exits use `Log.exit()` and normal TUI exits return through the top-level shutdown.
 
-CLI hard exits now use `Log.exit()`, normal TUI exits return through the top-level shutdown, and the worker closes its log before potentially long teardown work. This guarantees pending records are handled before the process or worker terminates.
+The logger no longer treats stderr as a fallback sink. Records reach stderr only under `--print-logs`; without a usable file sink they are dropped, and sink failures are swallowed rather than reported. The TUI worker flushes before its bounded teardown and closes its log as the last teardown step, so instance disposal and bus unsubscribe records land in the file instead of on the rendered screen.
 
-**Verification** — `bun test test/util/log.test.ts test/effect/app-runtime-logger.test.ts test/effect/runner-warn-log.test.ts` passed with 20 tests and 52 expectations under the CI-equivalent `main` role; the focused log suite also passed all 12 tests under both `main` and `worker` roles. `bun typecheck` passed. Targeted oxlint completed with zero errors and only pre-existing warnings. An isolated `bun dev run` error-path check exited with code 1 and produced zero active logs and one completed log. `git diff --check` passed, and the final independent reviews found no critical issues.
+**Verification** — `MIMOCODE_PROCESS_ROLE=main bun test test/util/log.test.ts` passed 18 tests / 53 expectations, and `MIMOCODE_PROCESS_ROLE=worker bun test test/util/log.test.ts test/effect/app-runtime-logger.test.ts test/effect/runner-warn-log.test.ts` passed 26 tests. `bun typecheck` passed. oxlint on the changed files reported zero warnings and zero errors.
+
+Reproduction, before and after: running the same child-process script against the pre-fix `log.ts` leaked `INFO … teardown after shutdown` to stderr, while the fixed logger emitted nothing. End-to-end, a tmux-driven `bun dev <dir>` quit through the `exit` prompt command on `main` printed nine teardown records to stderr — the exact lines the user reported — with the worker log file ending at `worker shutting down`; on the delivered head stderr stayed empty and the worker log file contained the full teardown sequence through `service=bus type=session.updated unsubscribing`.
 
 **Journey log**
 
 - The first review exposed that a write queue alone is insufficient; lifecycle mutations must use the same queue.
 - Capturing a stream before queued rotation can make shutdown close the wrong resource; shutdown now resolves the current stream only when its queued operation runs.
 - Bun main and worker contexts share a PID, so stale worker recovery also needs the process role.
-- TUI worker logging must close before the 30-second drain because the host may terminate the worker after 5 seconds.
-- Isolated dev CLI driving verified the real exit path without touching user configuration or session data.
+- Closing the worker log before its teardown traded one bug for another: the records were durable but were printed over the TUI. Flushing, then closing last, satisfies both; a worker killed mid-drain leaves an `.active.log` that the next initialization recovers.
+- Gating the failure report behind print mode made it unreachable — print mode never opens a file — which is why the reporting path was removed instead of gated. Attempting to test a branch is the cheapest way to discover it cannot happen.
+- `bun dev` writes its logs under the checkout's `.dev-home` (`MIMOCODE_HOME` in `script/dev.ts`), so redirecting only stderr to a file keeps the TUI on the real terminal while making a leak trivially greppable.
 
 ## [S1] Problem
 
@@ -36,11 +39,19 @@ With rotation enabled, queued records that individually fit within the threshold
 
 ## [S3] Failure And Shutdown Behavior
 
-Stream failures are consumed by the logger and reported directly to stderr at most once per initialization; they must not create unhandled promise rejections or recursively call the logger. `flush()` waits for queued writes. `shutdown()` runs after earlier queued rotations, closes the final stream, and marks its file completed. CLI hard exits use `Log.exit()`, normal TUI exits return through the top-level shutdown, and the TUI worker closes its log before bounded teardown can be terminated by the host.
+Stream failures are consumed by the logger and must not create unhandled promise rejections, crash on a stream `error` event, or recursively call the logger. They are not reported to any stream: a file failure can only happen while logging to a file, which is exactly when stderr belongs to the rendered TUI screen, so the missing or short log file is the only signal. `flush()` waits for queued writes and leaves the file sink open. `shutdown()` runs after earlier queued rotations, closes the final stream, and marks its file completed. CLI hard exits use `Log.exit()`, and normal TUI exits return through the top-level shutdown.
+
+## [S4] Terminal Isolation
+
+The logger writes to stderr only when the process was initialized with `print` (`--print-logs`), and then only the records themselves. Without a usable file sink — before initialization, after `shutdown()`, or when opening or finalizing the file failed — records are dropped. The TUI renders on the same terminal the process writes stderr to, so a leaked line corrupts the screen; a dropped record is preferable to a corrupted display.
+
+The TUI worker therefore flushes, not closes, before its bounded teardown: queued records must be durable in case the host kills the worker mid-drain, while the teardown that follows (checkpoint drain, instance disposal, server stop) must still log to the file. The worker closes its log as the last teardown step. A worker killed before that leaves an `.active.log` that the next initialization recovers.
 
 ## [S5] Testing Boundaries
 
-Tests use real temporary files and streams. They cover unique ownership across repeated and concurrent initialization, same-PID worker recovery, ordered concurrent writes, size rotation, shutdown queued behind a rotation, retention by count and total bytes, active-file preservation, disabled rotation, write failure without unhandled rejection, and flush/shutdown persistence. An isolated dev CLI run verifies that a post-initialization command error exits nonzero with no active log and one completed log.
+Tests use real temporary files and streams. They cover unique ownership across repeated and concurrent initialization, same-PID worker recovery, ordered concurrent writes, size rotation, shutdown queued behind a rotation, retention by count and total bytes, active-file preservation, disabled rotation, write failure without unhandled rejection, and flush/shutdown persistence.
+
+Terminal isolation is verified in a child process, because the sink state is module-level: records emitted before initialization and after `shutdown()` produce empty stdout and stderr while earlier records remain in the file, an unusable log directory produces no output at all, and `print` mode still writes records to stderr — without creating a file, and unaffected by an unusable log directory. An isolated dev CLI run verifies that a post-initialization command error exits nonzero with no active log and one completed log.
 
 ## [S6] Out Of Scope
 
@@ -51,3 +62,5 @@ This change does not introduce per-record truncation, modify MCP/ACP/voice loggi
 - [x] T1: Implement unique active-file ownership and a serialized lifecycle queue — acceptance: concurrent initialization cannot target, leak, or clean another live active file, and file/count/total limits hold (covers: S2)
 - [x] T2: Add failure-safe flush, shutdown, and command exit lifecycle — acceptance: write/finalization failures do not reject globally or resume unsafe file writes, and CLI/TUI/worker exit paths close pending logs before termination (covers: S3; depends: T1)
 - [x] T3: Add and run focused tests and package typecheck — acceptance: all S5 cases pass from packages/opencode and typecheck succeeds (covers: S5; depends: T1, T2)
+- [x] T4: Confine log records to the file sink unless print mode is active — acceptance: a record emitted after `shutdown()` or before `init()` produces no stderr output, while `--print-logs` still prints (covers: S4)
+- [x] T5: Keep the worker's file sink open across teardown — acceptance: a TUI quit writes the worker teardown records (instance disposal, bus unsubscribe) to the log file and nothing to stderr (covers: S4; depends: T4)

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -89,7 +89,10 @@ export const rpc = {
   },
   async shutdown() {
     Log.Default.info("worker shutting down")
-    await Log.shutdown()
+    // Flush instead of closing: the host may kill the worker during the drain
+    // below, so queued records must already be on disk. Closing here would
+    // leave the rest of teardown without a file sink.
+    await Log.flush()
 
     // Give in-flight background checkpoint writers a bounded chance to finish
     // before we tear down instances. A checkpoint writer can run for minutes on
@@ -106,6 +109,7 @@ export const rpc = {
 
     await Instance.disposeAll()
     if (server) await server.stop(true)
+    await Log.shutdown()
   },
 }
 

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -65,7 +65,6 @@ let written = 0
 let rotation = true
 let sequence = 0
 let pending = Promise.resolve()
-let failureReported = false
 let printing = false
 
 function stamp() {
@@ -77,7 +76,6 @@ export async function init(options: Options) {
     await closeCurrent()
     if (options.level) level = options.level
     rotation = options.rotate ?? !Flag.MIMOCODE_DISABLE_LOG_ROTATION
-    failureReported = false
     printing = options.print
     const role = (process.env.MIMOCODE_PROCESS_ROLE ?? "main").replace(/[^a-zA-Z0-9._-]/g, "-")
     await cleanup(Global.Path.log, { pid: process.pid, role })
@@ -95,22 +93,18 @@ export async function init(options: Options) {
   })
 }
 
-function report(error: unknown) {
-  if (failureReported) return
-  failureReported = true
-  if (!printing) return
-  const message = error instanceof Error ? error.message : String(error)
-  try {
-    process.stderr.write(`mimocode log write failed: ${message}\n`)
-  } catch {}
-}
+// Log failures are swallowed. Streams still need a listener so an "error" event
+// cannot crash the process, but there is nowhere safe to report to: file
+// failures only happen when logging to a file, and that is exactly when stderr
+// belongs to the TUI screen. A missing or short log file is the only signal.
+function swallow() {}
 
 function write(msg: string) {
   void enqueue(() => append(msg))
 }
 
 function enqueue(operation: () => void | Promise<void>) {
-  pending = pending.then(operation).catch(report)
+  pending = pending.then(operation).catch(swallow)
   return pending
 }
 
@@ -150,7 +144,7 @@ async function rotate() {
 async function open(targetPath: string) {
   const target = createWriteStream(targetPath, { flags: "a" })
   stream = target
-  target.on("error", report)
+  target.on("error", swallow)
   const opened = await new Promise<boolean>((resolve) => {
     target.once("open", () => resolve(true))
     target.once("error", () => resolve(false))
@@ -166,11 +160,7 @@ async function move(source: string, target: string) {
   if (renamed) return true
   const copied = await fs.copyFile(source, target).then<"copied", "missing" | "failed">(
     () => "copied",
-    (error) => {
-      if (error instanceof Error && "code" in error && error.code === "ENOENT") return "missing"
-      report(error)
-      return "failed"
-    },
+    (error) => (error instanceof Error && "code" in error && error.code === "ENOENT" ? "missing" : "failed"),
   )
   if (copied === "missing") return true
   if (copied === "failed") return false
@@ -181,10 +171,7 @@ async function move(source: string, target: string) {
   if (removed) return true
   return fs.truncate(source, 0).then(
     () => true,
-    (error) => {
-      report(error)
-      return false
-    },
+    () => false,
   )
 }
 

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -98,6 +98,7 @@ export async function init(options: Options) {
 function report(error: unknown) {
   if (failureReported) return
   failureReported = true
+  if (!printing) return
   const message = error instanceof Error ? error.message : String(error)
   try {
     process.stderr.write(`mimocode log write failed: ${message}\n`)

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -93,10 +93,10 @@ export async function init(options: Options) {
   })
 }
 
-// Log failures are swallowed. Streams still need a listener so an "error" event
-// cannot crash the process, but there is nowhere safe to report to: file
-// failures only happen when logging to a file, and that is exactly when stderr
-// belongs to the TUI screen. A missing or short log file is the only signal.
+// Log failures are swallowed: a file failure happens while logging to a file,
+// which is exactly when stderr belongs to the rendered TUI screen, and print
+// mode can only fail on the very stderr a report would need. The listener stays
+// because an unhandled stream "error" event would crash the process.
 function swallow() {}
 
 function write(msg: string) {

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -66,6 +66,7 @@ let rotation = true
 let sequence = 0
 let pending = Promise.resolve()
 let failureReported = false
+let printing = false
 
 function stamp() {
   return new Date().toISOString().replace(/[:.]/g, "")
@@ -77,6 +78,7 @@ export async function init(options: Options) {
     if (options.level) level = options.level
     rotation = options.rotate ?? !Flag.MIMOCODE_DISABLE_LOG_ROTATION
     failureReported = false
+    printing = options.print
     const role = (process.env.MIMOCODE_PROCESS_ROLE ?? "main").replace(/[^a-zA-Z0-9._-]/g, "-")
     await cleanup(Global.Path.log, { pid: process.pid, role })
     if (options.print) {
@@ -116,7 +118,11 @@ async function append(msg: string) {
   if (rotation && written > 0 && written + size > MAX_FILE_SIZE) await rotate()
   const target = stream
   if (!target) {
-    process.stderr.write(msg)
+    // Only --print-logs may reach the terminal. Without a file sink (before
+    // init, after shutdown, or when the sink failed) records are dropped: the
+    // TUI shares stderr with the rendered screen, so leaking log lines there
+    // corrupts the display.
+    if (printing) process.stderr.write(msg)
     return
   }
   await new Promise<void>((resolve, reject) => {

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -326,3 +326,17 @@ test("an unusable log directory reports nothing to stderr", async () => {
   expect(result.stderr).toBe("")
   expect(result.stdout).toBe("")
 })
+
+test("print mode is unaffected by an unusable log directory", async () => {
+  await using tmp = await tmpdir()
+  const blocked = path.join(tmp.path, "not-a-directory")
+  await fs.writeFile(blocked, "file")
+
+  const result = await isolate(
+    [`await Log.init({ print: true })`, `Log.Default.info("printed record")`, `await Log.flush()`].join("\n"),
+    blocked,
+  )
+
+  expect(result.stderr).toContain("printed record")
+  expect(result.stderr).not.toContain("failed")
+})

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -229,3 +229,86 @@ test("shutdown flushes and marks the active file completed", async () => {
     ),
   ).toBe(false)
 })
+
+test("flush persists records without closing the file sink", async () => {
+  await using tmp = await tmpdir()
+  Global.Path.log = tmp.path
+  await Log.init({ print: false })
+  const active = Log.file()
+  Log.Default.info("before flush")
+
+  await Log.flush()
+  expect(await fs.readFile(active, "utf8")).toContain("before flush")
+
+  Log.Default.info("during teardown")
+  await Log.shutdown()
+
+  expect(await fs.readFile(Log.file(), "utf8")).toContain("during teardown")
+})
+
+// The TUI renders on the same terminal the process writes stderr to, so a log
+// record must never reach stderr unless the user asked for printed logs. A
+// child process keeps the module-level sink state honest.
+async function isolate(body: string, dir: string) {
+  const src = path.join(import.meta.dir, "..", "..", "src")
+  const child = Bun.spawn(
+    [
+      process.execPath,
+      "-e",
+      [
+        `const { Global } = await import(${JSON.stringify(path.join(src, "global", "index.ts"))})`,
+        `const Log = await import(${JSON.stringify(path.join(src, "util", "log.ts"))})`,
+        `Global.Path.log = ${JSON.stringify(dir)}`,
+        body,
+      ].join("\n"),
+    ],
+    { stdout: "pipe", stderr: "pipe", env: { ...process.env, [MIMOCODE_PROCESS_ROLE]: "worker" } },
+  )
+  const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text()])
+  expect(await child.exited).toBe(0)
+  return { stdout, stderr }
+}
+
+test("records written after shutdown never reach stderr", async () => {
+  await using tmp = await tmpdir()
+
+  const result = await isolate(
+    [
+      `await Log.init({ print: false })`,
+      `Log.Default.info("before shutdown")`,
+      `await Log.shutdown()`,
+      `Log.Default.info("teardown after shutdown")`,
+      `await Log.flush()`,
+    ].join("\n"),
+    tmp.path,
+  )
+
+  expect(result.stderr).toBe("")
+  expect(result.stdout).toBe("")
+  const files = await fs.readdir(tmp.path)
+  expect(files).toHaveLength(1)
+  const contents = await fs.readFile(path.join(tmp.path, files[0]), "utf8")
+  expect(contents).toContain("before shutdown")
+  expect(contents).not.toContain("teardown after shutdown")
+})
+
+test("records written before initialization never reach stderr", async () => {
+  await using tmp = await tmpdir()
+
+  const result = await isolate([`Log.Default.info("before init")`, `await Log.flush()`].join("\n"), tmp.path)
+
+  expect(result.stderr).toBe("")
+  expect(result.stdout).toBe("")
+})
+
+test("print mode keeps writing records to stderr", async () => {
+  await using tmp = await tmpdir()
+
+  const result = await isolate(
+    [`await Log.init({ print: true })`, `Log.Default.info("printed record")`, `await Log.flush()`].join("\n"),
+    tmp.path,
+  )
+
+  expect(result.stderr).toContain("printed record")
+  expect(await fs.readdir(tmp.path)).toHaveLength(0)
+})

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -312,3 +312,17 @@ test("print mode keeps writing records to stderr", async () => {
   expect(result.stderr).toContain("printed record")
   expect(await fs.readdir(tmp.path)).toHaveLength(0)
 })
+
+test("an unusable log directory reports nothing to stderr", async () => {
+  await using tmp = await tmpdir()
+  const blocked = path.join(tmp.path, "not-a-directory")
+  await fs.writeFile(blocked, "file")
+
+  const result = await isolate(
+    [`await Log.init({ print: false })`, `Log.Default.info("cannot be written")`, `await Log.flush()`].join("\n"),
+    blocked,
+  )
+
+  expect(result.stderr).toBe("")
+  expect(result.stdout).toBe("")
+})


### PR DESCRIPTION
## Problem

Regression from #1904 (`fix(log): isolate writers and flush safely on exit`). Quitting the TUI printed log records over the rendered screen:

```
INFO  2026-07-27T04:32:01 +3ms service=server-proxy disposing all instances
INFO  2026-07-27T04:32:01 +0ms service=server-proxy directory=/Users/…/mimo-desktop disposing instance
INFO  2026-07-27T04:32:01 +1ms service=bus type=* unsubscribing
…
```

Two causes, both introduced by that PR:

1. `append()` in `src/util/log.ts` wrote `process.stderr.write(msg)` whenever no file stream was open. Before #1904, `init()` replaced `write` with a file-only implementation, so after initialization no record could reach stderr. The TUI worker is a Bun `Worker` thread sharing the host's stderr, which is the same terminal the TUI renders on.
2. `rpc.shutdown()` in `src/cli/cmd/tui/worker.ts` called `await Log.shutdown()` as its **first** step, before the checkpoint drain, `Instance.disposeAll()` and `server.stop()`. Every teardown record therefore hit a closed sink and was printed.

## Solution

**Terminal isolation.** The logger writes to stderr only when initialized with `print` (`--print-logs`). Without a usable file sink — before `init()`, after `shutdown()`, or when opening/finalizing the file failed — records are dropped. A dropped record is preferable to a corrupted TUI screen.

**No failure reporting.** Gating the one-line `mimocode log write failed: …` report behind print mode made it unreachable: print mode never opens a file, so it never produces a stream failure. The reporting path and its `failureReported` bookkeeping are removed; the stream `error` listener stays (with a no-op body) because an unhandled `error` event would crash the process.

**Worker lifecycle.** The worker now `flush()`es before its bounded teardown instead of closing — queued records must be durable because the host may terminate the worker during the 30s checkpoint drain — and `shutdown()`s as the last teardown step, so disposal and bus-unsubscribe records land in the file. A worker killed mid-drain leaves an `.active.log` that the next `init()` recovers via the existing `cleanup()` takeover.

## Compatibility

Unchanged: call sites, log levels, `--print-logs` behavior, filenames, the 50 MiB / 10 archive / 200 MiB retention policy, `MIMOCODE_DISABLE_LOG_ROTATION`.

Intentional: a broken log file is now silent outside `--print-logs` (no `mimocode log write failed` line), and records emitted before `Log.init()` or after `Log.shutdown()` are dropped instead of printed.

## Verification

- `MIMOCODE_PROCESS_ROLE=main bun test test/util/log.test.ts` — 18 passed, 0 failed, 53 expectations
- `MIMOCODE_PROCESS_ROLE=worker bun test test/util/log.test.ts test/effect/app-runtime-logger.test.ts test/effect/runner-warn-log.test.ts` — 26 passed, 0 failed
- `bun typecheck` — passed; `oxlint` on the changed files — 0 warnings, 0 errors
- Pre-fix reproduction: the same child-process script run against the pre-fix `log.ts` leaked `INFO … teardown after shutdown` to stderr; the fixed logger emits nothing.
- End-to-end, tmux-driven `bun dev <dir>` quit through the `exit` prompt command: on `main`, stderr captured the nine teardown lines above and the worker log file ended at `worker shutting down`; on this branch stderr stayed empty and the worker log file contained the full teardown sequence through `service=bus type=session.updated unsubscribing`.

New tests spawn a real child process (no mocks) because the sink state is module level and `test/preload.ts` already calls `Log.init`. They cover: silence after `shutdown()`, silence before `init()`, silence on an unusable log directory, print mode still writing records with no file created, and print mode unaffected by an unusable log directory.

Spec: `docs/compose/spec/log-safety.md` gains `[S4] Terminal Isolation` and is marked delivered.

Two independent reviews found no critical issues.