### PR TITLE
feat(exec): restore MCP dispatch with request-scoped gating, structured results, and live sub-call trace

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2316,6 +2316,22 @@ function ToolScript(props: ToolProps<typeof ToolScriptTool>) {
     if (isRunning()) return base
     return failed() ? `${status()} · ${base}` : base
   })
+  // Per-call trace tail published live via ctx.metadata (see publishProgress
+  // in tool-script.ts). While running, show the last few sub-calls under the
+  // summary line so long batches aren't a black box.
+  type RecentCall = { name: string; status: string; durationMs: number; error?: string }
+  const recent = createMemo(() => {
+    const r = meta().recent as RecentCall[] | undefined
+    return Array.isArray(r) ? r : []
+  })
+  const recentLines = createMemo(() =>
+    recent()
+      .slice(-5)
+      .map(
+        (t) =>
+          `  ${t.status === "error" ? "✗" : "✓"} ${t.name} [${t.durationMs}ms]${t.error ? ` ${t.error.slice(0, 80)}` : ""}`,
+      ),
+  )
 
   const code = createMemo(() => ((props.input.code as string | undefined) ?? "").trim())
   // exec embeds nested tool output (a `bash` call's stdout) into <return_value>
@@ -2343,6 +2359,9 @@ function ToolScript(props: ToolProps<typeof ToolScriptTool>) {
         >
           <box gap={1}>
             <text fg={theme.textMuted}>{clip(code())}</text>
+            <Show when={recentLines().length > 0}>
+              <text fg={theme.textMuted}>{recentLines().join("\n")}</text>
+            </Show>
             <Show when={output()}>
               <text fg={failed() ? theme.error : theme.text}>{clip(output())}</text>
             </Show>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2367,6 +2367,7 @@ function ToolScript(props: ToolProps<typeof ToolScriptTool>) {
             onClick={() => setExpanded(true)}
           >
             <text fg={theme.textMuted}>{recentLines().join("\n")}</text>
+            <text fg={theme.textMuted}>Click to expand</text>
           </BlockTool>
         </Show>
       }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2286,14 +2286,14 @@ function WorkItemTask(props: ToolProps<typeof TaskTool>) {
   )
 }
 
