### PR TITLE
fix(actor): derive liveness from last activity, not last completed step — a child blocked mid-step was indistinguishable from a dead one

### DIFF
--- a/packages/opencode/migration/20260729000000_actor_registry_last_activity_time/migration.sql
+++ b/packages/opencode/migration/20260729000000_actor_registry_last_activity_time/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `actor_registry` ADD COLUMN `last_activity_time` integer;

--- a/packages/opencode/src/actor/actor.sql.ts
+++ b/packages/opencode/src/actor/actor.sql.ts
@@ -24,6 +24,14 @@ export const ActorRegistryTable = sqliteTable(
     tools: text({ mode: "json" }).$type<readonly string[] | "INHERIT">(),
     last_turn_time: integer().notNull(),
     turn_count: integer().notNull().default(0),
+    // Last time ANY part write landed for this actor's (session_id, agent_id)
+    // slice — the last moment something actually succeeded, at per-API-call
+    // granularity instead of per-completed-step. Nullable on purpose: rows that
+    // predate this column, and a row read in the instant between register() and
+    // its first part write, have genuinely recorded no activity, and NULL states
+    // that rather than inventing a timestamp. Written by the PartUpdated
+    // projector (session/projectors.ts), the single writer of `part` rows.
+    last_activity_time: integer(),
     last_error: text(),
     instance_id: text().notNull(),
     time_completed: integer(),

--- a/packages/opencode/src/actor/events.ts
+++ b/packages/opencode/src/actor/events.ts
@@ -41,17 +41,21 @@ export const ActorStuck = BusEvent.define(
 )
 
 // Emitted by the T40 stall watchdog when a background peer/subagent transitions
-// into `stalled` liveness (running/pending but no turn advance past the stall
-// window) and the one-shot parent notification is pushed. Fires once per stall
-// episode — re-arms only after the child resumes (turnCount advances) or reaches
-// terminal. Observability hook for tests + TUI.
+// into `stalled` liveness (running/pending but nothing has landed for the actor's
+// slice past the stall window) and the one-shot parent notification is pushed.
+// Fires once per stall episode — re-arms only once activity lands again or the
+// child reaches terminal. Observability hook for tests + TUI.
+// `lastActivityTime` is the reference the verdict was actually computed from (the
+// last part write, or spawn time when nothing has landed yet), NOT last_turn_time:
+// a payload reporting a different quantity than its own predicate used is how this
+// signal came to be misread.
 export const ActorStalled = BusEvent.define(
   "actor.stalled",
   z.object({
     sessionID: SessionID.zod,
     actorID: z.string(),
     description: z.string(),
-    lastTurnTime: z.number(),
+    lastActivityTime: z.number(),
     stalledDuration: z.number(),
   }),
 )

--- a/packages/opencode/src/actor/registry.ts
+++ b/packages/opencode/src/actor/registry.ts
@@ -41,6 +41,7 @@ function fromRow(row: ActorRow): Actor {
     tools: row.tools ?? undefined,
     lastTurnTime: row.last_turn_time,
     turnCount: row.turn_count,
+    lastActivityTime: row.last_activity_time ?? undefined,
     lastError: row.last_error ?? undefined,
     time: {
       created: row.time_created,
@@ -145,6 +146,10 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
         tools: input.tools ?? null,
         last_turn_time: now,
         turn_count: 0,
+        // No part has landed for this actor yet. NULL, not `now`: deriveLiveness
+        // falls back to time_created when activity is absent, so seeding a fake
+        // activity timestamp here would assert something happened that did not.
+        last_activity_time: null,
         last_error: null,
         instance_id: instanceID,
         time_completed: null,

--- a/packages/opencode/src/actor/schema.ts
+++ b/packages/opencode/src/actor/schema.ts
@@ -73,13 +73,41 @@ export type Actor = z.infer<typeof Actor>
 export const Liveness = z.enum(["progressing", "stalled", "success", "failure", "cancelled", "idle"])
 export type Liveness = z.infer<typeof Liveness>
 
-// Default staleness threshold: a running child with no activity for this long is
-// reported `stalled` (still routable — a display distinction, not a verdict).
-// 90s was chosen against the per-step cadence; against the activity signal it is
-// if anything more meaningful, because measured inter-activity gaps for real peer
-// children are p50 994ms / p90 6.7s / p99 38s, so 90s of true silence is already
-// past the 99th percentile.
-export const DEFAULT_LIVENESS_STALL_MS = 90_000
+// Default staleness threshold: a running child with no ACTIVITY for this long is
+// reported `stalled` (still routable — a display distinction, not a verdict) and
+// is the condition the T40 watchdog notifies the child's parent about.
+//
+// 6 minutes, not the 90s this was. 90s was picked against the per-step cadence,
+// where it meant "no COMPLETED STEP for 90s". Read against activity the same
+// number means "no PART WRITE for 90s", a far stronger claim of silence, and the
+// measured distribution says that claim is false too often: across 43,120 real
+// inter-activity gaps on a 172-child roster the gaps run p50 994ms / p90 6.7s /
+// p99 38.0s / p99.9 296.8s, so 90s lands strictly BETWEEN p99 and p99.9 —
+// between 0.1% and 1% of gaps produced by perfectly HEALTHY children exceed it.
+// That was not hypothetical: two children sitting inside single long steps (`bun
+// ci`, a full test suite, `git worktree add`) emitted a dozen-plus "appears
+// stalled" notifications at ~90-130s of apparent silence while writing parts
+// continuously. A channel that cries wolf teaches its reader to ignore it, which
+// costs exactly the true stall the channel exists to surface.
+//
+// Bounded from below by two measurements, not by taste:
+//   - the deepest measured natural silence, p99.9 = 296,811ms. A threshold at or
+//     under that fires on healthy children by construction.
+//   - plus ACTIVITY_COALESCE_MS (below). Recorded activity lags reality by up to
+//     one coalesce interval, so apparent age is the real gap plus up to 5s; the
+//     threshold has to clear p99.9 + 5s = 301,811ms or the coalescing lag ALONE
+//     can flip a tail-but-healthy row. That is what disqualifies the otherwise
+//     tidy 300_000 (== registry.ts STUCK_THRESHOLD_MS): 300,000 < 301,811.
+// Bounded from above by DEFAULT_LIVENESS_ABANDON_MS (600s), which must stay the
+// larger of the two or `stalled` becomes unreachable.
+//
+// 360_000 is 1.21x p99.9, clears p99.9 + coalesce by 58.2s (11.6 coalesce
+// intervals), is 72x ACTIVITY_COALESCE_MS, and is 0.6x the abandonment bound —
+// leaving a 240s `stalled` band, ~5 scans at WATCHDOG_SCAN_INTERVAL_MS (45s).
+// The cost is accepted deliberately: a genuine stall now surfaces within ~6
+// minutes instead of ~90 seconds. The abandonment bound still catches a row whose
+// owner is actually gone, and a signal believed late beats one not believed.
+export const DEFAULT_LIVENESS_STALL_MS = 6 * 60_000
 
 // Abandonment bound: how long a row may keep CLAIMING `running`/`pending` before
 // we stop believing it. `progressing` and `stalled` both read as "in progress" to
@@ -126,10 +154,10 @@ export const DEFAULT_LIVENESS_ABANDON_MS = 10 * 60_000
 //
 // 5 seconds, derived from the two consumers of the column, both of which are
 // three orders of magnitude coarser than that write rate:
-//   - DEFAULT_LIVENESS_STALL_MS (90s, above): the progressing/stalled display.
+//   - DEFAULT_LIVENESS_STALL_MS (360s, above): the progressing/stalled display.
 //     An actively-writing actor's recorded activity now lags reality by at most
-//     this interval, so worst-case apparent age is 5s against a 90s threshold —
-//     18x of margin, and the flip is unreachable by coalescing alone.
+//     this interval, so worst-case apparent age is 5s against a 360s threshold —
+//     72x of margin, and the flip is unreachable by coalescing alone.
 //   - DEFAULT_LIVENESS_ABANDON_MS (600s, above): the routable/idle bound. 120x
 //     of margin.
 // Also sits above the measured p50 inter-activity gap (994ms) so it actually

--- a/packages/opencode/src/actor/schema.ts
+++ b/packages/opencode/src/actor/schema.ts
@@ -36,6 +36,10 @@ export const Actor = z
     tools: ToolWhitelist.optional(),
     lastTurnTime: z.number(),
     turnCount: z.number(),
+    // Last part write for this actor's slice. Optional because the column is
+    // nullable — see actor.sql.ts. This is the liveness evidence; lastTurnTime
+    // and turnCount are step bookkeeping and are NOT read by deriveLiveness.
+    lastActivityTime: z.number().optional(),
     lastError: z.string().optional(),
     time: z.object({
       created: z.number(),
@@ -47,16 +51,20 @@ export const Actor = z
 export type Actor = z.infer<typeof Actor>
 
 // Derived liveness: a pull-side signal computed from an actor row's honest
-// registry fields (status, lastOutcome, lastTurnTime). It answers the question
-// raw `status` cannot — is a running child PROGRESSING or STALLED?
-//   - progressing: running/pending AND its last turn advanced within the
-//     staleness window (updateTurn bumps last_turn_time per step, so a recent
-//     last_turn_time == recent progress). Also covers a not-yet-started child
-//     (turnCount === 0): its last_turn_time is the spawn time, so a slow first
-//     turn (queued behind the concurrency gate, model cold-start) must NOT be
-//     mistaken for a stall — it has not had the chance to run even once.
-//   - stalled: running/pending, HAS run at least one turn, BUT no turn advance
-//     for longer than the window.
+// registry fields (status, lastOutcome, lastActivityTime). It answers the
+// question raw `status` cannot — is a running child PROGRESSING or STALLED?
+//
+// The evidence is LAST ACTIVITY, not last completed step. `last_activity_time`
+// advances on every part write for the actor's slice (session/projectors.ts),
+// so a child inside a long tool call, a slow model call or a retry/backoff keeps
+// advancing it; only a child where nothing at all is landing goes quiet. The
+// previous signal was `last_turn_time`, whose sole writer is the per-step
+// heartbeat ActorRegistry.updateTurn — so the finest thing it could see was a
+// COMPLETED step, and a child blocked mid-step was indistinguishable from a dead
+// one. That coarseness is why the bound below used to be 30 minutes.
+//   - progressing: running/pending AND activity within the staleness window.
+//   - stalled: running/pending, but nothing has landed for longer than the
+//     window. Still routable — it means "quiet", not "dead".
 //   - success | failure | cancelled: terminal, taken straight from lastOutcome.
 //   - idle: finished with no recorded outcome, an unknown state, OR a row whose
 //     claim to be running/pending has outlived DEFAULT_LIVENESS_ABANDON_MS — see
@@ -65,11 +73,12 @@ export type Actor = z.infer<typeof Actor>
 export const Liveness = z.enum(["progressing", "stalled", "success", "failure", "cancelled", "idle"])
 export type Liveness = z.infer<typeof Liveness>
 
-// Default staleness threshold: a running child with no turn advance for this
-// long is reported `stalled`. 90s sits between the per-step turn cadence and
-// the 5-minute stuck-detection cutoff, so a briefly-thinking child still reads
-// as progressing while a genuinely wedged one flips to stalled well before the
-// watchdog (T40) would fire.
+// Default staleness threshold: a running child with no activity for this long is
+// reported `stalled` (still routable — a display distinction, not a verdict).
+// 90s was chosen against the per-step cadence; against the activity signal it is
+// if anything more meaningful, because measured inter-activity gaps for real peer
+// children are p50 994ms / p90 6.7s / p99 38s, so 90s of true silence is already
+// past the 99th percentile.
 export const DEFAULT_LIVENESS_STALL_MS = 90_000
 
 // Abandonment bound: how long a row may keep CLAIMING `running`/`pending` before
@@ -80,31 +89,43 @@ export const DEFAULT_LIVENESS_STALL_MS = 90_000
 // ActorRegistry's orphan sweep, and that sweep runs ONCE at process init and only
 // for rows carrying a DIFFERENT instance_id; until it runs — and for any row it
 // cannot reach — the row asserts progress with nothing behind it.
-// 30 minutes, picked the same way DEFAULT_LIVENESS_STALL_MS was: a child that has
-// genuinely begun bumps last_turn_time on EVERY step (updateTurn is the per-step
-// heartbeat), so 30m of silence is an order of magnitude past the 5-minute
-// stuck-detection cutoff and unreachable by a live turn; a child that has not
-// begun is waiting on the concurrency gate, which admits work continuously, so
-// 30m of zero admissions means its process is gone. Past the bound we report
-// `idle` — "finished with no recorded outcome (or an unknown state)", the honest
-// reading and the only non-routable bucket.
-export const DEFAULT_LIVENESS_ABANDON_MS = 30 * 60_000
+//
+// 10 minutes. This replaces a 30-minute bound that existed only because the old
+// signal was step-grained: a single legitimate step in this repo can run 20+
+// minutes (a live test run ~1225s), so any bound had to clear that. Activity
+// granularity removes that constraint, and the number is anchored to measurement
+// rather than to the longest possible step:
+//   - 2x STUCK_THRESHOLD_MS (registry.ts) — the repo's own existing "stuck" cutoff
+//     — rather than a fresh magic number;
+//   - ~16x the measured p99 inter-activity gap (38.0s) and ~2x p99.9 (296.8s) over
+//     43,120 real gaps across a 172-child roster;
+//   - ~345x the worst measured first-activity latency after spawn (1735ms, n=172,
+//     p50 194ms), which is what licensed deleting the old turnCount === 0 case:
+//     the "slow first turn queued behind the concurrency gate" it protected is
+//     empirically under two seconds, not minutes, because the user message that
+//     starts the turn is itself persisted as a part.
+// Direction of error is unchanged and deliberate: prefer a duplicate child
+// (wasteful) over routing into a corpse with re-dispatch suppressed
+// (unrecoverable). Past the bound we report `idle` — "finished with no recorded
+// outcome (or an unknown state)", the honest reading and the only non-routable
+// bucket.
+export const DEFAULT_LIVENESS_ABANDON_MS = 10 * 60_000
 
 export function deriveLiveness(
-  actor: Pick<Actor, "status" | "lastOutcome" | "lastTurnTime" | "turnCount" | "time">,
+  actor: Pick<Actor, "status" | "lastOutcome" | "lastActivityTime" | "time">,
   now: number = Date.now(),
   stallMs: number = DEFAULT_LIVENESS_STALL_MS,
   abandonMs: number = DEFAULT_LIVENESS_ABANDON_MS,
 ): Liveness {
   if (actor.status === "running" || actor.status === "pending") {
-    // A started child's evidence of life is its last turn; a not-yet-started one
-    // has none, so its spawn time is the only honest reference.
-    if (now - (actor.turnCount === 0 ? actor.time.created : actor.lastTurnTime) > abandonMs) return "idle"
-    // Not-yet-started child (no turn completed): a slow first turn (queued behind
-    // the concurrency gate / cold-start) is not a stall — the leniency is kept,
-    // but bounded by abandonMs above rather than unbounded.
-    if (actor.turnCount === 0) return "progressing"
-    return now - actor.lastTurnTime <= stallMs ? "progressing" : "stalled"
+    // One reference for every row, no per-row special case: the last thing that
+    // landed, or — when nothing has landed yet — the spawn time. `?? ` (not
+    // `=== undefined`) because the column is nullable, so this value arrives as
+    // `null` for pre-migration rows and a `!== undefined` guard would silently
+    // pass them through. See AGENTS.md "Reading a nullable column".
+    const since = actor.lastActivityTime ?? actor.time.created
+    if (now - since > abandonMs) return "idle"
+    return now - since <= stallMs ? "progressing" : "stalled"
   }
   if (actor.lastOutcome === "success") return "success"
   if (actor.lastOutcome === "failure") return "failure"

--- a/packages/opencode/src/actor/schema.ts
+++ b/packages/opencode/src/actor/schema.ts
@@ -111,6 +111,34 @@ export const DEFAULT_LIVENESS_STALL_MS = 90_000
 // bucket.
 export const DEFAULT_LIVENESS_ABANDON_MS = 10 * 60_000
 
+// Write-coalescing interval for the `last_activity_time` heartbeat, applied as a
+// staleness guard in the PartUpdated projector's WHERE (session/projectors.ts):
+// the row is touched only when it records no activity yet, or when the activity
+// it records is already older than this. At most one UPDATE per actor per
+// interval. The column's meaning is unchanged — only its resolution is capped.
+//
+// Needed because the heartbeat rides the part-write path, which is unthrottled.
+// `ctx.metadata` in the bash tool (tool/bash.ts, per decoded stdout chunk)
+// reaches Session.updatePart via SessionProcessor.updateToolCall
+// (session/processor.ts) with no interval check anywhere on the way, so a chatty
+// command drove a measured 539-867 registry UPDATEs/sec — each carrying a
+// correlated subquery over `message` — strictly 1:1 with part upserts.
+//
+// 5 seconds, derived from the two consumers of the column, both of which are
+// three orders of magnitude coarser than that write rate:
+//   - DEFAULT_LIVENESS_STALL_MS (90s, above): the progressing/stalled display.
+//     An actively-writing actor's recorded activity now lags reality by at most
+//     this interval, so worst-case apparent age is 5s against a 90s threshold —
+//     18x of margin, and the flip is unreachable by coalescing alone.
+//   - DEFAULT_LIVENESS_ABANDON_MS (600s, above): the routable/idle bound. 120x
+//     of margin.
+// Also sits above the measured p50 inter-activity gap (994ms) so it actually
+// coalesces the dense traffic it targets, while staying below p90 (6.7s) so an
+// ordinarily-paced child still records very nearly every activity it has.
+// Updating more often than this buys no consumer anything: nothing reads the
+// column at a finer resolution than tens of seconds.
+export const ACTIVITY_COALESCE_MS = 5_000
+
 export function deriveLiveness(
   actor: Pick<Actor, "status" | "lastOutcome" | "lastActivityTime" | "time">,
   now: number = Date.now(),

--- a/packages/opencode/src/actor/schema.ts
+++ b/packages/opencode/src/actor/schema.ts
@@ -58,7 +58,9 @@ export type Actor = z.infer<typeof Actor>
 //   - stalled: running/pending, HAS run at least one turn, BUT no turn advance
 //     for longer than the window.
 //   - success | failure | cancelled: terminal, taken straight from lastOutcome.
-//   - idle: finished with no recorded outcome (or an unknown state).
+//   - idle: finished with no recorded outcome, an unknown state, OR a row whose
+//     claim to be running/pending has outlived DEFAULT_LIVENESS_ABANDON_MS — see
+//     that constant for why an unbounded claim is not honest.
 // Never fabricates: every value maps 1:1 to fields the engine actually wrote.
 export const Liveness = z.enum(["progressing", "stalled", "success", "failure", "cancelled", "idle"])
 export type Liveness = z.infer<typeof Liveness>
@@ -70,14 +72,37 @@ export type Liveness = z.infer<typeof Liveness>
 // watchdog (T40) would fire.
 export const DEFAULT_LIVENESS_STALL_MS = 90_000
 
+// Abandonment bound: how long a row may keep CLAIMING `running`/`pending` before
+// we stop believing it. `progressing` and `stalled` both read as "in progress" to
+// every consumer (the orchestrator roster, `session list`, the fleet table) — they
+// mark a child as routable and imply something is already in flight. That claim
+// needs an upper bound, because the only repair for a row whose owner died is
+// ActorRegistry's orphan sweep, and that sweep runs ONCE at process init and only
+// for rows carrying a DIFFERENT instance_id; until it runs — and for any row it
+// cannot reach — the row asserts progress with nothing behind it.
+// 30 minutes, picked the same way DEFAULT_LIVENESS_STALL_MS was: a child that has
+// genuinely begun bumps last_turn_time on EVERY step (updateTurn is the per-step
+// heartbeat), so 30m of silence is an order of magnitude past the 5-minute
+// stuck-detection cutoff and unreachable by a live turn; a child that has not
+// begun is waiting on the concurrency gate, which admits work continuously, so
+// 30m of zero admissions means its process is gone. Past the bound we report
+// `idle` — "finished with no recorded outcome (or an unknown state)", the honest
+// reading and the only non-routable bucket.
+export const DEFAULT_LIVENESS_ABANDON_MS = 30 * 60_000
+
 export function deriveLiveness(
-  actor: Pick<Actor, "status" | "lastOutcome" | "lastTurnTime" | "turnCount">,
+  actor: Pick<Actor, "status" | "lastOutcome" | "lastTurnTime" | "turnCount" | "time">,
   now: number = Date.now(),
   stallMs: number = DEFAULT_LIVENESS_STALL_MS,
+  abandonMs: number = DEFAULT_LIVENESS_ABANDON_MS,
 ): Liveness {
   if (actor.status === "running" || actor.status === "pending") {
-    // Not-yet-started child (no turn completed): last_turn_time is the spawn
-    // time, so a slow first turn (queued/cold-start) is not a stall.
+    // A started child's evidence of life is its last turn; a not-yet-started one
+    // has none, so its spawn time is the only honest reference.
+    if (now - (actor.turnCount === 0 ? actor.time.created : actor.lastTurnTime) > abandonMs) return "idle"
+    // Not-yet-started child (no turn completed): a slow first turn (queued behind
+    // the concurrency gate / cold-start) is not a stall — the leniency is kept,
+    // but bounded by abandonMs above rather than unbounded.
     if (actor.turnCount === 0) return "progressing"
     return now - actor.lastTurnTime <= stallMs ? "progressing" : "stalled"
   }

--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -39,10 +39,10 @@ export const MAX_PRE_REACT = 3
 /** Cap on postStop ReAct re-entries per spawn. See MAX_PRE_REACT TODO. */
 export const MAX_POST_REACT = 3
 /**
- * T40 stall watchdog scan cadence. Sits between the per-step turn heartbeat and
- * the DEFAULT_LIVENESS_STALL_MS (90s) window, and just under the registry's own
- * 60s stuck-scan, so a genuinely stalled child is caught within ~one window of
- * flipping to `stalled` without hammering the DB.
+ * T40 stall watchdog scan cadence. Well inside the DEFAULT_LIVENESS_STALL_MS (6m)
+ * window and just under the registry's own 60s stuck-scan, so a genuinely stalled
+ * child is caught within one scan of flipping to `stalled` without hammering the
+ * DB.
  */
 export const WATCHDOG_SCAN_INTERVAL_MS = 45_000
 const RETURN_FORMAT_INSTRUCTION = `
@@ -864,17 +864,17 @@ export const layer = Layer.effect(
     // Event-driven stall detection: a background fiber periodically scans active
     // background actors (ActorRegistry.listActive → pending/running + background),
     // computes deriveLiveness for each, and when a PEER/subagent flips to
-    // `stalled` (running/pending but now-lastTurnTime > DEFAULT_LIVENESS_STALL_MS
-    // AND turnCount not advancing — deriveLiveness encodes exactly that) pushes
-    // ONE actor_notification{stalled} to its parent. Reuses the notifyTerminal
-    // shape (inbox.send actor_notification + renderActorNotification + a TUI
-    // toast) so stalled joins completed/failed/cancelled on one contract.
+    // `stalled` (running/pending but nothing has landed for the actor's slice for
+    // longer than DEFAULT_LIVENESS_STALL_MS — deriveLiveness encodes exactly that)
+    // pushes ONE actor_notification{stalled} to its parent. Reuses the
+    // notifyTerminal shape (inbox.send actor_notification + renderActorNotification
+    // + a TUI toast) so stalled joins completed/failed/cancelled on one contract.
     //
     // Debounce — the crux: `notified` holds the "sessionID:actorID" of actors we
     // have ALREADY warned about for their CURRENT stall episode. We emit only on
     // the not-yet-notified → stalled edge; while it STAYS stalled across ticks it
     // is in `notified` and we skip. We re-arm (delete the key) the moment the
-    // actor is no longer stalled — it resumed (turnCount advanced so
+    // actor is no longer stalled — it resumed (activity landed again, so
     // deriveLiveness reads `progressing`), went terminal, or vanished — so a
     // later re-stall notifies again. One notification per stall episode.
     const notified = new Set<string>()
@@ -910,13 +910,16 @@ export const layer = Layer.effect(
             sessionID: actor.sessionID,
             actorID: actor.actorID,
             description: actor.description,
-            lastTurnTime: actor.lastTurnTime,
+            // Same reference the classification used, for the same reason the
+            // notification carries it: an observability payload that reports the
+            // step clock while the predicate read the activity clock is a trap.
+            lastActivityTime: actor.lastActivityTime ?? actor.time.created,
             stalledDuration: stalledForMs,
           })
           .pipe(Effect.ignore)
         yield* Effect.promise(() =>
           Bus.publish(TuiEvent.ToastShow, {
-            message: `Child "${actor.description}" appears stalled`,
+            message: `Child "${actor.description}" appears stalled (no activity for ${Math.floor(stalledForMs / 1000)}s)`,
             variant: "info",
           }),
         ).pipe(Effect.ignore)

--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -933,7 +933,11 @@ export const layer = Layer.effect(
         if (live === "stalled") {
           if (notified.has(key)) continue // already warned this episode — debounce
           notified.add(key)
-          yield* notifyStalled(actor, now - actor.lastTurnTime)
+          // Report the quantity the classification actually used — silence since
+          // the last part write, or since spawn when nothing has landed — not
+          // time since the last completed step, which deriveLiveness no longer
+          // reads. A number that disagrees with its own predicate is a bug.
+          yield* notifyStalled(actor, now - (actor.lastActivityTime ?? actor.time.created))
           continue
         }
         // Not stalled (progressing/terminal) → re-arm so a future re-stall notifies.

--- a/packages/opencode/src/inbox/render.ts
+++ b/packages/opencode/src/inbox/render.ts
@@ -36,7 +36,10 @@ export function renderActorNotification(event: {
   error?: string
   reportedStatus?: string
   reportedSummary?: string
-  // For a stalled notification: how long (ms) since the child's last turn advanced.
+  // For a stalled notification: how long (ms) the child has been SILENT — nothing
+  // has landed for its slice. NOT time since the last completed step: the T40
+  // watchdog classifies on last_activity_time (actor/schema.ts deriveLiveness),
+  // and a child inside one long step keeps writing parts, so it never lands here.
   stalledForMs?: number
 }): string {
   const header = `Background sub-session "${event.description}" (actor_id: ${event.actorID})`
@@ -68,9 +71,14 @@ export function renderActorNotification(event: {
     return `<actor-notification>\n${header} failed.\nError: ${event.error ?? "unknown"}\n</actor-notification>`
   }
   if (event.status === "stalled") {
+    // "no activity", not "no turn advance". The quantity is silence since the last
+    // part write; saying "turn" described a signal the derivation stopped reading
+    // and made healthy children inside long steps look wedged. Likewise "nothing
+    // has landed" rather than "has made no progress" — a long step IS progress,
+    // and we cannot see inside one, only whether anything is coming out.
     const forLine =
-      event.stalledForMs !== undefined ? ` (no turn advance for ${Math.floor(event.stalledForMs / 1000)}s)` : ""
-    return `<actor-notification>\n${header} appears stalled${forLine}. It is still running but has made no progress. Consider checking on it, sending it a nudge, or cancelling it.\n</actor-notification>`
+      event.stalledForMs !== undefined ? ` (no activity for ${Math.floor(event.stalledForMs / 1000)}s)` : ""
+    return `<actor-notification>\n${header} appears stalled${forLine}. It is still running, but nothing has landed for it in that time. Consider checking on it, sending it a nudge, or cancelling it.\n</actor-notification>`
   }
   return `<actor-notification>\n${header} was cancelled.\n</actor-notification>`
 }

--- a/packages/opencode/src/session/projectors.ts
+++ b/packages/opencode/src/session/projectors.ts
@@ -144,7 +144,7 @@ export default [
       // part-write path this hangs off is unthrottled — the bash tool's
       // ctx.metadata fires per decoded stdout chunk — which measured 539-867 of
       // these UPDATEs per second, each running the correlated subquery below,
-      // while the only consumers (deriveLiveness's 90s stall display and 10m
+      // while the only consumers (deriveLiveness's 6m stall display and 10m
       // abandonment bound) cannot resolve anything finer than tens of seconds.
       // The staleness predicate is part of the WHERE rather than a process-local
       // cache so it stays correct across instances and restarts, and it also

--- a/packages/opencode/src/session/projectors.ts
+++ b/packages/opencode/src/session/projectors.ts
@@ -4,6 +4,7 @@ import * as Session from "./session"
 import { MessageV2 } from "./message-v2"
 import { SessionTable, MessageTable, PartTable } from "./session.sql"
 import { ActorRegistryTable } from "@/actor/actor.sql"
+import { ACTIVITY_COALESCE_MS } from "@/actor/schema"
 import { Log } from "../util"
 
 const log = Log.create({ service: "session.projector" })
@@ -138,6 +139,20 @@ export default [
       // `message`), so the owning actor is resolved through the message's primary
       // key; together with session_id that hits actor_registry's PK directly. A
       // 0-row no-op when the session has no registry row, exactly like updateTurn.
+      //
+      // Coalesced to at most one write per actor per ACTIVITY_COALESCE_MS. The
+      // part-write path this hangs off is unthrottled — the bash tool's
+      // ctx.metadata fires per decoded stdout chunk — which measured 539-867 of
+      // these UPDATEs per second, each running the correlated subquery below,
+      // while the only consumers (deriveLiveness's 90s stall display and 10m
+      // abandonment bound) cannot resolve anything finer than tens of seconds.
+      // The staleness predicate is part of the WHERE rather than a process-local
+      // cache so it stays correct across instances and restarts, and it also
+      // makes the column monotonic: an out-of-order event carrying an older
+      // `data.time` no longer drags it backwards. `IS NULL` is the first
+      // disjunct because the column is nullable and a fresh row records NULL,
+      // which must still take its first write (AGENTS.md, "Reading a nullable
+      // column").
       db.update(ActorRegistryTable)
         .set({ last_activity_time: data.time })
         .where(
@@ -147,6 +162,7 @@ export default [
               ActorRegistryTable.actor_id,
               sql`(SELECT ${MessageTable.agent_id} FROM ${MessageTable} WHERE ${MessageTable.id} = ${messageID})`,
             ),
+            sql`(${ActorRegistryTable.last_activity_time} IS NULL OR ${ActorRegistryTable.last_activity_time} < ${data.time - ACTIVITY_COALESCE_MS})`,
           ),
         )
         .run()

--- a/packages/opencode/src/session/projectors.ts
+++ b/packages/opencode/src/session/projectors.ts
@@ -1,8 +1,9 @@
-import { NotFoundError, eq, and } from "../storage"
+import { NotFoundError, eq, and, sql } from "../storage"
 import { SyncEvent } from "@/sync"
 import * as Session from "./session"
 import { MessageV2 } from "./message-v2"
 import { SessionTable, MessageTable, PartTable } from "./session.sql"
+import { ActorRegistryTable } from "@/actor/actor.sql"
 import { Log } from "../util"
 
 const log = Log.create({ service: "session.projector" })
@@ -128,6 +129,26 @@ export default [
           data: rest,
         })
         .onConflictDoUpdate({ target: PartTable.id, set: { data: rest } })
+        .run()
+      // Activity heartbeat for actor liveness (actor/schema.ts deriveLiveness).
+      // This projector is the single writer of `part` rows, so it is the one
+      // place that already fires on every part write — no new hook in the session
+      // loop. Sequenced after the insert so activity is recorded only if the part
+      // actually landed. `part` carries no agent id (the agent slice lives on
+      // `message`), so the owning actor is resolved through the message's primary
+      // key; together with session_id that hits actor_registry's PK directly. A
+      // 0-row no-op when the session has no registry row, exactly like updateTurn.
+      db.update(ActorRegistryTable)
+        .set({ last_activity_time: data.time })
+        .where(
+          and(
+            eq(ActorRegistryTable.session_id, sessionID),
+            eq(
+              ActorRegistryTable.actor_id,
+              sql`(SELECT ${MessageTable.agent_id} FROM ${MessageTable} WHERE ${MessageTable.id} = ${messageID})`,
+            ),
+          ),
+        )
         .run()
     } catch (err) {
       if (!foreign(err)) throw err

--- a/packages/opencode/src/tool/fleet.ts
+++ b/packages/opencode/src/tool/fleet.ts
@@ -44,7 +44,10 @@ export interface FleetRow {
   liveness: Liveness
   status: string
   turnCount: number
-  // ms since the last turn advanced; undefined when there is no actor row.
+  // ms since anything last LANDED for this actor (falling back to spawn time when
+  // nothing has); undefined when there is no actor row. Not the step clock — the
+  // field name means what it says, and it is the quantity the liveness above was
+  // derived from.
   lastActivityMs?: number
   // Worktree correlation — present only for isolated children whose directory
   // matched a `git worktree list` entry.
@@ -149,7 +152,7 @@ function worktreeCell(r: FleetRow): string {
 
 const HEADINGS: Record<FleetBucket, string> = {
   progressing: "In progress — progressing (advancing)",
-  stalled: "In progress — stalled (no recent turn)",
+  stalled: "In progress — stalled (no recent activity)",
   idle: "Finished / idle",
   failed: "Failed",
   cancelled: "Cancelled",

--- a/packages/opencode/src/tool/fleet.ts
+++ b/packages/opencode/src/tool/fleet.ts
@@ -104,7 +104,12 @@ export function assembleFleet(
       liveness,
       status: actor?.status ?? "unknown",
       turnCount: actor?.turnCount ?? 0,
-      ...(actor ? { lastActivityMs: Math.max(0, now - actor.lastTurnTime) } : {}),
+      // Age of the last thing that actually landed, using the same reference
+      // deriveLiveness classifies on (activity, falling back to spawn) so the
+      // displayed age cannot disagree with the displayed liveness. It used to be
+      // computed from lastTurnTime, i.e. the last COMPLETED step, which made a
+      // column named "last activity" report something else.
+      ...(actor ? { lastActivityMs: Math.max(0, now - (actor.lastActivityTime ?? actor.time.created)) } : {}),
       ...(wt ? { worktreeDir: wt.directory, branch: wt.branch, ahead: wt.ahead } : {}),
     }
   })

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -955,10 +955,10 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
           return { title: "Child sessions: 0", output: "No child sessions.", metadata: {} as Metadata }
         // The actor row's status enum is only pending|running|idle; a terminal
         // idle carries a lastOutcome (success/failure/cancelled). deriveLiveness
-        // maps (status, lastOutcome, lastTurnTime) to a display bucket:
-        // running/pending split into progressing vs stalled by whether the last
-        // turn advanced within the staleness window (updateTurn bumps
-        // last_turn_time per step — recent == progressing); terminal idle rows
+        // maps (status, lastOutcome, lastActivityTime) to a display bucket:
+        // running/pending split into progressing vs stalled by whether anything
+        // LANDED within the staleness window (the PartUpdated projector bumps
+        // last_activity_time per part — recent == progressing); terminal idle rows
         // map to success(→idle)/failure/cancelled. Never fabricate a state the
         // data lacks: a missing actor row is a plain idle.
         const now = Date.now()
@@ -981,7 +981,7 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
         }
         const groups: { bucket: keyof typeof counts; heading: string }[] = [
           { bucket: "progressing", heading: "In progress — progressing (running/pending, advancing)" },
-          { bucket: "stalled", heading: "In progress — stalled (running/pending, no recent turn)" },
+          { bucket: "stalled", heading: "In progress — stalled (running/pending, no recent activity)" },
           { bucket: "idle", heading: "Finished / idle" },
           { bucket: "failed", heading: "Failed" },
           { bucket: "cancelled", heading: "Cancelled" },
@@ -1056,8 +1056,9 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
         // Derived pull-side liveness for one child. A peer registers with
         // session_id === actor_id === its own child id (see the create branch /
         // Actor.spawnPeer), so key the row by (childID, childID). deriveLiveness
-        // turns the honest registry fields (status/lastOutcome/lastTurnTime) into
-        // progressing|stalled|terminal — never fabricating a state the row lacks.
+        // turns the honest registry fields (status/lastOutcome/lastActivityTime)
+        // into progressing|stalled|terminal — never fabricating a state the row
+        // lacks.
         const childID = op.sessionID
         const found = yield* actorReg.liveness(childID as SessionID, childID)
         if (!found)
@@ -1066,16 +1067,24 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
             output: `No actor registered for ${childID}. It may not exist or never started.`,
             metadata: { sessionID: childID } as Metadata,
           }
-        const ageMs = Date.now() - found.actor.lastTurnTime
-        const ageStr = ageMs < 60_000 ? `${Math.floor(ageMs / 1000)}s` : `${Math.floor(ageMs / 60_000)}m`
+        const age = (ms: number) => (ms < 60_000 ? `${Math.floor(ms / 1000)}s` : `${Math.floor(ms / 60_000)}m`)
+        const nowMs = Date.now()
+        // Report the age the verdict was computed from FIRST. `?? time.created` is
+        // the same fallback deriveLiveness uses, and the column is nullable so it
+        // arrives as `null` — see AGENTS.md "Reading a nullable column".
+        const activityAge = age(nowMs - (found.actor.lastActivityTime ?? found.actor.time.created))
+        // turnCount/lastTurnTime stay on the dump as step bookkeeping, explicitly
+        // labelled as not being what the liveness above was derived from.
+        const turnAge = age(nowMs - found.actor.lastTurnTime)
         const outcome = found.actor.lastOutcome ? ` (last outcome: ${found.actor.lastOutcome})` : ""
         return {
           title: `Status ${childID}: ${found.liveness}`,
           output:
             `${childID} — ${found.liveness}${outcome}\n` +
             `  raw status: ${found.actor.status}\n` +
+            `  lastActivityTime: ${found.actor.lastActivityTime ?? "(none)"} (${activityAge} ago) — liveness derives from this\n` +
             `  turnCount: ${found.actor.turnCount}\n` +
-            `  lastTurnTime: ${found.actor.lastTurnTime} (${ageStr} ago)`,
+            `  lastTurnTime: ${found.actor.lastTurnTime} (${turnAge} ago) — last COMPLETED step, not the liveness input`,
           metadata: { sessionID: childID } as Metadata,
         }
       }

--- a/packages/opencode/test/actor/liveness.test.ts
+++ b/packages/opencode/test/actor/liveness.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Layer, ManagedRuntime, Effect } from "effect"
 import { ActorRegistry } from "../../src/actor/registry"
-import { deriveLiveness, DEFAULT_LIVENESS_STALL_MS } from "../../src/actor/schema"
+import { deriveLiveness, DEFAULT_LIVENESS_STALL_MS, DEFAULT_LIVENESS_ABANDON_MS } from "../../src/actor/schema"
 import { Bus } from "../../src/bus"
 import { Session } from "../../src/session"
 import { SessionID } from "../../src/session/schema"
@@ -38,14 +38,29 @@ describe("deriveLiveness (T39 derivation rule)", () => {
 
   test("running + recent turn (within window) → progressing", () => {
     expect(
-      deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 1_000, turnCount: 1 }, now),
+      deriveLiveness(
+        {
+          status: "running",
+          lastOutcome: undefined,
+          lastTurnTime: now - 1_000,
+          turnCount: 1,
+          time: { created: now - 2_000, updated: now - 1_000 },
+        },
+        now,
+      ),
     ).toBe("progressing")
   })
 
   test("running + turn older than the window → stalled", () => {
     expect(
       deriveLiveness(
-        { status: "running", lastOutcome: undefined, lastTurnTime: now - (DEFAULT_LIVENESS_STALL_MS + 1), turnCount: 1 },
+        {
+          status: "running",
+          lastOutcome: undefined,
+          lastTurnTime: now - (DEFAULT_LIVENESS_STALL_MS + 1),
+          turnCount: 1,
+          time: { created: now - (DEFAULT_LIVENESS_STALL_MS + 2), updated: now },
+        },
         now,
       ),
     ).toBe("stalled")
@@ -57,13 +72,25 @@ describe("deriveLiveness (T39 derivation rule)", () => {
     // must read progressing, not stalled.
     expect(
       deriveLiveness(
-        { status: "pending", lastOutcome: undefined, lastTurnTime: now - 10 * 60_000, turnCount: 0 },
+        {
+          status: "pending",
+          lastOutcome: undefined,
+          lastTurnTime: now - 10 * 60_000,
+          turnCount: 0,
+          time: { created: now - 10 * 60_000, updated: now - 10 * 60_000 },
+        },
         now,
       ),
     ).toBe("progressing")
     expect(
       deriveLiveness(
-        { status: "running", lastOutcome: undefined, lastTurnTime: now - 10 * 60_000, turnCount: 0 },
+        {
+          status: "running",
+          lastOutcome: undefined,
+          lastTurnTime: now - 10 * 60_000,
+          turnCount: 0,
+          time: { created: now - 10 * 60_000, updated: now - 10 * 60_000 },
+        },
         now,
       ),
     ).toBe("progressing")
@@ -71,17 +98,35 @@ describe("deriveLiveness (T39 derivation rule)", () => {
 
   test("pending is treated as live and split by the same window (once it has run a turn)", () => {
     expect(
-      deriveLiveness({ status: "pending", lastOutcome: undefined, lastTurnTime: now, turnCount: 1 }, now),
+      deriveLiveness(
+        { status: "pending", lastOutcome: undefined, lastTurnTime: now, turnCount: 1, time: { created: now, updated: now } },
+        now,
+      ),
     ).toBe("progressing")
     expect(
-      deriveLiveness({ status: "pending", lastOutcome: undefined, lastTurnTime: now - 10 * 60_000, turnCount: 1 }, now),
+      deriveLiveness(
+        {
+          status: "pending",
+          lastOutcome: undefined,
+          lastTurnTime: now - 10 * 60_000,
+          turnCount: 1,
+          time: { created: now - 11 * 60_000, updated: now - 10 * 60_000 },
+        },
+        now,
+      ),
     ).toBe("stalled")
   })
 
   test("exactly at the threshold boundary is still progressing (<= window)", () => {
     expect(
       deriveLiveness(
-        { status: "running", lastOutcome: undefined, lastTurnTime: now - DEFAULT_LIVENESS_STALL_MS, turnCount: 1 },
+        {
+          status: "running",
+          lastOutcome: undefined,
+          lastTurnTime: now - DEFAULT_LIVENESS_STALL_MS,
+          turnCount: 1,
+          time: { created: now - DEFAULT_LIVENESS_STALL_MS - 1, updated: now },
+        },
         now,
       ),
     ).toBe("progressing")
@@ -89,24 +134,104 @@ describe("deriveLiveness (T39 derivation rule)", () => {
 
   test("custom stallMs overrides the default window", () => {
     // 5s-old turn: stalled under a 1s window, progressing under a 60s window.
-    expect(
-      deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 5_000, turnCount: 1 }, now, 1_000),
-    ).toBe("stalled")
-    expect(
-      deriveLiveness({ status: "running", lastOutcome: undefined, lastTurnTime: now - 5_000, turnCount: 1 }, now, 60_000),
-    ).toBe("progressing")
+    const wedged = {
+      status: "running" as const,
+      lastOutcome: undefined,
+      lastTurnTime: now - 5_000,
+      turnCount: 1,
+      time: { created: now - 6_000, updated: now - 5_000 },
+    }
+    expect(deriveLiveness(wedged, now, 1_000)).toBe("stalled")
+    expect(deriveLiveness(wedged, now, 60_000)).toBe("progressing")
   })
 
   test("terminal outcomes come straight from lastOutcome regardless of turn age", () => {
-    expect(deriveLiveness({ status: "idle", lastOutcome: "success", lastTurnTime: 0, turnCount: 1 }, now)).toBe("success")
-    expect(deriveLiveness({ status: "idle", lastOutcome: "failure", lastTurnTime: 0, turnCount: 1 }, now)).toBe("failure")
-    expect(deriveLiveness({ status: "idle", lastOutcome: "cancelled", lastTurnTime: 0, turnCount: 1 }, now)).toBe(
-      "cancelled",
-    )
+    const terminal = { status: "idle" as const, lastTurnTime: 0, turnCount: 1, time: { created: 0, updated: 0 } }
+    expect(deriveLiveness({ ...terminal, lastOutcome: "success" }, now)).toBe("success")
+    expect(deriveLiveness({ ...terminal, lastOutcome: "failure" }, now)).toBe("failure")
+    expect(deriveLiveness({ ...terminal, lastOutcome: "cancelled" }, now)).toBe("cancelled")
   })
 
   test("idle with no outcome → idle", () => {
-    expect(deriveLiveness({ status: "idle", lastOutcome: undefined, lastTurnTime: 0, turnCount: 0 }, now)).toBe("idle")
+    expect(
+      deriveLiveness(
+        { status: "idle", lastOutcome: undefined, lastTurnTime: 0, turnCount: 0, time: { created: 0, updated: 0 } },
+        now,
+      ),
+    ).toBe("idle")
+  })
+
+  // === Defect B: the turnCount-0 leniency is bounded, not unbounded ===
+  // A child that died BEFORE its first turn used to read `progressing` forever,
+  // because `turnCount === 0` returned early and skipped every staleness check.
+  // The leniency is still there — it is now measured from spawn time and capped
+  // by DEFAULT_LIVENESS_ABANDON_MS.
+  test("never-started child spawned long ago does NOT read progressing", () => {
+    const stillborn = {
+      status: "pending" as const,
+      lastOutcome: undefined,
+      lastTurnTime: now - 24 * 60 * 60_000,
+      turnCount: 0,
+      time: { created: now - 24 * 60 * 60_000, updated: now - 24 * 60 * 60_000 },
+    }
+    expect(deriveLiveness(stillborn, now)).not.toBe("progressing")
+    expect(deriveLiveness(stillborn, now)).toBe("idle")
+    expect(deriveLiveness({ ...stillborn, status: "running" }, now)).toBe("idle")
+  })
+
+  test("the turnCount-0 leniency still holds inside the abandonment bound", () => {
+    // Just under the bound: a queued / cold-starting first turn is still progress.
+    const created = now - (DEFAULT_LIVENESS_ABANDON_MS - 1)
+    expect(
+      deriveLiveness(
+        { status: "pending", lastOutcome: undefined, lastTurnTime: created, turnCount: 0, time: { created, updated: created } },
+        now,
+      ),
+    ).toBe("progressing")
+    // Exactly at the bound is still lenient (> abandonMs, same <= convention as stallMs).
+    const atBound = now - DEFAULT_LIVENESS_ABANDON_MS
+    expect(
+      deriveLiveness(
+        { status: "pending", lastOutcome: undefined, lastTurnTime: atBound, turnCount: 0, time: { created: atBound, updated: atBound } },
+        now,
+      ),
+    ).toBe("progressing")
+  })
+
+  // === Defect A (read side): a row whose process is gone is not routable ===
+  // ActorRegistry's orphan sweep is the only repair for a row whose owner died,
+  // and it runs once at process init for rows of a different instance. Until then
+  // the row keeps claiming running/pending, and both `progressing` and `stalled`
+  // are presented to the orchestrator as "in progress" — routable, and implying
+  // work is already in flight. Past the abandonment bound the derivation stops
+  // believing the claim.
+  test("started child still claiming running long after its last turn is not routable", () => {
+    // The measured fixture: peer "Fix calc.py add() bug", turnCount 26, replayed
+    // a day after its last turn.
+    const dead = {
+      status: "running" as const,
+      lastOutcome: undefined,
+      lastTurnTime: now - 24 * 60 * 60_000,
+      turnCount: 26,
+      time: { created: now - 25 * 60 * 60_000, updated: now - 24 * 60 * 60_000 },
+    }
+    const live = deriveLiveness(dead, now)
+    expect(live).not.toBe("stalled")
+    expect(live).not.toBe("progressing")
+    expect(live).toBe("idle")
+  })
+
+  test("custom abandonMs overrides the default bound", () => {
+    const row = {
+      status: "running" as const,
+      lastOutcome: undefined,
+      lastTurnTime: now - 10 * 60_000,
+      turnCount: 3,
+      time: { created: now - 11 * 60_000, updated: now - 10 * 60_000 },
+    }
+    // 10m-old turn: stalled under the default 30m bound, abandoned under a 5m one.
+    expect(deriveLiveness(row, now)).toBe("stalled")
+    expect(deriveLiveness(row, now, DEFAULT_LIVENESS_STALL_MS, 5 * 60_000)).toBe("idle")
   })
 })
 

--- a/packages/opencode/test/actor/liveness.test.ts
+++ b/packages/opencode/test/actor/liveness.test.ts
@@ -136,6 +136,11 @@ describe("deriveLiveness (T39 derivation rule)", () => {
     ).toBe("progressing")
   })
 
+  // REWRITTEN (the stalled leg was `lastActivityTime: now - 5 * 60_000`). That
+  // 5-minute age was a bare number chosen when the window was 90s; at a 6-minute
+  // window it silently became a `progressing` fixture asserting `stalled`. Stated
+  // against the constant instead, so it pins "past the window" — the thing the
+  // case is about — at any window value. Not a relaxation: the claim is identical.
   test("pending is treated as live and split by the same window", () => {
     expect(
       deriveLiveness(
@@ -148,8 +153,8 @@ describe("deriveLiveness (T39 derivation rule)", () => {
         {
           status: "pending",
           lastOutcome: undefined,
-          lastActivityTime: now - 5 * 60_000,
-          time: { created: now - 6 * 60_000, updated: now - 5 * 60_000 },
+          lastActivityTime: now - (DEFAULT_LIVENESS_STALL_MS + 1),
+          time: { created: now - (DEFAULT_LIVENESS_STALL_MS + 60_000), updated: now - DEFAULT_LIVENESS_STALL_MS },
         },
         now,
       ),
@@ -245,6 +250,82 @@ describe("deriveLiveness (T39 derivation rule)", () => {
     expect(DEFAULT_LIVENESS_ABANDON_MS).toBeGreaterThan(DEFAULT_LIVENESS_STALL_MS)
   })
 
+  // === The stall window, re-derived for the activity signal ===
+  // Measured inter-activity gaps over 43,120 real gaps on a 172-child roster.
+  // These are the same numbers the abandonment bound was anchored to; the stall
+  // window is now anchored to the same set instead of to the old step cadence.
+  const GAP_P99_MS = 38_048
+  const GAP_P99_9_MS = 296_811
+
+  // THE FALSE POSITIVE THIS CHANGE FIXES, at the age it was actually observed.
+  // Two background children sitting inside single long steps (`bun ci`, a full
+  // test suite, `git worktree add`) emitted "appears stalled" notifications at
+  // ~90-130s of apparent silence while writing parts continuously — a tool's
+  // streaming output calls ctx.metadata per chunk, which reaches updatePart and
+  // advances last_activity_time. Under the old 90s window every one of those was
+  // a lie. lastTurnTime is deliberately ancient to prove the step clock is not
+  // consulted. Fails on a 90s window; passes on the re-derived one.
+  test("a child inside a long step whose activity is 130s old is NOT stalled", () => {
+    for (const silentForMs of [90_001, 100_000, 130_000, GAP_P99_9_MS]) {
+      expect(
+        deriveLiveness(
+          {
+            status: "running",
+            lastOutcome: undefined,
+            lastActivityTime: now - silentForMs,
+            // No completed step for 25 minutes — mid-step the whole time.
+            time: { created: now - 25 * 60_000, updated: now - silentForMs },
+          },
+          now,
+        ),
+      ).toBe("progressing")
+    }
+  })
+
+  // The converse, so widening the window cannot quietly disable the verdict:
+  // genuine silence past the window still reads stalled, and stays routable
+  // (stalled, not idle) until the abandonment bound.
+  test("a child with genuinely no activity past the window IS stalled", () => {
+    const quiet = (silentForMs: number) => ({
+      status: "running" as const,
+      lastOutcome: undefined,
+      lastActivityTime: now - silentForMs,
+      time: { created: now - (silentForMs + 60_000), updated: now - silentForMs },
+    })
+    // Exactly at the window is still progressing (<= convention); one ms past it flips.
+    expect(deriveLiveness(quiet(DEFAULT_LIVENESS_STALL_MS), now)).toBe("progressing")
+    expect(deriveLiveness(quiet(DEFAULT_LIVENESS_STALL_MS + 1), now)).toBe("stalled")
+    // And it stays stalled — not idle — right up to the abandonment bound.
+    expect(deriveLiveness(quiet(DEFAULT_LIVENESS_ABANDON_MS), now)).toBe("stalled")
+    expect(deriveLiveness(quiet(DEFAULT_LIVENESS_ABANDON_MS + 1), now)).toBe("idle")
+  })
+
+  // Pinned as a VALUE so re-narrowing it back toward the step-cadence number is a
+  // test failure, not a review question — the same treatment the abandonment bound
+  // gets above.
+  test("the stall window is 6 minutes", () => {
+    expect(DEFAULT_LIVENESS_STALL_MS).toBe(6 * 60_000)
+  })
+
+  // The two measurements that produced that value, as executable invariants.
+  test("the stall window clears the measured activity tail plus the coalescing lag", () => {
+    // 90s sat strictly between p99 and p99.9, i.e. between 0.1% and 1% of gaps
+    // from HEALTHY children exceeded it. That is what made it a false-positive
+    // generator, and it is the property the window must not have again.
+    expect(90_000).toBeGreaterThan(GAP_P99_MS)
+    expect(90_000).toBeLessThan(GAP_P99_9_MS)
+    // Above the deepest measured natural silence...
+    expect(DEFAULT_LIVENESS_STALL_MS).toBeGreaterThan(GAP_P99_9_MS)
+    // ...and above it by more than one coalesce interval, so the up-to-5s lag
+    // between a real part write and the recorded column cannot by itself flip a
+    // tail-but-healthy row. This is what disqualifies 300_000 (== registry.ts
+    // STUCK_THRESHOLD_MS): 300_000 < 296_811 + 5_000.
+    expect(DEFAULT_LIVENESS_STALL_MS).toBeGreaterThan(GAP_P99_9_MS + ACTIVITY_COALESCE_MS)
+    expect(300_000).toBeLessThan(GAP_P99_9_MS + ACTIVITY_COALESCE_MS)
+    // Still leaves a usable stalled band: the watchdog scans every 45s.
+    expect(DEFAULT_LIVENESS_ABANDON_MS - DEFAULT_LIVENESS_STALL_MS).toBeGreaterThanOrEqual(4 * 45_000)
+  })
+
   // === Defect A (read side): a row whose process is gone is not routable ===
   // ActorRegistry's orphan sweep is the only repair for a row whose owner died,
   // and it runs once at process init for rows of a different instance. Until then
@@ -266,16 +347,24 @@ describe("deriveLiveness (T39 derivation rule)", () => {
     expect(live).toBe("idle")
   })
 
+  // REWRITTEN (was `lastActivityTime: now - 4 * 60_000` with a 2-minute custom
+  // bound). 4 minutes was "past the 90s window but inside the 10m bound"; at a
+  // 6-minute window it fell back inside the window and the default-bound leg would
+  // have read `progressing`. Restated relative to both constants so it keeps
+  // testing the only thing it was ever about — that abandonMs is honoured and
+  // overridable — without re-encoding either threshold's value.
   test("custom abandonMs overrides the default bound", () => {
+    const silentFor = DEFAULT_LIVENESS_STALL_MS + 60_000
     const row = {
       status: "running" as const,
       lastOutcome: undefined,
-      lastActivityTime: now - 4 * 60_000,
-      time: { created: now - 11 * 60_000, updated: now - 4 * 60_000 },
+      lastActivityTime: now - silentFor,
+      time: { created: now - (silentFor + 60_000), updated: now - silentFor },
     }
-    // 4m-old activity: stalled under the default 10m bound, abandoned under a 2m one.
+    // Past the stall window and inside the default 10m bound → stalled; abandoned
+    // under a bound tighter than the silence.
     expect(deriveLiveness(row, now)).toBe("stalled")
-    expect(deriveLiveness(row, now, DEFAULT_LIVENESS_STALL_MS, 2 * 60_000)).toBe("idle")
+    expect(deriveLiveness(row, now, DEFAULT_LIVENESS_STALL_MS, silentFor - 1)).toBe("idle")
   })
 
   // A nullable column arrives as `null`, not `undefined`, for every row written

--- a/packages/opencode/test/actor/liveness.test.ts
+++ b/packages/opencode/test/actor/liveness.test.ts
@@ -4,7 +4,8 @@ import { ActorRegistry } from "../../src/actor/registry"
 import { deriveLiveness, DEFAULT_LIVENESS_STALL_MS, DEFAULT_LIVENESS_ABANDON_MS } from "../../src/actor/schema"
 import { Bus } from "../../src/bus"
 import { Session } from "../../src/session"
-import { SessionID } from "../../src/session/schema"
+import { SessionID, MessageID, PartID } from "../../src/session/schema"
+import { ProviderID, ModelID } from "../../src/provider/schema"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
@@ -33,73 +34,107 @@ async function withRegistry(
 
 // Pure-derivation table: deriveLiveness maps honest registry fields to the
 // pull-side signal. No I/O — this pins the rule + threshold exactly.
+//
+// The evidence is lastActivityTime (the last part write for the actor's slice),
+// NOT lastTurnTime/turnCount. Cases marked REWRITTEN below previously asserted
+// step-grained semantics — chiefly that a `turnCount === 0` row reads
+// `progressing` however long it has been silent. That leniency existed because
+// the old signal could only see a COMPLETED step; with activity granularity it
+// is a fabrication, so those assertions were deliberately changed rather than
+// relaxed. Nothing here was weakened to go green: every rewritten case makes a
+// strictly more specific claim than the one it replaced.
 describe("deriveLiveness (T39 derivation rule)", () => {
   const now = 1_000_000
 
-  test("running + recent turn (within window) → progressing", () => {
+  test("running + recent activity (within window) → progressing", () => {
     expect(
       deriveLiveness(
         {
           status: "running",
           lastOutcome: undefined,
-          lastTurnTime: now - 1_000,
-          turnCount: 1,
-          time: { created: now - 2_000, updated: now - 1_000 },
+          lastActivityTime: now - 1_000,
+          time: { created: now - 60_000, updated: now - 1_000 },
         },
         now,
       ),
     ).toBe("progressing")
   })
 
-  test("running + turn older than the window → stalled", () => {
+  test("running + activity older than the window → stalled", () => {
     expect(
       deriveLiveness(
         {
           status: "running",
           lastOutcome: undefined,
-          lastTurnTime: now - (DEFAULT_LIVENESS_STALL_MS + 1),
-          turnCount: 1,
-          time: { created: now - (DEFAULT_LIVENESS_STALL_MS + 2), updated: now },
+          lastActivityTime: now - (DEFAULT_LIVENESS_STALL_MS + 1),
+          time: { created: now - 10 * 60_000, updated: now },
         },
         now,
       ),
     ).toBe("stalled")
   })
 
-  test("not-yet-started child (turnCount 0) is never stalled — slow first turn is not a stall", () => {
-    // last_turn_time is the spawn time; even far outside the window a child that
-    // has not completed a turn (queued behind the concurrency gate / cold-start)
-    // must read progressing, not stalled.
-    expect(
-      deriveLiveness(
-        {
-          status: "pending",
-          lastOutcome: undefined,
-          lastTurnTime: now - 10 * 60_000,
-          turnCount: 0,
-          time: { created: now - 10 * 60_000, updated: now - 10 * 60_000 },
-        },
-        now,
-      ),
-    ).toBe("progressing")
+  // THE DEFECT THIS CHANGE FIXES. A child inside a long tool call has completed
+  // no step, so lastTurnTime and turnCount are frozen at their pre-step values
+  // — under the old signal it was indistinguishable from a dead row and read
+  // stalled (or, past the bound, idle). Its parts keep landing, so activity is
+  // recent and it now reads progressing. lastTurnTime is deliberately ancient
+  // here to prove the derivation does not consult it.
+  test("child mid-step (no completed turn for 25m) but with recent activity is progressing", () => {
     expect(
       deriveLiveness(
         {
           status: "running",
           lastOutcome: undefined,
-          lastTurnTime: now - 10 * 60_000,
-          turnCount: 0,
-          time: { created: now - 10 * 60_000, updated: now - 10 * 60_000 },
+          lastActivityTime: now - 2_000,
+          time: { created: now - 25 * 60_000, updated: now - 2_000 },
         },
         now,
       ),
     ).toBe("progressing")
   })
 
-  test("pending is treated as live and split by the same window (once it has run a turn)", () => {
+  // The converse: plenty of completed steps, but nothing has landed since. A
+  // step counter cannot express this, which is why it is no longer the evidence.
+  test("child with many completed turns but no activity for an hour is not routable", () => {
+    const live = deriveLiveness(
+      {
+        status: "running",
+        lastOutcome: undefined,
+        lastActivityTime: now - 60 * 60_000,
+        time: { created: now - 2 * 60 * 60_000, updated: now - 60 * 60_000 },
+      },
+      now,
+    )
+    expect(live).not.toBe("progressing")
+    expect(live).not.toBe("stalled")
+    expect(live).toBe("idle")
+  })
+
+  // REWRITTEN (was: "not-yet-started child (turnCount 0) is never stalled").
+  // The old case asserted `progressing` for a row silent for 10 minutes. The
+  // replacement keeps the real intent — a freshly spawned child must not be
+  // mistaken for wedged — and states it against the fallback that now carries
+  // it: with no activity recorded, spawn time is the reference.
+  test("freshly spawned child with no activity yet reads progressing via the spawn fallback", () => {
     expect(
       deriveLiveness(
-        { status: "pending", lastOutcome: undefined, lastTurnTime: now, turnCount: 1, time: { created: now, updated: now } },
+        { status: "pending", lastOutcome: undefined, lastActivityTime: undefined, time: { created: now - 500, updated: now - 500 } },
+        now,
+      ),
+    ).toBe("progressing")
+    expect(
+      deriveLiveness(
+        { status: "running", lastOutcome: undefined, lastActivityTime: undefined, time: { created: now - 500, updated: now - 500 } },
+        now,
+      ),
+    ).toBe("progressing")
+  })
+
+  test("pending is treated as live and split by the same window", () => {
+    expect(
+      deriveLiveness(
+        { status: "pending", lastOutcome: undefined, lastActivityTime: now, time: { created: now - 60_000, updated: now } },
         now,
       ),
     ).toBe("progressing")
@@ -108,9 +143,8 @@ describe("deriveLiveness (T39 derivation rule)", () => {
         {
           status: "pending",
           lastOutcome: undefined,
-          lastTurnTime: now - 10 * 60_000,
-          turnCount: 1,
-          time: { created: now - 11 * 60_000, updated: now - 10 * 60_000 },
+          lastActivityTime: now - 5 * 60_000,
+          time: { created: now - 6 * 60_000, updated: now - 5 * 60_000 },
         },
         now,
       ),
@@ -123,8 +157,7 @@ describe("deriveLiveness (T39 derivation rule)", () => {
         {
           status: "running",
           lastOutcome: undefined,
-          lastTurnTime: now - DEFAULT_LIVENESS_STALL_MS,
-          turnCount: 1,
+          lastActivityTime: now - DEFAULT_LIVENESS_STALL_MS,
           time: { created: now - DEFAULT_LIVENESS_STALL_MS - 1, updated: now },
         },
         now,
@@ -133,20 +166,19 @@ describe("deriveLiveness (T39 derivation rule)", () => {
   })
 
   test("custom stallMs overrides the default window", () => {
-    // 5s-old turn: stalled under a 1s window, progressing under a 60s window.
+    // 5s-old activity: stalled under a 1s window, progressing under a 60s window.
     const wedged = {
       status: "running" as const,
       lastOutcome: undefined,
-      lastTurnTime: now - 5_000,
-      turnCount: 1,
+      lastActivityTime: now - 5_000,
       time: { created: now - 6_000, updated: now - 5_000 },
     }
     expect(deriveLiveness(wedged, now, 1_000)).toBe("stalled")
     expect(deriveLiveness(wedged, now, 60_000)).toBe("progressing")
   })
 
-  test("terminal outcomes come straight from lastOutcome regardless of turn age", () => {
-    const terminal = { status: "idle" as const, lastTurnTime: 0, turnCount: 1, time: { created: 0, updated: 0 } }
+  test("terminal outcomes come straight from lastOutcome regardless of activity age", () => {
+    const terminal = { status: "idle" as const, lastActivityTime: 0, time: { created: 0, updated: 0 } }
     expect(deriveLiveness({ ...terminal, lastOutcome: "success" }, now)).toBe("success")
     expect(deriveLiveness({ ...terminal, lastOutcome: "failure" }, now)).toBe("failure")
     expect(deriveLiveness({ ...terminal, lastOutcome: "cancelled" }, now)).toBe("cancelled")
@@ -155,23 +187,22 @@ describe("deriveLiveness (T39 derivation rule)", () => {
   test("idle with no outcome → idle", () => {
     expect(
       deriveLiveness(
-        { status: "idle", lastOutcome: undefined, lastTurnTime: 0, turnCount: 0, time: { created: 0, updated: 0 } },
+        { status: "idle", lastOutcome: undefined, lastActivityTime: undefined, time: { created: 0, updated: 0 } },
         now,
       ),
     ).toBe("idle")
   })
 
-  // === Defect B: the turnCount-0 leniency is bounded, not unbounded ===
-  // A child that died BEFORE its first turn used to read `progressing` forever,
-  // because `turnCount === 0` returned early and skipped every staleness check.
-  // The leniency is still there — it is now measured from spawn time and capped
-  // by DEFAULT_LIVENESS_ABANDON_MS.
+  // === The abandonment bound, now measured against activity ===
+  // A row that died before producing anything used to read `progressing` forever
+  // (turnCount === 0 returned early and skipped every check). It is now judged by
+  // the same single bound as every other row, from spawn time when no activity
+  // was ever recorded.
   test("never-started child spawned long ago does NOT read progressing", () => {
     const stillborn = {
       status: "pending" as const,
       lastOutcome: undefined,
-      lastTurnTime: now - 24 * 60 * 60_000,
-      turnCount: 0,
+      lastActivityTime: undefined,
       time: { created: now - 24 * 60 * 60_000, updated: now - 24 * 60 * 60_000 },
     }
     expect(deriveLiveness(stillborn, now)).not.toBe("progressing")
@@ -179,23 +210,34 @@ describe("deriveLiveness (T39 derivation rule)", () => {
     expect(deriveLiveness({ ...stillborn, status: "running" }, now)).toBe("idle")
   })
 
-  test("the turnCount-0 leniency still holds inside the abandonment bound", () => {
-    // Just under the bound: a queued / cold-starting first turn is still progress.
-    const created = now - (DEFAULT_LIVENESS_ABANDON_MS - 1)
-    expect(
-      deriveLiveness(
-        { status: "pending", lastOutcome: undefined, lastTurnTime: created, turnCount: 0, time: { created, updated: created } },
-        now,
-      ),
-    ).toBe("progressing")
-    // Exactly at the bound is still lenient (> abandonMs, same <= convention as stallMs).
-    const atBound = now - DEFAULT_LIVENESS_ABANDON_MS
-    expect(
-      deriveLiveness(
-        { status: "pending", lastOutcome: undefined, lastTurnTime: atBound, turnCount: 0, time: { created: atBound, updated: atBound } },
-        now,
-      ),
-    ).toBe("progressing")
+  // REWRITTEN (was: "the turnCount-0 leniency still holds inside the abandonment
+  // bound", which asserted `progressing` at 30m-minus-1ms of silence). Under one
+  // uniform bound the honest reading of a quiet-but-not-abandoned row is
+  // `stalled` — still routable, so nothing is lost operationally, and the
+  // "in progress" claim is no longer manufactured.
+  test("a quiet row inside the bound reads stalled, and stays routable", () => {
+    const quiet = {
+      status: "pending" as const,
+      lastOutcome: undefined,
+      lastActivityTime: undefined,
+      time: { created: now - (DEFAULT_LIVENESS_ABANDON_MS - 1), updated: now },
+    }
+    expect(deriveLiveness(quiet, now)).toBe("stalled")
+    // Exactly at the bound is still inside it (> abandonMs, same <= convention
+    // as stallMs).
+    const atBound = { ...quiet, time: { created: now - DEFAULT_LIVENESS_ABANDON_MS, updated: now } }
+    expect(deriveLiveness(atBound, now)).toBe("stalled")
+    // One millisecond past it, the claim is no longer believed.
+    const past = { ...quiet, time: { created: now - (DEFAULT_LIVENESS_ABANDON_MS + 1), updated: now } }
+    expect(deriveLiveness(past, now)).toBe("idle")
+  })
+
+  // The bound is 10 minutes, down from the 30 that the step-grained signal
+  // needed (a single legitimate step can run 20+ minutes). Pinned as a value so
+  // a silent re-widening is a test failure, not a review question.
+  test("the abandonment bound is 10 minutes", () => {
+    expect(DEFAULT_LIVENESS_ABANDON_MS).toBe(10 * 60_000)
+    expect(DEFAULT_LIVENESS_ABANDON_MS).toBeGreaterThan(DEFAULT_LIVENESS_STALL_MS)
   })
 
   // === Defect A (read side): a row whose process is gone is not routable ===
@@ -205,14 +247,12 @@ describe("deriveLiveness (T39 derivation rule)", () => {
   // are presented to the orchestrator as "in progress" — routable, and implying
   // work is already in flight. Past the abandonment bound the derivation stops
   // believing the claim.
-  test("started child still claiming running long after its last turn is not routable", () => {
-    // The measured fixture: peer "Fix calc.py add() bug", turnCount 26, replayed
-    // a day after its last turn.
+  test("started child still claiming running long after its last activity is not routable", () => {
+    // The measured fixture: peer "Fix calc.py add() bug", replayed a day later.
     const dead = {
       status: "running" as const,
       lastOutcome: undefined,
-      lastTurnTime: now - 24 * 60 * 60_000,
-      turnCount: 26,
+      lastActivityTime: now - 24 * 60 * 60_000,
       time: { created: now - 25 * 60 * 60_000, updated: now - 24 * 60 * 60_000 },
     }
     const live = deriveLiveness(dead, now)
@@ -225,13 +265,30 @@ describe("deriveLiveness (T39 derivation rule)", () => {
     const row = {
       status: "running" as const,
       lastOutcome: undefined,
-      lastTurnTime: now - 10 * 60_000,
-      turnCount: 3,
-      time: { created: now - 11 * 60_000, updated: now - 10 * 60_000 },
+      lastActivityTime: now - 4 * 60_000,
+      time: { created: now - 11 * 60_000, updated: now - 4 * 60_000 },
     }
-    // 10m-old turn: stalled under the default 30m bound, abandoned under a 5m one.
+    // 4m-old activity: stalled under the default 10m bound, abandoned under a 2m one.
     expect(deriveLiveness(row, now)).toBe("stalled")
-    expect(deriveLiveness(row, now, DEFAULT_LIVENESS_STALL_MS, 5 * 60_000)).toBe("idle")
+    expect(deriveLiveness(row, now, DEFAULT_LIVENESS_STALL_MS, 2 * 60_000)).toBe("idle")
+  })
+
+  // A nullable column arrives as `null`, not `undefined`, for every row written
+  // before the migration. A `!== undefined` guard would typecheck, read
+  // correctly, and let those rows through with `now - null === now` — i.e. always
+  // past the bound, so every pre-migration running row would read idle. Pinned
+  // with a raw-shaped row because that is the shape the DB actually produces.
+  // See AGENTS.md "Reading a nullable column".
+  test("a null activity column falls back to spawn time instead of being treated as present", () => {
+    const raw = {
+      status: "running" as const,
+      lastOutcome: undefined,
+      lastActivityTime: null as unknown as number | undefined,
+      time: { created: now - 1_000, updated: now - 1_000 },
+    }
+    expect(deriveLiveness(raw, now)).toBe("progressing")
+    const old = { ...raw, time: { created: now - 24 * 60 * 60_000, updated: now } }
+    expect(deriveLiveness(old, now)).toBe("idle")
   })
 })
 
@@ -290,21 +347,85 @@ describe("ActorRegistry.liveness (T39 integration)", () => {
     })
   })
 
-  test("not-yet-started row (turnCount 0) reads progressing even far past the window", async () => {
+  // REWRITTEN (was: "not-yet-started row (turnCount 0) reads progressing even
+  // far past the window"). That case pinned the unconditional turnCount-0
+  // leniency: with a 1ms window it demanded `progressing`. The row is now judged
+  // by activity, of which a freshly registered row has none, so spawn time is the
+  // reference — progressing under the real window, stalled under a 1ms one. The
+  // operational guarantee that mattered (a queued child is not called dead) is
+  // preserved and asserted; the fabricated "progressing" is not.
+  test("freshly registered row has no recorded activity and rides the spawn fallback", async () => {
     await using tmp = await tmpdir({ git: true })
     await withRegistry(tmp.path, async (rt) => {
       const child = await rt.runPromise(Session.Service.use((s) => s.create()))
       await rt.runPromise(ActorRegistry.Service.use((reg) => register(reg, child.id)))
       await rt.runPromise(ActorRegistry.Service.use((reg) => reg.updateStatus(child.id, child.id, { status: "running" })))
 
-      // No updateTurn: last_turn_time is the spawn time, turnCount stays 0. Even
-      // with a 1ms staleness window (spawn time is now far outside it), a child
-      // that has not run once must NOT read stalled — this is the slow-start
-      // (queued / cold-start) false-positive guard.
+      const row = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.get(child.id, child.id)))
+      // register() writes NULL, and fromRow flattens it to undefined.
+      expect(row!.lastActivityTime).toBeUndefined()
+      expect(row!.turnCount).toBe(0)
+
+      // Under the real window the spawn fallback keeps it routable and in-flight.
+      const live = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id)))
+      expect(live!.liveness).toBe("progressing")
+
+      // Under a 1ms window the same row is honestly quiet — and `stalled` is
+      // still a routable bucket, so nothing is dropped.
       await new Promise((r) => setTimeout(r, 5))
-      const found = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id, 1)))
-      expect(found!.actor.turnCount).toBe(0)
-      expect(found!.liveness).toBe("progressing")
+      const tight = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id, 1)))
+      expect(tight!.liveness).toBe("stalled")
+    })
+  })
+
+  // End-to-end for the writer: a real part write must advance the actor row's
+  // last_activity_time. This is the whole mechanism — MAX(part.time_updated) is
+  // already emitted today, and the PartUpdated projector is the single writer of
+  // part rows, so it is where the heartbeat is recorded. turn_count stays 0
+  // throughout: progress is visible with ZERO completed steps, which is exactly
+  // what the step-grained signal could not express.
+  test("a part write advances last_activity_time with turn_count still at 0", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withRegistry(tmp.path, async (rt) => {
+      const child = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => register(reg, child.id)))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => reg.updateStatus(child.id, child.id, { status: "running" })))
+
+      const before = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.get(child.id, child.id)))
+      expect(before!.lastActivityTime).toBeUndefined()
+
+      // A peer child's actor_id IS its own session id, and runAgentLoop passes
+      // that actorID as the message's agentID — so the slice the projector
+      // resolves through message.agent_id is this row.
+      const messageID = MessageID.ascending()
+      await rt.runPromise(
+        Session.Service.use((s) =>
+          s.updateMessage({
+            id: messageID,
+            role: "user" as const,
+            sessionID: child.id,
+            agentID: child.id,
+            agent: "build",
+            model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+            time: { created: Date.now() },
+          }),
+        ),
+      )
+      await rt.runPromise(
+        Session.Service.use((s) =>
+          s.updatePart({ id: PartID.ascending(), messageID, sessionID: child.id, type: "text", text: "working" }),
+        ),
+      )
+
+      const after = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.get(child.id, child.id)))
+      expect(after!.lastActivityTime).toBeDefined()
+      expect(after!.lastActivityTime!).toBeGreaterThanOrEqual(before!.time.created)
+      // The step counter did not move — activity is a strictly finer signal.
+      expect(after!.turnCount).toBe(0)
+      expect(after!.lastTurnTime).toBe(before!.lastTurnTime)
+
+      const live = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id)))
+      expect(live!.liveness).toBe("progressing")
     })
   })
 

--- a/packages/opencode/test/actor/liveness.test.ts
+++ b/packages/opencode/test/actor/liveness.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Layer, ManagedRuntime, Effect } from "effect"
 import { ActorRegistry } from "../../src/actor/registry"
-import { deriveLiveness, DEFAULT_LIVENESS_STALL_MS, DEFAULT_LIVENESS_ABANDON_MS } from "../../src/actor/schema"
+import {
+  deriveLiveness,
+  DEFAULT_LIVENESS_STALL_MS,
+  DEFAULT_LIVENESS_ABANDON_MS,
+  ACTIVITY_COALESCE_MS,
+} from "../../src/actor/schema"
 import { Bus } from "../../src/bus"
 import { Session } from "../../src/session"
 import { SessionID, MessageID, PartID } from "../../src/session/schema"
@@ -460,4 +465,141 @@ describe("ActorRegistry.liveness (T39 integration)", () => {
       expect(found).toBeUndefined()
     })
   })
+
+  // The heartbeat rides the part-write path, and that path is unthrottled: the
+  // bash tool's ctx.metadata fires once per decoded stdout chunk and reaches
+  // Session.updatePart with no interval check, measured at 453-575 registry row
+  // writes/sec for a chatty command. ACTIVITY_COALESCE_MS caps the column's
+  // resolution via a staleness predicate in the projector's WHERE, so redundant
+  // writes inside the interval match 0 rows instead of rewriting the row.
+  test("coalescing: repeated part writes inside ACTIVITY_COALESCE_MS do not re-advance the column", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withRegistry(tmp.path, async (rt) => {
+      const child = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => register(reg, child.id)))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => reg.updateStatus(child.id, child.id, { status: "running" })))
+
+      const messageID = MessageID.ascending()
+      await rt.runPromise(
+        Session.Service.use((s) =>
+          s.updateMessage({
+            id: messageID,
+            role: "user" as const,
+            sessionID: child.id,
+            agentID: child.id,
+            agent: "build",
+            model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+            time: { created: Date.now() },
+          }),
+        ),
+      )
+      const writePart = (text: string) => {
+        const partID = PartID.ascending()
+        return rt
+          .runPromise(
+            Session.Service.use((s) => s.updatePart({ id: partID, messageID, sessionID: child.id, type: "text", text })),
+          )
+          .then(() => partID)
+      }
+
+      // First write: the column is NULL, and the `IS NULL` disjunct must let it
+      // through — a fresh row has to record its first activity.
+      await writePart("first")
+      const first = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.get(child.id, child.id)))
+      expect(first!.lastActivityTime).toBeDefined()
+
+      // Now a burst well inside the interval. Every one of these is a part write
+      // that previously rewrote the registry row.
+      const BURST = 40
+      let lastPartID = ""
+      for (let i = 0; i < BURST; i++) lastPartID = await writePart(`chunk ${i}`)
+
+      const after = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.get(child.id, child.id)))
+      // Pinned to the first write: all BURST redundant registry writes suppressed.
+      expect(after!.lastActivityTime).toBe(first!.lastActivityTime)
+
+      // The suppression is specific to the registry heartbeat — the parts
+      // themselves still landed, so nothing was lost from the session.
+      const stored = await rt.runPromise(
+        Session.Service.use((s) => s.getPart({ sessionID: child.id, messageID, partID: lastPartID as any })),
+      )
+      expect(stored).toBeDefined()
+
+      // And the coalesced row is still classified live, not stalled or idle.
+      const live = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id)))
+      expect(live!.liveness).toBe("progressing")
+    })
+  }, 60_000)
+
+  // Semantics-preservation: coalescing must not let a genuinely active actor
+  // drift out of `progressing`. Runs longer than ACTIVITY_COALESCE_MS with parts
+  // arriving continuously and samples liveness at EVERY step, so a guard that
+  // froze the column would surface as a stalled/idle sample rather than only at
+  // the end.
+  test("continuous activity keeps reading progressing across an interval longer than ACTIVITY_COALESCE_MS", async () => {
+    // The safety of coalescing rests entirely on the interval being far below
+    // the stall window: worst-case apparent age equals ACTIVITY_COALESCE_MS, so
+    // the progressing/stalled flip is unreachable while this holds.
+    expect(ACTIVITY_COALESCE_MS * 2).toBeLessThan(DEFAULT_LIVENESS_STALL_MS)
+    expect(ACTIVITY_COALESCE_MS * 2).toBeLessThan(DEFAULT_LIVENESS_ABANDON_MS)
+
+    await using tmp = await tmpdir({ git: true })
+    await withRegistry(tmp.path, async (rt) => {
+      const child = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => register(reg, child.id)))
+      await rt.runPromise(ActorRegistry.Service.use((reg) => reg.updateStatus(child.id, child.id, { status: "running" })))
+
+      const messageID = MessageID.ascending()
+      await rt.runPromise(
+        Session.Service.use((s) =>
+          s.updateMessage({
+            id: messageID,
+            role: "user" as const,
+            sessionID: child.id,
+            agentID: child.id,
+            agent: "build",
+            model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+            time: { created: Date.now() },
+          }),
+        ),
+      )
+
+      const SPAN_MS = ACTIVITY_COALESCE_MS + 1_500
+      const CADENCE_MS = 250
+      const started = Date.now()
+      const observed = new Set<number>()
+      let samples = 0
+
+      while (Date.now() - started < SPAN_MS) {
+        await rt.runPromise(
+          Session.Service.use((s) =>
+            s.updatePart({
+              id: PartID.ascending(),
+              messageID,
+              sessionID: child.id,
+              type: "text",
+              text: `t+${Date.now() - started}`,
+            }),
+          ),
+        )
+        const found = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.liveness(child.id, child.id)))
+        samples++
+        // The whole point: an actor that never stops emitting parts is never
+        // reported as anything but progressing, however coarse the column is.
+        expect(found!.liveness).toBe("progressing")
+        // The recorded activity is allowed to lag by the coalescing interval and
+        // at most one more write cadence — never more.
+        expect(Date.now() - found!.actor.lastActivityTime!).toBeLessThanOrEqual(ACTIVITY_COALESCE_MS + CADENCE_MS * 4)
+        observed.add(found!.actor.lastActivityTime!)
+        await new Promise((r) => setTimeout(r, CADENCE_MS))
+      }
+
+      // Real coverage of the window, not one lucky iteration.
+      expect(samples).toBeGreaterThan(SPAN_MS / CADENCE_MS / 2)
+      expect(Date.now() - started).toBeGreaterThan(ACTIVITY_COALESCE_MS)
+      // The column is coalesced, not frozen: it advanced at least once more
+      // after its first value now that the span exceeded the interval.
+      expect(observed.size).toBeGreaterThanOrEqual(2)
+    })
+  }, 120_000)
 })

--- a/packages/opencode/test/actor/stall-watchdog.test.ts
+++ b/packages/opencode/test/actor/stall-watchdog.test.ts
@@ -209,18 +209,41 @@ const parentInboxRows = (parentID: SessionID) =>
     ),
   )
 
-// Backdate a peer's last_turn_time so deriveLiveness reads `stalled` on the next
-// scan WITHOUT advancing turn_count — exactly the wedged-child shape the watchdog
-// exists to catch. turn_count is forced to >= 1 (the child has run at least one
-// turn, then wedged): a not-yet-started child (turnCount 0) is deliberately
-// exempt from the stall path, so a stalled row must have run once. Keeps status
-// pending/running so it stays in listActive().
+// Backdate a peer's activity so deriveLiveness reads `stalled` on the next scan
+// WITHOUT advancing turn_count — exactly the wedged-child shape the watchdog
+// exists to catch. last_activity_time is the field the derivation reads;
+// last_turn_time is aged alongside it so the row stays internally consistent
+// (and so the separate STUCK_THRESHOLD_MS step-completion scan still sees what it
+// always saw). turn_count is forced to >= 1 to keep expressing "has run, then
+// wedged" — it is no longer load-bearing for the stall path, since the
+// turnCount-0 exemption is gone. Keeps status running so it stays in listActive().
 const backdateTurn = (sessionID: SessionID, actorID: string, agoMs: number) =>
   Effect.sync(() =>
     Database.use((db) =>
       db
         .update(ActorRegistryTable)
-        .set({ status: "running", last_turn_time: Date.now() - agoMs, turn_count: sql`max(${ActorRegistryTable.turn_count}, 1)` })
+        .set({
+          status: "running",
+          last_turn_time: Date.now() - agoMs,
+          last_activity_time: Date.now() - agoMs,
+          turn_count: sql`max(${ActorRegistryTable.turn_count}, 1)`,
+        })
+        .where(and(eq(ActorRegistryTable.session_id, sessionID), eq(ActorRegistryTable.actor_id, actorID)))
+        .run(),
+    ),
+  )
+
+// The inverse of backdateTurn: work lands again, which is what a resuming child
+// actually does (its parts get written, bumping last_activity_time). Expressed as
+// a direct row update rather than a real part write so this file stays a
+// watchdog test and does not depend on the message/part projection path — that
+// end-to-end link is covered in test/actor/liveness.test.ts.
+const freshenActivity = (sessionID: SessionID, actorID: string) =>
+  Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .update(ActorRegistryTable)
+        .set({ last_activity_time: Date.now() })
         .where(and(eq(ActorRegistryTable.session_id, sessionID), eq(ActorRegistryTable.actor_id, actorID)))
         .run(),
     ),
@@ -277,9 +300,12 @@ describe("Actor stall watchdog (T40)", () => {
         yield* actor.scanStalledOnce!()
         expect((yield* parentInboxRows(parent.id)).length).toBe(1)
 
-        // (4) Child resumes (a turn advances → recent last_turn_time + turnCount++).
-        //     Now PROGRESSING: a scan sends nothing new AND re-arms the debounce.
+        // (4) Child resumes: work lands again (a part write bumps
+        //     last_activity_time) and a turn completes. Now PROGRESSING: a scan
+        //     sends nothing new AND re-arms the debounce. updateTurn alone is no
+        //     longer sufficient — the derivation reads activity, not step count.
         yield* actorReg.updateTurn(child.id, child.id)
+        yield* freshenActivity(child.id, child.id)
         yield* actor.scanStalledOnce!()
         expect((yield* parentInboxRows(parent.id)).length).toBe(1)
 

--- a/packages/opencode/test/inbox/parse-actor-notification.test.ts
+++ b/packages/opencode/test/inbox/parse-actor-notification.test.ts
@@ -190,3 +190,42 @@ describe("parseActorNotification", () => {
     })
   })
 })
+
+// The stalled notification is the one user-visible surface of deriveLiveness, and
+// its wording is load-bearing: it told operators "no turn advance" long after the
+// derivation stopped reading the turn clock, so healthy children inside a single
+// long step (`bun ci`, a full test suite) produced a dozen-plus notifications that
+// read as flat contradictions of what the child was visibly doing. The reader
+// learned to ignore the channel — which is the real cost, because a true stall then
+// goes unread. The number and the noun have to describe the same thing.
+describe("renderActorNotification stalled wording", () => {
+  const stalledText = (stalledForMs?: number) =>
+    renderActorNotification({
+      actorID: "general-7",
+      description: "long step child",
+      status: "stalled",
+      stalledForMs,
+    })
+
+  test("reports silence, not turn advance", () => {
+    const text = stalledText(372_000)
+    expect(text).toContain("(no activity for 372s)")
+    expect(text).not.toContain("no turn advance")
+    expect(text).not.toContain("turn")
+  })
+
+  test("does not claim the child made no progress, only that nothing landed", () => {
+    // A long step IS progress; we cannot see inside one, only whether output is
+    // coming out of it. The old text asserted the stronger, unknowable claim.
+    const text = stalledText(372_000)
+    expect(text).not.toContain("has made no progress")
+    expect(text).toContain("nothing has landed for it")
+    expect(text).toContain("It is still running")
+  })
+
+  test("omits the duration clause entirely when no duration is supplied", () => {
+    const text = stalledText(undefined)
+    expect(text).toContain("appears stalled.")
+    expect(text).not.toContain("no activity for")
+  })
+})

--- a/packages/opencode/test/tool/fleet.test.ts
+++ b/packages/opencode/test/tool/fleet.test.ts
@@ -33,15 +33,22 @@ function sess(id: string, title: string, directory: string): FleetActorInput["se
 describe("assembleFleet", () => {
   test("correlates liveness, turn telemetry, and worktree mapping into grouped rows", () => {
     const inputs: FleetActorInput[] = [
-      // progressing: running, turn advanced just now
+      // progressing: running, something landed just now. lastTurnTime is kept in
+      // sync only so the fixture stays readable — the derivation reads activity.
       {
         session: sess("ses_a", "port parser", "/wt/a"),
-        actor: actor({ agent: "build", status: "running", lastTurnTime: NOW - 1_000, turnCount: 5 }),
+        actor: actor({ agent: "build", status: "running", lastActivityTime: NOW - 1_000, lastTurnTime: NOW - 1_000, turnCount: 5 }),
       },
-      // stalled: running but no turn advance for longer than the window
+      // stalled: running but nothing has landed for longer than the window
       {
         session: sess("ses_b", "billing schema", "/wt/b"),
-        actor: actor({ agent: "compose", status: "running", lastTurnTime: NOW - DEFAULT_LIVENESS_STALL_MS - 5_000, turnCount: 2 }),
+        actor: actor({
+          agent: "compose",
+          status: "running",
+          lastActivityTime: NOW - DEFAULT_LIVENESS_STALL_MS - 5_000,
+          lastTurnTime: NOW - DEFAULT_LIVENESS_STALL_MS - 5_000,
+          turnCount: 2,
+        }),
       },
       // terminal success → idle bucket
       {
@@ -150,7 +157,7 @@ describe("renderFleetTable", () => {
     const inputs: FleetActorInput[] = [
       {
         session: sess("ses_a", "port parser", "/wt/a"),
-        actor: actor({ agent: "build", status: "running", lastTurnTime: NOW - 2_000, turnCount: 5 }),
+        actor: actor({ agent: "build", status: "running", lastActivityTime: NOW - 2_000, lastTurnTime: NOW - 2_000, turnCount: 5 }),
       },
       { session: sess("ses_z", "idle one", "/shared"), actor: null },
     ]

--- a/packages/opencode/test/tool/fleet.test.ts
+++ b/packages/opencode/test/tool/fleet.test.ts
@@ -107,6 +107,38 @@ describe("assembleFleet", () => {
     expect(summary.counts).toEqual({ progressing: 0, stalled: 0, idle: 0, failed: 0, cancelled: 0 })
     expect(summary.rows).toEqual([])
   })
+
+  // Defect A: a child whose process is gone but whose registry row was never
+  // reconciled must NOT be reported as routable. Both `progressing` and
+  // `stalled` are "in progress" buckets — the orchestrator routes work to them
+  // and treats them as already in flight — so a row that has claimed
+  // running/pending for longer than any live turn could must land in `idle`.
+  // Field values are the two real fixture rows measured in an isolated dev home
+  // (peers "Fix calc.py add() bug" turnCount 26 and "Modernize docs/README.md
+  // install steps" turnCount 20), replayed a day after their last turn.
+  test("a row still claiming running a day after its last turn is not routable", () => {
+    const DAY = 24 * 60 * 60_000
+    const inputs: FleetActorInput[] = [
+      {
+        session: sess("ses_05c0af252ffeigpmiJbqaa8vUV", "[topic:calc-py] Fix calc.py add() bug", "/wt/calc"),
+        actor: actor({ status: "running", lastTurnTime: NOW - DAY, turnCount: 26, time: { created: NOW - DAY - 60_000, updated: NOW - DAY } }),
+      },
+      {
+        session: sess("ses_05c08a1e9ffeFg2DEKBuhhBxuS", "[topic:docs-readme] Modernize docs/README.md", "/wt/docs"),
+        actor: actor({ status: "pending", lastTurnTime: NOW - DAY, turnCount: 20, time: { created: NOW - DAY - 60_000, updated: NOW - DAY } }),
+      },
+      // A never-started child spawned a day ago (defect B at the consumer layer).
+      {
+        session: sess("ses_never", "queued forever", "/wt/never"),
+        actor: actor({ status: "pending", lastTurnTime: NOW - DAY, turnCount: 0, time: { created: NOW - DAY, updated: NOW - DAY } }),
+      },
+    ]
+    const summary = assembleFleet(inputs, [], NOW)
+    expect(summary.counts.progressing).toBe(0)
+    expect(summary.counts.stalled).toBe(0)
+    expect(summary.counts.idle).toBe(3)
+    expect(summary.rows.map((r) => r.liveness)).toEqual(["idle", "idle", "idle"])
+  })
 })
 
 describe("renderFleetTable", () => {

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -671,12 +671,13 @@ describe("session tool", () => {
         )
         const progID = prog.metadata.sessionID!
 
-        // A stalled peer: running, having run at least one turn, but with an old
-        // last_turn_time far past the default staleness window → deriveLiveness
-        // reports stalled. Force status running and turn_count >= 1 (a
-        // not-yet-started child with turnCount 0 is exempt from the stall path),
-        // then age its last_turn_time via a direct row update (updateTurn would
-        // bump last_turn_time to now; we need it OLD while turn_count stays put).
+        // A stalled peer: running, but with nothing landed for far longer than the
+        // default staleness window → deriveLiveness reports stalled. Age
+        // last_activity_time (the field the derivation reads) via a direct row
+        // update; last_turn_time is aged with it so the row stays internally
+        // consistent. 5 minutes is past the 90s stall window and comfortably
+        // inside the 10-minute abandonment bound, so this reads `stalled`, not
+        // `idle`.
         const stalled = yield* tool.execute(
           { operation: { action: "create", task: "wedged", mode: "build", title: "Wedged" } },
           ctx(parent.id),
@@ -687,7 +688,11 @@ describe("session tool", () => {
           Database.use((db) =>
             db
               .update(ActorRegistryTable)
-              .set({ last_turn_time: Date.now() - 10 * 60_000, turn_count: 1 })
+              .set({
+                last_turn_time: Date.now() - 5 * 60_000,
+                last_activity_time: Date.now() - 5 * 60_000,
+                turn_count: 1,
+              })
               .where(and(eq(ActorRegistryTable.session_id, SessionID.make(stalledID)), eq(ActorRegistryTable.actor_id, stalledID)))
               .run(),
           ),

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -10,6 +10,7 @@ import { Agent } from "../../src/agent/agent"
 import { Actor } from "../../src/actor/spawn"
 import { ActorRegistry } from "../../src/actor/registry"
 import { ActorRegistryTable } from "../../src/actor/actor.sql"
+import { DEFAULT_LIVENESS_STALL_MS } from "../../src/actor/schema"
 import { Database, and, eq } from "../../src/storage"
 import { Bus } from "../../src/bus"
 import { TuiEvent } from "../../src/cli/cmd/tui/event"
@@ -628,6 +629,12 @@ describe("session tool", () => {
         expect(running.output).toContain("progressing")
         expect(running.output).toContain("turnCount:")
         expect(running.output).toContain("lastTurnTime:")
+        // The dump must also show the quantity the verdict was DERIVED from, and
+        // label which of the two clocks that is. Showing only the step clock next
+        // to an activity-derived verdict is how this signal got misread.
+        expect(running.output).toContain("lastActivityTime:")
+        expect(running.output).toContain("liveness derives from this")
+        expect(running.output).toContain("not the liveness input")
 
         // Flip to a terminal idle+success: derived liveness surfaces the outcome.
         yield* actorReg.updateStatus(SessionID.make(childID), childID, { status: "idle", lastOutcome: "success" })
@@ -675,9 +682,14 @@ describe("session tool", () => {
         // default staleness window → deriveLiveness reports stalled. Age
         // last_activity_time (the field the derivation reads) via a direct row
         // update; last_turn_time is aged with it so the row stays internally
-        // consistent. 5 minutes is past the 90s stall window and comfortably
-        // inside the 10-minute abandonment bound, so this reads `stalled`, not
-        // `idle`.
+        // consistent.
+        // REWRITTEN: this used a bare `5 * 60_000`, justified in-line as "past the
+        // 90s stall window and comfortably inside the 10-minute abandonment bound".
+        // The window is now 6 minutes, so that literal quietly became a
+        // `progressing` fixture asserting `stalled`. Derived from the constant
+        // instead — one minute past the window, still well inside the bound — so it
+        // cannot silently invert again.
+        const silentForMs = DEFAULT_LIVENESS_STALL_MS + 60_000
         const stalled = yield* tool.execute(
           { operation: { action: "create", task: "wedged", mode: "build", title: "Wedged" } },
           ctx(parent.id),
@@ -689,8 +701,8 @@ describe("session tool", () => {
             db
               .update(ActorRegistryTable)
               .set({
-                last_turn_time: Date.now() - 5 * 60_000,
-                last_activity_time: Date.now() - 5 * 60_000,
+                last_turn_time: Date.now() - silentForMs,
+                last_activity_time: Date.now() - silentForMs,
                 turn_count: 1,
               })
               .where(and(eq(ActorRegistryTable.session_id, SessionID.make(stalledID)), eq(ActorRegistryTable.actor_id, stalledID)))
@@ -701,7 +713,10 @@ describe("session tool", () => {
         const result = yield* tool.execute({ operation: { action: "list" } }, ctx(parent.id))
 
         expect(result.output).toContain("In progress — progressing (running/pending, advancing) (1):")
-        expect(result.output).toContain("In progress — stalled (running/pending, no recent turn) (1):")
+        // Heading reworded with the signal: the bucket means "no recent ACTIVITY",
+        // not "no recent turn" — a child mid-step advances activity and never lands
+        // in this bucket.
+        expect(result.output).toContain("In progress — stalled (running/pending, no recent activity) (1):")
         expect(result.output).toContain("(1 progressing, 1 stalled)")
         // Each child lands under its own group.
         const progSection = result.output.split("In progress — progressing")[1]?.split("In progress — stalled")[0] ?? ""


### PR DESCRIPTION
## What this PR ships — two steps, kept as two commits

This PR does two things to the same function, in order, and the commits are kept separate
because the second one largely retires the first:

1. **`773edc5db` — bound the unreliable signal.** `deriveLiveness` placed *unbounded* trust
   in a `running`/`pending` row, so a dead child stayed routable forever. This adds
   `DEFAULT_LIVENESS_ABANDON_MS` so the claim expires. Correct on its own, and its revert
   probes stay attributable to it.
2. **`2375280de` — replace the signal so the bound barely matters.** The reason the bound had
   to be so lenient (30 minutes) is that the signal was *step-grained*: it could only see a
   **completed step**, so a child blocked mid-step looked exactly like a dead one. This reads
   last **activity** instead, which already exists in the database and is written today. With
   that, the `turnCount === 0` special case and the 30-minute window both collapse into a
   single 10-minute bound.

Read step 2 as the real fix and step 1 as the stopgap it grew out of. Sections below are
labelled by step.

---

## Why this matters more than a display nit

The orchestrator's fleet roster exists for exactly one purpose: make the
orchestrator **route work to an existing child instead of creating a new one** — that is
#1741's whole point. So a dead child displayed as `progressing` is *worse than no roster
entry at all*: the orchestrator routes work into a session that can never answer, and
`progressing` additionally suppresses re-dispatch because something appears to already be
in flight. Every consumer of `deriveLiveness` inherits this: the roster, `session list`
(which groups `progressing`/`stalled` under the heading "In progress"), `session status`,
and the fleet table. #1741's route-to-existing mechanism is only as good as the liveness
signal it reads, so an over-optimistic signal weakens it directly.

`stalled` is not a safe fallback either. It also lives under "In progress" and it also
marks the child as routable; it only says "no recent turn", not "nobody is home".

## Step 1 — the defect: an unbounded claim

`deriveLiveness` (`src/actor/schema.ts`) placed **unbounded** trust in a `running`/`pending`
row. Two shapes:

- **A never-started child reads `progressing` forever.** `if (actor.turnCount === 0) return
  "progressing"` returned early and bypassed the staleness window entirely. The comment's
  intent is right — a queued or cold-starting first turn must not be misread as a stall —
  but it implemented that leniency as *unbounded*.
- **A started child that died reads `stalled` forever**, i.e. still "in progress".

The only repair for a row whose owner died is `ActorRegistry`'s orphan sweep
(`registry.ts`: `UPDATE actor_registry SET status='idle', last_outcome='failure',
last_error='orphaned: process restarted' WHERE status IN ('pending','running') AND
instance_id != $instanceID`). That sweep runs **once, at process init, and only for rows
carrying a different `instance_id`**. Until it runs — and for any row it cannot reach — the
derivation is the only thing standing between a corpse and the router, and it asserted
progress. Same defect class as #1960's orphaned `running` tool parts: a persisted transient
whose repair lives on exactly one path.

## Step 1 — the fix: bound the claim

One new constant and one guard, both in `deriveLiveness`:

```ts
export const DEFAULT_LIVENESS_ABANDON_MS = 30 * 60_000

if (now - (actor.turnCount === 0 ? actor.time.created : actor.lastTurnTime) > abandonMs) return "idle"
if (actor.turnCount === 0) return "progressing"   // leniency KEPT, now bounded
```

Reference clock per row shape: a started child's evidence of life is its last turn; a
never-started one has none, so its **spawn time** (`time.created`) is the only honest
reference — which is what B needed: a longer bound measured from spawn, not removal of the
leniency.

**Why 30 minutes**, picked the way `DEFAULT_LIVENESS_STALL_MS`'s comment picks 90s:
`updateTurn` is a **per-step** heartbeat, so a child that has genuinely begun cannot go 30m
without bumping `last_turn_time` — that is an order of magnitude past the 5-minute
stuck-detection cutoff (`STUCK_THRESHOLD_MS`) and unreachable by a live turn. A child that
has *not* begun is waiting on the concurrency gate, which admits work continuously, so 30m
of zero admissions means its process is gone.

Past the bound the row reads `idle` — already documented as "finished with no recorded
outcome (or an unknown state)" — and `idle` is the one bucket no consumer treats as
routable or in-flight. **Deliberate direction of error:** past the bound we would rather
report a still-queued child as `idle` (worst case: the orchestrator creates a duplicate,
which is wasteful) than as `progressing` (worst case: work routed into a corpse and
re-dispatch suppressed, which is unrecoverable).

Nothing is written to the database and no new repair mechanism is introduced; this is
purely the read side becoming honest.

> **Superseded in part by step 2.** The 30 minutes below, and the `turnCount === 0`
> special case it protects, are both artefacts of a step-grained signal. Step 2 replaces
> the signal with last *activity* and collapses both into a single 10-minute bound; the
> reasoning kept here is what step 1 shipped, not the PR's final state. `abandonMs` is a 4th parameter with the same
override shape `stallMs` already has.

## Step 1 — what I could NOT confirm, and the named follow-up

The report I worked from assumed the registry "never reconciles rows whose process is gone
— they never even became `idle`". **Measured on the two real fixture rows, that is not
true**, and I am reporting it rather than fixing a defect that is not there. Both rows in
the isolated dev home read:

| session | mode | status | lastOutcome | turnCount | lastTurnTime | lastError |
|---|---|---|---|---|---|---|
| `ses_05c0af252ffeigpmiJbqaa8vUV` ("Fix calc.py add() bug") | peer | `idle` | `failure` | 26 | 1785163372484 | `orphaned: process restarted` |
| `ses_05c08a1e9ffeFg2DEKBuhhBxuS` ("Modernize docs/README.md install steps") | peer | `idle` | `failure` | 20 | 1785162766301 | `orphaned: process restarted` |

All six orphaned rows share `time_completed = 1785163573647` — one sweep, at process init.
So the sweep works and reached exactly these rows; the roster that showed
`stalled`/`progressing` was rendered while they were still `running` under the then-live
instance, and reconciliation only came at the next process start. That reframes the
registry-side defect from "no reconciliation exists" to "**reconciliation is bound to
process init, so it cannot see a row whose owner is the CURRENT instance**".

That residual half is genuinely larger than this PR:

> **FOLLOW-UP — per-actor liveness ownership.** Peers run in-process (`Actor.spawnPeer` →
> `runTurn` fibers) and are registered with the *parent's* `PROCESS_INSTANCE_ID`, so
> `instance_id` cannot distinguish a dead child from a live one inside one process. `Actor`
> does not even expose `instance_id` (`fromRow` drops it), so no consumer can ask. Detecting
> a within-instance dead actor needs a new ownership signal (a per-actor heartbeat or an
> owning-fiber liveness probe) plus a reconcile pass at the read point, gated the way
> #1960's sweep is gated (`if ((yield* status.get(sessionID)).type !== "idle") return`, main
> slice only). That is a schema + lifecycle change and is deliberately **not** in this PR.
> This PR ships the part that is correct on its own: the read side stops asserting progress
> it cannot justify, which closes the routing hazard for both the pre-sweep window and any
> row the sweep cannot reach.

**Completing that follow-up — the other half is signal *granularity*, and step 2 supplies it.**
As written above, the follow-up covers only **ownership**: peers share the parent's
`PROCESS_INSTANCE_ID` and `Actor.fromRow` drops `instance_id`, so no consumer can ask who owns
a row. That is still open and still needs a lifecycle change. But it is not the whole residual,
and the part it omits turned out to need no new schema at all: the reason the bound above had to
be *30 minutes* is that `last_turn_time` is written only by the per-step heartbeat
(`ActorRegistry.updateTurn`, `registry.ts:223`, called once from `prompt.ts:3322` after
`step++`), so the finest event liveness could observe was a **completed step** — and a single
legitimate step here can run 20+ minutes. `MAX(part.time_updated)` already records "the last
time anything succeeded" at per-API-call granularity and is written today
(`session.sql.ts:68` → `storage/schema.sql.ts:3`; measured: 750,545 of 840,186 part rows have
`time_updated > time_created`). Reading *that* is the real fix, and it is what commit
`2375280de` in this PR does — which is why the bound is now 10 minutes and the
`turnCount === 0` special case is gone. **Ownership remains the open follow-up; granularity is
closed here.**

## Step 1 — current scope on `main`: this caveat was stale, and it inverted

An earlier revision of this description flagged that `<active-sessions>` and
`listPeerChildren` were **not on `main`** (#1741 open, head `8847d324e`, zero grep hits) and
that the roster therefore could not be reached from here. **#1741 has since merged** —
`origin/main` is now its merge commit `57ff02ed5` — so that caveat is false, and what it
implied is inverted: this is not a scope downgrade, it means **the routing hazard this PR
fixes is live on `main` today.** Verified on `origin/main` blobs at `57ff02ed5`:

- `src/session/llm.ts:36` imports `deriveLiveness`; `:348` calls `actorReg.listPeerChildren`;
  `:355` maps every child through `deriveLiveness`; `:366` keeps exactly `progressing` and
  `stalled` as the routable "working" set; `:377` renders that status into the injected
  roster line. The roster is on `main` and it reads this signal.
- `src/actor/schema.ts:81` on `main` still returns `"progressing"` unconditionally when
  `turnCount === 0`, and `:82` bounds a started row by `stallMs` alone — `deriveLiveness`
  there takes no `abandonMs` at all. So a child that died before its first turn reads
  `progressing` forever, directly into the roster the orchestrator routes from.
- The on-`main` tool consumers this PR asserts through are unchanged: `tool/fleet.ts:97`,
  `tool/session.ts:697` and `:967`, which group `progressing`/`stalled` under "In progress"
  (`tool/session.ts:983-984`, `tool/fleet.ts:146-147`).

Two things follow from the merge that I am correcting rather than restating. The literal
`<active-sessions>` tag no longer exists anywhere on `main` — #1741's final commit deleted
it — so the block is `ROSTER_HEADER` (`session/llm.ts:73-76`) and the prompt calls it your
"FLEET ROSTER" (`orchestrator.txt:30`); naming it by the old tag would now be wrong. And
while the roster is reachable, **this PR adds no test at that injection point**:
`test/session/llm.test.ts` and `test/session/system.test.ts` on `main` have zero hits for
`deriveLiveness`, `ROSTER_HEADER` or `listPeerChildren`, and I did not add one. The fix is
in the shared derivation, so the roster inherits it; what is directly asserted below is the
tool consumers.

## Step 1 tests — one per defect, each revert-probed

`test/actor/liveness.test.ts` (+4) and `test/tool/fleet.test.ts` (+1). The fleet test uses
the two measured fixture rows' real field values (turnCount 26 / 20) replayed a day after
their last turn, and asserts through `assembleFleet` — the consumer — that neither lands in
a routable bucket.

Every pre-existing expectation is unchanged; the existing literals only gained the `time`
field the widened `Pick` now requires, and the existing "10-minute-old cold start is still
progressing" case still passes (10m < 30m), which is the point of keeping the leniency.

**Probe 1 — restore the unbounded `turnCount === 0` early return (defect B):**

```
177 |     expect(deriveLiveness(stillborn, now)).not.toBe("progressing")
                                                     ^
error: expect(received).not.toBe(expected)
Expected: not "progressing"
(fail) deriveLiveness (T39 derivation rule) > never-started child spawned long ago does NOT read progressing [1.47ms]

137 |     expect(summary.counts.progressing).toBe(0)
                                             ^
error: expect(received).toBe(expected)
Expected: 0
Received: 1
(fail) assembleFleet > a row still claiming running a day after its last turn is not routable [7.93ms]

 21 pass  2 fail
```

**Probe 2 — keep B's spawn bound, drop the bound for rows that HAVE run a turn (defect A):**

```
218 |     const live = deriveLiveness(dead, now)
219 |     expect(live).not.toBe("stalled")
                           ^
error: expect(received).not.toBe(expected)
Expected: not "stalled"
(fail) deriveLiveness (T39 derivation rule) > started child still claiming running long after its last turn is not routable [0.34ms]

234 |     expect(deriveLiveness(row, now, DEFAULT_LIVENESS_STALL_MS, 5 * 60_000)).toBe("idle")
                                                                                  ^
error: expect(received).toBe(expected)
Expected: "idle"
Received: "stalled"
(fail) deriveLiveness (T39 derivation rule) > custom abandonMs overrides the default bound [2.02ms]

138 |     expect(summary.counts.stalled).toBe(0)
                                         ^
error: expect(received).toBe(expected)
Expected: 0
Received: 2
(fail) assembleFleet > a row still claiming running a day after its last turn is not routable [0.75ms]

 20 pass  3 fail
```

## Step 1 suite numbers

`bun typecheck` exit 0.

Scoped run only (`test/actor` + everything that references the signal, found with
`rg -l 'deriveLiveness|active-sessions|listPeerChildren' test`), because concurrent
heavyweight suites on this host starve each other. Same command both sides
(`bun test test/actor test/tool/fleet.test.ts test/tool/session-tool.test.ts --timeout 120000`),
same worktree and `node_modules`, the three changed files reverted to `origin/main` for the
baseline:

| | pass | skip | fail | tests | files |
|---|---|---|---|---|---|
| pristine `origin/main` (60af8f1) | 178 | 3 | 5 | 186 | 22 |
| this branch | 187 | 3 | 1 | 191 | 22 |

Note on the baseline commit: `60af8f1` predates the #1741 merge that is now `main`'s tip
(`57ff02ed5`). These numbers are the record of that comparison run, not a claim about
today's `main`. The three files this PR changes are unchanged by that merge, which is why
the branch still applies cleanly.

`+5 tests` is exactly the five new cases. My failure set is a strict **subset** of the
baseline's: both runs fail `spawn no-deadlock (F56) > checkpoint-writer settles (no hang)
when session permission is '*':'ask' …`, and the baseline additionally fails four
`session tool join` cases on their 30s timeouts. The runs were sequential rather than
side-by-side, so the four extra baseline failures are load-dependent flakes, not a
regression — none of them is touched by this change, and none appears on this branch.
---

## Step 2 — the signal itself was too coarse

### Mechanism

`deriveLiveness`'s inputs all came from the actor registry row, and the only writer of
`turn_count` / `last_turn_time` is `ActorRegistry.updateTurn`
(`packages/opencode/src/actor/registry.ts:223`), called from exactly one place —
`packages/opencode/src/session/prompt.ts:3322`, immediately after `step++`, commented
"Per-step turn heartbeat: only writer of turn_count".

So **the finest thing liveness could see was a completed step.** A child blocked mid-step —
inside a long tool call, a slow model call, a retry/backoff — was indistinguishable from a
dead one. That is why the bounds had to be stretched: a single legitimate step in this repo
can run 20+ minutes (a live test run ≈1225 s; `git worktree add` >120 s), so any bound had to
clear the longest possible step, and the 30 minutes in step 1 existed *only* because the
signal was coarse.

The finer signal already exists and was simply not read. `PartTable`
(`packages/opencode/src/session/session.sql.ts:68`) spreads `...Timestamps`, and `Timestamps`
(`packages/opencode/src/storage/schema.sql.ts:3`) declares
`time_updated: integer().notNull().$onUpdate(() => Date.now())`. Part rows are written when a
tool call starts and updated as it progresses, so `MAX(part.time_updated)` over an actor's
slice is already "the last time anything succeeded", at per-API-call granularity.

**Verified that it is really written, rather than assumed** — the projector writes parts with
`onConflictDoUpdate`, and it was not obvious that Drizzle's `$onUpdate` fires on that path.
Measured on a 5.4 GB production database:

```
parts total                     840186
part.time_updated > time_created 750545   (89%)
part.time_updated IS NULL             0
```

Deltas on individual rows (23644 ms, 8988 ms, 118 ms, 1 ms) show a single part row being
updated repeatedly while one tool call runs. Streaming token deltas do **not** hit the table
— `Session.updatePartDelta` (`packages/opencode/src/session/session.ts:771`) only publishes a
bus event — so the write rate is bounded by discrete part lifecycle events plus
`ctx.metadata()` progress calls, not by tokens.

### Shape: denormalised column, chosen by measurement

The seam to respect: `part` rows carry `session_id` but **no agent id** — the agent slice
lives on the `message` row — so a per-slice read needs a join to `MessageTable`, not a
single-table read.

The roster is rebuilt per request and iterates every peer child
(`packages/opencode/src/session/llm.ts:348`), so read-time cost is paid on a hot path. Measured
against the worst real roster on disk — a parent with **172 peer children** and **45,377
parts** across them:

| shape | per roster build | per part write |
|---|---|---|
| (a) read-time join, N+1 (one `MAX` per child) | 172 queries — **25 ms warm / 487 ms cold** | 0 |
| (a′) read-time join, single grouped query | 1 query — **32–38 ms warm / 339 ms cold** | 0 |
| (b) denormalised `last_activity_time` column | **0 extra queries** (rides in the row `listPeerChildren` already selects) | 1 message-PK lookup + 1 registry-PK update, sub-millisecond |

Batching does **not** rescue the read-time shape: (a′) is no better than (a) because the cost
is scanning the 45 k parts, not per-query overhead, and it grows without bound as children
accumulate history. So **(b)**.

The writer is `packages/opencode/src/session/projectors.ts:118` — the `MessageV2.Event.PartUpdated`
projector, which is the single writer of `part` rows and therefore already fires on every part
write. No new hook in the session loop. It is sequenced *after* the part insert inside the same
`try`, so activity is recorded only if the part actually landed, and it resolves the owning
actor through the message's primary key (`session_id` + `message.agent_id`), which hits
`actor_registry`'s primary key directly and stays correct for peers, subagents and `main`
alike. For peers this is exact because `runAgentLoop` passes the actor id as the message's
`agentID` (`packages/opencode/src/actor/spawn.ts:263`).

### The bound: 10 minutes, and why that number

```ts
export const DEFAULT_LIVENESS_ABANDON_MS = 10 * 60_000

const since = actor.lastActivityTime ?? actor.time.created
if (now - since > abandonMs) return "idle"
return now - since <= stallMs ? "progressing" : "stalled"
```

One reference for every row and no per-row special case. Measured over **43,120 real
inter-activity gaps** across that 172-child roster, and over the first-activity latency of all
172:

| quantity | value |
|---|---|
| inter-activity gap p50 | 994 ms |
| p90 | 6,740 ms |
| p99 | 38,048 ms |
| p99.9 | 296,811 ms (≈5 min) |
| first activity after spawn — p50 | 194 ms |
| first activity after spawn — **max** | **1,735 ms** |
| children with no activity at all | **0 of 172** |

10 minutes is therefore:

- **2× `STUCK_THRESHOLD_MS`** (`packages/opencode/src/actor/registry.ts:16`), the repo's own
  existing "stuck" cutoff — an anchor that already survived review, not a fresh magic number;
- **~16× the measured p99** inter-activity gap and **~2× p99.9**;
- **~345× the worst measured first-activity latency.** This is what licensed *deleting* the
  `turnCount === 0` leniency rather than keeping it: the "slow first turn queued behind the
  concurrency gate" it protected is empirically **under two seconds**, because the user message
  that starts the turn is itself persisted as a part. Step 1's comment reasoned that a
  not-yet-begun child "is waiting on a continuously-admitting concurrency gate" and so needed
  30 minutes of grace; measurement says it needs about two.

Direction of error is unchanged and still deliberate: prefer a duplicate child (wasteful) over
routing into a corpse with re-dispatch suppressed (unrecoverable).

`DEFAULT_LIVENESS_STALL_MS` stays at 90 s. It is a display distinction only — `stalled` is
still routable — and against the activity signal it became *more* meaningful, not less: 90 s of
true silence is already past the 99th percentile.

### `turnCount` is a counter again

It is no longer in `deriveLiveness`'s `Pick`, so the compiler now prevents it being read as
evidence of life. `updateTurn` still writes it and `turn-heartbeat.test.ts` still pins that it
advances per step — that test needed no change, because the per-step heartbeat is still a real
thing, just not the liveness signal.

Two consequences fixed in the same commit, both cases of a number disagreeing with its own
predicate:

- `packages/opencode/src/actor/spawn.ts:940` reported the stall duration as
  `now - actor.lastTurnTime` while classifying on activity; it now reports the quantity the
  classification actually used.
- `packages/opencode/src/tool/fleet.ts:112` computed a column literally named `lastActivityMs`
  from `lastTurnTime`, i.e. from the last *completed step*; it now uses the same reference
  `deriveLiveness` classifies on, so the displayed age cannot contradict the displayed liveness.

Deliberately **not** touched: the separate stuck-detection scan at
`packages/opencode/src/actor/registry.ts:477` still filters on `last_turn_time` in SQL. It
answers a different question — "is a step taking too long to complete" — which remains
meaningful and is not liveness.

### The nullable column

`last_activity_time` is nullable on purpose: rows predating the migration, and a row read
between `register()` and its first part write, have genuinely recorded no activity, and `NULL`
says so instead of inventing a timestamp. `register` writes `null` explicitly
(`packages/opencode/src/actor/registry.ts:152`) and `fromRow` flattens with `?? undefined`
(`:44`).

The comparison uses `??`, never `!== undefined`. Per `AGENTS.md` § "Reading a nullable column",
a `!== undefined` guard on a nullable column is a silent no-op that typechecks and reads
correctly — `null !== undefined` is `true`. Probe 2 below is that exact mutation, and it turns
a live child `idle`.

### Step 2 files changed

| file:line | change |
|---|---|
| `packages/opencode/src/actor/schema.ts:112` | `DEFAULT_LIVENESS_ABANDON_MS` 30 min → 10 min |
| `packages/opencode/src/actor/schema.ts:115` | `Pick` drops `lastTurnTime`/`turnCount`, adds `lastActivityTime` |
| `packages/opencode/src/actor/schema.ts:126` | single reference `lastActivityTime ?? time.created`; `turnCount === 0` case deleted |
| `packages/opencode/src/actor/schema.ts:37-42` | `Actor.lastActivityTime` (optional) |
| `packages/opencode/src/actor/actor.sql.ts:34` | `last_activity_time: integer()` (nullable) |
| `packages/opencode/migration/20260729000000_actor_registry_last_activity_time/migration.sql` | `ALTER TABLE … ADD COLUMN` |
| `packages/opencode/src/actor/registry.ts:44` | `fromRow` reads it with `?? undefined` |
| `packages/opencode/src/actor/registry.ts:152` | `register` writes `null` |
| `packages/opencode/src/session/projectors.ts:6,140-152` | the per-part writer |
| `packages/opencode/src/actor/spawn.ts:940` | stall duration matches its predicate |
| `packages/opencode/src/tool/fleet.ts:112` | `lastActivityMs` reads activity |

### Step 2 tests, and the ones deliberately rewritten

New in `test/actor/liveness.test.ts`: the mid-step child (recent activity, no completed turn
for 25 m) reads `progressing`; the converse (many turns, an hour of silence) is not routable;
the bound is pinned to 10 minutes as a value; a `null` activity column falls back to spawn
time; and an end-to-end case where a **real part write** advances `last_activity_time` while
`turn_count` stays at 0 — progress visible with zero completed steps, which is exactly what
the old signal could not express.

**Rewritten, not weakened.** Several tests encoded the old step-grained semantics. Each is
marked in-file and makes a strictly *more specific* claim than the one it replaced:

- `liveness.test.ts` "not-yet-started child (turnCount 0) is never stalled" asserted
  `progressing` for a row silent 10 minutes. That assertion *was* the fabrication being
  removed. Replaced by the spawn-fallback case, which keeps the real intent (a freshly spawned
  child is not mistaken for wedged) and states it against the mechanism that now carries it.
- `liveness.test.ts` "the turnCount-0 leniency still holds inside the abandonment bound"
  asserted `progressing` at 30 min − 1 ms of silence. Under one uniform bound the honest
  reading is `stalled` — still routable, so nothing is lost operationally — and the case now
  also pins both sides of the boundary plus one millisecond past it.
- `liveness.test.ts` integration "not-yet-started row reads progressing even far past the
  window" — same reason; now asserts the row has *no recorded activity*, is `progressing` under
  the real window, and `stalled` under a 1 ms one.
- `fleet.test.ts` and `session-tool.test.ts` expressed "wedged" by backdating
  `last_turn_time`. They now backdate activity; the assertions themselves are untouched. The
  `session-tool` fixture moved from 10 min to 5 min of silence so it still means `stalled`
  under the tighter bound rather than sliding into `idle`.
- `stall-watchdog.test.ts` expressed "child resumed" as `updateTurn`, which is no longer
  activity, so the re-arm step silently stopped re-arming. It now also freshens activity —
  which is what a resuming child really does. The notification-count assertions are unchanged.

`fleet.test.ts`'s "a row still claiming running a day after its last turn is not routable" —
the one built from the measured fixture rows — **passed unchanged**, because a day-old row with
no activity falls back to spawn time and is still past the bound.

### Step 2 revert probes, verbatim

**Probe 1 — remove the per-part writer in `projectors.ts` (the mechanism):**

```
416 |           s.updatePart({ id: PartID.ascending(), messageID, sessionID: child.id, type: "text", text: "working" }),
417 |         ),
418 |       )
419 | 
420 |       const after = await rt.runPromise(ActorRegistry.Service.use((reg) => reg.get(child.id, child.id)))
421 |       expect(after!.lastActivityTime).toBeDefined()
      ^
error: expect(received).toBeDefined()

Received: undefined

      at toBeDefined (unknown:1:1)
      at /Users/mi/projects/mi/mimocode/.worktrees/act-live/packages/opencode/test/actor/liveness.test.ts:421:39
(fail) ActorRegistry.liveness (T39 integration) > a part write advances last_activity_time with turn_count still at 0 [550.40ms]

 21 pass  1 fail
```

**Probe 2 — change the nullable read `?? ` into `!== undefined` (the `AGENTS.md` hazard):**

```
285 |       lastOutcome: undefined,
286 |       lastActivityTime: null as unknown as number | undefined,
287 |       time: { created: now - 1_000, updated: now - 1_000 },
288 |     }
289 |     expect(deriveLiveness(raw, now)).toBe("progressing")
                                           ^
error: expect(received).toBe(expected)

Expected: "progressing"
Received: "idle"

      at <anonymous> (/Users/mi/projects/mi/mimocode/.worktrees/act-live/packages/opencode/test/actor/liveness.test.ts:289:38)
(fail) deriveLiveness (T39 derivation rule) > a null activity column falls back to spawn time instead of being treated as present [1.70ms]
```

A guard whose *field* is right but whose *predicate* is wrong: the mutation typechecks, reads
correctly in review, and turns a one-second-old live child into `idle`.

**Probe 3 — widen the bound back to 30 minutes:**

```
237 |   // a silent re-widening is a test failure, not a review question.
238 |   test("the abandonment bound is 10 minutes", () => {
239 |     expect(DEFAULT_LIVENESS_ABANDON_MS).toBe(10 * 60_000)
                                              ^
error: expect(received).toBe(expected)

Expected: 600000
Received: 1800000

      at <anonymous> (/Users/mi/projects/mi/mimocode/.worktrees/act-live/packages/opencode/test/actor/liveness.test.ts:239:41)
(fail) deriveLiveness (T39 derivation rule) > the abandonment bound is 10 minutes [0.34ms]
```

**Probe 4 — restore the step-grained rule (`turnCount === 0 ? time.created : lastTurnTime`),
i.e. revert step 2's core claim while keeping step 1:**

```
 91 |         },
 92 |         now,
 93 |       ),
 94 |     ).toBe("progressing")
           ^
error: expect(received).toBe(expected)

Expected: "progressing"
Received: "idle"

      at <anonymous> (/Users/mi/projects/mi/mimocode/.worktrees/act-live/packages/opencode/test/actor/liveness.test.ts:94:7)
(fail) deriveLiveness (T39 derivation rule) > child mid-step (no completed turn for 25m) but with recent activity is progressing [0.29ms]

162 |         },
163 |         now,
164 |       ),
165 |     ).toBe("progressing")
            ^
error: expect(received).toBe(expected)

Expected: "progressing"
Received: "stalled"

      at <anonymous> (/Users/mi/projects/mi/mimocode/.worktrees/act-live/packages/opencode/test/actor/liveness.test.ts:165:7)
(fail) deriveLiveness (T39 derivation rule) > exactly at the threshold boundary is still progressing (<= window) [0.19ms]

269 |       time: { created: now - 11 * 60_000, updated: now - 4 * 60_000 },
270 |     }
271 |     // 4m-old activity: stalled under the default 10m bound, abandoned under a 2m one.
272 |     expect(deriveLiveness(row, now)).toBe("stalled")
                                           ^
