### PR TITLE
fix(checkpoint): delete the writer's blind failure count, classify the failure, and give the final threshold a bounded recovery

### DIFF
--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -19,6 +19,7 @@ import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import { MessageV2 } from "@/session/message-v2"
+import { SessionRetry } from "@/session/retry"
 import { Inbox } from "@/inbox"
 import { renderActorNotification } from "@/inbox/render"
 import { Plugin, HookEvent } from "@/plugin"
@@ -120,8 +121,87 @@ export type AgentOutcome =
       // only when reportedStatus was downgraded to "partial"/"blocked".
       incompleteTasks?: string[]
     }
-  | { status: "failure"; error: string }
+  | { status: "failure"; error: string; failure?: FailureInfo }
   | { status: "cancelled" }
+
+/**
+ * Coarse, provider-agnostic category of a settled failure. Deliberately small:
+ * a consumer needs to answer "will this recur identically?", not to know which
+ * provider spelled which body which way. The provider-specific taxonomy has
+ * already been collapsed upstream by MessageV2.fromError, which runs
+ * ProviderError.parseAPICallError / isOverflow / isOpenAiErrorRetryable.
+ */
+export type FailureKind = "transient" | "overflow" | "auth" | "aborted" | "other"
+
+/**
+ * Classification carried on a `failure` outcome so a consumer can branch without
+ * string-matching `error`.
+ *
+ * PRESENT only when the failure came from a settled assistant error — i.e. the
+ * child's turn ran and persisted a normalized named error. ABSENT when the work
+ * fiber failed some other way (a defect during teardown, or a hand-built outcome
+ * such as checkpoint's "timeout"): there is no provider taxonomy to report and
+ * asserting one would be a lie. Read it with truthiness / `== null`, never
+ * `=== undefined` (AGENTS.md, "Reading a nullable column").
+ *
+ * `retryable` means "belonged to the retryable class", NOT "please retry". The
+ * child's LLM calls already run through SessionRetry's ladder (session/retry.ts,
+ * consumed by session/llm.ts and session/processor.ts), so any failure reaching
+ * a consumer is ALREADY post-retry.
+ */
+export interface FailureInfo {
+  readonly kind: FailureKind
+  readonly retryable: boolean
+  /** The persisted NamedError name, e.g. "APIError" / "ContextOverflowError". */
+  readonly name: string
+}
+
+/**
+ * Classify a settled assistant error where the typed error still exists.
+ *
+ * Reuses SessionRetry.retryable as the retryability oracle rather than adding a
+ * taxonomy: its input type IS this data shape (`Err` === `NamedError.toObject()`)
+ * and it already folds in isRetryableTransientError plus every 429 / 5xx / quota
+ * special case. `kind` is then read off the named-error identity, which is what
+ * MessageV2.fromError derived from ProviderError.parseAPICallError.
+ */
+function classifyAssistantError(err: SessionRetry.Err): FailureInfo {
+  // Truthiness, not `!== undefined`: retryable() returns a status *message*, and
+  // an empty one is not a usable retry signal.
+  const retryable = !!SessionRetry.retryable(err)
+  // 401/403 read off the statusCode ProviderError.parseAPICallError already
+  // extracted — not a new taxonomy and not a re-parse of prose. MessageV2.AuthError
+  // ("ProviderAuthError") only covers a MISSING key (LoadAPIKeyError); a rejected
+  // one arrives as an APIError, and both are the same thing to a consumer.
+  const status = MessageV2.APIError.isInstance(err) ? err.data.statusCode : undefined
+  const kind: FailureKind = MessageV2.ContextOverflowError.isInstance(err)
+    ? "overflow"
+    : MessageV2.AuthError.isInstance(err) || status === 401 || status === 403
+      ? "auth"
+      : MessageV2.AbortedError.isInstance(err)
+        ? "aborted"
+        : retryable
+          ? "transient"
+          : "other"
+  return { kind, retryable, name: err.name }
+}
+
+/**
+ * Raised by runAgentLoop when the child's turn settled with an assistant error.
+ * Exists solely to carry the classification across the Effect failure channel to
+ * forkWork's onFailure — that is the only place AgentOutcome is built, and the
+ * typed error is not reachable from there. Deliberately a plain Error subclass:
+ * Cause.pretty renders it byte-identically to `new Error(message)`, so the human
+ * `error` string is unchanged.
+ */
+class AssistantSettledError extends Error {
+  constructor(
+    message: string,
+    readonly failure: FailureInfo,
+  ) {
+    super(message)
+  }
+}
 
 export interface SpawnInput {
   mode: SpawnMode
@@ -274,7 +354,15 @@ export const layer = Layer.effect(
       // duplicating the result downstream. See spec §5.2.
       const info = (result as MessageV2.WithParts | undefined)?.info
       if (info?.role === "assistant" && info.error) {
-        return yield* Effect.fail(new Error(`Actor assistant failed: ${info.error.name}`))
+        // Classify HERE: `info.error` is the persisted, already-normalized named
+        // error. Downstream (forkWork's onFailure) only has Cause.pretty's string,
+        // so re-deriving the class there would mean re-parsing prose.
+        return yield* Effect.fail(
+          new AssistantSettledError(
+            `Actor assistant failed: ${info.error.name}`,
+            classifyAssistantError(info.error),
+          ),
+        )
       }
       const structured = info?.role === "assistant" ? info.structured : undefined
       const finalText =
@@ -642,10 +730,18 @@ export const layer = Layer.effect(
               Effect.gen(function* () {
                 const cancelled = Cause.hasInterruptsOnly(cause)
                 const error = Cause.pretty(cause)
+                // Recover the classification runAgentLoop attached. Squash is the
+                // established idiom here (see session/prompt.ts, tool/shell-wrap.ts).
+                // A failure raised anywhere else carries none, and the field stays
+                // absent rather than being guessed from `error`.
+                const squashed = Cause.squash(cause)
+                const failure = squashed instanceof AssistantSettledError ? squashed.failure : undefined
                 yield* notify(cancelled ? "cancelled" : "failed", cancelled ? {} : { error })
                 yield* Deferred.succeed(
                   outcome,
-                  cancelled ? { status: "cancelled" as const } : { status: "failure" as const, error },
+                  cancelled
+                    ? { status: "cancelled" as const }
+                    : { status: "failure" as const, error, ...(failure ? { failure } : {}) },
                 )
                 yield* Effect.sync(() => forkContexts.delete(input.actorID))
               }),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -275,10 +275,6 @@ const InfoSchema = Schema.Struct({
       reserved: Schema.optional(NonNegativeInt).annotate({
         description: "Token buffer reserved for checkpoint operations. Default: 20000.",
       }),
-      max_writer_failures: Schema.optional(PositiveInt).annotate({
-        description:
-          "Maximum consecutive writer failures per session before checkpointing stops retrying until process restart. Default: 3.",
-      }),
       fork: Schema.optional(Schema.Boolean).annotate({
         description:
           "Whether to fork the parent agent's message prefix into the writer session for prefix-cache reuse. Requires provider cache-breakpoint support. Default: false.",

--- a/packages/opencode/src/session/checkpoint-align.ts
+++ b/packages/opencode/src/session/checkpoint-align.ts
@@ -10,8 +10,11 @@ type AlignMsg = {
  *
  * Used to align a delta slice's start so the LLM does not see an orphan
  * tool_result. If no qualifying message exists in `[0, idx]`, returns 0
- * (caller may still receive an LLM rejection, in which case writerFailures
- * increments via the existing path — degenerate sessions only).
+ * (caller may still receive an LLM rejection; that surfaces as a writer
+ * failure, which increments writerFailures only once prune's retry watcher
+ * observes the writer SETTLE — a rejection landing past the watcher's wait
+ * bound is still booked, but the watcher's wait is capped, so a writer that
+ * never settles at all is counted nowhere — degenerate sessions only).
  *
  * If `idx` is past the end of `msgs`, returns `idx` unchanged: the empty
  * delta is a legitimate (post-watermark) state.

--- a/packages/opencode/src/session/checkpoint-align.ts
+++ b/packages/opencode/src/session/checkpoint-align.ts
@@ -11,10 +11,8 @@ type AlignMsg = {
  * Used to align a delta slice's start so the LLM does not see an orphan
  * tool_result. If no qualifying message exists in `[0, idx]`, returns 0
  * (caller may still receive an LLM rejection; that surfaces as a writer
- * failure, which increments writerFailures only once prune's retry watcher
- * observes the writer SETTLE — a rejection landing past the watcher's wait
- * bound is still booked, but the watcher's wait is capped, so a writer that
- * never settles at all is counted nowhere — degenerate sessions only).
+ * failure, which leaves the previous checkpoint and its watermark in place, so
+ * the next threshold crossing re-covers the same delta).
  *
  * If `idx` is past the end of `msgs`, returns `idx` unchanged: the empty
  * delta is a legitimate (post-watermark) state.

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -7,7 +7,7 @@ import { Memory } from "@/memory"
 import { MemoryFtsTable } from "@/memory/fts.sql"
 import { TaskRegistry } from "@/task/registry"
 import { ActorRegistry } from "@/actor/registry"
-import type { AgentOutcome, ForkContext } from "@/actor/spawn"
+import type { AgentOutcome, FailureInfo, ForkContext } from "@/actor/spawn"
 import { spawnRef } from "@/actor/spawn-ref"
 import { prefixCaptureRef } from "./prefix-capture-ref"
 import { Database, and, eq, or } from "@/storage"
@@ -431,6 +431,20 @@ export interface Interface {
   readonly waitForWriter: (sessionID: SessionID) => Effect.Effect<WriterOutcome | "no-writer">
 
   /**
+   * The same bounded wait as `waitForWriter`, additionally surfacing the
+   * failure classification the writer's outcome already carries.
+   *
+   * `waitForWriter` is #1938's contract — three flat values, one of which
+   * ("timeout") means "still in flight". That contract is deliberately left
+   * alone; this is the shape a caller needs when the CLASS of a failure
+   * changes what it does next (prune's recovery gate). Both are one
+   * implementation: `waitForWriter` projects `.outcome` off this, so the two
+   * can never disagree about what a settled writer did.
+   */
+  readonly waitForWriterSettlement: (sessionID: SessionID) => Effect.Effect<WriterSettlement>
+
+
+  /**
    * Await all in-flight writers across sessions up to `timeoutMs`. Used by
    * the CLI shutdown path so headless `mimo run` invocations don't exit
    * while a forked checkpoint writer is still waiting on its LLM round-trip.
@@ -518,6 +532,22 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Se
 // unsuccessfully). See waitForWriter for why conflating the two silently
 // disables checkpointing for a session whose writers are merely slow.
 export type WriterOutcome = "success" | "failure" | "timeout"
+
+/**
+ * A settled (or bound-expired) writer, plus the classification its
+ * AgentOutcome already carried.
+ *
+ * `failure` is present only when `outcome === "failure"` AND the writer's
+ * error was classifiable at the construction site. It is absent for a
+ * cancelled writer and for a failure whose error never reached
+ * classifyAssistantError — so "absent" means "unknown class", never
+ * "retryable".
+ */
+export type WriterSettlement = {
+  outcome: WriterOutcome | "no-writer"
+  failure?: FailureInfo
+}
+
 
 interface WriterState {
   // Holds the AgentOutcome Deferred returned by Actor.spawn so callers can
@@ -1007,9 +1037,11 @@ export const layer: Layer.Layer<
       return "started" as const
     })
 
-    const waitForWriter = Effect.fn("SessionCheckpoint.waitForWriter")(function* (sessionID: SessionID) {
+    const waitForWriterSettlement = Effect.fn("SessionCheckpoint.waitForWriterSettlement")(function* (
+      sessionID: SessionID,
+    ) {
       const state = writers.get(sessionID)
-      if (!state) return "no-writer" as const
+      if (!state) return { outcome: "no-writer" as const }
 
       // v2 writers manage 3 file types and frequently take 60-180s, so the
       // wait is bounded at 5min rather than left unbounded. AgentOutcome →
@@ -1024,9 +1056,9 @@ export const layer: Layer.Layer<
       // last_checkpoint_message_id after we stop waiting. Reporting "failure"
       // here made a slow-but-working writer indistinguishable from a broken
       // one, which is why the two outcomes stay distinct. Callers must be able
-      // to tell "still in flight" from "settled unsuccessfully"; prune's only
-      // use of this wait is to make the expiry below observable, and it books
-      // no outcome either way (see prune.ts).
+      // to tell "still in flight" from "settled unsuccessfully": prune arms its
+      // recovery gate on a settled TRANSIENT failure only, and "timeout" must
+      // never reach that gate — the writer may still be about to succeed.
       const outcome = yield* Deferred.await(state.writing).pipe(
         Effect.timeout(300_000),
         Effect.catch(() => Effect.succeed("timeout" as const)),
@@ -1039,10 +1071,25 @@ export const layer: Layer.Layer<
           sessionID,
           boundMs: 300_000,
         })
-        return "timeout" as const
+        return { outcome: "timeout" as const }
       }
-      return outcome.status === "success" ? ("success" as const) : ("failure" as const)
+      if (outcome.status === "success") return { outcome: "success" as const }
+      // `failure` is optional and its source is nullable — truthiness, never
+      // `=== undefined` (AGENTS.md, "Reading a nullable column"). A cancelled
+      // outcome has no failure arm at all, so it lands here unclassified.
+      const failure = outcome.status === "failure" ? outcome.failure : undefined
+      return failure ? { outcome: "failure" as const, failure } : { outcome: "failure" as const }
     })
+
+    // #1938's contract, unchanged: three flat values, "timeout" distinct from
+    // "failure". Projected off waitForWriterSettlement rather than duplicated,
+    // so the classification-aware caller and this one can never disagree.
+    const waitForWriter: (sessionID: SessionID) => Effect.Effect<WriterOutcome | "no-writer"> = Effect.fn(
+      "SessionCheckpoint.waitForWriter",
+    )(function* (sessionID: SessionID) {
+      return (yield* waitForWriterSettlement(sessionID)).outcome
+    })
+
 
     const drainWriters = Effect.fn("SessionCheckpoint.drainWriters")(function* (input?: { timeoutMs?: number }) {
       const timeoutMs = input?.timeoutMs ?? 120_000
@@ -1604,6 +1651,7 @@ export const layer: Layer.Layer<
     return Service.of({
       tryStartCheckpointWriter,
       waitForWriter,
+      waitForWriterSettlement,
       drainWriters,
       hasCheckpoint,
       hasMemoryOrTasks,

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -982,13 +982,14 @@ export const layer: Layer.Layer<
       const state = writers.get(sessionID)
       if (!state) return "no-writer" as const
 
-      // v2 writers manage 3 file types and frequently take 60-180s; pad to
-      // 5min so a long-but-honest writer is not mistaken for a failure by
-      // the prune retry watcher. AgentOutcome → WriterOutcome translation:
-      // success → "success", failure / cancelled → "failure".
+      // v2 writers manage 3 file types and frequently take 60-180s, so the
+      // wait is bounded at 5min rather than left unbounded. AgentOutcome →
+      // WriterOutcome translation: success → "success", failure / cancelled →
+      // "failure", bound expired with the writer still unsettled → "timeout".
       //
-      // The bound expiring is NOT a writer failure. This timeout does not
-      // cancel the writer, and the settle watcher that owns the watermark
+      // The bound expiring is NOT a writer failure — the padding is not what
+      // keeps the two apart, the distinct return value is. This timeout does
+      // not cancel the writer, and the settle watcher that owns the watermark
       // advance (see tryStartCheckpointWriter) awaits the SAME Deferred with no
       // bound — so a slow-but-successful writer still advances
       // last_checkpoint_message_id after we stop waiting. Reporting "failure"
@@ -996,13 +997,23 @@ export const layer: Layer.Layer<
       // and MAX_WRITER_FAILURES such waits then tripped "gave up after max
       // consecutive failures", permanently disabling checkpointing for a
       // session whose every writer had actually succeeded. Report "timeout" so
-      // callers can distinguish "still in flight" from "settled unsuccessfully"
-      // (prune's `result !== "failure"` guard already skips the counter).
+      // callers can distinguish "still in flight" from "settled unsuccessfully";
+      // prune's `result !== "failure"` guard skips the counter, and prune keeps
+      // waiting so the writer's real outcome is still booked (see prune.ts).
       const outcome = yield* Deferred.await(state.writing).pipe(
         Effect.timeout(300_000),
         Effect.catch(() => Effect.succeed("timeout" as const)),
       )
-      if (outcome === "timeout") return "timeout" as const
+      if (outcome === "timeout") {
+        // Hitting the bound must stay observable: the caller reports neither a
+        // success nor a failure, so without this line a writer stuck past 5min
+        // produces no log at all until it finally settles.
+        log.info("checkpoint writer wait bound expired — writer still in flight", {
+          sessionID,
+          boundMs: 300_000,
+        })
+        return "timeout" as const
+      }
       return outcome.status === "success" ? ("success" as const) : ("failure" as const)
     })
 

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -927,10 +927,39 @@ export const layer: Layer.Layer<
             ),
           )
         } else {
-          log.warn("checkpoint writer did not succeed — leaving watermark unchanged so the delta is re-covered", {
-            sessionID: input.sessionID,
-            status: outcome.status,
-          })
+          // Classify instead of count. This is the replacement for the failure
+          // accounting deleted earlier in this branch: the same "is this writer
+          // broken?" question, answered by reading the outcome the writer already
+          // carries instead of accumulating a tally across thresholds.
+          //
+          // A TRANSIENT failure needs nothing here — the writer's LLM calls run
+          // through SessionRetry's ladder (session/retry.ts), so it is already
+          // post-retry, and the next threshold crossing re-covers the delta with
+          // fresher context. A DETERMINISTIC one (overflow / auth / bad request)
+          // will recur identically at every future threshold, so it is reported
+          // as the distinct thing it is rather than as one more copy of an
+          // undifferentiated line.
+          //
+          // Deliberately STATELESS: no per-session memory of previous failures.
+          // Such memory is a trend detector, and the trend is the deferred
+          // user-facing-warning change's own state — accumulating it here under a
+          // new name is precisely what this branch removed.
+          // `failure` is optional and its source is nullable — truthiness, never
+          // `=== undefined` (AGENTS.md, "Reading a nullable column").
+          const failure = outcome.status === "failure" ? outcome.failure : undefined
+          const classified = failure ? { kind: failure.kind, cause: failure.name } : {}
+          if (failure && !failure.retryable) {
+            log.warn(
+              "checkpoint writer failed deterministically — this will recur at every threshold until the cause is fixed; leaving watermark unchanged so the delta is re-covered",
+              { sessionID: input.sessionID, status: outcome.status, ...classified },
+            )
+          } else {
+            log.warn("checkpoint writer did not succeed — leaving watermark unchanged so the delta is re-covered", {
+              sessionID: input.sessionID,
+              status: outcome.status,
+              ...classified,
+            })
+          }
         }
 
         // F40: capture pending before deleting the slot so a queued writer

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -993,13 +993,11 @@ export const layer: Layer.Layer<
       // advance (see tryStartCheckpointWriter) awaits the SAME Deferred with no
       // bound — so a slow-but-successful writer still advances
       // last_checkpoint_message_id after we stop waiting. Reporting "failure"
-      // here made the prune retry watcher count a working writer as broken,
-      // and MAX_WRITER_FAILURES such waits then tripped "gave up after max
-      // consecutive failures", permanently disabling checkpointing for a
-      // session whose every writer had actually succeeded. Report "timeout" so
-      // callers can distinguish "still in flight" from "settled unsuccessfully";
-      // prune's `result !== "failure"` guard skips the counter, and prune keeps
-      // waiting so the writer's real outcome is still booked (see prune.ts).
+      // here made a slow-but-working writer indistinguishable from a broken
+      // one, which is why the two outcomes stay distinct. Callers must be able
+      // to tell "still in flight" from "settled unsuccessfully"; prune's only
+      // use of this wait is to make the expiry below observable, and it books
+      // no outcome either way (see prune.ts).
       const outcome = yield* Deferred.await(state.writing).pipe(
         Effect.timeout(300_000),
         Effect.catch(() => Effect.succeed("timeout" as const)),

--- a/packages/opencode/src/session/prune.ts
+++ b/packages/opencode/src/session/prune.ts
@@ -24,12 +24,6 @@ const DEFAULT_CACHE_TTL = 300_000
 // Default safety buffer subtracted from windowSize to derive maxAllowed for
 // checkpoint thresholds. Users can override via cfg.checkpoint.reserved.
 const CHECKPOINT_RESERVED = 13_000
-const MAX_WRITER_FAILURES = 3
-// How many times the retry watcher re-enters the bounded waitForWriter (5min
-// each) before it stops waiting for a writer that has not settled. Caps the
-// watcher fiber's lifetime at ~1h so a permanently stuck writer cannot pin it
-// for the life of the process.
-const MAX_WRITER_WAIT_EXTENSIONS = 12
 
 /**
  * Default checkpoint thresholds by context window size.
@@ -175,11 +169,6 @@ export const layer: Layer.Layer<
     // Per-session signal: the max threshold was just crossed; prompt.ts should
     // trigger discard+rebuild on the next loop iteration.
     const maxCrossed = new Set<SessionID>()
-    // Per-session consecutive writer-failure count. Resets on success.
-    // After the configured `max_writer_failures` (default MAX_WRITER_FAILURES)
-    // consecutive failures, the session stops retrying checkpoint writes
-    // until the process restarts.
-    const writerFailures = new Map<SessionID, number>()
 
     const stripNonEssential = Effect.fn("SessionPrune.stripNonEssential")(function* (input: {
       sessionID: SessionID
@@ -277,8 +266,6 @@ export const layer: Layer.Layer<
       const thresholds = resolveThresholds(raw, windowSize, cfg.checkpoint?.reserved)
       if (thresholds.length === 0) return
 
-      const maxFailures = cfg.checkpoint?.max_writer_failures ?? MAX_WRITER_FAILURES
-
       const currentTokens =
         input.tokens.total ||
         input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write
@@ -299,79 +286,31 @@ export const layer: Layer.Layer<
           .pipe(Effect.catch(() => Effect.succeed<"started" | "queued" | "skipped">("skipped")))
 
         if (outcome === "started") {
-          // Fork a watcher that settles after the detached writer fiber
-          // finishes. On success, clear the failure counter. On failure,
-          // increment the counter; if below MAX_WRITER_FAILURES, clear the
-          // session's crossed thresholds so the next iteration retries. The
-          // wait is extended across bound expiries so what gets booked is the
-          // writer's REAL outcome, never the mere fact that it was slow.
+          // Observation only — no accounting, no in-place retry. A failed
+          // write is self-healing, so there is nothing to book:
+          //   - ensureCheckpointTemplate (checkpoint.ts:117-121) writes the
+          //     template ONLY when the file is absent, so a failed writer
+          //     cannot clobber the previous checkpoint.
+          //   - last_checkpoint_message_id advances ONLY on success
+          //     (checkpoint.ts:918-934).
+          // A failure therefore leaves file and watermark mutually consistent,
+          // both pointing at the last good checkpoint, and a rebuild uses that
+          // automatically. The cost of a failure is a STALER checkpoint, never
+          // a missing one, and the next threshold crossing is a natural retry
+          // with fresher context than an in-place one. Repeated failures mean
+          // the provider is broken — in which case the foreground turns are
+          // failing too and the user already knows. The writer's LLM calls run
+          // through the same retry ladder as the foreground (retry.ts), so any
+          // failure reaching here is already post-retry; counting it again adds
+          // nothing.
           //
-          // Known narrow race: between tryStartCheckpointWriter returning "started" and
-          // the watcher's forkDetach scheduling, a very-fast writer fiber can
-          // complete and delete itself from the writers map. waitForWriter
-          // then returns "no-writer" and the watcher exits without touching
-          // the counter. Impact is low — real writers run an LLM round-trip
-          // (seconds) vs. microseconds to schedule the fork, so observable
-          // failures tick the counter in practice. Proper fix: have
-          // tryStartCheckpointWriter return the Deferred handle so the watcher doesn't
-          // re-read the writers map.
-          yield* Effect.gen(function* () {
-            // waitForWriter is bounded (5min). Expiry means "still in flight",
-            // not "failed" — but returning here would book the writer's real
-            // outcome NOWHERE: this fiber is the only thing holding the
-            // per-fire accounting, and writerFailures is private to this
-            // layer, so the checkpoint settle watcher cannot reach it. A
-            // writer that genuinely fails at, say, 400s would then never tick
-            // the counter (making the cap unreachable for exactly the slow
-            // regime that motivated the "timeout" outcome), and a writer that
-            // succeeds at 400s would never CLEAR a counter left at 1-2 by
-            // earlier fast failures. So keep waiting across bound expiries and
-            // account for the settled result.
-            //
-            // Each extension re-enters waitForWriter, which re-reads the
-            // writers map. Two microsecond-wide windows are accepted rather
-            // than papered over: (1) the writer settles between our expiry and
-            // the re-entry, so the entry is gone and we get "no-writer" — no
-            // outcome to attribute, same as the pre-existing fast-writer race
-            // noted above; (2) a queued writer was drained into a fresh entry in
-            // that window, so we book ITS outcome instead — still a real
-            // outcome for this session. Extensions are capped so a permanently
-            // stuck writer cannot hold this fiber forever.
-            let result = yield* checkpoint.waitForWriter(input.sessionID)
-            for (let extension = 1; result === "timeout"; extension++) {
-              if (extension > MAX_WRITER_WAIT_EXTENSIONS) {
-                log.warn("checkpoint writer still in flight after max wait extensions — stopped waiting", {
-                  sessionID: input.sessionID,
-                  extensions: MAX_WRITER_WAIT_EXTENSIONS,
-                })
-                return
-              }
-              result = yield* checkpoint.waitForWriter(input.sessionID)
-            }
-            if (result === "success") {
-              writerFailures.delete(input.sessionID)
-              return
-            }
-            // Only "no-writer" reaches here besides "failure": the writer
-            // settled before we could observe it, so there is nothing to book.
-            if (result !== "failure") return
-            const next = (writerFailures.get(input.sessionID) ?? 0) + 1
-            writerFailures.set(input.sessionID, next)
-            if (next < maxFailures) {
-              crossed.delete(input.sessionID)
-              maxCrossed.delete(input.sessionID)
-              log.info("checkpoint writer failed — cleared thresholds for retry", {
-                sessionID: input.sessionID,
-                attempt: next,
-                maxAttempts: maxFailures,
-              })
-            } else {
-              log.warn("checkpoint writer gave up after max consecutive failures", {
-                sessionID: input.sessionID,
-                maxAttempts: maxFailures,
-              })
-            }
-          }).pipe(Effect.forkDetach)
+          // The wait is kept for ONE reason: the bound-expiry log inside
+          // waitForWriter (checkpoint.ts:1007-1015). A writer stuck past the
+          // 5min bound otherwise leaves no trace at all until it settles, and a
+          // log line exactly like it is what diagnosed #1938. Terminal outcomes
+          // are already logged by the settle watcher (checkpoint.ts:920-934),
+          // so the returned outcome is deliberately discarded here.
+          yield* checkpoint.waitForWriter(input.sessionID).pipe(Effect.forkDetach)
         }
 
         already.add(t)

--- a/packages/opencode/src/session/prune.ts
+++ b/packages/opencode/src/session/prune.ts
@@ -71,6 +71,16 @@ export function parseThreshold(s: string, windowSize: number): number {
 }
 
 /**
+ * The highest token count at which a checkpoint write is still meaningful:
+ * the window minus the safety buffer. Thresholds are clamped to it, and it is
+ * also the hard ceiling on prune's post-failure recovery gate — past this
+ * point there is no room left in the window for another attempt.
+ */
+export function maxAllowedFor(windowSize: number, reserved?: number): number {
+  return windowSize - (reserved ?? CHECKPOINT_RESERVED)
+}
+
+/**
  * Parse, validate, sort, and deduplicate checkpoint thresholds.
  *
  * - Values ≤ maxAllowed pass through.
@@ -82,7 +92,7 @@ export function parseThreshold(s: string, windowSize: number): number {
  */
 export function resolveThresholds(raw: readonly string[], windowSize: number, reserved?: number): number[] {
   const effectiveReserved = reserved ?? CHECKPOINT_RESERVED
-  const maxAllowed = windowSize - effectiveReserved
+  const maxAllowed = maxAllowedFor(windowSize, reserved)
   if (maxAllowed <= 0) {
     throw new Error(
       `Model window size (${windowSize}) is too small for checkpoints ` +
@@ -169,6 +179,15 @@ export const layer: Layer.Layer<
     // Per-session signal: the max threshold was just crossed; prompt.ts should
     // trigger discard+rebuild on the next loop iteration.
     const maxCrossed = new Set<SessionID>()
+    // Per-session RECOVERY GATE: the token count at or above which the FINAL
+    // threshold is allowed to fire a second time, armed only when that
+    // threshold's writer settled with a TRANSIENT failure.
+    //
+    // This is a position on the token axis, not a tally of failures. It is
+    // overwritten rather than accumulated, its value is derived from the
+    // threshold ladder and the window, and it is dropped the moment it fires.
+    // See the arming site below for why that distinction is the whole design.
+    const finalRetryAt = new Map<SessionID, number>()
 
     const stripNonEssential = Effect.fn("SessionPrune.stripNonEssential")(function* (input: {
       sessionID: SessionID
@@ -272,10 +291,31 @@ export const layer: Layer.Layer<
 
       const already = crossed.get(input.sessionID) ?? new Set<number>()
       const maxThreshold = thresholds[thresholds.length - 1]
+      // The ladder's own spacing: the token growth the design already accepts
+      // as worth one writer. Used below as the recovery gate's step so a retry
+      // can never fire faster than a normal threshold would have.
+      const step = thresholds.length > 1 ? maxThreshold - thresholds[thresholds.length - 2] : maxThreshold
+      const maxAllowed = maxAllowedFor(windowSize, cfg.checkpoint?.reserved)
 
       for (const t of thresholds) {
         if (currentTokens < t) break // sorted ascending; nothing more to trigger
-        if (already.has(t)) continue
+        if (already.has(t)) {
+          // The FINAL threshold is the only one that may fire twice, and only
+          // once its recovery gate has been reached. Every other threshold has
+          // a successor in the ladder, which is its retry.
+          const gate = finalRetryAt.get(input.sessionID)
+          if (t !== maxThreshold || gate == null || currentTokens < gate) continue
+          // Consume the gate before firing: one gate is one attempt. A further
+          // transient failure re-arms it a step higher (below), which is what
+          // makes the retry budget the remaining window rather than a count.
+          finalRetryAt.delete(input.sessionID)
+          log.info("checkpoint recovery gate reached — re-firing the final threshold", {
+            sessionID: input.sessionID,
+            threshold: t,
+            gate,
+            currentTokens,
+          })
+        }
 
         const outcome = yield* checkpoint
           .tryStartCheckpointWriter({
@@ -286,31 +326,97 @@ export const layer: Layer.Layer<
           .pipe(Effect.catch(() => Effect.succeed<"started" | "queued" | "skipped">("skipped")))
 
         if (outcome === "started") {
-          // Observation only — no accounting, no in-place retry. A failed
+          // No accounting, no in-place retry on an arbitrary threshold. A failed
           // write is self-healing, so there is nothing to book:
           //   - ensureCheckpointTemplate (checkpoint.ts:117-121) writes the
           //     template ONLY when the file is absent, so a failed writer
           //     cannot clobber the previous checkpoint.
           //   - last_checkpoint_message_id advances ONLY on success
-          //     (checkpoint.ts:918-934).
+          //     (checkpoint.ts:954).
           // A failure therefore leaves file and watermark mutually consistent,
           // both pointing at the last good checkpoint, and a rebuild uses that
           // automatically. The cost of a failure is a STALER checkpoint, never
-          // a missing one, and the next threshold crossing is a natural retry
+          // a missing one, and the NEXT THRESHOLD CROSSING is a natural retry
           // with fresher context than an in-place one. Repeated failures mean
-          // the provider is broken — in which case the foreground turns are
-          // failing too and the user already knows. The writer's LLM calls run
-          // through the same retry ladder as the foreground (retry.ts), so any
-          // failure reaching here is already post-retry; counting it again adds
-          // nothing.
+          // the provider is broken — the writer runs on the SAME model the
+          // foreground turn passed in (this call's `model`, which wins over any
+          // agent-configured model at prompt.ts's `inputModel ?? agentModel`),
+          // so the user's own turns are failing too and they already know. The
+          // writer's LLM calls also run through the same retry ladder as the
+          // foreground (retry.ts), so any failure reaching here is already
+          // post-retry; counting it again adds nothing.
           //
-          // The wait is kept for ONE reason: the bound-expiry log inside
-          // waitForWriter (checkpoint.ts:1007-1015). A writer stuck past the
-          // 5min bound otherwise leaves no trace at all until it settles, and a
-          // log line exactly like it is what diagnosed #1938. Terminal outcomes
-          // are already logged by the settle watcher (checkpoint.ts:920-934),
-          // so the returned outcome is deliberately discarded here.
-          yield* checkpoint.waitForWriter(input.sessionID).pipe(Effect.forkDetach)
+          // WHAT THAT ARGUMENT DOES NOT COVER — the FINAL threshold. "The next
+          // threshold is the retry" presumes a next threshold; the last one has
+          // none. Its only would-be successor is the discard+rebuild that
+          // maxThresholdCrossed triggers, because a successful rebuild calls
+          // resetThresholds (prompt.ts:428) and re-arms the whole ladder. But
+          // rebuildFromCheckpoint returns false when lastBoundary is unset
+          // (prompt.ts:413), and the watermark is unset precisely when no
+          // writer has EVER succeeded — so in the one case that needs recovery
+          // most, there is no reset, no further crossing, and the session never
+          // checkpoints again until overflow.
+          //
+          // So the final threshold gets a gate, on two conditions that between
+          // them replace the deleted counter:
+          //   1. CLASS, not history — arm only when the settled failure is
+          //      retryable. A deterministic one (overflow / auth / bad request)
+          //      recurs identically, so re-firing is pure waste; an unclassified
+          //      one carries no evidence a retry helps, so it is treated the
+          //      same. This reads ONLY this failure, so it needs no memory.
+          //   2. PROGRESS, not attempts — the gate sits one ladder STEP above
+          //      the token count that fired, clamped to maxAllowed. A retry can
+          //      therefore never fire faster than a normal threshold would, the
+          //      number of retries is whatever the remaining window affords
+          //      (zero once firedAt + step is past maxAllowed), and a
+          //      conversation that stops growing stops retrying by itself.
+          // Neither condition accumulates anything across attempts, which is
+          // what makes this a gate rather than MAX_WRITER_FAILURES renamed.
+          //
+          // The wait is also still what makes a stuck writer observable: the
+          // bound-expiry log inside waitForWriterSettlement. A writer stuck past
+          // the 5min bound otherwise leaves no trace at all until it settles,
+          // and a log line exactly like it is what diagnosed #1938. Terminal
+          // outcomes are already logged by the settle watcher, so nothing else
+          // is reported from here.
+          const isFinal = t === maxThreshold
+          const firedAt = currentTokens
+          yield* Effect.gen(function* () {
+            const settled = yield* checkpoint.waitForWriterSettlement(input.sessionID)
+            if (!isFinal) return
+            // "timeout" means STILL IN FLIGHT — the writer may yet succeed and
+            // advance the watermark, so it must not arm anything.
+            if (settled.outcome !== "failure") return
+            // Truthiness, not `=== undefined` (AGENTS.md, "Reading a nullable
+            // column"): absent classification is "unknown", not "retryable".
+            if (!settled.failure?.retryable) {
+              log.info("final checkpoint threshold failed without a retryable class — no recovery gate armed", {
+                sessionID: input.sessionID,
+                threshold: t,
+                kind: settled.failure?.kind,
+                cause: settled.failure?.name,
+              })
+              return
+            }
+            const gate = Math.min(firedAt + step, maxAllowed)
+            if (gate <= firedAt) {
+              log.info("final checkpoint threshold failed transiently but the window has no room left for a retry", {
+                sessionID: input.sessionID,
+                threshold: t,
+                firedAt,
+                maxAllowed,
+              })
+              return
+            }
+            finalRetryAt.set(input.sessionID, gate)
+            log.info("final checkpoint threshold failed transiently — recovery gate armed", {
+              sessionID: input.sessionID,
+              threshold: t,
+              firedAt,
+              gate,
+              kind: settled.failure.kind,
+            })
+          }).pipe(Effect.forkDetach)
         }
 
         already.add(t)
@@ -423,6 +529,10 @@ export const layer: Layer.Layer<
     const resetThresholds = Effect.fn("SessionPrune.resetThresholds")(function* (sessionID: SessionID) {
       crossed.delete(sessionID)
       maxCrossed.delete(sessionID)
+      // A rebuild re-arms the whole ladder, which supersedes any pending
+      // recovery gate — leaving it set would let the (now re-armable) final
+      // threshold fire out of order.
+      finalRetryAt.delete(sessionID)
     })
 
     return Service.of({ prune, fireCheckpoints, maxThresholdCrossed, resetThresholds })

--- a/packages/opencode/src/session/prune.ts
+++ b/packages/opencode/src/session/prune.ts
@@ -25,6 +25,11 @@ const DEFAULT_CACHE_TTL = 300_000
 // checkpoint thresholds. Users can override via cfg.checkpoint.reserved.
 const CHECKPOINT_RESERVED = 13_000
 const MAX_WRITER_FAILURES = 3
+// How many times the retry watcher re-enters the bounded waitForWriter (5min
+// each) before it stops waiting for a writer that has not settled. Caps the
+// watcher fiber's lifetime at ~1h so a permanently stuck writer cannot pin it
+// for the life of the process.
+const MAX_WRITER_WAIT_EXTENSIONS = 12
 
 /**
  * Default checkpoint thresholds by context window size.
@@ -297,7 +302,9 @@ export const layer: Layer.Layer<
           // Fork a watcher that settles after the detached writer fiber
           // finishes. On success, clear the failure counter. On failure,
           // increment the counter; if below MAX_WRITER_FAILURES, clear the
-          // session's crossed thresholds so the next iteration retries.
+          // session's crossed thresholds so the next iteration retries. The
+          // wait is extended across bound expiries so what gets booked is the
+          // writer's REAL outcome, never the mere fact that it was slow.
           //
           // Known narrow race: between tryStartCheckpointWriter returning "started" and
           // the watcher's forkDetach scheduling, a very-fast writer fiber can
@@ -309,15 +316,44 @@ export const layer: Layer.Layer<
           // tryStartCheckpointWriter return the Deferred handle so the watcher doesn't
           // re-read the writers map.
           yield* Effect.gen(function* () {
-            const result = yield* checkpoint.waitForWriter(input.sessionID)
+            // waitForWriter is bounded (5min). Expiry means "still in flight",
+            // not "failed" — but returning here would book the writer's real
+            // outcome NOWHERE: this fiber is the only thing holding the
+            // per-fire accounting, and writerFailures is private to this
+            // layer, so the checkpoint settle watcher cannot reach it. A
+            // writer that genuinely fails at, say, 400s would then never tick
+            // the counter (making the cap unreachable for exactly the slow
+            // regime that motivated the "timeout" outcome), and a writer that
+            // succeeds at 400s would never CLEAR a counter left at 1-2 by
+            // earlier fast failures. So keep waiting across bound expiries and
+            // account for the settled result.
+            //
+            // Each extension re-enters waitForWriter, which re-reads the
+            // writers map. Two microsecond-wide windows are accepted rather
+            // than papered over: (1) the writer settles between our expiry and
+            // the re-entry, so the entry is gone and we get "no-writer" — no
+            // outcome to attribute, same as the pre-existing fast-writer race
+            // noted above; (2) a queued writer was drained into a fresh entry in
+            // that window, so we book ITS outcome instead — still a real
+            // outcome for this session. Extensions are capped so a permanently
+            // stuck writer cannot hold this fiber forever.
+            let result = yield* checkpoint.waitForWriter(input.sessionID)
+            for (let extension = 1; result === "timeout"; extension++) {
+              if (extension > MAX_WRITER_WAIT_EXTENSIONS) {
+                log.warn("checkpoint writer still in flight after max wait extensions — stopped waiting", {
+                  sessionID: input.sessionID,
+                  extensions: MAX_WRITER_WAIT_EXTENSIONS,
+                })
+                return
+              }
+              result = yield* checkpoint.waitForWriter(input.sessionID)
+            }
             if (result === "success") {
               writerFailures.delete(input.sessionID)
               return
             }
-            // "no-writer" and "timeout" both mean "not a settled failure". A
-            // timed-out wait leaves the writer in flight (and still able to
-            // advance the watermark), so counting it would retire a
-            // merely-slow-but-working writer. Only a real failure ticks below.
+            // Only "no-writer" reaches here besides "failure": the writer
+            // settled before we could observe it, so there is nothing to book.
             if (result !== "failure") return
             const next = (writerFailures.get(input.sessionID) ?? 0) + 1
             writerFailures.set(input.sessionID, next)

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/config.md
@@ -123,7 +123,6 @@ The trigger is the model's prompt capacity (`limit.input` when the provider publ
 | `compaction.max_context` | Compact earlier than the model window. One value for all models, or a map keyed `"<providerID>/<modelID>"` (wildcards allowed, longest pattern wins). Values: token count, `"300K"`, `"1M"`, or `"50%"` of the window. Always clamped to the provider cap — can only lower the trigger, never raise it. `0` = no budget. Set it from the TUI with `/context-limit` |
 | `checkpoint.thresholds` | Context-fill triggers, e.g. `["40%","60%","80%"]` |
 | `checkpoint.reserved` | Token buffer for checkpoint ops (default 20000) |
-| `checkpoint.max_writer_failures` | Consecutive writer failures before pausing (default 3) |
 | `checkpoint.fork` | Fork parent prefix into writer session for cache reuse (default false) |
 | `checkpoint.push_caps.*` | Per-section token caps for rebuild context (tasks_ledger, focus_task, checkpoint, memory, notes, global, recent_user, …) |
 | `checkpoint.task_archive_days` | Days before done/abandoned tasks filtered out (default 7) |

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -121,7 +121,7 @@ const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const run = SessionRunState.layer.pipe(Layer.provide(status))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
 
-function makeLayer() {
+function makeLayer(opts?: { settledError: () => NonNullable<MessageV2.Assistant["error"]> | undefined }) {
   const deps = Layer.mergeAll(
     Session.defaultLayer,
     Snapshot.defaultLayer,
@@ -187,7 +187,7 @@ function makeLayer() {
   return Layer.mergeAll(
     TestLLMServer.layer,
     Actor.layer.pipe(
-      Layer.provideMerge(prompt),
+      Layer.provideMerge(opts?.settledError ? settledPromptLayer(opts.settledError, prompt) : prompt),
       Layer.provide(Worktree.defaultLayer),
       Layer.provideMerge(taskRegistry),
       Layer.provide(TaskRegistry.defaultLayer),
@@ -195,6 +195,52 @@ function makeLayer() {
       Layer.provide(Inbox.defaultLayer),
     ),
   ).pipe(Layer.provide(summary))
+}
+
+/**
+ * Failure-classification tests only. Replaces SessionPrompt.prompt so the child's
+ * turn settles with a CHOSEN assistant error, then hands that to the real spawn
+ * machinery. Everything under test downstream of this point is production code:
+ * runAgentLoop's classify call, the failure carrier, Cause.squash in onFailure and
+ * the AgentOutcome assembly. Only the upstream provider round-trip is stood in for,
+ * which is what makes a transient case testable at all — SessionRetry's ladder is
+ * uncapped, so a genuinely retryable provider error never settles on its own.
+ */
+function settledPromptLayer<A, E, R>(
+  settledError: () => NonNullable<MessageV2.Assistant["error"]> | undefined,
+  real: Layer.Layer<A, E, R>,
+) {
+  return Layer.effect(
+    SessionPrompt.Service,
+    Effect.gen(function* () {
+      const inner = yield* SessionPrompt.Service
+      return SessionPrompt.Service.of({
+        ...inner,
+        prompt: (input) => {
+          const settled = settledError()
+          // Truthiness, not `!== undefined` — see AGENTS.md "Reading a nullable column".
+          if (!settled) return inner.prompt(input)
+          const info: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            sessionID: input.sessionID,
+            agentID: input.agentID,
+            role: "assistant",
+            time: { created: Date.now(), completed: Date.now() },
+            error: settled,
+            parentID: MessageID.ascending(),
+            modelID: ModelID.make("test-model"),
+            providerID: ProviderID.make("test"),
+            mode: "build",
+            agent: input.agent ?? "build",
+            path: { cwd: process.cwd(), root: process.cwd() },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          }
+          return Effect.succeed({ info, parts: [] } satisfies MessageV2.WithParts)
+        },
+      })
+    }),
+  ).pipe(Layer.provideMerge(real))
 }
 
 const it = testEffect(makeLayer())
@@ -1342,6 +1388,158 @@ describe("Actor.spawn return-format injection (F21)", () => {
         const subAgentUser = msgs.find((m) => m.info.role === "user" && m.info.agentID === result.actorID)
         const text = subAgentUser?.parts.find((p) => p.type === "text")?.text ?? ""
         expect(text).not.toContain("Return format (required)")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+})
+
+// ---------------------------------------------------------------------------
+// AgentOutcome failure classification (see actor/spawn.ts FailureInfo).
+//
+// The point of these tests is that a consumer can tell a transient failure from
+// a deterministic one WITHOUT string-matching `error`. Both drive the real
+// construction path: runAgentLoop classifies the settled assistant error, raises
+// the carrier, and forkWork's onFailure squashes it back out and assembles the
+// AgentOutcome. Nothing here hand-builds an outcome object.
+// ---------------------------------------------------------------------------
+let settled: NonNullable<MessageV2.Assistant["error"]> | undefined
+const itSettled = testEffect(makeLayer({ settledError: () => settled }))
+
+describe("AgentOutcome failure classification", () => {
+  itSettled.live("a transient provider failure is classified retryable/transient", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const parent = yield* session.create({
+          title: "x",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        // A 429 the provider SDK itself marked retryable — SessionRetry.retryable
+        // returns a status for it, which is the oracle spawn.ts reuses.
+        settled = new MessageV2.APIError(
+          { message: "Too Many Requests", statusCode: 429, isRetryable: true },
+        ).toObject()
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "build",
+          task: "t",
+          context: "none",
+          tools: ["read"],
+          background: false,
+          model: ref,
+        })
+        const outcome = yield* Deferred.await(result.outcome)
+        expect(outcome.status).toBe("failure")
+        if (outcome.status !== "failure") throw new Error("expected failure")
+        // The human string is still there and unchanged.
+        expect(outcome.error).toContain("Actor assistant failed: APIError")
+        // ...and the classification is there alongside it.
+        expect(outcome.failure).toBeTruthy()
+        expect(outcome.failure?.retryable).toBe(true)
+        expect(outcome.failure?.kind).toBe("transient")
+        expect(outcome.failure?.name).toBe("APIError")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  itSettled.live("a deterministic overflow failure is classified non-retryable/overflow", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const parent = yield* session.create({
+          title: "x",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        // Context overflow is the canonical "will recur identically" failure:
+        // ProviderError.isOverflow matched it upstream and SessionRetry.retryable
+        // explicitly refuses to retry it.
+        settled = new MessageV2.ContextOverflowError({
+          message: "Input exceeds context window of this model",
+        }).toObject()
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "build",
+          task: "t",
+          context: "none",
+          tools: ["read"],
+          background: false,
+          model: ref,
+        })
+        const outcome = yield* Deferred.await(result.outcome)
+        expect(outcome.status).toBe("failure")
+        if (outcome.status !== "failure") throw new Error("expected failure")
+        expect(outcome.error).toContain("Actor assistant failed: ContextOverflowError")
+        expect(outcome.failure).toBeTruthy()
+        expect(outcome.failure?.retryable).toBe(false)
+        expect(outcome.failure?.kind).toBe("overflow")
+        expect(outcome.failure?.name).toBe("ContextOverflowError")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  itSettled.live("a rejected credential is classified non-retryable/auth", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const parent = yield* session.create({
+          title: "x",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        settled = new MessageV2.APIError(
+          { message: "Unauthorized", statusCode: 401, isRetryable: false },
+        ).toObject()
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "build",
+          task: "t",
+          context: "none",
+          tools: ["read"],
+          background: false,
+          model: ref,
+        })
+        const outcome = yield* Deferred.await(result.outcome)
+        if (outcome.status !== "failure") throw new Error("expected failure")
+        expect(outcome.failure?.retryable).toBe(false)
+        expect(outcome.failure?.kind).toBe("auth")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  it.live("a failure that never reached a provider carries no classification", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const parent = yield* session.create({
+          title: "x",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* llm.text("done")
+        const result = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: parent.id,
+          agentType: "build",
+          task: "t",
+          context: "none",
+          tools: ["read"],
+          background: false,
+          model: ref,
+        })
+        const outcome = yield* Deferred.await(result.outcome)
+        // A clean turn must not invent a classification; `failure` is only ever
+        // present on a settled-assistant-error failure.
+        if (outcome.status === "failure") expect(outcome.failure == null).toBe(true)
+        else expect(outcome.status).toBe("success")
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/session/checkpoint-child-session.test.ts
+++ b/packages/opencode/test/session/checkpoint-child-session.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
 import { Deferred, Effect, Layer } from "effect"
 import { eq } from "drizzle-orm"
 import { Bus } from "../../src/bus"
@@ -11,6 +13,7 @@ import { spawnRef } from "../../src/actor/spawn-ref"
 import { prefixCaptureRef } from "../../src/session/prefix-capture-ref"
 import { TaskRegistry } from "../../src/task/registry"
 import { SessionCheckpoint } from "../../src/session/checkpoint"
+import { checkpointPath } from "../../src/session/checkpoint-paths"
 import { SessionPrune } from "../../src/session/prune"
 import { Database } from "../../src/storage"
 import { SessionTable, MessageTable } from "../../src/session/session.sql"
@@ -377,9 +380,9 @@ describe("checkpoint writer child-session isolation", () => {
         expect(running).toBe(false)
 
         // Lock cleared → a fresh tryStartCheckpointWriter call can fire a new
-        // writer, proving no permanent gate persists in checkpoint.ts itself.
-        // (writerFailures lives in prune.ts as closure-private state — its
-        // counter is observed indirectly via T10's MAX_WRITER_FAILURES gate.)
+        // writer, proving no permanent gate persists after a failure. There is
+        // no failure counter anywhere either: T10 pins that a failure is
+        // self-healing rather than accounted.
         const r2 = yield* svc.tryStartCheckpointWriter({
           sessionID: info.id,
           model: { providerID: "test", modelID: "test-model" },
@@ -407,10 +410,23 @@ describe("checkpoint writer child-session isolation", () => {
   )
 
   it.live(
-    "T10: MAX_WRITER_FAILURES consecutive failures stops fireCheckpoints from spawning more writers",
-    // fork:true for the same reason as T9: tiny-seed fixture would hit M1
-    // empty-delta short-circuit on iterations 2+ if fork:false were used.
-    // The failure-counter gate this test verifies is fork-agnostic.
+    "T10: a failed writer is self-healing — previous checkpoint content and watermark both survive, and no in-place retry fires",
+    // Replaces the former "MAX_WRITER_FAILURES consecutive failures stops
+    // fireCheckpoints from spawning more writers". That test asserted the
+    // give-up cap: failures 1-2 cleared `crossed` so the SAME threshold
+    // re-fired, and failure 3 tripped the cap so a 4th fire spawned nothing.
+    // Both halves encoded in-place retry plus a give-up gate as requirements.
+    // Neither is a requirement now. What must hold instead is the redundancy
+    // that made the accounting unnecessary in the first place, asserted here
+    // directly: after a failed write the checkpoint FILE still holds the
+    // previous content (ensureCheckpointTemplate writes only when the file is
+    // absent) and lastBoundary still returns the previous boundary (the
+    // watermark advances only on success) — so the two stay mutually
+    // consistent at the last good checkpoint and a rebuild picks it up. The
+    // failure must also NOT re-arm its own threshold.
+    //
+    // fork:true for the same reason as T9: a tiny-seed fixture would hit the M1
+    // empty-delta short-circuit on iterations 2+ under fork:false.
     provideTmpdirInstance(
       () =>
       Effect.gen(function* () {
@@ -425,11 +441,8 @@ describe("checkpoint writer child-session isolation", () => {
         })
         // Tokens above the FIRST threshold only (default thresholds for the
         // fake model's 200K window: 20%/40%/60%/80% = 40K/80K/120K/160K).
-        // We deliberately stop at one crossed threshold per call: triggering
-        // multiple in the same call would queue pending writers (1-slot
-        // queue, see checkpoint.ts:508-517), and the settle watcher would
-        // drain pending into a fresh spawn — masking the failure-counter
-        // gate by re-populating the writers Map.
+        // Staying at one crossed threshold keeps the 1-slot pending queue out
+        // of the picture (checkpoint.ts:508-517).
         const oneOverFirstThreshold = {
           input: 50_000,
           output: 0,
@@ -437,76 +450,83 @@ describe("checkpoint writer child-session isolation", () => {
           cache: { read: 0, write: 0 },
         } as const
 
-        // Drive MAX_WRITER_FAILURES (default 3) consecutive failures via
-        // fireCheckpoints — that's the entry point that owns writerFailures.
-        // Each iteration:
-        //   1. fireCheckpoints triggers tryStartCheckpointWriter ("started")
-        //   2. Test settles the captured outcome with failure
-        //   3. Poll until settle watcher clears writers Map (lock released)
-        //   4. Poll a bit longer so prune's forkDetach watcher reads the
-        //      failure (otherwise the writers.delete race documented in
-        //      prune.ts:321-329 would leave the counter un-incremented and
-        //      the test flaky).
-        for (let attempt = 1; attempt <= 3; attempt++) {
-          const before = spawnLog.count
-          yield* prune.fireCheckpoints({
-            sessionID: info.id,
-            model: fakeModel,
-            tokens: oneOverFirstThreshold,
-            promptOps: {} as never,
-          })
-          expect(spawnLog.count).toBe(before + 1)
+        // Stand in for a PREVIOUS successful checkpoint: known file content
+        // plus a watermark pointing at it. Both must be untouched by the
+        // failure below.
+        const cpFile = checkpointPath(info.id)
+        const previousContent = "# previous good checkpoint\n\nsection body from the last successful write\n"
+        yield* Effect.promise(async () => {
+          await fs.mkdir(path.dirname(cpFile), { recursive: true })
+          await Bun.write(cpFile, previousContent)
+        })
+        const previousBoundary = MessageID.ascending()
+        yield* Effect.sync(() =>
+          Database.use((d) =>
+            d.update(SessionTable)
+              .set({ last_checkpoint_message_id: previousBoundary })
+              .where(eq(SessionTable.id, info.id))
+              .run(),
+          ),
+        )
+        expect(yield* svc.lastBoundary(info.id)).toBe(previousBoundary)
 
-          // Wait for the prune-side watcher fiber (forkDetach) to actually
-          // start AND grab the WriterState reference via `writers.get(...)`
-          // inside `waitForWriter`. That read MUST happen before we settle
-          // the outcome below — otherwise the checkpoint-side settle watcher
-          // (which is forked first, inside tryStartCheckpointWriter) clears
-          // the writers Map and the prune watcher then sees "no-writer",
-          // missing the failure and never incrementing writerFailures.
-          // (See prune.ts:321-329 for the documented race; the runtime
-          // tick here is the test-side mitigation.)
-          yield* Effect.sleep("50 millis")
-
-          // Settle the just-spawned writer with failure. Both watchers now
-          // wake from their Deferred.await: the checkpoint-side runs
-          // writers.delete + DB update; the prune-side runs
-          // writerFailures.set and (when attempt < maxFailures)
-          // crossed.delete so the next iteration can re-fire the threshold.
-          const outcome = pendingOutcomes[pendingOutcomes.length - 1]
-          yield* Deferred.succeed(outcome, { status: "failure", error: `attempt ${attempt}` })
-
-          // Poll until the checkpoint-side settle watcher has cleared the
-          // writers Map (lock released).
-          let running = yield* svc.isWriterRunning(info.id)
-          for (let i = 0; i < 50 && running; i++) {
-            yield* Effect.sleep("20 millis")
-            running = yield* svc.isWriterRunning(info.id)
-          }
-          expect(running).toBe(false)
-          // Extra ticks so the prune-side watcher's continuation
-          // (writerFailures.set + crossed.delete) lands before the next
-          // fireCheckpoints reads `crossed` / `already`.
-          yield* Effect.sleep("100 millis")
-        }
-
-        // After 3 failures, fireCheckpoints should NOT spawn a 4th writer.
-        // Mechanism: on the 3rd failure the prune watcher hits
-        // `next >= maxFailures` and skips `crossed.delete`. The threshold
-        // remains in `already`, so the 4th fireCheckpoints invocation finds
-        // `already.has(t)` === true and continues without calling
-        // tryStartCheckpointWriter. (See prune.ts:339-352.)
-        const beforeFourth = spawnLog.count
-        expect(beforeFourth).toBe(3)
+        // Fire the threshold; the writer spawns and then FAILS.
         yield* prune.fireCheckpoints({
           sessionID: info.id,
           model: fakeModel,
           tokens: oneOverFirstThreshold,
           promptOps: {} as never,
         })
-        expect(spawnLog.count).toBe(beforeFourth)
+        expect(spawnLog.count).toBe(1)
+
+        // Let prune's observation fork reach `writers.get(...)` inside
+        // waitForWriter before we settle the outcome. Without this tick the
+        // checkpoint-side settle watcher (forked first) can clear the writers
+        // Map and the observation fork sees "no-writer" instead — the race
+        // documented in prune.ts. Keeping the tick means the final
+        // no-respawn assertion below exercises the real post-failure path
+        // rather than passing by accident.
+        yield* Effect.sleep("50 millis")
+
+        const outcome = pendingOutcomes[pendingOutcomes.length - 1]
+        yield* Deferred.succeed(outcome, { status: "failure", error: "writer blew up" })
+
+        // Wait for the checkpoint-side settle watcher to release the lock.
+        let running = yield* svc.isWriterRunning(info.id)
+        for (let i = 0; i < 50 && running; i++) {
+          yield* Effect.sleep("20 millis")
+          running = yield* svc.isWriterRunning(info.id)
+        }
+        expect(running).toBe(false)
+        yield* Effect.sleep("100 millis")
+
+        // Self-healing property 1: the previous checkpoint content is intact.
+        // tryStartCheckpointWriter ran ensureCheckpointTemplate on this path
+        // before spawning, and that is a CONDITIONAL write — so the scaffold
+        // did not overwrite the previous checkpoint with a blank template.
+        expect(yield* Effect.promise(() => Bun.file(cpFile).text())).toBe(previousContent)
+
+        // Self-healing property 2: the watermark still points at the previous
+        // boundary, so a rebuild reads the file above and re-covers exactly the
+        // delta the failed writer did not capture. File and watermark are
+        // mutually consistent — that consistency is what makes a failure cost a
+        // STALER checkpoint rather than a missing one, and it is the whole
+        // reason no failure accounting is needed.
+        expect(yield* svc.lastBoundary(info.id)).toBe(previousBoundary)
+
+        // No in-place retry: the crossed threshold was not re-armed, so firing
+        // again at the same token level spawns nothing. Under the old code the
+        // failure watcher cleared `crossed` and this spawned a 2nd writer.
+        yield* prune.fireCheckpoints({
+          sessionID: info.id,
+          model: fakeModel,
+          tokens: oneOverFirstThreshold,
+          promptOps: {} as never,
+        })
+        expect(spawnLog.count).toBe(1)
       }),
       { config: { checkpoint: { fork: true } } },
     ),
   )
+
 })

--- a/packages/opencode/test/session/checkpoint-writer-wait-timeout.test.ts
+++ b/packages/opencode/test/session/checkpoint-writer-wait-timeout.test.ts
@@ -196,10 +196,10 @@ describe("SessionCheckpoint.waitForWriter", () => {
         yield* TestClock.adjust("2 minutes")
         const result = yield* Fiber.join(fiber)
 
-        // Regression: this used to be "failure", which made the prune retry
-        // watcher tick writerFailures and (after MAX_WRITER_FAILURES) trip
-        // "gave up after max consecutive failures" — permanently disabling
-        // checkpointing for a session whose writers were only slow.
+        // Regression: this used to be "failure", which made a slow-but-working
+        // writer indistinguishable from a broken one. The accounting that used
+        // to act on that confusion is gone, but the distinction itself is #1938's
+        // contract and is what keeps the expiry log below honest.
         expect(result).toBe("timeout")
 
         // The expiry must not have cancelled or retired the writer: it is still
@@ -222,8 +222,8 @@ describe("SessionCheckpoint.waitForWriter", () => {
         const late = yield* timeoutThenSettle({ status: "success" } as AgentOutcome)
 
         // Not "timeout" and not "no-writer": the late success survives the
-        // expiry, which is what lets prune clear writerFailures instead of
-        // leaving a healthy-but-slow session stuck near the failure cap.
+        // expiry, so the outcome a caller observes after re-entering the wait is
+        // the writer's real one rather than the mere fact that it was slow.
         expect(late).toBe("success")
       }),
     ),

--- a/packages/opencode/test/session/checkpoint-writer-wait-timeout.test.ts
+++ b/packages/opencode/test/session/checkpoint-writer-wait-timeout.test.ts
@@ -27,8 +27,11 @@ const ref = {
   modelID: ModelID.make("test-model"),
 }
 
-// Actor stub whose outcome Deferred never resolves — a writer still grinding
-// through LLM round-trips when the caller's bounded wait expires.
+// Actor stub whose outcome Deferred is left unresolved — a writer still
+// grinding through LLM round-trips when the caller's bounded wait expires.
+// Each spawn's Deferred is captured so a test can settle it LATE, i.e. after
+// the caller has already been told "timeout".
+const outcomes: Deferred.Deferred<AgentOutcome>[] = []
 const hangingActor = Layer.effect(
   Actor.Service,
   Effect.gen(function* () {
@@ -39,6 +42,7 @@ const hangingActor = Layer.effect(
         Effect.gen(function* () {
           counter += 1
           const outcome = yield* Deferred.make<AgentOutcome>()
+          outcomes.push(outcome)
           return { actorID: `${input.agentType}-${counter}`, sessionID: input.sessionID, outcome }
         }),
       cancel: () => Effect.void,
@@ -74,6 +78,76 @@ const env = Layer.mergeAll(
 )
 
 const it = testEffect(env)
+
+// Seed a session with one message and start a writer, returning THIS writer's
+// outcome Deferred (located by the array-length delta so concurrent tests never
+// settle each other's writer). Resolving that Deferred is how the actor — the
+// only thing that knows the writer's real result — reports it, so a late
+// resolve models "the writer finally settled, long after the wait bound".
+function seedAndStartWriter() {
+  return Effect.gen(function* () {
+    const svc = yield* SessionCheckpoint.Service
+    const ssn = yield* SessionNs.Service
+    const info = yield* ssn.create({})
+    const user = yield* ssn.updateMessage({
+      id: MessageID.ascending(),
+      role: "user",
+      sessionID: info.id,
+      agent: "build",
+      model: ref,
+      time: { created: Date.now() },
+    })
+    yield* ssn.updatePart({
+      id: PartID.ascending(),
+      messageID: user.id,
+      sessionID: info.id,
+      type: "text",
+      text: "seed",
+    })
+    const idxBefore = outcomes.length
+    const started = yield* svc.tryStartCheckpointWriter({
+      sessionID: info.id,
+      model: { providerID: "test", modelID: "test-model" },
+      promptOps: {} as never,
+    })
+    expect(started).toBe("started")
+    return { info, outcome: outcomes[idxBefore]! }
+  })
+}
+
+// Drive one writer past the 5-minute bound and re-enter the wait exactly the
+// way prune's retry watcher does (prune.ts:338-349), then settle the writer
+// LATE and return what the re-entered wait reports. This is the seam the
+// prune-side tests cannot cover: they stub waitForWriter, so they ASSUME a
+// late-settling writer yields "timeout" then its real outcome. Here the real
+// service produces it.
+function timeoutThenSettle(settled: AgentOutcome) {
+  return Effect.gen(function* () {
+    const svc = yield* SessionCheckpoint.Service
+    const { info, outcome } = yield* seedAndStartWriter()
+
+    // First wait: expires with the writer genuinely still in flight.
+    const first = yield* Effect.forkChild(svc.waitForWriter(info.id))
+    yield* TestClock.adjust("6 minutes")
+    expect(yield* Fiber.join(first)).toBe("timeout")
+
+    // The caller has now been told "timeout" and the writer is still running.
+    expect(yield* svc.isWriterRunning(info.id)).toBe(true)
+
+    // Prune re-enters the bounded wait. Advancing the clock (well short of a
+    // second bound) both lets the fiber reach Deferred.await and proves it is
+    // parked there rather than having returned early: the writers-map entry is
+    // still present, because it is only deleted AFTER the writer settles
+    // (checkpoint.ts:939).
+    const second = yield* Effect.forkChild(svc.waitForWriter(info.id))
+    yield* TestClock.adjust("1 minute")
+    expect(second.pollUnsafe()).toBeUndefined()
+
+    // The writer finally settles — ~7 minutes in, long past the first bound.
+    yield* Deferred.succeed(outcome, settled)
+    return yield* Fiber.join(second)
+  })
+}
 
 describe("SessionCheckpoint.waitForWriter", () => {
   it.effect(
@@ -132,6 +206,40 @@ describe("SessionCheckpoint.waitForWriter", () => {
         // in flight and still owns the watermark advance. This is the property
         // that makes "timeout" honest rather than a renamed failure.
         expect(yield* svc.isWriterRunning(info.id)).toBe(true)
+      }),
+    ),
+  )
+
+  // The PR claims the writer's REAL outcome is still booked after the bound
+  // expires. Booking happens in prune, whose counter is closure-private — but
+  // prune learns the outcome from exactly one place, waitForWriter's return on
+  // the re-entered wait, and that IS public. These two cases pin it for both
+  // terminal states.
+  it.effect(
+    "a writer that SUCCEEDS after the bound reports 'success' to the re-entered wait",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const late = yield* timeoutThenSettle({ status: "success" } as AgentOutcome)
+
+        // Not "timeout" and not "no-writer": the late success survives the
+        // expiry, which is what lets prune clear writerFailures instead of
+        // leaving a healthy-but-slow session stuck near the failure cap.
+        expect(late).toBe("success")
+      }),
+    ),
+  )
+
+  it.effect(
+    "a writer that FAILS after the bound reports 'failure' to the re-entered wait",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const late = yield* timeoutThenSettle({ status: "failure", error: "boom" })
+
+        // This is the direction that keeps the failure cap reachable in the slow
+        // regime: if the late failure were lost (returning "timeout" forever, or
+        // "no-writer" because the settle watcher had already removed the map
+        // entry), a permanently broken slow writer would never be counted.
+        expect(late).toBe("failure")
       }),
     ),
   )

--- a/packages/opencode/test/session/checkpoint-writer-wait-timeout.test.ts
+++ b/packages/opencode/test/session/checkpoint-writer-wait-timeout.test.ts
@@ -116,11 +116,10 @@ function seedAndStartWriter() {
 }
 
 // Drive one writer past the 5-minute bound and re-enter the wait exactly the
-// way prune's retry watcher does (prune.ts:338-349), then settle the writer
-// LATE and return what the re-entered wait reports. This is the seam the
-// prune-side tests cannot cover: they stub waitForWriter, so they ASSUME a
-// late-settling writer yields "timeout" then its real outcome. Here the real
-// service produces it.
+// way prune's settle watcher does, then settle the writer LATE and return what
+// the re-entered wait reports. This is the seam the prune-side tests cannot
+// cover: they stub the checkpoint service, so they ASSUME a late-settling writer
+// yields "timeout" then its real outcome. Here the real service produces it.
 function timeoutThenSettle(settled: AgentOutcome) {
   return Effect.gen(function* () {
     const svc = yield* SessionCheckpoint.Service
@@ -146,6 +145,30 @@ function timeoutThenSettle(settled: AgentOutcome) {
     // The writer finally settles — ~7 minutes in, long past the first bound.
     yield* Deferred.succeed(outcome, settled)
     return yield* Fiber.join(second)
+  })
+}
+
+// Enter waitForWriterSettlement while the writer is still in flight, then settle
+// it, and return the settlement the real service produced.
+//
+// The wait MUST be entered before the Deferred resolves: the settle watcher
+// removes the writers-map entry once the writer settles, so a wait entered
+// afterwards returns { outcome: "no-writer" } — which would pass any assertion
+// about "no failure classification" vacuously, asserting nothing about the
+// failure arm at all.
+function settlementAfterSettle(settled: AgentOutcome) {
+  return Effect.gen(function* () {
+    const svc = yield* SessionCheckpoint.Service
+    const { info, outcome } = yield* seedAndStartWriter()
+
+    const waiting = yield* Effect.forkChild(svc.waitForWriterSettlement(info.id))
+    yield* TestClock.adjust("1 second")
+    // Parked on the Deferred, not returned early — so what comes back below is
+    // the settlement of THIS writer.
+    expect(waiting.pollUnsafe()).toBeUndefined()
+
+    yield* Deferred.succeed(outcome, settled)
+    return yield* Fiber.join(waiting)
   })
 }
 
@@ -210,11 +233,24 @@ describe("SessionCheckpoint.waitForWriter", () => {
     ),
   )
 
-  // The PR claims the writer's REAL outcome is still booked after the bound
-  // expires. Booking happens in prune, whose counter is closure-private — but
-  // prune learns the outcome from exactly one place, waitForWriter's return on
-  // the re-entered wait, and that IS public. These two cases pin it for both
-  // terminal states.
+  // These two cases pin #1938's contract: after the bounded wait expires, the
+  // writer's REAL terminal outcome is still what a re-entered wait reports —
+  // "success" or "failure", never a sticky "timeout" and never "no-writer"
+  // because the settle watcher had already removed the map entry.
+  //
+  // (An earlier revision of this comment justified them by "keeping the failure
+  // cap reachable" so a broken slow writer "would never be counted". The cap and
+  // the counting — MAX_WRITER_FAILURES and the writerFailures map — were deleted
+  // by this branch. Nothing counts writer failures now, so that justification
+  // described machinery the tests no longer touch.)
+  //
+  // What consumes the distinction in production: prune reads it through
+  // waitForWriterSettlement (the same implementation, projected differently) and
+  // arms its final-threshold recovery gate ONLY on a settled "failure" — a
+  // "timeout" must never arm it, because the writer may still be about to
+  // succeed and advance the watermark. The flat three-value `waitForWriter`
+  // asserted below has no production caller of its own; it is the contract these
+  // tests hold still so the settlement shape cannot drift away from it.
   it.effect(
     "a writer that SUCCEEDS after the bound reports 'success' to the re-entered wait",
     provideTmpdirInstance(() =>
@@ -235,11 +271,105 @@ describe("SessionCheckpoint.waitForWriter", () => {
       Effect.gen(function* () {
         const late = yield* timeoutThenSettle({ status: "failure", error: "boom" })
 
-        // This is the direction that keeps the failure cap reachable in the slow
-        // regime: if the late failure were lost (returning "timeout" forever, or
-        // "no-writer" because the settle watcher had already removed the map
-        // entry), a permanently broken slow writer would never be counted.
+        // The failing direction of the same contract: a late failure is reported
+        // as a failure. Losing it (returning "timeout" forever, or "no-writer"
+        // after the settle watcher removed the map entry) would leave a
+        // permanently broken slow writer indistinguishable from a slow healthy
+        // one to every caller, including prune's recovery gate.
         expect(late).toBe("failure")
+      }),
+    ),
+  )
+})
+
+// The real-service half of prune's recovery gate. prune decides whether to
+// re-fire the final threshold from `settlement.failure?.retryable`, and its own
+// tests stub the checkpoint service — so without these the plumbing that carries
+// the classification off AgentOutcome and onto the settlement is asserted
+// nowhere, and every prune-side gate test would be resting on an assumption.
+describe("SessionCheckpoint.waitForWriterSettlement", () => {
+  it.effect(
+    "carries the failure classification off the writer's outcome",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const settlement = yield* settlementAfterSettle({
+          status: "failure",
+          error: "context length exceeded",
+          failure: { kind: "overflow", retryable: false, name: "ContextOverflowError" },
+        })
+
+        expect(settlement.outcome).toBe("failure")
+        // Not just "some object": prune branches on `retryable`, so the exact
+        // field has to survive the AgentOutcome → WriterSettlement hop.
+        expect(settlement.failure).toEqual({
+          kind: "overflow",
+          retryable: false,
+          name: "ContextOverflowError",
+        })
+      }),
+    ),
+  )
+
+  it.effect(
+    "carries a retryable classification through unchanged",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const settlement = yield* settlementAfterSettle({
+          status: "failure",
+          error: "upstream 503",
+          failure: { kind: "transient", retryable: true, name: "APIError" },
+        })
+
+        expect(settlement.outcome).toBe("failure")
+        expect(settlement.failure?.retryable).toBe(true)
+      }),
+    ),
+  )
+
+  it.effect(
+    "reports a CANCELLED writer as an unclassified failure, never a retryable one",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const settlement = yield* settlementAfterSettle({ status: "cancelled" })
+
+        // "cancelled" has no failure arm to classify. It must not acquire one by
+        // default: a shutdown-cancelled writer arming prune's recovery gate would
+        // spend a writer on work the session is no longer doing.
+        expect(settlement.outcome).toBe("failure")
+        expect(settlement.failure == null).toBe(true)
+      }),
+    ),
+  )
+
+  it.effect(
+    "reports an unclassified failure when the outcome carries no classification",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const settlement = yield* settlementAfterSettle({ status: "failure", error: "boom" })
+
+        // Absent means UNKNOWN, not retryable — the distinction prune relies on
+        // to leave a failure it cannot classify alone.
+        expect(settlement.outcome).toBe("failure")
+        expect(settlement.failure == null).toBe(true)
+      }),
+    ),
+  )
+
+  it.effect(
+    "a bound expiry is 'timeout' with no classification attached",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const svc = yield* SessionCheckpoint.Service
+        const { info } = yield* seedAndStartWriter()
+
+        const waiting = yield* Effect.forkChild(svc.waitForWriterSettlement(info.id))
+        yield* TestClock.adjust("6 minutes")
+        const settlement = yield* Fiber.join(waiting)
+
+        // Still in flight. If this arrived as a "failure" — classified or not —
+        // prune's gate would treat a merely slow writer as a settled one.
+        expect(settlement.outcome).toBe("timeout")
+        expect(settlement.failure == null).toBe(true)
       }),
     ),
   )

--- a/packages/opencode/test/session/checkpoint-writer-wait-timeout.test.ts
+++ b/packages/opencode/test/session/checkpoint-writer-wait-timeout.test.ts
@@ -108,11 +108,18 @@ describe("SessionCheckpoint.waitForWriter", () => {
         })
         expect(started).toBe("started")
 
-        // Drive past the 5-minute internal bound on the TestClock. The writer's
-        // Deferred is still unresolved, so the wait expires while the writer is
-        // genuinely in flight.
+        // Pin the BOUND, not just the outcome. At 4 minutes the wait must still
+        // be pending: without this, shrinking the bound to (say) 1s would
+        // reintroduce the original bug in a new shape — every honest 60-180s
+        // writer would report "timeout" — and a lone `adjust("6 minutes")`
+        // assertion would still pass.
         const fiber = yield* Effect.forkChild(svc.waitForWriter(info.id))
-        yield* TestClock.adjust("6 minutes")
+        yield* TestClock.adjust("4 minutes")
+        expect(fiber.pollUnsafe()).toBeUndefined()
+
+        // Now cross the 5-minute bound. The writer's Deferred is still
+        // unresolved, so the wait expires while the writer is genuinely in flight.
+        yield* TestClock.adjust("2 minutes")
         const result = yield* Fiber.join(fiber)
 
         // Regression: this used to be "failure", which made the prune retry
@@ -120,7 +127,11 @@ describe("SessionCheckpoint.waitForWriter", () => {
         // "gave up after max consecutive failures" — permanently disabling
         // checkpointing for a session whose writers were only slow.
         expect(result).toBe("timeout")
-        expect(result).not.toBe("failure")
+
+        // The expiry must not have cancelled or retired the writer: it is still
+        // in flight and still owns the watermark advance. This is the property
+        // that makes "timeout" honest rather than a renamed failure.
+        expect(yield* svc.isWriterRunning(info.id)).toBe(true)
       }),
     ),
   )

--- a/packages/opencode/test/session/prune-skip-system.test.ts
+++ b/packages/opencode/test/session/prune-skip-system.test.ts
@@ -63,6 +63,7 @@ describe("SessionPrune.fireCheckpoints — system-spawn skip", () => {
             return "started" as const
           }),
         waitForWriter: () => Effect.succeed("no-writer" as WriterOutcome | "no-writer"),
+        waitForWriterSettlement: () => Effect.succeed({ outcome: "no-writer" as const }),
         drainWriters: () => Effect.succeed({ drained: 0, timedOut: 0 }),
         hasCheckpoint: () => Effect.succeed(false),
         hasMemoryOrTasks: () => Effect.succeed(false),
@@ -140,6 +141,7 @@ describe("SessionPrune.fireCheckpoints — system-spawn skip", () => {
             return "started" as const
           }),
         waitForWriter: () => Effect.succeed("no-writer" as WriterOutcome | "no-writer"),
+        waitForWriterSettlement: () => Effect.succeed({ outcome: "no-writer" as const }),
         drainWriters: () => Effect.succeed({ drained: 0, timedOut: 0 }),
         hasCheckpoint: () => Effect.succeed(false),
         hasMemoryOrTasks: () => Effect.succeed(false),
@@ -217,6 +219,7 @@ describe("SessionPrune.fireCheckpoints — system-spawn skip", () => {
             return "started" as const
           }),
         waitForWriter: () => Effect.succeed("no-writer" as WriterOutcome | "no-writer"),
+        waitForWriterSettlement: () => Effect.succeed({ outcome: "no-writer" as const }),
         drainWriters: () => Effect.succeed({ drained: 0, timedOut: 0 }),
         hasCheckpoint: () => Effect.succeed(false),
         hasMemoryOrTasks: () => Effect.succeed(false),
@@ -279,6 +282,7 @@ describe("SessionPrune.fireCheckpoints — system-spawn skip", () => {
             return "started" as const
           }),
         waitForWriter: () => Effect.succeed("no-writer" as WriterOutcome | "no-writer"),
+        waitForWriterSettlement: () => Effect.succeed({ outcome: "no-writer" as const }),
         drainWriters: () => Effect.succeed({ drained: 0, timedOut: 0 }),
         hasCheckpoint: () => Effect.succeed(false),
         hasMemoryOrTasks: () => Effect.succeed(false),

--- a/packages/opencode/test/session/prune.test.ts
+++ b/packages/opencode/test/session/prune.test.ts
@@ -367,6 +367,85 @@ describe("SessionPrune.fireCheckpoints writer-failure retry", () => {
       { checkpoint: { thresholds: ["50%"] } },
     )
   })
+
+  // The PR's whole thesis lives here, not in waitForWriter's return value: a
+  // bounded wait that expires must not be booked as a writer failure, and must
+  // not lose the writer's real outcome either. The stub's outcome queue is
+  // shifted once per waitForWriter call, so a "timeout" entry models one
+  // expired 5-minute bound followed by whatever comes next.
+  test("a timed-out wait never ticks the counter, and the writer's real success clears it", async () => {
+    const harness = makeRetryHarness()
+    const promptOps = {} as any
+
+    await runWithHarness(
+      harness,
+      Effect.gen(function* () {
+        const svc = yield* SessionPrune.Service
+        const ssn = yield* SessionNs.Service
+        const info = yield* ssn.create({})
+        const model = createModel({ context: 100_000, output: 32_000 })
+
+        // Fires 1-2 fail fast → counter 1, 2 (each clears crossed, so the next
+        // fire re-enqueues). Fire 3's writer blows through two bound expiries
+        // and THEN succeeds: the counter must be cleared, not frozen at 2.
+        harness.outcomes.push("failure", "failure", "timeout", "timeout", "success")
+        for (let i = 0; i < 3; i++) {
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+          yield* Effect.sleep(100)
+        }
+        expect(harness.state.enqueueCount).toBe(3)
+
+        // Re-cross the threshold and fail fast twice more. Because fire 3's
+        // late success reset the counter, these land at 1 and 2 — below the cap
+        // — so each clears crossed and the following fire enqueues again.
+        // If a post-timeout success did NOT clear the counter (the gap this
+        // test pins), the first of these would land at 3, trip "gave up", keep
+        // crossed set, and the final fire would not enqueue → 5, not 6.
+        yield* svc.resetThresholds(info.id)
+        harness.outcomes.push("failure", "failure", "failure")
+        for (let i = 0; i < 3; i++) {
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+          yield* Effect.sleep(100)
+        }
+        expect(harness.state.enqueueCount).toBe(6)
+      }),
+      { checkpoint: { thresholds: ["50%"] } },
+    )
+  })
+
+  test("a writer that fails past the wait bound is still counted, so the cap stays reachable", async () => {
+    const harness = makeRetryHarness()
+    const promptOps = {} as any
+
+    await runWithHarness(
+      harness,
+      Effect.gen(function* () {
+        const svc = yield* SessionPrune.Service
+        const ssn = yield* SessionNs.Service
+        const info = yield* ssn.create({})
+        const model = createModel({ context: 100_000, output: 32_000 })
+
+        // Three writers, each slow enough to blow the bound and then genuinely
+        // failing — the realistic shape for a writer doing ~13 sequential LLM
+        // round-trips. If the watcher gave up at the bound instead of waiting,
+        // no failure would ever be booked: crossed would never be cleared, so
+        // fire 2 would not even enqueue and this would read 1.
+        harness.outcomes.push("timeout", "failure", "timeout", "failure", "timeout", "failure")
+        for (let i = 0; i < 3; i++) {
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+          yield* Effect.sleep(100)
+        }
+        expect(harness.state.enqueueCount).toBe(3)
+
+        // Fire 3's watcher hit the cap, so crossed was left set → no enqueue.
+        // A permanently-broken-but-slow writer now gives up like a fast one.
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+        yield* Effect.sleep(100)
+        expect(harness.state.enqueueCount).toBe(3)
+      }),
+      { checkpoint: { thresholds: ["50%"] } },
+    )
+  })
 })
 
 describe("defaultThresholdsFor (Part 2 density)", () => {

--- a/packages/opencode/test/session/prune.test.ts
+++ b/packages/opencode/test/session/prune.test.ts
@@ -225,9 +225,9 @@ describe("SessionPrune.prune", () => {
   )
 })
 
-describe("SessionPrune.fireCheckpoints writer-failure retry", () => {
-  // A programmable stub of SessionCheckpoint.Service drives the retry
-  // counter: tryStartCheckpointWriter always returns "started" (counted in
+describe("SessionPrune.fireCheckpoints writer failure is not retried in place", () => {
+  // A programmable stub of SessionCheckpoint.Service drives the writer
+  // outcomes: tryStartCheckpointWriter always returns "started" (counted in
   // stubEnqueueCount), waitForWriter returns pre-seeded outcomes in order.
   // Each test constructs a fresh harness so module state is per-test.
   function makeRetryHarness() {
@@ -288,41 +288,34 @@ describe("SessionPrune.fireCheckpoints writer-failure retry", () => {
     cache: { read: 0, write: 0 },
   })
 
-  test("three writer failures retry below cap, stop at cap", async () => {
-    const harness = makeRetryHarness()
-    const promptOps = {} as any
-
-    await runWithHarness(
-      harness,
-      Effect.gen(function* () {
-        const svc = yield* SessionPrune.Service
-        const ssn = yield* SessionNs.Service
-        const info = yield* ssn.create({})
-        const model = createModel({ context: 100_000, output: 32_000 })
-
-        // Pre-seed 3 failure outcomes — one per expected watcher.
-        harness.outcomes.push("failure", "failure", "failure")
-
-        // Fires 1-3: each fire enqueues (crossed was cleared by the prior
-        // watcher), watcher sees failure, counter increments 1→2→3.
-        // Fire 3's watcher hits cap (counter === 3) and does NOT clear crossed.
-        for (let i = 0; i < 3; i++) {
-          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-          yield* Effect.sleep(100)
-        }
-        expect(harness.state.enqueueCount).toBe(3)
-
-        // Fire 4: crossed still holds the 50% threshold (not cleared at cap)
-        // so the loop skips without enqueuing.
-        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-        yield* Effect.sleep(100)
-        expect(harness.state.enqueueCount).toBe(3)
-      }),
-      { checkpoint: { thresholds: ["50%"] } },
-    )
+  const makeTokensAt = (n: number) => ({
+    input: n,
+    output: 0,
+    reasoning: 0,
+    cache: { read: 0, write: 0 },
   })
 
-  test("success outcome resets failure counter", async () => {
+  // These cases replace the six that pinned the deleted accounting
+  // (writerFailures / MAX_WRITER_FAILURES / MAX_WRITER_WAIT_EXTENSIONS). What
+  // they used to assert, and why it is no longer the requirement:
+  //
+  //   - "three writer failures retry below cap, stop at cap" and "success
+  //     outcome resets failure counter" asserted that a failure BELOW the cap
+  //     re-armed the same threshold (enqueue 1->2->3) and that a success
+  //     cleared the counter. Both encoded in-place retry as the requirement.
+  //   - "a timed-out wait never ticks the counter..." and "a writer that fails
+  //     past the wait bound is still counted, so the cap stays reachable"
+  //     asserted the watcher kept re-entering the bounded wait so a late
+  //     outcome still reached the counter.
+  //   - the pair bracketing MAX_WRITER_WAIT_EXTENSIONS pinned the 13-call
+  //     boundary of that re-entry loop exactly.
+  //
+  // None of it is required now, because a failed write is self-healing:
+  // ensureCheckpointTemplate only writes when the file is ABSENT and the
+  // watermark advances only on success, so a failure leaves file and watermark
+  // consistent at the last good checkpoint. The requirement is the inverse --
+  // a failure must NOT retry in place, and the next crossing must still fire.
+  test("a failed writer does not re-arm its own threshold — no in-place retry", async () => {
     const harness = makeRetryHarness()
     const promptOps = {} as any
 
@@ -334,188 +327,88 @@ describe("SessionPrune.fireCheckpoints writer-failure retry", () => {
         const info = yield* ssn.create({})
         const model = createModel({ context: 100_000, output: 32_000 })
 
-        // Phase 1: two failures, then success. Success does NOT clear
-        // crossed (the checkpoint was written), so the next fire on the
-        // same threshold is a no-op. But it DOES reset the counter.
-        harness.outcomes.push("failure", "failure", "success")
-        for (let i = 0; i < 3; i++) {
-          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-          yield* Effect.sleep(100)
-        }
-        expect(harness.state.enqueueCount).toBe(3)
+        harness.outcomes.push("failure")
 
-        // Manually reset so the session "re-crosses" the threshold. This
-        // simulates the operator-visible case where a new checkpoint boundary
-        // is reached. The failure counter remains 0 (was reset by Phase 1's
-        // final success).
-        yield* svc.resetThresholds(info.id)
-
-        // Phase 2: three more failures. Because the counter was reset, all
-        // three fires land before the cap. Enqueue count goes 3→6.
-        harness.outcomes.push("failure", "failure", "failure")
-        for (let i = 0; i < 3; i++) {
-          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-          yield* Effect.sleep(100)
-        }
-        expect(harness.state.enqueueCount).toBe(6)
-
-        // Seventh fire: counter === 3 again, crossed stays → no enqueue.
-        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-        yield* Effect.sleep(100)
-        expect(harness.state.enqueueCount).toBe(6)
-      }),
-      { checkpoint: { thresholds: ["50%"] } },
-    )
-  })
-
-  // The PR's whole thesis lives here, not in waitForWriter's return value: a
-  // bounded wait that expires must not be booked as a writer failure, and must
-  // not lose the writer's real outcome either. The stub's outcome queue is
-  // shifted once per waitForWriter call, so a "timeout" entry models one
-  // expired 5-minute bound followed by whatever comes next.
-  test("a timed-out wait never ticks the counter, and the writer's real success clears it", async () => {
-    const harness = makeRetryHarness()
-    const promptOps = {} as any
-
-    await runWithHarness(
-      harness,
-      Effect.gen(function* () {
-        const svc = yield* SessionPrune.Service
-        const ssn = yield* SessionNs.Service
-        const info = yield* ssn.create({})
-        const model = createModel({ context: 100_000, output: 32_000 })
-
-        // Fires 1-2 fail fast → counter 1, 2 (each clears crossed, so the next
-        // fire re-enqueues). Fire 3's writer blows through two bound expiries
-        // and THEN succeeds: the counter must be cleared, not frozen at 2.
-        harness.outcomes.push("failure", "failure", "timeout", "timeout", "success")
-        for (let i = 0; i < 3; i++) {
-          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-          yield* Effect.sleep(100)
-        }
-        expect(harness.state.enqueueCount).toBe(3)
-
-        // Re-cross the threshold and fail fast twice more. Because fire 3's
-        // late success reset the counter, these land at 1 and 2 — below the cap
-        // — so each clears crossed and the following fire enqueues again.
-        // If a post-timeout success did NOT clear the counter (the gap this
-        // test pins), the first of these would land at 3, trip "gave up", keep
-        // crossed set, and the final fire would not enqueue → 5, not 6.
-        yield* svc.resetThresholds(info.id)
-        harness.outcomes.push("failure", "failure", "failure")
-        for (let i = 0; i < 3; i++) {
-          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-          yield* Effect.sleep(100)
-        }
-        expect(harness.state.enqueueCount).toBe(6)
-      }),
-      { checkpoint: { thresholds: ["50%"] } },
-    )
-  })
-
-  test("a writer that fails past the wait bound is still counted, so the cap stays reachable", async () => {
-    const harness = makeRetryHarness()
-    const promptOps = {} as any
-
-    await runWithHarness(
-      harness,
-      Effect.gen(function* () {
-        const svc = yield* SessionPrune.Service
-        const ssn = yield* SessionNs.Service
-        const info = yield* ssn.create({})
-        const model = createModel({ context: 100_000, output: 32_000 })
-
-        // Three writers, each slow enough to blow the bound and then genuinely
-        // failing — the realistic shape for a writer doing ~13 sequential LLM
-        // round-trips. If the watcher gave up at the bound instead of waiting,
-        // no failure would ever be booked: crossed would never be cleared, so
-        // fire 2 would not even enqueue and this would read 1.
-        harness.outcomes.push("timeout", "failure", "timeout", "failure", "timeout", "failure")
-        for (let i = 0; i < 3; i++) {
-          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-          yield* Effect.sleep(100)
-        }
-        expect(harness.state.enqueueCount).toBe(3)
-
-        // Fire 3's watcher hit the cap, so crossed was left set → no enqueue.
-        // A permanently-broken-but-slow writer now gives up like a fast one.
-        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-        yield* Effect.sleep(100)
-        expect(harness.state.enqueueCount).toBe(3)
-      }),
-      { checkpoint: { thresholds: ["50%"] } },
-    )
-  })
-
-  // MAX_WRITER_WAIT_EXTENSIONS (prune.ts:32) caps the watcher fiber at ~1h:
-  // one initial waitForWriter plus at most 12 re-entries of the 5-minute bound,
-  // so 13 calls total. These two cases sit on either side of that boundary, and
-  // the leftover length of the stub's queue counts the calls exactly — so
-  // moving the constant by one breaks one of them.
-  test("12 extensions is still inside the ~1h cap — the writer's real outcome is booked", async () => {
-    const harness = makeRetryHarness()
-    const promptOps = {} as any
-
-    await runWithHarness(
-      harness,
-      Effect.gen(function* () {
-        const svc = yield* SessionPrune.Service
-        const ssn = yield* SessionNs.Service
-        const info = yield* ssn.create({})
-        const model = createModel({ context: 100_000, output: 32_000 })
-
-        // 12 expired bounds (~60min) and then a real failure on the 13th call.
-        harness.outcomes.push(...Array(12).fill("timeout" as const), "failure")
-        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+        // Fire 1 crosses 30K and enqueues; its writer fails.
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(35_000), promptOps })
         yield* Effect.sleep(100)
         expect(harness.state.enqueueCount).toBe(1)
 
-        // Every seeded outcome was consumed ⇒ the 13th call happened, i.e. the
-        // 12th extension was still permitted.
-        expect(harness.outcomes.length).toBe(0)
+        // Fires 2-4 at the same token level must NOT re-enqueue: the threshold
+        // stays in `crossed`. The deleted watcher did `crossed.delete()` on a
+        // sub-cap failure, so under the old code these three fires would have
+        // read 2, then 3, then stopped at the 3-failure cap.
+        for (let i = 0; i < 3; i++) {
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(35_000), promptOps })
+          yield* Effect.sleep(100)
+        }
+        expect(harness.state.enqueueCount).toBe(1)
+      }),
+      { checkpoint: { thresholds: ["30K", "45K"] } },
+    )
+  })
 
-        // The failure was booked (counter 1, below the 3-failure cap), so crossed
-        // was cleared and this fire enqueues again. If the watcher had bailed at
-        // extension 12 instead, nothing would have been booked and this would
-        // still read 1.
-        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+  test("a failed writer at the max threshold leaves maxThresholdCrossed set", async () => {
+    const harness = makeRetryHarness()
+    const promptOps = {} as any
+
+    await runWithHarness(
+      harness,
+      Effect.gen(function* () {
+        const svc = yield* SessionPrune.Service
+        const ssn = yield* SessionNs.Service
+        const info = yield* ssn.create({})
+        const model = createModel({ context: 100_000, output: 32_000 })
+
+        harness.outcomes.push("failure", "failure")
+
+        // Cross BOTH thresholds in one fire so the max threshold is crossed and
+        // the observed outcome is a failure.
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(50_000), promptOps })
+        yield* Effect.sleep(150)
+
+        // The old watcher paired `crossed.delete` with `maxCrossed.delete` on a
+        // sub-cap failure, which withdrew the already-raised discard+rebuild
+        // signal that prompt.ts consumes. Overflow readiness must not depend on
+        // whether the checkpoint writer happened to succeed, so the signal
+        // stands: under the old code this read false.
+        expect(yield* svc.maxThresholdCrossed(info.id)).toBe(true)
+      }),
+      { checkpoint: { thresholds: ["30K", "45K"] } },
+    )
+  })
+
+  test("the next threshold crossing still fires after a failure", async () => {
+    const harness = makeRetryHarness()
+    const promptOps = {} as any
+
+    await runWithHarness(
+      harness,
+      Effect.gen(function* () {
+        const svc = yield* SessionPrune.Service
+        const ssn = yield* SessionNs.Service
+        const info = yield* ssn.create({})
+        const model = createModel({ context: 100_000, output: 32_000 })
+
+        harness.outcomes.push("failure", "failure")
+
+        // 30K crosses and fails.
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(35_000), promptOps })
+        yield* Effect.sleep(100)
+        expect(harness.state.enqueueCount).toBe(1)
+
+        // Tokens grow past 45K: the failure must not have suppressed the
+        // session, so this crossing fires. This is the retry the design relies
+        // on instead of an in-place one, and it carries fresher context than a
+        // re-fire of 30K would have. The old code reached a SECOND enqueue too
+        // -- the counter never gated a NEW threshold -- but it reached a THIRD,
+        // because the failure had also re-armed 30K. So the exact count, not
+        // just "it still fires", is what pins the absence of in-place retry.
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(50_000), promptOps })
         yield* Effect.sleep(100)
         expect(harness.state.enqueueCount).toBe(2)
       }),
-      { checkpoint: { thresholds: ["50%"] } },
-    )
-  })
-
-  test("the 13th extension is past the cap — the watcher stops waiting and books nothing", async () => {
-    const harness = makeRetryHarness()
-    const promptOps = {} as any
-
-    await runWithHarness(
-      harness,
-      Effect.gen(function* () {
-        const svc = yield* SessionPrune.Service
-        const ssn = yield* SessionNs.Service
-        const info = yield* ssn.create({})
-        const model = createModel({ context: 100_000, output: 32_000 })
-
-        // One expired bound more than the cap allows, then a failure that the
-        // watcher must never reach.
-        harness.outcomes.push(...Array(13).fill("timeout" as const), "failure")
-        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-        yield* Effect.sleep(100)
-        expect(harness.state.enqueueCount).toBe(1)
-
-        // The trailing "failure" is still queued ⇒ waitForWriter was called
-        // exactly 13 times and the watcher then gave up, so a permanently stuck
-        // writer cannot pin the fiber for the life of the process.
-        expect(harness.outcomes.length).toBe(1)
-
-        // Nothing was booked, so crossed stayed set → no further enqueue.
-        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
-        yield* Effect.sleep(100)
-        expect(harness.state.enqueueCount).toBe(1)
-      }),
-      { checkpoint: { thresholds: ["50%"] } },
+      { checkpoint: { thresholds: ["30K", "45K"] } },
     )
   })
 })

--- a/packages/opencode/test/session/prune.test.ts
+++ b/packages/opencode/test/session/prune.test.ts
@@ -446,6 +446,78 @@ describe("SessionPrune.fireCheckpoints writer-failure retry", () => {
       { checkpoint: { thresholds: ["50%"] } },
     )
   })
+
+  // MAX_WRITER_WAIT_EXTENSIONS (prune.ts:32) caps the watcher fiber at ~1h:
+  // one initial waitForWriter plus at most 12 re-entries of the 5-minute bound,
+  // so 13 calls total. These two cases sit on either side of that boundary, and
+  // the leftover length of the stub's queue counts the calls exactly — so
+  // moving the constant by one breaks one of them.
+  test("12 extensions is still inside the ~1h cap — the writer's real outcome is booked", async () => {
+    const harness = makeRetryHarness()
+    const promptOps = {} as any
+
+    await runWithHarness(
+      harness,
+      Effect.gen(function* () {
+        const svc = yield* SessionPrune.Service
+        const ssn = yield* SessionNs.Service
+        const info = yield* ssn.create({})
+        const model = createModel({ context: 100_000, output: 32_000 })
+
+        // 12 expired bounds (~60min) and then a real failure on the 13th call.
+        harness.outcomes.push(...Array(12).fill("timeout" as const), "failure")
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+        yield* Effect.sleep(100)
+        expect(harness.state.enqueueCount).toBe(1)
+
+        // Every seeded outcome was consumed ⇒ the 13th call happened, i.e. the
+        // 12th extension was still permitted.
+        expect(harness.outcomes.length).toBe(0)
+
+        // The failure was booked (counter 1, below the 3-failure cap), so crossed
+        // was cleared and this fire enqueues again. If the watcher had bailed at
+        // extension 12 instead, nothing would have been booked and this would
+        // still read 1.
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+        yield* Effect.sleep(100)
+        expect(harness.state.enqueueCount).toBe(2)
+      }),
+      { checkpoint: { thresholds: ["50%"] } },
+    )
+  })
+
+  test("the 13th extension is past the cap — the watcher stops waiting and books nothing", async () => {
+    const harness = makeRetryHarness()
+    const promptOps = {} as any
+
+    await runWithHarness(
+      harness,
+      Effect.gen(function* () {
+        const svc = yield* SessionPrune.Service
+        const ssn = yield* SessionNs.Service
+        const info = yield* ssn.create({})
+        const model = createModel({ context: 100_000, output: 32_000 })
+
+        // One expired bound more than the cap allows, then a failure that the
+        // watcher must never reach.
+        harness.outcomes.push(...Array(13).fill("timeout" as const), "failure")
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+        yield* Effect.sleep(100)
+        expect(harness.state.enqueueCount).toBe(1)
+
+        // The trailing "failure" is still queued ⇒ waitForWriter was called
+        // exactly 13 times and the watcher then gave up, so a permanently stuck
+        // writer cannot pin the fiber for the life of the process.
+        expect(harness.outcomes.length).toBe(1)
+
+        // Nothing was booked, so crossed stayed set → no further enqueue.
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+        yield* Effect.sleep(100)
+        expect(harness.state.enqueueCount).toBe(1)
+      }),
+      { checkpoint: { thresholds: ["50%"] } },
+    )
+  })
 })
 
 describe("defaultThresholdsFor (Part 2 density)", () => {

--- a/packages/opencode/test/session/prune.test.ts
+++ b/packages/opencode/test/session/prune.test.ts
@@ -3,7 +3,7 @@ import { Effect, Layer } from "effect"
 import { Bus } from "../../src/bus"
 import { Config } from "../../src/config"
 import { Agent } from "../../src/agent/agent"
-import { SessionCheckpoint, type WriterOutcome } from "../../src/session/checkpoint"
+import { SessionCheckpoint, type WriterSettlement } from "../../src/session/checkpoint"
 import { SessionPrune, defaultThresholdsFor } from "../../src/session/prune"
 import { Log } from "../../src/util"
 import { Plugin } from "../../src/plugin"
@@ -228,11 +228,20 @@ describe("SessionPrune.prune", () => {
 describe("SessionPrune.fireCheckpoints writer failure is not retried in place", () => {
   // A programmable stub of SessionCheckpoint.Service drives the writer
   // outcomes: tryStartCheckpointWriter always returns "started" (counted in
-  // stubEnqueueCount), waitForWriter returns pre-seeded outcomes in order.
+  // stubEnqueueCount), and the settlement queue is drained in order.
   // Each test constructs a fresh harness so module state is per-test.
+  //
+  // SCAFFOLDING NOTE (no assertion changed): the queue holds WriterSettlement
+  // objects rather than bare WriterOutcome strings, and waitForWriter projects
+  // `.outcome` off the same queue exactly as production does. prune reads the
+  // classification-bearing shape, so a stub that only implemented
+  // waitForWriter would leave every failure case below VACUOUS — the queue
+  // would never be drained and no failure would ever be observed.
   function makeRetryHarness() {
-    const outcomes: Array<WriterOutcome | "no-writer"> = []
+    const outcomes: Array<WriterSettlement> = []
     const state = { enqueueCount: 0 }
+
+    const nextSettlement = (): WriterSettlement => outcomes.shift() ?? { outcome: "no-writer" as const }
 
     const stubLayer = Layer.succeed(
       SessionCheckpoint.Service,
@@ -242,7 +251,8 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
             state.enqueueCount++
             return "started" as const
           }),
-        waitForWriter: () => Effect.sync(() => outcomes.shift() ?? ("no-writer" as const)),
+        waitForWriter: () => Effect.sync(() => nextSettlement().outcome),
+        waitForWriterSettlement: () => Effect.sync(nextSettlement),
         drainWriters: () => Effect.succeed({ drained: 0, timedOut: 0 }),
         hasCheckpoint: () => Effect.succeed(false),
         hasMemoryOrTasks: () => Effect.succeed(false),
@@ -315,6 +325,16 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
   // watermark advances only on success, so a failure leaves file and watermark
   // consistent at the last good checkpoint. The requirement is the inverse --
   // a failure must NOT retry in place, and the next crossing must still fire.
+  //
+  // STILL THE REQUIREMENT after the recovery gate was added. The gate is
+  // narrower than these cases on both axes: it needs a RETRYABLE class, and it
+  // only applies to the FINAL threshold. Every failure below pushes
+  // `{ outcome: "failure" }` with no `failure` field -- an UNCLASSIFIED failure,
+  // which the gate refuses -- and the first case's failure is at a non-final
+  // threshold anyway. So these three assertions are unchanged, not relaxed:
+  // they now also pin that an unclassified failure is treated as "cannot know
+  // whether a retry helps" and therefore behaves exactly as before. The gate's
+  // own behaviour is pinned separately in the describe block below.
   test("a failed writer does not re-arm its own threshold — no in-place retry", async () => {
     const harness = makeRetryHarness()
     const promptOps = {} as any
@@ -327,7 +347,7 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
         const info = yield* ssn.create({})
         const model = createModel({ context: 100_000, output: 32_000 })
 
-        harness.outcomes.push("failure")
+        harness.outcomes.push({ outcome: "failure" })
 
         // Fire 1 crosses 30K and enqueues; its writer fails.
         yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(35_000), promptOps })
@@ -360,7 +380,7 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
         const info = yield* ssn.create({})
         const model = createModel({ context: 100_000, output: 32_000 })
 
-        harness.outcomes.push("failure", "failure")
+        harness.outcomes.push({ outcome: "failure" }, { outcome: "failure" })
 
         // Cross BOTH thresholds in one fire so the max threshold is crossed and
         // the observed outcome is a failure.
@@ -390,7 +410,7 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
         const info = yield* ssn.create({})
         const model = createModel({ context: 100_000, output: 32_000 })
 
-        harness.outcomes.push("failure", "failure")
+        harness.outcomes.push({ outcome: "failure" }, { outcome: "failure" })
 
         // 30K crosses and fails.
         yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(35_000), promptOps })
@@ -410,6 +430,253 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
       }),
       { checkpoint: { thresholds: ["30K", "45K"] } },
     )
+  })
+
+  // The FINAL threshold's recovery gate. Sibling of the three cases above, not
+  // a reversal of them: those pin that a failure never re-arms its own
+  // threshold, and the gate is admitted only for the one threshold that has no
+  // successor in the ladder, only for a failure whose class says a retry could
+  // succeed, and only once the token count has grown by a full ladder step.
+  //
+  // Arithmetic all four cases depend on, stated once. createModel({ context:
+  // 100_000, output: 32_000 }) with no `limit.input` gives usable = 100_000 -
+  // (min(20_000, 32_000) compaction reserve + min(32_000, 20_000) output
+  // reserve) = 60_000, so maxAllowed = 60_000 - CHECKPOINT_RESERVED(13_000) =
+  // 47_000. Thresholds are written absolute ("20K"/"30K") so the ladder step is
+  // exactly 10_000 and nothing depends on percent-of-window rounding.
+  describe("final-threshold recovery gate", () => {
+    const TRANSIENT = { kind: "transient" as const, retryable: true, name: "APIError" }
+    const DETERMINISTIC = { kind: "overflow" as const, retryable: false, name: "ContextOverflowError" }
+
+    test("a DETERMINISTIC failure at the final threshold arms no gate", async () => {
+      const harness = makeRetryHarness()
+      const promptOps = {} as any
+
+      await runWithHarness(
+        harness,
+        Effect.gen(function* () {
+          const svc = yield* SessionPrune.Service
+          const ssn = yield* SessionNs.Service
+          const info = yield* ssn.create({})
+          const model = createModel({ context: 100_000, output: 32_000 })
+
+          harness.outcomes.push({ outcome: "failure" }, { outcome: "failure", failure: DETERMINISTIC })
+
+          // Cross the thresholds one at a time so each forked wait drains
+          // exactly one seeded settlement (two concurrent waits would race for
+          // the head of the queue).
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(21_000), promptOps })
+          yield* Effect.sleep(100)
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(31_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(2)
+
+          // A full ladder step of growth past the final threshold. A retry here
+          // would fail identically — overflow/auth/bad-request do not become
+          // valid by being repeated — so re-firing would spend a writer's dozen
+          // round-trips to reproduce the same error.
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(41_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(2)
+        }),
+        { checkpoint: { thresholds: ["20K", "30K"] } },
+      )
+    })
+
+    test("a TRANSIENT failure at the final threshold re-fires it, but only once growth reaches a full ladder step", async () => {
+      const harness = makeRetryHarness()
+      const promptOps = {} as any
+
+      await runWithHarness(
+        harness,
+        Effect.gen(function* () {
+          const svc = yield* SessionPrune.Service
+          const ssn = yield* SessionNs.Service
+          const info = yield* ssn.create({})
+          const model = createModel({ context: 100_000, output: 32_000 })
+
+          harness.outcomes.push({ outcome: "failure" }, { outcome: "failure", failure: TRANSIENT })
+
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(21_000), promptOps })
+          yield* Effect.sleep(100)
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(31_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(2)
+
+          // THE BOUND. Fired at 31_000, so the gate sits at min(31_000 + 10_000,
+          // 47_000) = 41_000. Below it nothing re-fires, however many turns go
+          // by — which is what stops the transient case from becoming a hot loop
+          // spawning a writer per runLoop iteration at an unchanged token count.
+          for (const tokens of [31_000, 35_000, 40_999]) {
+            yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(tokens), promptOps })
+            yield* Effect.sleep(100)
+          }
+          expect(harness.state.enqueueCount).toBe(2)
+
+          // At the gate it re-fires: there is now a step's worth of uncovered
+          // delta that the failed attempt never captured, and the watermark did
+          // not advance, so this is new work rather than a repeat.
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(41_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(3)
+        }),
+        { checkpoint: { thresholds: ["20K", "30K"] } },
+      )
+    })
+
+    test("a TRANSIENT failure arms no gate when the window has no room left for a retry", async () => {
+      const harness = makeRetryHarness()
+      const promptOps = {} as any
+
+      await runWithHarness(
+        harness,
+        Effect.gen(function* () {
+          const svc = yield* SessionPrune.Service
+          const ssn = yield* SessionNs.Service
+          const info = yield* ssn.create({})
+          const model = createModel({ context: 100_000, output: 32_000 })
+
+          harness.outcomes.push({ outcome: "failure" }, { outcome: "failure", failure: TRANSIENT })
+
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(21_000), promptOps })
+          yield* Effect.sleep(100)
+          // Final threshold 45K fired at maxAllowed itself, so the gate would be
+          // min(47_000 + 25_000, 47_000) = 47_000 — not ahead of where it fired.
+          // The retry budget IS the unused window, so here it is zero.
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(47_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(2)
+
+          for (const tokens of [47_000, 50_000, 59_000]) {
+            yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(tokens), promptOps })
+            yield* Effect.sleep(100)
+          }
+          expect(harness.state.enqueueCount).toBe(2)
+        }),
+        { checkpoint: { thresholds: ["20K", "45K"] } },
+      )
+    })
+
+    test("a TRANSIENT failure at a NON-final threshold arms no gate — its successor is the retry", async () => {
+      const harness = makeRetryHarness()
+      const promptOps = {} as any
+
+      await runWithHarness(
+        harness,
+        Effect.gen(function* () {
+          const svc = yield* SessionPrune.Service
+          const ssn = yield* SessionNs.Service
+          const info = yield* ssn.create({})
+          const model = createModel({ context: 100_000, output: 32_000 })
+
+          harness.outcomes.push({ outcome: "failure", failure: TRANSIENT })
+
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(21_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(1)
+
+          // 20K is not the final threshold, so 30K is already its retry. If the
+          // gate were armed here too it would sit at 31_000 and this crossing
+          // would enqueue TWICE — once for the re-armed 20K and once for 30K.
+          // The exact count, not "it still fires", is what pins that.
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(31_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(2)
+
+          // And the pollution this specifically rules out: the gate is keyed per
+          // SESSION, not per threshold, so a gate armed by a NON-final failure
+          // would be sitting at 31_000 for the final threshold to consume — the
+          // final threshold would fire a second time on the strength of a
+          // different threshold's failure. The admission rule alone does not stop
+          // that (30K IS the final threshold by the time it reads the gate);
+          // refusing to arm from a non-final threshold is what does.
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(31_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(2)
+        }),
+        { checkpoint: { thresholds: ["20K", "30K"] } },
+      )
+    })
+
+    test("a bound-expiry 'timeout' at the final threshold arms no gate", async () => {
+      const harness = makeRetryHarness()
+      const promptOps = {} as any
+
+      await runWithHarness(
+        harness,
+        Effect.gen(function* () {
+          const svc = yield* SessionPrune.Service
+          const ssn = yield* SessionNs.Service
+          const info = yield* ssn.create({})
+          const model = createModel({ context: 100_000, output: 32_000 })
+
+          harness.outcomes.push({ outcome: "failure" }, { outcome: "timeout" })
+
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(21_000), promptOps })
+          yield* Effect.sleep(100)
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(31_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(2)
+
+          // "timeout" means the writer is STILL IN FLIGHT (#1938's contract) and
+          // may yet succeed and advance the watermark, so it must not arm.
+          //
+          // Honest about what this pins: the `outcome !== "failure"` check alone
+          // is NOT observable here, because a timeout also carries no
+          // classification, so the retryable check rejects it too. Removing
+          // EITHER guard leaves this green; removing BOTH turns it red. It is
+          // pinned as the conjunction, and the invariant the redundancy rests on
+          // — a timeout never carries a classification — is asserted directly
+          // against the real service in checkpoint-writer-wait-timeout.test.ts.
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(41_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(2)
+        }),
+        { checkpoint: { thresholds: ["20K", "30K"] } },
+      )
+    })
+
+    test("resetThresholds drops a pending gate — a rebuild re-arms the whole ladder instead", async () => {
+      const harness = makeRetryHarness()
+      const promptOps = {} as any
+
+      await runWithHarness(
+        harness,
+        Effect.gen(function* () {
+          const svc = yield* SessionPrune.Service
+          const ssn = yield* SessionNs.Service
+          const info = yield* ssn.create({})
+          const model = createModel({ context: 100_000, output: 32_000 })
+
+          harness.outcomes.push({ outcome: "failure" }, { outcome: "failure", failure: TRANSIENT })
+
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(21_000), promptOps })
+          yield* Effect.sleep(100)
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(31_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(2)
+
+          // A successful discard+rebuild calls resetThresholds (prompt.ts:428).
+          // The whole ladder is re-armed from 20K, so a leftover gate on the
+          // final threshold would let it fire ahead of its own successors.
+          yield* svc.resetThresholds(info.id)
+
+          // Post-reset the ladder replays in order: this crossing enqueues for
+          // 20K and 30K, and NOT a third time for the stale gate.
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(41_000), promptOps })
+          yield* Effect.sleep(150)
+          expect(harness.state.enqueueCount).toBe(4)
+
+          // And the replayed final threshold is back to one-shot. A gate that
+          // survived the reset would still read 41_000 here — `already` now holds
+          // 30K again, so the stale gate would be exactly what admits a re-fire.
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(41_000), promptOps })
+          yield* Effect.sleep(100)
+          expect(harness.state.enqueueCount).toBe(4)
+        }),
+        { checkpoint: { thresholds: ["20K", "30K"] } },
+      )
+    })
   })
 })
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2204,10 +2204,6 @@ export type Config = {
      */
     reserved?: number
     /**
-     * Maximum consecutive writer failures per session before checkpointing stops retrying until process restart. Default: 3.
-     */
-    max_writer_failures?: number
-    /**
      * Whether to fork the parent agent's message prefix into the writer session for prefix-cache reuse. Requires provider cache-breakpoint support. Default: false.
      */
     fork?: boolean

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -13893,12 +13893,6 @@
                 "minimum": 0,
                 "maximum": 9007199254740991
               },
