### PR TITLE
fix(session): never let arg recovery rewrite a route into a new child

### DIFF
--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -330,10 +330,20 @@ function parseSessionScript(script: string): Effect.Effect<SessionOperation[], u
   })
 }
 
+// Fields that only make sense for an operation OTHER than `create` — they name
+// an already-existing session (or an ask/grant target). Their presence is
+// positive evidence the model meant to ROUTE, so recovery must never answer with
+// a synthesized `create`: that would silently spawn a duplicate child instead of
+// erroring, which is precisely the route-first violation #1741 exists to prevent
+// (and it is invisible — no error, just an extra session).
+const ROUTE_ONLY_FIELDS = ["sessionID", "session_id", "sessionIDs", "question", "target"]
+
 // Recover a shell-mode session call shaped like the JSON args (no `script`):
-// a stringified/nested `operation`, or the common bare `{task}` create.
-// Conservative — only the unambiguous create-from-task is synthesized; anything
-// else passes through (nested) or returns undefined (→ teach JSON). Mirrors
+// a stringified/nested `operation`, a FLATTENED `{operation|action, ...operands}`,
+// or the common bare `{task}` create. Conservative — a `create` is synthesized
+// only from an unambiguous bare `{task}` with no routing evidence; everything
+// else either reconstructs the operation the model actually named or returns
+// undefined (→ the call errors loudly and the model self-corrects). Mirrors
 // recoverTaskArgs in tool/task.ts.
 export function recoverSessionArgs(rawArgs: unknown): SessionOperation | undefined {
   if (rawArgs == null || typeof rawArgs !== "object") return undefined
@@ -346,7 +356,23 @@ export function recoverSessionArgs(rawArgs: unknown): SessionOperation | undefin
   }
   if (obj.operation && typeof obj.operation === "object" && !Array.isArray(obj.operation))
     return { operation: obj.operation } as SessionOperation
-  if (typeof obj.task === "string") {
+  // FLATTENED shape, repeatedly observed from mimo-v2.5:
+  //   {"operation":"send","sessionID":"ses_…","task":"…"}
+  // The discriminator sits at the TOP level — either as a bare `operation` verb
+  // that survived the JSON.parse above, or as `action` — with the operands as its
+  // siblings. Re-nest and validate against the real union so the model's actual
+  // intent runs. Note shell-wrap hands a recovered value straight to
+  // def.execute WITHOUT re-validating it, so validating here is what makes the
+  // reconstruction safe; a shape that does not validate returns undefined and
+  // surfaces as an "invalid arguments" error rather than being coerced.
+  const action =
+    typeof obj.action === "string" ? obj.action : typeof obj.operation === "string" ? obj.operation : undefined
+  if (action !== undefined) {
+    const operands = Object.fromEntries(Object.entries(obj).filter(([key]) => key !== "operation" && key !== "action"))
+    const parsed = parameters.safeParse({ operation: { ...operands, action } })
+    return parsed.success ? (parsed.data as SessionOperation) : undefined
+  }
+  if (typeof obj.task === "string" && !ROUTE_ONLY_FIELDS.some((field) => obj[field] !== undefined)) {
     const op: Record<string, unknown> = { action: "create", task: obj.task }
     if (obj.mode === "build" || obj.mode === "plan" || obj.mode === "compose") op.mode = obj.mode
     if (typeof obj.model === "string") op.model = obj.model

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -938,6 +938,85 @@ describe("recoverSessionArgs", () => {
       operation: { action: "create", task: "x" },
     })
   })
