### PR TITLE
feat(task): add worker-session link + queue statuses (schema + mutators, inert)

### DIFF
--- a/packages/opencode/migration/20260715000000_task_worker_link/migration.sql
+++ b/packages/opencode/migration/20260715000000_task_worker_link/migration.sql
@@ -1,0 +1,10 @@
+-- task: durable link from a task to the WORKER session executing it, plus the
+-- dispatch timestamp and a pointer to the outcome. All nullable so existing
+-- rows backfill to NULL (mirrors the `owner` column precedent).
+ALTER TABLE `task` ADD COLUMN `worker_session_id` text;
+--> statement-breakpoint
+ALTER TABLE `task` ADD COLUMN `dispatched_at` integer;
+--> statement-breakpoint
+ALTER TABLE `task` ADD COLUMN `result_ref` text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `task_worker_idx` ON `task` (`worker_session_id`,`status`);

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -44,16 +44,23 @@ function promptHeartbeatIntervalMs() {
   return Number(process.env["MIMOCODE_PROMPT_HEARTBEAT_INTERVAL_MS"]) || 10_000
 }
 
+// Maps the richer task queue statuses onto the 4-value todo vocabulary the UI
+// consumes. `failed` is terminal, so it must NOT fall through to `pending` —
+// that would render a dead task as still actionable. `dispatched` and
+// `human_review` are genuinely pending (queued on a worker / on the user).
+const TODO_STATUS: Record<Task["status"], string> = {
+  open: "pending",
+  dispatched: "pending",
+  in_progress: "in_progress",
+  blocked: "pending",
+  human_review: "pending",
+  done: "completed",
+  failed: "cancelled",
+  abandoned: "cancelled",
+}
+
 function taskToTodo(t: Task) {
-  const status =
-    t.status === "in_progress"
-      ? "in_progress"
-      : t.status === "done"
-        ? "completed"
-        : t.status === "abandoned"
-          ? "cancelled"
-          : "pending"
-  return { content: t.summary, status }
+  return { content: t.summary, status: TODO_STATUS[t.status] ?? "pending" }
 }
 
 /**

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -1250,7 +1250,16 @@ export const layer: Layer.Layer<
           byParent.set(t.parent_task_id, bucket)
         }
         const statusIcon = (s: string) =>
-          ({ open: "🔵", in_progress: "🔄", blocked: "🟡", done: "✅", abandoned: "❌" })[s] ?? s
+          ({
+            open: "🔵",
+            dispatched: "📤",
+            in_progress: "🔄",
+            blocked: "🟡",
+            human_review: "🙋",
+            done: "✅",
+            failed: "🔴",
+            abandoned: "❌",
+          })[s] ?? s
         const ledgerLines: string[] = []
         for (const t of topLevel) {
           ledgerLines.push(`- ${t.id} ${t.status} — ${t.summary}`)

--- a/packages/opencode/src/task/registry.ts
+++ b/packages/opencode/src/task/registry.ts
@@ -5,6 +5,7 @@ import { Config } from "../config"
 import type { SessionID } from "../session/schema"
 import { TaskTable, TaskEventTable } from "./task.sql"
 import type { Task, TaskEvent } from "./schema"
+import { NON_TERMINAL_TASK_STATUSES, isTerminalTaskStatus } from "./schema"
 import { Created as TaskCreated, Updated as TaskUpdated, type UpdatedKind } from "./events"
 import { RecoverableError } from "@/tool/recoverable"
 
@@ -27,6 +28,9 @@ function fromTaskRow(row: TaskRow): Task {
     status: row.status,
     summary: row.summary,
     owner: row.owner ?? undefined,
+    worker_session_id: (row.worker_session_id as SessionID | null) ?? undefined,
+    dispatched_at: row.dispatched_at ?? undefined,
+    result_ref: row.result_ref ?? undefined,
     created_at: row.created_at,
     last_event_at: row.last_event_at,
     ended_at: row.ended_at ?? undefined,
@@ -81,6 +85,33 @@ export interface Interface {
   readonly rename: (input: { session_id: SessionID; id: string; summary: string }) => Effect.Effect<Task>
 
   readonly start: (input: { session_id: SessionID; id: string; owner?: string; event_summary?: string }) => Effect.Effect<Task>
+
+  /** Assign a peer worker session and move the task onto the `dispatched` queue. */
+  readonly dispatch: (input: {
+    session_id: SessionID
+    id: string
+    worker_session_id: SessionID
+    event_summary?: string
+  }) => Effect.Effect<Task>
+
+  /** Move the task onto the `human_review` queue — it now waits on the USER. */
+  readonly requestReview: (input: {
+    session_id: SessionID
+    id: string
+    event_summary?: string
+    result_ref?: string
+  }) => Effect.Effect<Task>
+
+  /** Reject a reviewed result: back to `dispatched` (if it kept a worker) or `open`. */
+  readonly rework: (input: { session_id: SessionID; id: string; event_summary?: string }) => Effect.Effect<Task>
+
+  /** Terminal failure reported by a worker (distinct from operator-dropped `abandoned`). */
+  readonly fail: (input: {
+    session_id: SessionID
+    id: string
+    event_summary?: string
+    result_ref?: string
+  }) => Effect.Effect<Task>
 
   readonly events: (input: { session_id: SessionID; task_id: string }) => Effect.Effect<TaskEvent[]>
 }
