### PR TITLE
fix(checkpoint): don't count a timed-out writer wait as a writer failure

### DIFF
--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -513,7 +513,11 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Se
 // Writer state per session
 // ---------------------------------------------------------------------------
 
-export type WriterOutcome = "success" | "failure"
+// "timeout" means the caller's bounded wait expired while the writer was STILL
+// IN FLIGHT — it is deliberately distinct from "failure" (the writer settled
+// unsuccessfully). See waitForWriter for why conflating the two silently
+// disables checkpointing for a session whose writers are merely slow.
+export type WriterOutcome = "success" | "failure" | "timeout"
 
 interface WriterState {
   // Holds the AgentOutcome Deferred returned by Actor.spawn so callers can
@@ -982,10 +986,23 @@ export const layer: Layer.Layer<
       // 5min so a long-but-honest writer is not mistaken for a failure by
       // the prune retry watcher. AgentOutcome → WriterOutcome translation:
       // success → "success", failure / cancelled → "failure".
+      //
+      // The bound expiring is NOT a writer failure. This timeout does not
+      // cancel the writer, and the settle watcher that owns the watermark
+      // advance (see tryStartCheckpointWriter) awaits the SAME Deferred with no
+      // bound — so a slow-but-successful writer still advances
+      // last_checkpoint_message_id after we stop waiting. Reporting "failure"
+      // here made the prune retry watcher count a working writer as broken,
+      // and MAX_WRITER_FAILURES such waits then tripped "gave up after max
+      // consecutive failures", permanently disabling checkpointing for a
+      // session whose every writer had actually succeeded. Report "timeout" so
+      // callers can distinguish "still in flight" from "settled unsuccessfully"
+      // (prune's `result !== "failure"` guard already skips the counter).
       const outcome = yield* Deferred.await(state.writing).pipe(
         Effect.timeout(300_000),
-        Effect.catch(() => Effect.succeed<AgentOutcome>({ status: "failure", error: "timeout" })),
+        Effect.catch(() => Effect.succeed("timeout" as const)),
       )
+      if (outcome === "timeout") return "timeout" as const
       return outcome.status === "success" ? ("success" as const) : ("failure" as const)
     })
 

--- a/packages/opencode/src/session/prune.ts
+++ b/packages/opencode/src/session/prune.ts
@@ -314,6 +314,10 @@ export const layer: Layer.Layer<
               writerFailures.delete(input.sessionID)
               return
             }
+            // "no-writer" and "timeout" both mean "not a settled failure". A
+            // timed-out wait leaves the writer in flight (and still able to
+            // advance the watermark), so counting it would retire a
+            // merely-slow-but-working writer. Only a real failure ticks below.
             if (result !== "failure") return
             const next = (writerFailures.get(input.sessionID) ?? 0) + 1
             writerFailures.set(input.sessionID, next)

