### PR TITLE
fix: repair orphaned running tool parts; stop a directory 403 from killing the TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-worktree.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-worktree.tsx
@@ -5,6 +5,7 @@ import { useSDK } from "../context/sdk"
 import { useSync } from "@tui/context/sync"
 import { useRoute } from "@tui/context/route"
 import { useToast } from "../ui/toast"
+import { isDirectoryDeniedError } from "@/server/routes/instance/access"
 import path from "path"
 
 const CREATE_SENTINEL = "__create_worktree__"
@@ -53,9 +54,31 @@ export function DialogWorktree() {
 
   async function switchTo(directory: string) {
     setBusy("Switching to worktree...")
+    const previous = sdk.directory
     await sdk.client.instance.dispose().catch(() => {})
     sdk.switchDirectory(directory)
-    await sync.bootstrap()
+    // The server rejects any directory outside its cwd (instance middleware 403).
+    // That used to propagate out of bootstrap into the TUI's fatal-exit path and
+    // kill the whole session; treat it as a recoverable error: point the SDK back
+    // at the directory that was working, re-sync, and tell the user which path was
+    // refused and why.
+    const failure = await sync.bootstrap().then(
+      () => undefined,
+      (e) => e,
+    )
+    if (failure) {
+      if (previous) sdk.switchDirectory(previous)
+      await sync.bootstrap({ fatal: false }).catch(() => {})
+      setBusy(undefined)
+      dialog.clear()
+      toast.show({
+        message: isDirectoryDeniedError(failure)
+          ? `Cannot switch to ${directory}: outside this server's working directory`
+          : `Failed to switch to ${path.basename(directory)}`,
+        variant: "error",
+      })
+      return
+    }
     route.navigate({ type: "home" })
     dialog.clear()
     toast.show({ message: `Switched to ${path.basename(directory)}`, variant: "success" })

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -31,6 +31,7 @@ import { useArgs } from "./args"
 import { batch, onMount } from "solid-js"
 import { Log } from "@/util"
 import { isDirectoryDeniedError } from "@/server/routes/instance/access"
+import { useToastOptional } from "../ui/toast"
 import { emptyConsoleState, type ConsoleState } from "@/config/console-state"
 
 /**
@@ -265,6 +266,22 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const event = useEvent()
     const project = useProject()
     const sdk = useSDK()
+    const toast = useToastOptional()
+
+    // A bootstrap that nobody awaits still must not fail silently when the
+    // server's directory whitelist is the reason. `bootstrap` rethrows the
+    // recoverable policy rejection so an interactive caller can restore the
+    // previous directory and explain itself; the two fire-and-forget callers
+    // below have no such caller, so without this the TUI would sit with stale
+    // data and no indication why. Genuinely fatal failures already exited
+    // inside bootstrap, and anything else is logged there.
+    const reportDenied = (e: unknown) => {
+      if (!isDirectoryDeniedError(e)) return
+      toast?.show({
+        message: `Cannot use ${sdk.directory ?? "this directory"}: outside this server's working directory`,
+        variant: "error",
+      })
+    }
 
     const fullSyncedSessions = new Set<string>()
     let syncedWorkspace = project.workspace.current()
@@ -272,7 +289,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     event.subscribe((event) => {
       switch (event.type) {
         case "server.instance.disposed":
-          void bootstrap().catch(() => {})
+          void bootstrap().catch(reportDenied)
           break
         case "permission.replied": {
           const requests = store.permission[event.properties.sessionID]
@@ -808,7 +825,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       // Errors are already logged (and exited on, when fatal) inside bootstrap; the
       // rethrown recoverable case has no caller here, so swallow it rather than
       // emitting an unhandled rejection.
-      void bootstrap().catch(() => {})
+      void bootstrap().catch(reportDenied)
     })
 
     const result = {

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -30,6 +30,7 @@ import { useExit } from "./exit"
 import { useArgs } from "./args"
 import { batch, onMount } from "solid-js"
 import { Log } from "@/util"
+import { isDirectoryDeniedError } from "@/server/routes/instance/access"
 import { emptyConsoleState, type ConsoleState } from "@/config/console-state"
 
 /**
@@ -271,7 +272,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     event.subscribe((event) => {
       switch (event.type) {
         case "server.instance.disposed":
-          void bootstrap()
+          void bootstrap().catch(() => {})
           break
         case "permission.replied": {
           const requests = store.permission[event.properties.sessionID]
@@ -786,20 +787,28 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         })
         .catch(async (e) => {
           Log.Default.error("tui bootstrap failed", {
-            error: e instanceof Error ? e.message : String(e),
+            error: isDirectoryDeniedError(e) ? e.error : e instanceof Error ? e.message : String(e),
             name: e instanceof Error ? e.name : undefined,
             stack: e instanceof Error ? e.stack : undefined,
           })
-          if (fatal) {
+          // The server's directory whitelist rejecting the requested directory is a
+          // recoverable policy decision, not a broken TUI: exiting here would take
+          // the user's whole session down over a mistyped/untrusted path. Always
+          // rethrow so the switch caller can restore the previous directory and show
+          // the error. Genuinely fatal bootstrap failures still exit.
+          if (fatal && !isDirectoryDeniedError(e)) {
             await exit(e)
-          } else {
-            throw e
+            return
           }
+          throw e
         })
     }
 
     onMount(() => {
-      void bootstrap()
+      // Errors are already logged (and exited on, when fatal) inside bootstrap; the
+      // rethrown recoverable case has no caller here, so swallow it rather than
+      // emitting an unhandled rejection.
+      void bootstrap().catch(() => {})
     })
 
     const result = {

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -100,3 +100,10 @@ export function useToast() {
   }
   return value
 }
+
+// For contexts that want to surface a toast when one is available but must not
+// REQUIRE the toast stack (theme + terminal dimensions + border) as a dependency
+// — a data context should not be untestable because of a presentation concern.
+export function useToastOptional() {
+  return useContext(ctx)
+}

--- a/packages/opencode/src/server/routes/instance/access.ts
+++ b/packages/opencode/src/server/routes/instance/access.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared contract for the instance middleware's directory whitelist rejection.
+ *
+ * The rejection itself is correct policy (a client may not point the server at a
+ * directory outside its cwd), but a client has to be able to RECOGNISE it: the
+ * generated SDK throws the parsed response body, with no status code attached, so
+ * a 403 is otherwise indistinguishable from a transport failure and gets treated
+ * as fatal. `code` is the stable discriminator — never match on `error` prose.
+ *
+ * Leaf module on purpose: the TUI imports the guard, so this file must not pull
+ * the server's instance/bootstrap graph into the TUI bundle.
+ */
+export const DIRECTORY_DENIED_CODE = "directory_not_allowed"
+
+export function isDirectoryDeniedError(e: unknown): e is { code: string; error: string; directory?: string } {
+  return typeof e === "object" && e !== null && "code" in e && e.code === DIRECTORY_DENIED_CODE
+}

--- a/packages/opencode/src/server/routes/instance/middleware.ts
+++ b/packages/opencode/src/server/routes/instance/middleware.ts
@@ -9,6 +9,7 @@ import { Flag } from "@/flag/flag"
 import { Filesystem } from "@/util"
 import { Global } from "@/global"
 import path from "node:path"
+import { DIRECTORY_DENIED_CODE } from "./access"
 
 export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler {
   return async (c, next) => {
@@ -34,7 +35,17 @@ export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler
           ? Filesystem.resolve(path.join(Global.Path.data, "orchestrator"))
           : undefined
       if (!Filesystem.contains(cwd, directory) && directory !== orchestrator) {
-        return c.json({ error: "Access denied: directory must be within the server's working directory" }, 403)
+        // Keep the 403 and the prose message; add a stable `code` so a client can
+        // tell this policy rejection apart from a transport failure and surface it
+        // instead of dying (see ./access.ts).
+        return c.json(
+          {
+            code: DIRECTORY_DENIED_CODE,
+            error: "Access denied: directory must be within the server's working directory",
+            directory,
+          },
+          403,
+        )
       }
     }
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -358,6 +358,25 @@ export const ToolStateError = z
   })
 export type ToolStateError = z.infer<typeof ToolStateError>
 
+/**
+ * The terminal state for a tool part that was left unfinished by an
+ * interruption. A `pending`/`running` part is persisted the moment the tool
+ * starts (so the TUI can stream progress) and is only rewritten by whoever
+ * finalizes the turn — so every finalizer must produce the SAME shape, or the
+ * transcript renders interrupted calls inconsistently. Callers: the abort
+ * finalizer in `SessionProcessor.cleanup` and `SessionPrompt.sweepOrphanToolParts`.
+ */
+export function abortedToolState(state: ToolPart["state"], error = "Tool execution aborted"): ToolStateError {
+  const end = Date.now()
+  return {
+    status: "error",
+    input: state.input,
+    error,
+    metadata: { ...("metadata" in state && state.metadata ? state.metadata : {}), interrupted: true },
+    time: { start: "time" in state ? state.time.start : end, end },
+  }
+}
+
 export const ToolState = z
   .discriminatedUnion("status", [ToolStatePending, ToolStateRunning, ToolStateCompleted, ToolStateError])
   .meta({

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -743,21 +743,28 @@ export const layer: Layer.Layer<
         for (const toolCallID of Object.keys(ctx.toolcalls)) {
           const match = yield* readToolCall(toolCallID)
           if (!match) continue
-          const part = match.part
-          const end = Date.now()
-          const metadata = "metadata" in part.state && isRecord(part.state.metadata) ? part.state.metadata : {}
           yield* session.updatePart({
-            ...part,
-            state: {
-              ...part.state,
-              status: "error",
-              error: "Tool execution aborted",
-              metadata: { ...metadata, interrupted: true },
-              time: { start: "time" in part.state ? part.state.time.start : end, end },
-            },
+            ...match.part,
+            state: MessageV2.abortedToolState(match.part.state),
           })
         }
         ctx.toolcalls = {}
+        // Second pass, DB-driven. The loop above can only see calls this process
+        // still holds in `ctx.toolcalls`, so a call whose registration lost the race
+        // with teardown, or that arrived after the map was cleared, or whose
+        // `readToolCall` lookup missed, keeps its persisted `running` status forever
+        // — the transcript then shows a tool call that will never finish. Every tool
+        // part of THIS assistant message belongs to the turn being torn down here,
+        // so any part still `pending`/`running` is unfinalized by definition.
+        // Idempotent: the pass above already rewrote the tracked ones.
+        for (const part of yield* Effect.sync(() => MessageV2.parts(ctx.assistantMessage.id))) {
+          if (part.type !== "tool") continue
+          if (part.state.status !== "pending" && part.state.status !== "running") continue
+          yield* session.updatePart({
+            ...part,
+            state: MessageV2.abortedToolState(part.state),
+          })
+        }
         ctx.assistantMessage.time.completed = Date.now()
         yield* session.updateMessage(ctx.assistantMessage)
       })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -277,6 +277,7 @@ export interface Interface {
   readonly command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts>
   readonly resolvePromptParts: (template: string) => Effect.Effect<PromptInput["parts"]>
   readonly sweepOrphanAssistants: (sessionID: SessionID, immediate?: boolean) => Effect.Effect<void>
+  readonly sweepOrphanToolParts: (sessionID: SessionID) => Effect.Effect<void>
   readonly predict: (input: { sessionID: SessionID }) => Effect.Effect<string>
 }
 
@@ -2261,6 +2262,50 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       }
     })
 