@@ -151,6 +182,9 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
         status: "open",
         summary: input.summary,
         owner: input.owner ?? null,
+        worker_session_id: null,
+        dispatched_at: null,
+        result_ref: null,
         created_at: now,
         last_event_at: now,
         ended_at: null,
@@ -176,11 +210,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       if (input.status) conds.push(eq(TaskTable.status, input.status))
       if (input.owner) conds.push(eq(TaskTable.owner, input.owner))
       if (!input.include_terminal) {
-        const nonTerminal = or(
-          eq(TaskTable.status, "open"),
-          eq(TaskTable.status, "in_progress"),
-          eq(TaskTable.status, "blocked"),
-        )
+        const nonTerminal = or(...NON_TERMINAL_TASK_STATUSES.map((s) => eq(TaskTable.status, s)))
         if (nonTerminal) conds.push(nonTerminal)
       }
       if (!input.include_archived) {
@@ -259,6 +289,135 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       return updated
     })
 
+    // Queue transitions: dispatch → worker, requestReview → human, rework → back
+    // to the worker queue, fail → terminal.
+
+    const dispatch = Effect.fn("TaskRegistry.dispatch")(function* (input: {
+      session_id: SessionID
+      id: string
+      worker_session_id: SessionID
+      event_summary?: string
+    }) {
+      const now = Date.now()
+      const existing = yield* get({ session_id: input.session_id, id: input.id })
+      if (!existing) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
+      if (isTerminalTaskStatus(existing.status)) {
+        yield* Effect.logWarning(`refusing to dispatch terminal task ${input.id} (status=${existing.status})`)
+        return existing
+      }
+
+      Database.use((db) =>
+        db
+          .update(TaskTable)
+          .set({
+            status: "dispatched",
+            worker_session_id: input.worker_session_id,
+            dispatched_at: now,
+            last_event_at: now,
+          })
+          .where(and(eq(TaskTable.session_id, input.session_id), eq(TaskTable.id, input.id)))
+          .run(),
+      )
+      insertEvent(input.session_id, input.id, "dispatched", input.event_summary, now)
+      const updated = yield* get({ session_id: input.session_id, id: input.id })
+      if (!updated) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
+      publishUpdated(updated, "dispatched")
+      return updated
+    })
+
+    const requestReview = Effect.fn("TaskRegistry.requestReview")(function* (input: {
+      session_id: SessionID
+      id: string
+      event_summary?: string
+      result_ref?: string
+    }) {
+      const now = Date.now()
+      const existing = yield* get({ session_id: input.session_id, id: input.id })
+      if (!existing) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
+      if (isTerminalTaskStatus(existing.status)) {
+        yield* Effect.logWarning(`refusing to review terminal task ${input.id} (status=${existing.status})`)
+        return existing
+      }
+
+      Database.use((db) =>
+        db
+          .update(TaskTable)
+          .set({
+            status: "human_review",
+            last_event_at: now,
+            ...(input.result_ref !== undefined ? { result_ref: input.result_ref } : {}),
+          })
+          .where(and(eq(TaskTable.session_id, input.session_id), eq(TaskTable.id, input.id)))
+          .run(),
+      )
+      insertEvent(input.session_id, input.id, "review_requested", input.event_summary, now)
+      const updated = yield* get({ session_id: input.session_id, id: input.id })
+      if (!updated) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
+      publishUpdated(updated, "review_requested")
+      return updated
+    })
+
+    // The user rejected the result: push the task back onto the worker queue.
+    // Keeps its worker if it still has one (rework by the same session), else
+    // back to `open` so the orchestrator can dispatch a fresh worker.
+    const rework = Effect.fn("TaskRegistry.rework")(function* (input: {
+      session_id: SessionID
+      id: string
+      event_summary?: string
+    }) {
+      const now = Date.now()
+      const existing = yield* get({ session_id: input.session_id, id: input.id })
+      if (!existing) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
+      if (existing.status !== "human_review") {
+        yield* Effect.logWarning(`refusing to rework task ${input.id}: not in human_review (status=${existing.status})`)
+        return existing
+      }
+
+      const next = existing.worker_session_id ? "dispatched" : "open"
+      Database.use((db) =>
+        db
+          .update(TaskTable)
+          .set({ status: next, last_event_at: now })
+          .where(and(eq(TaskTable.session_id, input.session_id), eq(TaskTable.id, input.id)))
+          .run(),
+      )
+      insertEvent(input.session_id, input.id, "reworked", input.event_summary, now)
+      const updated = yield* get({ session_id: input.session_id, id: input.id })
+      if (!updated) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
+      publishUpdated(updated, "reworked")
+      return updated
+    })
+
+    // Terminal, like done()/abandon(): a worker reported failure. Distinct from
+    // `abandoned`, which is the operator dropping the work.
+    const fail = Effect.fn("TaskRegistry.fail")(function* (input: {
+      session_id: SessionID
+      id: string
+      event_summary?: string
+      result_ref?: string
+    }) {
+      const now = Date.now()
+      const cleanup = yield* cleanupAfter(now)
+      Database.use((db) =>
+        db
+          .update(TaskTable)
+          .set({
+            status: "failed",
+            ended_at: now,
+            cleanup_after: cleanup,
+            last_event_at: now,
+            ...(input.result_ref !== undefined ? { result_ref: input.result_ref } : {}),
+          })
+          .where(and(eq(TaskTable.session_id, input.session_id), eq(TaskTable.id, input.id)))
+          .run(),
+      )
+      insertEvent(input.session_id, input.id, "failed", input.event_summary, now)
+      const updated = yield* get({ session_id: input.session_id, id: input.id })
+      if (!updated) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
+      publishUpdated(updated, "failed")
+      return updated
+    })
+
     const start = Effect.fn("TaskRegistry.start")(function* (input: {
       session_id: SessionID
       id: string
@@ -272,11 +431,11 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       // Terminal states are final. Auto-start makes start() a structural side-effect of
       // every actor spawn, so a stale/reused task_id (ReAct re-entry, verification rerun,
       // operator typo colliding with an old TID) must NOT silently resurrect a
-      // done/abandoned task. done()/abandon() stamp ended_at + cleanup_after; start()
-      // does not clear them, so resurrection would leave a self-contradictory row
+      // done/failed/abandoned task. done()/fail()/abandon() stamp ended_at + cleanup_after;
+      // start() does not clear them, so resurrection would leave a self-contradictory row
       // (status=in_progress yet carrying ended_at/cleanup_after) that list() drops from
       // the active set the moment the old archive window elapses. No-op and warn instead.
-      if (existing.status === "done" || existing.status === "abandoned") {
+      if (isTerminalTaskStatus(existing.status)) {
         yield* Effect.logWarning(`refusing to start terminal task ${input.id} (status=${existing.status})`)
         return existing
       }
@@ -385,6 +544,10 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       abandon,
       rename,
       start,
+      dispatch,
+      requestReview,
+      rework,
+      fail,
     })
   }),
 )

