### PR TITLE
fix(provider): add MiMo v2.5 reasoning effort variants for OpenRouter

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1118,6 +1118,17 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   }
   if (id.includes("grok")) return {}
 
+  if (id.includes("mimo")) {
+    if (model.api.npm === "@openrouter/ai-sdk-provider") {
+      return {
+        low: { reasoning: { effort: "low" } },
+        medium: { reasoning: { effort: "medium" } },
+        high: { reasoning: { effort: "high" } },
+      }
+    }
+    return {}
+  }
+
   switch (model.api.npm) {
     case "@openrouter/ai-sdk-provider":
       if (!model.id.includes("gpt") && !model.id.includes("gemini-3") && !model.id.includes("claude")) return {}

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3293,6 +3293,37 @@ describe("ProviderTransform.variants", () => {
       expect(result.low).toEqual({ reasoning: { effort: "low" } })
       expect(result.high).toEqual({ reasoning: { effort: "high" } })
     })
+
+    test("mimo returns low, medium, and high with reasoning", () => {
+      const model = createMockModel({
+        id: "openrouter/xiaomi/mimo-v2.5-pro",
+        providerID: "openrouter",
+        api: {
+          id: "xiaomi/mimo-v2.5-pro",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+      expect(result.low).toEqual({ reasoning: { effort: "low" } })
+      expect(result.medium).toEqual({ reasoning: { effort: "medium" } })
+      expect(result.high).toEqual({ reasoning: { effort: "high" } })
+    })
+  })
+
+  test("mimo variants remain disabled for non-openrouter providers", () => {
+    const model = createMockModel({
+      id: "custom/xiaomi/mimo-v2.5-pro",
+      providerID: "custom",
+      api: {
+        id: "xiaomi/mimo-v2.5-pro",
+        url: "https://api.example.com",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({})
   })
 
   describe("@ai-sdk/gateway", () => {


### PR DESCRIPTION
Closes #1976

## What

Add Ctrl+T reasoning effort toggle for MiMo v2.5 models on OpenRouter.

## Why

MiMo v2.5 supports reasoning effort control (low, medium, high) via the Xiaomi API, but OpenRouter's model metadata doesn't expose supported_efforts for MiMo. The variants() filter only allows GPT/Gemini-3/Claude on OpenRouter.

## Changes

Add MiMo-specific handling for OpenRouter returning { low, medium, high } with reasoning.effort format, matching Xiaomi's API documentation.

Tests added for MiMo on OpenRouter and non-OpenRouter providers.

## Verification

- 244 transform tests pass
- TypeScript typecheck passes
- Change is minimal: 2 files, 42 added