+    // A tool part is persisted as `running` the moment the tool STARTS (so the TUI
+    // can stream progress) and is only rewritten by the abort finalizer in
+    // `SessionProcessor.cleanup`. Every exit path that skips that finalizer — process
+    // kill, crash, dev restart — leaves the row `running` forever, so the transcript
+    // permanently shows tool calls that will never finish. Nothing else repairs them:
+    // the model-message converter (`MessageV2.toModelMessages`) synthesizes an
+    // `output-error` for `pending`/`running` parts so the provider never sees a
+    // dangling `tool_use`, but it never touches the persisted row.
+    //
+    // SAFETY — a CURRENTLY EXECUTING tool part is also `running`, so an unscoped
+    // "rewrite every running row" sweep would corrupt live turns. Two guards, both
+    // required, both narrow:
+    //   1. session status must be `idle`. `busy`/`retry` mean an active runner owns
+    //      this session, and a tool can only execute inside a runner's turn. This is
+    //      the same gate `sweepOrphanAssistants`' caller relies on, kept INSIDE the
+    //      function here because that is where the danger lives.
+    //   2. the MAIN slice only (`sessions.messages` default). `SessionProcessor` only
+    //      publishes status for the main slice (`if (isMain) status.set(...)`), so a
+    //      subagent slice can be executing tools while the session status reads
+    //      `idle` — its parts are out of scope.
+    const sweepOrphanToolParts = Effect.fn("SessionPrompt.sweepOrphanToolParts")(function* (sessionID: SessionID) {
+      if ((yield* status.get(sessionID)).type !== "idle") return
+      for (const m of yield* sessions.messages({ sessionID })) {
+        if (m.info.role !== "assistant") continue
+        for (const part of m.parts) {
+          if (part.type !== "tool") continue
+          if (part.state.status !== "pending" && part.state.status !== "running") continue
+          yield* sessions
+            .updatePart({ ...part, state: MessageV2.abortedToolState(part.state) })
+            .pipe(
+              Effect.catchCause((cause) =>
+                elog.warn("orphan-tool-part-update-failed", { sessionID, partID: part.id, cause }),
+              ),
+            )
+          yield* elog.info("orphan-tool-part-cleared", {
+            sessionID,
+            messageID: m.info.id,
+            partID: part.id,
+            tool: part.tool,
+          })
+        }
+      }
+    })
+
     const prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.prompt")(
       function* (input: PromptInput) {
         const session = yield* sessions.get(input.sessionID)
@@ -2271,6 +2316,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           // so a fresh message is not rendered as stuck QUEUED behind it.
           const idle = (yield* status.get(input.sessionID)).type === "idle"
           yield* sweepOrphanAssistants(input.sessionID, idle)
+          // Same recovery point, same idleness argument: repair tool parts a killed
+          // process left stuck at `running`. Self-gated on idle (see the function).
+          yield* sweepOrphanToolParts(input.sessionID)
         }
         const message = yield* createUserMessage(input)
         yield* sessions.touch(input.sessionID)
