### PR TITLE
fix(tui): discard superseded bootstrap writes and stop minting duplicate orchestrator roots

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -537,23 +537,20 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           sdk.switchDirectory(dir)
           await sync.bootstrap()
         }
-        const existing = sync.data.session
-          .toSorted((a, b) => b.time.updated - a.time.updated)
-          .find((x) => x.parentID === undefined)?.id
-        if (existing) {
-          local.orchestrator.setSessionID(existing)
-          // A `-s` launch wanted to land IN the orchestrator session; a plain
-          // Tab-into-orchestrator from a stale launch-dir session wanted Home
-          // (the fresh-entry state). Either way navigate exactly once, AFTER
-          // bootstrap, so the switched view resolves directly to its target with
-          // no intermediate frame — the root now exists in orchestratorDir.
-          if (resumeIntoSession) route.navigate({ type: "session", sessionID: existing })
-          else if (switching) route.navigate({ type: "home" })
-        } else {
-          const res = await sdk.client.session.create({})
-          if (res.data?.id) local.orchestrator.setSessionID(res.data.id)
-          if (switching) route.navigate({ type: "home" })
-        }
+        // Authoritative resolve-or-create against the switched directory. Reading
+        // sync.data.session here raced bootstrap's NON-blocking session list —
+        // bootstrap resolves before the list lands, so the lookup missed the
+        // existing root and minted another one on every entry.
+        const root = await sync.session.resolveRoot()
+        if (root.id) local.orchestrator.setSessionID(root.id)
+        // A `-s` launch wanted to land IN the orchestrator session; a plain
+        // Tab-into-orchestrator from a stale launch-dir session wanted Home
+        // (the fresh-entry state). Either way navigate exactly once, AFTER
+        // bootstrap, so the switched view resolves directly to its target with
+        // no intermediate frame — the root now exists in orchestratorDir. A root
+        // we just created is empty, so resuming into it makes no sense: go Home.
+        if (root.id && !root.created && resumeIntoSession) route.navigate({ type: "session", sessionID: root.id })
+        else if (switching) route.navigate({ type: "home" })
       } catch (e) {
         toast.show({ message: `Failed to enter Orchestrator: ${e}`, variant: "error" })
       } finally {

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -700,6 +700,21 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         fullSyncedSessions.clear()
         syncedWorkspace = workspace
       }
+      // A bootstrap can outlive the directory it describes: `dispose +
+      // switchDirectory + bootstrap` ALSO re-fires bootstrap from the
+      // `server.instance.disposed` handler above, and that run built its requests
+      // from the PRE-switch client. Staleness therefore has to be re-checked AFTER
+      // each await rather than once before them — a switch landing while these
+      // requests are in flight must not write the old directory's data into the
+      // store. When no directory was ever set (single-directory mode) nothing can
+      // switch and this is always false.
+      const directory = sdk.directory
+      const stale = () => sdk.directory !== directory
+      const guard = <T,>(request: Promise<T>, apply: (value: T) => void) =>
+        request.then((value) => {
+          if (stale()) return
+          apply(value)
+        })
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       // roots: true so child sessions (subagents, workers) don't crowd root
       // sessions out of the server-side limit