-// Renderer for the `exec` batch-orchestration tool, shaped like <Bash>: once the
-// script source has streamed in it lives in a BlockTool, and collapsing only caps
-// how much of the script and its output are shown (head + "…") instead of hiding
-// both behind a one-line summary. The title carries the live aggregated call
-// counts published through ctx.metadata.
+// Renderer for the `exec` batch-orchestration tool. Collapsed view is a compact
+// BlockTool: summary title (spinner + live aggregated call counts published
+// through ctx.metadata) plus the last few sub-calls — one bordered clickable
+// unit, visible while running and kept after completion. Clicking swaps to the
+// full BlockTool with code, result, logs and trace. Before any sub-call lands
+// it stays a one-line InlineTool.
 function ToolScript(props: ToolProps<typeof ToolScriptTool>) {
   const { theme } = useTheme()
-  const ctx = use()
   const [expanded, setExpanded] = createSignal(false)
   const isRunning = createMemo(() => props.part.state.status === "running")
   const meta = createMemo(() =>
@@ -2317,8 +2317,9 @@ function ToolScript(props: ToolProps<typeof ToolScriptTool>) {
     return failed() ? `${status()} · ${base}` : base
   })
   // Per-call trace tail published live via ctx.metadata (see publishProgress
-  // in tool-script.ts). While running, show the last few sub-calls under the
-  // summary line so long batches aren't a black box.
+  // in tool-script.ts). Shown under the summary line while running AND after
+  // completion — the terminal returns re-publish it (completeToolCall replaces
+  // part metadata) so the trace doesn't vanish the moment a run finishes.
   type RecentCall = { name: string; status: string; durationMs: number; error?: string }
   const recent = createMemo(() => {
     const r = meta().recent as RecentCall[] | undefined
@@ -2332,51 +2333,57 @@ function ToolScript(props: ToolProps<typeof ToolScriptTool>) {
           `  ${t.status === "error" ? "✗" : "✓"} ${t.name} [${t.durationMs}ms]${t.error ? ` ${t.error.slice(0, 80)}` : ""}`,
       ),
   )
-
-  const code = createMemo(() => ((props.input.code as string | undefined) ?? "").trim())
   // exec embeds nested tool output (a `bash` call's stdout) into <return_value>
   // and <logs>, so escape sequences reach this renderer raw.
   const output = createMemo(() => stripAnsi(props.output?.trim() ?? ""))
-  const columns = createMemo(() => Collapse.columns(ctx.width))
-  const overflow = createMemo(
-    () =>
-      Collapse.rows(code(), columns()) > TOOL_BLOCK_COLLAPSE_MAX_ROWS ||
-      Collapse.rows(output(), columns()) > TOOL_BLOCK_COLLAPSE_MAX_ROWS,
-  )
-  const clip = (content: string) => {
-    if (expanded()) return content
-    return Collapse.clip(content, columns(), TOOL_BLOCK_COLLAPSE_MAX_ROWS)
-  }
 
   return (
-    <Switch>
-      <Match when={code()}>
-        <BlockTool
-          title={`# exec · ${summary()}`}
-          part={props.part}
-          spinner={isRunning()}
-          onClick={overflow() ? () => setExpanded((prev) => !prev) : undefined}
+    <Show
+      when={expanded()}
+      fallback={
+        // Collapsed: ONE compact BlockTool holding the summary title and the
+        // sub-call trace — a single bordered, hover-highlighted, clickable
+        // unit. An InlineTool with a loose text underneath read as two
+        // elements and the click target was easy to miss.
+        <Show
+          when={recentLines().length > 0}
+          fallback={
+            <InlineTool
+              icon="»"
+              pending="Writing script..."
+              complete={!isRunning()}
+              spinner={isRunning()}
+              part={props.part}
+              onClick={() => setExpanded(true)}
+            >
+              exec {summary()}
+            </InlineTool>
+          }
         >
-          <box gap={1}>
-            <text fg={theme.textMuted}>{clip(code())}</text>
-            <Show when={recentLines().length > 0}>
-              <text fg={theme.textMuted}>{recentLines().join("\n")}</text>
-            </Show>
-            <Show when={output()}>
-              <text fg={failed() ? theme.error : theme.text}>{clip(output())}</text>
-            </Show>
-            <Show when={overflow()}>
-              <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
-            </Show>
-          </box>
-        </BlockTool>
-      </Match>
-      <Match when={true}>
-        <InlineTool icon="»" pending="Writing script..." complete={false} part={props.part}>
-          exec
-        </InlineTool>
-      </Match>
-    </Switch>
+          <BlockTool
+            title={`# exec · ${summary()}`}
+            part={props.part}
+            spinner={isRunning()}
+            onClick={() => setExpanded(true)}
+          >
+            <text fg={theme.textMuted}>{recentLines().join("\n")}</text>
+          </BlockTool>
+        </Show>
+      }
+    >
+      <BlockTool title={`# exec · ${summary()}`} part={props.part} onClick={() => setExpanded(false)}>
+        <box gap={1}>
+          <text fg={theme.textMuted}>{((props.input.code as string | undefined) ?? "").trim()}</text>
+          <Show when={recentLines().length > 0}>
+            <text fg={theme.textMuted}>{recentLines().join("\n")}</text>
+          </Show>
+          <Show when={output()}>
+            <text fg={failed() ? theme.error : theme.text}>{output()}</text>
+          </Show>
+          <text fg={theme.textMuted}>Click to collapse</text>
+        </box>
+      </BlockTool>
+    </Show>
   )
 }
 

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -220,6 +220,9 @@ export const Flag = {
   MIMOCODE_EXPERIMENTAL_OXFMT: MIMOCODE_EXPERIMENTAL || truthy("MIMOCODE_EXPERIMENTAL_OXFMT"),
   MIMOCODE_EXPERIMENTAL_LSP_TY: truthy("MIMOCODE_EXPERIMENTAL_LSP_TY"),
   MIMOCODE_EXPERIMENTAL_LSP_TOOL: MIMOCODE_EXPERIMENTAL || truthy("MIMOCODE_EXPERIMENTAL_LSP_TOOL"),
+  // Defaults to OFF: exec (tool_script orchestration) is registered only for
+  // GPT-toolset models. Opt in here to expose it to every model.
+  MIMOCODE_ENABLE_EXEC_TOOL: truthy("MIMOCODE_ENABLE_EXEC_TOOL"),
   // Defaults to OFF for non-GPT models. GPT models enable MCP Tool Search in
   // SessionPrompt regardless of this flag. Opt in here to enable it for every
   // function-calling model.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -125,7 +125,6 @@ import {
   type McpToolSearchMetadata,
 } from "@/tool/mcp-tool-search"
 import { isMcpToolSearchEnabled } from "@/tool/gpt"
-import { toolScriptMcp } from "@/tool/tool-script-ref"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -945,6 +944,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const loadedMcpTools = new Set<string>()
       const mcpSearchEntries: McpToolSearchEntry[] = []
       const mcpCatalog = { current: createMcpToolSearchCatalog([]) }
+      // exec's request-scoped MCP view. Holder object (same pattern as
+      // mcpCatalog above): referenced by the context() closure below, filled
+      // at the end of this pass once activeTools is settled. Travels through
+      // ctx.extra — NOT a module-level ref, which concurrent sessions in the
+      // same process would overwrite (request state must never live in a
+      // global; see toolWhitelist/mcpToolSearch precedent).
+      const execMcp: { current: Record<string, AITool> } = { current: {} }
       const useMcpToolSearch = isMcpToolSearchEnabled(
         Flag.MIMOCODE_EXPERIMENTAL_MCP_TOOL_SEARCH,
         input.model.id,
@@ -1014,6 +1020,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           promptOps,
           ...(whitelist ? { toolWhitelist: [...whitelist] } : {}),
           mcpToolSearch: mcpCatalog.current,
+          execMcp,
         },
         agent: input.agent.name,
         actorID: input.agentID,
@@ -1389,18 +1396,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       }
       loadedMcpTools.forEach((name) => activeTools.add(name))
 
