### PR TITLE
fix(session): discharge the max-threshold signal when the overflow gate compacts

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3499,10 +3499,17 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // still produced nothing — the ONE condition that may compact.
             if (attempt === "writer-failed") {
               // THE single compaction fallback: no checkpoint existed AND the
-              // writer failed / never ran / the bound expired. Note this is a
-              // bare boundary insert, not an LLM summary — everything before it
-              // is dropped unsummarized (compaction.ts:499, message-v2.ts:1037)
-              // — which is exactly why we tried to write a checkpoint first.
+              // writer failed / never ran / the bound expired.
+              //
+              // What this inserts is a bare boundary (compaction.ts's `create`,
+              // three local writes, no LLM call). It is NOT the end of the story
+              // though: the next iteration sees that boundary on the last user
+              // message and routes to compaction.process (the "Detect compaction
+              // boundary" branch above), which does run the summarizer and marks
+              // its assistant `summary: true`. So the history before the boundary
+              // is summarized, not dropped raw — which also means the summary
+              // marker only suppresses this gate for the single iteration that
+              // produces it, and cannot bound how often we end up here.
               yield* compaction
                 .create({
                   sessionID,
@@ -3512,6 +3519,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   agentID: lastUser.agentID,
                 })
                 .pipe(Effect.ignore)
+              // Discharge the max-threshold signal, the same duty the "rebuilt"
+              // branch discharges via rebuildFromCheckpoint → resetThresholds.
+              // The boundary just inserted reduces the context the rebuild was
+              // going to reduce, so the request has been served. Left standing it
+              // re-fires this same fallback — and another doomed writer with it —
+              // every time tokens climb back, because a rebuild can never insert
+              // while the watermark is unset. Narrower than resetThresholds on
+              // purpose: see dischargeMaxThreshold in prune.ts.
+              yield* prune.dischargeMaxThreshold(sessionID)
               skipOverflowCheck = true
               continue
             }

--- a/packages/opencode/src/session/prune.ts
+++ b/packages/opencode/src/session/prune.ts
@@ -145,6 +145,13 @@ export interface Interface {
   }) => Effect.Effect<void>
   /** True when the current tokens have just crossed the max checkpoint threshold. */
   readonly maxThresholdCrossed: (sessionID: SessionID) => Effect.Effect<boolean>
+  /**
+   * Clear ONLY the max-threshold rebuild signal, leaving the crossed-threshold
+   * ladder untouched. For the caller that acted on the signal by compacting
+   * instead of rebuilding — see the implementation for why that is not
+   * resetThresholds.
+   */
+  readonly dischargeMaxThreshold: (sessionID: SessionID) => Effect.Effect<void>
   /** Clear the crossed-threshold state for a session (e.g. after discard+rebuild). */
   readonly resetThresholds: (sessionID: SessionID) => Effect.Effect<void>
 }
@@ -445,12 +452,45 @@ export const layer: Layer.Layer<
       return maxCrossed.has(sessionID)
     })
 
