### PR TITLE
fix(tui): reconcile the three store writes that mean "replace", not "merge"

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/frecency.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/frecency.tsx
@@ -2,7 +2,7 @@ import path from "path"
 import { Global } from "@/global"
 import { Filesystem } from "@/util"
 import { onMount } from "solid-js"
-import { createStore } from "solid-js/store"
+import { createStore, reconcile } from "solid-js/store"
 import { createSimpleContext } from "../../context/helper"
 import { appendFile, writeFile } from "fs/promises"
 
@@ -11,6 +11,21 @@ function calculateFrecency(entry?: { frequency: number; lastOpen: number }): num
   const daysSince = (Date.now() - entry.lastOpen) / 86400000 // ms per day
   const weight = 1 / (1 + daysSince)
   return entry.frequency * weight
+}
+
+/**
+ * Both writes of the whole `data` map are PRUNES: they hand over the surviving
+ * entries and mean the rest to be gone.
+ *
+ * Solid's store setter merges plain objects into the existing node
+ * (`mergeStoreNode` only writes `Object.keys(next)`), so the pruned keys used to
+ * survive in the store while the on-disk file was rewritten without them. The
+ * MAX_FRECENCY_ENTRIES cap therefore never took effect in memory: `store.data`
+ * grew without bound, every subsequent open re-ran the prune, and dropped paths
+ * kept scoring in the file picker.
+ */
+export function nextFrecencyData(data: Record<string, { frequency: number; lastOpen: number }>) {
+  return reconcile(data)
 }
 
 const MAX_FRECENCY_ENTRIES = 1000
@@ -47,8 +62,10 @@ export const { use: useFrecency, provider: FrecencyProvider } = createSimpleCont
 
       setStore(
         "data",
-        Object.fromEntries(
-          sorted.map((entry) => [entry.path, { frequency: entry.frequency, lastOpen: entry.lastOpen }]),
+        nextFrecencyData(
+          Object.fromEntries(
+            sorted.map((entry) => [entry.path, { frequency: entry.frequency, lastOpen: entry.lastOpen }]),
+          ),
         ),
       )
 
@@ -75,7 +92,7 @@ export const { use: useFrecency, provider: FrecencyProvider } = createSimpleCont
         const sorted = Object.entries(store.data)
           .sort(([, a], [, b]) => b.lastOpen - a.lastOpen)
           .slice(0, MAX_FRECENCY_ENTRIES)
-        setStore("data", Object.fromEntries(sorted))
+        setStore("data", nextFrecencyData(Object.fromEntries(sorted)))
         const content = sorted.map(([path, entry]) => JSON.stringify({ path, ...entry })).join("\n") + "\n"
         writeFile(frecencyPath, content).catch(() => {})
       }

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -65,6 +65,23 @@ export type WorkflowRun = {
   updatedAt?: number
 }
 
+/**
+ * A `workflow.started` event mints a FRESH run row, so it is authoritative for
+ * the whole object — including the optional fields it omits.
+ *
+ * Solid's store setter merges plain objects into the existing node
+ * (`mergeStoreNode` only writes `Object.keys(next)`), and a resume reuses the
+ * SAME runID: `WorkflowRuntime.resume` hands `input.runID` back to `launch`
+ * (workflow/runtime.ts:1577), which republishes `WorkflowStarted`
+ * (workflow/runtime.ts:712). Without reconcile the row that resume calls fresh
+ * inherits the PREVIOUS attempt's `currentPhase` and `error`, so /workflows
+ * shows a running run stamped with the phase it died in and the error it just
+ * retried past, until the resumed run happens to emit its first phase.
+ */
+export function nextWorkflowRun(run: WorkflowRun) {
+  return reconcile(run)
+}
+
 // Mirror of the runtime's WorkflowNode union (server route serializes it as
 // z.array(z.any())). The single TUI-side definition reused by the detail dialog
 // and the tree renderer.
@@ -698,15 +715,19 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         case "workflow.started": {
           // Upsert a fresh run row; counters stay zero until loadWorkflows /
           // the dialog's poll (T7) refreshes them from the list route.
-          setStore("workflow", event.properties.runID, {
-            runID: event.properties.runID,
-            sessionID: event.properties.sessionID,
-            name: event.properties.name,
-            status: "running",
-            running: 0,
-            succeeded: 0,
-            failed: 0,
-          })
+          setStore(
+            "workflow",
+            event.properties.runID,
+            nextWorkflowRun({
+              runID: event.properties.runID,
+              sessionID: event.properties.sessionID,
+              name: event.properties.name,
+              status: "running",
+              running: 0,
+              succeeded: 0,
+              failed: 0,
+            }),
+          )
           break
         }
 

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, type ParentProps, Show } from "solid-js"
-import { createStore } from "solid-js/store"
+import { createStore, reconcile } from "solid-js/store"
 import { useTheme } from "@tui/context/theme"
 import { useTerminalDimensions } from "@opentui/solid"
 import { SplitBorder } from "../component/border"