--- a/packages/opencode/test/session/checkpoint-writer-wait-timeout.test.ts
+++ b/packages/opencode/test/session/checkpoint-writer-wait-timeout.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect } from "bun:test"
+import { Deferred, Effect, Fiber, Layer } from "effect"
+import * as TestClock from "effect/testing/TestClock"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config"
+import { Agent } from "../../src/agent/agent"
+import { Memory } from "../../src/memory"
+import { ActorRegistry } from "../../src/actor/registry"
+import { Actor, type AgentOutcome } from "../../src/actor/spawn"
+import { spawnRef } from "../../src/actor/spawn-ref"
+import { TaskRegistry } from "../../src/task/registry"
+import { SessionCheckpoint } from "../../src/session/checkpoint"
+import { Log } from "../../src/util"
+import { Plugin } from "../../src/plugin"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { Session as SessionNs } from "../../src/session"
+import { MessageID, PartID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { ProviderTest } from "../fake/provider"
+import { testEffect } from "../lib/effect"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+
+void Log.init({ print: false })
+
+const ref = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("test-model"),
+}
+
+// Actor stub whose outcome Deferred never resolves — a writer still grinding
+// through LLM round-trips when the caller's bounded wait expires.
+const hangingActor = Layer.effect(
+  Actor.Service,
+  Effect.gen(function* () {
+    const prevSpawnRef = spawnRef.current
+    let counter = 0
+    const impl = Actor.Service.of({
+      spawn: (input) =>
+        Effect.gen(function* () {
+          counter += 1
+          const outcome = yield* Deferred.make<AgentOutcome>()
+          return { actorID: `${input.agentType}-${counter}`, sessionID: input.sessionID, outcome }
+        }),
+      cancel: () => Effect.void,
+      getForkContext: () => Effect.succeed(undefined),
+    })
+    spawnRef.current = impl
+    yield* Effect.addFinalizer(
+      () =>
+        Effect.sync(() => {
+          if (spawnRef.current === impl) spawnRef.current = prevSpawnRef
+        }),
+    )
+    return impl
+  }),
+)
+
+const deps = Layer.mergeAll(
+  ProviderTest.fake().layer,
+  Agent.defaultLayer,
+  Plugin.defaultLayer,
+  Bus.layer,
+  Config.defaultLayer,
+  Memory.defaultLayer,
+  TaskRegistry.defaultLayer,
+  ActorRegistry.defaultLayer,
+  hangingActor,
+)
+
+const env = Layer.mergeAll(
+  SessionNs.defaultLayer,
+  CrossSpawnSpawner.defaultLayer,
+  SessionCheckpoint.layer.pipe(Layer.provide(SessionNs.defaultLayer), Layer.provideMerge(deps)),
+)
+
+const it = testEffect(env)
+
+describe("SessionCheckpoint.waitForWriter", () => {
+  it.effect(
+    "in-flight writer past the wait bound reports 'timeout', never 'failure'",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const svc = yield* SessionCheckpoint.Service
+        const ssn = yield* SessionNs.Service
+        const info = yield* ssn.create({})
+
+        // Writer needs at least one message to get past the empty-delta guard.
+        const user = yield* ssn.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: info.id,
+          agent: "build",
+          model: ref,
+          time: { created: Date.now() },
+        })
+        yield* ssn.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: info.id,
+          type: "text",
+          text: "seed",
+        })
+
+        const started = yield* svc.tryStartCheckpointWriter({
+          sessionID: info.id,
+          model: { providerID: "test", modelID: "test-model" },
+          promptOps: {} as never,
+        })
+        expect(started).toBe("started")
+
+        // Drive past the 5-minute internal bound on the TestClock. The writer's
+        // Deferred is still unresolved, so the wait expires while the writer is
+        // genuinely in flight.
+        const fiber = yield* Effect.forkChild(svc.waitForWriter(info.id))
+        yield* TestClock.adjust("6 minutes")
+        const result = yield* Fiber.join(fiber)
+
+        // Regression: this used to be "failure", which made the prune retry
+        // watcher tick writerFailures and (after MAX_WRITER_FAILURES) trip
+        // "gave up after max consecutive failures" — permanently disabling
+        // checkpointing for a session whose writers were only slow.
+        expect(result).toBe("timeout")
+        expect(result).not.toBe("failure")
+      }),
+    ),
+  )
+})


### PR DESCRIPTION
## Problem

`waitForWriter` bounds the writer's `Deferred` at 300s and maps the expiry to `{status:"failure"}` (`packages/opencode/src/session/checkpoint.ts:989-993` on main).

That expiry **does not cancel the writer**. The settle watcher that owns the watermark advance awaits the *same* `Deferred` with no bound (`checkpoint.ts:911-921`), so a slow-but-successful writer still advances `last_checkpoint_message_id` after the bounded wait gave up.

So the prune retry watcher (`prune.ts:312-337`) books a *working* writer as broken:

- `writerFailures` ticks
- the session's `crossed` / `maxCrossed` thresholds are cleared → `checkpoint writer failed — cleared thresholds for retry`
- after `MAX_WRITER_FAILURES` such waits → `checkpoint writer gave up after max consecutive failures`, and the session stops being checkpointed **even though every writer actually succeeded**