+    // maxCrossed is a ONE-SHOT REQUEST ("reduce this context"), so it has to be
+    // discharged by whoever acts on it — not by one particular outcome of
+    // acting. Its only reader is the overflow gate in runLoop, and that gate
+    // always acts: it rebuilds when a checkpoint boundary can be produced, and
+    // compacts when the writer it just waited on produced nothing. Only the
+    // first of those cleared the request, via resetThresholds inside
+    // rebuildFromCheckpoint, so the compaction fallback left the request
+    // standing and the gate re-fired on it as soon as tokens climbed back.
+    //
+    // The fallback runs precisely when the watermark is unset — no writer has
+    // EVER succeeded for this session — so nothing else was ever going to clear
+    // it: the in-place retry above only clears while under the failure cap, and
+    // once the cap is reached maxCrossed is re-added by every later crossing.
+    // The result was a fresh fallback compaction, plus another doomed writer, on
+    // essentially every iteration for the rest of the turn.
+    //
+    // Deliberately NOT resetThresholds, which also clears `crossed` and would
+    // re-arm a threshold whose writer just failed — reinstating the in-place
+    // retry past the point the cap exists to stop. A rebuild may re-arm the
+    // ladder because it re-bases the context the ladder is measured against; a
+    // fallback compaction has not made the failed thresholds un-fired.
+    //
+    // The accepted cost is the direction the failure cap already chose: while
+    // the writer stays broken this session stops checkpointing (the "gave up
+    // after max consecutive failures" warning above is where that is reported),
+    // rather than compacting forever. Overflow is still caught — the gate's
+    // other disjunct is the real overflow check.
+    const dischargeMaxThreshold = Effect.fn("SessionPrune.dischargeMaxThreshold")(function* (
+      sessionID: SessionID,
+    ) {
+      maxCrossed.delete(sessionID)
+    })
+
     const resetThresholds = Effect.fn("SessionPrune.resetThresholds")(function* (sessionID: SessionID) {
       crossed.delete(sessionID)
       maxCrossed.delete(sessionID)
     })
 
-    return Service.of({ prune, fireCheckpoints, maxThresholdCrossed, resetThresholds })
+    return Service.of({ prune, fireCheckpoints, maxThresholdCrossed, dischargeMaxThreshold, resetThresholds })
   }),
 )
 