-      // Populate the exec sandbox's MCP view (late-bound ref, see
-      // tool-script-ref.ts) with the REQUEST-SCOPED set: exactly the MCP tools
+      // Fill exec's request-scoped MCP view (holder declared at the top of
+      // this pass, delivered via ctx.extra.execMcp): exactly the MCP tools
       // active for this request. Under mcp_tool_search gating that means only
-      // search-loaded tools — exec must not bypass the discovery gate. The map
-      // is rebuilt on every resolveTools pass, so the view tracks each turn.
-      const execMcpView: Record<string, AITool> = {}
+      // search-loaded tools — exec must not bypass the discovery gate.
       for (const [key] of mcpTools) {
         if (!tools[key] || !activeTools.has(key)) continue
         if (key === MCP_TOOL_SEARCH_ID) continue
-        execMcpView[key] = tools[key]
+        execMcp.current[key] = tools[key]
       }
-      toolScriptMcp.current = () => Effect.succeed(execMcpView)
 
       return {
         tools,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -125,6 +125,7 @@ import {
   type McpToolSearchMetadata,
 } from "@/tool/mcp-tool-search"
 import { isMcpToolSearchEnabled } from "@/tool/gpt"
+import { toolScriptMcp } from "@/tool/tool-script-ref"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1387,6 +1388,19 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         activeTools.add(MCP_TOOL_SEARCH_ID)
       }
       loadedMcpTools.forEach((name) => activeTools.add(name))
