### PR TITLE
test: make three environment-dependent suites deterministic

### DIFF
--- a/docs/compose/spec/flaky-test-isolation.md
+++ b/docs/compose/spec/flaky-test-isolation.md
@@ -1,0 +1,131 @@
+---
+feature: flaky-test-isolation
+status: delivered
+updated: 2026-07-27
+branch: fix/flaky-test-isolation
+commits: 028f3178..f4daa79e
+---
+
+# Flaky Test Isolation
+
+## Report
+
+**What was built** — Three suites that failed off-CI for environment reasons now assert the behavior
+they claim to. `assertSafeUrl` takes the DNS resolver as an optional parameter, so the fail-closed and
+rebinding assertions run against a stub instead of whichever resolver the developer's network hands
+them; the rebinding branch gained its first test. `checkpoint-rebuild-unify` wipes
+`ActorRegistryTable` before each test, because `renderRebuildContext` reads the process-wide
+`ActorRegistry.listActive()` and earlier test files leave background actors behind in the singleton
+SQLite client.
+
+The workflow cancel-cascade test no longer times out. Its assertions always passed in ~280ms; the
+budget was consumed by an unbounded teardown. Reclaiming the run's children notifies the parent
+session's `main` inbox, which re-arms the parent's `main` runner against the auto-answering test LLM,
+and `SessionRunState`'s instance-state finalizer then awaits `Runner.cancel` from inside an
+uninterruptible finalizer, where no timeout can fire. The test drains that runner itself, bounded, on
+the interruptible side of scope close. The same drain let the previously-skipped orphan-on-cancel
+regression test come back, restoring the only coverage of that bug; its recorded skip rationale
+blamed a slow `cancel`, which measurement disproved.
+
+**Verification** — `bun test test/util/ssrf.test.ts` passed 23 tests.
+`bun test test/actor test/session/checkpoint-rebuild-unify.test.ts` passed 130 tests / 2 skip, having
+reproduced the failure on the same command before the fix.
+`bun test test/workflow/runtime.test.ts` passed three consecutive times (28 pass, 1 skip) and again
+after the review follow-up. `bun test` (full suite) passed three times: 4360 pass / 0 fail twice
+before the unskip and 4361 pass / 37 skip / 0 fail after, 4399 tests across 418 files.
+`bun typecheck` passed. oxlint on the four changed files reported 49 warnings / 0 errors against 48 /
+0 on `main`; the single added warning is another instance of the `await-thenable` false positive that
+already fires 20 times in that file.
+
+**Journey log**
+
+- The first fix attempt for the cancel test — swapping `llm.hang` for `hangUntil` + release, the
+  idiom `runtime-worktree.test.ts` uses — made it strictly worse: releasing the hang lets the child
+  resume, so it was still Running at teardown and the isolated run started hanging too. The
+  established idiom in a sibling file was the wrong tool here.
+- Measuring before theorising was what cracked it. Probes showed the assertions finishing in 280ms,
+  raising the budget to 180s still timing out (so: deadlock, not slowness), and
+  `process._getActiveHandles()` empty (so: an Effect fiber, not a socket).
+- Naming the stuck disposer needed the stack captured at the `InstanceState.make` call site, outside
+  the returned `Effect.gen` — inside it, every frame is Effect runtime internals. A first attempt
+  filtered stack lines on `/src/`, which matches every path under `~/src`, and silently kept nothing.
+- Effect finalizers run uninterruptibly, so an `Effect.timeout` placed inside one never fires. That
+  is why the deadlock presented as infinite rather than as a bounded 6s stall.
+- Bisecting showed *any* predecessor test triggered the hang, which ruled out a specific
+  interaction and pointed at process-global state instead.
+
+## [S1] Problem
+
+Three suites in `packages/opencode` fail off-CI for reasons unrelated to the behavior they claim to
+cover. Each failure is an environment or harness artifact, not a product defect, so each one trains
+readers to ignore red output.
+
+1. `test/util/ssrf.test.ts` asserts that `assertSafeUrl` rejects an unresolvable hostname by asking
+   the real resolver for a `.invalid` name. Resolvers that answer for `.invalid` (ISP or corporate
+   DNS, mDNS) make the call succeed, so the assertion depends on which network the developer sits on.
+2. `test/session/checkpoint-rebuild-unify.test.ts` asserts that `insertRebuildBoundary` returns
+   `false` when there is nothing to push. `renderRebuildContext` reads
+   `ActorRegistry.listActive()`, which is process-wide, and the SQLite client is a process-level
+   singleton, so background actors left `pending`/`running` by an earlier test file make the context
+   non-empty. It passes alone and fails in a whole-suite run.
+3. `test/workflow/runtime.test.ts` "cancel stops in-flight child agents and marks the run cancelled"
+   exhausts its 30s budget. The assertions complete in ~280ms; the remaining time is a teardown
+   deadlock, and it is not a slow path but an unbounded one — raising the budget to 180s still times
+   out.
+
+## [S2] Design
+
+**SSRF resolver injection.** `assertSafeUrl` takes the resolver as an optional second parameter
+defaulting to `dns/promises.lookup`, mirroring the `fetchImpl` parameter `safeFetch` already exposes
+for the same reason. The DNS-dependent assertions inject a stub, so they pin the behavior that
+matters — resolution failure means reject, and a hostname resolving into a blocked range means
+reject — without consulting a real resolver. Production callers are unchanged.
+
+**Rebuild-context actor leakage.** `listActive()` stays process-wide: peer actors legitimately live
+in child sessions, so scoping the query to one `session_id` would drop live children from the "Active
+actors" section. The test instead wipes `ActorRegistryTable` in `beforeEach`, the same isolation
+`test/session/checkpoint-rebuild-v3.test.ts` already applies for the same reason, and consistent with
+how that test already neutralizes the other inputs (deleting the memory dirs, capping `recent_user`
+to 0).
+
+**Cancel-cascade teardown deadlock.** Reclaiming the workflow's children makes each one notify the
+parent session's `main` inbox, which re-arms the parent's `main` runner against the auto-answering
+test LLM. `SessionRunState`'s instance-state finalizer cancels every runner still in its map, and
+`Runner.cancel` awaits `Deferred.await(run.done)`. Effect finalizers run uninterruptibly, so that
+await cannot be bounded from inside and the instance disposer never returns. The test drains the
+runner map itself — `SessionRunState.cancel(parent.id)`, bounded and ignored — after its assertions
+and before the fixture scope closes, where the cancel is still interruptible and the bound applies.
+
+Out of the three, only the SSRF change touches `src/`, and it is additive.
+
+**Restored orphan-on-cancel coverage.** The sibling test in the same describe, "cancel during an
+in-flight fan-out reclaims every child (no orphan)", was skipped under the same symptom with the
+diagnosis "`cancel` itself does not return before the test deadline". That diagnosis is wrong —
+`cancel` returns in ~300ms — and the real cause is the teardown deadlock above. With the same drain
+applied it is unskipped, restoring the only coverage of the MR104 orphan-on-cancel regression.
+
+## [S3] Out of Scope
+
+- Bounding `Instance.dispose()` so a stuck instance-state finalizer cannot wedge teardown.
+  `Instance.disposeDirectory` already bounds its path with `DIRECTORY_DISPOSE_TIMEOUT`; the direct
+  `dispose()` path does not. That is a real robustness gap, reachable in production whenever an
+  instance is disposed while a session run is live, but changing teardown semantics is a separate
+  change with its own risk surface.
+- Session-scoping the "Active actors" rebuild section.
+- The other `llm.hang` call sites in `test/workflow/runtime.test.ts`. They pass today; converting
+  them is unverified churn.
+
+## Tasks
+
+- [x] T1: Inject the resolver into `assertSafeUrl` and rewrite the DNS assertions against a stub —
+      acceptance: `bun test test/util/ssrf.test.ts` passes with no network dependency (covers: S2)
+- [x] T2: Wipe leaked `ActorRegistryTable` rows in `checkpoint-rebuild-unify` — acceptance:
+      `bun test test/actor test/session/checkpoint-rebuild-unify.test.ts` passes, having failed
+      before (covers: S2)
+- [x] T3: Quiesce the parent session before teardown in the cancel-cascade test — acceptance:
+      `bun test test/workflow/runtime.test.ts` passes with zero failures (covers: S2)
+- [x] T4: Confirm no further local-only failures across two full runs — acceptance: the union of two
+      `bun test` runs adds no failure attributable to this branch (covers: S1)
+- [x] T5: Unskip the orphan-on-cancel test with the same drain — acceptance:
+      `bun test test/workflow/runtime.test.ts` green three consecutive times and a full run stays
+      green (covers: S2; depends: T3)