--- a/packages/opencode/test/session/prompt-overflow-fallback-loop.test.ts
+++ b/packages/opencode/test/session/prompt-overflow-fallback-loop.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Regression: the overflow gate's compaction FALLBACK used to re-fire forever.
+ *
+ * prune's max-threshold signal (maxCrossed, read via prune.maxThresholdCrossed)
+ * is a one-shot request meaning "reduce this context". Its only reader is the
+ * overflow gate in runLoop, and that gate always acts on it: it rebuilds when a
+ * checkpoint boundary can be produced, and compacts when the writer it just
+ * waited on produced nothing. Only the rebuild branch discharged the request
+ * (rebuildFromCheckpoint -> prune.resetThresholds); the "writer-failed"
+ * compaction fallback did not.
+ *
+ * That fallback runs precisely when the watermark is unset — no writer has ever
+ * succeeded — so in that state nothing else was going to clear the signal
+ * either: the in-place retry only clears while under the writer-failure cap, and
+ * once the cap is reached every later crossing re-adds maxCrossed. The gate then
+ * re-fired on the standing request on essentially every iteration, each time
+ * inserting a fresh compaction boundary AND starting another doomed writer.
+ *
+ * These tests drive the REAL runLoop against a scripted HTTP LLM stub (the
+ * established pattern — see main-runloop-history-invariant.test.ts) because what
+ * is under test is loop control flow, not a pure function: whether the gate
+ * re-fires depends on skipOverflowCheck, on lastFinished, and on the
+ * `lastFinished.summary !== true` guard. Only a real loop settles whether those
+ * self-limit, and they do not — the fallback inserts a USER boundary, and the
+ * summary assistant that compaction.process then produces blocks the gate for
+ * exactly one iteration before the cycle resumes.
+ *
+ * Measured on this file before the fix, with max_writer_failures = 1: 24
+ * fallback compactions across 24 scripted tool steps and 12 across 12 — one per
+ * iteration, i.e. LINEAR IN TURN LENGTH. After the fix: 1 in both, so the count
+ * is bounded by the writer-failure budget instead of by how long the turn runs.
+ * That length-independence, not the literal 1, is the invariant.
+ */
+
+import path from "path"
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionCheckpoint } from "../../src/session/checkpoint"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Log } from "../../src/util"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+function run<A, E>(
+  fx: Effect.Effect<A, E, SessionPrompt.Service | Session.Service | SessionCheckpoint.Service>,
+) {
+  return Effect.runPromise(
+    fx.pipe(
+      Effect.scoped,
+      Effect.provide(
+        Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer, SessionCheckpoint.defaultLayer),
+      ),
+    ),
+  )
+}
+
+const chunk = (o: Record<string, unknown>) => `data: ${JSON.stringify(o)}\n\n`
+
+// The provider sends stream_options.include_usage, so a trailing usage-only
+// chunk is what puts a chosen token total on the assistant message — and that
+// total is the whole input to the checkpoint ladder.
+const usageChunk = (promptTokens: number) =>
+  chunk({
+    id: "c",
+    object: "chat.completion.chunk",
+    choices: [],
+    usage: { prompt_tokens: promptTokens, completion_tokens: 100, total_tokens: promptTokens + 100 },
+  })
+
+function toolCallLines(id: string, name: string, args: string, promptTokens: number): string[] {
+  return [
+    chunk({ id: "c", object: "chat.completion.chunk", choices: [{ delta: { role: "assistant" } }] }),
+    chunk({
+      id: "c",
+      object: "chat.completion.chunk",
+      choices: [{ delta: { tool_calls: [{ index: 0, id, type: "function", function: { name, arguments: "" } }] } }],
+    }),
+    chunk({
+      id: "c",
+      object: "chat.completion.chunk",
+      choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: args } }] } }],
+    }),
+    chunk({ id: "c", object: "chat.completion.chunk", choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+    usageChunk(promptTokens),
+    "data: [DONE]\n\n",
+  ]
+}
+
+function textStopLines(text: string, promptTokens: number): string[] {
+  return [
+    chunk({ id: "c", object: "chat.completion.chunk", choices: [{ delta: { role: "assistant" } }] }),
+    chunk({ id: "c", object: "chat.completion.chunk", choices: [{ delta: { content: text } }] }),
+    chunk({ id: "c", object: "chat.completion.chunk", choices: [{ delta: {}, finish_reason: "stop" }] }),
+    usageChunk(promptTokens),
+    "data: [DONE]\n\n",
+  ]
+}
+
+/** compaction.ts's summarizer template. A request carrying it is the compaction
+ * summarization, which MUST be answered with plain text: answering it with a
+ * tool call trips processor.ts's "Tool call not allowed while generating
+ * summary" guard, ending the turn for a harness reason and hiding the loop under
+ * test. Asserted to have been seen, so a reworded template shows up as a failed
+ * expectation rather than as a silently different run. */
+const SUMMARIZE_MARKER = "When constructing the summary"
+
+/** checkpoint.ts composeWriterPrompt's preamble. Requests carrying it are the
+ * checkpoint WRITER's own LLM calls, failed here with a NON-retryable 400 so the
+ * writer can never succeed — the precondition of the whole scenario. A retryable
+ * status would be wrong: the session retry ladder would keep retrying it and the
+ * turn would never progress. */
+const WRITER_MARKER = "operating in checkpoint-writer mode"
+
+function startStub(opts: { toolSteps: number; promptTokens: number; readPath: string }) {
+  const calls: ("summarize" | "tool" | "stop" | "writer-denied")[] = []
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      if (!new URL(req.url).pathname.endsWith("/chat/completions")) return new Response("nf", { status: 404 })
+      const body = (await req.json()) as { messages: Array<{ role: string; content: unknown }> }
+      const raw = JSON.stringify(body.messages)
+      if (raw.includes(WRITER_MARKER)) {
+        calls.push("writer-denied")
+        return new Response(
+          JSON.stringify({ error: { message: "checkpoint writer denied by test", type: "invalid_request_error" } }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        )
+      }
+      let lines: string[]
+      if (raw.includes(SUMMARIZE_MARKER)) {
+        calls.push("summarize")
+        lines = textStopLines("## Goal\nPrior work, summarized.\n", 400)
+      } else if (calls.filter((c) => c === "tool").length < opts.toolSteps) {
+        calls.push("tool")
+        lines = toolCallLines(
+          `call_${calls.length}`,
+          "read",
+          JSON.stringify({ filePath: opts.readPath }),
+          opts.promptTokens,
+        )
+      } else {
+        calls.push("stop")
+        lines = textStopLines("done.", opts.promptTokens)
+      }
+      const enc = new TextEncoder()
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(ctrl) {
+            for (const l of lines) ctrl.enqueue(enc.encode(l))
+            ctrl.close()
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      )
+    },
+  })
+  return {
+    get origin() {
+      return server.url.origin
+    },
+    calls,
+    stop: () => server.stop(true),
+  }
+}
+
+/**
+ * One turn against the stub.
+ *
+ * `watermark` is returned so callers assert the precondition rather than assume
+ * it: with a watermark set, rebuildEnsuringCheckpoint would report "rebuilt" and
+ * the fallback under test would never be reached at all.
+ */
+async function driveTurn(opts: {
+  title: string
+  thresholds: string[]
+  toolSteps: number
+  promptTokens: number
+  maxWriterFailures: number
+}) {
+  await using tmp = await tmpdir({ git: true })
+  const readPath = path.join(tmp.path, "README.md")
+  const stub = startStub({ toolSteps: opts.toolSteps, promptTokens: opts.promptTokens, readPath })
+  try {
+    await Bun.write(readPath, "# Hello\n")
+    await Bun.write(
+      path.join(tmp.path, "mimocode.json"),
+      JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        enabled_providers: ["alibaba"],
+        provider: { alibaba: { options: { apiKey: "test-key", baseURL: `${stub.origin}/v1` } } },
+        agent: { build: { model: "alibaba/qwen-plus" } },
+        checkpoint: { thresholds: opts.thresholds, max_writer_failures: opts.maxWriterFailures },
+      }),
+    )
+    return await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            const prompt = yield* SessionPrompt.Service
+            const checkpoint = yield* SessionCheckpoint.Service
+            const session = yield* sessions.create({ title: opts.title })
+            yield* prompt.prompt({
+              sessionID: session.id,
+              agent: "build",
+              parts: [{ type: "text", text: "Please keep reading the README." }],
+            })
+            const msgs = yield* sessions.messages({ sessionID: session.id, agentID: "main" })
+            const watermark = yield* checkpoint
+              .lastBoundary(session.id)
+              .pipe(Effect.catch(() => Effect.succeed(undefined)))
+            return {
+              watermark,
+              calls: [...stub.calls],
+              toolSteps: stub.calls.filter((c) => c === "tool").length,
+              compactions: msgs.filter((m) => m.parts.some((p) => p.type === "compaction")).length,
+            }
+          }),
+        ),
+    })
+  } finally {
+    await stub.stop()
+  }
+}
+
+// qwen-plus reports limit.context 1_000_000, so usable is 960_000: a
+// 35_100-token step is far below hard overflow (isOverflow === false at that
+// count), which is what makes the max-threshold signal the ONLY thing that can
+// open the gate in the crossed case.
+const PROMPT_TOKENS = 35_000
+// One allowed writer attempt, so the failure cap is reached on the first failure
+// and the in-place retry stops clearing the signal immediately. Explicit rather
+// than relying on the default, so the expected count below is arithmetic and not
+// a snapshot.
+const MAX_WRITER_FAILURES = 1
+
+describe("overflow gate: the compaction fallback is discharged, not re-fired", () => {
+  test(
+    "with a writer that can never succeed, fallback compactions do not grow with turn length",
+    async () => {
+      const short = await driveTurn({
+        title: "fallback-loop short",
+        thresholds: ["20K", "30K"],
+        toolSteps: 12,
+        promptTokens: PROMPT_TOKENS,
+        maxWriterFailures: MAX_WRITER_FAILURES,
+      })
+      const long = await driveTurn({
+        title: "fallback-loop long",
+        thresholds: ["20K", "30K"],
+        toolSteps: 24,
+        promptTokens: PROMPT_TOKENS,
+        maxWriterFailures: MAX_WRITER_FAILURES,
+      })
+
+      // Non-vacuity: the writer never succeeded in either run, so no boundary
+      // exists and the gate's rebuild branch could never insert. This is THE
+      // precondition — without it the test could pass simply because rebuilds were
+      // working. It holds whether the writer was spawned and denied or could not
+      // be spawned at all: "never succeeds" is all the gate needs, and a sibling
+      // file in this directory swaps spawnRef, so whether a writer process
+      // actually starts is not stable across a multi-file run.
+      expect(short.watermark == null).toBe(true)
+      expect(long.watermark == null).toBe(true)
+      // Non-vacuity: the fallback really was reached, and reached the summarizer
+      // that follows it — so the stub's summarize discriminator still matches the
+      // template it keys on.
+      expect(short.compactions).toBeGreaterThan(0)
+      expect(short.calls).toContain("summarize")
+      // Non-vacuity: both turns really did run to their full scripted length, so
+      // "long" is genuinely the longer turn.
+      expect(short.toolSteps).toBe(12)
+      expect(long.toolSteps).toBe(24)
+
+      // THE REGRESSION. The fallback discharges the signal it served, so the
+      // count is bounded by the writer-failure budget and is INDEPENDENT of how
+      // long the turn runs. Before the fix the signal stood and the gate re-fired
+      // on it every iteration: 12 compactions in the short turn and 24 in the
+      // long one — exactly one per iteration, linear in turn length.
+      expect(long.compactions).toBe(short.compactions)
+      expect(long.compactions).toBeLessThanOrEqual(MAX_WRITER_FAILURES)
+      expect(long.compactions).toBe(1)
+    },
+    900_000,
+  )
+
+  test(
+    "control: an identical run whose thresholds are never crossed compacts zero times",
+    async () => {
+      const never = await driveTurn({
+        title: "fallback-loop control",
+        thresholds: ["500K", "600K"],
+        toolSteps: 24,
+        promptTokens: PROMPT_TOKENS,
+        maxWriterFailures: MAX_WRITER_FAILURES,
+      })
+
+      // Same model, same token report, same script — only the ladder moved out of
+      // reach. Zero compactions here is what attributes the other case's
+      // compactions to the max-threshold signal rather than to hard overflow.
+      expect(never.watermark == null).toBe(true)
+      expect(never.toolSteps).toBe(24)
+      expect(never.compactions).toBe(0)
+      expect(never.calls).not.toContain("summarize")
+    },
+    900_000,
+  )
+})