@@ -4321,6 +4369,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       command,
       resolvePromptParts,
       sweepOrphanAssistants,
+      sweepOrphanToolParts,
       predict,
     })
     sessionPromptRef.current = { loop: impl.loop }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2318,6 +2318,17 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           yield* sweepOrphanAssistants(input.sessionID, idle)
           // Same recovery point, same idleness argument: repair tool parts a killed
           // process left stuck at `running`. Self-gated on idle (see the function).
+          //
+          // These two look mergeable into one message fetch. They are not:
+          // `sweepOrphanAssistants` reads EVERY slice (`agentID: "*"`) while this one
+          // reads the MAIN slice only, and that difference is load-bearing.
+          // `SessionProcessor` publishes status for the main slice alone, so a subagent
+          // slice can be mid-tool while the session status reads `idle` — scanning only
+          // main is what stops this sweep from rewriting a live subagent's `running`
+          // part. Sharing a fetch would mean taking the wider read and re-filtering
+          // here, which is precisely where that property would get lost. The cost is
+          // also smaller than it looks: this returns after one status lookup unless the
+          // session is genuinely idle.
           yield* sweepOrphanToolParts(input.sessionID)
         }
         const message = yield* createUserMessage(input)

--- a/packages/opencode/test/cli/tui/bootstrap-directory-denied.test.tsx
+++ b/packages/opencode/test/cli/tui/bootstrap-directory-denied.test.tsx
@@ -1,0 +1,129 @@
+/** @jsxImportSource @opentui/solid */
+import { afterEach, describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import type { GlobalEvent } from "@mimo-ai/sdk/v2"
+import { onMount } from "solid-js"
+import { ArgsProvider } from "../../../src/cli/cmd/tui/context/args"
+import { ExitProvider } from "../../../src/cli/cmd/tui/context/exit"
+import { ProjectProvider } from "../../../src/cli/cmd/tui/context/project"
+import { SDKProvider } from "../../../src/cli/cmd/tui/context/sdk"
+import { SyncProvider, useSync } from "../../../src/cli/cmd/tui/context/sync"
+import { DIRECTORY_DENIED_CODE } from "../../../src/server/routes/instance/access"
+
+const DENIED = "/somewhere/outside/the/server/cwd"
+
+afterEach(() => {
+  delete process.env.MIMOCODE_FAST_BOOT
+})
+
+async function wait(fn: () => boolean, timeout = 5000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+/**
+ * Stands in for a server whose instance middleware refuses the requested
+ * directory. Shape matches `InstanceMiddleware`: HTTP 403 + a JSON body carrying
+ * the stable `code`.
+ */
+function denyingFetch(status: number, body: unknown): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch
+}
+
+const events = {
+  subscribe: async () => () => {},
+}
+
+async function mount(fetchDouble: typeof fetch) {
+  // SyncProvider gates its children behind `ready` (status !== "loading"), which a
+  // failing bootstrap never reaches — reuse the fast-boot escape hatch so the probe
+  // mounts and can drive bootstrap directly.
+  process.env.MIMOCODE_FAST_BOOT = "1"
+  const exits: unknown[] = []
+  let sync!: ReturnType<typeof useSync>
+  let ready!: () => void
+  const mounted = new Promise<void>((resolve) => {
+    ready = resolve
+  })
+
+  const app = await testRender(() => (
+    <ExitProvider
+      onExit={async () => {
+        exits.push("exit")
+      }}
+    >
+      <ArgsProvider>
+        <SDKProvider url="http://test" directory="/tmp/root" fetch={fetchDouble} events={events as never}>
+          <ProjectProvider>
+            <SyncProvider>
+              <Probe
+                onReady={(ctx) => {
+                  sync = ctx
+                  ready()
+                }}
+              />
+            </SyncProvider>
+          </ProjectProvider>
+        </SDKProvider>
+      </ArgsProvider>
+    </ExitProvider>
+  ))
+
+  await mounted
+  return { app, exits, sync }
+}
+
+function Probe(props: { onReady: (sync: ReturnType<typeof useSync>) => void }) {
+  const sync = useSync()
+  onMount(() => props.onReady(sync))
+  return <box />
+}
+
+describe("tui bootstrap directory rejection", () => {
+  test("a 403 from the instance middleware never reaches the fatal-exit path", async () => {
+    const { app, exits, sync } = await mount(
+      denyingFetch(403, {
+        code: DIRECTORY_DENIED_CODE,
+        error: "Access denied: directory must be within the server's working directory",
+        directory: DENIED,
+      }),
+    )
+
+    try {
+      const failure = await sync.bootstrap().then(
+        () => undefined,
+        (e) => e,
+      )
+
+      // Surfaced to the caller so it can restore the previous directory + toast...
+      expect(failure).toBeDefined()
+      expect((failure as { code?: string }).code).toBe(DIRECTORY_DENIED_CODE)
+      expect((failure as { directory?: string }).directory).toBe(DENIED)
+      // ...and the TUI is still alive: exit() was never invoked.
+      await Bun.sleep(50)
+      expect(exits).toEqual([])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("a genuinely fatal bootstrap failure still exits", async () => {
+    const { app, exits } = await mount(denyingFetch(500, { error: "boom" }))
+
+    try {
+      // The mount-time bootstrap is enough: a 500 is not a recoverable policy
+      // rejection, so the fatal path must still fire.
+      await wait(() => exits.length > 0)
+      expect(exits).toEqual(["exit"])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})

--- a/packages/opencode/test/cron/end-to-end.test.ts
+++ b/packages/opencode/test/cron/end-to-end.test.ts
@@ -81,6 +81,7 @@ const stubPrompt = Layer.succeed(
     command: () => Effect.die("command not expected in end-to-end test"),
     resolvePromptParts: () => Effect.succeed([]),
     sweepOrphanAssistants: () => Effect.void,
+    sweepOrphanToolParts: () => Effect.void,
     predict: () => Effect.succeed(""),
   }),
 )

--- a/packages/opencode/test/session/cron-bridge.integration.test.ts
+++ b/packages/opencode/test/session/cron-bridge.integration.test.ts
@@ -67,6 +67,7 @@ const makeCaptureLayer = (captured: { value: CapturedPrompt[] }) =>
       command: () => Effect.die("command not expected in cron-bridge test"),
       resolvePromptParts: () => Effect.succeed([]),
       sweepOrphanAssistants: () => Effect.void,
+      sweepOrphanToolParts: () => Effect.void,
       predict: () => Effect.succeed(""),
     }),
   )

--- a/packages/opencode/test/session/keepalive.integration.test.ts
+++ b/packages/opencode/test/session/keepalive.integration.test.ts
@@ -73,6 +73,7 @@ const stubPrompt = Layer.succeed(
     command: () => Effect.die("command not expected in keepalive test"),
     resolvePromptParts: () => Effect.succeed([]),
     sweepOrphanAssistants: () => Effect.void,
+    sweepOrphanToolParts: () => Effect.void,
     predict: () => Effect.succeed(""),
   }),
 )