--- a/packages/opencode/src/task/schema.ts
+++ b/packages/opencode/src/task/schema.ts
@@ -4,8 +4,37 @@ import { SessionID } from "../session/schema"
 export const TaskID = z.string().regex(/^T\d+(\.\d+)*$/, "Task ID must be Tn or Tn.m...")
 export type TaskID = z.infer<typeof TaskID>
 
-export const TaskStatus = z.enum(["open", "in_progress", "blocked", "done", "abandoned"])
+// Task statuses double as queue names: a task's status IS the queue it sits in.
+// `dispatched` = handed to a worker session that has not reported running yet.
+// `human_review` = a first-class queue waiting on the USER, not on any worker.
+// `failed` = a worker reported failure; terminal but distinct from `abandoned`,
+// which is an operator dropping the work.
+export const TaskStatus = z.enum([
+  "open",
+  "dispatched",
+  "in_progress",
+  "blocked",
+  "human_review",
+  "done",
+  "failed",
+  "abandoned",
+])
 export type TaskStatus = z.infer<typeof TaskStatus>
+
+// Terminal = cannot be resurrected by start(). done/abandon/fail all stamp
+// ended_at + cleanup_after, so a restart would leave a self-contradictory row.
+export const TERMINAL_TASK_STATUSES = ["done", "failed", "abandoned"] as const satisfies readonly TaskStatus[]
+export const NON_TERMINAL_TASK_STATUSES = [
+  "open",
+  "dispatched",
+  "in_progress",
+  "blocked",
+  "human_review",
+] as const satisfies readonly TaskStatus[]
+
+export function isTerminalTaskStatus(status: TaskStatus): boolean {
+  return (TERMINAL_TASK_STATUSES as readonly TaskStatus[]).includes(status)
+}
 
 export const Task = z.object({
   id: TaskID,
@@ -14,6 +43,12 @@ export const Task = z.object({
   status: TaskStatus,
   summary: z.string(),
   owner: z.string().optional(),
+  // The peer worker session executing this task. Soft link (no FK): a worker
+  // session can be torn down while the task row must survive as history.
+  worker_session_id: SessionID.zod.optional(),
+  dispatched_at: z.number().optional(),
+  // Pointer to the outcome: branch, commit, summary or notification id.
+  result_ref: z.string().optional(),
   created_at: z.number(),
   last_event_at: z.number(),
   ended_at: z.number().optional(),
@@ -23,11 +58,15 @@ export type Task = z.infer<typeof Task>
 
 export const TaskEventKind = z.enum([
   "created",
+  "dispatched",
   "started",
   "unstarted",
   "blocked",
   "unblocked",
+  "review_requested",
+  "reworked",
   "done",
+  "failed",
   "abandoned",
   "renamed",
 ])

--- a/packages/opencode/src/task/task.sql.ts
+++ b/packages/opencode/src/task/task.sql.ts
@@ -11,9 +11,19 @@ export const TaskTable = sqliteTable(
       .notNull()
       .references(() => SessionTable.id, { onDelete: "cascade" }),
     parent_task_id: text(),
-    status: text().$type<"open" | "in_progress" | "blocked" | "done" | "abandoned">().notNull(),
+    status: text()
+      .$type<
+        "open" | "dispatched" | "in_progress" | "blocked" | "human_review" | "done" | "failed" | "abandoned"
+      >()
+      .notNull(),
     summary: text().notNull(),
     owner: text(),
+    // Deliberately NOT a foreign key to SessionTable: a worker session may be
+    // torn down (or its row cascade-deleted) while the task must survive as
+    // durable history. Same soft-link treatment `owner` already gets.
+    worker_session_id: text().$type<SessionID>(),
+    dispatched_at: integer(),
+    result_ref: text(),
     created_at: integer().notNull(),
     last_event_at: integer().notNull(),
     ended_at: integer(),
@@ -24,6 +34,7 @@ export const TaskTable = sqliteTable(
     index("task_session_idx").on(table.session_id),
     index("task_parent_idx").on(table.session_id, table.parent_task_id),
     index("task_status_idx").on(table.status),
+    index("task_worker_idx").on(table.worker_session_id, table.status),
   ],
 )
 

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -43,7 +43,16 @@ function suggestVerb(input: string): string | undefined {
 
 const id = "task"
 
-const statusSchema = z.enum(["open", "in_progress", "blocked", "done", "abandoned"])
+const statusSchema = z.enum([
+  "open",
+  "dispatched",
+  "in_progress",
+  "blocked",
+  "human_review",
+  "done",
+  "failed",
+  "abandoned",
+])
 
 const createOperation = z.strictObject({
   action: z.literal("create"),

--- a/packages/opencode/test/storage/task-worker-migration.test.ts
+++ b/packages/opencode/test/storage/task-worker-migration.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, readdirSync } from "fs"
+import os from "os"
+import path from "path"
+import { migrate } from "drizzle-orm/bun-sqlite/migrator"
+import { sql } from "drizzle-orm"
+import { init } from "../../src/storage/db.bun"
+
+const MIGRATION_DIR = path.join(import.meta.dirname, "../../migration")
+const NEW_MIGRATION = "20260715000000_task_worker_link"
+
+type Journal = { sql: string; timestamp: number; name: string }[]
+
+function stamp(tag: string) {
+  const m = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(tag)
+  if (!m) return 0
+  return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]), Number(m[4]), Number(m[5]), Number(m[6]))
+}
+
+function journal(): Journal {
+  return readdirSync(MIGRATION_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => existsSync(path.join(MIGRATION_DIR, name, "migration.sql")))
+    .map((name) => ({
+      sql: readFileSync(path.join(MIGRATION_DIR, name, "migration.sql"), "utf-8"),
+      timestamp: stamp(name),
+      name,
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp)
+}
+
+describe("task worker-link migration", () => {
+  test("applies on an existing DB and backfills old task rows with NULLs", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "task-worker-migration-"))
+    const db = init(path.join(dir, "test.db"))
+    db.$client.run("PRAGMA foreign_keys = ON")
+
+    const all = journal()
+    const before = all.filter((m) => m.name !== NEW_MIGRATION)
+    expect(before.length).toBe(all.length - 1)
+    // the new migration must sort last so it applies after every existing one
+    expect(all[all.length - 1].name).toBe(NEW_MIGRATION)
+
+    // 1. bring the DB up to the state that shipped before this PR
+    migrate(db, before)
+
+    // pre-migration `task` has no worker columns
+    const oldCols = db.$client
+      .query("select name from pragma_table_info('task')")
+      .all()
+      .map((r: any) => r.name)
+    expect(oldCols).not.toContain("worker_session_id")
+
+    // 2. seed a legacy row through raw SQL (the old column set)
+    db.$client.run(
+      "insert into project (id, worktree, sandboxes, time_created, time_updated) values (?, ?, ?, ?, ?)",
+      ["prj_legacy", dir, "[]", 1, 1],
+    )
+    db.$client.run(
+      "insert into session (id, project_id, slug, directory, title, version, time_created, time_updated) values (?, ?, ?, ?, ?, ?, ?, ?)",
+      ["ses_legacy", "prj_legacy", "legacy", dir, "legacy", "0.0.0", 1, 1],
+    )
+    db.$client.run(
+      "insert into task (id, session_id, status, summary, created_at, last_event_at) values (?, ?, ?, ?, ?, ?)",
+      ["T1", "ses_legacy", "open", "legacy task", 1, 1],
+    )
+
+    // 3. apply the new migration
+    migrate(db, all)
+
+    const cols = db.$client
+      .query("select name from pragma_table_info('task')")
+      .all()
+      .map((r: any) => r.name)
+    expect(cols).toContain("worker_session_id")
+    expect(cols).toContain("dispatched_at")
+    expect(cols).toContain("result_ref")
+
+    const row = db.$client
+      .query("select worker_session_id, dispatched_at, result_ref, status from task where id = 'T1'")
+      .get() as any
+    expect(row.worker_session_id).toBeNull()
+    expect(row.dispatched_at).toBeNull()
+    expect(row.result_ref).toBeNull()
+    expect(row.status).toBe("open")
+
+    const indexes = db.$client
+      .query("select name from sqlite_master where type = 'index' and tbl_name = 'task'")
+      .all()
+      .map((r: any) => r.name)
+    expect(indexes).toContain("task_worker_idx")
+
+    // the new columns are writable on the legacy row
+    db.all(sql`update task set worker_session_id = 'ses_worker', dispatched_at = 42 where id = 'T1'`)
+    const updated = db.$client
+      .query("select worker_session_id, dispatched_at from task where id = 'T1'")
+      .get() as any
+    expect(updated.worker_session_id).toBe("ses_worker")
+    expect(updated.dispatched_at).toBe(42)
+
+    db.$client.close()
+  })
+})

--- a/packages/opencode/test/task/registry.test.ts
+++ b/packages/opencode/test/task/registry.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect } from "bun:test"
-import { Cause, Effect, Layer } from "effect"
+import { Cause, Effect, Layer, Stream } from "effect"
 import { Bus } from "../../src/bus"
 import { Session } from "../../src/session"
 import { TaskRegistry } from "../../src/task/registry"
+import * as TaskEvents from "../../src/task/events"
 import { Instance } from "../../src/project/instance"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -165,6 +166,277 @@ describe("TaskRegistry.list", () => {
 
         const list = yield* reg.list({ session_id: sess.id, include_terminal: true })
         expect(list.length).toBe(1)
+      }),
+    ),
+  )
+
+  it.live("treats dispatched and human_review as non-terminal, failed as terminal", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const worker = yield* seedSession()
+
+        const dispatched = yield* reg.create({ session_id: sess.id, summary: "dispatched" })
+        yield* reg.dispatch({ session_id: sess.id, id: dispatched.id, worker_session_id: worker.id })
+        const review = yield* reg.create({ session_id: sess.id, summary: "review" })
+        yield* reg.requestReview({ session_id: sess.id, id: review.id })
+        const failed = yield* reg.create({ session_id: sess.id, summary: "failed" })
+        yield* reg.fail({ session_id: sess.id, id: failed.id })
+
+        const active = yield* reg.list({ session_id: sess.id })
+        expect(active.map((t) => t.summary).sort()).toEqual(["dispatched", "review"])
+
+        const all = yield* reg.list({ session_id: sess.id, include_terminal: true })
+        expect(all.length).toBe(3)
+      }),
+    ),
+  )
+
+  it.live("filters by the new statuses", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const worker = yield* seedSession()
+        const a = yield* reg.create({ session_id: sess.id, summary: "a" })
+        yield* reg.dispatch({ session_id: sess.id, id: a.id, worker_session_id: worker.id })
+        yield* reg.create({ session_id: sess.id, summary: "b" })
+
+        const list = yield* reg.list({ session_id: sess.id, status: "dispatched" })
+        expect(list.length).toBe(1)
+        expect(list[0].id).toBe(a.id)
+      }),
+    ),
+  )
+})
+
+describe("TaskRegistry worker-session link columns", () => {
+  it.live("new columns default to undefined on create and round-trip", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const t = yield* reg.create({ session_id: sess.id, summary: "a" })
+        expect(t.worker_session_id).toBeUndefined()
+        expect(t.dispatched_at).toBeUndefined()
+        expect(t.result_ref).toBeUndefined()
+
+        const fetched = yield* reg.get({ session_id: sess.id, id: t.id })
+        expect(fetched?.worker_session_id).toBeUndefined()
+        expect(fetched?.dispatched_at).toBeUndefined()
+        expect(fetched?.result_ref).toBeUndefined()
+      }),
+    ),
+  )
+
+  it.live("result_ref round-trips through fail()", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const t = yield* reg.create({ session_id: sess.id, summary: "a" })
+        const failed = yield* reg.fail({ session_id: sess.id, id: t.id, result_ref: "branch:wip/x" })
+        expect(failed.result_ref).toBe("branch:wip/x")
+
+        const fetched = yield* reg.get({ session_id: sess.id, id: t.id })
+        expect(fetched?.result_ref).toBe("branch:wip/x")
+      }),
+    ),
+  )
+})
+
+describe("TaskRegistry.dispatch", () => {
+  it.live("sets worker_session_id + dispatched_at and moves to dispatched", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const worker = yield* seedSession()
+        const t = yield* reg.create({ session_id: sess.id, summary: "ship it" })
+
+        const before = Date.now()
+        const out = yield* reg.dispatch({ session_id: sess.id, id: t.id, worker_session_id: worker.id })
+        expect(out.status).toBe("dispatched")
+        expect(out.worker_session_id).toBe(worker.id)
+        expect(out.dispatched_at).toBeGreaterThanOrEqual(before)
+
+        const events = yield* reg.events({ session_id: sess.id, task_id: t.id })
+        expect(events.map((e) => e.kind)).toEqual(["created", "dispatched"])
+      }),
+    ),
+  )
+
+  it.live("refuses to dispatch a terminal task", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const worker = yield* seedSession()
+        const t = yield* reg.create({ session_id: sess.id, summary: "a" })
+        yield* reg.done({ session_id: sess.id, id: t.id })
+
+        const out = yield* reg.dispatch({ session_id: sess.id, id: t.id, worker_session_id: worker.id })
+        expect(out.status).toBe("done")
+        expect(out.worker_session_id).toBeUndefined()
+      }),
+    ),
+  )
+
+  it.live("dispatch on a nonexistent id is agent-recoverable", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const worker = yield* seedSession()
+
+        const exit = yield* Effect.exit(
+          reg.dispatch({ session_id: sess.id, id: "T99", worker_session_id: worker.id }),
+        )
+        expect(exit._tag).toBe("Failure")
+        if (exit._tag !== "Failure") return
+        expect(isRecoverableError(Cause.squash(exit.cause))).toBe(true)
+      }),
+    ),
+  )
+})
+
+describe("TaskRegistry.requestReview / rework", () => {
+  it.live("requestReview moves the task into the human_review queue", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const t = yield* reg.create({ session_id: sess.id, summary: "a" })
+        yield* reg.start({ session_id: sess.id, id: t.id })
+
+        const out = yield* reg.requestReview({ session_id: sess.id, id: t.id, event_summary: "please look" })
+        expect(out.status).toBe("human_review")
+        expect(out.ended_at).toBeUndefined()
+
+        const events = yield* reg.events({ session_id: sess.id, task_id: t.id })
+        expect(events.map((e) => e.kind)).toEqual(["created", "started", "review_requested"])
+      }),
+    ),
+  )
+
+  it.live("rework returns a reviewed task with a worker to dispatched", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const worker = yield* seedSession()
+        const t = yield* reg.create({ session_id: sess.id, summary: "a" })
+        yield* reg.dispatch({ session_id: sess.id, id: t.id, worker_session_id: worker.id })
+        yield* reg.requestReview({ session_id: sess.id, id: t.id })
+
+        const out = yield* reg.rework({ session_id: sess.id, id: t.id, event_summary: "not quite" })
+        expect(out.status).toBe("dispatched")
+        expect(out.worker_session_id).toBe(worker.id)
+
+        const events = yield* reg.events({ session_id: sess.id, task_id: t.id })
+        expect(events.map((e) => e.kind)).toEqual(["created", "dispatched", "review_requested", "reworked"])
+      }),
+    ),
+  )
+
+  it.live("rework returns a reviewed task without a worker to open", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const t = yield* reg.create({ session_id: sess.id, summary: "a" })
+        yield* reg.requestReview({ session_id: sess.id, id: t.id })
+
+        const out = yield* reg.rework({ session_id: sess.id, id: t.id })
+        expect(out.status).toBe("open")
+      }),
+    ),
+  )
+
+  it.live("rework is a no-op when the task is not awaiting review", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const t = yield* reg.create({ session_id: sess.id, summary: "a" })
+
+        const out = yield* reg.rework({ session_id: sess.id, id: t.id })
+        expect(out.status).toBe("open")
+        const events = yield* reg.events({ session_id: sess.id, task_id: t.id })
+        expect(events.map((e) => e.kind)).toEqual(["created"])
+      }),
+    ),
+  )
+})
+
+describe("TaskRegistry.fail", () => {
+  it.live("marks failed and stamps ended_at + cleanup_after", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const t = yield* reg.create({ session_id: sess.id, summary: "a" })
+
+        const out = yield* reg.fail({ session_id: sess.id, id: t.id, event_summary: "worker crashed" })
+        expect(out.status).toBe("failed")
+        expect(out.ended_at).toBeGreaterThan(0)
+        expect(out.cleanup_after).toBeGreaterThan(out.ended_at!)
+
+        const events = yield* reg.events({ session_id: sess.id, task_id: t.id })
+        expect(events.map((e) => e.kind)).toEqual(["created", "failed"])
+        expect(events[1].summary).toBe("worker crashed")
+      }),
+    ),
+  )
+
+  it.live("failed is terminal — start refuses to resurrect it", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const sess = yield* seedSession()
+        const t = yield* reg.create({ session_id: sess.id, summary: "a" })
+        yield* reg.fail({ session_id: sess.id, id: t.id })
+
+        const out = yield* reg.start({ session_id: sess.id, id: t.id })
+        expect(out.status).toBe("failed")
+
+        const events = yield* reg.events({ session_id: sess.id, task_id: t.id })
+        expect(events.map((e) => e.kind)).toEqual(["created", "failed"])
+      }),
+    ),
+  )
+})
+
+describe("TaskRegistry queue transitions publish task.updated", () => {
+  it.live("emits the matching kind on the bus for each new mutator", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* TaskRegistry.Service
+        const bus = yield* Bus.Service
+        const sess = yield* seedSession()
+        const worker = yield* seedSession()
+
+        const seen: string[] = []
+        yield* bus.subscribe(TaskEvents.Updated).pipe(
+          Stream.runForEach((p) =>
+            Effect.sync(() => {
+              seen.push(p.properties.kind)
+            }),
+          ),
+          Effect.forkScoped,
+        )
+        // let the forked fiber actually attach its subscription before publishing
+        yield* Effect.sleep("50 millis")
+
+        const t = yield* reg.create({ session_id: sess.id, summary: "a" })
+        yield* reg.dispatch({ session_id: sess.id, id: t.id, worker_session_id: worker.id })
+        yield* reg.requestReview({ session_id: sess.id, id: t.id })
+        yield* reg.rework({ session_id: sess.id, id: t.id })
+        yield* reg.fail({ session_id: sess.id, id: t.id })
+        yield* Effect.sleep("50 millis")
+
+        expect(seen).toEqual(["dispatched", "review_requested", "reworked", "failed"])
       }),
     ),
   )


