### PR TITLE
fix(tui): keep the transcript alive after a directory switch

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -537,23 +537,20 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           sdk.switchDirectory(dir)
           await sync.bootstrap()
         }
-        const existing = sync.data.session
-          .toSorted((a, b) => b.time.updated - a.time.updated)
-          .find((x) => x.parentID === undefined)?.id
-        if (existing) {
-          local.orchestrator.setSessionID(existing)
-          // A `-s` launch wanted to land IN the orchestrator session; a plain
-          // Tab-into-orchestrator from a stale launch-dir session wanted Home
-          // (the fresh-entry state). Either way navigate exactly once, AFTER
-          // bootstrap, so the switched view resolves directly to its target with
-          // no intermediate frame — the root now exists in orchestratorDir.
-          if (resumeIntoSession) route.navigate({ type: "session", sessionID: existing })
-          else if (switching) route.navigate({ type: "home" })
-        } else {
-          const res = await sdk.client.session.create({})
-          if (res.data?.id) local.orchestrator.setSessionID(res.data.id)
-          if (switching) route.navigate({ type: "home" })
-        }
+        // Authoritative resolve-or-create against the switched directory. Reading
+        // sync.data.session here raced bootstrap's NON-blocking session list —
+        // bootstrap resolves before the list lands, so the lookup missed the
+        // existing root and minted another one on every entry.
+        const root = await sync.session.resolveRoot()
+        if (root.id) local.orchestrator.setSessionID(root.id)
+        // A `-s` launch wanted to land IN the orchestrator session; a plain
+        // Tab-into-orchestrator from a stale launch-dir session wanted Home
+        // (the fresh-entry state). Either way navigate exactly once, AFTER
+        // bootstrap, so the switched view resolves directly to its target with
+        // no intermediate frame — the root now exists in orchestratorDir. A root
+        // we just created is empty, so resuming into it makes no sense: go Home.
+        if (root.id && !root.created && resumeIntoSession) route.navigate({ type: "session", sessionID: root.id })
+        else if (switching) route.navigate({ type: "home" })
       } catch (e) {
         toast.show({ message: `Failed to enter Orchestrator: ${e}`, variant: "error" })
       } finally {

--- a/packages/opencode/src/cli/cmd/tui/context/project.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/project.tsx
@@ -57,10 +57,17 @@ export const { use: useProject, provider: ProjectProvider } = createSimpleContex
     }
 
     async function syncWorkspace() {
+      const directory = sdk.directory
       const listed = await sdk.client.experimental.workspace.list().catch(() => undefined)
       if (!listed?.data) return
       const status = await sdk.client.experimental.workspace.status().catch(() => undefined)
       const next = Object.fromEntries((status?.data ?? []).map((item) => [item.workspaceID, item.status]))
+      // Same generation check as sync() above: this runs unguarded inside
+      // bootstrap's non-blocking Promise.all, so a directory switch landing
+      // during either await would otherwise write the old directory's workspace
+      // list — and worse, clear workspace.current because the pre-switch list
+      // does not contain it.
+      if (sdk.directory !== directory) return
 
       batch(() => {
         setStore("workspace", "list", reconcile(listed.data))

--- a/packages/opencode/src/cli/cmd/tui/context/project.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/project.tsx
@@ -35,10 +35,20 @@ export const { use: useProject, provider: ProjectProvider } = createSimpleContex
 
     async function sync() {
       const workspace = store.workspace.current
+      const directory = sdk.directory
       const [path, project] = await Promise.all([
         sdk.client.path.get({ workspace }),
         sdk.client.project.current({ workspace }),
       ])
+
+      // A directory switch (worktree dialog, orchestrator entry) disposes the old
+      // instance and bootstraps the new one, and the resulting
+      // server.instance.disposed event fires a SECOND bootstrap whose requests
+      // were built from the pre-switch client. That stale run can resolve last
+      // and describe a directory the client no longer talks to; writing it makes
+      // instance.path disagree with sdk.directory, which silently drops every
+      // live event in useEvent (it filters on instance.directory()).
+      if (sdk.directory !== directory) return
 
       batch(() => {
         setStore("instance", "path", reconcile(path.data || defaultPath))

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -267,6 +267,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     const fullSyncedSessions = new Set<string>()
     let syncedWorkspace = project.workspace.current()
+    let syncedDirectory = sdk.directory
 
     event.subscribe((event) => {
       switch (event.type) {
@@ -696,10 +697,25 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     async function bootstrap(input: { fatal?: boolean } = {}) {
       const fatal = input.fatal ?? true
       const workspace = project.workspace.current()
-      if (workspace !== syncedWorkspace) {
+      const directory = sdk.directory
+      // fullSyncedSessions exists to keep a re-entered session from refetching its
+      // whole transcript on every navigation. That cache is scoped to the data
+      // source, so it must be dropped whenever the source changes — a workspace
+      // switch OR a directory switch (sdk.switchDirectory). Without the directory
+      // half, a session synced before the switch can never be re-synced, so any
+      // update missed during the switch window stays invisible for the rest of the
+      // session. An unchanged workspace+directory still short-circuits.
+      if (workspace !== syncedWorkspace || directory !== syncedDirectory) {
         fullSyncedSessions.clear()
         syncedWorkspace = workspace
+        syncedDirectory = directory
       }
+      // A bootstrap triggered before a directory switch (e.g. the
+      // server.instance.disposed handler above, which fires while the switch is
+      // mid-flight) issues its requests against the OLD directory. Its responses
+      // must not be written once the client has moved on, or the store ends up
+      // describing a directory sdk no longer talks to.
+      const stale = () => sdk.directory !== directory
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       // roots: true so child sessions (subagents, workers) don't crowd root
       // sessions out of the server-side limit
@@ -743,6 +759,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             configResponse,
             ...(sessionListResponse ? [sessionListResponse] : []),
           ]).then((responses) => {
+            if (stale()) return
             const providers = responses[0]
             const providerList = responses[1]
             const consoleState = responses[2]
@@ -762,6 +779,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           })
         })
         .then(() => {
+          if (stale()) return
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           void Promise.all([

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -710,12 +710,22 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         syncedWorkspace = workspace
         syncedDirectory = directory
       }
-      // A bootstrap triggered before a directory switch (e.g. the
-      // server.instance.disposed handler above, which fires while the switch is
-      // mid-flight) issues its requests against the OLD directory. Its responses
-      // must not be written once the client has moved on, or the store ends up
-      // describing a directory sdk no longer talks to.
+      // A bootstrap can outlive the directory it describes: `dispose +
+      // switchDirectory + bootstrap` ALSO re-fires bootstrap from the
+      // `server.instance.disposed` handler above, and that run built its requests
+      // from the PRE-switch client. Staleness therefore has to be re-checked AFTER
+      // each await rather than once before them — a switch landing while these
+      // requests are in flight must not write the old directory's data into the
+      // store, or the store ends up describing a directory sdk no longer talks to.
+      // When no directory was ever set (single-directory mode) nothing can switch
+      // and this is always false. `directory` above is the captured generation.
       const stale = () => sdk.directory !== directory
+      // Same check for the NON-blocking writes, which each resolve on their own.
+      const guard = <T,>(request: Promise<T>, apply: (value: T) => void) =>
+        request.then((value) => {
+          if (stale()) return
+          apply(value)
+        })
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       // roots: true so child sessions (subagents, workers) don't crowd root
       // sessions out of the server-side limit
@@ -783,22 +793,27 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           void Promise.all([
-            ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
-            consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
-            sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
-            sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),
-            sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data ?? {}))),
-            sdk.client.experimental.resource
-              .list({ workspace })
-              .then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
-            sdk.client.formatter.status({ workspace }).then((x) => setStore("formatter", reconcile(x.data ?? []))),
-            sdk.client.session.status({ workspace }).then((x) => {
+            ...(args.continue
+              ? []
+              : [guard(sessionListPromise, (sessions) => setStore("session", reconcile(sessions)))]),
+            guard(consoleStatePromise, (consoleState) => setStore("console_state", reconcile(consoleState))),
+            guard(sdk.client.command.list({ workspace }), (x) => setStore("command", reconcile(x.data ?? []))),
+            guard(sdk.client.lsp.status({ workspace }), (x) => setStore("lsp", reconcile(x.data ?? []))),
+            guard(sdk.client.mcp.status({ workspace }), (x) => setStore("mcp", reconcile(x.data ?? {}))),
+            guard(sdk.client.experimental.resource.list({ workspace }), (x) =>
+              setStore("mcp_resource", reconcile(x.data ?? {})),
+            ),
+            guard(sdk.client.formatter.status({ workspace }), (x) => setStore("formatter", reconcile(x.data ?? []))),
+            guard(sdk.client.session.status({ workspace }), (x) => {
               setStore("session_status", reconcile(x.data ?? {}))
             }),
-            sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
-            sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
+            guard(sdk.client.provider.auth({ workspace }), (x) => setStore("provider_auth", reconcile(x.data ?? {}))),
+            guard(sdk.client.vcs.get({ workspace }), (x) => setStore("vcs", reconcile(x.data))),
             project.workspace.sync(),
           ]).then(() => {
+            // A superseded run must not declare the CURRENT directory's sync
+            // complete — that would unblock the UI on data it never wrote.
+            if (stale()) return
             setStore("status", "complete")
           })
         })
@@ -845,6 +860,25 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             .list({ start, roots: true })
             .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
           setStore("session", reconcile(list))
+        },
+        // Resolve THE root session of the directory the client currently talks
+        // to, creating one only when the server really has none.
+        //
+        // Reading store.session for this is a race: bootstrap issues session.list
+        // as a NON-BLOCKING request (it only joins blockingRequests for
+        // `--continue`), so `await bootstrap()` resolves BEFORE the list lands. A
+        // caller that reads the store right after it sees an empty (or pre-switch)
+        // list, concludes there is no root, and mints another one — entering
+        // Orchestrator three times produced three roots. Refreshing from the
+        // server first makes the decision depend on data instead of on timing.
+        async resolveRoot() {
+          await result.session.refresh()
+          const existing = store.session
+            .filter((x) => x.parentID === undefined)
+            .toSorted((a, b) => b.time.updated - a.time.updated)
+            .at(0)
+          if (existing) return { id: existing.id, created: false }
+          return { id: (await sdk.client.session.create({})).data?.id, created: true }
         },
         status(sessionID: string) {
           const session = result.session.get(sessionID)

--- a/packages/opencode/test/cli/tui/bootstrap-race.test.tsx
+++ b/packages/opencode/test/cli/tui/bootstrap-race.test.tsx
@@ -1,0 +1,235 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import type { GlobalEvent } from "@mimo-ai/sdk/v2"
+import { onMount } from "solid-js"
+import { ArgsProvider } from "../../../src/cli/cmd/tui/context/args"
+import { ExitProvider } from "../../../src/cli/cmd/tui/context/exit"
+import { ProjectProvider, useProject } from "../../../src/cli/cmd/tui/context/project"
+import { SDKProvider, useSDK } from "../../../src/cli/cmd/tui/context/sdk"
+import { SyncProvider, useSync } from "../../../src/cli/cmd/tui/context/sync"
+
+// DIR_A stands in for the launch directory, DIR_B for the globally-unique
+// Orchestrator workspace the entry effect switches into.
+const DIR_A = "/tmp/bootrace-a"
+const DIR_B = "/tmp/bootrace-b"
+
+async function wait(fn: () => boolean, timeout = 5000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(5)
+  }
+}
+
+function sessionRow(id: string, directory: string, updated: number) {
+  return {
+    id,
+    projectID: "p",
+    directory,
+    title: "t",
+    version: "test",
+    time: { created: updated, updated },
+  }
+}
+
+/**
+ * HTTP double for the endpoints project/sync touch. It keeps per-directory
+ * server-side session state so `POST /session` is observable, can delay a route
+ * (so a non-blocking store write lands after an await the caller already
+ * returned from), and can park one in-flight request until the test releases it.
+ */
+function createFetch(input: { sessions?: Record<string, string[]>; delay?: Record<string, number> } = {}) {
+  const seen: { method: string; path: string; directory?: string }[] = []
+  const sessions: Record<string, string[]> = input.sessions ?? {}
+  const delay = input.delay ?? {}
+  let held: { path: string; directory: string; parked: boolean; release: () => void } | undefined
+  let created = 0
+
+  function body(method: string, path: string, directory?: string): unknown {
+    if (path === "/path")
+      return { home: "/home", state: "/state", config: "/config", worktree: "", directory: directory ?? "" }
+    if (path === "/project/current") return { id: "p" }
+    if (path === "/config/providers") return { providers: [], default: {} }
+    if (path === "/provider") return { all: [], default: {}, connected: [], authenticated: [] }
+    // vcs is a NON-blocking bootstrap write, and its payload identifies the
+    // directory that produced it — that is what makes a stale write visible.
+    if (path === "/vcs") return { branch: directory === DIR_B ? "branch-b" : "branch-a" }
+    if (path === "/session" && method === "POST") {
+      created += 1
+      const id = `ses_created_${created}`
+      sessions[directory ?? ""] = [...(sessions[directory ?? ""] ?? []), id]
+      return sessionRow(id, directory ?? "", 1000 + created)
+    }
+    if (path === "/session")
+      return (sessions[directory ?? ""] ?? []).map((id, i) => sessionRow(id, directory ?? "", 100 + i))
+    if (path === "/experimental/console") return {}
+    if (path === "/agent" || path === "/command" || path === "/experimental/workspace") return []
+    if (path === "/experimental/workspace/status" || path === "/lsp" || path === "/formatter") return []
+    return {}
+  }
+
+  const fetcher = (async (request: Request) => {
+    const url = new URL(request.url)
+    const raw = url.searchParams.get("directory")
+    const directory = raw ? decodeURIComponent(raw) : undefined
+    seen.push({ method: request.method, path: url.pathname, directory })
+
+    if (held && url.pathname === held.path && directory === held.directory) {
+      const gate = held
+      held = undefined
+      gate.parked = true
+      await new Promise<void>((resolve) => {
+        gate.release = resolve
+      })
+    }
+
+    const ms = delay[url.pathname]
+    if (ms) await Bun.sleep(ms)
+
+    return new Response(JSON.stringify(body(request.method, url.pathname, directory)), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }) as unknown as typeof fetch
+
+  return {
+    fetch: fetcher,
+    count(method: string, path: string) {
+      return seen.filter((x) => x.method === method && x.path === path).length
+    },
+    roots(directory: string) {
+      return sessions[directory] ?? []
+    },
+    /** Park the next request for `path` in `directory` until the returned fn is called. */
+    hold(path: string, directory: string) {
+      const gate = { path, directory, parked: false, release: () => {} }
+      held = gate
+      return { parked: () => gate.parked, release: () => gate.release() }
+    },
+  }
+}
+
+function createEvents() {
+  let fn: ((event: GlobalEvent) => void) | undefined
+  return {
+    subscribe: async (handler: (event: GlobalEvent) => void) => {
+      fn = handler
+      return () => {
+        if (fn === handler) fn = undefined
+      }
+    },
+  }
+}
+
+async function mount(http: ReturnType<typeof createFetch>) {
+  let ctx!: {
+    project: ReturnType<typeof useProject>
+    sdk: ReturnType<typeof useSDK>
+    sync: ReturnType<typeof useSync>
+  }
+  let done!: () => void
+  const ready = new Promise<void>((resolve) => {
+    done = resolve
+  })
+
+  function Probe() {
+    const project = useProject()
+    const sdk = useSDK()
+    const sync = useSync()
+    onMount(() => {
+      ctx = { project, sdk, sync }
+      done()
+    })
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <SDKProvider url="http://test" directory={DIR_A} fetch={http.fetch} events={createEvents()}>
+      <ProjectProvider>
+        <ArgsProvider>
+          <ExitProvider>
+            <SyncProvider>
+              <Probe />
+            </SyncProvider>
+          </ExitProvider>
+        </ArgsProvider>
+      </ProjectProvider>
+    </SDKProvider>
+  ))
+
+  await ready
+  return { app, ...ctx }
+}
+
+describe("tui bootstrap directory race", () => {
+  test("a non-blocking bootstrap write that resolves after a directory switch is discarded", async () => {
+    const http = createFetch({ sessions: { [DIR_A]: [], [DIR_B]: ["ses_orch"] } })
+    const { app, sdk, sync } = await mount(http)
+
+    try {
+      await wait(() => sync.data.vcs?.branch === "branch-a")
+
+      // Park the OLD directory's /vcs so the stale run's non-blocking write is
+      // still in flight when the switch lands. The request has to be issued
+      // before the switch — `sdk.client` is read when the non-blocking group
+      // runs, so waiting for the park is what makes this the real window.
+      const gate = http.hold("/vcs", DIR_A)
+      const staleRun = sync.bootstrap({ fatal: false })
+      await wait(() => gate.parked())
+
+      sdk.switchDirectory(DIR_B)
+      await sync.bootstrap({ fatal: false })
+      await wait(() => sync.data.vcs?.branch === "branch-b")
+
+      gate.release()
+      await staleRun
+      // bootstrap does not await its own non-blocking group (it is `void
+      // Promise.all`), so give the released write every chance to land.
+      await Bun.sleep(50)
+
+      // The store must keep describing the directory the client actually talks
+      // to. A superseded write here is how pre-switch data gets resurrected.
+      expect(sync.data.vcs?.branch).toBe("branch-b")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("entering the orchestrator repeatedly resolves the one existing root instead of creating more", async () => {
+    // The launch directory has no root sessions, which is what the live repro
+    // looked like: the store is empty at the moment the entry effect reads it.
+    const http = createFetch({
+      sessions: { [DIR_A]: [], [DIR_B]: ["ses_orch"] },
+      // The session list is a NON-blocking bootstrap request, so `await
+      // bootstrap()` returns before it lands. Delaying it makes that ordering
+      // explicit rather than incidental.
+      delay: { "/session": 30 },
+    })
+    const { app, sdk, sync } = await mount(http)
+
+    try {
+      const resolved: { id?: string; created: boolean }[] = []
+      for (let i = 0; i < 3; i++) {
+        // The entry effect's sequence: switch into the orchestrator workspace,
+        // bootstrap it, then resolve the root it must land on.
+        sdk.switchDirectory(DIR_B)
+        await sync.bootstrap({ fatal: false })
+        resolved.push(await sync.session.resolveRoot())
+        // Leaving orchestrator again, so the next iteration is a real re-entry:
+        // wait until the store actually describes the launch directory, which is
+        // the state every entry starts from.
+        sdk.switchDirectory(DIR_A)
+        await sync.bootstrap({ fatal: false })
+        await wait(() => sync.data.session.length === 0)
+      }
+
+      expect(resolved.map((x) => x.id)).toEqual(["ses_orch", "ses_orch", "ses_orch"])
+      expect(resolved.every((x) => x.created === false)).toBe(true)
+      expect(http.count("POST", "/session")).toBe(0)
+      expect(http.roots(DIR_B)).toEqual(["ses_orch"])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})

--- a/packages/opencode/test/cli/tui/directory-switch.test.tsx
+++ b/packages/opencode/test/cli/tui/directory-switch.test.tsx
@@ -1,0 +1,201 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import type { GlobalEvent } from "@mimo-ai/sdk/v2"
+import { onMount } from "solid-js"
+import { ArgsProvider } from "../../../src/cli/cmd/tui/context/args"
+import { ExitProvider } from "../../../src/cli/cmd/tui/context/exit"
+import { ProjectProvider, useProject } from "../../../src/cli/cmd/tui/context/project"
+import { SDKProvider, useSDK } from "../../../src/cli/cmd/tui/context/sdk"
+import { SyncProvider, useSync } from "../../../src/cli/cmd/tui/context/sync"
+
+const DIR_A = "/tmp/blanktx-a"
+const DIR_B = "/tmp/blanktx-b"
+
+async function wait(fn: () => boolean, timeout = 5000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(5)
+  }
+}
+
+function sessionRow() {
+  return {
+    id: "ses_a",
+    projectID: "p",
+    directory: DIR_A,
+    title: "t",
+    version: "test",
+    time: { created: 1, updated: 1 },
+  }
+}
+
+/**
+ * HTTP double for the endpoints the project/sync contexts touch. Records the
+ * directory the client sent with each request, and can hold one `/path` response
+ * open so a test can make an in-flight bootstrap resolve AFTER a directory switch.
+ */
+function createFetch() {
+  const seen: { path: string; directory?: string }[] = []
+  let held: { directory: string; release: () => void } | undefined
+
+  function body(path: string, directory?: string): unknown {
+    if (path === "/path")
+      return { home: "/home", state: "/state", config: "/config", worktree: "", directory: directory ?? "" }
+    if (path === "/project/current") return { id: "p" }
+    if (path === "/config/providers") return { providers: [], default: {} }
+    if (path === "/provider") return { all: [], default: {}, connected: [], authenticated: [] }
+    if (path === "/session") return [sessionRow()]
+    if (path === "/vcs") return { branch: "main" }
+    if (path === "/experimental/console") return {}
+    if (path.startsWith("/session/ses_a")) return path === "/session/ses_a" ? sessionRow() : []
+    if (path === "/agent" || path === "/command" || path === "/experimental/workspace") return []
+    if (path === "/experimental/workspace/status" || path === "/lsp" || path === "/formatter") return []
+    return {}
+  }
+
+  const fetcher = (async (request: Request) => {
+    const url = new URL(request.url)
+    const raw = url.searchParams.get("directory")
+    const directory = raw ? decodeURIComponent(raw) : undefined
+    seen.push({ path: url.pathname, directory })
+
+    if (held && url.pathname === "/path" && directory === held.directory) {
+      const gate = held
+      held = undefined
+      await new Promise<void>((resolve) => {
+        gate.release = resolve
+      })
+    }
+
+    return new Response(JSON.stringify(body(url.pathname, directory)), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }) as unknown as typeof fetch
+
+  return {
+    fetch: fetcher,
+    count(path: string) {
+      return seen.filter((x) => x.path === path).length
+    },
+    hold(directory: string) {
+      const gate = { directory, release: () => {} }
+      held = gate
+      return () => gate.release()
+    },
+  }
+}
+
+function createEvents() {
+  let fn: ((event: GlobalEvent) => void) | undefined
+  return {
+    subscribe: async (handler: (event: GlobalEvent) => void) => {
+      fn = handler
+      return () => {
+        if (fn === handler) fn = undefined
+      }
+    },
+  }
+}
+
+async function mount() {
+  const http = createFetch()
+  let ctx!: {
+    project: ReturnType<typeof useProject>
+    sdk: ReturnType<typeof useSDK>
+    sync: ReturnType<typeof useSync>
+  }
+  let done!: () => void
+  const ready = new Promise<void>((resolve) => {
+    done = resolve
+  })
+
+  function Probe() {
+    const project = useProject()
+    const sdk = useSDK()
+    const sync = useSync()
+    onMount(() => {
+      ctx = { project, sdk, sync }
+      done()
+    })
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <SDKProvider url="http://test" directory={DIR_A} fetch={http.fetch} events={createEvents()}>
+      <ProjectProvider>
+        <ArgsProvider>
+          <ExitProvider>
+            <SyncProvider>
+              <Probe />
+            </SyncProvider>
+          </ExitProvider>
+        </ArgsProvider>
+      </ProjectProvider>
+    </SDKProvider>
+  ))
+
+  await ready
+  return { app, http, ...ctx }
+}
+
+describe("tui directory switch", () => {
+  test("a bootstrap started before the switch cannot rewrite instance.path to the old directory", async () => {
+    const { app, http, project, sdk, sync } = await mount()
+
+    try {
+      await wait(() => project.instance.directory() === DIR_A)
+
+      // Reproduces the app's switch sequence: dispose fires
+      // server.instance.disposed, whose handler bootstraps against the OLD
+      // directory; the client then switches and bootstraps the new one. The
+      // stale run resolves LAST.
+      const release = http.hold(DIR_A)
+      const staleRun = sync.bootstrap({ fatal: false })
+      sdk.switchDirectory(DIR_B)
+      await sync.bootstrap({ fatal: false })
+      expect(project.instance.directory()).toBe(DIR_B)
+
+      release()
+      await staleRun
+
+      // instance.path must keep describing the directory the client actually
+      // talks to: useEvent filters every live event on instance.directory(), so
+      // a stale value silently drops the whole transcript.
+      expect(project.instance.directory()).toBe(DIR_B)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("a session is re-syncable after a directory switch and still short-circuits without one", async () => {
+    const { app, http, sdk, sync } = await mount()
+
+    try {
+      await sync.session.sync("ses_a")
+      expect(http.count("/session/ses_a/message")).toBe(1)
+
+      // Invariant that fullSyncedSessions exists for: navigating back to an
+      // already-synced session must not refetch its transcript...
+      await sync.session.sync("ses_a")
+      expect(http.count("/session/ses_a/message")).toBe(1)
+
+      // ...and a bootstrap that stays in the same directory keeps that cache.
+      await sync.bootstrap({ fatal: false })
+      await sync.session.sync("ses_a")
+      expect(http.count("/session/ses_a/message")).toBe(1)
+
+      // A directory switch changes the data source, so the cache must be
+      // dropped — otherwise a session synced before the switch can never be
+      // re-synced and anything missed stays invisible for the whole session.
+      sdk.switchDirectory(DIR_B)
+      await sync.bootstrap({ fatal: false })
+      await sync.session.sync("ses_a")
+      expect(http.count("/session/ses_a/message")).toBe(2)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})


### PR DESCRIPTION
> **Scope note:** this PR now carries **three** fixes for one race window. #1958 (`fix/tui-bootstrap-stale-writes-dup-root`) was folded in here — its half (a) was a review finding on *this* PR's own file and defect family, and its half (b) lives in the same unguarded window. #1958 is closed and points here. Its `stale()` helper was deliberately named to match this branch's, and the merge resolved to **one** definition now shared by the blocking and non-blocking write paths.

## The bug

Entering an agent that switches the working directory — `Tab` into **Orchestrator** from any other project directory, or the worktree dialog — leaves the **entire transcript blank** and unrecoverable without restarting the TUI. The user bubble shows, then nothing: no reasoning, no reply, `0 tokens`, `$0.00`, while the DB already holds the full answer.

Reproduced on `origin/main` (`076b790d9`) with a live dev TUI: pane showed only the user bubble; the DB for that session had the assistant message with `"text":"OK"` and `tokens.total=49581`.

## Confirmed mechanism (measured, not guessed)

`dispose + switchDirectory + bootstrap` (`app.tsx:536`, `dialog-worktree.tsx:57`) produces **two concurrent bootstraps**:

1. `sync.tsx` `case "server.instance.disposed": void bootstrap()` fires because *we* just disposed the old instance. Its HTTP requests are built from the **pre-switch** client, so they describe the **old** directory.
2. The switch's own `await sync.bootstrap()` describes the new directory.

The stale one resolves **last** — the just-disposed old instance has to be re-created and re-bootstrapped, which is slower than the new one. Instrumented `project.sync()`, three calls in one entry:

```
requested=<ws>          got=<ws>            # startup
requested=<orchestrator> got=<orchestrator>  # switch bootstrap
requested=<orchestrator> got=<ws>            # +689ms: STALE run wins the store
```

`useEvent` (`context/event.ts`) delivers an event only when `event.directory === project.instance.directory()`, so once `instance.path` points at the directory the client left, **every** live event is silently dropped — instrumentation counted **220 dropped `message.updated` / `message.part.updated`** events for a single prompt. The one remaining path to content, the full HTTP sync at `routes/session/index.tsx:274`, is short-circuited forever by `fullSyncedSessions` (`sync.tsx:842`), which was cleared only on a **workspace** change — that is the "unrecoverable in-session" half.

Note the earlier hypothesis (`fullSyncedSessions` alone) explains the unrecoverability but **not** the initial blank: a freshly resolved session id was never in that set. The dropped-events race is the primary cause.

The unifying principle for all three fixes below: **check staleness AFTER the await, not before.**

---

## Fix 1 — the blank transcript (blocking writes + `project.sync()`)

- `project.tsx` `sync()`: ignore a `path`/`project.current` response whose request was issued for a directory the client has since left. This is what restores event delivery.
- `sync.tsx` `bootstrap()`: the same generation guard around the provider/agent/config/session store writes, and invalidate `fullSyncedSessions` on a **directory** change as well as a workspace change.

### Invariant preserved

`fullSyncedSessions` exists so re-entering an already-synced session does not refetch its whole transcript on every navigation. That is kept: with **unchanged** workspace **and** directory the short-circuit still applies (asserted, including across a same-directory `bootstrap()`); only a real change of data source drops the cache.

## Fix 2 — the non-blocking bootstrap writes were unguarded (absorbed from #1958)

This is Fix 1's unfinished business, in the same function. `context/sync.tsx` launches ~11 requests as `void Promise.all([...])`, and every `.then` called `setStore` with **no** directory check at all. Since `dispose + switchDirectory + bootstrap` always spawns that second, pre-switch bootstrap, a switch landing while these are in flight writes the old directory's `vcs` / `command` / `lsp` / `mcp` / `session` / … into a store that is supposed to describe the directory the client actually talks to.

Fix: the **same** captured directory generation and the **same** `stale()` predicate introduced by Fix 1, re-checked after each response resolves, via a single `guard()` helper rather than eleven copies of the same `if`. A superseded run also no longer flips `status` to `complete` — it must not unblock the UI on data it never wrote.

## Fix 3 — duplicate orchestrator roots (absorbed from #1958)

`app.tsx:540` read `sync.data.session` immediately after `await sync.bootstrap()`. But `session.list` only joins `blockingRequests` when `--continue` is set, so **bootstrap resolves before the session list lands**. The `existing` lookup missed the real root and the `else` branch called `session.create({})`, minting a new one on each entry (3 roots observed across 3 entries — the item this PR's previous revision listed as "separate bug, out of scope").

Fix: root resolution moves into `sync.session.resolveRoot()`, which refreshes from the server first, so resolve-or-create depends on data instead of on timing.

**Why not "promote `session.list` into `blockingRequests`"**: that would make every launch — not just orchestrator entry — wait on a 30-day, roots-only session list before the UI unblocks, a real startup regression on large histories. It would also leave correctness dependent on bootstrap's internal request classification, so a later refactor moving `session.list` around could silently reintroduce duplicate roots. Asking the server at the point of decision is cheaper for everyone else and structurally immune to that.

**Why Fix 3 cannot ship without Fix 2**: without the non-blocking guard, the stale bootstrap's session-list write can repopulate the store with the *launch* directory's roots **after** `resolveRoot()` has resolved — pointing the Orchestrator at a session from another directory. Fix 3 is the observed symptom of the window Fix 2 closes.

---

## Tests

Both files drive the **real** contexts (`SDKProvider` + `ProjectProvider`/`ArgsProvider`/`ExitProvider`/`SyncProvider`) against an HTTP double that records the directory each request carried and can hold a response open to recreate the race.

`test/cli/tui/directory-switch.test.tsx`

1. a bootstrap started before the switch cannot rewrite `instance.path` to the old directory
2. a session is re-syncable after a directory switch **and still short-circuits without one**

`test/cli/tui/bootstrap-race.test.tsx`

3. a non-blocking bootstrap write that resolves after a directory switch is discarded
4. entering the orchestrator repeatedly resolves the one existing root instead of creating more

### Revert probes, re-run AFTER the fold (one per fix, to prove the merge neutralised nothing)

**Fix 1** — `project.sync()`'s guard removed *and* the directory half of the `fullSyncedSessions` invalidation removed → `directory-switch.test.tsx` **0 pass / 2 fail**:

```
error: expect(received).toBe(expected)   Expected: "/tmp/blanktx-b"   Received: "/tmp/blanktx-a"
error: expect(received).toBe(expected)   Expected: 2                  Received: 1
```

**Fix 2** — the post-resolve `if (stale()) return` removed from `guard()` → **1 pass / 1 fail**:

```
error: expect(received).toBe(expected)
Expected: "branch-b"
Received: "branch-a"
```

**Fix 3** — `resolveRoot()`'s `await result.session.refresh()` removed, i.e. back to reading the store → **1 pass / 1 fail**:

```
error: expect(received).toEqual(expected)
  [
-   "ses_orch",
-   "ses_orch",
-   "ses_orch",
+   "ses_created_1",
+   "ses_created_2",
+   "ses_created_3",
  ]
```

Three entries, three roots — the reported symptom reproduced deterministically.

**Collision check** — neutralising the single merged `stale()` (`() => false`) fails test 3 while tests 1/2/4 still pass, confirming the one definition is load-bearing for the non-blocking path and that the blocking-path use is redundant defence-in-depth rather than what tests 1/2 rely on.

### Numbers

| suite | pristine (this branch before the fold) | after the fold |
|---|---|---|
| `test/cli/` | **266 pass / 0 fail** (37 files) | **268 pass / 0 fail** (38 files) |

(`main` baseline for the same command: 264 pass / 0 fail, 36 files.) `bun typecheck` → 12/12 successful, exit **0**.

## Live verification

Blank transcript (Fix 1), on the fixed build (dev TUI, model `mimo/mimo-v2.5`, cwd outside the orchestrator dir, `Tab` into Orchestrator, send): footer switches to `~/…/data/orchestrator` (was stuck on the launch dir), transcript renders user bubble → `Thought: 1.5s` → `OK` → `Orchestrator · mimo-v2.5 · 9.1s`, and the token counter reads `49.8K/960K (5%)` instead of `0 tokens`.

Duplicate roots (Fix 3): five Orchestrator entries — three in-process (Tab in/out) plus two from fresh processes (cold store) — leave **exactly one** root:

```
ORCH ROOTS = 1   (all roots in db = 1)
    ses_057aa2b18ffeeg1zBgS7w6ZIfj | New session - 2026-07-28T10:47:05.192Z | created 18:47:05
```

Honest caveat: a control build on pristine `main` in the same harness also produced only one root — the duplicate needs `session.list` to be slower than bootstrap's blocking group, and against a small local DB it is not. So that live run is a regression check; the discriminating proof is test 4, where the list latency is explicit (`delay: { "/session": 30 }`).

## Deliberately left alone

- The `server.instance.disposed` → `bootstrap()` handler stays; only its stale **writes** are discarded.
- Leaving Orchestrator (`Tab` away) does not switch the directory back.
- `project.workspace.sync()` inside the non-blocking group (different context).
- Pre-existing prettier drift in `app.tsx` / `sync.tsx` is untouched so the diff stays reviewable; only the changed regions are formatted.
