### PR TITLE
fix(session): inject every skill mentioned in a slash-command message

### DIFF
--- a/docs/compose/spec/skill-multi-injection.md
+++ b/docs/compose/spec/skill-multi-injection.md
@@ -1,0 +1,228 @@
+---
+feature: skill-multi-injection
+status: delivered
+updated: 2026-07-27
+branch: fix/skill-multi-injection
+commits: 014a2577..5e010a3c
+---
+
+# Skill Multi-Injection
+
+## Report
+
+**What was built** — The `cmd.source === "skill"` non-subtask branch of
+`SessionPrompt.command` no longer emits a `<skill_content>` part. Skill bodies
+now have exactly one injector: the mention scan in `insertReminders`, which
+detects the invoked skill from the leading `/${input.command}` token of the
+visible text part. `insertReminders` itself is unchanged — its `alreadyWrapped`
+guard keeps its real job (stopping step 2+ from restacking step 1's blocks) and
+loses only its obsolete job (avoiding a double wrap with the command path).
+
+Because both sources of skills now flow into one `mentioned` list, the
+`MAX_AUTOLOAD = 3` budget and the `mentioned.length >= 2` orchestration reminder
+count them uniformly, with no reconciliation logic. `/a ... /b` injects both
+bodies plus the orchestration reminder; four or more mentions overflow to the
+Skill-tool hint as before.
+
+Test hygiene was fixed alongside: five skill-related test files were writing
+`MIMOCODE_DISABLE_*_SKILLS` at module scope, leaking into every file scheduled
+later in the same `bun test` process. They now share a `withEnv` helper
+(`test/lib/env.ts`) that applies flags in `beforeAll` and restores them in
+`afterAll`.
+
+**Verification** — all from `packages/opencode`:
+
+- `bun typecheck` — PASS (clean).
+- `bun test test/session/prompt-skill-command-multi.test.ts` — 2 pass. Confirmed
+  failing before the source change, with the intended symptom: only
+  `skill-alpha` injected, no `skill-beta` block, no orchestration reminder.
+- `bun test test/skill test/tool/skill-search.test.ts test/tool/skill.test.ts
+  test/session/prompt-skill-command-multi.test.ts
+  test/session/prompt-skill-mention.test.ts test/command` — 95 pass, 4 skip,
+  0 fail.
+- `bun test test/session test/tool` — 1536 pass, 22 skip, 1 fail.
+  `SessionCheckpoint.insertRebuildBoundary … when rebuild context is empty` is
+  `PRE-EXISTING`: the same suite on base `014a2577` fails it too, plus an extra
+  `snapshot race` flake. Both pass in isolation, so they are suite-order flakes
+  unrelated to skills.
+- Independent review by a fresh subagent: no critical findings; spec compliance,
+  correctness and consistency all cleared.
+
+The change is delivered on `fix/skill-multi-injection` as `5e010a3c`; this
+document is committed separately, outside the reviewed range.
+
+**Journey log**
+
+1. The bug was reproduced live in the authoring session itself: a message of the
+   form `/compose-next … /mimocode-docs …` delivered only the first skill's body.
+   The agent's own context was the evidence.
+2. The first design considered turning `alreadyWrapped` into a per-name set so
+   both injectors could coexist. Rejected: it keeps two injectors in sync by
+   hand, and the `MAX_AUTOLOAD` budget plus the orchestration-reminder count both
+   have to be reconciled manually — exactly the drift that caused the bug.
+3. What made the smaller fix safe was `prompt.ts:4182-4183`: skills already skip
+   the `$1..$N` / `$ARGUMENTS` template machinery, and the command path wrapped
+   the raw `templateCommand`, byte-identical to the `info.content` the scan
+   injects. Deleting the wrap therefore loses nothing. Zero of the 22 bundled
+   skills use `$ARGUMENTS` or `` !`bash` ``.
+4. Do not delete the whole branch: the `visibleText` part must stay, because the
+   scan's only handle on the invoked skill is its leading `/name` token.
+5. Injection correctness now depends on a regex over rendered text rather than a
+   registry lookup, so non-slug skill names (`skill/index.ts:30` accepts any
+   string) silently inject nothing. Accepted by explicit user decision — skills
+   are expected to use standard slugs.
+
+## [S1] Problem
+
+When a user message begins with a skill slash-invocation and mentions a second
+skill later in the same message, only the first skill's body is injected. The
+second one survives as literal text and the model never sees its `SKILL.md`.
+
+Reproduction: send `/compose-next 分析一下 ... /mimocode-docs 例如 ...`. The
+model receives one `<skill_content name="compose-next">` block, no
+`<skill_content name="mimocode-docs">` block, and no multi-skill orchestration
+reminder.
+
+Root cause is two independent injection points:
+
+1. **Command path.** `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx:1169-1177`
+   routes any input starting with `/` by resolving only the first token of the
+   first line as a command name. Skills are registered as commands
+   (`packages/opencode/src/command/index.ts:264-276`, `source: "skill"`), so
+   `/compose-next` matches and everything after it — including
+   `/mimocode-docs` — becomes `arguments`. Server-side,
+   `packages/opencode/src/session/prompt.ts:4259-4269` emits a visible text part
+   plus one `<skill_content>` part for `input.command` only.
+
+2. **Free-text scan.** `packages/opencode/src/session/prompt.ts:727-796` scans
+   the message body for all skill mentions and handles multiple skills
+   correctly (global regex at `prompt.ts:739`, dedupe, `MAX_AUTOLOAD` cap,
+   orchestration reminder at `prompt.ts:766`).
+
+The scan is gated by `alreadyWrapped` (`prompt.ts:724-727`), a message-level
+boolean that is true as soon as any part starts with `<skill_content name="`.
+The command path already pushed such a part, so the entire scan is skipped.
+The guard's granularity is the whole message, not the individual skill.
+
+The two paths inject equivalent content, so the split serves no purpose:
+`prompt.ts:4182-4183` makes skills skip the `$1..$N` / `$ARGUMENTS` template
+machinery entirely (`template = input.arguments`), and `prompt.ts:4265` wraps
+the raw `templateCommand`, which is `item.content`
+(`command/index.ts:271-273`) — byte-identical to the `info.content` the scan
+injects at `prompt.ts:760`.
+
+## [S2] Design
+
+Give skill-body injection a single owner: the free-text scan in
+`insertReminders`. The command path keeps alias resolution, argument expansion,
+attachment resolution, and the visible text, but stops injecting the body.
+
+**Command path contract** — `prompt.ts:4259-4269`, non-subtask
+`cmd.source === "skill"` branch:
+
+- Emit `parts = [visibleText, ...attachments, ...input.parts]`. Drop the
+  `skillPart`.
+- `visibleText` keeps its current form and must keep `/${input.command}` as the
+  leading token. This token is the detection signal for the scan.
+  `input.command` is the canonical skill name — the TUI resolves localized
+  slash aliases to it client-side via `resolveSkillSlash`
+  (`cli/cmd/tui/i18n/skill.ts:19-27`, used at `index.tsx:1174`) — so a
+  localized invocation such as `/深度研究` arrives as `/deep-research` and
+  matches the scan regex.
+- The subtask branch (`prompt.ts:4245-4258`) is unchanged. It inlines skill
+  content into a subtask prompt and never had the multi-skill defect.
+- `templateCommand` (`prompt.ts:4179`) stays — the subtask branch still reads
+  it at `prompt.ts:4247`.
+
+**Scan contract** — `prompt.ts:720-797` requires no change:
+
+- `alreadyWrapped` loses its stated purpose (the command path no longer wraps)
+  but retains its actual load-bearing role: cross-step idempotency.
+  `insertReminders` runs on every step (`prompt.ts:3387`) and `updatePart`
+  persists, so the parts injected at step 1 make the guard true at step 2+ and
+  prevent restacking. This is the same mechanism documented at
+  `prompt.ts:819`.
+- The command-invoked skill and any text-mentioned skills now enter one
+  `mentioned` list, so `MAX_AUTOLOAD` and the `mentioned.length >= 2`
+  orchestration reminder count them uniformly. No separate reconciliation
+  logic is needed.
+
+**Accepted behavior changes:**
+
+- The command-invoked skill counts against `MAX_AUTOLOAD = 3`
+  (`prompt.ts:749`). It appears first in the message text and the scan
+  preserves text order, so it is never the one dropped; a fourth mention
+  overflows to the Skill-tool hint instead.
+- `/a ... /b` now injects the orchestration reminder
+  (`prompt.ts:778-790`), which it previously suppressed.
+- Skill bodies move from "immediately after the visible text, before
+  attachments" to "appended to `userMessage.parts` during `insertReminders`",
+  and are created during the prompt loop rather than at message construction.
+- Injection becomes turn-scoped rather than persisted at message construction.
+  If a turn dies between persisting the user message and the first
+  `insertReminders` pass (cancel, agent-resolution failure), the message keeps
+  its `/skill-a` text with no body, and no later turn will backfill it —
+  `insertReminders` only ever targets the last user message (`prompt.ts:656`).
+- The `command.execute.before` plugin hook (`prompt.ts:4275-4279`) no longer sees
+  a `<skill_content>` part in `parts` for skill invocations, only the visible
+  text and attachments. No in-repo plugin reads it; external plugins that did
+  will observe the change.
+
+**Test isolation:** Bun runs every file of a `bun test` invocation in one
+process, so a module-level `process.env` write leaks into files scheduled later.
+Skill tests that force `MIMOCODE_DISABLE_*_SKILLS` must set the flag in
+`beforeAll` and restore it in `afterAll` — the flags are lazy getters
+(`flag/flag.ts:279-287`), so scoping them this way works.
+
+**Skill naming assumption:** skill names are standard slugs matching the scan
+regex `[A-Za-z][A-Za-z0-9_:-]*`. Colon-namespaced names such as `compose:ask`
+are covered.
+
+**Set equivalence:** the command registry enumerates via `Skill.all()`
+(`skill/index.ts:298-301`) and the scan via the same `all()`, neither applying
+`hidden` or permission filtering (that is `available()`,
+`skill/index.ts:307-314`). Every command-invokable skill is therefore
+scan-resolvable.
+
+## [S3] Out of Scope
+
+- Validating or normalizing skill names. `skill/index.ts:30` accepts any
+  string; enforcing slugs is a separate change. Non-slug names (CJK, digit-led)
+  are not supported by this design.
+- Changing the mention regex at `prompt.ts:739`.
+- Tuning `MAX_AUTOLOAD`.
+- The TUI leading-slash routing at `index.tsx:1169-1177` and the ACP equivalent
+  at `acp/agent.ts:1372-1383`. Both are unchanged and inherit the fix, since it
+  is server-side.
+- Skill invocation dispatched as a subtask.
+
+## Tasks
+
+- [x] T1: Add a failing end-to-end regression test that invokes a skill via
+      `SessionPrompt.command` with a second skill mentioned in the arguments,
+      following the real-layer harness in
+      `packages/opencode/test/session/plan-reminder-dedup.test.ts` (live
+      `SessionPrompt` + `Session` layers, tmpdir fixture, stubbed SSE stream) —
+      acceptance: the test runs and fails against the base commit because the
+      user message carries only `<skill_content name="skill-a">`, with no
+      `skill-b` block and no orchestration reminder (covers: S2)
+- [x] T2: Drop the `skillPart` from the non-subtask `cmd.source === "skill"`
+      branch in `packages/opencode/src/session/prompt.ts:4259-4269`, keeping the
+      visible text and attachments — acceptance: T1 passes; a lone `/skill-a`
+      still yields exactly one `<skill_content name="skill-a">` part; `/skill-a
+      args` still carries the argument text and any resolved attachment
+      (covers: S2; depends: T1)
+- [x] T3: Fix the stale source reference in
+      `packages/opencode/test/session/prompt-skill-mention.test.ts:3`, which
+      cites `src/session/prompt.ts:684` for a regex that has since moved —
+      acceptance: the comment points at the `mentionRe` symbol rather than a
+      line number, so it cannot rot again, and the existing regex tests still
+      pass (covers: S2)
+- [x] T4: Scope the `MIMOCODE_DISABLE_*_SKILLS` env writes in the skill tests so
+      they no longer leak across files in a shared `bun test` process, via a
+      single `withEnv` helper — acceptance: `test/skill/skill.test.ts`,
+      `test/skill/loop.test.ts`, `test/skill/bundle-discovery.test.ts`,
+      `test/tool/skill-search.test.ts` and the new multi-injection test all set
+      their flags through `withEnv` and restore the prior values, and
+      `bun test test/session test/tool` plus `bun test test/skill` show no new
+      failures (covers: S2)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -717,10 +717,8 @@ ${entries}
         }
       }
 