@@ -9,6 +9,21 @@ import { type TuiEvent } from "../event"
 import { useLanguage } from "@tui/context/language"
 
 export type ToastOptions = z.infer<typeof TuiEvent.ToastShow.properties>
+
+/**
+ * Each toast REPLACES the one on screen, so it is authoritative for the whole
+ * object — including `title`, which is optional.
+ *
+ * Solid's store setter merges plain objects into the existing node
+ * (`mergeStoreNode` only writes `Object.keys(next)`). A second toast raised
+ * before the first one's timer fires therefore lands on a non-null previous
+ * toast and inherits its `title`: `toast.error(err)` passes only
+ * `{ variant, message }`, so it used to render under whatever headline the
+ * preceding success toast had set, attributing a failure to unrelated work.
+ */
+export function nextToast(options: Omit<ToastOptions, "duration">) {
+  return reconcile(options)
+}
 
 export function Toast() {
   const toast = useToast()
@@ -60,7 +75,7 @@ function init() {
   const toast = {
     show(options: ToastOptions) {
       const { duration = 5000, ...currentToast } = options
-      setStore("currentToast", currentToast)
+      setStore("currentToast", nextToast(currentToast))
       if (timeoutHandle) clearTimeout(timeoutHandle)
       timeoutHandle = setTimeout(() => {
         setStore("currentToast", null)

--- a/packages/opencode/test/cli/tui/frecency-store.test.ts
+++ b/packages/opencode/test/cli/tui/frecency-store.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from "bun:test"
+import { readFileSync } from "fs"
+import path from "path"
+import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
+import { nextFrecencyData } from "../../../src/cli/cmd/tui/component/prompt/frecency"
+
+// Both whole-map writes of the frecency store are PRUNES, but solid MERGES plain
+// objects into the existing node — so the dropped keys used to survive in memory
+// while the .jsonl was rewritten without them. The MAX_FRECENCY_ENTRIES cap
+// therefore never took effect in the store.
+//
+// The real store lives inside the FrecencyProvider factory, which mounts and reads
+// the on-disk .jsonl; there is no Solid render harness for this route, so the
+// behavioural tests below drive a store wired exactly as frecency.tsx wires it and
+// pin nextFrecencyData's SEMANTICS. That the two production writes actually route
+// through it is pinned by the source-level (textual, NOT behavioural) assertion at
+// the bottom of this file.
+type Entry = { frequency: number; lastOpen: number }
+
+function harness() {
+  return createRoot((dispose) => {
+    const [store, setStore] = createStore<{ data: Record<string, Entry> }>({ data: {} })
+    return {
+      store,
+      // Mirrors updateFrecency()'s per-path write, which is not a prune.
+      touch: (file: string, entry: Entry) => setStore("data", file, entry),
+      // Mirrors both whole-map writes: the onMount load and the over-cap prune.
+      replace: (data: Record<string, Entry>) => setStore("data", nextFrecencyData(data)),
+      dispose,
+    }
+  })
+}
+
+describe("nextFrecencyData", () => {
+  test("a prune actually drops the entries it left out", () => {
+    const h = harness()
+    h.touch("/a.ts", { frequency: 1, lastOpen: 300 })
+    h.touch("/b.ts", { frequency: 4, lastOpen: 200 })
+    h.touch("/c.ts", { frequency: 9, lastOpen: 100 })
+    expect(Object.keys(h.store.data).sort()).toEqual(["/a.ts", "/b.ts", "/c.ts"])
+
+    // The over-cap branch keeps the most-recent survivors and rewrites the file
+    // with only those; the store must agree.
+    h.replace({ "/a.ts": { frequency: 1, lastOpen: 300 }, "/b.ts": { frequency: 4, lastOpen: 200 } })
+    expect(Object.keys(h.store.data).sort()).toEqual(["/a.ts", "/b.ts"])
+    expect(h.store.data["/c.ts"]).toBeUndefined()
+    h.dispose()
+  })
+
+  test("the store never grows past what a prune handed it", () => {
+    const h = harness()
+    for (let i = 0; i < 12; i++) h.touch(`/f${i}.ts`, { frequency: 1, lastOpen: i })
+    expect(Object.keys(h.store.data)).toHaveLength(12)
+
+    const kept = Object.fromEntries(
+      Object.entries(h.store.data)
+        .sort(([, a], [, b]) => b.lastOpen - a.lastOpen)
+        .slice(0, 5),
+    )
+    h.replace(kept)
+    expect(Object.keys(h.store.data)).toHaveLength(5)
+    h.dispose()
+  })
+
+  test("an authoritative load replaces rather than unions with what was already there", () => {
+    const h = harness()
+    // A file opened before the async onMount read resolves.
+    h.touch("/early.ts", { frequency: 1, lastOpen: 999 })
+    h.replace({ "/from-disk.ts": { frequency: 7, lastOpen: 5 } })
+    expect(Object.keys(h.store.data)).toEqual(["/from-disk.ts"])
+    h.dispose()
+  })
+
+  test("surviving entries keep their values through a prune", () => {
+    const h = harness()
+    h.touch("/keep.ts", { frequency: 3, lastOpen: 10 })
+    h.touch("/drop.ts", { frequency: 1, lastOpen: 1 })
+    h.replace({ "/keep.ts": { frequency: 3, lastOpen: 10 } })
+    expect(h.store.data["/keep.ts"]).toEqual({ frequency: 3, lastOpen: 10 })
+    h.dispose()
+  })
+})
+
+// SOURCE-LEVEL, NOT BEHAVIOURAL. The tests above wire their own store, so they
+// would still pass if frecency.tsx stopped pruning through nextFrecencyData.
+// This reads the production file so a revert at either write site fails here.
+describe("component/prompt/frecency.tsx wiring", () => {
+  const source = readFileSync(
+    path.join(import.meta.dir, "../../../src/cli/cmd/tui/component/prompt/frecency.tsx"),
+    "utf8",
+  )
+  const normalized = source.replace(/\s+/g, " ")
+  const matches = (re: RegExp) => (normalized.match(re) ?? []).length
+
+  test("both whole-map writes of `data` go through nextFrecencyData", () => {
+    // Two writes address the whole map (the onMount load and the over-cap prune);
+    // a third addresses one key and is excluded by the negative lookahead.
+    expect(matches(/setStore\( ?"data", (?!absolutePath)/g)).toBe(2)
+    expect(matches(/setStore\( ?"data", nextFrecencyData\(/g)).toBe(2)
+  })
+
+  test("the per-path touch write is deliberately left a merge", () => {
+    // Unchanged behaviour, pinned so a blanket reconcile sweep does not break it:
+    // this write targets ONE key and must not prune its siblings.
+    expect(matches(/setStore\("data", absolutePath, newEntry\)/g)).toBe(1)
+  })
+})

--- a/packages/opencode/test/cli/tui/toast-store.test.ts
+++ b/packages/opencode/test/cli/tui/toast-store.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from "bun:test"
+import { readFileSync } from "fs"
+import path from "path"
+import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
+import { nextToast, type ToastOptions } from "../../../src/cli/cmd/tui/ui/toast"
+
+// Each toast REPLACES the one on screen, but solid MERGES plain objects into the
+// existing store node — so a toast that omits the optional `title` used to
+// inherit the headline of the toast it replaced. `toast.error(err)` passes only
+// { variant, message }, so a failure rendered under an unrelated success title.
+//
+// `init()` in ui/toast.tsx is module-private and calls useLanguage(), so the real
+// store cannot be built without a provider tree, and there is no Solid render
+// harness for this route. The behavioural tests below therefore drive a store
+// wired exactly as toast.show() wires it — they pin nextToast's SEMANTICS. The
+// wiring itself (that show() actually routes through nextToast) is pinned
+// separately by the source-level assertion at the bottom of this file, which is
+// a textual check and NOT a behavioural one; it is labelled as such there.
+function harness() {
+  return createRoot((dispose) => {
+    const [store, setStore] = createStore<{ currentToast: Omit<ToastOptions, "duration"> | null }>({
+      currentToast: null,
+    })
+    return {
+      store,
+      // Mirrors toast.show(): duration is stripped, the rest becomes the toast.
+      show: (options: Omit<ToastOptions, "duration">) => setStore("currentToast", nextToast(options)),
+      expire: () => setStore("currentToast", null),
+      dispose,
+    }
+  })
+}
+
+describe("nextToast", () => {
+  test("a titled toast does not lend its title to the next untitled toast", () => {
+    const h = harness()
+    h.show({ title: "Session deleted", message: "3 sessions removed", variant: "success" })
+    expect(h.store.currentToast).toEqual({
+      title: "Session deleted",
+      message: "3 sessions removed",
+      variant: "success",
+    })
+
+    // toast.error(err) — raised before the 5s timer clears the previous toast.
+    h.show({ message: "Failed to send message", variant: "error" })
+    expect(h.store.currentToast?.title).toBeUndefined()
+    expect(h.store.currentToast).toEqual({ message: "Failed to send message", variant: "error" })
+    h.dispose()
+  })
+
+  test("a title is replaced, not accumulated, between titled toasts", () => {
+    const h = harness()
+    h.show({ title: "Plugin added", message: "acme", variant: "success" })
+    h.show({ title: "Plugin removed", message: "acme", variant: "info" })
+    expect(h.store.currentToast).toEqual({ title: "Plugin removed", message: "acme", variant: "info" })
+    h.dispose()
+  })
+
+  test("the first toast after an expiry is stored as-is", () => {
+    const h = harness()
+    h.show({ title: "Export complete", message: "/tmp/out.md", variant: "success" })
+    h.expire()
+    h.show({ message: "Failed to send message", variant: "error" })
+    expect(h.store.currentToast).toEqual({ message: "Failed to send message", variant: "error" })
+    h.dispose()
+  })
+
+  test("the first toast for a fresh store is stored as-is", () => {
+    const h = harness()
+    h.show({ title: "Welcome", message: "hello", variant: "info" })
+    expect(h.store.currentToast).toEqual({ title: "Welcome", message: "hello", variant: "info" })
+    h.dispose()
+  })
+})
+
+// SOURCE-LEVEL, NOT BEHAVIOURAL. The tests above would still pass if ui/toast.tsx
+// stopped calling nextToast, because they wire their own store. This reads the
+// production file instead, so dropping the call at the real write site fails here.
+describe("ui/toast.tsx wiring", () => {
+  const source = readFileSync(path.join(import.meta.dir, "../../../src/cli/cmd/tui/ui/toast.tsx"), "utf8")
+  const count = (needle: string) => source.split(needle).length - 1
+
+  test("show() writes currentToast through nextToast", () => {
+    expect(count(`setStore("currentToast", nextToast(currentToast))`)).toBe(1)
+    // A bare merge write at this key is the defect; it must not reappear.
+    expect(count(`setStore("currentToast", currentToast)`)).toBe(0)
+  })
+
+  test("the expiry write still clears the toast outright", () => {
+    // Unchanged behaviour, pinned so the fix cannot be 'completed' by removing it:
+    // null is not an object, so it replaces rather than merges and needs no reconcile.
+    expect(count(`setStore("currentToast", null)`)).toBe(1)
+  })
+})

--- a/packages/opencode/test/cli/tui/workflow-run-store.test.ts
+++ b/packages/opencode/test/cli/tui/workflow-run-store.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect } from "bun:test"
+import { readFileSync } from "fs"
+import path from "path"
+import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
+import { nextWorkflowRun, type WorkflowRun } from "../../../src/cli/cmd/tui/context/sync"
+
+// `workflow.started` mints a FRESH run row, but solid MERGES plain objects into
+// the existing store node. A resume reuses the SAME runID (runtime.ts:1577 hands
+// input.runID back to launch, which republishes WorkflowStarted at :712), so the
+// "fresh" row used to inherit the previous attempt's currentPhase and error.
+//
+// The real store lives inside the SyncProvider factory, which needs the sdk /
+// project contexts and a bootstrap; there is no Solid render harness for the
+// session route, so the behavioural tests below drive a store wired exactly as the
+// "workflow.started" case wires it and pin nextWorkflowRun's SEMANTICS. That the
+// event handler actually routes through it is pinned by the source-level (textual,
+// NOT behavioural) assertion at the bottom of this file.
+function harness() {
+  return createRoot((dispose) => {
+    const [store, setStore] = createStore<{ workflow: Record<string, WorkflowRun> }>({ workflow: {} })
+    return {
+      store,
+      // Mirrors the "workflow.started" case in sync.tsx.
+      started: (runID: string, sessionID: string, name: string) =>
+        setStore(
+          "workflow",
+          runID,
+          nextWorkflowRun({ runID, sessionID, name, status: "running", running: 0, succeeded: 0, failed: 0 }),
+        ),
+      // Mirrors loadWorkflows() / the "workflow.phase" and "workflow.finished" cases.
+      phase: (runID: string, title: string) => setStore("workflow", runID, "currentPhase", title),
+      finished: (runID: string, status: string) => setStore("workflow", runID, "status", status),
+      fail: (runID: string, error: string) => setStore("workflow", runID, "error", error),
+      dispose,
+    }
+  })
+}
+
+describe("nextWorkflowRun", () => {
+  test("a resumed run does not inherit the dead attempt's phase or error", () => {
+    const h = harness()
+    h.started("run_1", "ses_1", "deep-research")
+    h.phase("run_1", "Research")
+    h.fail("run_1", "agent timed out")
+    h.finished("run_1", "failed")
+    expect(h.store.workflow["run_1"].currentPhase).toBe("Research")
+
+    // resumeWorkflow(runID) -> WorkflowRuntime.resume -> launch(..., input.runID)
+    // republishes workflow.started for the SAME runID.
+    h.started("run_1", "ses_1", "deep-research")
+    expect(h.store.workflow["run_1"].currentPhase).toBeUndefined()
+    expect(h.store.workflow["run_1"].error).toBeUndefined()
+    expect(h.store.workflow["run_1"]).toEqual({
+      runID: "run_1",
+      sessionID: "ses_1",
+      name: "deep-research",
+      status: "running",
+      running: 0,
+      succeeded: 0,
+      failed: 0,
+    })
+    h.dispose()
+  })
+
+  test("a restart drops the phase a prior attempt reached", () => {
+    const h = harness()
+    h.started("run_2", "ses_2", "fact-check")
+    h.phase("run_2", "Crosscheck")
+    h.finished("run_2", "cancelled")
+
+    h.started("run_2", "ses_2", "fact-check")
+    expect(h.store.workflow["run_2"].status).toBe("running")
+    expect(h.store.workflow["run_2"].currentPhase).toBeUndefined()
+    h.dispose()
+  })
+
+  test("the first start for an unseen runID is stored as-is", () => {
+    const h = harness()
+    h.started("run_3", "ses_3", "compose")
+    expect(h.store.workflow["run_3"]).toEqual({
+      runID: "run_3",
+      sessionID: "ses_3",
+      name: "compose",
+      status: "running",
+      running: 0,
+      succeeded: 0,
+      failed: 0,
+    })
+    h.dispose()
+  })
+
+  test("a start for one runID leaves a sibling run untouched", () => {
+    const h = harness()
+    h.started("run_4", "ses_4", "compose")
+    h.phase("run_4", "Implement")
+    h.started("run_5", "ses_4", "deep-research")
+    expect(h.store.workflow["run_4"].currentPhase).toBe("Implement")
+    expect(h.store.workflow["run_5"].currentPhase).toBeUndefined()
+    h.dispose()
+  })
+})
+
+// SOURCE-LEVEL, NOT BEHAVIOURAL. The tests above wire their own store, so they
+// would still pass if the "workflow.started" case stopped reconciling. This reads
+// the production file so a revert at the real write site fails here.
+describe("context/sync.tsx wiring", () => {
+  const source = readFileSync(path.join(import.meta.dir, "../../../src/cli/cmd/tui/context/sync.tsx"), "utf8")
+  const normalized = source.replace(/\s+/g, " ")
+  const count = (needle: string) => normalized.split(needle).length - 1
+
+  test("the workflow.started upsert goes through nextWorkflowRun", () => {
+    expect(count(`setStore( "workflow", event.properties.runID, nextWorkflowRun({`)).toBe(1)
+  })
+
+  test("loadWorkflows already reconciled the same node and still does", () => {
+    // The list route was the ONLY writer of this node that replaced rather than
+    // merged; the event handler disagreeing with it was the bug. Pin both sides so
+    // they cannot drift apart again.
+    expect(count(`setStore("workflow", run.runID, reconcile(run))`)).toBe(1)
+  })
+
+  test("the per-field phase/status writes stay targeted merges", () => {
+    // Unchanged behaviour: these address a single field and must NOT prune the row.
+    expect(count(`setStore("workflow", event.properties.runID, "currentPhase", event.properties.title)`)).toBe(1)
+    expect(count(`setStore("workflow", event.properties.runID, "status", event.properties.status)`)).toBe(1)
+  })
+})


### PR DESCRIPTION
## What

Three TUI store writes mean **replace**, but Solid's store setter **merges** plain objects into the existing node — `mergeStoreNode` only writes `Object.keys(next)`, so an omitted key silently inherits its old value. Each of these three is authoritative for the whole object, so each was leaking a field across a transition that logically clears it.

Same `reconcile()` remedy and the same named-helper shape as the existing `nextSessionStatus` in `context/sync.tsx` (the #1752 fix), so this is a consistency pass over the remaining offenders rather than a new pattern.

## The three leaks

**`ui/toast.tsx` — `currentToast`**
`title` is `z.string().optional()` and `toast.error(err)` omits it *structurally* (`{ variant, message }`). `app.tsx:1339` shows a titled success toast with `duration: 10000`, so any error raised in that 10-second window landed on a non-null previous toast and rendered under the unrelated "updated" headline — attributing a failure to work that succeeded.

**`component/prompt/frecency.tsx` — `data`**
Both whole-map writes are **prunes**: they hand over the survivors and mean the rest to be gone. Merging meant the dropped keys stayed in the store while the `.jsonl` was rewritten without them, so `MAX_FRECENCY_ENTRIES` never took effect in memory — `store.data` grew unbounded, the over-cap branch re-fired on every open, and dropped paths kept scoring in the file picker.

**`context/sync.tsx` — `workflow[runID]`**
`workflow.started` mints a *fresh* run row, but a resume reuses the **same** `runID`: `WorkflowRuntime.resume` hands `input.runID` to `launch` (`workflow/runtime.ts:1577`), which republishes `WorkflowStarted` (`:712`). The "fresh" row therefore inherited the dead attempt's `currentPhase` and `error`, so `/workflows` showed a *running* run stamped with the phase it died in and the error it had just retried past. Note `loadWorkflows` already wrote this same node with `reconcile(run)` — only the event handler disagreed, and the two writers are now pinned together.

## Deliberately not changed

Targeted single-field writes stay merges, and are pinned as such so a blanket reconcile sweep cannot break them:
`setStore("data", absolutePath, newEntry)`, `setStore("workflow", runID, "currentPhase", …)`, `setStore("workflow", runID, "status", …)`, and the `setStore("currentToast", null)` expiry (null is not an object, so it replaces already).

`component/prompt/index.tsx`'s `setStore("prompt", { input: "", parts: [] })` was examined and **left alone**. It does structurally omit `PromptInfo.mode?`, which history navigation writes onto the node (`setStore("prompt", item)`), so the field really does survive the clear — but the single consumer is `history.append({ ...store.prompt, mode: currentMode })`, where `mode` is re-specified *after* the spread, and `store.prompt.mode` is read nowhere else in the tree. The leak is inert; changing it would be churn without a behaviour delta.

## Tests

`test/cli/tui/{toast,frecency,workflow-run}-store.test.ts`, following the existing `session-status-store.test.ts` idiom.

The real stores live inside provider factories (`init()` is module-private and calls `useLanguage()`; `SyncProvider` needs sdk/project contexts plus a bootstrap) and there is **no Solid render harness for this route**. So each file pairs:

1. **behavioural** tests driving a store wired exactly as production wires it — these pin the helper's semantics; and
2. a **source-level, explicitly non-behavioural** assertion on the production write site — these pin the *wiring*, which (1) cannot see.

Both halves are independently revert-probed: de-reconciling the helpers fails 6 behavioural tests; leaving the helpers correct but unwiring the three call sites fails exactly the 3 source-level tests. The in-file comments label which is which rather than implying behavioural coverage of the wiring.

## Verification

- `bun test test/cli/tui`: **152 pass → 171 pass** (+19). The 1 pre-existing fail / 1 error is unchanged — `thread.test.ts` aborted by a cross-file module-load error in `src/workflow/builtin/deep-research.js`, reproducible on unmodified `b8167087088ad361740d6e28fb35faae49afdf78` and unrelated to this change.
- `bun typecheck --force`: 12 successful, `Cached: 0 cached`.
- `bunx oxlint` on the six touched files: 0 errors; 14 warnings, all pre-existing and byte-identical to the same lint run on the pristine sources.

## Relationship to #1978

#1978 (`fix/trust-boundary-realpath`) owns the trusted-root/symlink work. `src/tool/external-directory.ts` is **untouched here** — verified identical to `origin/main` on the pushed branch. See the review note below for why the overlapping half of the stale branch this was recovered from was discarded rather than merged.