### PR DESCRIPTION
## What

**PR-1 of the Symphony-inspired Orchestrator task-queue design.** Schema + mutators only — **behavior-inert**: nothing in the codebase calls the new mutators yet, and no lifecycle hook or task-tool verb is wired. Merging this changes zero runtime behavior.

## The core gap this closes

Task tracking already had almost everything a queue needs (`TaskTable`, append-only `TaskEventTable`, `TaskRegistry` as the single mutator, `task.updated` bus events). What it did **not** have is a durable link from a task to the **worker session** executing it: `owner` is a free-text actorID, and `ActorRegistryTable` has no `task_id`. So "which peer child is working T3, and what came out of it" was only ever inferable from the model's context, never authoritative in the DB.

This PR adds that link plus the queue statuses the orchestrator needs to route work.

## Schema deltas

`packages/opencode/migration/20260715000000_task_worker_link/migration.sql` (timestamped after the newest existing migration, auto-discovered by `migrations()` in `src/storage/db.ts`):

```sql
ALTER TABLE `task` ADD COLUMN `worker_session_id` text;
ALTER TABLE `task` ADD COLUMN `dispatched_at` integer;
ALTER TABLE `task` ADD COLUMN `result_ref` text;
CREATE INDEX IF NOT EXISTS `task_worker_idx` ON `task` (`worker_session_id`,`status`);
```

