### PR TITLE
fix(session): stop persisting empty-shell assistant messages and repair the readers that assumed the row exists

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -639,6 +639,27 @@ function providerMeta(metadata: Record<string, any> | undefined) {
   return Object.keys(rest).length > 0 ? rest : undefined
 }
 
+/**
+ * Returns true when an assistant turn's parts carry content that actually
+ * reaches a provider. `toModelMessagesEffect` only converts text / tool /
+ * reasoning / step-start parts for an assistant, and step-start is stripped
+ * again before send — so a turn holding nothing but bookkeeping (step-start,
+ * step-finish, patch, snapshot, retry, agent) produces a ZERO-content assistant
+ * message, which Bedrock/Anthropic reject with a hard 400. Reasoning alone does
+ * not count: the error gate below already treats a reasoning-only aborted turn
+ * as having produced nothing.
+ *
+ * Assistant-side mirror of `hasSubstantiveContent` in session/prompt.ts, which
+ * does the same job for user messages.
+ */
+export function hasSubstantiveAssistantContent(parts: readonly Part[]): boolean {
+  return parts.some((part) => {
+    if (part.type === "text") return part.text.trim().length > 0
+    if (part.type === "tool") return true
+    return false
+  })
+}
+
 export const toModelMessagesEffect = Effect.fnUntraced(function* (
   input: WithParts[],
   model: Provider.Model,
@@ -704,7 +725,6 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         role: "user",
         parts: [],
       }
-      result.push(userMessage)
       for (const part of msg.parts) {
         if (part.type === "text" && !part.ignored)
           userMessage.parts.push({
@@ -747,6 +767,12 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           })
         }
       }
+      // Emit only when the message actually converted to something. A user
+      // message whose parts are all non-convertible (ignored text, text/plain
+      // or directory files, bookkeeping) would otherwise go on the wire with
+      // empty content, which Bedrock rejects with
+      // `messages.<N>: user messages must have non-empty content`.
+      if (userMessage.parts.length > 0) result.push(userMessage)
     }
 
     if (msg.info.role === "assistant") {
@@ -797,13 +823,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         return native
       }
 
-      if (
-        msg.info.error &&
-        !(
-          AbortedError.isInstance(msg.info.error) &&
-          msg.parts.some((part) => part.type !== "step-start" && part.type !== "reasoning")
-        )
-      ) {
+      if (msg.info.error && !(AbortedError.isInstance(msg.info.error) && hasSubstantiveAssistantContent(msg.parts))) {
         continue
       }
       const assistantMessage: UIMessage = {
@@ -909,6 +929,13 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           })
         }
       }
+      // Symmetric with the `msg.parts.length === 0` skip at the top of the loop:
+      // an assistant whose parts converted to NOTHING (only step-finish / patch /
+      // snapshot bookkeeping) must not be emitted at all. Emitting it produces a
+      // zero-content assistant message that Bedrock/Anthropic hard-400 on — and
+      // because a 400 writes another contentless assistant row, the failure is
+      // self-sustaining. This also neutralizes shells already on disk from older
+      // builds, which a trailing-only sweep cannot reach.
       if (assistantMessage.parts.length > 0) {
         result.push(assistantMessage)
         if (syntheticGroups.length > 0) {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1106,10 +1106,33 @@ export const filterCompactedEffect = Effect.fnUntraced(function* (
 
   // If watermark is set, truncate parent messages at the watermark point
   if (options.contextWatermark) {
-    const watermarkIdx = parentFiltered.findIndex((msg) => msg.info.id === options.contextWatermark)
+    const watermark = options.contextWatermark
+    const watermarkIdx = parentFiltered.findIndex((msg) => msg.info.id === watermark)
     if (watermarkIdx >= 0) {
       return [...parentFiltered.slice(0, watermarkIdx + 1), ...ownMessages]
     }
+    // The watermark ROW can be gone while the boundary it marks is still
+    // meaningful. A `context: "full"` subagent captures its watermark from
+    // Session.lastMainMessageID at spawn time (actor/spawn.ts), and a spawn
+    // issued from inside a turn captures THAT TURN'S IN-FLIGHT ASSISTANT — which
+    // SessionProcessor.cleanup then DELETES if the turn dies without substantive
+    // content (the empty-shell guard), as does sweepOrphanAssistants for an
+    // orphan. Falling straight through to "use all parent messages" would then
+    // silently widen the fork boundary the child was registered with, handing it
+    // the parent's entire history instead of the captured prefix — a boundary
+    // shift, not a display bug.
+    //
+    // MessageID is monotonic ascending, so the boundary survives the row: keep
+    // every parent message whose id does not exceed the watermark. This runs ONLY
+    // when the exact row is absent, so the resolved path above is untouched (and
+    // stays authoritative for array order, which is by time_created and can
+    // diverge from id order — insertRebuildBoundary back-dates time.created while
+    // still allocating an ascending id).
+    const truncated = parentFiltered.filter((msg) => msg.info.id <= watermark)
+    if (truncated.length > 0) return [...truncated, ...ownMessages]
+    // Watermark predates every surviving parent message: inherit nothing rather
+    // than everything.
+    return [...ownMessages]
   }
 
   // Fallback: use all parent messages

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -123,6 +123,14 @@ export type ReplayInput = {
 
 export interface Handle {
   readonly message: MessageV2.Assistant
+  /**
+   * True once the empty-shell guard in `cleanup` deleted this turn's assistant
+   * row: the turn died without producing any substantive content, so there was
+   * nothing worth persisting. `message` is still the authoritative in-memory
+   * record (error included) — SessionPrompt uses it as the turn's result so the
+   * failure is never silently swallowed.
+   */
+  readonly dropped: boolean
   readonly updateToolCall: (
     toolCallID: string,
     update: (part: MessageV2.ToolPart) => MessageV2.ToolPart,
@@ -239,6 +247,7 @@ export const layer: Layer.Layer<
         textNgramRepeat: false,
       }
       let aborted = false
+      let dropped = false
       // Only the main agent owns session-level status. Subagents (explore,
       // general, checkpoint-writer, etc.) share the parent sessionID but their
       // run-state onIdle deliberately does NOT reset status (run-state.ts) — so
@@ -765,6 +774,45 @@ export const layer: Layer.Layer<
             state: MessageV2.abortedToolState(part.state),
           })
         }
+        // EMPTY-SHELL GUARD (write side). A turn killed by a hard provider error
+        // before emitting any substantive content leaves an assistant row holding
+        // nothing but bookkeeping parts (step-start, step-finish, patch) or no
+        // parts at all. Persisting that shell is what makes a provider 400
+        // self-sustaining: the shell is replayed into the next request, the
+        // request is rejected, and the rejection writes another shell — one bad
+        // turn escalates into dozens (123 such APIError rows in the session that
+        // motivated this).
+        //
+        // The error is NOT swallowed: `halt` has already published it on
+        // Session.Event.Error and reset session status, and `dropped` tells
+        // SessionPrompt to report this turn from the in-memory message instead of
+        // re-reading the deleted row.
+        //
+        // A user ABORT is deliberately exempt: cancelling is a normal outcome the
+        // transcript should keep showing (see the "records aborted errors when
+        // prompt is cancelled mid-stream" regression test), and an errored
+        // assistant can never reach a provider anyway — toModelMessages' error
+        // gate drops it.
+        //
+        // ORDER: this runs AFTER the tool-part finalization passes above, never
+        // before. Those passes are what keep an interrupted-but-real turn out of
+        // this guard's reach — `hasSubstantiveAssistantContent` counts any `tool`
+        // part as content, so a turn that actually called a tool is never dropped,
+        // and this guard can only fire on a turn with no tool parts at all (where
+        // the loop above is a no-op). Running the guard first would let its early
+        // `return` skip the finalization entirely on the paths where the row
+        // survives.
+        if (
+          ctx.assistantMessage.error &&
+          !MessageV2.AbortedError.isInstance(ctx.assistantMessage.error) &&
+          !MessageV2.hasSubstantiveAssistantContent(MessageV2.parts(ctx.assistantMessage.id))
+        ) {
+          dropped = true
+          yield* session
+            .removeMessage({ sessionID: ctx.sessionID, messageID: ctx.assistantMessage.id })
+            .pipe(Effect.catchCause((cause) => Effect.sync(() => slog.warn("empty-shell-drop-failed", { cause }))))
+          return
+        }
         ctx.assistantMessage.time.completed = Date.now()
         yield* session.updateMessage(ctx.assistantMessage)
       })
@@ -1054,6 +1102,9 @@ export const layer: Layer.Layer<
       return {
         get message() {
           return ctx.assistantMessage
+        },
+        get dropped() {
+          return dropped
         },
         updateToolCall,
         completeToolCall,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2558,9 +2558,22 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               agentID: resolvedAgentID,
             }).pipe(Effect.catch(() => Effect.succeed([] as MessageV2.WithParts[])))
             const lastSlice = sliceMsgs.findLast((m) => m.info.role === "assistant")