--- a/packages/opencode/test/session/prompt-orphan-tool-parts.test.ts
+++ b/packages/opencode/test/session/prompt-orphan-tool-parts.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import path from "path"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Instance } from "../../src/project/instance"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionStatus } from "../../src/session/status"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID, type SessionID } from "../../src/session/schema"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const it = testEffect(
+  Layer.mergeAll(
+    SessionPrompt.defaultLayer,
+    Session.defaultLayer,
+    SessionStatus.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+  ),
+)
+
+const seedRunningToolPart = (dir: string, sessionID: SessionID) =>
+  Effect.gen(function* () {
+    const sessions = yield* Session.Service
+    const user = yield* sessions.updateMessage({
+      id: MessageID.ascending(),
+      role: "user" as const,
+      sessionID,
+      agent: "default",
+      model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+      time: { created: Date.now() },
+    })
+    const assistant = yield* sessions.updateMessage({
+      id: MessageID.ascending(),
+      role: "assistant" as const,
+      sessionID,
+      mode: "default",
+      agent: "default",
+      path: { cwd: path.resolve(dir), root: path.resolve(dir) },
+      cost: 0,
+      tokens: { output: 0, input: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: ModelID.make("test-model"),
+      providerID: ProviderID.make("test"),
+      parentID: user.id,
+      time: { created: Date.now() },
+    })
+    return yield* sessions.updatePart({
+      id: PartID.ascending(),
+      messageID: assistant.id,
+      sessionID,
+      type: "tool" as const,
+      tool: "bash",
+      callID: `call-${assistant.id}`,
+      state: {
+        status: "running" as const,
+        input: { command: "sleep 100" },
+        title: "sleep 100",
+        time: { start: Date.now() },
+      },
+    })
+  })
+
+const readPart = (sessionID: SessionID, partID: string) =>
+  Effect.gen(function* () {
+    const sessions = yield* Session.Service
+    for (const m of yield* sessions.messages({ sessionID })) {
+      const found = m.parts.find((p) => p.id === partID)
+      if (found) return found
+    }
+    return undefined
+  })
+
+describe("sweepOrphanToolParts", () => {
+  it.live("repairs a tool part orphaned at running when the session is idle", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const svc = yield* SessionPrompt.Service
+        const session = yield* sessions.create({})
+        const part = yield* seedRunningToolPart(dir, session.id)
+
+        yield* svc.sweepOrphanToolParts(session.id)
+
+        const after = yield* readPart(session.id, part.id)
+        expect(after?.type).toBe("tool")
+        if (after?.type !== "tool") throw new Error("expected a tool part")
+        expect(after.state.status).toBe("error")
+        if (after.state.status !== "error") throw new Error("expected an error state")
+        expect(after.state.error).toBe("Tool execution aborted")
+        expect(after.state.metadata?.interrupted).toBe(true)
+        // The original start time survives so the transcript keeps its duration.
+        expect(after.state.time.start).toBe(part.state.status === "running" ? part.state.time.start : 0)
+      }),
+    ),
+  )
+
+  it.live("leaves an in-flight tool part alone while the session is busy", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const status = yield* SessionStatus.Service
+        const svc = yield* SessionPrompt.Service
+        const session = yield* sessions.create({})
+        const part = yield* seedRunningToolPart(dir, session.id)
+
+        // A CURRENTLY EXECUTING tool is persisted as `running` too — this is the
+        // half that matters: a sweep that fires here would corrupt a live turn.
+        yield* status.set(session.id, { type: "busy" })
+        yield* svc.sweepOrphanToolParts(session.id)
+
+        const after = yield* readPart(session.id, part.id)
+        if (after?.type !== "tool") throw new Error("expected a tool part")
+        expect(after.state.status).toBe("running")
+      }),
+    ),
+  )
+
+  it.live("leaves a retrying session's tool part alone", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const status = yield* SessionStatus.Service
+        const svc = yield* SessionPrompt.Service
+        const session = yield* sessions.create({})
+        const part = yield* seedRunningToolPart(dir, session.id)
+
+        yield* status.set(session.id, { type: "retry", attempt: 1, message: "retrying", next: Date.now() + 1000 })
+        yield* svc.sweepOrphanToolParts(session.id)
+
+        const after = yield* readPart(session.id, part.id)
+        if (after?.type !== "tool") throw new Error("expected a tool part")
+        expect(after.state.status).toBe("running")
+      }),
+    ),
+  )
+
+  it.live("leaves completed tool parts untouched", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const svc = yield* SessionPrompt.Service
+        const session = yield* sessions.create({})
+        const user = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user" as const,
+          sessionID: session.id,
+          agent: "default",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() },
+        })
+        const assistant = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant" as const,
+          sessionID: session.id,
+          mode: "default",
+          agent: "default",
+          path: { cwd: path.resolve(dir), root: path.resolve(dir) },
+          cost: 0,
+          tokens: { output: 0, input: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: ModelID.make("test-model"),
+          providerID: ProviderID.make("test"),
+          parentID: user.id,
+          time: { created: Date.now() },
+        })
+        const part = yield* sessions.updatePart({
+          id: PartID.ascending(),
+          messageID: assistant.id,
+          sessionID: session.id,
+          type: "tool" as const,
+          tool: "read",
+          callID: `call-${assistant.id}`,
+          state: {
+            status: "completed" as const,
+            input: {},
+            output: "ok",
+            title: "read",
+            metadata: {},
+            time: { start: 1, end: 2 },
+          },
+        })
+
+        yield* svc.sweepOrphanToolParts(session.id)
+
+        const after = yield* readPart(session.id, part.id)
+        if (after?.type !== "tool") throw new Error("expected a tool part")
+        expect(after.state.status).toBe("completed")
+      }),
+    ),
+  )
+})
+
+describe("MessageV2.abortedToolState", () => {
+  it.live("keeps the original start time and stamps interrupted", () =>
+    Effect.sync(() => {
+      const state = MessageV2.abortedToolState({
+        status: "running",
+        input: { a: 1 },
+        metadata: { foo: "bar" },
+        time: { start: 42 },
+      })
+      expect(state.status).toBe("error")
+      expect(state.input).toEqual({ a: 1 })
+      expect(state.time.start).toBe(42)
+      expect(state.metadata).toMatchObject({ foo: "bar", interrupted: true })
+    }),
+  )
+
+  it.live("synthesizes a start time for a pending part", () =>
+    Effect.sync(() => {
+      const state = MessageV2.abortedToolState({ status: "pending", input: {}, raw: "" })
+      expect(state.status).toBe("error")
+      expect(state.time.start).toBe(state.time.end)
+      expect(state.metadata?.interrupted).toBe(true)
+    }),
+  )
+})