All three columns are nullable, exactly mirroring the `20260603000000_task_in_progress_owner` precedent, so existing rows backfill to NULL.

**`worker_session_id` is deliberately NOT a foreign key** to `SessionTable`. `session_id` (the owning orchestrator session) *is* an FK with `onDelete: cascade` because a task cannot outlive its owner. A *worker* session is different: it is a disposable peer child that gets torn down when its job ends, but the task row must survive as durable history (including `result_ref` pointing at the branch it produced). An FK with cascade would delete the task; an FK with restrict would block worker cleanup. Same soft-link treatment `owner` already gets.

### Statuses (the queues)

`TaskStatus` (src/task/schema.ts) and the drizzle `$type<>` (src/task/task.sql.ts) and the tool's separate `statusSchema` (src/tool/task.ts) all widen consistently. A task's status **is** the queue it sits in:

| status | queue meaning |
| --- | --- |
| `open` | queued, unassigned |
| `dispatched` *(new)* | assigned to a worker session, not yet reported running |
| `in_progress` | worker is running it |
| `blocked` | stalled on a dependency |
| `human_review` *(new)* | **first-class queue waiting on the USER**, not on any worker |
| `done` | terminal success |
| `failed` *(new)* | terminal — a worker reported failure, distinct from operator-dropped `abandoned` |
| `abandoned` | terminal — the operator dropped the work |