-            const finalAsst =
-              lastSlice && lastSlice.info.role === "assistant" ? lastSlice.info : undefined
-            const finalParts = lastSlice?.parts ?? []
+            // The empty-shell guard DELETED this turn's assistant row, so the
+            // persisted slice above can no longer answer "how did this turn end?"
+            // — `findLast` would skip past the hole to an OLDER, successful
+            // assistant (or find none) and report a failed turn as completed.
+            // `droppedShell` is the in-memory record of that deleted row, and it
+            // still carries the error, so it takes precedence here exactly as it
+            // does for `final` in runLoop's tail. Parts are empty because the row
+            // (and therefore its parts) is gone.
+            //
+            // Two independent readers of "the turn's final assistant" therefore
+            // both consult it: `lastAssistant` (runLoop's return value) and this
+            // hook, which feeds BOTH the `session.post` plugin outcome and #1851's
+            // MCP turn-lifecycle `status`. Missing this one made an
+            // `llm.error(400)` turn notify `status: "completed"`.
+            const finalAsst = droppedShell ?? (lastSlice?.info.role === "assistant" ? lastSlice.info : undefined)
+            const finalParts = droppedShell ? [] : (lastSlice?.parts ?? [])
             const failed = Exit.isFailure(exit)
             const finalIsError = !!finalAsst?.error
             const outcome: "completed" | "error" | "cancelled" = cancelled

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -270,7 +270,7 @@ export interface Interface {
   readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
   readonly command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts>
   readonly resolvePromptParts: (template: string) => Effect.Effect<PromptInput["parts"]>
-  readonly sweepOrphanAssistants: (sessionID: SessionID, immediate?: boolean) => Effect.Effect<void>
+  readonly sweepOrphanAssistants: (sessionID: SessionID) => Effect.Effect<void>
   readonly sweepOrphanToolParts: (sessionID: SessionID) => Effect.Effect<void>
   readonly predict: (input: { sessionID: SessionID }) => Effect.Effect<string>
 }
@@ -2345,52 +2345,40 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       return { info, parts }
     }, Effect.scoped)
 
-    const sweepOrphanAssistants = Effect.fn("SessionPrompt.sweepOrphanAssistants")(function* (
-      sessionID: SessionID,
-      // When true, sweep dangling assistants regardless of age. The caller sets
-      // this when the session is idle (no active runner), meaning any assistant
-      // without time.completed is definitively orphaned — left behind by a hard
-      // interruption (process crash / kill / disconnect) that skipped the normal
-      // `finish` effect, not an in-flight retry chain. Sweeping immediately
-      // matters because the TUI derives its "pending" marker from the newest
-      // incomplete assistant (routes/session/index.tsx `pending`): a stale
-      // orphan otherwise makes EVERY newly submitted message on an idle session
-      // render as stuck QUEUED for up to ORPHAN_AGE_MS (an hour). Defaults to
-      // false so background callers (spawn/hook) keep the age guard.
-      immediate = false,
-    ) {
+    const sweepOrphanAssistants = Effect.fn("SessionPrompt.sweepOrphanAssistants")(function* (sessionID: SessionID) {
+      // Minimal rule: if the session's history ENDS in an incomplete assistant,
+      // drop it. Only callers that have established the session is idle (no
+      // active runner) may invoke this — a trailing incomplete assistant on an
+      // idle session is definitively orphaned, left behind by a hard interruption
+      // (process crash / kill / disconnect) that skipped the normal `finish`
+      // effect. That is what makes the age gate unnecessary: there is no
+      // in-flight turn whose still-progressing assistant could be mistaken for
+      // residue, so waiting an hour only kept the orphan poisoning requests and
+      // made every newly submitted message render as stuck QUEUED (the TUI's
+      // "pending" marker derives from the newest incomplete assistant).
+      //
+      // Deleting rather than stamping an error matters: a stamped shell stays on
+      // disk and is replayed into every later request. Non-trailing shells are
+      // handled on the read side by MessageV2.toModelMessages, which never emits
+      // an assistant that converts to zero content.
       const msgs = yield* sessions.messages({ sessionID, agentID: "*" })
-      const now = Date.now()
-      // 1 hour — must exceed Task 1's chunkMs (300s) plus Task 2's
-      // PERSISTENT_RETRY worst-case backoff (10 attempts × 5 min cap =
-      // 50 min) so a still-active in-flight request is never falsely
-      // swept while its retry chain is making progress.
-      const ORPHAN_AGE_MS = 3_600_000
-      for (const m of msgs) {
-        if (m.info.role !== "assistant") continue
-        if (m.info.time?.completed) continue
-        const created = m.info.time?.created ?? 0
-        if (!immediate && now - created < ORPHAN_AGE_MS) continue
-        m.info.time = { ...m.info.time, completed: now }
-        m.info.error =
-          m.info.error ??
-          new MessageV2.AbortedError({
-            message: "Abandoned: previous request interrupted before completion",
-          }).toObject()
-        yield* sessions.updateMessage(m.info).pipe(
-          Effect.catchCause((cause) =>
-            elog.warn("orphan-update-failed", {
-              sessionID,
-              messageID: m.info.id,
-              cause,
-            }),
-          ),
-        )
-        yield* elog.info("orphan-assistant-cleared", {
-          sessionID,
-          messageID: m.info.id,
-        })
-      }
+      const last = msgs[msgs.length - 1]
+      if (!last) return
+      if (last.info.role !== "assistant") return
+      if (last.info.time?.completed) return
+      yield* sessions.removeMessage({ sessionID, messageID: last.info.id }).pipe(
+        Effect.catchCause((cause) =>
+          elog.warn("orphan-remove-failed", {
+            sessionID,
+            messageID: last.info.id,
+            cause,
+          }),
+        ),
+      )
+      yield* elog.info("orphan-assistant-dropped", {
+        sessionID,
+        messageID: last.info.id,
+      })
     })
 
     // A tool part is persisted as `running` the moment the tool STARTS (so the TUI
@@ -2442,13 +2430,17 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         const session = yield* sessions.get(input.sessionID)
         if (input.source !== "spawn" && input.source !== "hook") {
           yield* revert.cleanup(session)
-          // An idle session has no active runner, so any dangling assistant is a
-          // true orphan from a hard interruption — sweep it now (age-independent)
-          // so a fresh message is not rendered as stuck QUEUED behind it.
+          // An idle session has no active runner, so a trailing dangling
+          // assistant is a true orphan from a hard interruption — drop it now so
+          // a fresh message is not rendered as stuck QUEUED behind it, and so the
+          // shell never reaches a provider. Guarding on idle is what lets
+          // sweepOrphanAssistants skip an age check: a busy session's in-flight
+          // assistant is trailing and incomplete too, and must never be removed.
           const idle = (yield* status.get(input.sessionID)).type === "idle"
-          yield* sweepOrphanAssistants(input.sessionID, idle)
+          if (idle) yield* sweepOrphanAssistants(input.sessionID)
           // Same recovery point, same idleness argument: repair tool parts a killed
-          // process left stuck at `running`. Self-gated on idle (see the function).
+          // process left stuck at `running`. Self-gated on idle (see the function),
+          // which is why it is not wrapped in the caller's `idle` check above.
           //
           // These two look mergeable into one message fetch. They are not:
           // `sweepOrphanAssistants` reads EVERY slice (`agentID: "*"`) while this one
@@ -2532,6 +2524,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         // prose text instead of a structured tool_use). Local to runLoop so each
         // fresh user turn starts clean.
         let textToolCallRetries = 0
+        // Set when SessionProcessor's empty-shell guard deleted this step's
+        // assistant row (a turn that died before producing any substantive
+        // content). The row is gone, so `lastAssistant` would otherwise return an
+        // OLDER, successful assistant and report this failed turn as completed.
+        // Holding the in-memory record keeps the error visible to the caller.
+        let droppedShell: MessageV2.Assistant | undefined
         const resolvedAgentID = agentID ?? "main"
         const mcpContext: MCP.TurnContext = {
           sessionId: sessionID,
@@ -4152,9 +4150,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           if (outcome === "break") {
+            droppedShell = handle.dropped ? handle.message : undefined
             if (yield* goalGate(lastUser)) continue
             break
           }
+          droppedShell = undefined
           continue
         }
 
@@ -4170,7 +4170,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             })
             .pipe(Effect.ignore, Effect.forkIn(scope))
         }