### PR DESCRIPTION
Two independent robustness defects. Both are small and both are about surviving an
interruption, so they ride in one PR; the diffs do not overlap and can be reviewed
section by section.

## A — orphaned `running` tool parts are never repaired

A tool part is persisted as `running` the moment the tool STARTS, deliberately, so the
TUI can stream progress (`prompt.ts:1037/1461/1677`, `processor.ts:496`). Only the abort
finalizer in `SessionProcessor.cleanup` rewrites it, and that finalizer iterated the
**in-memory** `ctx.toolcalls` map of the owning process (`processor.ts:743-759`). Every
exit path that skips it leaves the DB row at `running` forever: process kill, crash, dev
restart, a second interruption after `ctx.toolcalls = {}`, a `readToolCall` miss, or the
250 ms `Deferred.await(...).pipe(Effect.timeout("250 millis"))` window. There was **no**
startup or session-load repair anywhere (`session/index.ts`, `storage/db.ts`: zero hits).
Live evidence, re-measured across the whole store: **168 orphaned tool parts (126 `running`
+ 42 `pending`) across 92 sessions**; in one two-week-old session `completed 2474 / error 105
/ running 48`, of which exactly one was genuinely in flight — i.e. a per-interruption leak.

### This is NOT the empty-content provider 400 — proven by wire-level construction