`TaskEventKind` gains the matching kinds: `dispatched`, `review_requested`, `reworked`, `failed`. `UpdatedKind` in `src/task/events.ts` is derived via `TaskEventKind.exclude(["created"])`, so `task.updated` auto-widens with no edit there.

Terminal/non-terminal membership is now expressed once as `TERMINAL_TASK_STATUSES` / `NON_TERMINAL_TASK_STATUSES` + `isTerminalTaskStatus()` in `src/task/schema.ts`, and both the `start()` guard and `list()`'s default filter read from it instead of hardcoding a status list.

## New registry mutators

All four follow the exact existing shape — validate, single `UPDATE`, `insertEvent`, `publishUpdated`, re-`get` with the shared agent-recoverable not-found message:

- **`dispatch({ session_id, id, worker_session_id, event_summary? })`** — sets `worker_session_id` + `dispatched_at`, status → `dispatched`, logs `dispatched`. Refuses (warn + no-op) on a terminal task, same as `start()`.
- **`requestReview({ session_id, id, event_summary?, result_ref? })`** — status → `human_review`, logs `review_requested`. Does **not** stamp `ended_at`: the task is still live, just waiting on a human. Refuses on terminal.
- **`rework({ session_id, id, event_summary? })`** — the user rejected the result: `human_review` → `dispatched` if the task still has a worker, else → `open` so the orchestrator can dispatch a fresh one. Logs `reworked`. No-op + warn if the task is not actually in `human_review`.
- **`fail({ session_id, id, event_summary?, result_ref? })`** — status → `failed`, stamps `ended_at` + `cleanup_after` like `done`/`abandon`. Logs `failed`.

