### PR TITLE
fix(tool): enforce isolated-child git safety in the bash tool (mechanism, not prompt text)

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -280,6 +280,22 @@ export const layer = Layer.effect(
       // hold isn't matched → we do NOT return here → it fails closed at the
       // non-interactive gate. No human wait, no hang.
       if (needsAsk && input.inherit && !forced) {
+        // An EXPLICIT `session grant-approval <child|all>` pre-authorizes this
+        // child. That grant is DB-backed (write-through in forwardRef.setGrant),
+        // so unlike the in-memory parentGrants snapshot it survives a restart and
+        // is visible to a child running in its own Instance/process. Checked here
+        // because `decideAskRouting` routes an ordinary background subagent to
+        // `inherit`, never to `forward` — the only other place grantAllowed is
+        // consulted — so without this the documented command silently does
+        // nothing for subagents and their asks fail closed below.
+        if (forwardRef.grantAllowed(input.inherit.parentSessionID, request.sessionID)) {
+          log.info("parent holds an explicit approval grant, auto-allowing", {
+            permission: request.permission,
+            patterns: request.patterns,
+            parentSessionID: input.inherit.parentSessionID,
+          })
+          return
+        }
         const parentSnapshot = forwardRef.getParentGrants(input.inherit.parentSessionID)
         if (parentSnapshot) {
           // Mirror the parent's own two-phase evaluation (see the deny loop

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -1,6 +1,6 @@
 import z from "zod"
 import os from "os"
-import { createWriteStream, readFileSync } from "node:fs"
+import { createWriteStream, existsSync, readFileSync } from "node:fs"
 import * as Tool from "./tool"
 import path from "path"
 import DESCRIPTION from "./bash.txt"
@@ -16,6 +16,7 @@ import { Flag } from "@/flag/flag"
 import { Shell } from "@/shell/shell"
 
 import { SessionCwd } from "./session-cwd"
+import * as IsolatedGit from "./isolated-git-guard"
 import { BashArity } from "@/permission/arity"
 import * as Truncate from "./truncate"
 import { Plugin } from "@/plugin"
@@ -764,6 +765,24 @@ export const BashTool = Tool.define(
               const timeout = params.timeout ?? DEFAULT_TIMEOUT
               const ps = PS.has(name)
               const root = yield* parse(params.command, ps)
+              // Cross-branch git guard for isolated children. Sits on the SAME
+              // parsed AST the permission scan uses, so every command node in a
+              // pipeline / `&&` chain / subshell is checked, and it runs BEFORE
+              // ask() so a rejected command never prompts and never spawns.
+              // Keyed on Instance.directory (the session's own worktree), not on
+              // `cwd` — a child that `cd`s into the main checkout and rebases
+              // there is exactly the accident this exists to stop.
+              const own = Instance.directory
+              if (IsolatedGit.isIsolatedWorktree(own)) {
+                IsolatedGit.assertIsolatedGitAllowed({
+                  commands: commands(root).map((node) => parts(node).map((item) => item.text)),
+                  sources: commands(root).map((node) => source(node)),
+                  directory: own,
+                  isolated: true,
+                  branch: IsolatedGit.ownBranch(own),
+                  isPath: (arg) => existsSync(path.resolve(cwd, arg)),
+                })
+              }
               const scan = yield* collect(root, cwd, ps, shell)
               if (!Instance.containsPath(cwd)) scan.dirs.add(cwd)
               // Delete-containing commands are authorized by askDelete alone —

--- a/packages/opencode/src/tool/isolated-git-guard.ts
+++ b/packages/opencode/src/tool/isolated-git-guard.ts
@@ -1,0 +1,313 @@
+import * as path from "path"
+import { readFileSync, realpathSync } from "node:fs"
+import { AppFileSystem } from "@mimo-ai/shared/filesystem"
+import { Global } from "../global"
+
+/**
+ * Cross-branch git guard for ISOLATED CHILD sessions.
+ *
+ * An isolated child (`session create --isolate`) runs in an app-managed git
+ * worktree under `<data>/worktree/<projectID>/<name>`. Every worktree of a
+ * repository shares ONE ref store (`--git-common-dir`), so a git command run
+ * from inside the child's worktree can mutate refs the MAIN checkout is sitting
+ * on — `git rebase main`, `git checkout main`, `git branch -f main …` all reach
+ * across and can move the main checkout's HEAD, corrupting the tree the user
+ * and other agents are actively working in. This has happened for real.
+ *
+ * The orchestrator prompt already tells children not to do this; this module
+ * makes it a mechanism instead of a suggestion. It only fires for isolated
+ * children — the orchestrator and ordinary sessions legitimately integrate
+ * branches and are never gated here.
+ *
+ * SCOPE / HONEST LIMITS
+ * - This is a string/argv-level check over the already-parsed command AST. A
+ *   determined command can evade it (shell aliases, `sh -c "$(printf …)"`,
+ *   `eval`, a wrapper script, a git alias configured in the repo). It is not a
+ *   sandbox and does not try to be one. The target is the ACCIDENTAL
+ *   HEAD-moving mistake that actually occurs in practice.
+ * - `git reset` is deliberately NOT gated: it can only move the CURRENT
+ *   worktree's own branch, so it cannot corrupt another checkout's HEAD. Its
+ *   destructive `--hard` form is already behind the forced-ask `bash_delete`
+ *   prompt in bash.ts.
+ * - `git pull` is deliberately NOT gated for the same reason: it only
+ *   fast-forwards/merges INTO the child's own branch and never writes another
+ *   branch's ref.
+ */
+
+/** git global options that consume the FOLLOWING token as their value. */
+const GLOBAL_WITH_VALUE = new Set([
+  "-C",
+  "-c",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--exec-path",
+  "--config-env",
+  "--super-prefix",
+])
+
+/** Flags that make `rebase`/`merge` operate on an ALREADY IN-PROGRESS operation
+ *  in this worktree only. Those are recovery actions, always allowed. */
+const IN_PROGRESS = new Set([
+  "--abort",
+  "--continue",
+  "--skip",
+  "--quit",
+  "--edit-todo",
+  "--show-current-patch",
+])
+
+/** `git branch` flags that delete, force-move or rename a ref. */
+const BRANCH_MUTATE = new Set(["-d", "-D", "--delete", "-f", "--force", "-m", "-M", "--move"])
+
+/** `git worktree` subcommands that write the shared worktree registry. */
+const WORKTREE_MUTATE = new Set(["add", "remove", "move", "prune", "repair", "lock", "unlock"])
+
+export type Violation = {
+  /** The single command that was rejected, as written. */
+  command: string
+  /** Short human reason, e.g. "git rebase rewrites shared refs". */
+  reason: string
+}
+
+function unquote(text: string) {
+  if (text.length < 2) return text
+  const first = text[0]
+  if ((first === '"' || first === "'") && first === text[text.length - 1]) return text.slice(1, -1)
+  return text
+}
+
+/**
+ * Splits a git argv into `{ sub, args }`, skipping git's global options so
+ * `git --no-pager -C /elsewhere rebase main` is still seen as `rebase`.
+ * Returns undefined when the command is not git or has no subcommand.
+ */
+export function gitInvocation(tokens: string[]): { sub: string; args: string[] } | undefined {
+  const argv = tokens.map(unquote).filter((tok) => tok.length > 0)
+  if (argv.length < 2) return
+  const head = path.basename(argv[0]).toLowerCase()
+  if (head !== "git" && head !== "git.exe") return
+  let i = 1
+  while (i < argv.length) {
+    const tok = argv[i]
+    if (!tok.startsWith("-")) break
+    if (GLOBAL_WITH_VALUE.has(tok)) {
+      i += 2
+      continue
+    }
+    i += 1
+  }
+  if (i >= argv.length) return
+  return { sub: argv[i], args: argv.slice(i + 1) }
+}
+
+/** Positional (non-flag) arguments. A bare `-` is positional: `git checkout -`
+ *  switches to the previous branch. */
+function positionals(args: string[]) {
+  return args.filter((arg) => arg === "-" || !arg.startsWith("-"))
+}
+
+function valueOf(args: string[], flags: Set<string>) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    for (const flag of flags) {
+      if (arg === flag) return args[i + 1]
+      if (arg.startsWith(flag + "=")) return arg.slice(flag.length + 1)
+    }
+  }
+}
+
+/** Normalizes a push refspec to the branch name it WRITES on the remote. */
+function pushTarget(refspec: string) {
+  const spec = refspec.startsWith("+") ? refspec.slice(1) : refspec
+  const colon = spec.lastIndexOf(":")
+  const dst = colon === -1 ? spec : spec.slice(colon + 1)
+  return dst.replace(/^refs\/heads\//, "")
+}
+
+/**
+ * Decides whether a single git invocation crosses the isolated child's branch
+ * boundary. Pure: `isPath` is injected so the caller owns filesystem access.
+ * `branch` is the child's own branch (undefined when it could not be read —
+ * ownership-sensitive rules then fail closed, which is safe because those forms
+ * are destructive and a child never needs them).
+ */
+export function violates(input: {
+  tokens: string[]
+  branch?: string
+  isPath?: (arg: string) => boolean
+}): string | undefined {
+  const git = gitInvocation(input.tokens)
+  if (!git) return
+  const { sub, args } = git
+  const branch = input.branch
+  const isPath = input.isPath ?? (() => false)
+  const owns = (name: string) => Boolean(branch) && (name === branch || name === "HEAD")
+
+  switch (sub) {
+    case "rebase": {
+      if (args.some((arg) => IN_PROGRESS.has(arg))) return
+      return "`git rebase` rewrites history against another branch and writes the shared ref store"
+    }
+    case "merge": {
+      if (args.some((arg) => IN_PROGRESS.has(arg))) return
+      return "`git merge` integrates another branch — integration is the orchestrator's job"
+    }
+    case "checkout":
+    case "switch": {
+      // With `--`, or with 2+ positionals, git restores FILES from a tree-ish
+      // and never moves HEAD. Always allowed.
+      if (args.includes("--")) return
+      const pos = positionals(args)
+      if (pos.length !== 1) {
+        if (args.includes("--detach")) return "`--detach` moves this worktree's HEAD off its own branch"
+        return
+      }
+      // Creating a brand-new branch is the child's own ref: allowed.
+      const created = valueOf(args, new Set(["-b", "-c", "--orphan"]))
+      if (created !== undefined) return
+      // `-B`/`-C` force-create, which RESETS an existing branch — only safe on its own.
+      const forced = valueOf(args, new Set(["-B", "-C"]))
+      if (forced !== undefined) {
+        if (owns(forced)) return
+        return `\`git ${sub}\` force-creating '${forced}' resets a branch this session does not own`
+      }
+      const target = pos[0]
+      if (isPath(target)) return
+      if (owns(target)) return
+      return `switching this worktree to '${target}' moves a ref/HEAD in the shared ref store`
+    }
+    case "branch": {
+      if (!args.some((arg) => BRANCH_MUTATE.has(arg))) return
+      const pos = positionals(args)
+      if (pos.length > 0 && pos.every((name) => owns(name))) return
+      return "deleting, force-moving or renaming a branch mutates the shared ref store"
+    }
+    case "push": {
+      const pos = positionals(args)
+      const specs = pos.slice(1)
+      const forced =
+        args.includes("--force") || args.includes("-f") || specs.some((spec) => spec.startsWith("+"))
+      const deleting = args.includes("--delete") || specs.some((spec) => spec.startsWith(":"))
+      if (!forced && !deleting) return
+      // No refspec ⇒ the current (own) branch.
+      if (specs.length === 0) return
+      const foreign = specs.map(pushTarget).filter((name) => !owns(name))
+      if (foreign.length === 0) return
+      return `force-pushing or deleting '${foreign[0]}' rewrites a branch this session does not own`
+    }
+    case "worktree": {
+      const pos = positionals(args)
+      if (pos.length === 0 || !WORKTREE_MUTATE.has(pos[0])) return
+      return `\`git worktree ${pos[0]}\` mutates the shared worktree registry`
+    }
+    case "update-ref": {
+      const pos = positionals(args)
+      const ref = pos[0] ?? ""
+      if (owns(ref.replace(/^refs\/heads\//, ""))) return
+      return "`git update-ref` writes the shared ref store directly"
+    }
+    case "symbolic-ref": {
+      // One positional is a READ (`git symbolic-ref HEAD`); two is a write.
+      const pos = positionals(args)
+      if (pos.length < 2 && !args.includes("--delete") && !args.includes("-d")) return
+      return "`git symbolic-ref` repoints HEAD in the shared ref store"
+    }
+    default:
+      return
+  }
+}
+
+/** True when `directory` is one of the app-managed worktrees that back an
+ *  isolated child session (`<data>/worktree/<projectID>/<name>`). The
+ *  orchestrator and ordinary sessions run in the user's project directory and
+ *  are therefore never gated. Mirrors the trusted-root test already used by
+ *  `src/tool/external-directory.ts`, but additionally compares realpaths:
+ *  `Instance.provide` stores a realpath-resolved directory, so on a symlinked
+ *  prefix (macOS `/var` → `/private/var`) a raw string-prefix test misses. */
+export function isIsolatedWorktree(directory: string | undefined, root?: string) {
+  if (!directory) return false
+  const base = root ?? path.join(Global.Path.data, "worktree")
+  if (AppFileSystem.contains(base, directory)) return true
+  return AppFileSystem.contains(real(base), real(directory))
+}
+
+function real(target: string) {
+  try {
+    return realpathSync(target)
+  } catch {
+    return path.resolve(target)
+  }
+}
+
+/** Best-effort read of the branch a worktree is on, without spawning git.
+ *  `<worktree>/.git` is a file containing `gitdir: <repo>/.git/worktrees/<name>`,
+ *  whose `HEAD` holds `ref: refs/heads/<branch>`. Returns undefined on any
+ *  surprise (detached HEAD, unreadable, plain clone layout is handled too). */
+export function ownBranch(directory: string): string | undefined {
+  try {
+    const dotGit = path.join(directory, ".git")
+    let gitDir = dotGit
+    try {
+      const pointer = readFileSync(dotGit, "utf-8")
+      const match = pointer.match(/^gitdir:\s*(.+)$/m)
+      if (match) gitDir = path.resolve(directory, match[1].trim())
+    } catch {
+      // `.git` is a directory (ordinary clone) — read HEAD from it directly.
+    }
+    const head = readFileSync(path.join(gitDir, "HEAD"), "utf-8").trim()
+    const ref = head.match(/^ref:\s*refs\/heads\/(.+)$/)
+    return ref ? ref[1] : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function message(input: { violation: Violation; directory: string; branch?: string }) {
+  const branch = input.branch ?? "(could not be determined)"
+  return (
+    `Blocked in an isolated child session: ${input.violation.command}\n` +
+    `Reason: ${input.violation.reason}.\n\n` +
+    `Every worktree of this repository shares ONE .git/ ref store, so a cross-branch git\n` +
+    `operation run from inside your worktree writes refs the MAIN checkout is using and can\n` +
+    `move its HEAD — corrupting the working tree the user and other agents are in right now.\n\n` +
+    `  your worktree: ${input.directory}\n` +
+    `  your branch:   ${branch}\n\n` +
+    `Do this instead:\n` +
+    `  - work only in your worktree, on your own branch\n` +
+    `  - \`git add\` + \`git commit\` + \`git push\` YOUR branch, and nothing else\n` +
+    `  - ask the orchestrator to rebase/merge/land it — cross-branch integration is its job\n`
+  )
+}
+
+/**
+ * The gate. Throws (loudly, with remediation) when any command in a bash
+ * invocation crosses the isolated child's branch boundary. No-ops when the
+ * session is not an isolated child.
+ */
+export function assertIsolatedGitAllowed(input: {
+  /** argv of every command node in the parsed invocation (pipelines, `&&`
+   *  chains and subshells each contribute one entry). */
+  commands: string[][]
+  /** Rendered source of each command, index-aligned with `commands`; used only
+   *  for the error text. Falls back to the joined argv. */
+  sources?: string[]
+  directory: string
+  isolated: boolean
+  branch?: string
+  isPath?: (arg: string) => boolean
+}): void {
+  if (!input.isolated) return
+  for (let i = 0; i < input.commands.length; i++) {
+    const tokens = input.commands[i]
+    const reason = violates({ tokens, branch: input.branch, isPath: input.isPath })
+    if (!reason) continue
+    throw new Error(
+      message({
+        violation: { command: input.sources?.[i] ?? tokens.join(" "), reason },
+        directory: input.directory,
+        branch: input.branch,
+      }),
+    )
+  }
+}

--- a/packages/opencode/test/permission/inherit.test.ts
+++ b/packages/opencode/test/permission/inherit.test.ts
@@ -17,6 +17,7 @@ afterEach(async () => {
 
 beforeEach(() => {
   forwardRef.parentGrants.clear()
+  forwardRef.clearGrantsForParent("ses_parent")
 })
 
 const bus = Bus.layer
@@ -136,6 +137,89 @@ describe("Permission.ask parent-grant inheritance", () => {
         const result = yield* perm.ask(childAsk(["/x/file.ts"])).pipe(Effect.exit)
         expect(result._tag).toBe("Failure")
         expect((yield* perm.list()).length).toBe(0)
+      }),
+    ),
+  )
+})
+
+// An EXPLICIT `session grant-approval <child|all>` must reach a background
+// SUBAGENT too. decideAskRouting routes such a child to `inherit` (never to
+// `forward`), so before this the DB-backed grant was consulted nowhere on the
+// subagent's path: `grant-approval` silently did nothing and the child's
+// external_directory ask failed closed. Unlike the in-memory parentGrants
+// snapshot, this grant survives a restart and a separate-process child, so it
+// cannot lapse mid-task.
+describe("Permission.ask explicit grant-approval reaches a background subagent", () => {
+  it.live(
+    "grant-approval for this child auto-approves with NO parent snapshot at all",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        forwardRef.setGrant("ses_parent", "ses_child")
+        let asked = 0
+        const unsub = Bus.subscribe(Permission.Event.Asked, () => {
+          asked += 1
+        })
+        // No setParentGrants: this is exactly the "snapshot missing / lapsed"
+        // case (separate-process child, or a parent that never asked).
+        const result = yield* perm
+          .ask(childAsk(["/Users/me/projects/app/*"], { permission: "external_directory" as never }))
+          .pipe(Effect.exit)
+        unsub()
+        expect(result._tag).toBe("Success")
+        expect(asked).toBe(0)
+        expect((yield* perm.list()).length).toBe(0)
+      }),
+    ),
+  )
+
+  it.live(
+    "an 'all' grant covers any child of that parent",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        forwardRef.setGrant("ses_parent", "*")
+        const result = yield* perm
+          .ask(childAsk(["/anywhere/x.ts"], { sessionID: "ses_other_child" as never }))
+          .pipe(Effect.exit)
+        expect(result._tag).toBe("Success")
+      }),
+    ),
+  )
+
+  it.live(
+    "WITHOUT a grant and without a snapshot the subagent still fails closed",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        const result = yield* perm.ask(childAsk(["/ungranted/x.ts"])).pipe(Effect.exit)
+        expect(result._tag).toBe("Failure")
+      }),
+    ),
+  )
+
+  it.live(
+    "a grant for a DIFFERENT child does not leak to this one",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        forwardRef.setGrant("ses_parent", "ses_someone_else")
+        const result = yield* perm.ask(childAsk(["/ungranted/x.ts"])).pipe(Effect.exit)
+        expect(result._tag).toBe("Failure")
+      }),
+    ),
+  )
+
+  it.live(
+    "forced-ask (bash_delete) is NOT auto-approved by a grant",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        forwardRef.setGrant("ses_parent", "*")
+        const result = yield* perm
+          .ask(childAsk(["rm -rf /"], { permission: "bash_delete" as never }))
+          .pipe(Effect.exit)
+        expect(result._tag).toBe("Failure")
       }),
     ),
   )