+
+      // Populate the exec sandbox's MCP view (late-bound ref, see
+      // tool-script-ref.ts) with the REQUEST-SCOPED set: exactly the MCP tools
+      // active for this request. Under mcp_tool_search gating that means only
+      // search-loaded tools — exec must not bypass the discovery gate. The map
+      // is rebuilt on every resolveTools pass, so the view tracks each turn.
+      const execMcpView: Record<string, AITool> = {}
+      for (const [key] of mcpTools) {
+        if (!tools[key] || !activeTools.has(key)) continue
+        if (key === MCP_TOOL_SEARCH_ID) continue
+        execMcpView[key] = tools[key]
+      }
+      toolScriptMcp.current = () => Effect.succeed(execMcpView)
 
       return {
         tools,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -378,7 +378,7 @@ export const layer = Layer.effect(
     }) {
       const useGPTTools = usesGPTToolset(input.modelID)
       let filtered = (yield* all()).filter((tool) => {
-        if (tool.id === ToolScriptTool.id) return useGPTTools
+        if (tool.id === ToolScriptTool.id) return useGPTTools || Flag.MIMOCODE_ENABLE_EXEC_TOOL
         if (tool.id === CodeSearchTool.id || tool.id === WebSearchTool.id) {
           if (tool.id === WebSearchTool.id) {
             return (

--- a/packages/opencode/src/tool/tool-script-ref.ts
+++ b/packages/opencode/src/tool/tool-script-ref.ts
@@ -6,6 +6,7 @@
 // the registry layer populates this module-local reference on initialisation and
 // the tool reads it at call time.
 import type { Effect } from "effect"
+import type { Tool as AiTool } from "ai"
 import type { Agent } from "../agent/agent"
 import type { ModelID, ProviderID } from "../provider/schema"
 import type * as Tool from "./tool"
@@ -14,6 +15,18 @@ export const toolScriptRegistry: {
   current:
     | ((input?: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info }) => Effect.Effect<Tool.Def[]>)
     | undefined
+} = { current: undefined }
+
+// MCP tools live outside ToolRegistry (SessionPrompt assembles them straight
+// from MCP.Service), so exec reaches them through this second ref, populated
+// per-request by the SessionPrompt layer. The populated map is the
+// REQUEST-SCOPED view: when mcp_tool_search gating is active, only tools the
+// model has already loaded via search are present — exec must not become a
+// backdoor around the discovery gate. Reusing the ref pattern keeps MCP's
+// layer out of the registry graph (providing MCP.defaultLayer to the registry
+// would spin up a SECOND set of MCP client connections).
+export const toolScriptMcp: {
+  current: (() => Effect.Effect<Record<string, AiTool>>) | undefined
 } = { current: undefined }
 
 // Agent control-flow tools make no sense inside a script (they steer the

--- a/packages/opencode/src/tool/tool-script-ref.ts
+++ b/packages/opencode/src/tool/tool-script-ref.ts
@@ -6,7 +6,6 @@
 // the registry layer populates this module-local reference on initialisation and
 // the tool reads it at call time.
 import type { Effect } from "effect"
-import type { Tool as AiTool } from "ai"
 import type { Agent } from "../agent/agent"
 import type { ModelID, ProviderID } from "../provider/schema"
 import type * as Tool from "./tool"
@@ -15,18 +14,6 @@ export const toolScriptRegistry: {
   current:
     | ((input?: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info }) => Effect.Effect<Tool.Def[]>)
     | undefined
-} = { current: undefined }
-
-// MCP tools live outside ToolRegistry (SessionPrompt assembles them straight
-// from MCP.Service), so exec reaches them through this second ref, populated
-// per-request by the SessionPrompt layer. The populated map is the
-// REQUEST-SCOPED view: when mcp_tool_search gating is active, only tools the
-// model has already loaded via search are present — exec must not become a
-// backdoor around the discovery gate. Reusing the ref pattern keeps MCP's
-// layer out of the registry graph (providing MCP.defaultLayer to the registry
-// would spin up a SECOND set of MCP client connections).
-export const toolScriptMcp: {
-  current: (() => Effect.Effect<Record<string, AiTool>>) | undefined
 } = { current: undefined }
 
 // Agent control-flow tools make no sense inside a script (they steer the

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -9,7 +9,7 @@ import { Log, Filesystem } from "@/util"
 import { Agent } from "@/agent/agent"
 import type { ModelID, ProviderID } from "../provider/schema"
 import { evalScript, type HostFn } from "../workflow/sandbox"
-import { toolScriptRegistry, toolScriptMcp, TOOL_SCRIPT_ALIASES, TOOL_SCRIPT_EXCLUDED } from "./tool-script-ref"
+import { toolScriptRegistry, TOOL_SCRIPT_ALIASES, TOOL_SCRIPT_EXCLUDED } from "./tool-script-ref"
 import DESCRIPTION from "./tool-script.txt"
 import * as Tool from "./tool"
 import * as Truncate from "./truncate"
@@ -378,11 +378,13 @@ export const ToolScriptTool = Tool.define(
             )
           ).filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id) && (!whitelist || whitelist.has(def.id)))
           const byId = new Map(defs.map((def) => [def.id, def]))
-          // MCP tools (late-bound ref, populated per-request by SessionPrompt
-          // with the request-scoped view — search-gated tools only appear after
-          // the model loaded them via mcp_tool_search). Builtin ids win on
-          // collision — an MCP server must not shadow `read`/`grep`.
-          const mcpTools = toolScriptMcp.current ? yield* toolScriptMcp.current() : {}
+          // MCP tools (request-scoped view delivered via ctx.extra.execMcp,
+          // filled by SessionPrompt's resolveTools for THIS request — under
+          // mcp_tool_search gating only search-loaded tools appear, so exec
+          // cannot bypass the discovery gate; a module-level ref would be
+          // overwritten by concurrent sessions). Builtin ids win on collision
+          // — an MCP server must not shadow `read`/`grep`.
+          const mcpTools = (ctx.extra?.execMcp as { current?: Record<string, AiTool> } | undefined)?.current ?? {}
           const mcpById = new Map(
             Object.entries(mcpTools).filter(([id]) => !byId.has(id) && (!whitelist || whitelist.has(id))),
           )

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -3,12 +3,13 @@ import os from "os"
 import fs from "fs"
 import path from "path"
 import { Effect } from "effect"
+import type { Tool as AiTool } from "ai"
 import { EffectBridge, InstanceState } from "@/effect"
 import { Log, Filesystem } from "@/util"
 import { Agent } from "@/agent/agent"
 import type { ModelID, ProviderID } from "../provider/schema"
 import { evalScript, type HostFn } from "../workflow/sandbox"
-import { toolScriptRegistry, TOOL_SCRIPT_ALIASES, TOOL_SCRIPT_EXCLUDED } from "./tool-script-ref"
+import { toolScriptRegistry, toolScriptMcp, TOOL_SCRIPT_ALIASES, TOOL_SCRIPT_EXCLUDED } from "./tool-script-ref"
 import DESCRIPTION from "./tool-script.txt"
 import * as Tool from "./tool"
 import * as Truncate from "./truncate"
@@ -25,6 +26,7 @@ const MAX_RESULT_BYTES = 256 * 1024
 const MAX_LOG_BYTES = 64 * 1024
 const MAX_CODE_BYTES = 128 * 1024
 const MAX_FILE_BYTES = 10 * 1024 * 1024
+const TRACE_TAIL_ENTRIES = 20
 
 /** JSON Schema (zod v4 toJSONSchema output) → compact TS type text. Best-effort:
  * anything unrecognized renders as `unknown`, which is safe for declarations. */
@@ -82,10 +84,12 @@ export function renderToolScriptDeclarations(defs: Tool.Def[]): string {
   })
   return [
     "```ts",
-    "type ToolResult = { title: string; output: string; metadata: Record<string, unknown> }",
+    "type ToolResult = { title: string; output: string; metadata: Record<string, unknown>; structured?: unknown }",
     "declare const tools: {",
     ...lines,
     ...aliasLines,
+    "  /** Active MCP tools (if any) are also callable as tools.<name>(input). MCP results carry parsed structuredContent in `structured` when the server provides it. */",
+    "  [mcpToolName: string]: (input: Record<string, unknown>) => Promise<ToolResult>",
     "}",
     "// Raw file IO for machine-to-machine data (pipelines across executions).",
     "declare const files: {",
@@ -340,10 +344,21 @@ export const ToolScriptTool = Tool.define(
             }
             return counts
           }