This shape was investigated as a candidate producer of `messages.<N>: user messages must
have non-empty content` and **excluded**. The exclusion is now a construction, not an
argument: a prompt captured from a real `LanguageModelV3.doStream` shows that an assistant
message whose ONLY part is an orphaned `running`/`pending` tool part converts to

```
assistant([tool-call])  +  tool([tool-result { type: "error-text",
                                               value: "[Tool execution was interrupted]" }])
```

yielding **zero** empty-content messages. `message-v2.ts:886-899` (the correct lines; an
earlier revision of this description cited the stale `:872-883`) matches **both**
discriminants and substitutes a hard-coded non-empty literal that no data can empty, and
`ai@6.0.168`'s empty-text strip (`dist/index.mjs:1424`) lives in the `role:"user"` branch
and only inspects `type:"text"` parts — it never drops a `tool-result` from a `role:"tool"`
block. So no tool part in any state can yield `content: []`.

The timeline agrees: 74 recorded 400s span 2026-07-14 → 07-28 while the first orphan-only
assistant message in that session is 2026-07-28, so **62 of 74 predate the shape**, and 6 of
the 7 sessions carrying the shape have zero 400s. The real producer was a bare-string
continuation turn in `ProviderTransform.ensureTrailingUserMessage` — see #1948.