+
+  // --- route-first safety -------------------------------------------------
+  // The recovery fallback must never answer a malformed call with a `create`
+  // when the payload carries evidence of a different intent. A silently
+  // synthesized `create` spawns a DUPLICATE child instead of relaying to the
+  // existing one — the route-first violation #1741 exists to prevent, and it is
+  // invisible (no error, just an extra session). A loud failure is acceptable;
+  // silent misrouting is not.
+
+  test("NEVER yields a create when the payload carries a routing field", () => {
+    // Each of these names an existing session (or an ask/grant target), so the
+    // model cannot have meant "spawn a new child".
+    const routed = [
+      { task: "relay this", sessionID: "ses_abc" },
+      { task: "relay this", session_id: "ses_abc" },
+      { task: "relay this", sessionIDs: ["ses_abc"] },
+      { task: "relay this", question: "what is the status?" },
+      { task: "relay this", target: "ses_abc" },
+      { task: "relay this", sessionID: "ses_abc", mode: "compose", model: "standard", title: "T" },
+    ]
+    for (const args of routed) {
+      const out = recoverSessionArgs(args)
+      expect(out?.operation?.action).not.toBe("create")
+      // Nothing here is a complete, unambiguous operation, so recovery declines
+      // and the call surfaces as an "invalid arguments" error the model can fix.
+      expect(out).toBeUndefined()
+    }
+  })
+
+  test("reconstructs the FLATTENED send that mimo-v2.5 actually emits", () => {
+    // Observed verbatim from mimo-v2.5: the discriminator is hoisted to the top
+    // level and the operands become its siblings.
+    expect(recoverSessionArgs({ operation: "send", sessionID: "ses_abc", task: "continue the refactor" })).toEqual({
+      operation: { action: "send", sessionID: "ses_abc", task: "continue the refactor" },
+    })
+    // Same shape with `action` as the top-level discriminator.
+    expect(recoverSessionArgs({ action: "send", sessionID: "ses_abc", task: "continue the refactor" })).toEqual({
+      operation: { action: "send", sessionID: "ses_abc", task: "continue the refactor" },
+    })
+  })
+
+  test("reconstructs other flattened operations", () => {
+    expect(recoverSessionArgs({ operation: "status", sessionID: "ses_abc" })).toEqual({
+      operation: { action: "status", sessionID: "ses_abc" },
+    })
+    expect(recoverSessionArgs({ operation: "cancel", sessionID: "ses_abc" })).toEqual({
+      operation: { action: "cancel", sessionID: "ses_abc" },
+    })
+    expect(recoverSessionArgs({ action: "ask", session_id: "ses_abc", question: "done?" })).toEqual({
+      operation: { action: "ask", session_id: "ses_abc", question: "done?" },
+    })
+    expect(recoverSessionArgs({ operation: "list" })).toEqual({ operation: { action: "list" } })
+    // A flattened create is still a create — the verb, not the field set, decides.
+    expect(recoverSessionArgs({ operation: "create", task: "build a login page" })).toEqual({
+      operation: { action: "create", task: "build a login page" },
+    })
+  })
+
+  test("a flattened operation that does not validate fails loudly instead of degrading to a create", () => {
+    // `send` without its required `task`: recovery must not fall through to the
+    // bare-{task} create branch, and must not hand execute a half-built op
+    // (shell-wrap routes a recovered value to def.execute WITHOUT re-validating).
+    expect(recoverSessionArgs({ operation: "send", sessionID: "ses_abc" })).toBeUndefined()
+    // `send` without its required `sessionID`.
+    expect(recoverSessionArgs({ operation: "send", task: "relay this" })).toBeUndefined()
+    // An unknown verb, with a task present that would previously have been
+    // rewritten into a create.
+    expect(recoverSessionArgs({ operation: "teleport", task: "relay this" })).toBeUndefined()
+    expect(recoverSessionArgs({ action: "teleport", task: "relay this" })).toBeUndefined()
+  })
+
+  test("a bare {task} with no routing evidence still creates (unchanged)", () => {
+    expect(recoverSessionArgs({ task: "build a login page" })).toEqual({
+      operation: { action: "create", task: "build a login page" },
+    })
+    expect(recoverSessionArgs({ task: "x", topic: "auth" })).toEqual({
+      operation: { action: "create", task: "x", topic: "auth" },
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

`recoverSessionArgs` (`src/tool/session.ts:338` at `origin/main`) is the shell-mode fallback for a malformed `session` tool call. Its last branch synthesizes a **`create`** from *any* payload that carries a `task` string:

```ts
if (typeof obj.task === "string") {
  const op: Record<string, unknown> = { action: "create", task: obj.task }
  ...
```

`mimo-v2.5` repeatedly emits a **FLATTENED** shape instead of the nested one:

```json
{"operation":"send","sessionID":"ses_0582701b9ffenkU394MLPdIi6d","task":"…"}
```

`strictObject` rejects that with "Invalid arguments" today, so the recovery path is **not** reached in practice (the call errors loudly first and the model retries correctly — verified in live runs). But if it ever were, a correct **route-to-existing-child `send` would be silently converted into a NEW child `create`** — the exact route-first violation #1741 exists to prevent, and invisible: no error surfaces, you just get a duplicate child session doing the work the standing child should have picked up.

The same hazard applies to `{"action":"send","sessionID":…,"task":…}`, and to any `{task, sessionID}` pair with no verb at all.

## The fix, and why this shape

Two changes, both in `recoverSessionArgs`:

1. **Reconstruct the flattened shape properly rather than merely erroring.** The top-level discriminator — a bare `operation` verb string that survived the `JSON.parse` attempt, or `action` — is re-nested with its sibling operands and **validated against the real `parameters` union**. On success the model's actual intent runs (`send` stays a `send`); on failure we return `undefined`.

   Justification for recovering rather than only erroring: this is a real, repeatedly observed model output, the intent is unambiguous (the verb is stated explicitly), and the reconstruction is *checked* — so it cannot misroute. Validation is load-bearing here, not decoration: `shell-wrap.ts:44-47` hands a recovered value straight to `def.execute` **without** re-validating it against `parameters` (the comment there claiming otherwise is wrong), so an unvalidated re-nest could have pushed a half-built op into the send branch. A loud error remains the outcome for anything that does not validate.

2. **Never synthesize a `create` when the payload carries routing evidence.** If any of `sessionID` / `session_id` / `sessionIDs` / `question` / `target` is present, the model named an existing session (or an ask/grant target) and cannot have meant "spawn a new child" — recovery declines and returns `undefined`, so the call errors loudly and the model self-corrects. A loud error that makes the model retry is acceptable; silent misrouting is not.

A bare `{task}` with no routing evidence still recovers into a `create`, unchanged.

## Tests (`test/tool/session-tool.test.ts`)

- **`NEVER yields a create when the payload carries a routing field`** — a battery of malformed payloads (`sessionID`, `session_id`, `sessionIDs`, `question`, `target`, and one with create-ish decorations alongside a `sessionID`) each assert `action !== "create"` and that recovery declines.
- **`reconstructs the FLATTENED send that mimo-v2.5 actually emits`** — both the `operation:"send"` and `action:"send"` variants become `{operation:{action:"send",sessionID,task}}`.
- **`reconstructs other flattened operations`** — `status`, `cancel`, `ask` (with its snake_case `session_id`), `list`, and a flattened `create`.
- **`a flattened operation that does not validate fails loudly instead of degrading to a create`** — `send` missing `task`, `send` missing `sessionID`, and unknown verbs all return `undefined` rather than falling through to the create branch.
- **`a bare {task} with no routing evidence still creates (unchanged)`** plus all seven pre-existing `recoverSessionArgs` tests, untouched and passing.

Revert-probed: with the function body restored to its `origin/main` form, exactly these 4 new tests fail, the central one verbatim as

```
error: expect(received).not.toBe(expected)
Expected: not "create"
(fail) recoverSessionArgs > NEVER yields a create when the payload carries a routing field
```

`bun typecheck` exits 0; `test/tool/session-tool.test.ts` is 56 pass / 1 skip / 0 fail.