-        const final = yield* lastAssistant(sessionID, agentID)
+        const final: MessageV2.WithParts = droppedShell
+          ? { info: droppedShell, parts: [] }
+          : yield* lastAssistant(sessionID, agentID)
         const finalIsError = final.info.role === "assistant" && !!final.info.error
         const lastUserForMetrics = yield* sessions.findMessage(
           sessionID,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2346,39 +2346,56 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     }, Effect.scoped)
 
     const sweepOrphanAssistants = Effect.fn("SessionPrompt.sweepOrphanAssistants")(function* (sessionID: SessionID) {
-      // Minimal rule: if the session's history ENDS in an incomplete assistant,
-      // drop it. Only callers that have established the session is idle (no
-      // active runner) may invoke this — a trailing incomplete assistant on an
-      // idle session is definitively orphaned, left behind by a hard interruption
-      // (process crash / kill / disconnect) that skipped the normal `finish`
-      // effect. That is what makes the age gate unnecessary: there is no
+      // Rule: on an idle session, EVERY incomplete assistant in the MAIN slice is
+      // orphaned — drop it. Only callers that have established the session is
+      // idle may invoke this; such an assistant is residue from a hard
+      // interruption (process crash / kill / disconnect) that skipped the normal
+      // `finish` effect. That is what makes the age gate unnecessary: there is no
       // in-flight turn whose still-progressing assistant could be mistaken for
       // residue, so waiting an hour only kept the orphan poisoning requests and
       // made every newly submitted message render as stuck QUEUED (the TUI's
-      // "pending" marker derives from the newest incomplete assistant).
+      // "pending" marker derives from the newest incomplete assistant —
+      // routes/session/index.tsx `pending`).
       //
       // Deleting rather than stamping an error matters: a stamped shell stays on
-      // disk and is replayed into every later request. Non-trailing shells are
-      // handled on the read side by MessageV2.toModelMessages, which never emits
-      // an assistant that converts to zero content.
-      const msgs = yield* sessions.messages({ sessionID, agentID: "*" })
-      const last = msgs[msgs.length - 1]
-      if (!last) return
-      if (last.info.role !== "assistant") return
-      if (last.info.time?.completed) return
-      yield* sessions.removeMessage({ sessionID, messageID: last.info.id }).pipe(
-        Effect.catchCause((cause) =>
-          elog.warn("orphan-remove-failed", {
-            sessionID,
-            messageID: last.info.id,
-            cause,
-          }),
-        ),
-      )
-      yield* elog.info("orphan-assistant-dropped", {
-        sessionID,
-        messageID: last.info.id,
-      })
+      // disk and is replayed into every later request.
+      //
+      // ⚠️SLICE SCOPE IS LOAD-BEARING, for the SAME reason spelled out at the
+      // `sweepOrphanToolParts` call site: SessionProcessor publishes status for
+      // the main slice alone, so a subagent slice can be mid-turn while the
+      // session status reads `idle`. Reading `agentID: "*"` and removing a row
+      // would therefore DELETE a live subagent's in-flight assistant out from
+      // under its own processor, which keeps calling updatePart against that
+      // messageID. The idle gate proves only that MAIN has no active runner, so
+      // main is the only slice this may touch.
+      //
+      // ⚠️AND IT IS EVERY INCOMPLETE ASSISTANT, not just the trailing one. The
+      // sweep runs BEFORE createUserMessage, so a single-slice orphan is trailing
+      // here — but one is left non-trailing whenever a later message already
+      // exists: a concurrent subagent's row (under the old `agentID: "*"` read),
+      // or a previous `source: "spawn" | "hook"` prompt that skipped this whole
+      // block. A trailing-only rule strands those forever, and the TUI's `pending`
+      // derives from the newest INCOMPLETE assistant in the slice regardless of
+      // whether anything follows it — so the stranded row keeps rendering fresh
+      // messages as stuck QUEUED, the exact symptom this sweep exists to prevent.
+      const msgs = yield* sessions.messages({ sessionID, agentID: "main" })
+      for (const m of msgs) {
+        if (m.info.role !== "assistant") continue
+        if (m.info.time?.completed) continue
+        yield* sessions.removeMessage({ sessionID, messageID: m.info.id }).pipe(
+          Effect.catchCause((cause) =>
+            elog.warn("orphan-remove-failed", {
+              sessionID,
+              messageID: m.info.id,
+              cause,
+            }),
+          ),
+        )
+        yield* elog.info("orphan-assistant-dropped", {
+          sessionID,
+          messageID: m.info.id,
+        })
+      }
     })
 
     // A tool part is persisted as `running` the moment the tool STARTS (so the TUI
@@ -2430,28 +2447,28 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         const session = yield* sessions.get(input.sessionID)
         if (input.source !== "spawn" && input.source !== "hook") {
           yield* revert.cleanup(session)
-          // An idle session has no active runner, so a trailing dangling
-          // assistant is a true orphan from a hard interruption — drop it now so
-          // a fresh message is not rendered as stuck QUEUED behind it, and so the
-          // shell never reaches a provider. Guarding on idle is what lets
-          // sweepOrphanAssistants skip an age check: a busy session's in-flight
-          // assistant is trailing and incomplete too, and must never be removed.
+          // An idle session has no active runner in its MAIN slice, so every
+          // dangling assistant there is a true orphan from a hard interruption —
+          // drop them now so a fresh message is not rendered as stuck QUEUED
+          // behind one, and so the shell never reaches a provider. Guarding on
+          // idle is what lets sweepOrphanAssistants skip an age check: a busy
+          // session's in-flight assistant is incomplete too, and must never be
+          // removed.
           const idle = (yield* status.get(input.sessionID)).type === "idle"
           if (idle) yield* sweepOrphanAssistants(input.sessionID)
           // Same recovery point, same idleness argument: repair tool parts a killed
           // process left stuck at `running`. Self-gated on idle (see the function),
           // which is why it is not wrapped in the caller's `idle` check above.
           //
-          // These two look mergeable into one message fetch. They are not:
-          // `sweepOrphanAssistants` reads EVERY slice (`agentID: "*"`) while this one
-          // reads the MAIN slice only, and that difference is load-bearing.
-          // `SessionProcessor` publishes status for the main slice alone, so a subagent
-          // slice can be mid-tool while the session status reads `idle` — scanning only
-          // main is what stops this sweep from rewriting a live subagent's `running`
-          // part. Sharing a fetch would mean taking the wider read and re-filtering
-          // here, which is precisely where that property would get lost. The cost is
-          // also smaller than it looks: this returns after one status lookup unless the
-          // session is genuinely idle.
+          // Both now read the MAIN slice only, and that scope is load-bearing for
+          // both: `SessionProcessor` publishes status for the main slice alone, so a
+          // subagent slice can be mid-turn while the session status reads `idle`.
+          // Scanning only main is what stops these sweeps from rewriting a live
+          // subagent's `running` part — or, for the assistant sweep, from DELETING
+          // that subagent's in-flight assistant row. They still do not share a
+          // message fetch: this one reads main tool parts, the other reads main
+          // messages, and the cost is smaller than it looks — each returns after one
+          // status lookup unless the session is genuinely idle.
           yield* sweepOrphanToolParts(input.sessionID)
         }
         const message = yield* createUserMessage(input)