So the defect fixed here is **data hygiene and UI truthfulness**, not provider legality: the
transcript permanently shows tool calls that will never finish. It never touches the
persisted row today.

Fix, two layers:

- **`cleanup()` gets a second, DB-driven pass** over the assistant message's own tool
  parts (`MessageV2.parts(ctx.assistantMessage.id)`), so a call whose registration raced
  teardown, arrived after the map was cleared, or whose `readToolCall` lookup missed is
  still finalized. Every tool part of that message belongs to the turn being torn down,
  so any part still `pending`/`running` is unfinalized by definition. Idempotent.
- **`SessionPrompt.sweepOrphanToolParts`** repairs rows a *previous* process left behind,
  at the same recovery point as the existing `sweepOrphanAssistants` (start of `prompt()`
  for non-spawn/hook sources).

### Safety of the sweep's scoping

A currently executing tool part is also `running`, so a naive "rewrite every running row"
sweep corrupts live turns. Two guards, both required, and the gate lives **inside** the
function rather than in the caller contract:

1. **Session status must be `idle`.** `busy`/`retry` mean an active runner owns the
   session, and a tool can only execute inside a runner's turn. Same argument the shipped
   `sweepOrphanAssistants` caller relies on.
2. **Main slice only** (`sessions.messages` default). `SessionProcessor` publishes status
   for the main slice only (`if (isMain) status.set(...)`), so a subagent slice can be
   executing tools while the session status reads `idle` — its parts are out of scope.