error: expect(received).toBe(expected)

Expected: "stalled"
Received: "idle"

      at <anonymous> (/Users/mi/projects/mi/mimocode/.worktrees/act-live/packages/opencode/test/actor/liveness.test.ts:272:38)
(fail) deriveLiveness (T39 derivation rule) > custom abandonMs overrides the default bound [0.24ms]

 19 pass  3 fail
```

### Step 2 suite numbers

`bun typecheck` exit **0**.

Same command both sides, same worktree and `node_modules`, baseline detached at the same
`origin/main` this branch is rebased onto (`b81670870`):

```
bun test test/actor test/tool/fleet.test.ts test/tool/session-tool.test.ts --timeout 120000
```

| | pass | skip | fail | tests | files | wall |
|---|---|---|---|---|---|---|
| pristine `origin/main` (`b81670870`) | 193 | 3 | **0** | 196 | 22 | 155.9 s |
| this branch (`2375280de`) | 203 | 3 | **0** | 206 | 22 | 144.3 s |

`+10 tests`, **zero failures on either side** — so unlike step 1's run there is no shared
flake set to reason about. (Step 1's table above, with its 5 baseline / 1 branch failures, is
the record of an older run at `60af8f1`; the flakes there were load-dependent `session tool
join` timeouts.)

### What I did NOT verify

- **No TUI or live-model run.** No `RUN_ORCHESTRATOR_LIVE` suite was executed; a gated suite
  that has not been run is not verification.
- **No test at the roster injection point.** Same gap step 1 declared: `test/session/llm.test.ts`
  and `test/session/system.test.ts` still have zero hits for `deriveLiveness` / `ROSTER_HEADER` /
  `listPeerChildren`, and I did not add one. The fix is in the shared derivation and is asserted
  through the tool consumers (`assembleFleet`, `session list`).
- **The measurements are from one host's databases**, not a synthetic benchmark: the timings are
  `sqlite3` warm/cold on a 5.4 GB file and will differ elsewhere. The *ordering* they establish
  (0 extra queries beats 25–38 ms warm on a per-request path) is what the shape decision rests
  on, not the absolute numbers.
- **The gap percentiles cannot isolate "healthy running" silence.** They are computed over all
  sub-hour gaps in each slice's activity stream, which includes a child sitting idle between
  turns. A row that is genuinely `idle` never reaches the window, so those gaps inflate the
  tail rather than the reverse — but I cannot prove from history that no healthy *running*
  actor is ever silent longer than 10 minutes, which is why the bound keeps ~2× margin over
  p99.9 and errs toward keeping the child routable.
- **I did not migrate an existing database and re-read it.** The nullable/pre-migration path is
  covered by a unit case pinning the `null` shape, not by an on-disk upgrade.
- **A silent tool call is the residual risk.** `bash` calls `ctx.metadata()` per output chunk
  (`packages/opencode/src/tool/bash.ts:679`), so a chatty command advances activity
  continuously; a command that emits nothing for minutes (e.g. `git worktree add`) advances it
  only at start and end. That case is still bounded by the 10 minutes rather than by the step
  window, which is the margin the number is carrying.


---

## Follow-up commit `40f6c807f` — the heartbeat's write rate, measured then coalesced

A re-review raised one substantive concern about `2375280de`: the activity heartbeat writes far
more often than its consumer's resolution requires. It was right, and the reason it slipped
through is worth stating plainly — the affordability argument in `2375280de`'s message cited
`updatePartDelta` (`packages/opencode/src/session/session.ts:771`), which only calls
`bus.publish` and never touches the DB. That is true, but it is **a different function from the
`updatePart` on the metadata path**, so the argument was made about the wrong code path and the
actual rate was never measured.

### The path, re-verified on this branch

`packages/opencode/src/tool/bash.ts:679` ends its per-chunk handler with a bare
`return ctx.metadata({ ... })` — no interval check, no coalescing. For the bash tool that
`ctx.metadata` is the one constructed at `packages/opencode/src/session/prompt.ts:1161`, which
calls `SessionProcessor.updateToolCall`; that lands on `session.updatePart` at
`packages/opencode/src/session/processor.ts:332` with no throttle anywhere in between;
`updatePart` (`session.ts:583`) runs `SyncEvent.run(PartUpdated, …)`, and the projector
(`packages/opencode/src/session/projectors.ts:119`) then does the part upsert **plus** the
registry UPDATE with its correlated subquery over `message`.

### Measured, before

End-to-end on this branch: real `BashTool`, real `Stream.decodeText` chunks from a real spawned
shell, real projector against a real SQLite DB, counting statement executions **and rows
changed** at the `bun:sqlite` statement level (a 200,000-line `echo` loop, three runs):

| | registry rows rewritten/s | part rows written/s | ratio |
|---|---|---|---|
| run 1 | 575 | 575 | 1:1 |
| run 2 | 573 | 573 | 1:1 |
| run 3 | 453 | 453 | 1:1 |

Strictly one registry UPDATE per part upsert per decoded stdout chunk, each one running the
correlated subquery. So the concern was real, not hypothetical.

Two instrumentation artifacts were found and removed before trusting any of these numbers, both
of which had inflated an earlier reading: patching both `Database.prototype.prepare` and
`Database.prototype.query` double-wraps the same statement (`query` is built on `prepare`), and
building the service layer inside the metadata callback constructs a fresh `ActorRegistry` layer
per call, whose init re-runs the orphan sweep.

### Measured, after

`0` registry rows rewritten across the entire burst, bounded at one write per actor per 5 s.

Stated precisely, because it is the honest limit of a `WHERE`-clause guard: **the UPDATE
statement still executes per part write** — the guard suppresses the row mutation, not the
statement. That is the intended and sufficient reduction (no dirtied page, no WAL append, no
index or `time_updated` churn), and the predicate was deliberately kept in the `WHERE` rather
than a process-local cache so it stays correct across instances and restarts. It also makes the
column monotonic as a side effect: an out-of-order event carrying an older `data.time` can no
longer drag it backwards.

### The constant

`ACTIVITY_COALESCE_MS = 5_000`, named next to the other liveness constants in
`packages/opencode/src/actor/schema.ts` (not inlined in the query), and justified against both
consumers of the column — which are the only things that read it, and are three orders of
magnitude coarser than the write rate:

- **`DEFAULT_LIVENESS_STALL_MS` (90 s)** — the `progressing`/`stalled` display. An
  actively-writing actor's recorded activity now lags reality by at most the interval, so
  worst-case apparent age is 5 s against a 90 s threshold: **18× of margin**, and the flip is
  unreachable by coalescing alone.
- **`DEFAULT_LIVENESS_ABANDON_MS` (10 min)** — the routable/`idle` bound: **120× of margin**.
- Above the measured p50 inter-activity gap (994 ms) so it actually coalesces the dense traffic
  it targets, and below p90 (6.7 s) so an ordinarily-paced child still records very nearly every
  activity it has.

`IS NULL` is the first disjunct because the column is nullable and a fresh row records `NULL`,
which must still take its first write.

### Tests, with revert probes

Two tests were added and neither existing assertion was relaxed — in particular the cases pinning
the 10-minute bound as a value and pinning `lastActivityTime ?? time.created` are untouched.

1. **Coalescing suppresses redundant writes.** A burst of 40 part writes inside the interval
   leaves the column at its first value, while the parts themselves still land and the row still
   reads `progressing`. Removing the staleness predicate fails it:
   `expect(received).toBe(expected) / Expected: 1785347884813 / Received: 1785347884821`.
   Inverting the comparison (`<` → `>`), which silently degrades to no coalescing at all, fails
   it the same way.
2. **Semantics did not move.** An actor emitting parts continuously across a span longer than
   `ACTIVITY_COALESCE_MS` reads `progressing` at *every* sample and never lags by more than the
   interval. Keeping only the `IS NULL` disjunct — so the column freezes after its first write —
   fails it: `expect(received).toBeLessThanOrEqual(expected) / Expected: <= 6000 / Received: 6069`.
   Raising the constant above the stall window fails its safety precondition:
   `expect(received).toBeLessThan(expected) / Expected: < 90000 / Received: 240000`.

Scoped run (`liveness`, `stall-watchdog`, `turn-heartbeat`, `registry`, `registry-status`,
`fleet`, `session-tool`, `message-v2`): **153 pass, 1 skip, 0 fail**, against **141 pass, 1 skip,
0 fail** for the identical command on this branch's base `b81670870` — +12 is the 2 new cases
plus the 10 the branch's earlier commit added. `bun typecheck` exit 0; `oxlint` 0 errors.

## The "saturated concurrency gate" scenario has no mechanism here

The same re-review flagged that a pending child emitting no part for over 10 minutes now reads
`idle`, hypothesising a *saturated concurrency gate* holding it un-started. **That premise does
not exist in this codebase.** There is no semaphore, permit or concurrency limit anywhere in
`packages/opencode/src/actor/` — a search for `Semaphore` / `makeSemaphore` / `withPermits` /
`maxConcurrent` across that directory returns nothing. The spawn admission path is an immediate
unbounded fork: `Actor.spawn` (`packages/opencode/src/actor/spawn.ts:782`) → `forkWork` →
`Effect.forkIn(scope)` at `packages/opencode/src/actor/spawn.ts:657`, with nothing gating it. The
single `concurrency:` occurrence in the whole directory is
`packages/opencode/src/actor/spawn.ts:841`, and it reads `concurrency: "unbounded"` — in
`Actor.cancel`'s cascade, not on the spawn path at all.

Combined with this branch's own measurement of first activity after spawn (p50 194 ms, max
1,735 ms, and 0 of 172 children with no activity at all), a child sitting un-started for more
than 10 minutes has no reachable mechanism. Recorded here so the concern is answered rather than
left hanging.

The genuine residual is unchanged and already noted above: a silent tool call such as
`git worktree add` that writes parts only at start and end.


---

## Follow-up commit `2e5f0886d` — the verdict's wording, and its window, re-derived for the activity signal

The two earlier commits switched the *input* of `deriveLiveness` to `last_activity_time`. This one
finishes that change on the two things it left behind: every surface that *reports* the verdict
still described the step clock, and the threshold was still the number chosen for the step clock.
Both were wrong in the same direction, and together they produced a measured false-positive
channel.

### The evidence: a dozen-plus false notifications in one evening

`stalled` is not display-only. It drives a user-visible notification —
`packages/opencode/src/actor/spawn.ts:919` (TUI toast) plus the inbox card rendered by
`renderActorNotification` — and the card read:

```
Background sub-session "…" (actor_id: …) appears stalled (no turn advance for 118s).
It is still running but has made no progress.
```

Two long-running background children spent the evening emitting that at **~90-130 s** while
**healthy and demonstrably writing parts continuously**. They were inside single long steps
(`bun ci`, a whole test suite, `git worktree add`), and a tool's streaming output calls
`ctx.metadata` per chunk, which reaches `updatePart` and therefore advances
`last_activity_time`. So the *number* in the message was silence since the last part write, while
the *noun* said "turn advance" — two different clocks in one sentence, and the message asserted
`has made no progress` about children that were visibly progressing.

Over a dozen such notifications were emitted, and the operator began treating every one of them
as noise. **That is the actual damage**: a false-positive channel trains its reader to ignore it,
so a true stall would have been missed. The fix needed no new mechanism — the column already
exists, is already written, and was already validated on this branch.

### The seam, `file:line` before → after

| what | before (`40f6c807f`) | after (`2e5f0886d`) |
| --- | --- | --- |
| notification text | `src/inbox/render.ts:72` — `` ` (no turn advance for ${…}s)` `` | `src/inbox/render.ts:80` — `` ` (no activity for ${…}s)` `` |
| notification body claim | `src/inbox/render.ts:73` — `has made no progress` | `src/inbox/render.ts:81` — `nothing has landed for it in that time` |
| `stalledForMs` doc | `src/inbox/render.ts:39` — "since the child's last turn advanced" | `src/inbox/render.ts:39-42` — silence; explicitly *not* time since the last completed step |
| TUI toast | `src/actor/spawn.ts:919` — `appears stalled` (no duration) | `src/actor/spawn.ts:927` — `appears stalled (no activity for Ns)` |
| `ActorStalled` payload | `src/actor/events.ts:54` — `lastTurnTime` | `src/actor/events.ts:58` — `lastActivityTime` (the reference the predicate used) |
| `ActorStalled` doc | `src/actor/events.ts:44-47` — "no turn advance … re-arms after turnCount advances" | `src/actor/events.ts:43-51` — nothing landed … re-arms once activity lands |
| watchdog doc | `src/actor/spawn.ts:867-868` — "now-lastTurnTime > STALL_MS AND turnCount not advancing" | `src/actor/spawn.ts:867-869` — nothing landed past `DEFAULT_LIVENESS_STALL_MS` |
| watchdog re-arm doc | `src/actor/spawn.ts:878` — "turnCount advanced" | `src/actor/spawn.ts:879` — "activity landed again" |
| scan-cadence doc | `src/actor/spawn.ts:42-45` — "between the per-step turn heartbeat and the … (90s) window" | `src/actor/spawn.ts:42-45` — "well inside the … (6m) window" |
| `session list` heading | `src/tool/session.ts:984` — `stalled (running/pending, no recent turn)` | `src/tool/session.ts:989` — `stalled (running/pending, no recent activity)` |
| `session list` doc | `src/tool/session.ts:958-961` — "(…, lastTurnTime) … updateTurn bumps last_turn_time per step" | `src/tool/session.ts:958-961` — "(…, lastActivityTime) … the PartUpdated projector bumps last_activity_time per part" |
| `session status` doc | `src/tool/session.ts:1059` — "(status/lastOutcome/lastTurnTime)" | `src/tool/session.ts:1059-1060` — "(status/lastOutcome/lastActivityTime)" |
| `session status` output | `src/tool/session.ts:1069-1078` — printed only `lastTurnTime` next to the verdict | `src/tool/session.ts:1078-1085` — prints `lastActivityTime … — liveness derives from this` **and** keeps `lastTurnTime … — last COMPLETED step, not the liveness input` |
| fleet heading | `src/tool/fleet.ts:152` — `stalled (no recent turn)` | `src/tool/fleet.ts:155` — `stalled (no recent activity)` |
| `lastActivityMs` doc | `src/tool/fleet.ts:47` — "ms since the last turn advanced" | `src/tool/fleet.ts:47-50` — ms since anything last landed; "not the step clock" |
| projector doc | `src/session/projectors.ts:147` — "deriveLiveness's 90s stall display" | `src/session/projectors.ts:147` — "deriveLiveness's 6m stall display" |

Fourteen sites. The three flagged as at-minimum (`schema.ts:58`, `schema.ts:66`, `events.ts:44` as
numbered on `main`) were already correct in `schema.ts` after `2375280de`; `events.ts` was not, and
eleven more were not. Every one of them described "turn advance" for a predicate that had stopped
reading the turn clock — the same class of stale comment that caused real misreadings in this
codebase.

### The threshold: 90 s → 6 min, and why 90 s did not survive the change

Under the old signal 90 s meant *"no completed step in 90 s"*. Under the new one it means
*"no part written in 90 s"* — a much stronger statement about silence. Re-checked against this
branch's own measurements rather than assumed to carry over:

| quantity | value | 90 s verdict |
| --- | --- | --- |
| inter-activity gap p50 | 994 ms | — |
| p90 | 6,740 ms | — |
| p99 | 38,048 ms | 90 s is **above** p99 |
| p99.9 | 296,811 ms (≈297 s) | 90 s is **below** p99.9 |

90 s lands **strictly between p99 and p99.9**, so **between 0.1 % and 1 % of inter-activity gaps
produced by perfectly healthy children exceed it**. Across the 43,120 measured gaps that is up to
~430 natural trips. So switching the signal did not leave 90 s harmless — it converted it into a
*new* class of false positive, which is exactly what was observed at ~90-130 s.

The number is bounded from below by two measurements:

1. **The deepest measured natural silence, p99.9 = 296,811 ms.** Any threshold at or under that
   fires on healthy children by construction.
2. **Plus `ACTIVITY_COALESCE_MS = 5_000`.** Coalescing means an actor's *apparent* age lags reality
   by up to one interval, so apparent age = real gap + up to 5 s. The threshold must clear
   **296,811 + 5,000 = 301,811 ms**, or the coalescing lag *alone* can flip a tail-but-healthy row.
   This is what disqualifies the otherwise tidy `300_000` (which would have equalled
   `STUCK_THRESHOLD_MS` and read very cleanly): **300,000 < 301,811**. It is asserted as a test.

And from above by `DEFAULT_LIVENESS_ABANDON_MS = 600_000`, which must remain the larger of the two
or `stalled` becomes unreachable.

**`DEFAULT_LIVENESS_STALL_MS = 6 * 60_000`** (`src/actor/schema.ts:110`):

- 1.21× p99.9;
- clears p99.9 + coalesce by 58,189 ms ≈ **11.6 coalesce intervals** of headroom, so the lag cannot
  come near flipping a verdict;
- **72× `ACTIVITY_COALESCE_MS`**;
- 0.6× the abandonment bound, leaving a **240 s `stalled` band** ≈ 5 scans at
  `WATCHDOG_SCAN_INTERVAL_MS = 45_000`;
- comfortably above the residual noted at the end of this PR (a silent tool call such as
  `git worktree add` that writes parts only at start and end).

**Cost, accepted deliberately:** a genuine stall now surfaces within ~6 min instead of ~90 s. The
10-minute abandonment bound still catches a row whose owner is actually gone. A signal that is
believed late beats one that is not believed at all — which is precisely what the old number
produced. Pinned as a **value**, the same treatment `DEFAULT_LIVENESS_ABANDON_MS` already gets, so
re-narrowing it fails a test rather than passing review.

`stalled` remains a **distinct verdict with its own threshold** — it is not merged into `idle`.

### `registry.ts`'s stuck scan is intentionally unchanged

`STUCK_THRESHOLD_MS = 5 * 60 * 1000` and its SQL filter on `last_turn_time`
(`src/actor/registry.ts`) are **deliberately left on the step signal and are not touched by this
commit** — verified: `registry.ts` does not appear in `2e5f0886d`'s file list. That scan answers a
different question, *"is a step taking too long"*, for which the last-completed-step clock is the
correct input. Nothing here argues it should change.

### The two required tests, with revert probes verbatim

**1. A child inside a long step with recent activity is NOT stalled** —
`test/actor/liveness.test.ts`, at the ages actually observed (90,001 / 100,000 / 130,000 ms and
p99.9 = 296,811 ms), with `time.created` 25 minutes old so no completed step exists to rescue it.
Reverting only `src/actor/schema.ts` to `40f6c807f` (90 s window) and keeping the tests:

```
281 |       ).toBe("progressing")
              ^