`start()`'s terminal guard now covers `failed` too, so a failed task cannot be silently resurrected into a self-contradictory row (`in_progress` while carrying `ended_at`/`cleanup_after`).

## Compatibility

There is no exhaustive `switch` on `TaskStatus`, and status is plain `TEXT` in SQLite, so old rows and old values keep working. The two render sites were checked:

- `session/checkpoint.ts` `statusIcon` has a `?? s` fallback — icons added for the three new statuses anyway.
- `server/routes/instance/session.ts` `taskToTodo` had a `pending` else-branch, which would have rendered a **failed** (dead) task as still actionable. Rewritten as an explicit exhaustive `Record<Task["status"], string>`: `failed` → `cancelled` (joining `abandoned`), while `dispatched` and `human_review` correctly stay `pending` (genuinely queued — on a worker / on the user).

## Tests

`bun test` — 154 pass / 0 fail across the task, storage, tool/task, actor spawn-autostart and session-task-route suites. `bun typecheck` exits 0.

- `test/task/registry.test.ts`: new columns default to `undefined` and round-trip; `result_ref` round-trips through `fail`; `dispatch` sets `worker_session_id`/`dispatched_at`/status and emits `dispatched`; `dispatch` refuses a terminal task and is agent-recoverable on an unknown id; `requestReview` enters `human_review` without stamping `ended_at`; `rework` returns to `dispatched` with a worker and `open` without one, and no-ops outside `human_review`; `fail` stamps `ended_at`/`cleanup_after` and `start` refuses to resurrect it; `list` treats `dispatched`/`human_review` as non-terminal and `failed` as terminal, and filters by the new statuses; all four mutators publish the matching `task.updated` kind on the bus.
- `test/storage/task-worker-migration.test.ts`: real on-disk SQLite with `foreign_keys = ON` — applies every migration *except* the new one, seeds a legacy `task` row through raw SQL with the old column set, then applies the new migration and asserts the three columns exist and are NULL on the old row, `task_worker_idx` exists, and the new columns are writable.

## Next

**PR-2** wires the actual behavior: session-create / worker-terminal lifecycle hooks driving `dispatch`/`fail`/`requestReview`, and the `task` tool verbs (`dispatch`, `review`, `rework`, `fail`) so the orchestrator can operate the queues.