### PR TITLE
fix(tool): share the realpath-comparing trust-boundary test instead of leaving it in one file

### DIFF
--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -226,6 +226,12 @@ export const layer = Layer.effect(
 
     const getClients = Effect.fnUntraced(function* (file: string) {
       const ctx = yield* InstanceState.context
+      // Deliberately the LEXICAL `contains`, not the realpath-comparing
+      // `withinTrustedRoot` used by the permission gates. This is not a trust
+      // boundary: a false negative only skips LSP enrichment for one file, and
+      // getClients runs on every LSP touch, so paying two realpath syscalls per
+      // out-of-project file would be the wrong trade. If LSP silently stops
+      // attaching on a symlinked project prefix, this is the line to change.
       if (
         !AppFileSystem.contains(ctx.directory, file) &&
         (ctx.worktree === "/" || !AppFileSystem.contains(ctx.worktree, file))

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -157,14 +157,21 @@ export const Instance = {
    * Check if a path is within the project boundary.
    * Returns true if path is inside Instance.directory OR Instance.worktree.
    * Paths within the worktree but outside the working directory should not trigger external_directory permission.
+   *
+   * This is the first gate of the external_directory permission check, so it uses
+   * the trust-boundary predicate rather than a lexical prefix test: `Instance.provide`
+   * stores a REALPATH-RESOLVED directory, while a filepath arriving from a tool call
+   * carries whatever normalisation the caller gave it. A lexical-only comparison of
+   * two differently-normalised paths returns a false negative and sends an in-project
+   * write to the ask.
    */
   containsPath(filepath: string, ctx?: InstanceContext) {
     const instance = ctx ?? Instance
-    if (AppFileSystem.contains(instance.directory, filepath)) return true
+    if (AppFileSystem.withinTrustedRoot(instance.directory, filepath)) return true
     // Non-git projects set worktree to "/" which would match ANY absolute path.
     // Skip worktree check in this case to preserve external_directory permissions.
     if (instance.worktree === "/") return false
-    return AppFileSystem.contains(instance.worktree, filepath)
+    return AppFileSystem.withinTrustedRoot(instance.worktree, filepath)
   },
   /**
    * Captures the current instance ALS context and returns a wrapper that

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -189,6 +189,11 @@ export const ApplyPatchTool = Tool.define(
       const title = files.length === 1 ? files[0]!.relativePath : `${files.length} files`
 
       // Check permissions if needed
+      // Deliberately the lexical `contains`: this mirrors the memory-region deferral
+      // in external-directory.ts, whose delegate (memory-path-guard) is still lexical.
+      // Widening only this filter would drop the `edit` ask for memory paths spelled
+      // through a symlinked data root — paths assertMemoryWriteAllowed skips entirely.
+      // See the note at the memory branch of assertExternalDirectoryEffect.
       const permissionChanges = fileChanges.filter(
         (change) => !AppFileSystem.contains(path.join(Global.Path.data, "memory"), change.movePath ?? change.filePath),
       )

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -34,6 +34,15 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
   // is redundant and, in headless run mode (no permission replier), deadlocks on a
   // never-resolved Deferred. memory-path-guard allows a task-bound subagent its own
   // tasks/<taskId>/*.md and rejects cross-task / wrong-agent writes.
+  //
+  // DELIBERATELY the lexical `contains`, not withinTrustedRoot — unlike the worktree
+  // base below, this early return is a DEFERRAL, and its soundness depends on the
+  // delegate actually governing what is waved through here. memory-path-guard is
+  // still lexical: assertMemoryWriteAllowed returns early on `!target.startsWith(root)`,
+  // so a memory path spelled through a symlinked data root is governed by NOTHING.
+  // Widening this test alone would therefore drop the prompt for exactly the paths
+  // the guard does not inspect. These two must be promoted together; until then the
+  // conservative answer (ask) is the safe one.
   if (AppFileSystem.contains(path.join(Global.Path.data, "memory"), full)) return
 
   // Orchestrator-created worktrees live under <data>/worktree/<projectID>/<name>.
@@ -47,7 +56,15 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
   // Since this base is created and owned by the app itself (not a foreign user path),
   // trust it here, exactly as the memory subtree above. Genuinely external user paths
   // are unaffected and still prompt.
-  if (AppFileSystem.contains(path.join(Global.Path.data, "worktree"), full)) return
+  //
+  // withinTrustedRoot is what makes that trust survive normalisation: `Instance.provide`
+  // stores a realpath-resolved directory while Global.Path.data keeps the symlinked
+  // form, so a purely lexical test can miss an in-worktree path and re-introduce the
+  // very deadlock described above. Unlike the memory branch this trust is terminal —
+  // nothing downstream re-checks it — so widening it cannot silently bypass a
+  // delegate. Same predicate as IsolatedGit.isIsolatedWorktree, which gates on this
+  // identical base.
+  if (AppFileSystem.withinTrustedRoot(path.join(Global.Path.data, "worktree"), full)) return
 
   const kind = options?.kind ?? "file"
   const dir = kind === "directory" ? full : path.dirname(full)
@@ -136,7 +153,11 @@ export const assertWriteAllowed = Effect.fn("Tool.assertWriteAllowed")(function*
  * Outside the memory tree, ask exactly as the write tools did inline before.
  *
  * Mirrors the external_directory memory-region deferral added in the 2026-06-04
- * poststop-progress-permission-deadlock fix (see assertExternalDirectoryEffect).
+ * poststop-progress-permission-deadlock fix (see assertExternalDirectoryEffect),
+ * including its choice of the LEXICAL test: this is a deferral to memory-path-guard,
+ * and that guard is still lexical, so widening only this side would drop the ask for
+ * memory paths the guard does not govern. See the note at the memory branch of
+ * assertExternalDirectoryEffect — the two move together or not at all.
  */
 export const askEditUnlessMemory = Effect.fn("Tool.askEditUnlessMemory")(function* (
   ctx: Tool.Context,

--- a/packages/opencode/src/tool/isolated-git-guard.ts
+++ b/packages/opencode/src/tool/isolated-git-guard.ts
@@ -1,5 +1,5 @@
 import * as path from "path"
-import { readFileSync, realpathSync } from "node:fs"
+import { readFileSync } from "node:fs"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { Global } from "../global"
 
@@ -256,23 +256,14 @@ export function violates(input: {
 /** True when `directory` is one of the app-managed worktrees that back an
  *  isolated child session (`<data>/worktree/<projectID>/<name>`). The
  *  orchestrator and ordinary sessions run in the user's project directory and
- *  are therefore never gated. Mirrors the trusted-root test already used by
- *  `src/tool/external-directory.ts`, but additionally compares realpaths:
- *  `Instance.provide` stores a realpath-resolved directory, so on a symlinked
- *  prefix (macOS `/var` → `/private/var`) a raw string-prefix test misses. */
+ *  are therefore never gated. Delegates to the shared trust-boundary predicate,
+ *  which compares realpaths as well as lexical prefixes;
+ *  `src/tool/external-directory.ts` now applies that same predicate to this
+ *  same base, so the two trusted-root tests cannot drift apart again. */
 export function isIsolatedWorktree(directory: string | undefined, root?: string) {
   if (!directory) return false
   const base = root ?? path.join(Global.Path.data, "worktree")
-  if (AppFileSystem.contains(base, directory)) return true
-  return AppFileSystem.contains(real(base), real(directory))
-}
-
-function real(target: string) {
-  try {
-    return realpathSync(target)
-  } catch {
-    return path.resolve(target)
-  }
+  return AppFileSystem.withinTrustedRoot(base, directory)
 }
 
 /** Best-effort read of the branch a worktree is on, without spawning git.

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
+import os from "os"
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from "node:fs"
 import { Effect } from "effect"
 import type { Tool } from "../../src/tool"
 import { Instance } from "../../src/project/instance"
@@ -192,6 +194,129 @@ describe("tool.assertExternalDirectory", () => {
       directory: "/tmp/project",
       fn: async () => {
         await assertExternalDirectory(ctx, "/tmp/worktree/foreign/file.txt")
+      },
+    })
+
+    expect(requests.find((r) => r.permission === "external_directory")).toBeDefined()
+  })
+
+  test("does NOT ask for an in-project path named through a symlinked project prefix", async () => {
+    const { requests, ctx } = makeCtx()
+
+    // A REAL symlinked prefix: <base>/link -> <base>/real, project at <...>/project.
+    // `Instance.provide` realpath-resolves what it stores, so Instance.directory
+    // becomes the <real> spelling while the tool call still carries the <link>
+    // spelling. The two sides are then differently normalised — no attacker and no
+    // exotic setup required — and a lexical-only containment test answers "outside",
+    // raising external_directory:ask for a write that is plainly inside the project.
+    // For a background/isolated child there is no interactive replier, so that ask
+    // hangs on a never-resolved Deferred and the child deadlocks.
+    const base = mkdtempSync(path.join(realpathSync(os.tmpdir()), "extdir-symlink-"))
+    const realProject = path.join(base, "real", "project")
+    mkdirSync(realProject, { recursive: true })
+    symlinkSync(path.join(base, "real"), path.join(base, "link"), "dir")
+    const linkedProject = path.join(base, "link", "project")
+
+    await Instance.provide({
+      directory: linkedProject,
+      fn: async () => {
+        await assertExternalDirectory(ctx, path.join(linkedProject, "src", "file.ts"))
+      },
+    })
+
+    expect(requests.length).toBe(0)
+    // Pin the asymmetry the test depends on, so a future fixture change cannot make
+    // this pass for the wrong reason: the two spellings really are lexically foreign.
+    expect(Filesystem.contains(realProject, path.join(linkedProject, "src", "file.ts"))).toBe(false)
+  })
+
+  test("still asks for a path outside a symlinked project prefix (regression)", async () => {
+    const { requests, ctx } = makeCtx()
+
+    // The realpath comparison must not become a blanket allow: a sibling directory
+    // beside the project, reached through the same symlink, is still external.
+    const base = mkdtempSync(path.join(realpathSync(os.tmpdir()), "extdir-symlink-out-"))
+    mkdirSync(path.join(base, "real", "project"), { recursive: true })
+    mkdirSync(path.join(base, "real", "elsewhere"), { recursive: true })
+    symlinkSync(path.join(base, "real"), path.join(base, "link"), "dir")
+
+    await Instance.provide({
+      directory: path.join(base, "link", "project"),
+      fn: async () => {
+        await assertExternalDirectory(ctx, path.join(base, "link", "elsewhere", "file.ts"))
+      },
+    })
+
+    expect(requests.find((r) => r.permission === "external_directory")).toBeDefined()
+  })
+
+  // The two <data>-rooted gates read Global.Path.data, which is fixed at import
+  // time, so these name the SAME trusted file through a symlink that points at the
+  // real data root. That is the production asymmetry — one side canonical, the other
+  // not — without writing anything into the developer's real data directory.
+  function dataRootAliasedTo(prefix: string) {
+    const base = mkdtempSync(path.join(realpathSync(os.tmpdir()), prefix))
+    const alias = path.join(base, "datalink")
+    symlinkSync(Global.Path.data, alias, "dir")
+    return alias
+  }
+
+  test("does NOT ask for a worktree path named through an aliased data root", async () => {
+    const { requests, ctx } = makeCtx()
+
+    // Regression guard for the deadlock the <data>/worktree trust exists to prevent:
+    // if this gate answers "outside", a background/isolated child with no permission
+    // replier hangs forever on the ask.
+    const alias = dataRootAliasedTo("extdir-datalink-wt-")
+    const target = path.join(alias, "worktree", "p_abc", "child-1", "packages", "opencode", "src", "tool", "session.ts")
+
+    // Pin the hazard: lexically this is foreign to the canonical worktree base.
+    expect(Filesystem.contains(path.join(Global.Path.data, "worktree"), target)).toBe(false)
+
+    await Instance.provide({
+      directory: "/tmp/project",
+      fn: async () => {
+        await assertExternalDirectory(ctx, target)
+      },
+    })
+
+    expect(requests.length).toBe(0)
+  })
+
+  test("still asks for a memory path named through an aliased data root (deferral stays lexical)", async () => {
+    const { requests, ctx } = makeCtx()
+
+    // NOT an oversight. The memory early-return is a DEFERRAL to memory-path-guard,
+    // and that guard is still lexical — assertMemoryWriteAllowed returns early on
+    // `!target.startsWith(root)`, so an aliased memory path is governed by nothing.
+    // Widening the deferral alone would drop the ask for precisely those paths, so
+    // the memory branch deliberately keeps `contains` until the guard moves with it.
+    // This test pins that decision so a future change has to confront it.
+    const alias = dataRootAliasedTo("extdir-datalink-mem-")
+    const target = path.join(alias, "memory", "sessions", "ses_test", "tasks", "T3", "progress.md")
+
+    await Instance.provide({
+      directory: "/tmp/project",
+      fn: async () => {
+        await assertExternalDirectory(ctx, target)
+      },
+    })
+
+    expect(requests.find((r) => r.permission === "external_directory")).toBeDefined()
+  })
+
+  test("still asks for a foreign path reached through an aliased data root (regression)", async () => {
+    const { requests, ctx } = makeCtx()
+
+    // Aliasing the data root must not admit paths that are outside it even after
+    // resolution — the trust stays scoped to the worktree subtree.
+    const alias = dataRootAliasedTo("extdir-datalink-neg-")
+    const target = path.join(alias, "not-a-trusted-subtree", "file.ts")
+
+    await Instance.provide({
+      directory: "/tmp/project",
+      fn: async () => {
+        await assertExternalDirectory(ctx, target)
       },
     })
 

--- a/packages/opencode/test/tool/isolated-git-guard.test.ts
+++ b/packages/opencode/test/tool/isolated-git-guard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import * as path from "path"
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import {
   assertIsolatedGitAllowed,
@@ -177,6 +177,28 @@ describe("isolated-git-guard / isolation signal", () => {
 
   test("undefined directory is not an isolated child", () => {
     expect(isIsolatedWorktree(undefined, root)).toBe(false)
+  })
+
+  test("a symlinked worktree base still recognises its own children", () => {
+    // The realpath half of this check now comes from AppFileSystem.withinTrustedRoot.
+    // `Instance.provide` hands this function a realpath-resolved directory while the
+    // base is derived from Global.Path.data, which keeps its symlinked form — the two
+    // sides arrive differently normalised, so a lexical test alone misses.
+    const base = mkdtempSync(path.join(realpathSync(tmpdir()), "isolation-signal-"))
+    const realBase = path.join(base, "worktree")
+    const linkBase = path.join(base, "worktree-link")
+    const child = path.join(realBase, "p_abc", "child-1")
+    mkdirSync(child, { recursive: true })
+    symlinkSync(realBase, linkBase, "dir")
+
+    expect(isIsolatedWorktree(child, linkBase)).toBe(true)
+    expect(isIsolatedWorktree(path.join(linkBase, "p_abc", "child-1"), realBase)).toBe(true)
+    // A worktree directory that has not been created yet must resolve too: the
+    // isolation signal is read while a child is still being set up, and a plain
+    // `catch -> path.resolve` fallback keeps the link spelling and misses here.
+    expect(isIsolatedWorktree(path.join(linkBase, "p_abc", "child-not-created-yet"), realBase)).toBe(true)
+    // A sibling outside the base is still not isolated, symlink or not.
+    expect(isIsolatedWorktree(path.join(base, "elsewhere"), linkBase)).toBe(false)
   })
 })
 

--- a/packages/shared/src/filesystem.ts
+++ b/packages/shared/src/filesystem.ts
@@ -1,5 +1,5 @@
 import { NodeFileSystem } from "@effect/platform-node"
-import { dirname, join, relative, resolve as pathResolve } from "path"
+import { basename, dirname, join, relative, resolve as pathResolve } from "path"
 import { realpathSync } from "fs"
 import * as NFS from "fs/promises"
 import { lookup } from "mime-types"
@@ -232,5 +232,56 @@ export namespace AppFileSystem {
 
   export function contains(parent: string, child: string) {
     return !relative(parent, child).startsWith("..")
+  }
+
+  /**
+   * Boundary test for TRUST decisions: is `child` inside `root`?
+   *
+   * Use this — not `contains` — wherever the answer gates a permission, a
+   * sandbox, or any other security boundary. `contains` is pure lexical path
+   * arithmetic, and in a real trust check the two sides routinely arrive with
+   * DIFFERENT degrees of normalisation: `Instance.provide` stores a
+   * realpath-resolved directory while `Global.Path.data` keeps the symlinked
+   * form (macOS `/var` → `/private/var`, `/tmp` → `/private/tmp`). A lexical
+   * test then returns a false NEGATIVE and the caller treats an in-boundary
+   * path as external — which, on the `external_directory` gate, means a
+   * background child with no interactive replier deadlocks on the ask.
+   *
+   * Note the hazard does NOT require a symlink to be involved: it is enough
+   * that one side has been resolved and the other has not.
+   *
+   * Ordering is load-bearing for cost, not just clarity: the lexical test runs
+   * first and short-circuits, so realpath syscalls are paid ONLY on the
+   * negative path — the case that was already about to escalate to an ask.
+   *
+   * A path whose leaf does not exist yet still has to be comparable, because
+   * the commonest boundary question of all is "may I CREATE this file". Plain
+   * `realpathSync` throws there, and falling back to `path.resolve` is not
+   * enough either — `resolve` does no symlink resolution, so the unresolved
+   * spelling survives and the comparison misses exactly when it matters. So
+   * canonicalize the deepest ancestor that DOES exist and re-append the
+   * remainder, the same technique `src/tool/tool-script.ts` uses for its jail.
+   */
+  export function withinTrustedRoot(root: string, child: string) {
+    if (contains(root, child)) return true
+    return contains(realpathBestEffort(root), realpathBestEffort(child))
+  }
+
+  function realpathBestEffort(target: string) {
+    let cur = pathResolve(target)
+    let suffix = ""
+    while (true) {
+      try {
+        const resolved = realpathSync(cur)
+        return suffix ? join(resolved, suffix) : resolved
+      } catch {
+        const parent = dirname(cur)
+        // Reached the root with nothing resolvable: no part of this path exists,
+        // so the lexically resolved form is the best comparable answer.
+        if (parent === cur) return pathResolve(target)
+        suffix = suffix ? join(basename(cur), suffix) : basename(cur)
+        cur = parent
+      }
+    }
   }
 }

--- a/packages/shared/test/filesystem/filesystem.test.ts
+++ b/packages/shared/test/filesystem/filesystem.test.ts
@@ -4,6 +4,8 @@ import { NodeFileSystem } from "@effect/platform-node"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { testEffect } from "../lib/effect"
 import path from "path"
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
 
 const live = AppFileSystem.layer.pipe(Layer.provideMerge(NodeFileSystem.layer))
 const { effect: it } = testEffect(live)
@@ -333,6 +335,92 @@ describe("AppFileSystem", () => {
       expect(AppFileSystem.overlaps("/a/b", "/a/b/c")).toBe(true)
       expect(AppFileSystem.overlaps("/a/b/c", "/a/b")).toBe(true)
       expect(AppFileSystem.overlaps("/a", "/b")).toBe(false)
+    })
+  })
+
+  describe("withinTrustedRoot", () => {
+    // A REAL symlinked prefix, not a stub of `contains`: <tmp>/link -> <tmp>/real,
+    // so one file can be named through either. This is the shape the trust callers
+    // actually hit — `Instance.provide` stores a realpath-resolved directory while
+    // `Global.Path.data` keeps the symlinked form.
+    function symlinkFixture() {
+      const base = mkdtempSync(path.join(realpathSync(tmpdir()), "trusted-root-"))
+      const real = path.join(base, "real")
+      const link = path.join(base, "link")
+      mkdirSync(path.join(real, "nested"), { recursive: true })
+      writeFileSync(path.join(real, "nested", "file.ts"), "x")
+      symlinkSync(real, link, "dir")
+      return { base, real, link }
+    }
+
+    test("agrees with contains whenever the paths are lexically related", () => {
+      expect(AppFileSystem.withinTrustedRoot("/a/b", "/a/b/c")).toBe(true)
+      expect(AppFileSystem.withinTrustedRoot("/a/b", "/a/b")).toBe(true)
+    })
+
+    test("a genuinely foreign path is still outside", () => {
+      expect(AppFileSystem.withinTrustedRoot("/a/b", "/a/c")).toBe(false)
+      // A path that merely resembles the root by name must not be admitted.
+      expect(AppFileSystem.withinTrustedRoot("/data/worktree", "/tmp/worktree/foreign")).toBe(false)
+    })
+
+    test("root named through a symlink still contains a child named through the real path", () => {
+      const { real, link } = symlinkFixture()
+      const child = path.join(real, "nested", "file.ts")
+
+      // The defect being fixed: purely lexical arithmetic says "outside".
+      expect(AppFileSystem.contains(link, child)).toBe(false)
+      expect(AppFileSystem.withinTrustedRoot(link, child)).toBe(true)
+    })
+
+    test("root named through the real path still contains a child named through the symlink", () => {
+      const { real, link } = symlinkFixture()
+      const child = path.join(link, "nested", "file.ts")
+
+      expect(AppFileSystem.contains(real, child)).toBe(false)
+      expect(AppFileSystem.withinTrustedRoot(real, child)).toBe(true)
+    })
+
+    test("a child that does not exist yet is still comparable", () => {
+      // Load-bearing: a write names its file BEFORE it exists, so realpath throws
+      // and the fallback must still resolve it against the realpath'd root.
+      const { real, link } = symlinkFixture()
+      const notYet = path.join(real, "nested", "created-later.ts")
+
+      expect(AppFileSystem.contains(link, notYet)).toBe(false)
+      expect(AppFileSystem.withinTrustedRoot(link, notYet)).toBe(true)
+    })
+
+    test("a not-yet-existing child named THROUGH the symlink is still inside", () => {
+      // The case a plain `catch -> path.resolve` fallback gets wrong: `resolve`
+      // performs no symlink resolution, so the link spelling survives and the
+      // comparison misses. Since "may I create this file" is the commonest
+      // boundary question on the write path, this is the dominant case, not a
+      // corner one — the deepest existing ancestor must be canonicalized and
+      // the missing tail re-appended.
+      const { link } = symlinkFixture()
+      const notYet = path.join(link, "nested", "created-later.ts")
+
+      expect(AppFileSystem.withinTrustedRoot(link, notYet)).toBe(true)
+      // And through the real root, which is the direction Instance.provide creates.
+      const { real: real2, link: link2 } = symlinkFixture()
+      expect(AppFileSystem.withinTrustedRoot(real2, path.join(link2, "nested", "created-later.ts"))).toBe(true)
+    })
+
+    test("a deep chain of missing components resolves without throwing", () => {
+      const { real, link } = symlinkFixture()
+      const deep = path.join(link, "nested", "a", "b", "c", "d.ts")
+
+      expect(AppFileSystem.withinTrustedRoot(link, deep)).toBe(true)
+      expect(AppFileSystem.withinTrustedRoot(real, deep)).toBe(true)
+      // A missing chain that escapes the root is still outside.
+      expect(AppFileSystem.withinTrustedRoot(path.join(real, "nested"), path.join(link, "sibling", "x.ts"))).toBe(false)
+    })
+
+    test("neither side existing falls back to lexical resolution rather than throwing", () => {
+      const ghost = path.join(tmpdir(), "definitely-absent-" + Math.random().toString(36).slice(2))
+      expect(AppFileSystem.withinTrustedRoot(ghost, path.join(ghost, "child.ts"))).toBe(true)
+      expect(AppFileSystem.withinTrustedRoot(ghost, "/elsewhere/child.ts")).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## The defect

`AppFileSystem.contains` (`packages/shared/src/filesystem.ts:233`) is pure lexical path arithmetic:

```ts
export function contains(parent: string, child: string) {
  return !relative(parent, child).startsWith("..")
}
```

No realpath, no symlink normalisation. Several callers nevertheless use it as a **trust boundary**, and one of them gates a deadlock. `tool/external-directory.ts` trusts the app-managed worktree base; the comment above that line says what the early return prevents — *every in-worktree write hits `external_directory:ask`, and a background/isolated child has no interactive replier, so the ask hangs on a never-resolved `Deferred` and the child deadlocks*. A false negative there re-introduces that deadlock.

**The hazard does not require a symlink to exist.** `Instance.provide` stores a **realpath-resolved** directory (`instance.ts:121`, via `AppFileSystem.resolve`), while `Global.Path.data` keeps whatever spelling it was configured with. It is enough that one side has been resolved and the other has not — the two sides merely need different degrees of normalisation.

**The repo had already fixed this in exactly one place.** `tool/isolated-git-guard.ts` carried a local two-step test, and its own doc comment named the sibling call site (`src/tool/external-directory.ts`) that still had the hole — so whoever wrote it knew the other callers shared the bug and fixed only their own.

## What this changes

Promotes that two-step test into one shared predicate, `AppFileSystem.withinTrustedRoot(root, child)`, and applies it at the boundary call sites.

`contains` itself is **unchanged**. Widening it would silently alter every caller's semantics, including those that genuinely want lexical answers. The pre-existing test that pins its lexical behaviour (`packages/shared/test/filesystem/filesystem.test.ts`) still passes untouched, which is itself the evidence.

### Where the predicate lives, and why

`packages/shared/src/filesystem.ts`, directly below `contains`.

The concern with putting it in `shared` is dragging a node dependency into a package other consumers use. **Checked before choosing — that concern is already moot for this exact file:** `shared/src/filesystem.ts:3` already imports `realpathSync` from `"fs"` and uses it at `:193` (`normalizePath`) and `:211` (`resolve`). `@effect/platform-node` is already a declared dependency. So this adds no new dependency edge, and it puts the two predicates side by side where a reader choosing between them sees both. `packages/opencode` already imports `AppFileSystem` at every affected site, `isolated-git-guard.ts` included.

### Caller table — all 11 sites of `AppFileSystem.contains`

Inventory re-derived on `origin/main` @ `b81670870`; matches, 11 sites.

| site | semantics | action |
|---|---|---|
| `tool/isolated-git-guard.ts:266` | trust boundary | **now delegates** to the shared predicate; local `real()` copy deleted so the two cannot drift |
| `tool/external-directory.ts:67` (`<data>/worktree`) | trust boundary, **gates the deadlock** | **promoted** |
| `project/instance.ts:170`, `:174` | in-project test, first gate of `external_directory` | **promoted** |
| `tool/external-directory.ts:46` (`<data>/memory`) | trust boundary, **deferral** | left lexical — see below |
| `tool/external-directory.ts:168` (`<data>/memory`) | trust boundary, **deferral** | left lexical — see below |
| `tool/apply_patch.ts:198`, `:214` (`<data>/memory`) | trust boundary, **deferral** | left lexical — see below |
| `lsp/lsp.ts:236`, `:237` | out-of-project → skip LSP | left lexical, deliberately |

### Why the four `<data>/memory` sites were deliberately NOT promoted

This is the one place the brief's plan and the code disagreed, and the code won.

Those four are not terminal trusts — they are **deferrals**. The comment at `external-directory.ts` says so: the memory tree *"has its own finer authority (memory-path-guard)"*. Their soundness depends on the delegate actually governing what is waved through. **The delegate is still lexical:**

- `tool/memory-path-guard.ts:168` — `assertMemoryWriteAllowed` does `if (!target.startsWith(normalizedRoot)) return`, so a memory path spelled through a symlinked data root is governed by **nothing**.
- `tool/memory-path-guard.ts:35-36` — `assertAgentWriteSandbox` resolves both sides with `path.resolve`, which does not follow symlinks.

So widening only the deferral would **drop the prompt for exactly the paths the delegate never inspects** — a net loss of oversight, not a fix. Demonstrated, not theorised: an aliased memory write under `checkpoint-writer` fails closed in the guard with

```
error: Agent 'checkpoint-writer' may only write under the memory tree.
  memory: /var/folders/0s/fm84ntp94712pvplln0lf9940000gn/T/mimocode-test-data-28641/share/mimocode/memory
You attempted: /private/var/folders/0s/fm84ntp94712pvplln0lf9940000gn/T/applypatch-datalink-6RzBQo/datalink/memory/sessions/ses_test/aliased-checkpoint.md
      at assertAgentWriteSandbox (src/tool/memory-path-guard.ts:39:15)
```

— the `/var/...` root against the `/private/var/...` target is this very bug, live, in a third file. The memory sites and `memory-path-guard.ts` must be promoted **together**; the reason is recorded at each site, and a test pins the current answer so a future change has to confront it rather than silently flip it.

### `lsp.ts`: left lexical, on purpose

Not a trust boundary — a false negative only skips LSP enrichment for one file — and `getClients` runs on every LSP touch. Paying realpath syscalls per out-of-project file is the wrong trade. Recorded at the site, including which line to change if LSP ever stops attaching under a symlinked prefix.

### The fallback is stronger than the copy it replaces

The guard's `real()` was `catch -> path.resolve`. `path.resolve` performs **no** symlink resolution, so a **not-yet-existing** path keeps its unresolved spelling and the comparison still misses — and *"may I create this file"* is the commonest boundary question on the write path. This was caught by the end-to-end test failing **with the fix applied**, not by inspection.

So `realpathBestEffort` canonicalizes the deepest ancestor that **does** exist and re-appends the remainder — the technique already proven in-tree at `tool/tool-script.ts:250`. The load-bearing property is preserved and strengthened: it never throws, and a path that does not exist yet is still comparable — now also when it is named *through* a symlink.

## Cost: worst-case syscall rate on the permission path

Ordering preserved: **lexical test first, realpath only on the negative path.**

`realpathBestEffort` costs 1 syscall, plus 1 per missing trailing component. One `withinTrustedRoot` miss therefore costs 2 resolutions; for the realistic shape (a new file under an existing directory) that is ~3 syscalls.

Per `assertExternalDirectoryEffect` call:

- **In-project write, matching spelling — the hot case: 0 extra syscalls.** `Instance.containsPath`'s lexical test hits and returns immediately.
- **Project under a symlinked prefix (the case this fixes) — worst *sustained* rate: ~3 `realpathSync` per file-tool call.** `containsPath` misses lexically, resolves, hits. Negligible beside the file I/O the tool is about to perform.
- **Genuinely external path — worst case ~9.** Up to three `withinTrustedRoot` evaluations (`directory`, `worktree`, `<data>/worktree`) all miss. This is the call that then raises an interactive `external_directory:ask`, i.e. a human round-trip measured in seconds. The memory branch stays lexical and adds 0.

## Verification

Baseline and post-change runs are the **same commands at the same sha**, `b8167087088ad361740d6e28fb35faae49afdf78`:

| command | baseline | after |
|---|---|---|
| `packages/shared` `bun test test/filesystem/filesystem.test.ts` | 24 pass / 0 fail / 35 expects | **32 pass / 0 fail / 52 expects** |
| `packages/opencode` `bun test test/tool/{external-directory,isolated-git-guard,apply_patch}.test.ts` | 133 pass / 0 fail / 178 expects | **139 pass / 0 fail / 189 expects** |
| `bun typecheck` `packages/shared` | exit 0 | **exit 0** |
| `bun typecheck` `packages/opencode` | exit 0 | **exit 0** |
| `bun lint` (oxlint) | 3930 warnings / 0 errors | **3930 warnings / 0 errors** (identical; 24 file-specific warnings both before and after) |

Repo-wide turbo typecheck via the pre-push hook: **12 successful, 12 total.**

### The fixture is a real symlink, not a mock

`<tmp>/link -> <tmp>/real`, so one file can be named through either spelling; plus a symlink pointing at the actual data root, so the two `<data>`-rooted gates are exercised with one side canonical and the other not. Nothing stubs `contains`.

### Revert probes — each quoted verbatim

**P1 — `project/instance.ts` back to lexical `contains`:**
```
227 |     expect(requests.length).toBe(0)
                                  ^
error: expect(received).toBe(expected)

Expected: 0
Received: 1

(fail) tool.assertExternalDirectory > does NOT ask for an in-project path named through a symlinked project prefix [2.34ms]
 13 pass  1 fail
```

**P2 — the `<data>/worktree` gate back to lexical `contains` (isolated):**
```
283 |     expect(requests.length).toBe(0)
                                  ^
error: expect(received).toBe(expected)

Expected: 0
Received: 1

(fail) tool.assertExternalDirectory > does NOT ask for a worktree path named through an aliased data root [1.09ms]
 13 pass  1 fail
```

**P3 — fallback replaced by the old `catch -> path.resolve` semantics:**
```
(fail) AppFileSystem > withinTrustedRoot > a not-yet-existing child named THROUGH the symlink is still inside [1.10ms]

415 |       expect(AppFileSystem.withinTrustedRoot(real, deep)).toBe(true)
                                                                ^
error: expect(received).toBe(expected)

Expected: true
Received: false

(fail) AppFileSystem > withinTrustedRoot > a deep chain of missing components resolves without throwing [0.54ms]
 30 pass  2 fail
```

**P4 — `isolated-git-guard.ts` keeps its own local two-step copy instead of delegating:**
```
199 |     expect(isIsolatedWorktree(path.join(linkBase, "p_abc", "child-not-created-yet"), realBase)).toBe(true)
                                                                                                      ^
error: expect(received).toBe(expected)

Expected: true
Received: false

(fail) isolated-git-guard / isolation signal > a symlinked worktree base still recognises its own children [3.68ms]
 92 pass  1 fail
```

P4 confirms the delegation is a behaviour improvement, not a cosmetic refactor. `lsp.ts` is comment-only and has no probe by construction.

## Comments corrected

Stale comments that would have described behaviour the code no longer has:

1. **`isolated-git-guard.ts:256-262`** — said it *"Mirrors the trusted-root test already used by `src/tool/external-directory.ts`, but additionally compares realpaths"*. Both halves were about to become wrong: it no longer holds a local special case, and the sibling now applies the same predicate. Rewritten to state the delegation and the anti-drift reason.
2. **`external-directory.ts`, worktree branch** — extended to say why the predicate must be realpath-comparing, and that this trust is *terminal* (nothing downstream re-checks it), which is what distinguishes it from the memory branch.
3. **`external-directory.ts`, memory branch** — new note recording that the lexical test is a deliberate choice and naming the coupling to `memory-path-guard`.
4. **`askEditUnlessMemory` doc comment** — previously claimed only to mirror the memory deferral; now also records that it mirrors its *lexical* choice, and why.
5. **`apply_patch.ts` permission filter** — same note, so the two sites are not read as an oversight.
6. **`instance.ts` `containsPath` doc comment** — records that it is the first gate of `external_directory` and why `Instance.provide`'s realpath resolution forces the boundary predicate.
7. **`lsp.ts` `getClients`** — new comment recording the deliberate non-change and its cost reasoning.

## Also found, not fixed here

- **A second, duplicated lexical `contains`** at `packages/opencode/src/util/filesystem.ts:164`, byte-identical to the shared one, with 6 callers of its own — including `server/routes/instance/middleware.ts:37` and `server/routes/instance/httpapi/server.ts:106`, which gate a **403 directory-access decision** and compare an already-`Filesystem.resolve`d `cwd` (realpath) against a request-supplied `directory` (not). Same asymmetry, in HTTP authorization. Not touched here: changing an auth path needs its own reasoning and tests.
- **`memory-path-guard.ts:35-36` and `:168`** — the delegate discussed above.
- **`workflow/workspace.ts:21`** — a sandbox jail whose comment already documents the limitation as deferred-by-design. Worth noting `withinTrustedRoot` would **not** fix it: its hazard is a symlink *inside* the root pointing *out* (a false positive), and the predicate short-circuits on the lexical `true`. Applying it there would look like a fix while changing nothing.
- **`tool/tool-script.ts:250`** — a third independent reimplementation of the realpath dance, which is the evidence that this pattern was being reinvented per-site.