@@ -765,22 +780,27 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           void Promise.all([
-            ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
-            consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
-            sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
-            sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),
-            sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data ?? {}))),
-            sdk.client.experimental.resource
-              .list({ workspace })
-              .then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
-            sdk.client.formatter.status({ workspace }).then((x) => setStore("formatter", reconcile(x.data ?? []))),
-            sdk.client.session.status({ workspace }).then((x) => {
+            ...(args.continue
+              ? []
+              : [guard(sessionListPromise, (sessions) => setStore("session", reconcile(sessions)))]),
+            guard(consoleStatePromise, (consoleState) => setStore("console_state", reconcile(consoleState))),
+            guard(sdk.client.command.list({ workspace }), (x) => setStore("command", reconcile(x.data ?? []))),
+            guard(sdk.client.lsp.status({ workspace }), (x) => setStore("lsp", reconcile(x.data ?? []))),
+            guard(sdk.client.mcp.status({ workspace }), (x) => setStore("mcp", reconcile(x.data ?? {}))),
+            guard(sdk.client.experimental.resource.list({ workspace }), (x) =>
+              setStore("mcp_resource", reconcile(x.data ?? {})),
+            ),
+            guard(sdk.client.formatter.status({ workspace }), (x) => setStore("formatter", reconcile(x.data ?? []))),
+            guard(sdk.client.session.status({ workspace }), (x) => {
               setStore("session_status", reconcile(x.data ?? {}))
             }),
-            sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
-            sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
+            guard(sdk.client.provider.auth({ workspace }), (x) => setStore("provider_auth", reconcile(x.data ?? {}))),
+            guard(sdk.client.vcs.get({ workspace }), (x) => setStore("vcs", reconcile(x.data))),
             project.workspace.sync(),
           ]).then(() => {
+            // A superseded run must not declare the CURRENT directory's sync
+            // complete — that would unblock the UI on data it never wrote.
+            if (stale()) return
             setStore("status", "complete")
           })
         })
@@ -827,6 +847,25 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             .list({ start, roots: true })
             .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
           setStore("session", reconcile(list))
