### PR TITLE
fix(tui): align slash autocomplete descriptions for CJK aliases

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -1,7 +1,6 @@
 import type { BoxRenderable, TextareaRenderable, KeyEvent, ScrollBoxRenderable } from "@opentui/core"
 import { pathToFileURL } from "bun"
 import fuzzysort from "fuzzysort"
-import { firstBy } from "remeda"
 import { createMemo, createResource, createEffect, onMount, onCleanup, Index, Show, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useSDK } from "@tui/context/sdk"
@@ -424,11 +423,14 @@ export function Autocomplete(props: {
 
     results.sort((a, b) => a.display.localeCompare(b.display))
 
-    const max = firstBy(results, [(x) => x.display.length, "desc"])?.display.length
+    // Pad in terminal columns, not code units: CJK slash aliases (e.g. zh "前端设计")
+    // render two cells wide, so String.length + padEnd() would push the right-hand
+    // description column out of alignment.
+    const max = Math.max(0, ...results.map((x) => Bun.stringWidth(x.display)))
     if (!max) return results
     return results.map((item) => ({
       ...item,
-      display: item.display.padEnd(max + 2),
+      display: item.display + " ".repeat(Math.max(0, max + 2 - Bun.stringWidth(item.display))),
     }))
   })
 


### PR DESCRIPTION
Fixes #1979

TUI 输入 `/` 的补全弹窗中，中文技能别名行（`/前端设计`、`/深度研究` 等）右侧描述列与英文行不对齐。

原因：`commands` memo 的填充用 `String.length` + `padEnd()`，按 code unit 而非终端列宽计算。中文占 2 列但按 1 列算，中文行渲染宽度超出填充宽度，右侧描述被顶出 2~6 列。

改动：改用 `Bun.stringWidth` 计算列宽后填充（同文件 extmark 偏移已在用这个宽度函数）。

Before / after（数字为各行描述起始列）：

```
Before: 16 / 18 / 20 / 22 混杂
/help           |Show help
/前端设计           |前端设计技能

After: 统一为 16
/help           |Show help
/前端设计       |前端设计技能
```

验证：

- `bun run build:local` 构建后在 TUI 输入 `/`，中英文行描述列已对齐
- 全仓 `tsgo --noEmit` 0 errors；oxlint 无新增告警；autocomplete-detect 测试 25/25 通过
- `exactSubmitOption` 与 fuzzysort 均对 `display.trimEnd()` 比较，填充宽度变化不影响命令匹配