-      // Explicit multi-skill mentions in free text ("/foo ... /bar ..."). This
-      // is separate from the SessionPrompt.command single-command path, which
-      // already wraps SKILL.md content itself. Guard against double-wrapping
-      // by checking whether userMessage.parts already contains such a block.
+      // Sole injection point for skill bodies — free-text mentions ("/foo ... /bar") and slash-command
+      // invocations alike. Runs every step, so the guard keeps step 2+ from restacking step 1's blocks.
       const alreadyWrapped = userMessage.parts.some(
         (p) => p.type === "text" && p.text.startsWith('<skill_content name="'),
       )
@@ -4257,16 +4255,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           },
         ]
       } else if (cmd.source === "skill") {
+        // Body injection belongs to the mention scan in insertReminders, which keys off this leading token.
         const visibleText = input.arguments.trim()
           ? `/${input.command} ${input.arguments}`
           : `/${input.command}`
-        const skillPart = {
-          type: "text" as const,
-          text: `<skill_content name="${input.command}">\n${templateCommand}\n</skill_content>`,
-          synthetic: true,
-        }
         const attachments = templateParts.filter((p): p is Exclude<typeof p, { type: "text" }> => p.type !== "text")
-        parts = [{ type: "text" as const, text: visibleText }, skillPart, ...attachments, ...(input.parts ?? [])]
+        parts = [{ type: "text" as const, text: visibleText }, ...attachments, ...(input.parts ?? [])]
       } else {
         parts = [...templateParts, ...(input.parts ?? [])]
       }