+        },
+        // Resolve THE root session of the directory the client currently talks
+        // to, creating one only when the server really has none.
+        //
+        // Reading store.session for this is a race: bootstrap issues session.list
+        // as a NON-BLOCKING request (it only joins blockingRequests for
+        // `--continue`), so `await bootstrap()` resolves BEFORE the list lands. A
+        // caller that reads the store right after it sees an empty (or pre-switch)
+        // list, concludes there is no root, and mints another one — entering
+        // Orchestrator three times produced three roots. Refreshing from the
+        // server first makes the decision depend on data instead of on timing.
+        async resolveRoot() {
+          await result.session.refresh()
+          const existing = store.session
+            .filter((x) => x.parentID === undefined)
+            .toSorted((a, b) => b.time.updated - a.time.updated)
+            .at(0)
+          if (existing) return { id: existing.id, created: false }
+          return { id: (await sdk.client.session.create({})).data?.id, created: true }
         },
         status(sessionID: string) {
           const session = result.session.get(sessionID)

--- a/packages/opencode/test/cli/tui/bootstrap-race.test.tsx
+++ b/packages/opencode/test/cli/tui/bootstrap-race.test.tsx
@@ -1,0 +1,235 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import type { GlobalEvent } from "@mimo-ai/sdk/v2"
+import { onMount } from "solid-js"
+import { ArgsProvider } from "../../../src/cli/cmd/tui/context/args"
+import { ExitProvider } from "../../../src/cli/cmd/tui/context/exit"
+import { ProjectProvider, useProject } from "../../../src/cli/cmd/tui/context/project"
+import { SDKProvider, useSDK } from "../../../src/cli/cmd/tui/context/sdk"
+import { SyncProvider, useSync } from "../../../src/cli/cmd/tui/context/sync"
+
+// DIR_A stands in for the launch directory, DIR_B for the globally-unique
+// Orchestrator workspace the entry effect switches into.
+const DIR_A = "/tmp/bootrace-a"
+const DIR_B = "/tmp/bootrace-b"
+
+async function wait(fn: () => boolean, timeout = 5000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(5)
+  }
+}
+
+function sessionRow(id: string, directory: string, updated: number) {
+  return {
+    id,
+    projectID: "p",
+    directory,
+    title: "t",
+    version: "test",
+    time: { created: updated, updated },
+  }
+}
+
+/**
+ * HTTP double for the endpoints project/sync touch. It keeps per-directory
+ * server-side session state so `POST /session` is observable, can delay a route
+ * (so a non-blocking store write lands after an await the caller already
+ * returned from), and can park one in-flight request until the test releases it.
+ */
+function createFetch(input: { sessions?: Record<string, string[]>; delay?: Record<string, number> } = {}) {
+  const seen: { method: string; path: string; directory?: string }[] = []
+  const sessions: Record<string, string[]> = input.sessions ?? {}
+  const delay = input.delay ?? {}
+  let held: { path: string; directory: string; parked: boolean; release: () => void } | undefined
+  let created = 0
+
+  function body(method: string, path: string, directory?: string): unknown {
+    if (path === "/path")
+      return { home: "/home", state: "/state", config: "/config", worktree: "", directory: directory ?? "" }
+    if (path === "/project/current") return { id: "p" }
+    if (path === "/config/providers") return { providers: [], default: {} }
+    if (path === "/provider") return { all: [], default: {}, connected: [], authenticated: [] }
+    // vcs is a NON-blocking bootstrap write, and its payload identifies the
+    // directory that produced it — that is what makes a stale write visible.
+    if (path === "/vcs") return { branch: directory === DIR_B ? "branch-b" : "branch-a" }
+    if (path === "/session" && method === "POST") {
+      created += 1
+      const id = `ses_created_${created}`
+      sessions[directory ?? ""] = [...(sessions[directory ?? ""] ?? []), id]
+      return sessionRow(id, directory ?? "", 1000 + created)
+    }
+    if (path === "/session")
+      return (sessions[directory ?? ""] ?? []).map((id, i) => sessionRow(id, directory ?? "", 100 + i))
+    if (path === "/experimental/console") return {}
+    if (path === "/agent" || path === "/command" || path === "/experimental/workspace") return []
+    if (path === "/experimental/workspace/status" || path === "/lsp" || path === "/formatter") return []
+    return {}
+  }
+
+  const fetcher = (async (request: Request) => {
+    const url = new URL(request.url)
+    const raw = url.searchParams.get("directory")
+    const directory = raw ? decodeURIComponent(raw) : undefined
+    seen.push({ method: request.method, path: url.pathname, directory })
+
+    if (held && url.pathname === held.path && directory === held.directory) {
+      const gate = held
+      held = undefined
+      gate.parked = true
+      await new Promise<void>((resolve) => {
+        gate.release = resolve
+      })
+    }
+
+    const ms = delay[url.pathname]
+    if (ms) await Bun.sleep(ms)
+
+    return new Response(JSON.stringify(body(request.method, url.pathname, directory)), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }) as unknown as typeof fetch
+
+  return {
+    fetch: fetcher,
+    count(method: string, path: string) {
+      return seen.filter((x) => x.method === method && x.path === path).length
+    },
+    roots(directory: string) {
+      return sessions[directory] ?? []
+    },
+    /** Park the next request for `path` in `directory` until the returned fn is called. */
+    hold(path: string, directory: string) {
+      const gate = { path, directory, parked: false, release: () => {} }
+      held = gate
+      return { parked: () => gate.parked, release: () => gate.release() }
+    },
+  }
+}
+
+function createEvents() {
+  let fn: ((event: GlobalEvent) => void) | undefined
+  return {
+    subscribe: async (handler: (event: GlobalEvent) => void) => {
+      fn = handler
+      return () => {
+        if (fn === handler) fn = undefined
+      }
+    },
+  }
+}
+
+async function mount(http: ReturnType<typeof createFetch>) {
+  let ctx!: {
+    project: ReturnType<typeof useProject>
+    sdk: ReturnType<typeof useSDK>
+    sync: ReturnType<typeof useSync>
+  }
+  let done!: () => void
+  const ready = new Promise<void>((resolve) => {
+    done = resolve
+  })
+
+  function Probe() {
+    const project = useProject()
+    const sdk = useSDK()
+    const sync = useSync()
+    onMount(() => {
+      ctx = { project, sdk, sync }
+      done()
+    })
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <SDKProvider url="http://test" directory={DIR_A} fetch={http.fetch} events={createEvents()}>
+      <ProjectProvider>
+        <ArgsProvider>
+          <ExitProvider>
+            <SyncProvider>
+              <Probe />
+            </SyncProvider>
+          </ExitProvider>
+        </ArgsProvider>
+      </ProjectProvider>
+    </SDKProvider>
+  ))
+
+  await ready
+  return { app, ...ctx }
+}
+
+describe("tui bootstrap directory race", () => {
+  test("a non-blocking bootstrap write that resolves after a directory switch is discarded", async () => {
+    const http = createFetch({ sessions: { [DIR_A]: [], [DIR_B]: ["ses_orch"] } })
+    const { app, sdk, sync } = await mount(http)
+
+    try {
+      await wait(() => sync.data.vcs?.branch === "branch-a")
+
+      // Park the OLD directory's /vcs so the stale run's non-blocking write is
+      // still in flight when the switch lands. The request has to be issued
+      // before the switch — `sdk.client` is read when the non-blocking group
+      // runs, so waiting for the park is what makes this the real window.
+      const gate = http.hold("/vcs", DIR_A)
+      const staleRun = sync.bootstrap({ fatal: false })
+      await wait(() => gate.parked())
+
+      sdk.switchDirectory(DIR_B)
+      await sync.bootstrap({ fatal: false })
+      await wait(() => sync.data.vcs?.branch === "branch-b")
+
+      gate.release()
+      await staleRun
+      // bootstrap does not await its own non-blocking group (it is `void
+      // Promise.all`), so give the released write every chance to land.
+      await Bun.sleep(50)
+
+      // The store must keep describing the directory the client actually talks
+      // to. A superseded write here is how pre-switch data gets resurrected.
+      expect(sync.data.vcs?.branch).toBe("branch-b")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("entering the orchestrator repeatedly resolves the one existing root instead of creating more", async () => {
+    // The launch directory has no root sessions, which is what the live repro
+    // looked like: the store is empty at the moment the entry effect reads it.
+    const http = createFetch({
+      sessions: { [DIR_A]: [], [DIR_B]: ["ses_orch"] },
+      // The session list is a NON-blocking bootstrap request, so `await
+      // bootstrap()` returns before it lands. Delaying it makes that ordering
+      // explicit rather than incidental.
+      delay: { "/session": 30 },
+    })
+    const { app, sdk, sync } = await mount(http)
+
+    try {
+      const resolved: { id?: string; created: boolean }[] = []
+      for (let i = 0; i < 3; i++) {
+        // The entry effect's sequence: switch into the orchestrator workspace,
+        // bootstrap it, then resolve the root it must land on.
+        sdk.switchDirectory(DIR_B)
+        await sync.bootstrap({ fatal: false })
+        resolved.push(await sync.session.resolveRoot())
+        // Leaving orchestrator again, so the next iteration is a real re-entry:
+        // wait until the store actually describes the launch directory, which is
+        // the state every entry starts from.
+        sdk.switchDirectory(DIR_A)
+        await sync.bootstrap({ fatal: false })
+        await wait(() => sync.data.session.length === 0)
+      }
+
+      expect(resolved.map((x) => x.id)).toEqual(["ses_orch", "ses_orch", "ses_orch"])
+      expect(resolved.every((x) => x.created === false)).toBe(true)
+      expect(http.count("POST", "/session")).toBe(0)
+      expect(http.roots(DIR_B)).toEqual(["ses_orch"])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})


### PR DESCRIPTION
Follow-up to #1953 (predecessor, still open). Both PRs are self-contained and can merge in either order — this one is based on `main`, not on #1953's branch.

## The one root cause

#1953 established the principle: **check staleness AFTER the await, not before**. Two remaining defects live in the same window — the gap between `await sync.bootstrap()` returning and the writes it left in flight.

### Defect 1 — the non-blocking bootstrap writes were unguarded

`context/sync.tsx:780-802` launches ~11 requests as `void Promise.all([...])`, and on `main` every `.then` called `setStore` with no directory check at all. `dispose + switchDirectory + bootstrap` always spawns a second bootstrap through the `server.instance.disposed` handler (`sync.tsx:273`) whose requests were built from the **pre-switch** client, so a switch landing while these are in flight writes the old directory's `vcs` / `command` / `lsp` / `mcp` / `session` / … into a store that is supposed to describe the directory the client actually talks to.

Fix: capture the directory generation once and re-check it **after** each response resolves, via a single `guard()` helper rather than eleven copies of the same `if`. A superseded run also no longer flips `status` to `complete` — it must not unblock the UI on data it never wrote.

### Defect 2 — duplicate orchestrator roots (the observed symptom of that same window)

`app.tsx:540` read `sync.data.session` immediately after `await sync.bootstrap()`. But `session.list` only joins `blockingRequests` when `--continue` is set (`sync.tsx:726`), so **bootstrap resolves before the session list lands**. The `existing` lookup missed the real root and the `else` branch called `session.create({})`, minting a new one on each entry.

Fix: root resolution moves into `sync.session.resolveRoot()`, which refreshes from the server first, so resolve-or-create depends on data instead of on timing.

**Why not "promote `session.list` into `blockingRequests`"**: that would make every launch — not just orchestrator entry — wait on a 30-day, roots-only session list before the UI unblocks, a real startup regression on large histories. It would also leave correctness dependent on bootstrap's internal request classification, so a later refactor moving `session.list` around could silently reintroduce duplicate roots. Asking the server at the point of decision is both cheaper for everyone else and structurally immune to that.

**Why they must land together**: without Defect 1's guard, the stale bootstrap's session-list write can repopulate the store with the *launch* directory's roots after Defect 2 has resolved — which would point the Orchestrator at a session from another directory. The "strictly narrower race with no observed symptom" framing was wrong; Defect 2 is its symptom.

## Tests

`test/cli/tui/bootstrap-race.test.tsx`, driving the real contexts (`SDKProvider` + `ProjectProvider/ArgsProvider/ExitProvider/SyncProvider`) with a fetch double — the pattern #1953 introduced.

Both are proven regression tests by reverting only their src change:

- *a non-blocking bootstrap write that resolves after a directory switch is discarded* — with the post-resolve check removed:
  ```
  error: expect(received).toBe(expected)
  Expected: "branch-b"
  Received: "branch-a"
  ```
- *entering the orchestrator repeatedly resolves the one existing root instead of creating more* — with `resolveRoot` reverted to the old store read:
  ```
  error: expect(received).toEqual(expected)
    [
  -   "ses_orch",
  -   "ses_orch",
  -   "ses_orch",
  +   "ses_created_1",
  +   "ses_created_2",
  +   "ses_created_3",
    ]
  ```
  i.e. three entries, three roots — the reported symptom reproduced deterministically.

`test/cli/`: **266 pass / 0 fail** (688 expect, 37 files) vs pristine `60af8f1ff` baseline **264 pass / 0 fail** (683 expect, 36 files). `bun typecheck` exit 0.

## Live verification (`mimo/mimo-v2.5`, isolated dev home)

Five Orchestrator entries — three in-process (Tab in/out) plus two from fresh processes (cold store, the exact scenario the fix targets) — leave **exactly one** root:

```
ORCH ROOTS = 1   (all roots in db = 1)
    ses_057aa2b18ffeeg1zBgS7w6ZIfj | New session - 2026-07-28T10:47:05.192Z | created 18:47:05
```

created only at the first (legitimate) entry, when the server genuinely had none.

Honest caveat: a control build on pristine `main` in the same harness also produced only one root. The duplicate needs `session.list` to be slower than bootstrap's blocking group, and against a small local DB it is not — so the live run here is a regression check, not the discriminating proof. The discriminating proof is the unit test above, where the list latency is explicit.

## Deliberately left alone

- Bootstrap's **blocking** writes and `project.sync()` — that is #1953's scope. Consequence, still visible live on `main`: after entering Orchestrator the footer keeps showing the launch directory (the stale `instance.path`), which is exactly the blank-transcript bug #1953 fixes.
- `project.workspace.sync()` inside the non-blocking group (different context, #1953 territory).
- Pre-existing prettier drift in `app.tsx` / `sync.tsx` was left untouched so the diff stays reviewable; only the changed regions are formatted.

The `stale()` helper is named to match #1953's so a merge conflict resolves to simply keeping one definition.