--- a/packages/opencode/src/util/ssrf.ts
+++ b/packages/opencode/src/util/ssrf.ts
@@ -76,7 +76,14 @@ export async function safeFetch(
   throw new Error("SSRF protection: too many redirects")
 }
 
-export async function assertSafeUrl(url: string): Promise<void> {
+// lookupImpl is injectable so the DNS-dependent behavior (fail-closed on
+// resolution failure, rebinding rejection) is testable without a live resolver —
+// a local/corporate resolver that answers for .invalid otherwise makes those
+// assertions environment-dependent.
+export async function assertSafeUrl(
+  url: string,
+  lookupImpl: (hostname: string) => Promise<{ address: string; family: number }> = lookup,
+): Promise<void> {
   const parsed = new URL(url)
   const hostname = parsed.hostname.replace(/^\[|\]$/g, "")
 
@@ -102,7 +109,7 @@ export async function assertSafeUrl(url: string): Promise<void> {
 
   // DNS resolution check to prevent DNS rebinding
   try {
-    const { address, family } = await lookup(hostname)
+    const { address, family } = await lookupImpl(hostname)
     if (family === 4 && isBlockedIPv4(address)) {
       throw new Error(`SSRF protection: hostname "${hostname}" resolves to blocked IP "${address}"`)
     }

--- a/packages/opencode/test/session/checkpoint-rebuild-unify.test.ts
+++ b/packages/opencode/test/session/checkpoint-rebuild-unify.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect } from "bun:test"
+import { afterEach, beforeEach, describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import * as fs from "fs/promises"
 import path from "path"
@@ -11,6 +11,8 @@ import { checkpointPath } from "../../src/session/checkpoint-paths"
 import { SessionCompaction } from "../../src/session/compaction"
 import { TaskRegistry } from "../../src/task/registry"
 import { ActorRegistry } from "../../src/actor/registry"
+import { ActorRegistryTable } from "../../src/actor/actor.sql"
+import { Database } from "../../src/storage"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Instance } from "../../src/project/instance"
@@ -28,6 +30,17 @@ const ref = {
 
 afterEach(async () => {
   await Instance.disposeAll()
+})
+
+// renderRebuildContext's "Active actors" section reads ActorRegistry.listActive(),
+// which is process-wide (pending/running + background), not session-scoped — peer
+// actors legitimately live in child sessions. Database.Client is a process-level
+// singleton and orphan recovery only clears rows from OTHER instance_ids, so
+// background actors left running by earlier test files survive into this one and
+// make the "nothing to push" context non-empty. Wipe them, same as
+// checkpoint-rebuild-v3.test.ts.
+beforeEach(() => {
+  Database.use((db) => db.delete(ActorRegistryTable).run())
 })
 
 const it = testEffect(

--- a/packages/opencode/test/util/ssrf.test.ts
+++ b/packages/opencode/test/util/ssrf.test.ts
@@ -71,9 +71,23 @@ describe("assertSafeUrl", () => {
   })
 
   describe("DNS fail-closed", () => {
-    test("rejects unresolvable hostnames", async () => {
-      await expect(assertSafeUrl("http://this-domain-definitely-does-not-exist-xyz123.invalid/")).rejects.toThrow(
+    // The resolver is injected: a real lookup of a `.invalid` name is
+    // environment-dependent (a local/corporate resolver may answer for it), which
+    // is what made this suite fail off-CI. The behavior under test is "resolution
+    // failed ⇒ reject", not "this hostname happens to be unresolvable here".
+    test("rejects a hostname whose resolution fails", async () => {
+      const failing = async () => {
+        throw Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" })
+      }
+      await expect(assertSafeUrl("http://nope.example.com/", failing)).rejects.toThrow(
         "SSRF protection: DNS resolution failed",
+      )
+    })
+
+    test("rejects a hostname that resolves to a blocked IP (rebinding)", async () => {
+      const rebinding = async () => ({ address: "169.254.169.254", family: 4 })
+      await expect(assertSafeUrl("http://rebind.example.com/", rebinding)).rejects.toThrow(
+        "SSRF protection: hostname",
       )
     })
   })

--- a/packages/opencode/test/workflow/runtime.test.ts
+++ b/packages/opencode/test/workflow/runtime.test.ts
@@ -374,8 +374,10 @@ describe("WorkflowRuntime cancel cascade", () => {
       }),
       { git: true, config: providerCfg },
     ),
-    // Same budget as the 3-child sibling above: this one adds up to 3s of registry
-    // polling, an 8-way fan-out, and the bounded drain, so it needs at least as much.
+    // Same budget as the 3-child sibling above. Worst case is dominated by cancel's
+    // own two 5s bounds (fiber interrupt + child reclaim, the latter unbounded-
+    // concurrency so the 8-way fan-out costs one bound, not eight); on top of that
+    // this case adds up to 3s of registry polling and the bounded 5s drain.
     30000,
   )
 })

--- a/packages/opencode/test/workflow/runtime.test.ts
+++ b/packages/opencode/test/workflow/runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, afterEach } from "bun:test"
 import { Effect } from "effect"
 import { Session } from "../../src/session"
+import { SessionRunState } from "../../src/session/run-state"
 import { Instance } from "../../src/project/instance"
 import { provideTmpdirServer } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -282,6 +283,15 @@ describe("WorkflowRuntime cancel cascade", () => {
         yield* runtime.cancel({ runID })
         const s = yield* runtime.status({ runID })
         expect(s.status).toBe("cancelled")
+        // Quiesce the parent session before the fixture scope closes. Reclaiming the
+        // children makes each one notify the parent's main inbox, which re-arms the
+        // parent's `main` runner against the auto-answering test LLM. A runner still
+        // "Running" when SessionRunState's instance-state finalizer fires deadlocks
+        // teardown: finalizers run uninterruptibly, so the finalizer's
+        // `Deferred.await(run.done)` cannot be timed out and the test hangs long
+        // after this assertion already passed. Cancelling here (interruptible, so
+        // the bound actually applies) drains the runner map first.
+        yield* (yield* SessionRunState.Service).cancel(parent.id).pipe(Effect.timeout(5000), Effect.ignore)
       }),
       { git: true, config: providerCfg },
     ),
@@ -308,12 +318,11 @@ describe("WorkflowRuntime cancel cascade", () => {
   // graceful-cancelled child can be re-driven by the auto-answering test LLM and
   // bounce back to running:success later, which is a mock artifact unrelated to
   // the orphan bug; the cancel-stamp at t0 is the stable signal.
-  // SKIPPED — intermittently times out at the 20s budget when run with the rest
-  // of the file (passes 10/10 in isolation). Under CI/contention, the reclaim
-  // pass inside `runtime.cancel` can stall on `Fiber.interrupt` for a hung LLM
-  // fetch, so `cancel` itself does not return before the test deadline. Skipping
-  // matches the prior pattern for cancellation-path flakes (commit e7db5a8).
-  it.live.skip("cancel during an in-flight fan-out reclaims every child (no orphan)", () =>
+  // Previously skipped as a "cancel is too slow under contention" flake. That
+  // diagnosis was wrong: `cancel` returns in ~300ms. What blew the budget was
+  // teardown — see the quiesce note in the test above — so the test is restored
+  // with the same drain.
+  it.live("cancel during an in-flight fan-out reclaims every child (no orphan)", () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {
         const runtime = yield* WorkflowRuntime.Service
@@ -360,6 +369,8 @@ describe("WorkflowRuntime cancel cascade", () => {
         // Every spawned child was reclaimed: cancel stamped lastOutcome="cancelled"
         // on each. An orphan (never reclaimed) would have lastOutcome unset here.
         expect(children.filter((a) => a.lastOutcome !== "cancelled")).toEqual([])
+        // Drain the parent's runner map before the fixture scope closes (see above).
+        yield* (yield* SessionRunState.Service).cancel(parent.id).pipe(Effect.timeout(5000), Effect.ignore)
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/workflow/runtime.test.ts
+++ b/packages/opencode/test/workflow/runtime.test.ts
@@ -291,7 +291,7 @@ describe("WorkflowRuntime cancel cascade", () => {
         // `Deferred.await(run.done)` cannot be timed out and the test hangs long
         // after this assertion already passed. Cancelling here (interruptible, so
         // the bound actually applies) drains the runner map first.
-        yield* (yield* SessionRunState.Service).cancel(parent.id).pipe(Effect.timeout(5000), Effect.ignore)
+        yield* (yield* SessionRunState.Service).cancel(parent.id).pipe(Effect.timeout("5 seconds"), Effect.ignore)
       }),
       { git: true, config: providerCfg },
     ),
@@ -370,11 +370,13 @@ describe("WorkflowRuntime cancel cascade", () => {
         // on each. An orphan (never reclaimed) would have lastOutcome unset here.
         expect(children.filter((a) => a.lastOutcome !== "cancelled")).toEqual([])
         // Drain the parent's runner map before the fixture scope closes (see above).
-        yield* (yield* SessionRunState.Service).cancel(parent.id).pipe(Effect.timeout(5000), Effect.ignore)
+        yield* (yield* SessionRunState.Service).cancel(parent.id).pipe(Effect.timeout("5 seconds"), Effect.ignore)
       }),
       { git: true, config: providerCfg },
     ),
-    20000,
+    // Same budget as the 3-child sibling above: this one adds up to 3s of registry
+    // polling, an 8-way fan-out, and the bounded drain, so it needs at least as much.
+    30000,
   )
 })
 


### PR DESCRIPTION
## Summary

Three suites in `packages/opencode` failed locally for environment/harness reasons rather than product defects. Each is now deterministic, and one previously-skipped regression test is restored.

- **`test/util/ssrf.test.ts`** — the DNS fail-closed assertion asked the real resolver about a `.invalid` hostname, so it passed only on networks that refuse to answer. `assertSafeUrl` now takes the resolver as an optional parameter (mirroring the `fetchImpl` parameter `safeFetch` already exposes for the same reason) and the test injects a stub. The DNS-rebinding branch got its first test.
- **`test/session/checkpoint-rebuild-unify.test.ts`** — `renderRebuildContext` reads the process-wide `ActorRegistry.listActive()`, and the SQLite client is a process-level singleton, so background actors left by earlier test *files* made the "nothing to push" context non-empty. Wipes `ActorRegistryTable` in `beforeEach`, the same isolation `checkpoint-rebuild-v3.test.ts` already applies. `listActive()` is deliberately *not* session-scoped: peer actors legitimately live in child sessions.
- **`test/workflow/runtime.test.ts` cancel cascade** — not slow, deadlocked. The assertions finish in ~280ms; raising the budget to 180s still timed out. Reclaiming the run's children notifies the parent session's `main` inbox, which re-arms the parent's `main` runner against the auto-answering test LLM; `SessionRunState`'s instance-state finalizer then awaits `Runner.cancel` from inside an uninterruptible finalizer, where no timeout can fire. The test drains that runner itself, bounded, on the interruptible side of scope close.
- **Restored `no orphan` test** — its skip rationale blamed a slow `cancel`; measurement disproved that (`cancel` returns in ~300ms). Same drain applied, budget aligned with its 3-child sibling.

Only `src/util/ssrf.ts` touches production code, and additively — every existing caller keeps the real resolver by default.

## Verification

| command | result |
| --- | --- |
| `bun test test/util/ssrf.test.ts` | 23 pass |
| `bun test test/actor test/session/checkpoint-rebuild-unify.test.ts` | 130 pass / 2 skip (reproduced the failure on this exact command before the fix) |
| `bun test test/workflow/runtime.test.ts` | 28 pass / 1 skip, green 3 consecutive runs + again after review follow-up |
| `bun test` (full suite) | green 3×: 4360 pass / 0 fail twice pre-unskip, **4361 pass / 37 skip / 0 fail** post-unskip (4399 tests, 418 files) |
| `bun typecheck` | pass |
| `oxlint` on changed files | 49 warnings / 0 errors vs 48 / 0 on `main`; the one addition is another instance of the `await-thenable` false positive that already fires 20× in that file |

## Follow-ups (deliberately out of scope)

- `Instance.dispose()` is unbounded while `Instance.disposeDirectory` bounds cleanup with `DIRECTORY_DISPOSE_TIMEOUT`. A stuck instance-state finalizer can wedge teardown in production, not just in tests.
- `ActorRegistry.listActive()` filters only `status` + `background`, so a long-lived session's "Active actors" rebuild section can list background actors of unrelated sibling top-level sessions.

Spec: `docs/compose/spec/flaky-test-isolation.md`