-              "max_writer_failures": {
-                "description": "Maximum consecutive writer failures per session before checkpointing stops retrying until process restart. Default: 3.",
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "maximum": 9007199254740991
-              },
               "push_caps": {
                 "description": "Per-section token caps for rebuild context (renderRebuildContext). Each section is loaded up to its cap so the rebuild stays within a predictable budget.",
                 "type": "object",


### PR DESCRIPTION
Follow-up to #1938 (merged). Two halves, worth reading as separate commits: **Part 1 deletes** the checkpoint writer's blind failure accounting, and **Part 2 replaces it** by making a spawned agent's failure classifiable, then using that classification in the writer's one reporting site.

Part 1's previous revision argued for *extending* prune's wait and adding a cap; that argument is void and has been removed from this description. It also recorded an owed follow-on — "classify the failure instead of counting it" — which was blocked on `AgentOutcome`'s failure arm carrying only a string. Part 2 widens that contract and discharges it, so this PR no longer reads as "deleted the accounting, replaced it with nothing".

#1938's core fix is untouched throughout: `waitForWriter` still returns a distinct `"timeout"` when its 300s bound expires with the writer still in flight.

# Part 1 — delete the blind failure count

What is deleted is the failure accounting layered on top of #1938 — including the pre-existing counter that predates it.

## Why: the premise the accounting was built on does not hold

The writer fires at **every threshold crossing** (4 @ 20% for mid-tier windows, 9 @ 10% for extended-context — see the schedule comment above `prune.ts:35`). It is designed fail-acceptable, and the code already implements that:

- `ensureCheckpointTemplate` (`checkpoint.ts:117-121`) writes the template **only when the file does not exist**, so a failed writer does **not** clobber the previous checkpoint. It is a conditional write, not a scaffold-then-fill.
- `last_checkpoint_message_id` advances **only** on a successful insert (`checkpoint.ts:918-934`; the sole external caller of `resetThresholds` is `prompt.ts:428`, gated on `if (inserted)`).

So one failed write leaves the file and the watermark **mutually consistent, both pointing at the last good checkpoint**. A rebuild uses that automatically. The cost of a failure is a **staler** checkpoint, never a missing one — and the next threshold crossing is a natural retry, with *fresher* context than an in-place re-fire of the same threshold would have had.

On top of that redundancy, the previous revision added machinery that did not trust it, and the failure model behind the counter was wrong: **a writer failing repeatedly means the provider is broken, in which case the foreground turns are failing too and the user already knows.** The writer's LLM calls go through the same retry ladder as the foreground (`retry.ts` — `isRetryableTransientError`, `RETRY_INITIAL_DELAY = 2000`, `RETRY_BACKOFF_FACTOR = 2`, consumed by `session/llm.ts:34` and `session/processor.ts:17`; the writer runs as a spawned subagent through the same prompt loop). Any failure that reaches prune is therefore **already post-retry**. Counting it again, three times, then falling silent, adds nothing.

## What was deleted

| what | where it was |
| --- | --- |
| `MAX_WRITER_WAIT_EXTENSIONS = 12` and the whole wait-extension loop | `prune.ts:32`, loop at `prune.ts:341-350` |
| `MAX_WRITER_FAILURES = 3` | `prune.ts:27` |
| `writerFailures` map + its comment | `prune.ts:178-182` |
| `maxFailures` config read | `prune.ts:280` |
| the in-place-retry path: `crossed.delete()` / `maxCrossed.delete()` on failure, plus the failure/give-up logs | `prune.ts:351-373` |
| `cfg.checkpoint.max_writer_failures` schema entry | `config/config.ts:278` |
| its docs row and generated SDK declarations | `mimocode-docs/reference/config.md:126`, `sdk/js/src/v2/gen/types.gen.ts:2209`, `sdk/openapi.json:13896` |

`grep -c "writerFailures\|MAX_WRITER_FAILURES\|MAX_WRITER_WAIT_EXTENSIONS\|max_writer_failures"` over the pushed blobs of all five source files returns **0**. (The only surviving mentions repo-wide are three comment lines in the rewritten tests that state, deliberately, what those tests used to assert.)

### The watcher fiber survives — as observation only, and that is load-bearing

The obvious reading of "delete the accounting" is to delete the forked watcher entirely, since nothing else consumed it. **That would have been wrong**, and the check is worth recording: `prune.ts:340` and `:349` were `waitForWriter`'s **only production callers** (`grep -rn waitForWriter src/`). Deleting the fork would have made #1938's bound-expiry log — the one thing this PR was asked to keep — unreachable in production, surviving only as a line that tests exercise.

So the fork remains, reduced to a single call whose result is discarded:

```ts
yield* checkpoint.waitForWriter(input.sessionID).pipe(Effect.forkDetach)
```

No loop, no counter, no retry. The wait exists purely so `waitForWriter`'s `checkpoint writer wait bound expired — writer still in flight` (`checkpoint.ts:1009`) still fires. That log is cheap, at most once per writer, and it is the only evidence a slow writer leaves; #1938's own diagnosis came from a log line exactly like it. Terminal outcomes are already logged by the settle watcher (`checkpoint.ts:920-934`), so nothing is lost by discarding the return value.

## The config surface: removed, not deprecated

`cfg.checkpoint?.max_writer_failures` was a public config surface, so removal vs. accept-and-ignore was a real decision. I expected the back-compat argument to force deprecation, and measured instead of assuming:

```
Config.Info.safeParse({ checkpoint: { bogus_key_xyz: 3 } })  -> success: true
Config.Info.safeParse({ bogus_top_xyz: 3 })                  -> success: false
   [{"code":"unrecognized_keys","keys":["bogus_top_xyz"],...}]
```

`.strict()` at `config/config.ts:485` is applied to the **top-level** object only and does not recurse. An unknown key *nested* under `checkpoint` is silently accepted. So **removing the field cannot break an existing config** — a user who still has `max_writer_failures` set gets no error, exactly as before.

That removes the only real argument for keeping it. Deprecating would be strictly worse: a knob still published in the JSON schema, the docs table, and the SDK types, which provably does nothing — a user setting `max_writer_failures: 10` would reasonably expect behaviour and get silence. Removed, with the docs row and both generated declarations removed alongside so no artifact advertises a knob the server dropped.

## Tests — rewritten, not deleted

Six cases in `prune.test.ts` and `T10` in `checkpoint-child-session.test.ts` pinned the deleted machinery. All seven are rewritten to pin the **opposite** requirement. Each rewrite states in-file what it used to assert and why that is no longer the requirement.

**What they used to assert:** that a failure *below* the cap re-armed its own threshold (enqueue 1→2→3); that a success cleared the counter; that the watcher kept re-entering the bounded wait so a late outcome still reached the counter; and the exact 13-call boundary of that re-entry loop. All of it encoded in-place retry plus a give-up gate as requirements. Neither is a requirement now.

**What is pinned instead** — `prune.test.ts` (3 cases, on the existing `makeRetryHarness`):

- **a failed writer does not re-arm its own threshold** — after a failure, three more fires at the same token level stay at 1 enqueue.
- **a failed writer at the max threshold leaves `maxThresholdCrossed` set** — the old watcher paired `crossed.delete` with `maxCrossed.delete`, which *withdrew* the already-raised discard+rebuild signal `prompt.ts` consumes. Overflow readiness must not depend on whether the writer happened to succeed.
- **the next threshold crossing still fires after a failure** — the retry path the design now relies on. The exact count is what pins it: the old code also reached a 2nd enqueue, but reached a **3rd**, because the failure had additionally re-armed the first threshold.

**And the self-healing property asserted directly** — `T10` now drives the real service, seeds a known previous checkpoint (file content + watermark), fails the writer, and asserts the premise this whole change rests on:

```
expect(yield* Effect.promise(() => Bun.file(cpFile).text())).toBe(previousContent)
expect(yield* svc.lastBoundary(info.id)).toBe(previousBoundary)
```

The file still holds the previous content and `lastBoundary` still returns the previous boundary — mutually consistent at the last good checkpoint. These two assertions pass under the old code as well, by design: they are properties of `checkpoint.ts`, not of the deleted accounting. They are here to make the premise executable rather than asserted in prose.

### Revert probe

Restoring **only** `src/session/prune.ts` to the pre-change blob (`git show HEAD:…`), keeping the new tests:

```
345 |         expect(harness.state.enqueueCount).toBe(1)
error: expect(received).toBe(expected)
Expected: 1
Received: 2
(fail) a failed writer does not re-arm its own threshold — no in-place retry [659.62ms]

375 |         expect(yield* svc.maxThresholdCrossed(info.id)).toBe(true)
error: expect(received).toBe(expected)
Expected: true
Received: false
(fail) a failed writer at the max threshold leaves maxThresholdCrossed set [456.32ms]

408 |         expect(harness.state.enqueueCount).toBe(2)
error: expect(received).toBe(expected)
Expected: 2
Received: 3
(fail) the next threshold crossing still fires after a failure [512.93ms]

 13 pass
 3 fail
 76 expect() calls
```

**The probe also caught a flaw in my own T10.** On that first run T10 *passed* under the reverted code — it should have failed. Cause: I had dropped the original T10's 50 ms pre-settle tick, so prune's fork had not yet reached `writers.get(...)` inside `waitForWriter` when the outcome settled, and it saw `"no-writer"` instead of the failure — the race documented in `prune.ts`. The test was passing by accident, not because the behaviour held. Tick restored (with a comment explaining why it is required), and T10 then discriminates:

```
526 |         expect(spawnLog.count).toBe(1)
error: expect(received).toBe(expected)
Expected: 1
Received: 2
(fail) T10: a failed writer is self-healing … and no in-place retry fires [378.74ms]

 5 pass
 1 fail
 30 expect() calls
```

`prune.ts` restored afterwards; `grep -c MAX_WRITER_WAIT_EXTENSIONS src/session/prune.ts` → 0.

# Part 2 — the replacement: classify the failure instead of counting it

Part 1 deletes the blind count. On its own that leaves the writer's failure handling with **nothing** in its place, which is precisely what this PR's earlier revision recorded as owed: the better replacement is to *classify* the failure. That was not implementable then, and the obstacle was a type.

```ts
// actor/spawn.ts, before
| { status: "failure"; error: string }
```

`AgentOutcome`'s failure arm carried **a stringified message and nothing else** — no `APICallError`, no status code, no retryable flag. A consumer could not tell a transient provider blip from a deterministic, will-never-work failure without matching on prose. Blind counting was the only thing the type permitted. So the count could be deleted honestly, but not *replaced*, until the contract was widened. That is what Part 2 does.

## The shape

```ts
export type FailureKind = "transient" | "overflow" | "auth" | "aborted" | "other"

export interface FailureInfo {
  readonly kind: FailureKind
  readonly retryable: boolean
  /** The persisted NamedError name, e.g. "APIError" / "ContextOverflowError". */
  readonly name: string
}

| { status: "failure"; error: string; failure?: FailureInfo }
```

Additive and backward-compatible: `error: string` is untouched and still carries the human text, and the new field is optional, so every existing consumer and every existing hand-built test literal still typechecks unchanged.

`failure` is **present only when the failure came from a settled assistant error**. A work fiber that failed some other way — a defect during teardown, or a hand-built outcome such as `waitForWriter`'s `{ status: "failure", error: "timeout" }` (`checkpoint.ts:986`) — leaves it absent rather than asserting a class it does not have.

`retryable` means "this error belonged to the retryable class", **not** "please retry". The child's LLM calls already run through `retry.ts`'s ladder, so any failure reaching a consumer is already post-retry — the same fact that licensed Part 1's deletion.

### The alternative I rejected

Two independent flat fields on the arm: `retryable?: boolean` and `kind?: FailureKind`. Rejected because they admit incoherent states (`kind: "overflow"` with `retryable` absent versus present-and-`false`) and because they force every read site to write its own absence guard — precisely the hazard AGENTS.md § "Reading a nullable column" describes, since a guard written `=== undefined` typechecks, reads correctly in review, and silently does nothing. One optional object is present-or-absent **as a unit**: a single truthiness check, after which the interior fields are non-optional and cannot disagree.

Also rejected: carrying `provider/error.ts`'s `ParsedAPICallError` directly. It is bound to the AI-SDK `APICallError` shape at the *provider* boundary; by the time a failure reaches spawn the error has already been normalized into the persisted named-error union, so re-deriving it there would mean re-parsing — the thing this change exists to avoid.

## Populated where the typed error still exists

`actor/spawn.ts:354`, inside `runAgentLoop`. That line previously threw the typed error away:

```ts
// before — the class of the error is reduced to its name inside a string
return yield* Effect.fail(new Error(`Actor assistant failed: ${info.error.name}`))
```

`info.error` is the assistant message's **already-normalized** named error, so no new taxonomy was added — the existing classifiers are reused at exactly this point:

- **`SessionRetry.retryable` (`session/retry.ts`) is the retryability oracle.** Its input type *is* this data shape (`Err` === the return of `NamedError["toObject"]`), and it already folds in `isRetryableTransientError` plus every 429 / 5xx / quota / `upstream_error` special case. Reusing it means the classification cannot drift from the ladder that actually decides retries.
- **`kind` is read off the named-error identity** that `MessageV2.fromError` (`message-v2.ts:1159-1186`) derived from `ProviderError.parseAPICallError` / `isOverflow` / `isOpenAiErrorRetryable`: `ContextOverflowError` → `overflow`, `ProviderAuthError` → `auth`, `MessageAbortedError` → `aborted`.
- One refinement: an `APIError` with `statusCode` 401/403 also maps to `auth`, reading the status code `parseAPICallError` already extracted. `ProviderAuthError` only covers a *missing* key (`LoadAPIKeyError`); a *rejected* one arrives as an `APIError`, and to a consumer they are the same thing.

Carrying it the last few frames needs one small class, because `forkWork`'s `onFailure` — the single place `AgentOutcome` is constructed (`spawn.ts:737-744`) — only has a `Cause`:

```ts
const squashed = Cause.squash(cause)   // established idiom: session/prompt.ts, tool/shell-wrap.ts
const failure = squashed instanceof AssistantSettledError ? squashed.failure : undefined
```

`AssistantSettledError` is a plain `Error` subclass, chosen deliberately: `Cause.pretty` renders it **byte-identically** to `new Error(message)` (measured before committing to it), so `error`'s existing text is unchanged rather than gaining a class prefix.

## Consumer inventory

Every consumer is an awaiter of the `AgentOutcome` `Deferred`. `grep -rn "Deferred.await" src/ | grep -i outcome` finds **six** production sites across four files:

| # | consumer | site | what it reads | verdict |
| --- | --- | --- | --- | --- |
| 1 | workflow runtime, shared-spawn step | `workflow/runtime.ts:845-852` | `status !== "success"`, then `(outcome as { error?: string }).error` | **no break** — additive field ignored |
| 2 | workflow runtime, isolated/worktree step | `workflow/runtime.ts:971-980` | same | **no break** |
| 3 | workflow runtime, disposition + deliverable | `workflow/runtime.ts:999-1023` | `status === "success"` only | **no break** — success arm untouched |
| 4 | ordinary subagents (`actor run`) | `tool/actor.ts:788-816` | `status === "failure"` → `.error` | **no break** |
| 5 | peer / fork-query (`session ask`) | `tool/session.ts:149-151` | `status === "failure" ? .error : .status` | **no break** |
| 6 | checkpoint writer, settle watcher | `checkpoint.ts:914-960` | `status === "success"` gates the watermark | **changed on purpose** (below); watermark logic untouched |
| 6b | checkpoint writer, `waitForWriter` translation | `checkpoint.ts:984-990` | maps to `success`/`failure`; also *constructs* `{ status: "failure", error: "timeout" }` | **no break** — the literal still typechecks and correctly carries no classification |

Two entries from the original consumer list turn out **not** to be consumers, and the check is worth recording:

- **`dream` / `distill` never see an `AgentOutcome`.** They are agent *types*, invoked through `sp.prompt({ agent: "dream" | "distill", … })` at `session/prompt.ts:3115` and `:3126` — they do not go through `Actor.spawn` at all. (`spawn.ts:217`'s comment lists them among spawn's callers, which is what makes this worth stating explicitly; the actual code path is a direct prompt.)
- **`actor/group.ts:141-146`** matches a grep for `outcome` but reads actor-registry status strings, not `AgentOutcome`.

Test literals that hand-build the failure arm — `auto-overflow-writer-first.test.ts:164`, `checkpoint-child-session.test.ts:367` and `:477`, `checkpoint-watermark-transactional.test.ts:131` — all still compile unchanged, which is the optional field doing its job.

`AgentOutcome` is an internal TypeScript type, never surfaced through the zod/OpenAPI layer: `grep -n "AgentOutcome\|FailureInfo\|FailureKind"` over `sdk/js/src/v2/gen/types.gen.ts` and `sdk/openapi.json` returns **nothing**, so Part 2 needs no artifact regeneration. Part 1's SDK edits, which remove `max_writer_failures`, stand as described above.

## The one behaviour change: the writer's log stops lying by omission

Part 1 leaves the settle watcher emitting **one undifferentiated warn for every non-success outcome** (`checkpoint.ts:930`), so "will fix itself at the next threshold" and "will never work" read identically. That is the hole the deletion opened. With the classification available:

- a **transient** failure keeps the existing line — it is the retry ladder's business, and the next crossing re-covers the delta with fresher context;
- a **deterministic** one (overflow / auth / bad request) says so and names the cause, because it will recur identically at every future threshold.

**Stateless on purpose.** No per-session memory of previous failures, under any name. Such memory *is* a trend detector, and the trend belongs to the user-facing warning described under "Residual" below — accumulating it here would be re-adding, with a different name, exactly what Part 1 removed. Read as "report a deterministic failure *as* the distinct thing it is", not as "suppress the repeat"; suppression would need that state.

Nothing else changes. No retry policy, no give-up logic, no user-facing warning, and no consumer other than #6 reads the new field.

## Tests for Part 2

Four cases in `test/actor/spawn.test.ts`, all driven through the **real construction path**: the classification is produced by `runAgentLoop`, carried across the failure channel, squashed back out and assembled by `forkWork`'s `onFailure`. No test builds an `AgentOutcome`.

- transient (`APIError` 429, `isRetryable: true`) → `kind: "transient"`, `retryable: true`
- deterministic (`ContextOverflowError`) → `kind: "overflow"`, `retryable: false`
- deterministic (`APIError` 401) → `kind: "auth"`, `retryable: false`
- a clean turn → `failure == null` (truthiness / `== null`, never `=== undefined`), so a success can never carry an invented classification

Each also asserts `error` still contains `Actor assistant failed: <Name>`, pinning the backward-compatible string.

The upstream provider round-trip is stood in for at the `SessionPrompt.prompt` boundary, and that is a deliberate, disclosed choice rather than convenience: **`SessionRetry.policy` is uncapped** — its schedule stops only when `retryable()` returns falsy — so a genuinely retryable provider error *never settles on its own*. A real-server transient case would hang, not fail. This is also why consumer #6 branches on `!failure.retryable` rather than trying to act on transient: in the current architecture `kind` carries the discriminating power and `retryable` is largely documentary.

### Revert probe

Restoring **only** the construction site at `spawn.ts:354` to its previous `new Error(...)` — keeping the new tests, so the field exists but is never populated:

```
1440 |         expect(outcome.failure).toBeTruthy()
       ^
error: expect(received).toBeTruthy()

Received: undefined

      at toBeTruthy (unknown:1:1)
      at /…/packages/opencode/test/actor/spawn.test.ts:1440:33

1478 |         expect(outcome.failure).toBeTruthy()
       ^
error: expect(received).toBeTruthy()

Received: undefined

      at /…/packages/opencode/test/actor/spawn.test.ts:1478:33

1511 |         expect(outcome.failure?.retryable).toBe(false)
       ^
error: expect(received).toBe(expected)

Expected: false
Received: undefined

      at /…/packages/opencode/test/actor/spawn.test.ts:1511:44

 1 pass
 26 filtered out
 3 fail
```

The single pass is the negative case — it asserts *absence*, so it must keep passing under the revert, and does. Construction site restored afterwards; `bun typecheck` exit 0 and the classification tests green again.

## Verification

`bun typecheck` → **exit 0** for `packages/opencode` and for `packages/sdk/js` (the two packages touched).

Scoped run, identical command both sides — `bun test test/session/prune.test.ts test/session/prune-skip-system.test.ts test/session/checkpoint-child-session.test.ts test/session/checkpoint-writer-wait-timeout.test.ts --timeout 120000`:

| | result |
| --- | --- |
| pristine baseline at `3068ed9f9`, before any edit | **26 pass / 0 fail**, 106 expects, 10.93s |
| after this change | **23 pass / 0 fail**, 94 expects, 10.36s |

Net −3 tests: six `prune.test.ts` cases replaced by three; `T10` replaced 1:1. 
**Part 2**, identical command both sides — `bun test test/actor/spawn.test.ts test/session/checkpoint-child-session.test.ts test/session/checkpoint-writer-wait-timeout.test.ts test/session/prune.test.ts --timeout 30000`, run in the same fresh worktree at the same base so the environment is a genuine control:

| | result |
| --- | --- |
| pristine baseline at `4e011eaf7` (Part 1's head), before any Part 2 edit | **45 pass / 0 fail**, 163 expects, 30.99s |
| after Part 2 | **49 pass / 0 fail**, 178 expects, 31.76s |

Net +4 tests, +15 expects, and the 45 pre-existing cases — including Part 1's rewritten `prune.test.ts` and `T10`, which pin "a failed writer does not re-arm its own threshold" — all still pass. No existing assertion was weakened or removed.

`bun typecheck` → **exit 0** for `packages/opencode` and for `packages/sdk/js`. The pre-push hook additionally ran the repo-wide typecheck: **12 of 12 tasks successful**.

The full suite was deliberately **not** run — other work is live on this box and concurrent full runs starve each other badly enough to make pass counts meaningless.

## Residual, stated plainly

**~~A session whose *last* threshold fails gets no further fire.~~ — CLOSED BY PART 3.** This was written down here as an accepted consequence of Part 1 (*"the retry *is* the next crossing, and a last threshold has no next"*). A review pushed back, and on measurement the consequence was **worse than recorded**: the final threshold's would-be successor is the discard+rebuild's `resetThresholds`, which never runs when `lastBoundary` is unset — i.e. exactly when no writer has ever succeeded — so the session stopped checkpointing permanently rather than merely going stale. Part 3 gives the final threshold a class-gated, window-bounded recovery gate. **The paragraph is kept rather than deleted so the reasoning that accepted the hole, and the measurement that overturned it, both stay on the record.**

**A user-visibility gap this PR deliberately does not close.** When checkpointing is persistently broken, the overflow fallback is compaction — and that fallback is lossy. **Correction, measured after this section was written** (see #1973): `compaction.create` in isolation is only 3 local writes (p50 **0.240 ms**), which is where the earlier "unsummarized amputation" claim came from — but `runLoop` pairs it with `compaction.process` (`prompt.ts:3290-3298`), a real LLM summarization, so the *path* does summarize. The in-tree comment that asserted otherwise was false and is corrected in #1973. The user-visibility gap therefore remains, but its stake is "your context is being summarized away repeatedly and silently", not "dropped unsummarized". The user should be warned about *that*, but the warning belongs in its own change, and its trigger must be a **trend** ("the last N thresholds all failed") or the moment a rebuild finds its checkpoint too stale — **never a failure count**, which is exactly the mechanism deleted here for being the wrong shape. Part 2 supplies the *input* such a warning needs (a deterministic failure is now identifiable as such) and deliberately stops there: it adds no per-session state, so nothing here is a trend detector wearing a new name.

## Relationship to #1938

Unchanged and not reverted: `waitForWriter` (now `checkpoint.ts:1087`), its 5-min bound, its distinct `"timeout"` outcome, the `WriterOutcome` type (`checkpoint.ts:534`), and the bound-expiry log (`checkpoint.ts:1070`). Part 3 moved the *implementation* into `waitForWriterSettlement` (`checkpoint.ts:1040`) and made `waitForWriter` a projection of it, so the contract is now **derived from** the same code path rather than sitting beside it — it cannot drift. Line numbers here are re-read from the pushed blob at `3ee914261`. #1938's `checkpoint-writer-wait-timeout.test.ts` assertions are all retained verbatim; only two of its **comments** changed, where they justified the `timeout`/`failure` distinction by pointing at the counter that no longer exists. The distinction itself stands on its own: a slow-but-working writer must not read as a broken one.

`checkpoint-align.ts`'s doc comment, which described when a rejection increments `writerFailures`, now describes what actually happens — the previous checkpoint and its watermark stay in place and the next crossing re-covers the same delta.

## Deliberately not included

- **The user-facing persistent-checkpoint-failure warning.** Specified above: trend or stale-at-rebuild, never a count. It needs state this PR deliberately does not introduce.
- **Acting on the classification anywhere but consumer #6.** The other five consumers are untouched by design; giving them retry or give-up policy is a behaviour change per consumer and belongs with whoever owns that consumer.
- **Wiring `kind` into the `WriterCachePerf` bus event.** That event is the natural substrate for cross-layer writer-health accounting, which is the trend detector's business, not this PR's.
- `computeBoundary` coverage pinning (`checkpoint.ts:254-293`) — it changes what a checkpoint *covers* and is a separate, riskier decision.

---

# Part 3 — recovery: the final threshold gets a gate

Part 1's argument was *"the next threshold crossing is the retry."* A review correctly pointed out that this presumes a next threshold, and the **last** one has none. Part 3 closes that, using Part 2's classification as the discriminator.

## What "no next threshold" actually costs — measured, because the naive statement understates it

The final threshold is not simply successor-less. It *has* a would-be successor, and that successor is conditional in exactly the wrong way:

1. When the final threshold fires, `fireCheckpoints` also sets `maxCrossed` (`prune.ts:428`), and the **same runLoop iteration** consumes it: `overflowCheck(...) || prune.maxThresholdCrossed(sessionID)` → `rebuildFromCheckpoint` (`prompt.ts:3308-3352`).
2. A **successful** rebuild calls `resetThresholds` (`prompt.ts:428`), which clears `crossed` — **re-arming the entire ladder from 20%.** So in the healthy case the final threshold *does* get a retry: the ladder restarts.
3. But `rebuildFromCheckpoint` returns `false` when `lastBoundary` is unset (`prompt.ts:413`), and the watermark is unset **precisely when no writer has ever succeeded.**

⇒ In the one case that needs recovery most — *the first checkpoint failed* — there is no boundary, no reset, `crossed` still holds every threshold, and **the session never fires another writer for the rest of its life.** Every subsequent iteration falls to compaction instead. That is not "a staler checkpoint"; it is the subsystem switched off silently.

(`maxCrossed` is also never cleared in that path, so the compaction fallback repeats every other iteration. That is a **pre-existing, separate** defect — it predates this branch and is not touched here.)

## The principle

> **A failed checkpoint write earns a retry only when the failure's *class* says a retry could succeed, and only where the token axis still has *room* for one. Both are readings of the present state, so neither needs any memory of previous failures.**

The mechanism below is meant to be readable as nothing more than that sentence applied to the one threshold that lacks a successor.

## The mechanism

`prune.ts` gains **one** piece of per-session state — `finalRetryAt: Map<SessionID, number>` (`prune.ts:190`), the token count at or above which the final threshold may fire a second time.

**Admission** (`prune.ts:303-318`) — the only threshold that can re-fire is the final one, and only past its gate:

```ts
if (already.has(t)) {
  const gate = finalRetryAt.get(input.sessionID)
  if (t !== maxThreshold || gate == null || currentTokens < gate) continue
  finalRetryAt.delete(input.sessionID)   // one gate is one attempt
}
```

**Arming** (`prune.ts:384-418`), in the forked settle watcher that Part 1 already kept for the bound-expiry log:

| condition | line | why |
| --- | --- | --- |
| `if (!isFinal) return` | `prune.ts:386` | every other threshold's successor **is** its retry |
| `if (settled.outcome !== "failure") return` | `prune.ts:389` | `"timeout"` means *still in flight* — the writer may yet succeed and advance the watermark |
| `if (!settled.failure?.retryable)` → log, return | `prune.ts:392` | deterministic (overflow / auth / bad request) recurs identically; **unclassified** carries no evidence a retry helps, so it is treated the same |
| `gate = Math.min(firedAt + step, maxAllowed)` | `prune.ts:401` | one **ladder step** above where it fired, capped at the last position a write is meaningful |
| `if (gate <= firedAt) return` | `prune.ts:402` | no room left in the window ⇒ no attempt |

`step` is the ladder's own spacing (`prune.ts:297`), and `maxAllowed` now comes from a shared `maxAllowedFor()` (`prune.ts:79`) that `resolveThresholds` also uses, so the clamp and the ceiling cannot drift apart. `resetThresholds` drops the gate (`prune.ts:535`): a rebuild re-arms the whole ladder, which supersedes it.

## Why this is not `MAX_WRITER_FAILURES` under a new name

This was the explicit bar, so it is answered directly rather than asserted.

| | the deleted counter | this gate |
| --- | --- | --- |
| what it measures | **attempts** — how many times an already-abandoned attempt was abandoned | a **position** on the token axis |
| across attempts | accumulates | overwritten, and dropped when consumed |
| where its value comes from | a stipulated constant (`3`) | the threshold ladder + the context window |
| conversation stops growing | still permits N retries | **stops retrying entirely** |
| conversation grows fast | still permits only N | keeps retrying — because there is genuinely new uncovered delta each time |
| retry rate | unbounded within N | can never exceed the ladder's own firing rate |

The retry **budget** is therefore the *unused window*, a physical quantity the system already measures: with the mid-tier ladder (4 @ 20%) the final threshold sits at 80% and one step overshoots `maxAllowed`, so it affords **at most one** retry; with a 1M-window ladder (18 @ 5%) it affords **two**. Nobody chose those numbers — geometry did.

## Measurement that decided the alternatives

**Rejected: "the loop is self-limiting because a broken writer means a broken provider, so the foreground dies too."** This needed checking specifically for the *writer*, since a separately-configured writer model could be rate-limited while the foreground works. **It does not have one.** `prune.ts:324` passes the foreground turn's own model into `tryStartCheckpointWriter`; `checkpoint.ts` forwards it to `actor.spawn({ model })`; `spawnSubagent` → `forkWork` → `runAgentLoop` → `sessionPrompt.prompt({ model })`, and the resolution is `inputModel ?? agentModel ?? lastModel(...)` (`prompt.ts:1836`) — **`inputModel` wins.** The `checkpoint-writer` agent definition (`agent/agent.ts:347`) declares no `model`/`modelRef` at all, so there is nothing to lose the race anyway. ⇒ the shared-fate argument **holds**, which is why persistent failure still needs no counter — but it says nothing about a *single* transient failure at the last threshold, which is the only case Part 3 acts on.

**Rejected: bound the retry with a count (even `1`).** Arbitrary, and it is the deleted mechanism with a smaller constant. Ruled out by the bar, not by measurement.

**Rejected: append `maxAllowed` to the ladder unconditionally**, so the final threshold always sits at the last meaningful position and "no successor" becomes a fact about the window rather than a defect. Elegant and needs **zero** new state — but it adds a **fifth writer per ladder cycle for every session**, failure or not. Paying that always, to fix a case that arises only on failure, is the wrong trade.

**Rejected: clear the threshold whenever the failure was transient.** This is the hot loop the brief warned about: `fireCheckpoints` runs at the start of every runLoop iteration, so an unchanged token count would spawn a writer — a dozen sequential round-trips — per iteration. The progress gate is precisely what removes it, and a test pins that (below).

## Plumbing: how the class reaches prune without touching #1938's contract

Part 2 put `FailureInfo` on `AgentOutcome`, but prune only sees `WriterOutcome` — three flat strings. Rather than widen that union (which would break every `=== "failure"` consumer and #1938's own test), `checkpoint.ts` gains a **companion**:

- `WriterSettlement = { outcome: WriterOutcome | "no-writer"; failure?: FailureInfo }` (`checkpoint.ts:546`)
- `waitForWriterSettlement` (`checkpoint.ts:1040`) holds the implementation — the same 5-min bound, the same bound-expiry log (`checkpoint.ts:1070`), plus the classification.
- `waitForWriter` (`checkpoint.ts:1087`) is now a **projection** of it: `(yield* waitForWriterSettlement(id)).outcome`.

So #1938's contract is not merely "still there" — it is derived from the same code path, and the two **cannot** disagree about what a settled writer did. `failure` is absent for a cancelled writer and for a failure that was never classifiable, i.e. **absent means unknown, never retryable**.

## Tests for Part 3 — six new cases, every one revert-probed

`test/session/prune.test.ts`, new nested describe `final-threshold recovery gate` (harness stub rewired so the settlement path — the one production calls — is the driver; a stub implementing only `waitForWriter` would have left every failure case in this file **vacuous**, since the seeded queue would never drain):

1. a **deterministic** failure at the final threshold arms no gate
2. a **transient** failure re-fires it, **but only once growth reaches a full ladder step** (fires at 31 000, gate at 41 000; asserts *no* re-fire at 31 000 / 35 000 / 40 999, then a re-fire at 41 000)
3. a transient failure arms no gate when the **window has no room** left
4. a transient failure at a **non-final** threshold arms no gate — including that it cannot leave a gate for the *final* threshold to consume
5. a bound-expiry **`"timeout"`** arms no gate
6. **`resetThresholds` drops a pending gate**

`test/session/checkpoint-writer-wait-timeout.test.ts`, new describe `SessionCheckpoint.waitForWriterSettlement` — five cases against the **real service** (prune's tests stub the checkpoint service, so without these the AgentOutcome → WriterSettlement hop would be asserted nowhere and every case above would rest on an assumption): classification carried through for a deterministic failure, for a retryable one, `cancelled` → unclassified, unclassified failure stays unclassified, and a bound expiry → `"timeout"` with no classification. Each enters the wait **before** settling the Deferred, because the settle watcher removes the writers-map entry on settlement and a later wait returns `"no-writer"` — which would pass "no classification" vacuously.

### Revert probes — all verbatim

| # | reverted | result |
| --- | --- | --- |
| 1 | admission block → `if (already.has(t)) continue` (Part 1's code) | `Expected: 3 / Received: 2` — *a TRANSIENT failure at the final threshold re-fires it…* · **14 pass / 1 fail** |
| 2 | drop `currentTokens < gate` (the progress bound) | `Expected: 2 / Received: 3` — same case · **14 pass / 1 fail** |
| 3 | arm on **any** settled failure (drop the `retryable` check) | `Expected: 2 / Received: 3` — *a DETERMINISTIC failure at the final threshold arms no gate* · **14 pass / 1 fail** |
| 4 | drop `if (!isFinal) return` | `Expected: 2 / Received: 3` — *a TRANSIENT failure at a NON-final threshold arms no gate* · **14 pass / 1 fail** |
| 5 | drop `if (gate <= firedAt) return` (the window ceiling) | `Expected: 2 / Received: 3` — *…no gate when the window has no room left for a retry* · **14 pass / 1 fail** |
| 6 | `resetThresholds` no longer clears the gate | `Expected: 4 / Received: 5` — *resetThresholds drops a pending gate…* · **14 pass / 1 fail** |
| 7 | drop the classification passthrough in `checkpoint.ts` | `expect(received).toEqual(expected)` `- Expected - 5 / + Received + 1` and `Expected: true / Received: undefined` — *carries the failure classification off the writer's outcome*, *carries a retryable classification through unchanged* · **6 pass / 2 fail** |

**Reported because it is a negative result, not hidden:** removing **only** `if (settled.outcome !== "failure") return` leaves the suite **16 pass / 0 fail**. That guard is intent-stating and structurally redundant, because a `"timeout"` settlement also carries no classification, so the `retryable` check rejects it anyway. Removing **both** guards turns it red (`Expected: 2 / Received: 3`, two cases). The test comment says exactly this rather than claiming a probe it does not have, and the invariant the redundancy rests on — *a timeout never carries a classification* — is asserted directly against the real service.

## Part 3 verification

Identical command both sides, same fresh worktree, same base — baseline sha printed and compared: **`e3bd071eb`** (Part 2's head) before and after.

`bun test test/session/prune.test.ts test/session/prune-skip-system.test.ts test/session/checkpoint-writer-wait-timeout.test.ts test/session/checkpoint-child-session.test.ts test/session/checkpoint-splitover-integration.test.ts`

| | result |
| --- | --- |
| pristine baseline at `e3bd071eb`, before any Part 3 edit | **27 pass / 0 fail**, 109 expects, 10.33s |
| after Part 3 | **38 pass / 0 fail**, 143 expects, 15.77s |

Net **+11 tests, +34 expects, 0 fail either side.** All 27 pre-existing cases still pass, **including** Part 1's three rewritten `prune.test.ts` cases that pin *"a failed writer does not re-arm its own threshold"* — see the next section for why they did **not** need rewriting.

`bun typecheck` → **exit 0** (12 of 12 turbo tasks). Nothing generated changed, so `packages/sdk/js` is untouched by Part 3. `oxlint` on the five changed files: **0 errors**, warnings 30 → 36, all six new ones the pre-existing `{} as any` promptOps pattern this file already uses throughout. The full suite was deliberately not run.

## No existing assertion was weakened — and why that is not luck

Part 1's cases assert that a failed writer does not re-arm its own threshold. The gate is **narrower than those cases on both axes**: it requires a `retryable` class, and it applies only to the final threshold. Every failure in those cases is pushed as `{ outcome: "failure" }` with **no** `failure` field — an *unclassified* failure, which the gate refuses — and the first case's failure is at a non-final threshold anyway. So all three assertions are unchanged, and they now additionally pin that an unclassified failure is treated as *"cannot know whether a retry helps"* and behaves exactly as before. The in-file comment records this explicitly so a future reader does not read the new describe block as a reversal of the old one.

The only edits to those tests are scaffolding: the seeded queue now holds `WriterSettlement` objects and the stub implements `waitForWriterSettlement` (the method production calls). One test was **strengthened** during review — the non-final case originally stopped one fire too early and did not actually catch probe 4; it now fires once more and does.

## The stale comment Part 1 left behind — treated as a defect, not a nit

`test/session/checkpoint-writer-wait-timeout.test.ts` still justified two #1938 cases with *"this is the direction that keeps the **failure cap** reachable in the slow regime … a permanently broken slow writer would never be **counted**"*, and *"booking happens in prune, whose **counter** is closure-private"*. **The cap and the counting were deleted by Part 1 of this very PR.** A stale test comment reads as intent and it caused a real misreading during this work.

Rewritten to state what the cases actually pin — #1938's success/failure/timeout contract — with the dead justification recorded as removed rather than quietly dropped. And the honest answer to *"is the distinction consumed only by tests?"*: **it was, and it no longer is.** Before Part 3, prune discarded the wait's return value entirely, so nothing in production read `"timeout"` differently from `"failure"`. Now prune's gate refuses to arm on `"timeout"` (`prune.ts:389`), so the distinction has a production consumer. The flat three-value `waitForWriter` itself, however, has **no** production caller left — prune uses the settlement shape — so it is now a contract these tests hold still, and that is stated in the file.