--- a/packages/opencode/test/session/prune.test.ts
+++ b/packages/opencode/test/session/prune.test.ts
@@ -367,6 +367,55 @@ describe("SessionPrune.fireCheckpoints writer-failure retry", () => {
       { checkpoint: { thresholds: ["50%"] } },
     )
   })
+
+  // dischargeMaxThreshold is what the overflow gate's compaction fallback calls
+  // to retire the max-threshold signal it just served. That signal's only reader
+  // is the gate, and the fallback runs exactly when the watermark is unset, so
+  // before this existed nothing cleared it once the failure cap was reached — the
+  // in-place retry above stops clearing at the cap, while every later crossing
+  // re-adds maxCrossed — and the gate re-fired on the standing signal for the
+  // rest of the turn.
+  //
+  // Its narrowness is the point, so assert what SURVIVES as well as what is
+  // cleared: resetThresholds would also drop `crossed`, re-arming a threshold
+  // whose writer just failed and reinstating the in-place retry past the point
+  // the cap exists to stop it.
+  test("dischargeMaxThreshold clears the signal only — the crossed ladder survives", async () => {
+    const harness = makeRetryHarness()
+    const promptOps = {} as any
+
+    await runWithHarness(
+      harness,
+      Effect.gen(function* () {
+        const svc = yield* SessionPrune.Service
+        const ssn = yield* SessionNs.Service
+        const info = yield* ssn.create({})
+        const model = createModel({ context: 100_000, output: 32_000 })
+
+        // max_writer_failures 1 ⇒ the first failure IS the cap, so the watcher
+        // clears nothing and the signal is left standing — the state the gate's
+        // fallback actually finds.
+        harness.outcomes.push("failure")
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+        yield* Effect.sleep(150)
+        expect(harness.state.enqueueCount).toBe(1)
+        expect(yield* svc.maxThresholdCrossed(info.id)).toBe(true)
+
+        yield* svc.dischargeMaxThreshold(info.id)
+        expect(yield* svc.maxThresholdCrossed(info.id)).toBe(false)
+
+        // `crossed` survived: the threshold that already fired stays fired, so a
+        // fire at the same token count enqueues nothing and no further writer is
+        // spawned. This is the assertion that would break if the fallback called
+        // resetThresholds instead.
+        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokens(), promptOps })
+        yield* Effect.sleep(100)
+        expect(harness.state.enqueueCount).toBe(1)
+        expect(yield* svc.maxThresholdCrossed(info.id)).toBe(false)
+      }),
+      { checkpoint: { thresholds: ["50%"], max_writer_failures: 1 } },
+    )
+  })
 })
 
 describe("defaultThresholdsFor (Part 2 density)", () => {


### PR DESCRIPTION
## The principle

`maxCrossed` is a **one-shot request** — *"reduce this context"*. A one-shot request has to be discharged by **whoever acts on it**, not by one particular *outcome* of acting. The overflow gate in `runLoop` is its only reader, and that gate **always** acts: it rebuilds when a checkpoint boundary can be produced, and compacts when the writer it just waited on produced nothing. Only the first of those discharged the request. So the gate kept re-firing on a request it had already served.

## The defect

`prune.maxThresholdCrossed` (`prune.ts:452`) is the gate's second disjunct (`prompt.ts:3446`). The signal is set at `prune.ts:344` on every crossing of the final threshold, and cleared **only** by `resetThresholds`, whose sole caller is `prompt.ts:423`, gated on `if (inserted)` — i.e. only when a rebuild actually inserted a boundary.

The `"writer-failed"` compaction fallback (`prompt.ts:3500`) did not discharge it. And that fallback runs **precisely when the watermark is unset** — when no writer has *ever* succeeded for the session — so nothing else was going to clear it either:

- the in-place retry in `fireCheckpoints` clears `crossed`/`maxCrossed` **only while under the writer-failure cap** (`prune.ts:322-326`);
- once the cap is reached it clears nothing, and **every later crossing re-adds `maxCrossed`**.

Result: the gate re-fired on the standing request, each time inserting a fresh compaction boundary **and starting another doomed writer**, for the rest of the turn.

## Reproduced, and attributed

The reproduction drives the **real `runLoop`** against a scripted HTTP LLM stub (the established pattern — see `main-runloop-history-invariant.test.ts`), because what is under test is loop control flow, not a pure function. The stub denies the checkpoint writer's own LLM calls with a **non-retryable 400**, so the writer can never succeed — the precondition of the whole scenario. With `max_writer_failures = 1`:

| turn length (scripted tool steps) | fallback compactions before | after |
| --- | --- | --- |
| 12 | **12** | **1** |
| 24 | **24** | **1** |
| 24, control: thresholds out of reach | **0** | **0** |

One compaction **per iteration** — linear in turn length, so the model's working context was amputated on essentially every step. The control run differs **only** in that its ladder is moved out of reach; zero compactions there is what attributes the others to the max-threshold signal rather than to hard overflow (`isOverflow` is `false` at these token counts — `qwen-plus` reports a 1M context, usable 960K).

The test pins **length-independence** (`long.compactions === short.compactions`), not the literal `1`, because that is the actual invariant: the count is now bounded by the writer-failure budget instead of by how long the turn runs.

### A comment that was wrong in a way that mattered

The fallback's own comment claimed the boundary *"is dropped unsummarized"*. It is not. `compaction.create` inserts a bare user boundary (three local writes, no LLM call) — but the **next iteration routes that boundary to `compaction.process`** (the "Detect compaction boundary" branch, `prompt.ts:3290-3298`), which runs the summarizer and marks its assistant `summary: true`. Measured: 24 compactions produced 24 summarizer calls.

That correction is load-bearing for this defect, because it is exactly why the `lastFinished.summary !== true` guard does **not** self-limit the loop: the summary marker suppresses the gate for the **single iteration that produces it**, then the cycle resumes. Corrected in place, since it describes the mechanism this PR changes.

## The fix

`prune.dischargeMaxThreshold` clears the signal **only** (`prune.ts:482`), called at the fallback (`prompt.ts:3530`).

Deliberately **not** `resetThresholds`, which also clears `crossed` and would re-arm a threshold whose writer just failed — reinstating the in-place retry past the point the cap exists to stop it. Measured, not assumed: swapping it makes `enqueueCount` go `1 → 2`, i.e. a second doomed writer. A rebuild has earned that re-arm because it re-bases the context the ladder is measured against; a fallback compaction has not made the failed thresholds un-fired.

This is state **derived from the present** (is the signal outstanding?), not a memory of past attempts — no counter is introduced.

**Failure direction accepted:** while the writer stays broken, the session **stops checkpointing** — the direction the failure cap already chose, and which its `"gave up after max consecutive failures"` warning already reports — rather than compacting forever. Real overflow is still caught by the gate's other disjunct.

## Verification

Revert probe (fix disabled, everything else in place), **verbatim**, and identical standalone and in a multi-file run:

```
error: expect(received).toBe(expected)
Expected: 12
Received: 24
(fail) overflow gate: the compaction fallback is discharged, not re-fired > with a writer that can never succeed, fallback compactions do not grow with turn length
```

Only the positive-direction assertion dies; the control survives. A second probe swaps `dischargeMaxThreshold` for `resetThresholds` in the unit test and fails on the survival assertion (`Expected: 1, Received: 2`).

Identical 15-file scoped command both sides, baseline sha printed and compared — **`b8167087088ad361740d6e28fb35faae49afdf78`** (= `origin/main`), clean tree:

| | tests | fail | expects |
| --- | --- | --- | --- |
| pristine `b81670870` | 124 | 0 | 326 |
| this branch | **125** | **0** | **331** |

Delta is exactly the one new unit case; **no existing assertion weakened or removed**. With the new file included: **127 pass / 0 fail / 338 expects across 16 files**, including `auto-overflow-writer-first.test.ts`, which covers this gate's start-and-wait rework. `bun typecheck` → **exit 0**. `oxlint` → **0 errors** (the one warning in the new file is the `as` cast pattern `test/lib/scripted-llm-server.ts:226` already uses verbatim). The full suite was deliberately not run.

## Relationship to #1945

#1945 is in this neighbourhood and was checked first. It is **not** the right home for this, and the two are complementary:

- **This defect is pre-existing on `main`**, gated behind the writer-failure cap — reachable once the cap is reached.
- **#1945 deletes that accounting**, which removes the sub-cap `maxCrossed.delete` that was *accidentally* mitigating this. On that branch the signal sticks from the **first** final-threshold failure, so #1945 makes this **easier** to reach. Its own `finalRetryAt` recovery gate does not help: it decides whether the final threshold re-fires a writer, and never clears `maxCrossed`. So the loop is **not** specific to a failure class — a transient failure leaves the signal standing too, and recovers only if one of the bounded retries actually succeeds.
- Folding into #1945 was attempted and **reverted**: that branch predates `main`'s rework of this very gate (`rebuildEnsuringCheckpoint` / `RebuildAttempt` vs. its older boolean `rebuildFromCheckpoint`), so the fix would target superseded code — and it made #1945 `CONFLICTING`. #1945 was restored to `3ee914261`, `MERGEABLE`, untouched.

Whichever lands second will need a trivial rebase of this hunk.

## Not verified

No live model run. The reproduction's writer failure is induced at the provider boundary (HTTP 400), not by a real broken writer. The transient-class claim above is structural (nothing clears `maxCrossed`) plus the unit test — a genuinely retryable failure was not driven end-to-end, because this repo's retry ladder is uncapped and would not settle.