--- a/packages/opencode/test/lib/env.ts
+++ b/packages/opencode/test/lib/env.ts
@@ -1,0 +1,18 @@
+import { afterAll, beforeAll } from "bun:test"
+
+// Bun runs every file of a test invocation in one process, so a module-level
+// `process.env` write leaks into all files scheduled after it. Flag getters read
+// env lazily, so tests must set their flags in beforeAll and restore in afterAll.
+export function withEnv(values: Record<string, string | undefined>) {
+  const saved = Object.keys(values).map((key) => [key, process.env[key]] as const)
+
+  const apply = (entries: readonly (readonly [string, string | undefined])[]) => {
+    for (const [key, value] of entries) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  }
+
+  beforeAll(() => apply(Object.entries(values)))
+  afterAll(() => apply(saved))
+}

--- a/packages/opencode/test/session/prompt-skill-command-multi.test.ts
+++ b/packages/opencode/test/session/prompt-skill-command-multi.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect } from "effect"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Log } from "../../src/util"
+import { provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { withEnv } from "../lib/env"
+import { makeLayer, providerCfg, ref } from "../workflow/lib"
+
+withEnv({ MIMOCODE_DISABLE_BUILTIN_SKILLS: "true", MIMOCODE_DISABLE_COMPOSE_SKILLS: "true" })
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const it = testEffect(makeLayer())
+
+function writeSkill(dir: string, name: string, marker: string) {
+  return Effect.promise(() =>
+    Bun.write(
+      path.join(dir, ".mimocode", "skill", name, "SKILL.md"),
+      `---\nname: ${name}\ndescription: ${name} used by multi-skill injection tests.\n---\n\n# ${name}\n\n${marker}\n`,
+    ),
+  )
+}
+
+const injected = (parts: MessageV2.WithParts["parts"]) =>
+  parts.flatMap((p) => (p.type === "text" ? (p.text.match(/^<skill_content name="([^"]+)">/)?.[1] ?? []) : []))
+
+// A skill invoked as a slash command routes through SessionPrompt.command,
+// while any further skill named in the same message is only reachable by the
+// mention scan in insertReminders. Both must end up injected: skill bodies have
+// a single owner, so invoking one skill cannot suppress the others.
+describe("skill command with additional mentions", () => {
+  it.live(
+    "injects every mentioned skill when the message is a skill command",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ dir, llm }) {
+          yield* writeSkill(dir, "skill-alpha", "ALPHA_BODY_MARKER")
+          yield* writeSkill(dir, "skill-beta", "BETA_BODY_MARKER")
+          yield* Effect.promise(() => Bun.write(path.join(dir, "notes.txt"), "attachment payload\n"))
+          yield* llm.text("ok")
+
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const session = yield* sessions.create({ title: "skill command multi" })
+
+          yield* prompt.command({
+            sessionID: session.id,
+            command: "skill-alpha",
+            arguments: "review @notes.txt and use /skill-beta as well",
+            model: `${ref.providerID}/${ref.modelID}`,
+          })
+
+          const msgs = yield* sessions.messages({ sessionID: session.id })
+          const user = msgs.find((m) => m.info.role === "user")
+          expect(user).toBeDefined()
+
+          expect(injected(user!.parts).toSorted()).toEqual(["skill-alpha", "skill-beta"])
+
+          const text = user!.parts.flatMap((p) => (p.type === "text" ? [p.text] : [])).join("\n")
+          expect(text).toContain("ALPHA_BODY_MARKER")
+          expect(text).toContain("BETA_BODY_MARKER")
+          expect(text).toContain("explicitly referenced multiple skills")
+          expect(text).toContain("review @notes.txt")
+
+          // The attachments resolved from the arguments must survive alongside the visible text.
+          expect(user!.parts.flatMap((p) => (p.type === "file" ? [p.filename] : []))).toContain("notes.txt")
+
+          yield* sessions.remove(session.id)
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30_000,
+  )
+
+  it.live(
+    "a lone skill command injects exactly one body and keeps the visible invocation",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ dir, llm }) {
+          yield* writeSkill(dir, "skill-alpha", "ALPHA_BODY_MARKER")
+          yield* writeSkill(dir, "skill-beta", "BETA_BODY_MARKER")
+          yield* llm.text("ok")
+
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const session = yield* sessions.create({ title: "skill command lone" })
+
+          yield* prompt.command({
+            sessionID: session.id,
+            command: "skill-alpha",
+            arguments: "",
+            model: `${ref.providerID}/${ref.modelID}`,
+          })
+
+          const msgs = yield* sessions.messages({ sessionID: session.id })
+          const user = msgs.find((m) => m.info.role === "user")
+          expect(user).toBeDefined()
+
+          expect(injected(user!.parts)).toEqual(["skill-alpha"])
+
+          const visible = user!.parts.filter((p) => p.type === "text" && !p.synthetic)
+          expect(visible.map((p) => (p.type === "text" ? p.text : ""))).toContain("/skill-alpha")
+
+          const text = user!.parts.flatMap((p) => (p.type === "text" ? [p.text] : [])).join("\n")
+          expect(text).not.toContain("BETA_BODY_MARKER")
+          expect(text).not.toContain("explicitly referenced multiple skills")
+
+          yield* sessions.remove(session.id)
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30_000,
+  )
+})

--- a/packages/opencode/test/session/prompt-skill-mention.test.ts
+++ b/packages/opencode/test/session/prompt-skill-mention.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-// This regex is duplicated from src/session/prompt.ts:684 to pin its behavior.
+// This regex is duplicated from `mentionRe` in src/session/prompt.ts to pin its behavior.
 // If the source regex changes, this test must be updated to match.
 const mentionRe = /(?:^|\s)\/([A-Za-z][A-Za-z0-9_:-]*)(?=[^A-Za-z0-9_:-]|$)/g
 

--- a/packages/opencode/test/skill/bundle-discovery.test.ts
+++ b/packages/opencode/test/skill/bundle-discovery.test.ts
@@ -6,10 +6,13 @@ import { Skill } from "../../src/skill"
 import { loadComposeBundle } from "../../src/skill/compose/bundle.macro"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
+import { withEnv } from "../lib/env"
 
-process.env.MIMOCODE_DISABLE_EXTERNAL_SKILLS = "true"
-delete process.env.MIMOCODE_DISABLE_BUILTIN_SKILLS
-delete process.env.MIMOCODE_DISABLE_COMPOSE_SKILLS
+withEnv({
+  MIMOCODE_DISABLE_EXTERNAL_SKILLS: "true",
+  MIMOCODE_DISABLE_BUILTIN_SKILLS: undefined,
+  MIMOCODE_DISABLE_COMPOSE_SKILLS: undefined,
+})
 
 const it = testEffect(Layer.mergeAll(Skill.defaultLayer, CrossSpawnSpawner.defaultLayer))
 

--- a/packages/opencode/test/skill/loop.test.ts
+++ b/packages/opencode/test/skill/loop.test.ts
@@ -4,12 +4,15 @@ import { Skill } from "../../src/skill"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
+import { withEnv } from "../lib/env"
 
 // Disable compose bundle to keep the skill universe small for this test; keep
 // the builtin bundle ON so the /loop skill is discoverable.
-process.env.MIMOCODE_DISABLE_COMPOSE_SKILLS = "true"
-process.env.MIMOCODE_DISABLE_EXTERNAL_SKILLS = "true"
-delete process.env.MIMOCODE_DISABLE_BUILTIN_SKILLS
+withEnv({
+  MIMOCODE_DISABLE_COMPOSE_SKILLS: "true",
+  MIMOCODE_DISABLE_EXTERNAL_SKILLS: "true",
+  MIMOCODE_DISABLE_BUILTIN_SKILLS: undefined,
+})
 
 const it = testEffect(Layer.mergeAll(Skill.defaultLayer, CrossSpawnSpawner.defaultLayer))
 

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -4,11 +4,11 @@ import { Skill } from "../../src/skill"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { provideInstance, provideTmpdirInstance, tmpdir } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
+import { withEnv } from "../lib/env"
 import path from "path"
 import fs from "fs/promises"
 
-process.env.MIMOCODE_DISABLE_COMPOSE_SKILLS = "true"
-process.env.MIMOCODE_DISABLE_BUILTIN_SKILLS = "true"
+withEnv({ MIMOCODE_DISABLE_COMPOSE_SKILLS: "true", MIMOCODE_DISABLE_BUILTIN_SKILLS: "true" })
 
 const node = CrossSpawnSpawner.defaultLayer
 

--- a/packages/opencode/test/tool/skill-search.test.ts
+++ b/packages/opencode/test/tool/skill-search.test.ts
@@ -1,6 +1,6 @@
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { Effect, Layer } from "effect"
-import { afterAll, beforeAll, describe, expect } from "bun:test"
+import { describe, expect } from "bun:test"
 import path from "path"
 import type { Permission } from "../../src/permission"
 import type { Tool } from "../../src/tool"
@@ -11,22 +11,11 @@ import { ToolRegistry } from "../../src/tool"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { testEffect } from "../lib/effect"
+import { withEnv } from "../lib/env"
 
-
-// The compose-next invisibility test below needs the builtin bundle extracted;
-// other test files in the same process (e.g. test/skill/skill.test.ts) set
-// MIMOCODE_DISABLE_BUILTIN_SKILLS at module top-level and never restore it.
-// The Flag getter reads env lazily, so clear it here and restore afterwards.
-const savedEnv = process.env.MIMOCODE_DISABLE_BUILTIN_SKILLS
-
-beforeAll(() => {
-  delete process.env.MIMOCODE_DISABLE_BUILTIN_SKILLS
-})
-
-afterAll(() => {
-  if (savedEnv === undefined) delete process.env.MIMOCODE_DISABLE_BUILTIN_SKILLS
-  else process.env.MIMOCODE_DISABLE_BUILTIN_SKILLS = savedEnv
-})
+// The compose-next invisibility test below needs the builtin bundle extracted,
+// and sibling files disable it, so force it back on for this file only.
+withEnv({ MIMOCODE_DISABLE_BUILTIN_SKILLS: undefined })
 
 const it = testEffect(
   Layer.mergeAll(ToolRegistry.defaultLayer, Agent.defaultLayer, Skill.defaultLayer, CrossSpawnSpawner.defaultLayer),


### PR DESCRIPTION
## Summary

A message like `/skill-a ... /skill-b ...` only ever injected the first skill's body. The second skill survived as literal text and the model never saw its `SKILL.md`.

Skills are registered as commands, so the leading token routed the whole message through `SessionPrompt.command`, which emitted its own `<skill_content>` part. That tripped the message-level `alreadyWrapped` guard in `insertReminders` and disabled the multi-skill mention scan outright — the guard's granularity was the whole message, not the individual skill.

The fix gives skill bodies a single owner rather than keeping two injectors in sync. The command path now emits only the visible text and attachments; the mention scan injects every skill it finds, keyed off the leading `/name` token. `insertReminders` itself is unchanged — its guard keeps its real job (stopping step 2+ from restacking step 1's blocks) and loses only its obsolete one.

This is safe to delete because the two injectors were already equivalent: `prompt.ts:4182-4183` makes skills skip the `$1..$N` / `$ARGUMENTS` template machinery, and the command path wrapped the raw `templateCommand`, which is byte-identical to the `info.content` the scan injects. Zero of the 22 bundled skills use `$ARGUMENTS` or `` !`bash` ``.

Because both sources now flow into one `mentioned` list, the `MAX_AUTOLOAD = 3` budget and the `mentioned.length >= 2` orchestration reminder count command-invoked and text-mentioned skills uniformly, with no reconciliation logic.

Design, accepted behavior changes, and out-of-scope boundaries are recorded in `docs/compose/spec/skill-multi-injection.md`.

## Also in this PR

Five skill-related test files were writing `MIMOCODE_DISABLE_*_SKILLS` at module scope. Bun runs every file of a `bun test` invocation in one process, so those writes leaked into files scheduled later. They now share a `withEnv` helper (`test/lib/env.ts`) that applies flags in `beforeAll` and restores them in `afterAll`.

## Test plan

- `bun typecheck` — clean.
- New `test/session/prompt-skill-command-multi.test.ts` drives the real `SessionPrompt.command` through live layers with a tmpdir instance and a stubbed LLM. Confirmed failing before the source change, with the intended symptom: only `skill-alpha` injected, no `skill-beta` block, no orchestration reminder. It also pins that a lone `/skill-a` still injects exactly one body and that `@file` attachments resolved from the arguments survive.
- `bun test test/skill test/tool/skill-search.test.ts test/tool/skill.test.ts test/session/prompt-skill-command-multi.test.ts test/session/prompt-skill-mention.test.ts test/command` — 95 pass, 4 skip, 0 fail.
- `bun test test/session test/tool` — 1536 pass, 22 skip, 1 fail. The failure (`SessionCheckpoint.insertRebuildBoundary … when rebuild context is empty`) is pre-existing: the same suite on base `014a2577` fails it too, plus an extra `snapshot race` flake. Both pass in isolation — suite-order flakes unrelated to skills.

## Note for reviewers

Injection correctness now depends on a regex over rendered text rather than a registry lookup. `skill/index.ts:30` types skill names as a bare `z.string()`, so a non-slug name (digit-led, CJK) is slash-invocable but not scan-detectable and would silently inject nothing. This is an accepted boundary — skills are expected to use standard slugs — but the schema is the natural place to enforce it if we ever want to.