--- a/packages/opencode/test/tool/bash-isolated-git-guard.test.ts
+++ b/packages/opencode/test/tool/bash-isolated-git-guard.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer, ManagedRuntime } from "effect"
+import fs from "fs/promises"
+import path from "path"
+import { BashTool } from "../../src/tool/bash"
+import { Instance } from "../../src/project/instance"
+import { Global } from "../../src/global"
+import { Agent } from "../../src/agent/agent"
+import { Truncate } from "../../src/tool"
+import { SessionID, MessageID } from "../../src/session/schema"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { AppFileSystem } from "@mimo-ai/shared/filesystem"
+import { Plugin } from "../../src/plugin"
+import { tmpdir } from "../fixture/fixture"
+
+// End-to-end proof that the cross-branch git guard is actually WIRED into the
+// bash tool (not just a unit-tested module): an isolated child's Instance
+// directory lives under `<data>/worktree/...`, and a cross-branch git command
+// executed there must be rejected before the process is spawned.
+
+const runtime = ManagedRuntime.make(
+  Layer.mergeAll(
+    CrossSpawnSpawner.defaultLayer,
+    AppFileSystem.defaultLayer,
+    Plugin.defaultLayer,
+    Truncate.defaultLayer,
+    Agent.defaultLayer,
+  ),
+)
+
+const ctx = {
+  sessionID: SessionID.make("ses_guard_test"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+const init = () => runtime.runPromise(BashTool.pipe(Effect.flatMap((info) => info.init())))
+
+async function withIsolatedWorktree(fn: (dir: string) => Promise<void>) {
+  const dir = path.join(Global.Path.data, "worktree", `guardtest-${Math.random().toString(36).slice(2)}`)
+  await fs.mkdir(dir, { recursive: true })
+  try {
+    await Instance.provide({ directory: dir, fn: () => fn(dir) })
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+const run = async (command: string) => {
+  const bash = await init()
+  return Effect.runPromise(bash.execute({ command, description: "guard probe" }, ctx))
+}
+
+describe("tool.bash isolated-child git guard", () => {
+  test("rejects `git rebase main` from an isolated child's worktree", async () => {
+    await withIsolatedWorktree(async (dir) => {
+      let text = ""
+      await run("git rebase main").then(
+        () => {},
+        (err) => {
+          text = String(err?.message ?? err)
+        },
+      )
+      expect(text).toContain("Blocked in an isolated child session")
+      expect(text).toContain("git rebase main")
+      expect(text).toContain("shares ONE .git/ ref store")
+      expect(text).toContain(dir)
+      expect(text).toContain("ask the orchestrator")
+    })
+  })
+
+  test("rejects `git checkout main` even when chained after legitimate work", async () => {
+    await withIsolatedWorktree(async () => {
+      let text = ""
+      await run("git add -A && git commit -m wip && git checkout main").then(
+        () => {},
+        (err) => {
+          text = String(err?.message ?? err)
+        },
+      )
+      expect(text).toContain("Blocked in an isolated child session")
+      expect(text).toContain("git checkout main")
+    })
+  })
+
+  test("allows the child's own work: `git status` runs normally", async () => {
+    await withIsolatedWorktree(async () => {
+      const result = await run("git status --porcelain")
+      // Not a repo, so git exits non-zero — the point is that it RAN rather
+      // than being rejected by the guard.
+      expect(typeof result.metadata.exit).toBe("number")
+      expect(result.output).not.toContain("Blocked in an isolated child session")
+    })
+  })
+
+  test("a NON-isolated session is unaffected — `git rebase` is not gated", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const result = await run("git rebase definitely-no-such-branch")
+        expect(result.output).not.toContain("Blocked in an isolated child session")
+        expect(result.metadata.exit).not.toBe(0)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/tool/isolated-git-guard.test.ts
+++ b/packages/opencode/test/tool/isolated-git-guard.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test"
+import * as path from "path"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import {
+  assertIsolatedGitAllowed,
+  gitInvocation,
+  isIsolatedWorktree,
+  ownBranch,
+  violates,
+} from "../../src/tool/isolated-git-guard"
+
+const BRANCH = "feat/child-work"
+const DIR = "/data/worktree/p_abc/child-1"
+
+// Every real filename the allowed-list tests lean on. `git checkout <file>` is
+// only distinguishable from `git checkout <branch>` by what exists on disk.
+const FILES = new Set(["src/tool/bash.ts", "README.md", ".", "packages"])
+const isPath = (arg: string) => FILES.has(arg)
+
+function reject(command: string) {
+  const tokens = command.split(/\s+/)
+  return violates({ tokens, branch: BRANCH, isPath })
+}
+
+describe("isolated-git-guard / blocked cross-branch operations", () => {
+  const blocked = [
+    "git rebase main",
+    "git rebase origin/main",
+    "git rebase -i HEAD~3",
+    "git merge main",
+    "git merge --no-ff origin/main",
+    "git checkout main",
+    "git checkout dev",
+    "git checkout origin/main",
+    "git checkout -",
+    "git switch main",
+    "git switch --detach",
+    "git checkout -B main",
+    "git branch -f main HEAD",
+    "git branch -D other/branch",
+    "git branch --delete dev",
+    "git branch -m dev renamed",
+    "git push --force origin main",
+    "git push -f origin HEAD:main",
+    "git push origin +main",
+    "git push origin :dev",
+    "git push --delete origin dev",
+    "git worktree add ../other -b x",
+    "git worktree remove ../other",
+    "git update-ref refs/heads/main HEAD",
+    "git symbolic-ref HEAD refs/heads/main",
+    // git global options must not smuggle the subcommand past the guard
+    "git --no-pager rebase main",
+    "git -C /elsewhere/repo checkout main",
+    "git -c core.pager=cat merge main",
+  ]
+
+  for (const command of blocked) {
+    test(`blocks: ${command}`, () => {
+      expect(reject(command)).toBeTruthy()
+    })
+  }
+})
+
+describe("isolated-git-guard / allowed child work", () => {
+  const allowed = [
+    "git add -A",
+    "git add src/tool/bash.ts",
+    "git commit -m wip",
+    "git commit --amend --no-edit",
+    "git status",
+    "git status --porcelain",
+    "git diff",
+    "git diff --cached",
+    "git log --oneline -5",
+    "git show HEAD",
+    "git fetch origin",
+    "git push",
+    "git push origin HEAD",
+    `git push -u origin ${BRANCH}`,
+    `git push --force origin ${BRANCH}`,
+    `git push --force-with-lease origin ${BRANCH}`,
+    "git stash",
+    "git stash pop",
+    "git checkout -- src/tool/bash.ts",
+    "git checkout -- .",
+    "git checkout HEAD -- src/tool/bash.ts",
+    "git checkout src/tool/bash.ts",
+    "git checkout .",
+    "git restore src/tool/bash.ts",
+    "git checkout -b feat/child-work-2",
+    "git switch -c feat/child-work-2",
+    `git checkout ${BRANCH}`,
+    `git checkout -B ${BRANCH}`,
+    "git rebase --abort",
+    "git rebase --continue",
+    "git merge --abort",
+    "git worktree list",
+    "git branch",
+    "git branch --show-current",
+    "git symbolic-ref HEAD",
+    // git reset / git pull are deliberately out of scope: neither can write a
+    // ref other than the current worktree's own branch.
+    "git reset --hard HEAD",
+    "git reset --hard origin/main",
+    "git pull",
+    "git pull origin main",
+    // non-git commands are never inspected
+    "bun test",
+    "rebase main",
+  ]
+
+  for (const command of allowed) {
+    test(`allows: ${command}`, () => {
+      expect(reject(command)).toBeUndefined()
+    })
+  }
+})
+
+describe("isolated-git-guard / unknown own branch fails closed on destructive forms", () => {
+  const check = (command: string) => violates({ tokens: command.split(/\s+/), isPath })
+
+  test("branch delete is blocked when the branch cannot be read", () => {
+    expect(check("git branch -D whatever")).toBeTruthy()
+  })
+
+  test("force push with an explicit refspec is blocked when the branch cannot be read", () => {
+    expect(check("git push --force origin whatever")).toBeTruthy()
+  })
+
+  test("plain commit/push still work when the branch cannot be read", () => {
+    expect(check("git commit -m wip")).toBeUndefined()
+    expect(check("git push")).toBeUndefined()
+  })
+})
+
+describe("isolated-git-guard / gitInvocation", () => {
+  test("skips global options that consume a value", () => {
+    expect(gitInvocation(["git", "-C", "/repo", "--no-pager", "merge", "main"])).toEqual({
+      sub: "merge",
+      args: ["main"],
+    })
+  })
+
+  test("ignores non-git commands", () => {
+    expect(gitInvocation(["bun", "rebase"])).toBeUndefined()
+    expect(gitInvocation(["git"])).toBeUndefined()
+  })
+
+  test("unquotes tokens", () => {
+    expect(gitInvocation(["git", "checkout", '"main"'])).toEqual({ sub: "checkout", args: ["main"] })
+  })
+})
+
+describe("isolated-git-guard / isolation signal", () => {
+  const root = path.join("/data", "worktree")
+
+  test("app-managed worktree directory is an isolated child", () => {
+    expect(isIsolatedWorktree(path.join(root, "p_abc", "child-1"), root)).toBe(true)
+  })
+
+  test("the user's project directory is NOT an isolated child", () => {
+    expect(isIsolatedWorktree("/Users/me/projects/app", root)).toBe(false)
+  })
+
+  test("undefined directory is not an isolated child", () => {
+    expect(isIsolatedWorktree(undefined, root)).toBe(false)
+  })
+})
+
+describe("isolated-git-guard / ownBranch", () => {
+  test("reads the branch through a linked worktree's .git pointer file", () => {
+    const base = mkdtempSync(path.join(tmpdir(), "guard-wt-"))
+    const gitDir = path.join(base, "repo", ".git", "worktrees", "child")
+    mkdirSync(gitDir, { recursive: true })
+    writeFileSync(path.join(gitDir, "HEAD"), `ref: refs/heads/${BRANCH}\n`)
+    const wt = path.join(base, "child")
+    mkdirSync(wt)
+    writeFileSync(path.join(wt, ".git"), `gitdir: ${gitDir}\n`)
+    expect(ownBranch(wt)).toBe(BRANCH)
+  })
+
+  test("returns undefined for a detached HEAD", () => {
+    const base = mkdtempSync(path.join(tmpdir(), "guard-detached-"))
+    mkdirSync(path.join(base, ".git"), { recursive: true })
+    writeFileSync(path.join(base, ".git", "HEAD"), "1234567890abcdef\n")
+    expect(ownBranch(base)).toBeUndefined()
+  })
+
+  test("returns undefined when nothing is readable", () => {
+    expect(ownBranch(path.join(tmpdir(), "definitely-not-a-repo-" + Date.now()))).toBeUndefined()
+  })
+})
+
+describe("isolated-git-guard / assertIsolatedGitAllowed", () => {
+  const call = (commands: string[][], isolated: boolean) =>
+    assertIsolatedGitAllowed({ commands, directory: DIR, isolated, branch: BRANCH, isPath })
+
+  test("a NON-isolated session is completely unaffected", () => {
+    expect(() => call([["git", "rebase", "main"]], false)).not.toThrow()
+    expect(() => call([["git", "checkout", "main"]], false)).not.toThrow()
+    expect(() => call([["git", "branch", "-D", "dev"]], false)).not.toThrow()
+  })
+
+  test("an isolated child is blocked", () => {
+    expect(() => call([["git", "rebase", "main"]], true)).toThrow()
+  })
+
+  test("every command node in a chain is checked, not just the first", () => {
+    expect(() =>
+      call(
+        [
+          ["git", "add", "-A"],
+          ["git", "commit", "-m", "wip"],
+          ["git", "checkout", "main"],
+        ],
+        true,
+      ),
+    ).toThrow(/git checkout main/)
+  })
+
+  test("the error names what was blocked, why, and what to do instead", () => {
+    let text = ""
+    try {
+      call([["git", "rebase", "main"]], true)
+    } catch (err) {
+      text = (err as Error).message
+    }
+    expect(text).toContain("git rebase main")
+    expect(text).toContain("shares ONE .git/ ref store")
+    expect(text).toContain(DIR)
+    expect(text).toContain(BRANCH)
+    expect(text).toContain("git push")
+    expect(text).toContain("ask the orchestrator")
+  })
+})


### PR DESCRIPTION
## Why

`packages/opencode/src/session/prompt/orchestrator.txt` (§ *Integrating an isolated child's work*) already tells an isolated child that it must operate only in its own worktree and touch only its own branch — never `git rebase` / `git merge` / `git checkout` a branch it does not own.

That rule had **zero enforcement**. And it matters at the mechanism level, not the etiquette level: **all worktrees of a repository share ONE `.git/` ref store** (`--git-common-dir`). A child running `git rebase main` or `git checkout main` *inside its own worktree* therefore writes refs the MAIN checkout is sitting on and **can move that checkout's HEAD**, corrupting the working tree the user and other agents are actively using. This has happened for real in this project.

A prior investigation concluded that a model-behaviour test can at most sample whether the orchestrator *mentions* the rule in a dispatched brief, and that the enforceable fix is mechanism-level: reject cross-branch git operations in an isolated child's bash tool. This is that PR.

## Where it hooks, and why there

`packages/opencode/src/tool/bash.ts` — inside `execute`, immediately after the command is parsed and **before** `collect`/`ask`:

```ts
const root = yield* parse(params.command, ps)
const own = Instance.directory
if (IsolatedGit.isIsolatedWorktree(own)) {
  IsolatedGit.assertIsolatedGitAllowed({ commands: …, sources: …, directory: own, isolated: true, branch: …, isPath: … })
}
const scan = yield* collect(root, cwd, ps, shell)
```

One choke point, chosen because:

- It reuses the **same tree-sitter AST** the permission scan already walks (`commands(root)` / `parts(node)`), so every command node in a pipeline, an `&&` chain or a subshell is inspected — no second parser, no regex over the raw string.
- It runs **before** `ask()`, so a rejected command never prompts the user and never spawns a process.
- It is keyed on `Instance.directory`, **not** on the command's `cwd`: a child that `cd`s into the main checkout and rebases *there* is precisely the accident this exists to stop, and keying on `cwd` would silently disable the guard for it.

## Isolation signal

`Instance.directory` under the app-managed worktree root `path.join(Global.Path.data, "worktree")`.

- `session create --isolate` creates the child's worktree at `<data>/worktree/<projectID>/<name>` (`src/worktree/index.ts` `makeWorktreeInfo`), and `src/tool/session.ts` spawns the peer with `cwd: effectiveDir` = that path; `spawn.ts` binds it as the child fiber's `InstanceRef`, which `Instance.directory` reads.
- Nothing persists an "isolated" bit on a session record (no `Worktree.get(sessionID)`, no `isolated` field on `Session.Info`), so directory containment is the reliable signal available synchronously at bash-execution time. Same trusted-root test already used by `src/tool/external-directory.ts`.
- An orchestrator or ordinary session runs in the user's project directory → not under that root → **guard never applies**. A `--isolate` that degraded to shared (non-git dir) also evaluates false, correctly.

One wrinkle worth flagging for future callers of this pattern: `Instance.provide` stores a **realpath-resolved** directory, so a raw string-prefix test misses on a symlinked prefix (macOS `/var` → `/private/var`). `isIsolatedWorktree` compares realpaths as a fallback. The existing `external-directory.ts` check has the same latent fragility.

The child's own branch is read without spawning git: `<worktree>/.git` → `gitdir:` pointer → `HEAD` → `ref: refs/heads/<branch>`. Best-effort; `undefined` on a detached HEAD or unreadable layout, in which case the ownership-sensitive rules fail closed (those forms are destructive and a child never needs them).

## Blocked

| form | why |
|---|---|
| `git rebase …` | rewrites history against another branch, writes shared refs |
| `git merge …` | integration is the orchestrator's job |
| `git checkout <branch>` / `git switch <branch>` / `git checkout -` | moves this worktree's HEAD onto a ref it does not own |
| `git checkout --detach` / `git switch --detach` | same |
| `git checkout -B <other>` / `git switch -C <other>` | force-create **resets** an existing foreign branch |
| `git branch -d/-D/--delete/-f/--force/-m/-M/--move <other>` | deletes / force-moves / renames a foreign ref |
| `git push --force`/`-f`/`+refspec` to a **non-own** branch | rewrites a branch it does not own |
| `git push --delete` / `:refspec` for a **non-own** branch | deletes a foreign remote branch |
| `git worktree add/remove/move/prune/repair/lock/unlock` | mutates the shared worktree registry |
| `git update-ref` (non-own ref), `git symbolic-ref <name> <ref>` | writes the shared ref store / repoints HEAD directly |

Leading git global options are skipped before the subcommand is read, so `git --no-pager rebase main`, `git -c core.pager=cat merge main` and `git -C /elsewhere checkout main` are all still seen.

## Allowed (regression-tested, because a false block breaks real work)

`git add`, `git commit` (incl. `--amend`), `git status`, `git diff`, `git log`, `git show`, `git fetch`, `git stash`/`stash pop`, `git restore`,
`git push` / `git push origin HEAD` / `git push -u origin <own>` / `git push --force origin <own>` / `--force-with-lease <own>`,
`git checkout -b <new>` / `git switch -c <new>`, `git checkout <own-branch>`, `git checkout -B <own-branch>`,
`git checkout -- <file>`, `git checkout .`, `git checkout <existing-path>`, `git checkout HEAD -- <file>`,
`git rebase --abort/--continue`, `git merge --abort`, `git worktree list`, `git branch`, `git branch --show-current`, `git symbolic-ref HEAD`.

`git checkout <arg>` is disambiguated by whether `<arg>` exists on disk, plus two structural facts that mean git cannot be switching branches: a `--` separator, or 2+ positionals (tree-ish + paths).

### Deliberately NOT blocked

- **`git reset` (incl. `--hard`)** — it can only move the *current* worktree's own branch, so it structurally cannot corrupt another checkout's HEAD. Its destructive form is already behind the forced-ask `bash_delete` prompt in `bash.ts`. A rule here would be theatre.
- **`git pull`** — only fast-forwards/merges *into* the child's own branch; never writes another branch's ref.

## Honest limitation: this is not a sandbox

A string/argv-level check over the parsed AST **cannot** stop a determined command. `eval`, `sh -c "$(printf …)"`, a wrapper script, a repo-configured git alias, or `$GIT_DIR` env tricks will all evade it. (`git -C` and leading global options *are* handled, but that is opportunistic, not a guarantee.)

The goal is explicitly narrower and worth stating plainly: **stop the accidental HEAD-moving mistake that actually happens**, and when it is stopped, say clearly what to do instead. A hostile process is out of scope, and pretending otherwise would be worse than nothing.

## Error output

```
Blocked in an isolated child session: git rebase main
Reason: `git rebase` rewrites history against another branch and writes the shared ref store.

Every worktree of this repository shares ONE .git/ ref store, so a cross-branch git
operation run from inside your worktree writes refs the MAIN checkout is using and can
move its HEAD — corrupting the working tree the user and other agents are in right now.

  your worktree: /…/worktree/p_abc/child-1
  your branch:   feat/child-work

Do this instead:
  - work only in your worktree, on your own branch
  - `git add` + `git commit` + `git push` YOUR branch, and nothing else
  - ask the orchestrator to rebase/merge/land it — cross-branch integration is its job
```

## Second, separate fix in here: `grant-approval` never reached background subagents

While investigating a related report (an `external_directory` grant "lapsing" mid-task and killing a subagent's `bash`/`read`/`edit` access to a worktree outright), I found a real gap on current `main`:

- `session grant-approval <child|all>` writes `forwardRef.setGrant`, which is **write-through to SQLite** precisely so it survives restarts and separate-process children.
- But `forwardRef.grantAllowed` is consulted in exactly **one** place: the `input.forward` branch of `Permission.ask` (`src/permission/index.ts`).
- `decideAskRouting` (`src/agent/config.ts`) routes an *ordinary background subagent* to `inherit`, **never** to `forward` — only orchestrator **peers** get `forward`.

Net effect: for a background subagent, `grant-approval` silently did nothing, even though the tool replies *"Future permission asks from child X will be auto-approved."* The child's ask fell through to the non-interactive gate and hard-denied. The `inherit` path's own mechanism (`forwardRef.getParentGrants`) is an **in-memory-only `Map`**, populated as a side effect of the *parent's* `ask()` calls and dropped on session delete — so it is absent for a separate-process/isolated child and for a parent that never asked, which is exactly what "the grant lapsed mid-task" looks like from the child's side.

Fix is three lines at the point `main`'s own design makes the decision — honor the DB-backed explicit grant inside the `inherit` branch:

```ts
if (needsAsk && input.inherit && !forced) {
  if (forwardRef.grantAllowed(input.inherit.parentSessionID, request.sessionID)) return
  const parentSnapshot = forwardRef.getParentGrants(input.inherit.parentSessionID)
  …
```

Deliberately **not** a re-application of the older stranded approach (see below): no `grantResolved` parameter, no `decideAskRouting` signature change, no re-routing of subagents to `forward`. Deny-precedence is untouched (it sits after the deny loop) and forced-ask (`bash_delete`) still falls through — both regression-tested.

## Tests

New:
- `test/tool/isolated-git-guard.test.ts` — 85 tests: every blocked form, every allowed form, global-option smuggling, unknown-own-branch fail-closed behaviour, the isolation signal, `ownBranch` parsing, and the error text.
- `test/tool/bash-isolated-git-guard.test.ts` — 4 end-to-end tests through the real `BashTool.execute`, proving the guard is actually **wired** (not just a unit-tested module) and that a **non-isolated** session is unaffected.
- `test/permission/inherit.test.ts` — 5 added tests for the grant fix (incl. no-grant fails closed, foreign-child grant does not leak, forced-ask not auto-approved).

### Intentional-failure proof (revert only the src change, observe the failure)

| probe | reverted | observed |
|---|---|---|
| A | hook disabled in `bash.ts` | `2 pass / 2 fail` — `Expected to contain: "Blocked in an isolated child session"` / `Received: ""` |
| B | `violates()` neutered to always allow | `54 pass / 35 fail` — `expect(received).toBeTruthy()` / `Received: undefined` across every blocked form |
| C | isolation gate removed inside `assertIsolatedGitAllowed` | `84 pass / 1 fail` — *"a NON-isolated session is completely unaffected"* fails with the full guard error thrown |
| D | `bash.ts` applies the guard to **every** session | non-isolated bash test fails, guard error raised for a plain tmpdir session |
| E | `grantAllowed` check removed from the `inherit` branch | `8 pass / 2 fail` — `Expected: "Success" / Received: "Failure"` |

### Suite results (this branch, `--timeout 120000` from `packages/opencode`)

- `test/tool test/permission test/agent test/cli` → **1314 pass / 10 skip / 0 fail** (1324 tests, 108 files)
- `test/tool` alone → 837 tests, **0 fail** (748 pre-existing + 89 new)
- `test/cli test/permission` → **417 pass / 0 fail**
- `bun typecheck` → **exit 0**

Pristine `main` baselines measured previously with the identical command were `test/cli + test/permission` → 396/0 and `test/tool` → ~745 pass **with 0 failures**; both failure *sets* here are still empty, and the test-count deltas are the newly added tests plus `main` moving forward.

## Investigation: the two PR #1624 rebase content divergences

Closed PR #1624's branch `fix/orchestrator-tui-and-infra-bugs` had two commits whose landed twins on `main` differ in content. Verdicts:

**1. `c05fe6f92` vs landed `426543c22` — REAL LOSS (178 changed lines → 4), but superseded, so NOT re-applied as-is.**

The landed twin is **comment-only**: 2 lines in `src/session/prompt.ts`. The stranded commit's actual mechanism — a `grantResolved` field on `decideAskRouting`, resolved via `forwardRef.grantAllowed`, routing a granted background subagent to `forward` — plus its 5 unit tests and 2 permission tests were all dropped. `git grep grantResolved origin/main` → absent.

But `main` did not simply lose the capability: it later implemented a **different and broader** mechanism, the `inherit` routing (`decideAskRouting` returns `{ interactive: false, inherit: { parentSessionID } }`, consumed by the parent-grant-inheritance branch in `Permission.ask`), which consults the parent's actual ruleset+approved snapshot with correct two-phase deny precedence. That is a deliberate adaptation and strictly better for path-based grants. Re-applying the old hunks would be a revert in disguise — the signature and the routing model both changed underneath.

What genuinely remained lost is the narrower thing above: explicit `grant-approval` never reaching a background subagent, because `grantAllowed` is only consulted on the `forward` path. That is the residual cause consistent with the reported symptom, and it is fixed here as a small re-expression against current `main` rather than a re-apply. The separate persistence fix `a0ced0655` → `241a6f048` is fully on `main` and is untouched.

**2. `b789c100f8` vs landed `e36926f7d` — NO LOSS. Pure rebase artifact.**

```
$ for c in b789c100f8 e36926f7d; do git show $c --format= | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | shasum; done
355c3ba54344743f54ad3a61dd45d7443e2656b5  -
355c3ba54344743f54ad3a61dd45d7443e2656b5  -
```

The changed lines are **byte-identical**. The whole diff-of-diffs is blob indices, hunk line offsets (`@@ -458,11` → `@@ -484,12`), and one extra **context** line (`skipPermissions,`) that exists on `main` but not on the stranded branch's base. Nothing to do.

## Left alone deliberately

- `orchestrator.txt` prose — unchanged; the prompt guidance is still correct and now backed by a mechanism.
- `session create --isolate`'s existing git-safety warning — unchanged.
- The `inherit` design itself, and the in-memory-only nature of `parentGrants` — I only added the DB-backed explicit-grant check. Making the `parentGrants` snapshot durable/cross-process is a real but larger design question and belongs in its own PR.
- `git reset` / `git pull` — see *Deliberately NOT blocked* above.