Losing checkpoint coverage also degrades `/rebuild`: the span it can release is exactly the span the checkpoint covers.

## Evidence (live TUI, dev build)

Real run on `mimo-v2.5`, checkpoint writer on the parent's model:

| event | timestamp |
| --- | --- |
| `threshold=60000 currentTokens=112596` → writer spawned | `10:47:07` |
| `checkpoint writer failed — cleared thresholds for retry` (`attempt=1`) | `10:52:07` (**exactly +300s**) |
| same writer settles **successfully**, watermark advances `msg1 → msg4` | shortly after |

Reproduced twice in a single session. The `+300s` alignment is exact — it is the wait bound expiring, not a writer error.

## Fix

Return a distinct `"timeout"` outcome instead of `"failure"`.

- `prune.ts`'s existing `if (result !== "failure") return` guard then skips the counter and leaves thresholds untouched — **no prune logic change needed**.
- `/rebuild` is unaffected — and more strongly than an earlier revision of this description claimed. That revision cited a case-2 `if (writerOutcome !== "success")` bail at `prompt.ts:4073-4082`. **No such code exists**: `git grep writerOutcome` has zero hits repo-wide, and `prompt.ts:4073-4082` is actor-notification rendering. The real shared path is `rebuildFromCheckpoint` (`prompt.ts:398-430`), used by both the automatic overflow path and manual `/rebuild`, and it **never consults the writer outcome at all** — it gates on `hasCheckpoint` + `lastBoundary` and deliberately does not block on an in-flight writer (see its own comment at `prompt.ts:394-397`). Changing the outcome value therefore cannot affect it.
- Retrying while the writer is still in flight was already a no-op: `isWriterRunning` short-circuits new threshold triggers, so nothing is lost by not counting.

## Test

New `test/session/checkpoint-writer-wait-timeout.test.ts` uses `TestClock` to drive past the 5-minute bound with the writer's `Deferred` still unresolved.

Verified it is a real regression test — with the source fix reverted it fails with `Expected: "timeout"` / `Received: "failure"`.

- `bun run typecheck` → exit 0
- focused suites (drain, prune, prune-skip-system, watermark-transactional, thresholds, new test) → **41 pass / 0 fail**
- full `test/session/` → 821 pass / 1 flaky fail that also passes on re-run and is unrelated to this change

## Notes

### An accidental benefit was removed along with the bug

Stating the trade honestly: on `main`, the mistaken `timeout → failure` mapping cleared `crossed` **and** `maxCrossed` (`prune.ts:325-326`). That had a beneficial side effect nobody designed — after a slow writer finally settled, the threshold re-fired. This PR removes that re-fire together with the false failure.

Mitigation: at the max threshold `maxCrossed` now stays set, so `prompt.ts:3308-3314` still reaches `rebuildFromCheckpoint`, which calls `prune.resetThresholds` when it succeeds (`prompt.ts:428`) and re-arms the thresholds. Checkpointing is therefore not permanently stalled.

### Follow-up

Two gaps this PR left behind are fixed in #1945: hitting the bound became completely silent (no log from either layer), and a writer that genuinely fails — or succeeds — past 300s had its real outcome booked nowhere, since prune's watcher returned on `"timeout"` and never re-awaited.


Independent of #1752 — the defect is present on `main` and this PR is deliberately **not** bundled into it.

Two related issues found during the same investigation are **not** addressed here (they need their own discussion):
1. **Coverage pinning** — thresholds fire mid-turn, but `computeBoundary` anchors on the last *finished* assistant and returns `msgs[0]` when there is none. A token blowup inside the first assistant turn pins `coveredUpTo` to message 1, so a full 5-minute writer run covers exactly one message.
2. **Writer wall-clock** — the writer inherits the parent's model (no `model` field on the `checkpoint-writer` agent) and needs ~13 sequential LLM round-trips (~20-25s each) to read prior checkpoint/memory and write its 3-4 files, which is what puts it near the 300s line in the first place.