Both finalizers now share `MessageV2.abortedToolState`, so an interrupted part has one
consistent shape (`status: "error"`, `error: "Tool execution aborted"`,
`metadata.interrupted: true`, original `time.start` preserved).

## B — a rejected directory 403 killed the TUI

`server/routes/instance/middleware.ts` rejects any directory outside the server cwd
(except the app-owned orchestrator workspace) with a 403. The generated SDK throws the
parsed response **body** with no status attached, so `sync.tsx`'s bootstrap catch could
not tell a policy rejection from a broken server and ran `await exit(e)` — destroying the
renderer. A user who picked a non-whitelisted worktree lost their entire session.

The whitelist is correct policy and is unchanged. Only its recognisability and client
handling change:

- the 403 body now carries a stable `code: "directory_not_allowed"` plus the rejected
  `directory` (new leaf module `instance/access.ts` owns the code + guard so the TUI does
  not import the server's instance/bootstrap graph);
- `bootstrap` classifies that error as recoverable and rethrows instead of exiting;
  everything else is still fatal;
- the worktree switch restores the previous directory, re-syncs, and toasts
  `Cannot switch to <dir>: outside this server's working directory`.

## Tests

`test/session/prompt-orphan-tool-parts.test.ts` (6) — an orphaned `running` part is
repaired when idle; it is **not** touched while the session is `busy`, nor while it is
`retry`; `completed` parts are untouched; `abortedToolState` shape.

`test/cli/tui/bootstrap-directory-denied.test.tsx` (2) — a 403 from the middleware never
reaches the fatal-exit path (`exit` is never invoked and the error is handed to the
caller); a non-403 bootstrap failure still exits.

Revert probes (each src change reverted alone):

- remove the idle gate → both safety tests fail with `Expected: "running" / Received: "error"`
  (exactly the live-turn corruption the gate prevents);
- neuter the repair → `Expected: "error" / Received: "running"`;
- restore `if (fatal)` → `expect(failure).toBeDefined()` fails, `Received: undefined`
  (bootstrap exited instead of surfacing), while the "still exits" test keeps passing.

`bun typecheck` exit 0.

Test suites compared against a pristine `origin/main` worktree with the identical command
(`bun test test/session/ test/cron/ test/cli/tui/ --timeout 120000`), the two runs
executed side by side:

| | pass | skip | fail | files |
|---|---|---|---|---|
| pristine `origin/main` (60af8f1) | 1015 | 12 | 10 | 124 |
| this branch | 1023 | 12 | 10 | 126 |

`+8 pass / +2 files` is exactly the two new test files. The failure **sets** are byte
identical (`diff` of the sorted `(fail)` lines is empty) — 10 pre-existing failures in the
`session/loop` busy/cancel/queue group, which flake under concurrent suite load and fail
the same way without this change.

Live-verified against `mimo/mimo-v2.5` in an isolated dev home: selecting a worktree
outside the server cwd shows the toast, leaves the transcript intact, and the session
still answers a following turn.

