### PR TITLE
fix(inbox): stop the drain from persisting an empty user text part (the Bedrock 400 producer)

### DIFF
--- a/packages/opencode/src/inbox/inbox.ts
+++ b/packages/opencode/src/inbox/inbox.ts
@@ -248,6 +248,44 @@ export const layer: Layer.Layer<
         return 0
       }
 
+      // Render BEFORE writing anything, and drop any row that renders blank.
+      // The drain is the one user-message producer that does NOT go through
+      // SessionPrompt.createUserMessage, so `hasSubstantiveContent` never sees
+      // it — a blank render would persist a user message whose only part is
+      // {type:"text",text:""}. The AI SDK's user branch filters empty text
+      // parts out with NO backfill, so that message reaches the provider as
+      // `content: []` and is rejected ("user messages must have non-empty
+      // content"). renderInboxRow already substitutes a placeholder for a
+      // blank body; this is the structural invariant that keeps the shape
+      // unreachable no matter what any future row type renders.
+      const rendered = rows.flatMap((row) => {
+        const text = renderInboxRow(row)
+        if (text.trim().length > 0) return [{ row, text }]
+        log.warn("inbox.drain: dropping row that rendered blank (would produce an empty user text part)", {
+          sessionID,
+          actorID,
+          rowID: row.id,
+          type: row.type,
+        })
+        return []
+      })
+
+      // Every row rendered blank: consume them (they carry no information and
+      // must not be re-drained forever) without writing a message at all. A
+      // zero-part user message would be skipped downstream anyway, so writing
+      // one is pure litter.
+      if (rendered.length === 0) {
+        yield* Effect.sync(() =>
+          Database.use((db) =>
+            db
+              .delete(InboxTable)
+              .where(inArray(InboxTable.id, rows.map((r) => r.id)))
+              .run(),
+          ),
+        )
+        return 0
+      }
+
       // Non-transactional crash window: updateMessage + updatePart commit
       // before the inbox DELETE. A crash between them re-renders the same
       // rows on next drain — LLM sees duplicated notifications. Tolerable;
@@ -265,14 +303,14 @@ export const layer: Layer.Layer<
         agent: seed.agent,
         model: seed.model,
       })
-      for (const row of rows) {
+      for (const entry of rendered) {
         yield* sessions.updatePart({
           id: PartID.ascending(),
           messageID: msgID,
           sessionID,
           type: "text" as const,
           synthetic: true,
-          text: renderInboxRow(row),
+          text: entry.text,
         })
       }
       yield* Effect.sync(() =>
@@ -284,7 +322,7 @@ export const layer: Layer.Layer<
         ),
       )
 
-      return rows.length
+      return rendered.length
     })
 
     const impl = Service.of({ send, drain })

--- a/packages/opencode/src/inbox/render.ts
+++ b/packages/opencode/src/inbox/render.ts
@@ -1,11 +1,21 @@
 import type { InboxRow } from "./inbox.sql"
 
