### PR TITLE
fix(tui): show a visible marker where /rebuild inserted a context boundary

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -560,6 +560,10 @@ export const dict: Record<string, string> = {
   // Session badges
   "tui.session.badge.auto": "Auto",
 
+  // Context rebuild boundary marker (inserted by /rebuild)
+  "tui.session.rebuild_boundary.label": "context rebuilt",
+  "tui.session.rebuild_boundary.detail": "earlier messages summarized",
+
   // Workspace trust
   "trust.title": "Accessing workspace:",
   "trust.safety_check": "Quick safety check: Is this a project you created or one you trust? (Like your own code, a well-known open source project, or work from your team). If not, take a moment to review what's in this folder first.",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -581,6 +581,10 @@ export const dict = {
   // Session badges
   "tui.session.badge.auto": "自动",
 
+  // Context rebuild boundary marker (inserted by /rebuild)
+  "tui.session.rebuild_boundary.label": "上下文已重建",
+  "tui.session.rebuild_boundary.detail": "较早消息已摘要",
+
   // Workspace trust
   "trust.title": "访问工作区：",
   "trust.safety_check": "安全确认：这是你自己创建或信任的项目吗？（如你自己的代码、知名开源项目或团队内部项目）。如果不是，请先检查此目录下的内容。",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -550,6 +550,10 @@ export const dict = {
   // Session badges
   "tui.session.badge.auto": "自動",
 
+  // Context rebuild boundary marker (inserted by /rebuild)
+  "tui.session.rebuild_boundary.label": "上下文已重建",
+  "tui.session.rebuild_boundary.detail": "較早訊息已摘要",
+
   // Workspace trust
   "trust.title": "存取工作區：",
   "trust.safety_check": "安全確認：這是你自己建立或信任的專案嗎？（如你自己的程式碼、知名開源專案或團隊內部專案）。如果不是，請先檢查此目錄下的內容。",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1536,7 +1536,16 @@ function UserMessage(props: {
       return parsed ? [parsed] : []
     })[0]
   })
+  // A context rebuild (`/rebuild`) inserts a single user message carrying a
+  // `checkpoint` part plus `synthetic: true` text parts (the rendered context
+  // and index). Neither renders — `checkpoint` has no PART_MAPPING entry and
+  // synthetic text is excluded from `text()` above — so the boundary used to be
+  // completely invisible in the transcript, unlike compaction which at least
+  // leaves a visible summary message behind. Surface it as a one-line marker
+  // row so the user can see that a rebuild happened and where.
+  const rebuildBoundary = createMemo(() => props.parts.some((x) => x.type === "checkpoint"))
   const { theme } = useTheme()
+  const t = useLanguage().t
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
   const color = createMemo(() => local.agent.color(props.message.agent))
@@ -1602,6 +1611,17 @@ function UserMessage(props: {
             </box>
           )
         }}
+      </Show>
+      <Show when={rebuildBoundary()}>
+        <box id={props.message.id} marginTop={props.index === 0 ? 0 : 1} paddingLeft={2} flexDirection="row" gap={1}>
+          <text fg={theme.textMuted}>
+            <span style={{ bg: theme.backgroundElement, fg: theme.primary, bold: true }}>
+              {" "}
+              ⟲ {t("tui.session.rebuild_boundary.label")}{" "}
+            </span>
+            <span style={{ fg: theme.textMuted }}> {t("tui.session.rebuild_boundary.detail")}</span>
+          </text>
+        </box>
       </Show>
       <Show when={text() && !actorNotification()}>
         <box

--- a/packages/opencode/test/cli/cmd/tui/rebuild-boundary-marker.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/rebuild-boundary-marker.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { dict as en } from "../../../../src/cli/cmd/tui/i18n/en"
+import { dict as zh } from "../../../../src/cli/cmd/tui/i18n/zh"
+import { dict as zht } from "../../../../src/cli/cmd/tui/i18n/zht"
+
+// A `/rebuild` inserts one user message carrying a `checkpoint` part plus
+// synthetic text parts. The TUI renders it as a one-line marker row in
+// UserMessage (routes/session/index.tsx) so the boundary is visible in the
+// transcript. The label copy is localized; the marker row would render an empty
+// badge if these keys ever went missing, so pin them here.
+const KEYS = ["tui.session.rebuild_boundary.label", "tui.session.rebuild_boundary.detail"] as const
+
+describe("rebuild boundary marker copy", () => {
+  test("english copy names the rebuild and what happened to earlier messages", () => {
+    expect(en["tui.session.rebuild_boundary.label"]).toBe("context rebuilt")
+    expect(en["tui.session.rebuild_boundary.detail"]).toBe("earlier messages summarized")
+  })
+
+  test("localized dictionaries define the marker copy", () => {
+    for (const key of KEYS) {
+      for (const [name, dict] of Object.entries({ en, zh, zht })) {
+        expect(dict[key], `${name} is missing ${key}`).toBeTruthy()
+      }
+      // Untranslated keys silently fall back to English via the `base` merge in
+      // context/language.tsx, so an English string here means a missed
+      // translation rather than a crash — assert it is actually translated.
+      expect(zh[key]).not.toBe(en[key])
+      expect(zht[key]).not.toBe(en[key])
+    }
+  })
+})


