### PR TITLE
fix(retry): retry streamed server errors

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -134,7 +134,7 @@ export type ParsedStreamError =
   | {
       type: "api_error"
       message: string
-      isRetryable: false
+      isRetryable: boolean
       responseBody: string
     }
 
@@ -171,6 +171,13 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
         type: "api_error",
         message: typeof body?.error?.message === "string" ? body?.error?.message : "Invalid prompt.",
         isRetryable: false,
+        responseBody,
+      }
+    case "server_error":
+      return {
+        type: "api_error",
+        message: typeof body?.error?.message === "string" ? body.error.message : "Server error.",
+        isRetryable: true,
         responseBody,
       }
   }

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -124,6 +124,24 @@ describe("session.retry.delay", () => {
 })
 
 describe("session.retry.retryable", () => {
+  test("retries streamed server_error events", () => {
+    const input = {
+      type: "error",
+      sequence_number: 59,
+      error: {
+        type: "server_error",
+        code: "server_error",
+        message: "An error occurred while processing your request. You can retry your request.",
+        param: null,
+      },
+    }
+    const error = MessageV2.fromError(input, { providerID })
+
+    expect(MessageV2.APIError.isInstance(error)).toBe(true)
+    expect(SessionRetry.retryable(error)).toBe(input.error.message)
+    expect((error as MessageV2.APIError).data.responseBody).toBe(JSON.stringify(input))
+  })
+
   test("maps too_many_requests json messages", () => {
     const error = wrap(JSON.stringify({ type: "error", error: { type: "too_many_requests" } }))
     expect(SessionRetry.retryable(error)).toBe("Too Many Requests")


### PR DESCRIPTION
### Issue for this PR

Closes #1970

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI Responses API `server_error` events arrive inside the stream without an HTTP status. They previously fell through `parseStreamError()` as unknown errors, so `SessionRetry` could not classify them and the turn stopped.

This change recognizes the explicit `server_error` code as retryable while preserving the upstream message and response body. It reuses the existing visible retry/backoff policy and does not change system prompts, retry timing, or handling for unknown stream errors.

A regression test covers the event from #1970 end to end through `MessageV2.fromError()` and `SessionRetry.retryable()`.

### How did you verify your code works?

- `bun test test/provider/error.test.ts test/session/retry.test.ts` from `packages/opencode` — 60 passed, 0 failed
- `bun typecheck` from `packages/opencode` — passed
- Repository pre-push typecheck — 12 packages passed

A reviewer can confirm the fix by passing the event shape from #1970 to `MessageV2.fromError()` and checking that it produces a retryable `MessageV2.APIError` with the original message and serialized body.

### Screenshots / recordings

Not applicable; this is a non-UI error-handling change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