--- a/packages/opencode/test/session/context-watermark.test.ts
+++ b/packages/opencode/test/session/context-watermark.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Instance } from "../../src/project/instance"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID } from "../../src/session/schema"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const it = testEffect(Layer.mergeAll(Session.defaultLayer, CrossSpawnSpawner.defaultLayer))
+
+const userAt = (sessionID: MessageV2.User["sessionID"], created: number) => ({
+  id: MessageID.ascending(),
+  role: "user" as const,
+  sessionID,
+  agent: "default",
+  model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+  time: { created },
+})
+
+// A fork's inherited-context boundary is stored as a MESSAGE ID
+// (actor_registry.context_watermark, captured from Session.lastMainMessageID).
+// SessionProcessor.cleanup's empty-shell guard and sweepOrphanAssistants both
+// DELETE assistant rows, so that stored id can outlive the row it names — and a
+// spawn issued from inside a turn captures precisely the row most likely to be
+// deleted: that turn's own in-flight assistant.
+describe("filterCompactedEffect contextWatermark", () => {
+  it.live("truncates at the boundary even after the watermark row is deleted", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const parent = yield* sessions.create({})
+        const child = yield* sessions.create({})
+
+        const first = yield* sessions.updateMessage(userAt(parent.id, Date.now() - 5_000))
+        const boundary = yield* sessions.updateMessage(userAt(parent.id, Date.now() - 4_000))
+        const afterBoundary = yield* sessions.updateMessage(userAt(parent.id, Date.now() - 3_000))
+
+        // Sanity: with the row present, the watermark resolves and truncates.
+        const resolved = yield* MessageV2.filterCompactedEffect(child.id, {
+          contextFrom: parent.id,
+          contextWatermark: boundary.id,
+        })
+        expect(resolved.map((m) => m.info.id)).toEqual([first.id, boundary.id])
+
+        // Now the boundary row is gone, exactly as the empty-shell guard leaves it.
+        yield* sessions.removeMessage({ sessionID: parent.id, messageID: boundary.id })
+
+        const dangling = yield* MessageV2.filterCompactedEffect(child.id, {
+          contextFrom: parent.id,
+          contextWatermark: boundary.id,
+        })
+        // The boundary must still hold: `first` is inherited, `afterBoundary` is NOT.
+        // Falling back to the full parent history would hand the child context it
+        // was never registered for.
+        expect(dangling.map((m) => m.info.id)).toEqual([first.id])
+        expect(dangling.some((m) => m.info.id === afterBoundary.id)).toBe(false)
+      }),
+    ),
+  )
+
+  it.live("inherits nothing when the deleted watermark predates every surviving message", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const parent = yield* sessions.create({})
+        const child = yield* sessions.create({})
+
+        const boundary = yield* sessions.updateMessage(userAt(parent.id, Date.now() - 5_000))
+        const later = yield* sessions.updateMessage(userAt(parent.id, Date.now() - 4_000))
+
+        yield* sessions.removeMessage({ sessionID: parent.id, messageID: boundary.id })
+
+        const msgs = yield* MessageV2.filterCompactedEffect(child.id, {
+          contextFrom: parent.id,
+          contextWatermark: boundary.id,
+        })
+        expect(msgs.some((m) => m.info.id === later.id)).toBe(false)
+        expect(msgs).toHaveLength(0)
+      }),
+    ),
+  )
+})

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1244,6 +1244,123 @@ describe("session.message-v2.toModelMessage", () => {
     expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([])
   })
 