+          // Bounded per-call trace tail for the TUI (last N calls, error text
+          // truncated) — kept small so metadata deltas stay cheap on 500-call
+          // runs. Re-published on terminal returns for the same reason as
+          // tally(): completeToolCall replaces part metadata.
+          const recentTail = () =>
+            trace.slice(-TRACE_TAIL_ENTRIES).map((t) => ({
+              name: t.name,
+              status: t.status,
+              durationMs: t.durationMs,
+              ...(t.error && { error: t.error.slice(0, 200) }),
+            }))
           if (Buffer.byteLength(params.code, "utf8") > MAX_CODE_BYTES) {
             return {
               title: "code too large",
-              metadata: { status: "code_error", toolCalls: 0, counts: tally() },
+              metadata: { status: "code_error", toolCalls: 0, counts: tally(), recent: recentTail() },
               output: `<exec status="code_error">\n<error_message>\ncode exceeds ${MAX_CODE_BYTES} bytes\n</error_message>\n</exec>`,
             }
           }
@@ -363,6 +378,14 @@ export const ToolScriptTool = Tool.define(
             )
           ).filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id) && (!whitelist || whitelist.has(def.id)))
           const byId = new Map(defs.map((def) => [def.id, def]))
+          // MCP tools (late-bound ref, populated per-request by SessionPrompt
+          // with the request-scoped view — search-gated tools only appear after
+          // the model loaded them via mcp_tool_search). Builtin ids win on
+          // collision — an MCP server must not shadow `read`/`grep`.
+          const mcpTools = toolScriptMcp.current ? yield* toolScriptMcp.current() : {}
+          const mcpById = new Map(
+            Object.entries(mcpTools).filter(([id]) => !byId.has(id) && (!whitelist || whitelist.has(id))),
+          )
           // Non-git projects report worktree === "/" (see Instance.containsPath) —
           // "/" as a jail root would allow EVERYTHING. Fall back to the project
           // directory in that case. Relative guest paths resolve against roots[0].