error: expect(received).toBe(expected)

Expected: "progressing"
Received: "stalled"

      at <anonymous> (…/test/actor/liveness.test.ts:281:9)
(fail) deriveLiveness (T39 derivation rule) > a child inside a long step whose activity is 130s old is NOT stalled [0.86ms]
```

The same probe also fails the value pin and the measurement invariant:

```
306 |   test("the stall window is 6 minutes", () => {
307 |     expect(DEFAULT_LIVENESS_STALL_MS).toBe(6 * 60_000)
                                            ^
error: expect(received).toBe(expected)

Expected: 360000
Received: 90000
```

```
318 |     expect(DEFAULT_LIVENESS_STALL_MS).toBeGreaterThan(GAP_P99_9_MS)
                                            ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 296811
Received: 90000
```

→ `25 pass, 3 fail` on that file with the window reverted; `28 pass, 0 fail` with it restored.

**2. A child with genuinely no activity past the threshold IS stalled** — same file: exactly at the
window is still `progressing` (the `<=` convention), one ms past it flips to `stalled`, and it stays
`stalled` — routable, not `idle` — right up to the abandonment bound, flipping to `idle` one ms
past it. This is the guard that widening the window cannot quietly disable the verdict.

**3. The notification says what it measures** — `test/inbox/parse-actor-notification.test.ts`.
Reverting only `src/inbox/render.ts` to `40f6c807f`:

```
210 |   test("reports silence, not turn advance", () => {
211 |     const text = stalledText(372_000)
212 |     expect(text).toContain("(no activity for 372s)")
                       ^
error: expect(received).toContain(expected)

Expected to contain: "(no activity for 372s)"
Received: "<actor-notification>\nBackground sub-session \"long step child\" (actor_id: general-7) appears stalled (no turn advance for 372s). It is still running but has made no progress. Consider checking on it, sending it a nudge, or cancelling it.\n</actor-notification>"

      at <anonymous> (…/test/inbox/parse-actor-notification.test.ts:212:18)
(fail) renderActorNotification stalled wording > reports silence, not turn advance [0.19ms]
```

```
221 |     expect(text).not.toContain("has made no progress")
                           ^
error: expect(received).not.toContain(expected)

Expected to not contain: "has made no progress"
Received: "…appears stalled (no turn advance for 372s). It is still running but has made no progress.…"

      at <anonymous> (…/test/inbox/parse-actor-notification.test.ts:221:22)
(fail) renderActorNotification stalled wording > does not claim the child made no progress, only that nothing landed [0.20ms]
```

→ `15 pass, 2 fail` on that file with the text reverted.

Before each probe the working diff was dumped to a patch **outside** the worktree and verified with
`git apply --reverse --check`; after each probe the tree was restored from that patch and confirmed
byte-identical with `git diff | diff -q -`.

### Fixtures deliberately rewritten (no assertion weakened)

Three fixtures encoded the *old* window as a bare literal and had silently become `progressing`
rows asserting `stalled`. Each is restated against the constants, with an in-file `REWRITTEN` note:

| fixture | was | now |
| --- | --- | --- |
| `liveness.test.ts` "pending is treated as live and split by the same window" | `lastActivityTime: now - 5 * 60_000` | `now - (DEFAULT_LIVENESS_STALL_MS + 1)` |
| `liveness.test.ts` "custom abandonMs overrides the default bound" | `now - 4 * 60_000`, custom bound `2 * 60_000` | `silentFor = STALL_MS + 60_000`, custom bound `silentFor - 1` |
| `session-tool.test.ts` stalled-peer row (in-line comment said "5 minutes is past the 90s stall window") | `Date.now() - 5 * 60_000` | `Date.now() - (DEFAULT_LIVENESS_STALL_MS + 60_000)` |

Each now pins *"past the window"* — the property the case was always about — at any window value,
so none of them can silently invert again. The claims are identical or stricter; nothing was
relaxed to go green. The `session list` heading assertion was updated to the reworded heading, and
the `session status` test **gained** three assertions (`lastActivityTime:`,
`liveness derives from this`, `not the liveness input`) while keeping its existing
`lastTurnTime:` assertion.

### Suite numbers, against a pristine baseline of the identical command

Command (from `packages/opencode`):
`bun test test/actor/liveness.test.ts test/actor/stall-watchdog.test.ts test/tool/fleet.test.ts test/tool/session-tool.test.ts test/inbox`

| tree | sha | pass | skip | fail | expect() | tests | files |
| --- | --- | --- | --- | --- | --- | --- | --- |
| pristine base of this branch | `b8167087088ad361740d6e28fb35faae49afdf78` | 129 | 1 | 0 | 411 | 130 | 14 |
| branch before this commit | `40f6c807f` | 141 | 1 | 0 | 503 | 142 | 14 |
| branch with this commit | `2e5f0886d` | **148** | 1 | **0** | 529 | 149 | 14 |

The baseline sha was printed and compared: it equals `git merge-base 40f6c807f origin/main`
(`b81670870`) — `origin/main` moved repeatedly today, so this is the branch's own base, not
whatever `main` happens to be now. +7 cases and +26 assertions over the previous head.

`bun typecheck` exit **0** (forced, `Cached: 0 cached, 12 total` — not a cache replay).
`oxlint` on the ten changed files: **0 errors, 42 warnings — identical count before and after**, so
this commit introduces none. `prettier --write` was not run (this repo is not prettier-clean under
its own config); surrounding style was hand-matched.

### Remote content verification

Verified by reading back the **pushed blobs**, not local files:

```
$ git rev-parse origin/fix/roster-liveness-dead-child
2e5f0886dd6f9bf16ec9d6a1a96c78e87162f40a

$ git show origin/fix/roster-liveness-dead-child:packages/opencode/src/actor/schema.ts | grep -n 'DEFAULT_LIVENESS_STALL_MS = '
110:export const DEFAULT_LIVENESS_STALL_MS = 6 * 60_000

$ git show origin/fix/roster-liveness-dead-child:packages/opencode/src/inbox/render.ts | grep -n 'no activity for'
80:      event.stalledForMs !== undefined ? ` (no activity for ${Math.floor(event.stalledForMs / 1000)}s)` : ""
```

A scan of every `.ts` file in the **pushed tree** for `no turn advance` / `no recent turn` /
`last turn advanced` / `turnCount advanc` returns exactly one hit — the deliberate contrast comment
at `src/inbox/render.ts:74` that explains the correction. `git merge-base --is-ancestor 40f6c807f
origin/fix/roster-liveness-dead-child` passes, so the three pre-existing commits are untouched and
this is a pure append.