+// A blank body must fall back to the placeholder, not just a missing one.
+// `?? placeholder` only catches null/undefined, but a blank body is stored as
+// "" (or whitespace) — and for actor_notification the body is passed through
+// RAW, so "" would become a user text part with text:"". The AI SDK's user
+// branch filters empty text parts out with no backfill, leaving `content: []`
+// and a provider 400 ("user messages must have non-empty content").
+function blankTo(text: string | undefined, placeholder: string) {
+  return text !== undefined && text.trim().length > 0 ? text : placeholder
+}
+
 export function renderInboxRow(row: InboxRow): string {
   if (row.type === "actor_notification") {
     // Pre-rendered notification text — sender produced the full
     // <actor-notification>...</actor-notification> wrapper.
     const content = row.content as { text?: string }
-    return content.text ?? "(no notification body)"
+    return blankTo(content.text, "(no notification body)")
   }
   // Default: type === "text" or unknown — wrap as <inbox> element so
   // the LLM can route by sender; the wrapper format mirrors the
@@ -15,7 +25,7 @@ export function renderInboxRow(row: InboxRow): string {
     ? `${row.sender_session_id}:${row.sender_actor_id ?? "?"}`
     : "system"
   const sentAt = new Date(row.created_at).toISOString()
-  return `<inbox from="${sender}" sent_at="${sentAt}">\n${content.text ?? "(empty)"}\n</inbox>`
+  return `<inbox from="${sender}" sent_at="${sentAt}">\n${blankTo(content.text, "(empty)")}\n</inbox>`
 }
 
 export function renderActorNotification(event: {

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -178,6 +178,18 @@ const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefin
       const { flags, rest } = yield* extractNamedFlags(args, ["session", "type"], line)
       if (rest.length !== 2)
         return yield* actorArityError("send", '<to_actor_id> "<content>" [--session <id>] [--type <t>]', rest, line)
+      // Parity with the JSON path's `content: z.string().min(1)`. shell-wrap
+      // hands a parsed shell op straight to execute WITHOUT re-validating it
+      // against `parameters`, so without this an `actor send x ""` stores a
+      // blank inbox row — and a blank `actor_notification` body is rendered
+      // through raw, producing a user message whose only part is an empty text
+      // part (a provider 400). Reject at the boundary instead.
+      if (rest[1].trim() === "")
+        return yield* Effect.fail({
+          kind: "flag" as const,
+          line,
+          detail: "actor: send: content must not be empty",
+        })
       return {
         operation: {
           action: "send" as const,

--- a/packages/opencode/test/inbox/drain-no-empty-part.test.ts
+++ b/packages/opencode/test/inbox/drain-no-empty-part.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Layer, ManagedRuntime } from "effect"
+import { Inbox } from "../../src/inbox"
+import { renderInboxRow } from "../../src/inbox/render"
+import type { InboxRow } from "../../src/inbox/inbox.sql"
+import { defaultModelRef } from "../../src/inbox/inbox-ref"
+import { ActorRegistry } from "../../src/actor/registry"
+import { Session } from "../../src/session"
+import { Bus } from "../../src/bus"
+import { Instance } from "../../src/project/instance"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { tmpdir } from "../fixture/fixture"
+
+// The inbox drain is the ONE user-message producer that does not go through
+// SessionPrompt.createUserMessage, so `hasSubstantiveContent` never inspects
+// it. A blank `actor_notification` body therefore used to be persisted verbatim
+// as a user message whose only part is {type:"text",text:""} — and ai@6's
+// `convertToLanguageModelMessage` user branch filters empty text parts out with
+// NO backfill, so that message reaches the provider as `content: []` and is
+// rejected with `messages.<N>: user messages must have non-empty content`.
+//
+// These tests pin the producer-side invariant: the drain never persists a blank
+// text part, for any row content.
+
+const base = Layer.mergeAll(Session.defaultLayer, ActorRegistry.defaultLayer, Bus.defaultLayer)
+const testLayer = Inbox.layer.pipe(Layer.provide(base), Layer.provideMerge(base))
+
+afterEach(async () => {
+  defaultModelRef.current = undefined
+  await Instance.disposeAll()
+})
+
+type RT = ManagedRuntime.ManagedRuntime<Inbox.Service | Session.Service | ActorRegistry.Service | Bus.Service, never>
+
+async function withInbox(directory: string, fn: (rt: RT) => Promise<void>) {
+  return Instance.provide({
+    directory,
+    fn: async () => {
+      const rt = ManagedRuntime.make(testLayer)
+      try {
+        await fn(rt)
+      } finally {
+        await rt.dispose()
+      }
+    },
+  })
+}
+
+async function seedRealMessage(rt: RT, sessionID: SessionID, actorID: string) {
+  return rt.runPromise(
+    Session.Service.use((sessions) =>
+      sessions.updateMessage({
+        id: MessageID.ascending(),
+        role: "user" as const,
+        sessionID,
+        agentID: actorID,
+        time: { created: Date.now() },
+        agent: "general",
+        model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+      }),
+    ),
+  )
+}
+
+async function registerActor(rt: RT, sessionID: SessionID, actorID: string) {
+  return rt.runPromise(
+    ActorRegistry.Service.use((reg) =>
+      reg.register({
+        sessionID,
+        actorID,
+        mode: "subagent",
+        parentActorID: undefined,
+        agent: "general",
+        description: "test",
+        contextMode: "none",
+        contextWatermark: undefined,
+        background: false,
+        lifecycle: "ephemeral",
+      }),
+    ),
+  )
+}
+
+function row(overrides: Partial<InboxRow>): InboxRow {
+  return {
+    id: "01JTESTROW",
+    receiver_session_id: SessionID.make("ses_receiver"),
+    receiver_actor_id: "main",
+    sender_session_id: SessionID.make("ses_sender"),
+    sender_actor_id: "explore-1",
+    type: "text",
+    content: { text: "hello" },
+    created_at: 1_700_000_000_000,
+    ...overrides,
+  } as InboxRow
+}
+
+describe("renderInboxRow never returns a blank string", () => {
+  // `content.text ?? placeholder` only catches null/undefined. An empty body is
+  // stored as "" and, for actor_notification, passed through RAW.
+  test("actor_notification with an empty body falls back to the placeholder", () => {
+    const rendered = renderInboxRow(row({ type: "actor_notification", content: { text: "" } }))
+    expect(rendered).toBe("(no notification body)")
+    expect(rendered.trim().length).toBeGreaterThan(0)
+  })
+
+  test("actor_notification with a whitespace-only body falls back to the placeholder", () => {
+    expect(renderInboxRow(row({ type: "actor_notification", content: { text: "   \n\t " } }))).toBe(
+      "(no notification body)",
+    )
+  })
+
+  test("actor_notification with a missing body still falls back", () => {
+    expect(renderInboxRow(row({ type: "actor_notification", content: {} }))).toBe("(no notification body)")
+  })
+
+  test("actor_notification with a real body is passed through verbatim", () => {
+    const body = "<actor-notification>\nchild completed.\n</actor-notification>"
+    expect(renderInboxRow(row({ type: "actor_notification", content: { text: body } }))).toBe(body)
+  })
+
+  test("a text row with an empty body renders the (empty) placeholder inside the wrapper", () => {
+    const rendered = renderInboxRow(row({ type: "text", content: { text: "" } }))
+    expect(rendered).toContain("(empty)")
+    expect(rendered.trim().length).toBeGreaterThan(0)
+  })
+})
+
+describe("Inbox.drain never persists an empty user text part", () => {
+  test("a blank actor_notification body yields a non-blank synthetic part", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withInbox(tmp.path, async (rt) => {
+      const session = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await registerActor(rt, session.id, "actor-empty")
+      await seedRealMessage(rt, session.id, "actor-empty")
+
+      // This is the reachable producer: a blank body reaches the inbox (the
+      // `actor` tool's JSON path guards it with .min(1), but the shell path did
+      // not, and inbox.send itself does not validate).
+      await rt.runPromise(
+        Inbox.Service.use((inbox) =>
+          inbox.send({
+            receiverSessionID: session.id,
+            receiverActorID: "actor-empty",
+            type: "actor_notification",
+            content: "",
+          }),
+        ),
+      )
+
+      const count = await rt.runPromise(Inbox.Service.use((inbox) => inbox.drain(session.id, "actor-empty")))
+      // The notification is NOT lost — it is rendered with a placeholder.
+      expect(count).toBe(1)
+
+      const msgs = await rt.runPromise(
+        Session.Service.use((sessions) => sessions.messages({ sessionID: session.id, agentID: "actor-empty" })),
+      )
+      const synthetic = msgs
+        .filter((m) => m.info.role === "user")
+        .flatMap((m) => m.parts)
+        .filter((p) => p.type === "text" && p.synthetic)
+
+      expect(synthetic.length).toBe(1)
+      // THE INVARIANT: no persisted user text part may be empty or blank.
+      for (const part of synthetic) {
+        expect(part.type === "text" && part.text).not.toBe("")
+        expect(part.type === "text" && part.text.trim().length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  test("a blank body mixed with a real one keeps both parts non-blank", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withInbox(tmp.path, async (rt) => {
+      const session = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await registerActor(rt, session.id, "actor-mixed")
+      await seedRealMessage(rt, session.id, "actor-mixed")
+
+      await rt.runPromise(
+        Inbox.Service.use((inbox) =>
+          inbox.send({
+            receiverSessionID: session.id,
+            receiverActorID: "actor-mixed",
+            type: "actor_notification",
+            content: "",
+          }),
+        ),
+      )
+      await rt.runPromise(
+        Inbox.Service.use((inbox) =>
+          inbox.send({
+            receiverSessionID: session.id,
+            receiverActorID: "actor-mixed",
+            type: "actor_notification",
+            content: "<actor-notification>\nreal body\n</actor-notification>",
+          }),
+        ),
+      )
+
+      const count = await rt.runPromise(Inbox.Service.use((inbox) => inbox.drain(session.id, "actor-mixed")))
+      expect(count).toBe(2)
+
+      const msgs = await rt.runPromise(
+        Session.Service.use((sessions) => sessions.messages({ sessionID: session.id, agentID: "actor-mixed" })),
+      )
+      const texts = msgs
+        .filter((m) => m.info.role === "user")
+        .flatMap((m) => m.parts)
+        .filter((p) => p.type === "text" && p.synthetic)
+        .map((p) => (p.type === "text" ? p.text : ""))
+
+      expect(texts.length).toBe(2)
+      expect(texts.every((t) => t.trim().length > 0)).toBe(true)
+      expect(texts).toContain("(no notification body)")
+    })
+  })
+})

--- a/packages/opencode/test/tool/actor.shell.test.ts
+++ b/packages/opencode/test/tool/actor.shell.test.ts
@@ -198,6 +198,34 @@ describe("actor.shell.parse: send", () => {
     expect(err.kind).toBe("arity")
     expect(err.detail).toContain("to_actor_id")
   })
+
+  // Parity with the JSON path's `content: z.string().min(1)` (actor.ts). shell-wrap
+  // hands a parsed shell op straight to execute WITHOUT re-validating it against
+  // `parameters`, so a blank content used to reach inbox.send — and a blank
+  // `actor_notification` body is rendered through RAW, producing a user message
+  // whose only part is an empty text part (the AI SDK drops it with no backfill
+  // → `content: []` → provider 400 "user messages must have non-empty content").
+  for (const script of [
+    'actor send main ""',
+    'actor send main "" --type actor_notification',
+    'actor send main "   " --type actor_notification',
+  ]) {
+    test(`send rejects a blank content: ${script}`, async () => {
+      const exit = await Effect.runPromise(Effect.exit(parseActorScript(script)))
+      expect(exit._tag).toBe("Failure")
+      const cause: any = (exit as any).cause
+      const fail = cause.reasons?.find?.((r: any) => r._tag === "Fail") ?? cause
+      const err = fail.error ?? fail
+      expect(err.detail).toContain("content must not be empty")
+    })
+  }
+
+  test("send still accepts a short non-blank content (guard is not over-broad)", async () => {
+    const out = await parse('actor send main "0" --type actor_notification')
+    expect(out).toEqual([
+      { operation: { action: "send", to_actor_id: "main", content: "0", type: "actor_notification" } },
+    ])
+  })
 })
 
 describe("actor.shell.parse: full parity flags", () => {


### PR DESCRIPTION
## What this is

The **producer** behind the live Bedrock 400 `messages.<N>: user messages must have non-empty content`.

`64a128523` ("never PRODUCE an empty-content user message") guarded `createUserMessage`, and #1948 adds a pre-send backstop. Neither covers `Inbox.drain` — **the one user-message producer that does not go through `createUserMessage`**, so `hasSubstantiveContent` (`prompt.ts:4386`) never inspects it. This closes that producer.

#1948's `ensureNonEmptyContent` is deliberately left **intact** — defence in depth is wanted here.

## Root cause

- `renderInboxRow` (`src/inbox/render.ts:8`) used `content.text ?? "(no notification body)"`. `??` only catches `null`/`undefined`; a blank body is stored as `""` (`inbox.ts:162` `content: { text: input.content }`), and an `actor_notification` body is passed through **RAW** with no wrapper. So a blank notification rendered to `""`.
- `Inbox.drain` (`src/inbox/inbox.ts:268-277`) wrote one text part per row unconditionally, so that `""` was persisted as a user message whose only part is `{type:"text",text:""}` — `parts.length === 1`, which every `content.length === 0` check misses.
- `ai@6.0.168`'s `convertToLanguageModelMessage` user branch filters empty text parts out with **no backfill** (`.filter(p => p.type !== "text" || p.text !== "")`), so that message reaches the provider as `content: []` → the 400.
- The blank body is **reachable**: the `actor` tool's JSON path guards content with `z.string().min(1)` (`src/tool/actor.ts:454`) but the **shell** path (`src/tool/actor.ts:177-189`) did not, and `shell-wrap.ts:121` hands a parsed shell op straight to `execute` without re-validating it against `parameters`.

## Changes (three layers, outermost first)

1. **`src/tool/actor.ts`** — the shell `send` parser rejects a blank content, restoring parity with the JSON path's `.min(1)`.
2. **`src/inbox/render.ts`** — a `blankTo` helper substitutes the placeholder for any **blank** body, not just a missing one, for both row kinds. A blank notification is now visible to the model as `(no notification body)` rather than silently empty, so nothing is lost.
3. **`src/inbox/inbox.ts`** — the drain renders **before** writing anything and drops any row that renders blank; if every row renders blank it consumes the rows without writing a message at all. This is the structural invariant that keeps the fatal shape unreachable regardless of what a future row type renders.

## Tests

- **`test/inbox/drain-no-empty-part.test.ts`** (new, 7 tests): `renderInboxRow` never returns a blank string (empty / whitespace-only / missing body, plus verbatim passthrough for a real body); end-to-end, a blank `actor_notification` drained into a session yields exactly one **non-blank** synthetic part, and a blank mixed with a real one keeps both parts non-blank.
- **`test/tool/actor.shell.test.ts`** (+4): the shell `send` parser rejects `""` and whitespace-only content, and still accepts a short non-blank one.

### Each test proven to fail without its src change

| revert | result | observed failure |
|---|---|---|
| `render.ts` alone | 5 fail | the drain filter catches the blank row, so the notification is dropped: `expect(count).toBe(1)` → `Received: 0` |
| `render.ts` **and** `inbox.ts` (= pristine `main`) | 5 fail | the original defect shape is persisted: `expect(received).not.toBe("")` → `Expected: not ""` |
| `tool/actor.ts` alone | 3 fail | `expect(exit._tag).toBe("Failure")` → `Received: "Success"` |

## Verification

`bun typecheck` exit 0. Affected suites (`test/inbox/`, `test/tool/actor.shell.test.ts`, `test/tool/session-tool.test.ts`): **127 pass / 1 skip / 0 fail**.

Full `bun test` was run on a superset of this diff; its 15 failures are all pre-existing load-flaky families on the build box (the `prompt-effect` loop/cancel/busy suite, `Vcs` branch watchers, workflow timeouts) and none touch inbox, render, or the actor shell parser.

## Not in scope

Defect B — `recoverSessionArgs` silently rewriting a correct `send` into a `create` — ships separately as #1962.