@@ -406,7 +429,7 @@ export const ToolScriptTool = Tool.define(
           if (typeof transpiled === "object") {
             return {
               title: "transpile error",
-              metadata: { status: "code_error", toolCalls: 0, counts: tally() },
+              metadata: { status: "code_error", toolCalls: 0, counts: tally(), recent: recentTail() },
               output: `<exec status="code_error">\n<error_message>\n${transpiled.error}\n</error_message>\n</exec>`,
             }
           }
@@ -417,12 +440,18 @@ export const ToolScriptTool = Tool.define(
           const withSlot = makeSemaphore(MAX_CONCURRENT)
 
           // Live progress for the TUI: after each settled call, publish the
-          // aggregated per-tool counts through the OUTER part's metadata (each
-          // ctx.metadata fires a part delta the ToolScript view renders
-          // reactively). Fire-and-forget — progress must never fail a call.
+          // aggregated per-tool counts plus a bounded tail of per-call trace
+          // entries through the OUTER part's metadata (each ctx.metadata fires
+          // a part delta the ToolScript view renders reactively). The tail is
+          // capped so metadata deltas stay small on 500-call runs.
+          // Fire-and-forget — progress must never fail a call.
           const publishProgress = () => {
             bridge
-              .promise(ctx.metadata({ metadata: { running: true, toolCalls: trace.length, counts: tally() } }))
+              .promise(
+                ctx.metadata({
+                  metadata: { running: true, toolCalls: trace.length, counts: tally(), recent: recentTail() },
+                }),
+              )
               .catch(() => {})
           }
 
@@ -430,7 +459,8 @@ export const ToolScriptTool = Tool.define(
             const id = String(name)
             const alias = TOOL_SCRIPT_ALIASES[id as keyof typeof TOOL_SCRIPT_ALIASES]
             const def = byId.get(alias ?? id)
-            if (!def) return Promise.reject(new Error(`unknown tool: ${id}`))
+            const mcpDef = def ? undefined : mcpById.get(id)
+            if (!def && !mcpDef) return Promise.reject(new Error(`unknown tool: ${id}`))
             calls++
             if (calls > maxToolCalls)
               return Promise.reject(new Error(`tool call budget exceeded (${maxToolCalls} per execution)`))
@@ -443,14 +473,58 @@ export const ToolScriptTool = Tool.define(
               // title in the UI — swallow it; the trace covers observability.
               metadata: () => Effect.void,
             }
+            // MCP path: the map holds SessionPrompt's WRAPPED executes, so the
+            // full direct-call pipeline applies unchanged — permission ask,
+            // plugin before/after hooks, metrics, normalizeToolResult folding,
+            // truncation. Here we only adapt the wrapped result shape for the
+            // guest: structuredContent (when the server sent it) crosses as a
+            // parsed value under `structured` so scripts can filter/aggregate
+            // without re-parsing text; media attachments cannot cross the
+            // sandbox string boundary and are dropped with a note.
+            const executeMcp = (tool: AiTool) =>
+              Effect.tryPromise({
+                try: () =>
+                  Promise.resolve(
+                    tool.execute!(args ?? {}, {
+                      toolCallId: subCtx.callID,
+                      messages: [],
+                      abortSignal: ctx.abort,
+                    }),
+                  ),
+                catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+              }).pipe(
+                Effect.map((result) => {
+                  const r = result as {
+                    output?: unknown
+                    metadata?: { mcp?: { structuredContent?: unknown } }
+                    attachments?: unknown[]
+                  }
+                  const structured = r?.metadata?.mcp?.structuredContent
+                  const dropped = Array.isArray(r?.attachments) && r.attachments.length
+                    ? `\n[note: ${r.attachments.length} non-text attachment(s) dropped — binary content cannot cross the exec sandbox]`
+                    : ""
+                  return {
+                    title: id,
+                    output: String(r?.output ?? "") + dropped,
+                    metadata: (r?.metadata ?? {}) as Record<string, unknown>,
+                    ...(structured !== undefined && { structured }),
+                  }
+                }),
+              )
             return withSlot(() =>
               bridge
-                .promise(def.execute(args, subCtx))
+                .promise(def ? def.execute(args, subCtx) : executeMcp(mcpDef!))
                 .then(
                   (result) => {
                     trace.push({ name: id, status: "success", durationMs: Date.now() - start })
                     publishProgress()
-                    return { title: result.title, output: result.output, metadata: result.metadata }
+                    const structured = (result as { structured?: unknown }).structured
+                    return {
+                      title: result.title,
+                      output: result.output,
+                      metadata: result.metadata,
+                      ...(structured !== undefined && { structured }),
+                    }
                   },
                   (err) => {
                     const message = err instanceof Error ? err.message : String(err)
@@ -554,7 +628,7 @@ return { __undef: __out.value === undefined, json: __out.value === undefined ? "
             log.warn("exec failed", { status, message: explained.slice(0, 500) })
             return {
               title: status,
-              metadata: { status, toolCalls: trace.length, counts: tally() },
+              metadata: { status, toolCalls: trace.length, counts: tally(), recent: recentTail() },
               output: `<exec status="${status}">\n<error_message>\n${explained}\n</error_message>\n${logBlock}${traceBlock}</exec>`,
             }
           }
@@ -573,14 +647,14 @@ return { __undef: __out.value === undefined, json: __out.value === undefined ? "
           if (returnedBytes > MAX_RESULT_BYTES) {
             return {
               title: "result too large",
-              metadata: { status: "budget_exceeded", toolCalls: trace.length, counts: tally() },
+              metadata: { status: "budget_exceeded", toolCalls: trace.length, counts: tally(), recent: recentTail() },
               output: `<exec status="budget_exceeded">\n<error_message>\nreturned value is ${returnedBytes} bytes (max ${MAX_RESULT_BYTES}). Aggregate or slice the data before returning.\n</error_message>\n${warningsBlock}${logBlock}${traceBlock}</exec>`,
             }
           }
 
           return {
             title: `${trace.length} tool calls`,
-            metadata: { status: "completed", toolCalls: trace.length, counts: tally() },
+            metadata: { status: "completed", toolCalls: trace.length, counts: tally(), recent: recentTail() },
             output: `<exec status="completed">\n<return_value>\n${returnedText}\n</return_value>\n${warningsBlock}${logBlock}${traceBlock}</exec>`,
           }
         }).pipe(Effect.orDie),

--- a/packages/opencode/src/tool/tool-script.txt
+++ b/packages/opencode/src/tool/tool-script.txt
@@ -12,6 +12,7 @@ Use `exec` when JavaScript can batch multiple independent tool calls, programmat
 The script environment provides JavaScript built-ins plus `tools`, `files`, and `console`. It does not provide Node.js modules, `import`, `require`, `process`, `fetch`, or timers. Use the available tools for external operations.
 
 - Call tools with `await tools.name(input)`.
+- Active MCP tools are also callable as `tools.<mcp_tool_name>(input)` with the same permission checks as direct calls. When the MCP server returns structured data, the result carries it pre-parsed in the `structured` field.
 - Use `Promise.all` or `Promise.allSettled` only for independent calls; at most 8 run concurrently.
 - Return a small JSON-serializable aggregate. Circular values, BigInt, and throwing getters fail execution.
 - Use `console.log` only for debugging; logs are included in the result.

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -8,7 +8,7 @@ import { evalScript } from "../../src/workflow/sandbox"
 import { Agent } from "../../src/agent/agent"
 import { Truncate, Tool } from "../../src/tool"
 import { ToolScriptTool, renderToolScriptDeclarations } from "../../src/tool/tool-script"
-import { toolScriptRegistry, toolScriptMcp, TOOL_SCRIPT_EXCLUDED } from "../../src/tool/tool-script-ref"
+import { toolScriptRegistry, TOOL_SCRIPT_EXCLUDED } from "../../src/tool/tool-script-ref"
 import { Instance } from "../../src/project/instance"
 
 describe("sandbox non-deterministic mode", () => {
@@ -98,9 +98,7 @@ async function runToolScript(
   },
 ) {
   const prev = toolScriptRegistry.current
-  const prevMcp = toolScriptMcp.current
   toolScriptRegistry.current = () => Effect.succeed(defs)
-  toolScriptMcp.current = opts?.mcp ? () => Effect.succeed(opts.mcp!) : undefined
   try {
     return await Instance.provide({
       directory: tmp,
@@ -120,7 +118,10 @@ async function runToolScript(
               agent: "build",
               abort: abort ?? new AbortController().signal,
               callID: "call_test",
-              extra: opts?.toolWhitelist ? { toolWhitelist: opts.toolWhitelist } : undefined,
+              extra: {
+                ...(opts?.toolWhitelist ? { toolWhitelist: opts.toolWhitelist } : {}),
+                ...(opts?.mcp ? { execMcp: { current: opts.mcp } } : {}),
+              },
               messages: [],
               metadata: () => Effect.void,
               ask: opts?.ask ?? (() => Effect.void),
@@ -131,7 +132,6 @@ async function runToolScript(
     })
   } finally {
     toolScriptRegistry.current = prev
-    toolScriptMcp.current = prevMcp
   }
 }
 

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -8,7 +8,7 @@ import { evalScript } from "../../src/workflow/sandbox"
 import { Agent } from "../../src/agent/agent"
 import { Truncate, Tool } from "../../src/tool"
 import { ToolScriptTool, renderToolScriptDeclarations } from "../../src/tool/tool-script"
-import { toolScriptRegistry, TOOL_SCRIPT_EXCLUDED } from "../../src/tool/tool-script-ref"
+import { toolScriptRegistry, toolScriptMcp, TOOL_SCRIPT_EXCLUDED } from "../../src/tool/tool-script-ref"
 import { Instance } from "../../src/project/instance"
 
 describe("sandbox non-deterministic mode", () => {
@@ -94,10 +94,13 @@ async function runToolScript(
     maxToolCalls?: number
     timeoutSeconds?: number
     toolWhitelist?: string[]
+    mcp?: Record<string, any>
   },
 ) {
   const prev = toolScriptRegistry.current
+  const prevMcp = toolScriptMcp.current
   toolScriptRegistry.current = () => Effect.succeed(defs)
+  toolScriptMcp.current = opts?.mcp ? () => Effect.succeed(opts.mcp!) : undefined
   try {
     return await Instance.provide({
       directory: tmp,
@@ -128,6 +131,7 @@ async function runToolScript(
     })
   } finally {
     toolScriptRegistry.current = prev
+    toolScriptMcp.current = prevMcp
   }
 }
 
@@ -563,4 +567,131 @@ describe("renderToolScriptDeclarations", () => {
     expect(text).toContain("Alias for bash")
   })
 
+})
+
+describe("exec MCP dispatch", () => {
+  // Mimics the SessionPrompt-wrapped MCP execute: resolves with the normalized
+  // {output, metadata, attachments} shape (permission/hooks/truncation already
+  // applied by the wrapper), rejects on tool failure.
+  function fakeMcpTool(execute: (args: any) => Promise<any>) {
+    return {
+      description: "fake mcp tool",
+      inputSchema: z.object({}),
+      execute,
+    }
+  }
+
+  test("MCP tool is callable and returns output text", async () => {
+    const mcp = {
+      srv_search: fakeMcpTool(async (args) => ({
+        output: `found: ${args.query}`,
+        metadata: { mcp: { isError: false } },
+        attachments: [],
+      })),
+    }
+    const result = await runToolScript(
+      `const r = await tools.srv_search({ query: "hello" }); return r.output`,
+      [],
+      undefined,
+      { mcp },
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("found: hello")
+  })
+
+  test("structuredContent crosses into the guest as parsed `structured`", async () => {
+    const mcp = {
+      srv_data: fakeMcpTool(async () => ({
+        output: "3 items",
+        metadata: { mcp: { isError: false, structuredContent: { items: [1, 2, 3], total: 3 } } },
+        attachments: [],
+      })),
+    }
+    const result = await runToolScript(
+      `const r = await tools.srv_data({});
+       return { total: r.structured.total, doubled: r.structured.items.map((x) => x * 2) }`,
+      [],
+      undefined,
+      { mcp },
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain('"total": 3')
+    expect(result.output).toContain("4")
+    expect(result.output).toContain("6")
+  })
+
+  test("MCP failure rejects catchably inside the guest", async () => {
+    const mcp = {
+      srv_fail: fakeMcpTool(async () => {
+        throw new Error("server exploded")
+      }),
+    }
+    const result = await runToolScript(
+      `try { await tools.srv_fail({}) } catch (e) { return "caught: " + e.message }`,
+      [],
+      undefined,
+      { mcp },
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("caught: srv_fail: server exploded")
+  })
+
+  test("builtin id wins on collision with an MCP tool", async () => {
+    const mcp = {
+      echo: fakeMcpTool(async () => ({ output: "mcp version", metadata: {}, attachments: [] })),
+    }
+    const result = await runToolScript(
+      `const r = await tools.echo({ value: "x" }); return r.output`,
+      [fakeDef("echo", async () => "builtin version")],
+      undefined,
+      { mcp },
+    )
+    expect(result.output).toContain("builtin version")
+  })
+
+  test("attachments are dropped with a note", async () => {
+    const mcp = {
+      srv_img: fakeMcpTool(async () => ({
+        output: "here is your chart",
+        metadata: { mcp: { isError: false } },
+        attachments: [{ mime: "image/png", url: "data:image/png;base64,xxxx" }],
+      })),
+    }
+    const result = await runToolScript(
+      `const r = await tools.srv_img({}); return r.output`,
+      [],
+      undefined,
+      { mcp },
+    )
+    expect(result.output).toContain("here is your chart")
+    expect(result.output).toContain("non-text attachment(s) dropped")
+  })
+
+  test("MCP calls count against the tool call budget", async () => {
+    const mcp = {
+      srv_a: fakeMcpTool(async () => ({ output: "a", metadata: {}, attachments: [] })),
+    }
+    const result = await runToolScript(
+      `for (let i = 0; i < 3; i++) await tools.srv_a({}); return "done"`,
+      [],
+      undefined,
+      { mcp, maxToolCalls: 2 },
+    )
+    expect(result.metadata.status).not.toBe("completed")
+    expect(result.output).toContain("budget exceeded")
+  })
+
+  test("whitelist filters MCP tools too", async () => {
+    const mcp = {
+      srv_blocked: fakeMcpTool(async () => ({ output: "should not run", metadata: {}, attachments: [] })),
+    }
+    const result = await runToolScript(
+      `try { await tools.srv_blocked({}) } catch (e) { return "denied: " + e.message }`,
+      [],
+      undefined,
+      { mcp, toolWhitelist: ["exec"] },
+    )
+    expect(result.output).toContain("denied:")
+    expect(result.output).toContain("unknown tool")
+  })
 })


### PR DESCRIPTION
- Restore the toolScriptMcp late-bound ref removed by 8c29041a, now populated per-request by SessionPrompt with only the active MCP view — under mcp_tool_search gating exec sees exactly the search-loaded tools, so it cannot bypass the discovery gate. Dispatch reuses SessionPrompt's wrapped executes (permission ask, plugin hooks, metrics, truncation).
- MCP structuredContent crosses into the guest pre-parsed as `structured` so scripts can aggregate data without re-parsing text output.
- publishProgress ships a bounded trace tail (last 20 calls) and the final metadata carries it over; the TUI renders the last 5 sub-calls live and keeps them visible after completion.
- New MIMOCODE_ENABLE_EXEC_TOOL flag exposes exec to all models (was GPT-toolset only).