### PR DESCRIPTION
## The UX gap

After a manual `/rebuild`, the TUI shows **nothing**. The user cannot tell that a rebuild happened, and cannot tell where the context boundary is.

`checkpoint.insertRebuildBoundary` (`src/session/checkpoint.ts:1444-1490`) inserts exactly one `role: "user"` message whose parts are:

- one `{ type: "checkpoint", coveredUpTo, ... }` part
- two-to-three `{ type: "text", synthetic: true }` parts (the rendered context + index + actor registry)

Neither renders in the TUI:

- `PART_MAPPING` in `src/cli/cmd/tui/routes/session/index.tsx:1845-1849` only maps `text`, `tool`, `reasoning` — a `checkpoint` part falls through `<Show when={component()}>` and renders nothing.
- `UserMessage` only draws its bubble when a **non-synthetic** text part exists (`index.tsx:1513`, gated at `index.tsx:1615`), so all the synthetic context text is hidden too.

Net effect: the whole boundary message renders as zero rows.

Compaction is locatable by comparison, because `SessionCompaction.processCompaction` writes a real assistant message (`agent: "compaction"`, `summary: true`, `src/session/compaction.ts:341-346`) whose text part renders normally — you see the summary block sitting in the transcript. Rebuild has no equivalent: its summary lives inside `synthetic: true` user text parts, which are never displayed.

(`filterCompacted`, `src/session/message-v2.ts:1029`, breaks the context slice on **either** part type, so both are equally real boundaries — only one of them was visible.)

## The fix

Render the `checkpoint` part as a one-line marker row in `UserMessage`, reusing the badge-row pattern the TUI already uses for cron fires and actor notifications (same `box marginTop/paddingLeft={2}`, same `backgroundElement` badge + muted trailing text):

```
 ⟲ context rebuilt  earlier messages summarized
```

Placed inline at the boundary message's position, so it marks *where* the rebuild happened, not just *that* it happened.

New i18n keys (`en` / `zh` / `zht`; other locales fall back to English via the `base` merge in `context/language.tsx:18`):

- `tui.session.rebuild_boundary.label` — `context rebuilt` / `上下文已重建` / `上下文已重建`
- `tui.session.rebuild_boundary.detail` — `earlier messages summarized` / `较早消息已摘要` / `較早訊息已摘要`

No rebuild or compaction logic is touched — this is purely making an already-existing boundary visible.

### Note on consistency

The web/share renderer (`packages/ui`) does have a dedicated divider: `PART_MAPPING["compaction"]` → `MessageDivider label={i18n.t("ui.messagePart.compaction")}` (`packages/ui/src/components/message-part.tsx:1325-1328`), and `session-turn.tsx:233` already treats a `checkpoint` part as a divider trigger. The **TUI** has no compaction divider at all — compaction is only visible there via its summary message. This PR does not add a TUI compaction divider (out of scope); the new marker follows the TUI's own inline badge-row language rather than importing the web divider.

## Verification

- `bun typecheck` (packages/opencode) — exit 0
- `bun test test/cli/cmd/tui/` — 68 pass / 0 fail
- `bun test test/session/checkpoint-rebuild-unify.test.ts` — 3 pass / 0 fail (this already pins the invariant the marker keys off: `expect(boundary.parts.some((p) => p.type === "checkpoint")).toBe(true)` at line 168)
- New `test/cli/cmd/tui/rebuild-boundary-marker.test.ts` pins the marker copy in en/zh/zht and asserts zh/zht are actually translated rather than silently falling back to English. There is no render/snapshot harness for TUI message parts (the existing TUI tests all cover pure helpers), so there was no compaction-marker snapshot test to mirror.

To see it live: open a TUI session with some history, run `/rebuild`, and the marker row appears inline at the point the boundary was inserted.