### PR TITLE
fix(tui): recover safely from invalid session routes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -176,16 +176,7 @@ export function tui(input: {
                 <LanguageProvider>
                   <UiI18nBridge>
                 <ToastProvider>
-                  <RouteProvider
-                    initialRoute={
-                      input.args.continue
-                        ? {
-                            type: "session",
-                            sessionID: "dummy",
-                          }
-                        : undefined
-                    }
-                  >
+                  <RouteProvider>
                     <TuiConfigProvider config={input.config}>
                       <SDKProvider
                         url={input.url}
@@ -405,7 +396,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   let continued = false
   createEffect(() => {
     // When using -c, session list is loaded in blocking phase, so we can navigate at "partial"
-    if (continued || sync.status === "loading" || !args.continue) return
+    // An explicit -s takes priority: skip continue resume so it can't override the chosen session.
+    if (continued || sync.status === "loading" || !args.continue || args.sessionID) return
     // RACE GUARD: orchestratorDirPath() resolves asynchronously (onMount above).
     // If sync reaches "partial" first, orchestratorDirPath() is still undefined
     // and we'd wrongly skip the orchestrator branch, resume the persistent
@@ -436,19 +428,22 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     const match = sync.data.session
       .toSorted((a, b) => b.time.updated - a.time.updated)
       .find((x) => x.parentID === undefined && !isSystemSession(x))?.id
-    if (match) {
+    if (!match) {
       continued = true
-      if (args.fork) {
-        void sdk.client.session.fork({ sessionID: match }).then((result) => {
-          if (result.data?.id) {
-            route.navigate({ type: "session", sessionID: result.data.id })
-          } else {
-            toast.show({ message: "Failed to fork session", variant: "error" })
-          }
-        })
-      } else {
-        route.navigate({ type: "session", sessionID: match })
-      }
+      toast.show({ message: "No previous session to continue", variant: "info" })
+      return
+    }
+    continued = true
+    if (args.fork) {
+      void sdk.client.session.fork({ sessionID: match }).then((result) => {
+        if (result.data?.id) {
+          route.navigate({ type: "session", sessionID: result.data.id })
+        } else {
+          toast.show({ message: "Failed to fork session", variant: "error" })
+        }
+      })
+    } else {
+      route.navigate({ type: "session", sessionID: match })
     }
   })
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -33,7 +33,7 @@ import type {
   ReasoningPart,
 } from "@mimo-ai/sdk/v2"
 import { useLocal } from "@tui/context/local"
-import { Locale } from "@/util"
+import { Locale, Log } from "@/util"
 import type { Tool } from "@/tool"
 import type { ReadTool } from "@/tool/read"
 import type { WriteTool } from "@/tool/write"
@@ -247,31 +247,61 @@ export function Session() {
   const toast = useToast()
   const sdk = useSDK()
 
-  createEffect(async () => {
+  createEffect(() => {
+    const sessionID = route.sessionID
     const previousWorkspace = project.workspace.current()
-    const result = await sdk.client.session.get({ sessionID: route.sessionID }, { throwOnError: true })
-    if (!result.data) {
+
+    const isCurrentRoute = () =>
+      fullRoute.data.type === "session" && fullRoute.data.sessionID === sessionID
+
+    void (async () => {
+      const result = await sdk.client.session.get({ sessionID })
+
+      if (!isCurrentRoute()) return
+
+      if (!result.data) {
+        toast.show({
+          message: result.response?.status === 404 ? "Session not found" : "Failed to load session",
+          variant: "error",
+        })
+        navigate({ type: "home" })
+        return
+      }
+
+      if (result.data.workspaceID !== previousWorkspace) {
+        project.workspace.set(result.data.workspaceID)
+
+        try {
+          await sync.bootstrap({ fatal: false })
+        } catch {
+          // Preserve existing non-fatal bootstrap behavior.
+        }
+
+        if (!isCurrentRoute()) return
+      }
+
+      if (!isCurrentRoute()) return
+
+      await sync.session.sync(sessionID)
+
+      if (!isCurrentRoute()) return
+
+      scroll?.scrollBy(100_000)
+    })().catch((error) => {
+      Log.Default.error("session route load failed", {
+        sessionID,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      })
+
+      if (!isCurrentRoute()) return
+
       toast.show({
-        message: `Session not found: ${route.sessionID}`,
+        message: "Failed to load session",
         variant: "error",
       })
       navigate({ type: "home" })
-      return
-    }
-
-    if (result.data.workspaceID !== previousWorkspace) {
-      project.workspace.set(result.data.workspaceID)
-
-      // Sync all the data for this workspace. Note that this
-      // workspace may not exist anymore which is why this is not
-      // fatal. If it doesn't we still want to show the session
-      // (which will be non-interactive)
-      try {
-        await sync.bootstrap({ fatal: false })
-      } catch (e) {}
-    }
-    await sync.session.sync(route.sessionID)
-    if (scroll) scroll.scrollBy(100_000)
+    })
   })
 
   let lastSwitch: string | undefined = undefined


### PR DESCRIPTION
## Summary

Fix the TUI black screen caused by failed session-route loads.

This covers two entry paths:

* `mimo -c`, where the TUI previously started on a fabricated `sessionID: "dummy"` route.
* Malformed or nonexistent `mimo -s <session-id>` values, where a failed session load could leave the TUI stuck on an unloadable route.

Fixes #1809.
Fixes #1936.

## Root cause

The `--continue` path used `"dummy"` as its initial session route while waiting to resolve a real session.

The session page then called `session.get()` with `throwOnError: true` from an asynchronous SolidJS effect without a complete rejection boundary. A 400, 404, network failure, or another rejection could therefore leave the route pointing at a session that could never load, resulting in a black screen.

The same missing recovery path could be reached through malformed or nonexistent values supplied using `--session/-s`.

## Changes

### `app.tsx`

* Remove the fabricated `"dummy"` initial route for `--continue`.
* Start on Home and navigate only after resolving a real resumable session.
* Give an explicit `--session` value priority over `--continue`.
* Mark the continue decision as complete when no resumable session exists, preventing a session created later from being resumed unexpectedly.
* Show a visible notification when there is no previous session to continue.

### `routes/session/index.tsx`

* Call `sdk.client.session.get()` without `throwOnError: true`, allowing ordinary HTTP failures to be handled as results.
* Show `Session not found` for 404 responses and a generic load error otherwise, then navigate back to Home.
* Add a final catch boundary for unexpected fetch, parsing, interceptor, or session-sync rejections.
* Check that the route is still current after session fetch, workspace bootstrap, and session sync before applying additional effects.
* Prevent stale asynchronous work from scrolling, navigating, or showing errors on a newly selected route.
* Avoid echoing the raw user-supplied session value in terminal notifications.

## Scope

* Two production files changed.
* One commit.
* No new session-ID regex or global identifier contract.
* No changes to `thread.ts`, `attach.ts`, or the lockfile.

## Verification

* All 21 existing TUI test files: **PASS** (`121` tests)
* `bun typecheck`: **PASS**
* Local workspace typecheck via Turbo (`12` packages): **PASS**

Fault injection and renderer-level CPU profiling were not automated. The change ensures that failed session loads terminate in a visible and recoverable Home-route state.