+  // An assistant message that survives the `parts.length === 0` guard but
+  // converts to NOTHING is the self-sustaining Bedrock 400: it goes on the wire
+  // with empty content, the provider 400s, and the 400 writes another
+  // contentless assistant row. These shapes exist on disk from older builds, so
+  // the converter — not just a trailing sweep — has to refuse to emit them.
+  test("drops an assistant message whose only part is step-finish", async () => {
+    const assistantID = "m-assistant-step-finish"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: assistantInfo(assistantID, "m-parent"),
+        parts: [
+          {
+            ...basePart(assistantID, "p1"),
+            type: "step-finish",
+            tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+            cost: 0,
+          },
+        ] as unknown as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([])
+  })
+
+  test("drops an assistant message whose only part is patch", async () => {
+    const assistantID = "m-assistant-patch"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: assistantInfo(assistantID, "m-parent"),
+        parts: [
+          {
+            ...basePart(assistantID, "p1"),
+            type: "patch",
+            hash: "deadbeef",
+            files: ["a.ts"],
+          },
+        ] as unknown as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([])
+  })
+
+  test("never emits a zero-content message when shells sit between real turns", async () => {
+    const userID = "m-user-real"
+    const shellA = "m-shell-a"
+    const shellB = "m-shell-b"
+    const shellC = "m-shell-c"
+    const assistantID = "m-assistant-real"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [{ ...basePart(userID, "u1"), type: "text", text: "hello" }] as MessageV2.Part[],
+      },
+      // step-finish-only shell (the msg_f5c5.../msg_fa33... shape)
+      {
+        info: assistantInfo(shellA, userID),
+        parts: [
+          {
+            ...basePart(shellA, "p1"),
+            type: "step-finish",
+            tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+            cost: 0,
+          },
+        ] as unknown as MessageV2.Part[],
+      },
+      // patch-only shell (the msg_f401... shape)
+      {
+        info: assistantInfo(shellB, userID),
+        parts: [
+          { ...basePart(shellB, "p1"), type: "patch", hash: "cafe", files: ["b.ts"] },
+        ] as unknown as MessageV2.Part[],
+      },
+      // zero-part error shell — the 123 rows the live session accumulated
+      {
+        info: assistantInfo(shellC, userID, { name: "APIError", data: { message: "boom" } } as never),
+        parts: [] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [{ ...basePart(assistantID, "p1"), type: "text", text: "answer" }] as MessageV2.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+
+    // Assert on the BUILT array: every outgoing message carries content.
+    for (const msg of result) {
+      const content = msg.content as unknown
+      if (typeof content === "string") expect(content.length).toBeGreaterThan(0)
+      else expect(Array.isArray(content) && content.length > 0).toBe(true)
+    }
+    expect(result).toStrictEqual([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ])
+  })
+
+  test("drops a user message whose parts all convert to nothing", async () => {
+    const userID = "m-user-empty"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          { ...basePart(userID, "u1"), type: "text", text: "ignored", ignored: true },
+          { ...basePart(userID, "u2"), type: "file", mime: "text/plain", url: "file:///a.txt" },
+        ] as unknown as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([])
+  })
+
   test("converts pending/running tool calls to error results to prevent dangling tool_use", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -502,6 +502,11 @@ it.live("session.processor effect tests do not retry unknown json errors", () =>
         expect(value).toBe("stop")
         expect(yield* llm.calls).toBe(1)
         expect(handle.message.error?.name).toBe("APIError")
+        // A hard provider error with no substantive content is the exact shape
+        // that accumulated 123 zero-part APIError shells in the wild. Not
+        // persisted — but the error is still on the caller's handle.
+        expect(handle.dropped).toBe(true)
+        expect(() => MessageV2.get({ sessionID: chat.id, messageID: msg.id })).toThrow()
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),
@@ -780,7 +785,6 @@ it.live("session.processor effect tests record aborted errors and idle state", (
 
         const exit = yield* Fiber.await(run)
         yield* Effect.promise(() => seen.promise)
-        const stored = MessageV2.get({ sessionID: chat.id, messageID: msg.id })
         const state = yield* sts.get(chat.id)
         off()
 
@@ -789,6 +793,11 @@ it.live("session.processor effect tests record aborted errors and idle state", (
           expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true)
         }
         expect(handle.message.error?.name).toBe("MessageAbortedError")
+        // A user ABORT is exempt from the empty-shell drop: cancelling is a normal
+        // outcome the transcript keeps showing, and an errored assistant can never
+        // reach a provider (toModelMessages' error gate drops it).
+        expect(handle.dropped).toBe(false)
+        const stored = MessageV2.get({ sessionID: chat.id, messageID: msg.id })
         expect(stored.info.role).toBe("assistant")
         if (stored.info.role === "assistant") {
           expect(stored.info.error?.name).toBe("MessageAbortedError")
@@ -842,11 +851,13 @@ it.live("session.processor effect tests mark interruptions aborted without manua
         yield* Fiber.interrupt(run)
 
         const exit = yield* Fiber.await(run)
-        const stored = MessageV2.get({ sessionID: chat.id, messageID: msg.id })
         const state = yield* sts.get(chat.id)
 
         expect(Exit.isFailure(exit)).toBe(true)
         expect(handle.message.error?.name).toBe("MessageAbortedError")
+        // Abort path: row preserved (see the abort exemption in cleanup).
+        expect(handle.dropped).toBe(false)
+        const stored = MessageV2.get({ sessionID: chat.id, messageID: msg.id })
         expect(stored.info.role).toBe("assistant")
         if (stored.info.role === "assistant") {
           expect(stored.info.error?.name).toBe("MessageAbortedError")

--- a/packages/opencode/test/session/prompt-sweep.test.ts
+++ b/packages/opencode/test/session/prompt-sweep.test.ts
@@ -110,7 +110,7 @@ describe("sweepOrphanAssistants", () => {
     ),
   )
 
-  it.live("leaves history whose last message is a user message untouched", () =>
+  it.live("drops a NON-trailing incomplete assistant in the main slice", () =>
     provideTmpdirInstance((dir) =>
       Effect.gen(function* () {
         const sessions = yield* Session.Service
@@ -125,12 +125,18 @@ describe("sweepOrphanAssistants", () => {
           model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
           time: { created: Date.now() - 9_000 },
         })
-        // A NON-trailing incomplete assistant. The minimal rule only touches the
-        // tail; non-trailing shells are neutralized on the read side by
-        // MessageV2.toModelMessages, which never emits a zero-content assistant.
+        // A NON-trailing incomplete assistant. The sweep runs before
+        // createUserMessage, so an orphan is trailing in the single-slice case —
+        // but it is left non-trailing whenever a later message already exists (a
+        // concurrent subagent row, or a previous source:"spawn"|"hook" prompt that
+        // skipped the sweep block). A trailing-only rule strands it forever, and
+        // the TUI's `pending` marker (routes/session/index.tsx) derives from the
+        // newest INCOMPLETE assistant regardless of what follows it — so the
+        // stranded row keeps rendering fresh messages as stuck QUEUED, the exact
+        // symptom this sweep exists to prevent.
         const assistant = makeAssistant(session.id, firstUser.id, dir, { created: Date.now() - 8_000 })
         yield* sessions.updateMessage(assistant)
-        yield* sessions.updateMessage({
+        const secondUser = yield* sessions.updateMessage({
           id: MessageID.ascending(),
           role: "user",
           sessionID: session.id,
@@ -142,7 +148,47 @@ describe("sweepOrphanAssistants", () => {
         yield* svc.sweepOrphanAssistants(session.id)
 
         const after = yield* sessions.messages({ sessionID: session.id })
-        expect(after.find((m) => m.info.id === assistant.id)).toBeDefined()
+        expect(after.find((m) => m.info.id === assistant.id)).toBeUndefined()
+        // Both user turns are untouched.
+        expect(after.find((m) => m.info.id === firstUser.id)).toBeDefined()
+        expect(after.find((m) => m.info.id === secondUser.id)).toBeDefined()
+      }),
+    ),
+  )
+
+  it.live("never touches a non-main slice, whose actor may still be mid-turn", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const svc = yield* SessionPrompt.Service
+        const session = yield* sessions.create({})
+
+        const userMsg = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "default",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() - 9_000 },
+        })
+        // SessionProcessor publishes status for the MAIN slice alone, so the idle
+        // gate the caller checks proves nothing about a subagent. This row is the
+        // newest message in the session AND incomplete — i.e. exactly what a live
+        // background actor's in-flight assistant looks like. Removing it would
+        // delete that row out from under the actor's own processor, which keeps
+        // calling updatePart against this messageID.
+        const subAssistant: MessageV2.Assistant = {
+          ...makeAssistant(session.id, userMsg.id, dir, { created: Date.now() - 1_000 }),
+          agentID: "explore-1",
+        }
+        yield* sessions.updateMessage(subAssistant)
+
+        yield* svc.sweepOrphanAssistants(session.id)
+
+        const sub = yield* sessions.messages({ sessionID: session.id, agentID: "explore-1" })
+        const survivor = sub.find((m) => m.info.id === subAssistant.id)
+        expect(survivor).toBeDefined()
+        expect((survivor!.info as MessageV2.Assistant).time.completed).toBeUndefined()
       }),
     ),
   )

--- a/packages/opencode/test/session/prompt-sweep.test.ts
+++ b/packages/opencode/test/session/prompt-sweep.test.ts
@@ -40,76 +40,7 @@ const makeAssistant = (
 })
 
 describe("sweepOrphanAssistants", () => {
-  it.live("marks an assistant message older than 60s as completed with AbortedError", () =>
-    provideTmpdirInstance((dir) =>
-      Effect.gen(function* () {
-        const sessions = yield* Session.Service
-        const svc = yield* SessionPrompt.Service
-        const session = yield* sessions.create({})
-
-        const userMsg = yield* sessions.updateMessage({
-          id: MessageID.ascending(),
-          role: "user",
-          sessionID: session.id,
-          agent: "default",
-          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
-          time: { created: Date.now() - 7_300_000 },
-        })
-
-        const now = Date.now()
-        const assistant = makeAssistant(session.id, userMsg.id, dir, { created: now - 7_200_000 })
-        yield* sessions.updateMessage(assistant)
-
-        yield* svc.sweepOrphanAssistants(session.id)
-
-        const after = yield* sessions.messages({ sessionID: session.id })
-        const updated = after.find((m) => m.info.id === assistant.id)
-        expect(updated).toBeDefined()
-        const info = updated!.info as MessageV2.Assistant
-        expect(info.role).toBe("assistant")
-        expect(info.time.completed).toBeDefined()
-        expect(info.time.completed!).toBeGreaterThanOrEqual(now)
-        expect(info.error).toBeDefined()
-        expect(JSON.stringify(info.error)).toContain("Abandoned")
-      }),
-    ),
-  )
-
-  it.live("leaves a recent (under 60s) incomplete assistant message untouched when not immediate", () =>
-    provideTmpdirInstance((dir) =>
-      Effect.gen(function* () {
-        const sessions = yield* Session.Service
-        const svc = yield* SessionPrompt.Service
-        const session = yield* sessions.create({})
-
-        const userMsg = yield* sessions.updateMessage({
-          id: MessageID.ascending(),
-          role: "user",
-          sessionID: session.id,
-          agent: "default",
-          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
-          time: { created: Date.now() - 1_900_000 },
-        })
-
-        const now = Date.now()
-        const assistant = makeAssistant(session.id, userMsg.id, dir, { created: now - 1_800_000 })
-        yield* sessions.updateMessage(assistant)
-
-        // immediate defaults to false → the age guard protects an in-flight
-        // (busy) turn's still-progressing assistant.
-        yield* svc.sweepOrphanAssistants(session.id)
-
-        const after = yield* sessions.messages({ sessionID: session.id })
-        const updated = after.find((m) => m.info.id === assistant.id)
-        expect(updated).toBeDefined()
-        const info = updated!.info as MessageV2.Assistant
-        expect(info.time.completed).toBeUndefined()
-        expect(info.error).toBeUndefined()
-      }),
-    ),
-  )
-
-  it.live("sweeps a recent (under 60s) incomplete assistant when immediate (idle session)", () =>
+  it.live("drops a trailing incomplete assistant regardless of age", () =>
     provideTmpdirInstance((dir) =>
       Effect.gen(function* () {
         const sessions = yield* Session.Service
@@ -125,28 +56,25 @@ describe("sweepOrphanAssistants", () => {
           time: { created: Date.now() - 5_000 },
         })
 
-        // A fresh orphan (well under ORPHAN_AGE_MS) — the exact shape a hard
-        // interruption leaves behind. On an idle session this must be swept so
-        // the next user message is not rendered as stuck QUEUED behind it.
+        // A FRESH orphan — the exact shape a hard interruption leaves behind.
+        // The old age gate kept it on disk for an hour, where it poisoned every
+        // request and made new messages render as stuck QUEUED. Callers only
+        // invoke the sweep on an idle session, so age is irrelevant now.
         const now = Date.now()
         const assistant = makeAssistant(session.id, userMsg.id, dir, { created: now - 3_000 })
         yield* sessions.updateMessage(assistant)
 
-        yield* svc.sweepOrphanAssistants(session.id, true)
+        yield* svc.sweepOrphanAssistants(session.id)
 
         const after = yield* sessions.messages({ sessionID: session.id })
-        const updated = after.find((m) => m.info.id === assistant.id)
-        expect(updated).toBeDefined()
-        const info = updated!.info as MessageV2.Assistant
-        expect(info.time.completed).toBeDefined()
-        expect(info.time.completed!).toBeGreaterThanOrEqual(now)
-        expect(info.error).toBeDefined()
-        expect(JSON.stringify(info.error)).toContain("Abandoned")
+        expect(after.find((m) => m.info.id === assistant.id)).toBeUndefined()
+        // The user turn it belonged to is untouched.
+        expect(after.find((m) => m.info.id === userMsg.id)).toBeDefined()
       }),
     ),
   )
 
-  it.live("leaves an already-completed assistant message untouched", () =>
+  it.live("leaves an already-completed trailing assistant untouched", () =>
     provideTmpdirInstance((dir) =>
       Effect.gen(function* () {
         const sessions = yield* Session.Service
@@ -178,6 +106,43 @@ describe("sweepOrphanAssistants", () => {
         const info = updated!.info as MessageV2.Assistant
         expect(info.time.completed).toBe(originalCompleted)
         expect(info.error).toBeUndefined()
+      }),
+    ),
+  )
+
+  it.live("leaves history whose last message is a user message untouched", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const svc = yield* SessionPrompt.Service
+        const session = yield* sessions.create({})
+
+        const firstUser = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "default",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() - 9_000 },
+        })
+        // A NON-trailing incomplete assistant. The minimal rule only touches the
+        // tail; non-trailing shells are neutralized on the read side by
+        // MessageV2.toModelMessages, which never emits a zero-content assistant.
+        const assistant = makeAssistant(session.id, firstUser.id, dir, { created: Date.now() - 8_000 })
+        yield* sessions.updateMessage(assistant)
+        yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "default",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() - 1_000 },
+        })
+
+        yield* svc.sweepOrphanAssistants(session.id)
+
+        const after = yield* sessions.messages({ sessionID: session.id })
+        expect(after.find((m) => m.info.id === assistant.id)).toBeDefined()
       }),
     ),
   )


### PR DESCRIPTION
## Why

**Read this first: this PR does not fix a live outage.** The justification it was opened with has expired, and the honest current one is narrower.

### What actually motivated it (evidence kept, conclusion retired)

A turn killed by a hard provider error leaves an assistant row carrying only bookkeeping parts (`step-start` / `step-finish` / `patch`) or no parts at all. In one live session (`ses_0c3e12b6affeoSCn4d940Q5gIT`) that produced **123 zero-part `APIError` assistant rows** plus 3 rows whose only parts were `step-finish` (×2) or `patch` (×1), and **62 messages in that slice carry `messages.<N>: user messages must have non-empty content`** (newest at `messages.260` / `messages.230`). That history is real and stays on the record.

What has *not* survived is the causal story built on top of it — that these shells are still being replayed into later requests and still escalating into 400s. Two independent measurements retired it:

**1. This PR's own replay experiment.** Replaying that session's real persisted history (4228 main-slice messages) through the **current** converter and the full pre-send pipeline (`toModelMessages` → `ProviderTransform.message`, Bedrock model):

```
window=4228 outgoing=6335 emptyContent=[]
window=300  outgoing=422  emptyContent=[]
window=262  outgoing=368  emptyContent=[]
[bedrock pipeline] window=262 outgoing=369 problematic=[]
```

**Today's `main` emits no zero-content message from that history.**

**2. The read side is behaviourally redundant.** All four of this PR's read-side assertions were ported into a probe and run on pristine `main`: **4 pass / 0 fail**. `main` already closes that path at

- `session/message-v2.ts:699` — `if (msg.parts.length === 0) continue`
- `session/message-v2.ts:912` — `if (assistantMessage.parts.length > 0)`
- `session/message-v2.ts:941` — `result.filter((msg) => msg.parts.some((part) => part.type !== "step-start"))`
- `provider/transform.ts:364`, wired at `:973` — merged #1948's `ensureNonEmptyContent`

⇒ **The 400s are already prevented on `main`.** Nothing in this PR is required to stop them.

### So what is left worth merging

**The read side: making an incidental guard explicit.** `main`'s protection is a side effect of a `parts.some(...)` filter that exists for a different reason. Delete that incidental filter and the difference shows up immediately:

| converter source | incidental `parts.some(...)` filter removed |
| --- | --- |
| pristine `main` | **2 fail** — `filters out messages with only ignored parts`, `drops a user message whose parts all convert to nothing` |
| this PR | **31 pass** |

Same observable behaviour today; different resilience to the next edit of that filter. That is the read side's entire value, and it is a clarity argument, not a bug fix.

**The write side: a structural trade, with a cost this PR paid in public.** Instead of requiring every reader of "the last message" to remember to filter an empty shell, the shell does not exist. But the trade is real and runs both ways:

> it exchanges *"every reader must filter empty content"* for *"every reader must handle the row being absent."*

That is not a hypothetical cost. `firePostSession` (`prompt.ts`) is a second, independent reader that re-derives the turn's final assistant from the persisted slice. With the row deleted its `findLast` skipped the hole to an older **successful** assistant, `finalIsError` went false, and `lifecycleStatus` published `"completed"` for a failed turn — breaking merged #1851's contract and silently mis-reporting the `session.post` plugin outcome. CI caught it; inspection had not. Commit `128849986` fixed that reader by consulting `droppedShell` first.

Deleting a persisted row therefore creates an obligation to audit **every** reader that assumed it existed. That audit is below, and it is what discharges the cost.

## Reader audit — every site that reads "the last message"

Re-derived on the branch head (line numbers below are from this branch, not `main`). Verdict per site, with the reasoning tied to `file:line`.

Two measurements against the local 5.4 GB DB decide most of it:

- The droppable population — errored, non-aborted, no substantive content — is **210 rows**: `APIError` 160, `UnknownError` 37, `InvalidOutputError` 12, `ContentFilterError` 1, `ContextOverflowError` 1.
- **195 of those carry `finish = NULL`; 15 carry `finish` set.** `ctx.assistantMessage.finish` is only assigned in `case "finish-step"` (`processor.ts:588`), which a hard 400 never reaches — but `InvalidOutputError` &co. do. So `finish`-gated readers are *not* automatically safe, and are assessed as affected.

| # | site | verdict | reasoning |
| --- | --- | --- | --- |
| 1 | `checkpoint.ts:258` `findLastIndex(assistant && finish !== undefined)` | **affected, not broken** | For the 15 `finish`-set shells, deletion moves `lastAsstIdx` earlier. Removing an element can never make `findLastIndex` select a *later* message, and `startIdx = lastAsstIdx - 1` then only walks backward ⇒ the boundary can only move **earlier or stay**. Boundary = first message to *preserve*, so it can only preserve more, never discard more. No data loss possible in this direction. Separately, the boundary ID can never dangle: it is always `≤ lastAsstIdx - 1`, i.e. strictly before the last assistant, while both deletions (`cleanup`, `sweepOrphanAssistants`) only ever remove a row that is last in its slice. |
| 2 | `compaction.ts:241` `findLastIndex(m => m.info.id === parentID)` | **unaffected** | ID-equality lookup for the compaction **parent**, which must be a `user` message (`throw` at :243 otherwise). Deleting an assistant cannot change which row has `id === parentID`; the index shifts but is consumed within the same post-deletion array. |
| 3 | `compaction.ts:255` `findLastIndex(i < parentIdx && role === "user" && parts.some(compaction))` | **unaffected** | Predicate filters `role === "user"`; the deleted row is an assistant and can never be selected. |
| 4 | `compaction.ts:296` `messages.at(-1)?.info.id === parentID` | **affected, strictly more correct** | This is the one boundary site where the hole is visible: with a shell sitting after the compaction parent, `at(-1)` was the shell and the parent marker was fed to the summarizer; with the shell gone, `at(-1)` is the parent and `slice(0, -1)` correctly drops the marker. The check exists precisely to exclude the marker, so the deletion makes it fire as intended. Direction is exclusion of a synthetic marker, not of user content. |
| 5 | `llm-request-prefix.ts:50` `findLast(m => role === "user")` | **unaffected** | Filters `role === "user"`; no index arithmetic, no positional dependency. |
| 6 | `message-v2.ts:1023` `slice.at(-1)` (was `:996` on `main`) | **unaffected** | Pagination cursor in `page()`. `slice` is the DB rows actually returned; `tail` is the oldest row of the page and is encoded as the cursor. A deleted row is simply absent from the result set — the cursor still names a row that exists. |
| 7 | `prompt.ts:787` `findLast(msg => role === "user")` | **unaffected** | `insertReminders`' user-message target; filters `role === "user"`. |
| 8 | `prompt.ts:824` `findLast(msg => role === "assistant")` | **affected, not broken** | Consumed only at `:944` as `assistantMessage?.info.agent === "plan"`. With a plan-mode shell deleted, this reads the previous assistant; the two branches diverge only at the moment plan mode is *entered*, where the effect is that the full plan prompt is injected onto the new user message instead of the short "still active" reminder. No duplicate stacking (the `:950` guard is per-message), no data loss, and the fuller prompt is the safer of the two. |
| 9 | `prompt.ts:950` `input.messages.at(-1) !== userMessage` | **unaffected** | Detects "fresh user turn". Within a turn, the current assistant row exists while steps run — `cleanup` deletes only at turn end. Across turns, `sweepOrphanAssistants` runs **before** `createUserMessage` (`prompt.ts:2474`), so the new user message is last either way. |
| 10 | `prompt.ts:1473` `findLast(assistant && !!finish)` | **affected, not broken** | For the 15 `finish`-set shells, `lastFinished` becomes an older real assistant. Effect: its `tokens` feed `contextPressureLevel` and `slice(lastFinishedIndex + 1)` covers more messages ⇒ pressure reads higher ⇒ a shorter MCP tool-search description. Conservative direction, and a real assistant's token counts are the more accurate input than a shell's. |

Sites beyond the ten, in the same class as `firePostSession` (post-turn result derivation) — this is where the risk actually lives:

| site | verdict | reasoning |
| --- | --- | --- |
| `prompt.ts:4188` `final = droppedShell ? … : lastAssistant(…)` | **affected, already handled** | The fix in `128849986`. Verified reachable on **every** drop, not just some: a drop implies `assistantMessage.error`, which forces `return "stop"` at `processor.ts:901`, which forces `outcome === "break"` at `prompt.ts:4003` — the only branch that assigns `droppedShell`. The `droppedShell = undefined` reset on the `continue` path is therefore unreachable after a drop. |
| `actor/spawn.ts:276` `if (info?.role === "assistant" && info.error) fail(…)` | **affected, already handled** | Consumes `runLoop`'s return value, so the same `droppedShell` patch is what lets a subagent's failed turn still surface as a failure instead of an older success. Worth naming: one fix repaired two readers. |
| `actor/waiter.ts:67`, `actor/group.ts:99` | **unaffected** | Both gated on success (`entry.lastOutcome === "success"` / `outcome === "success"`) before reading the last assistant. A dropped turn is never a success. |
| `prompt.ts` `goalGate` `findLast(assistant)?.info.id` | **affected, correct as-is** | The goal verdict marker is anchored to the newest surviving assistant. It *must* be: the marker is a message ID rendered by the TUI, so anchoring it to the deleted row would produce a dangling reference. Not a defect. |
| `prompt.ts:695` `predict` | **affected, more correct** | The per-turn assistant set is now empty ⇒ `return ""`, instead of running a prediction off a contentless shell. |
| `prompt.ts:3983` `assistantFinalText(handle.message, MessageV2.parts(handle.message.id))` and `:4014` `parts:` | **unaffected** | `cleanup` runs as `Effect.ensuring` (`processor.ts:896`), so these read the row *after* deletion and get `[]`. Classification only inspects `parts` for `tool` / `text`; `[]` and `[step-start, step-finish]` are indistinguishable to it, and a shell has no final text either way. |
| `prompt.ts:3123-3131` loop's backward scan for `lastAssistant` / `lastFinished`, consumed by `classifyAssistantStep` at `:3192` | **affected, not broken** | The classifier's guard #4 (`phase === "existing-assistant" && !(lastUser.id < assistant.id) → continue`) absorbs the hole: the older assistant predates `lastUser`, so it classifies `continue`, exactly as the 195 `finish`-NULL shells did via guard #2 on `main`. Across turns both sides agree for the same reason. |
| `tool/session.ts:83,94`, `tool/session.ts:1183-1184`, `acp/agent.ts:99` | **unaffected** | Cosmetic/derived only — fork watermark + `agentName` baseline, `set-mode` `agent` rewrite, context-limit lookup. A shell carries the same `agent`/`providerID`/`modelID` as the neighbouring real assistant. |

### Three defects the audit found, fixed in `3338fb03e`

**1. `sweepOrphanAssistants` could delete a *live* subagent's assistant row.** It read `agentID: "*"` and removed the session-global newest incomplete assistant. `SessionProcessor` publishes status for the main slice alone — the very fact the adjacent `sweepOrphanToolParts` comment calls load-bearing — so a background actor can be mid-turn while session status reads `idle`. Its in-flight row is then exactly what the sweep deletes, out from under its own processor, which keeps calling `updatePart` against that `messageID`. The old stamping behaviour was recoverable; deleting is not. Now scoped to the main slice, which is all the idle gate proves.

**2. Narrowing the sweep to the *trailing* message stranded every non-trailing orphan forever.** The sweep runs before `createUserMessage`, so a single-slice orphan is trailing — but one is left non-trailing by a concurrent subagent row, or by a previous `source: "spawn" | "hook"` prompt that skipped the sweep block. The TUI's `pending` marker (`routes/session/index.tsx:195`) derives from the newest **incomplete** assistant regardless of what follows it, so a stranded row keeps rendering fresh messages as stuck QUEUED — the exact symptom the age-independent sweep was introduced to prevent. Measured on the local 5.4 GB DB: **85 such rows** (78 mid-slice, 7 last-in-slice-but-not-last-in-session) across **33 sessions carrying 2+ incomplete assistants**.

⚠️ This means an assertion introduced by `64bcd6d34` — *"leaves history whose last message is a user message untouched"* — pinned the regression rather than a requirement. Its stated rationale covered only the replay path, which the read side already closes, and not the stuck-QUEUED path. It has been replaced, and that replacement is called out here rather than made quietly.

**3. `filterCompactedEffect` widened a fork boundary when the watermark row was deleted.** `message-v2.ts:1109` resolved a fork's `contextWatermark` by exact message ID and fell through to the **full parent history** when the row was missing. A `context: "full"` subagent captures that watermark from `Session.lastMainMessageID` (`actor/spawn.ts:728`), so a spawn issued *inside* a turn captures that turn's in-flight assistant — precisely the row the empty-shell guard then deletes. The child silently inherited more context than it was registered for: a boundary shift, not a display bug. `MessageID` is monotonic ascending, so the boundary survives the row; the fallback now truncates by ID. The resolved path is byte-identical and stays authoritative for array order, which is by `time_created` and can diverge from ID order (`insertRebuildBoundary` back-dates `time.created` while allocating an ascending ID).

## What changed

**Write side — `SessionProcessor.cleanup`**

Do not persist a contentless errored assistant; delete the row instead. The error is not swallowed: `halt` already published it on `Session.Event.Error` and reset session status, and a new `Handle.dropped` flag makes `SessionPrompt` report the turn from the in-memory message.

A **user abort is deliberately exempt**: cancelling is a normal outcome the transcript should keep showing (pinned by the pre-existing `records aborted errors when prompt is cancelled mid-stream` regression test), and an errored assistant can never reach a provider anyway because `toModelMessages`' error gate drops it.

**Write side — `sweepOrphanAssistants`**

Age gate removed (the caller establishes idleness), and orphans are **deleted** rather than stamped. Scope: the **main slice**, and **every** incomplete assistant in it, not just the trailing one — see defects 1 and 2 above for why both halves of that are load-bearing.

**Read side — restatement, plus one real fix**

- `toModelMessages` emits a user message only when it converted to at least one part, symmetric with the existing assistant guard.
- The assistant error gate uses a shared exported `hasSubstantiveAssistantContent` predicate instead of an inline part-type check that counted `step-finish` and `patch` as content — the assistant-side mirror of `hasSubstantiveContent` in `session/prompt.ts`.
- `filterCompactedEffect` no longer discards a fork boundary when the watermark row is gone (defect 3). This one is a behaviour fix, not a restatement.

## Tests — each verified as a real regression test

Every test was proved by reverting **only** its corresponding src change.

| revert | observed failure |
| --- | --- |
| `processor.ts` | `(fail) session.processor effect tests do not retry unknown json errors` — `expect(handle.dropped).toBe(true)` → `expect(received).toBe(expected)` (received `undefined`); same for both abort tests on `toBe(false)` |
| `prompt.ts` sweep (original) | `(fail) sweepOrphanAssistants > drops a trailing incomplete assistant regardless of age` — `expect(after.find(...)).toBeUndefined()` |
| `prompt.ts` sweep (this round) | `(fail) sweepOrphanAssistants > drops a NON-trailing incomplete assistant in the main slice` — `error: expect(received).toBeUndefined()` / `Received: {` · and `(fail) sweepOrphanAssistants > never touches a non-main slice, whose actor may still be mid-turn` — `error: expect(received).toBeDefined()` / `Received: undefined`, i.e. pristine really does delete the live actor's row |
| `message-v2.ts` watermark | `(fail) filterCompactedEffect contextWatermark > truncates at the boundary even after the watermark row is deleted` — `expect(received).toEqual(expected)`, diff `+ "msg_…5005hQbvxh2RBXSFkF"` (the post-boundary message leaking in) · and `(fail) … inherits nothing when the deleted watermark predates every surviving message` — `expect(received).toBe(expected)` / `Expected: false` / `Received: true` |
| `message-v2.ts` converter | converter suite still **31 pass** — reported honestly: on this head those protections already exist, so the new converter tests are characterization tests. Their load-bearing value is the 2-fail/31-pass table above. |

## Verification

- `bun typecheck` — exit 0, 12/12 tasks.
- Scoped run (`prompt-sweep`, `context-watermark`, `message-v2`, `processor-effect`, `prompt-effect`, `compaction-agent-scope`, `rebuild-microcompact`, `checkpoint-boundary`, `checkpoint-main-slice`, `checkpoint-child-session`): **126 pass / 5 skip / 0 fail** vs the identical command on the pristine branch head **123 pass / 5 skip / 0 fail** (+3 net new cases, zero failures either side). `prompt-effect.test.ts` — the suite carrying #1851's `turn-lifecycle` contract — is in that set and green.
- Earlier rounds: sibling empty-content suites **25 pass / 1 fail**, that failure being `whitespace-only text skips loop and returns empty parts` (5000 ms timeout), which reproduces **identically on pristine `main`** ⇒ pre-existing.

**No assertion was weakened.** One assertion was *replaced* — `64bcd6d34`'s non-trailing-orphan case — and it is reported as a finding above rather than adjusted in silence.

## Deliberately left alone

- Existing prettier disagreements in the touched files — they pre-exist on `main` (verified by stashing and re-running `prettier --check`).
- `ProviderTransform.normalizeMessages` / `ensureTrailingUserMessage` — already correct.
- `checkpoint.ts:258` and `prompt.ts:1473` are left as-is: both are affected only for the 15 `finish`-carrying shells, and in both cases the shift is provably in the conservative direction (preserve more / assume more pressure). Fixing them would add a `droppedShell` dependency to two hot paths for no behavioural gain.

## Title

Narrowed to the write side plus the reader repairs. The original *"and replaying"* half is now handled by `main` independently (`message-v2.ts:699/912/941` + #1948's `ensureNonEmptyContent`), so claiming it would overstate what this PR contributes.

Supersedes the closed PR #1702 (branch 348 commits behind `main`); this is a fresh branch off latest `origin/main`.

---

## Rebase onto `origin/main` (b81670870)

Rebased `1da2f1ba2` → `729c51768` (onto `f91eb6334`) → `64bcd6d34` (onto `b81670870`, after #1782 merged mid-rebase). Two rounds because `main` moved.

### Conflicts and how they were resolved

**1. `processor.ts` `cleanup` — co-located, kept both, order is load-bearing.**
#1960 added a DB-driven second pass finalizing orphaned tool parts; this PR adds the empty-shell guard. Both landed right after `ctx.toolcalls = {}` and collapsed onto the shared brace. #1960's pass now runs **first**, then the guard. Reason recorded inline at `processor.ts:797`: the guard ends in an early `return`, so running it first would skip #1960's finalization on the paths where the row survives. The reverse ordering is also *unnecessary* — `hasSubstantiveAssistantContent` counts any `tool` part as content regardless of state, so a turn that really called a tool is never dropped and the guard can only fire where #1960's loop is a no-op. Guarded by #1960's own suite: `prompt-orphan-tool-parts` **6 pass / 0 fail**, identical to the pristine baseline.

**2. `prompt.ts` interface + call site — co-located, kept both.**
#1960 added `sweepOrphanToolParts` on the line below `sweepOrphanAssistants`, whose signature this PR narrows (`immediate` removed). Kept #1960's new member *and* the narrowed signature; the idle gate moved to the caller while `sweepOrphanToolParts` stays self-gated. Both now read the main slice only, and `3338fb03e` records that shared scope and why it is load-bearing for both.

**3. `prompt.ts` `runLoop` — a genuine contradiction, resolved in `main`'s favour.**
#1782 (`b81670870`) is a revert: it deleted the empty-step guard (`emptyStepStreak`, `hardHalt`, `isEmptyStep`, `EMPTY_STEP_MAX_RECOVERY`) from `prompt.ts`. Those symbols appear as *context* in this PR's hunks. Taking this PR's side wholesale would have **resurrected code that was deliberately reverted**. Resolution: honour the revert — kept only `droppedShell` and its `outcome === "break"` assignment, dropped `emptyStepStreak`/`hardHalt` entirely. Verified: 0 occurrences of all four reverted symbols remain in `prompt.ts`.
