### PR TITLE
fix(provider): retry internal request timeouts

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -94,23 +94,138 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
     },
   })
 
-  return new Response(body, {
+  return wrapResponse(res, body)
+}
+
+function wrapResponse(res: Response, body: ReadableStream<Uint8Array>) {
+  const wrapped = new Response(body, {
     headers: new Headers(res.headers),
     status: res.status,
     statusText: res.statusText,
   })
+  Object.defineProperties(wrapped, {
+    redirected: { get: () => res.redirected },
+    type: { get: () => res.type },
+    url: { get: () => res.url },
+  })
+  return wrapped
 }
 
-function timeoutController(ms: number) {
+function timeoutController(ms: number, message = `Response header timed out after ${ms}ms`) {
   const ctl = new AbortController()
-  const id = setTimeout(
-    () => ctl.abort(Object.assign(new Error(`Response header timed out after ${ms}ms`), { code: "ETIMEDOUT" })),
-    ms,
-  )
+  const id = setTimeout(() => ctl.abort(Object.assign(new Error(message), { code: "ETIMEDOUT" })), ms)
   return {
     signal: ctl.signal,
     clear: () => clearTimeout(id),
   }
+}
+
+type AbortSource = "request" | "timeout"
+
+export function trackAbortSource(requestSignal: AbortSignal | null | undefined, timeoutSignals: AbortSignal[]) {
+  const signals = [requestSignal, ...timeoutSignals].filter((signal) => signal !== null && signal !== undefined)
+  let source: AbortSource | undefined = requestSignal?.aborted
+    ? "request"
+    : timeoutSignals.some((signal) => signal.aborted)
+      ? "timeout"
+      : undefined
+  let winner = requestSignal?.aborted ? requestSignal : timeoutSignals.find((signal) => signal.aborted)
+  const listeners = signals.map((signal, index) => {
+    const listener = () => {
+      if (source) return
+      source = index === 0 && requestSignal ? "request" : "timeout"
+      winner = signal
+    }
+    signal.addEventListener("abort", listener, { once: true })
+    if (signal.aborted) listener()
+    return { signal, listener }
+  })
+  return {
+    signal: signals.length === 0 ? undefined : signals.length === 1 ? signals[0] : AbortSignal.any(signals),
+    source: () => source,
+    winner: () => winner,
+    dispose: () => listeners.forEach((item) => item.signal.removeEventListener("abort", item.listener)),
+  }
+}
+
+export function normalizeTimeoutError(error: unknown, source: AbortSource | undefined, signal?: AbortSignal) {
+  if (source !== "timeout") return error
+  const reason = signal?.reason
+  return Object.assign(new Error(reason instanceof Error ? reason.message : "Request timed out"), {
+    code: "ETIMEDOUT",
+    cause: error,
+  })
+}
+
+export function requestSignal(input: RequestInfo | URL, init?: RequestInit) {
+  return init?.signal ?? (input instanceof Request ? input.signal : undefined)
+}
+
+export function wrapRequestTimeout(
+  res: Response,
+  requestSignal: AbortSignal | null | undefined,
+  timeoutSignal: AbortSignal,
+  clear: () => void,
+) {
+  const tracked = trackAbortSource(requestSignal, [timeoutSignal])
+  let finalized = false
+  const finalize = () => {
+    if (finalized) return
+    finalized = true
+    clear()
+    tracked.dispose()
+  }
+  if (!res.body) {
+    finalize()
+    return res
+  }
+
+  const reader = res.body.getReader()
+  return wrapResponse(
+    res,
+    new ReadableStream<Uint8Array>({
+      async pull(ctrl) {
+        const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
+          const onAbort = () => {
+            const error = normalizeTimeoutError(
+              tracked.signal?.reason ?? new DOMException("The operation was aborted", "AbortError"),
+              tracked.source(),
+              tracked.winner(),
+            )
+            cleanup()
+            void reader.cancel(error).catch(() => {})
+            reject(error)
+          }
+          const cleanup = () => tracked.signal?.removeEventListener("abort", onAbort)
+          if (tracked.signal?.aborted) return onAbort()
+          tracked.signal?.addEventListener("abort", onAbort, { once: true })
+          reader.read().then(
+            (part) => {
+              cleanup()
+              resolve(part)
+            },
+            (error) => {
+              cleanup()
+              reject(normalizeTimeoutError(error, tracked.source(), tracked.winner()))
+            },
+          )
+        }).catch((error) => {
+          finalize()
+          throw error
+        })
+        if (part.done) {
+          finalize()
+          ctrl.close()
+          return
+        }
+        ctrl.enqueue(part.value)
+      },
+      async cancel(reason) {
+        finalize()
+        await reader.cancel(reason)
+      },
+    }),
+  )
 }
 
 type BundledSDK = {
@@ -1532,28 +1647,44 @@ const layer: Layer.Layer<
         options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
           const fetchFn = customFetch ?? fetch
           const opts = init ?? {}
+          const callerSignal = requestSignal(input, opts)
           const chunkAbortCtl = typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
           const headerTimeoutMs = headerTimeout === false ? undefined : headerTimeout
           const headerTimeoutCtl = typeof headerTimeoutMs === "number" ? timeoutController(headerTimeoutMs) : undefined
-          const signals: AbortSignal[] = []
+          const requestTimeoutCtl =
+            typeof options["timeout"] === "number" && options["timeout"] > 0
+              ? timeoutController(options["timeout"], `Request timed out after ${options["timeout"]}ms`)
+              : undefined
+          const tracked = trackAbortSource(
+            callerSignal,
+            [headerTimeoutCtl?.signal, requestTimeoutCtl?.signal].filter((signal) => signal !== undefined),
+          )
+          const signals = [tracked.signal, chunkAbortCtl?.signal].filter((signal) => signal !== undefined)
+          if (signals.length > 0) opts.signal = signals.length === 1 ? signals[0] : AbortSignal.any(signals)
 
-          if (opts.signal) signals.push(opts.signal)
-          if (chunkAbortCtl) signals.push(chunkAbortCtl.signal)
-          if (headerTimeoutCtl) signals.push(headerTimeoutCtl.signal)
-          if (options["timeout"] !== undefined && options["timeout"] !== null && options["timeout"] !== false)
-            signals.push(AbortSignal.timeout(options["timeout"]))
+          const res = await Promise.resolve()
+            .then(() =>
+              fetchFn(input, {
+                ...opts,
+                // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
+                timeout: false,
+              }),
+            )
+            .catch((error: unknown) => {
+              requestTimeoutCtl?.clear()
+              tracked.dispose()
+              throw normalizeTimeoutError(error, tracked.source(), tracked.winner())
+            })
+            .finally(() => {
+              headerTimeoutCtl?.clear()
+            })
 
-          const combined = signals.length === 0 ? null : signals.length === 1 ? signals[0] : AbortSignal.any(signals)
-          if (combined) opts.signal = combined
-
-          const res = await fetchFn(input, {
-            ...opts,
-            // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
-            timeout: false,
-          }).finally(() => headerTimeoutCtl?.clear())
-
-          if (!chunkAbortCtl) return res
-          return wrapSSE(res, chunkTimeout, chunkAbortCtl)
+          tracked.dispose()
+          const bounded = requestTimeoutCtl
+            ? wrapRequestTimeout(res, callerSignal, requestTimeoutCtl.signal, requestTimeoutCtl.clear)
+            : res
+          if (!chunkAbortCtl) return bounded
+          return wrapSSE(bounded, chunkTimeout, chunkAbortCtl)
         }
 
         const bundledLoader = BUNDLED_PROVIDERS[model.api.npm]

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1095,12 +1095,7 @@ export function fromError(
 ): NonNullable<Assistant["error"]> {
   switch (true) {
     case e instanceof DOMException && e.name === "AbortError":
-      return new AbortedError(
-        { message: e.message },
-        {
-          cause: e,
-        },
-      ).toObject()
+      return new AbortedError({ message: e.message }, { cause: e }).toObject()
     // The AI SDK wraps the real failure in AI_RetryError after exhausting its
     // own maxRetries. Unwrap to the underlying error (.lastError) so the
     // APICallError branch below can extract statusCode/isRetryable/responseBody.
@@ -1134,6 +1129,18 @@ export function fromError(
           metadata: {
             code: (e as SystemError).code ?? "",
             syscall: (e as SystemError).syscall ?? "",
+            message: (e as SystemError).message ?? "",
+          },
+        },
+        { cause: e },
+      ).toObject()
+    case (e as SystemError)?.code === "ETIMEDOUT":
+      return new APIError(
+        {
+          message: (e as SystemError).message || "Request timed out",
+          isRetryable: true,
+          metadata: {
+            code: "ETIMEDOUT",
             message: (e as SystemError).message ?? "",
           },
         },

--- a/packages/opencode/test/provider/provider-timeout.test.ts
+++ b/packages/opencode/test/provider/provider-timeout.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeTimeoutError, requestSignal, trackAbortSource, wrapRequestTimeout } from "../../src/provider/provider"
+
+describe("provider timeout errors", () => {
+  test("turns an internal timeout abort into a retryable connection error", () => {
+    const request = new AbortController()
+    const timeout = new AbortController()
+    timeout.abort(new DOMException("The operation timed out", "TimeoutError"))
+
+    const result = normalizeTimeoutError(
+      new DOMException("The operation was aborted", "AbortError"),
+      "timeout",
+      timeout.signal,
+    )
+
+    expect(result).toBeInstanceOf(Error)
+    expect((result as Error & { code?: string }).code).toBe("ETIMEDOUT")
+  })
+
+  test("preserves an abort when the caller cancelled the request", () => {
+    const request = new AbortController()
+    const timeout = new AbortController()
+    const error = new DOMException("The user aborted the request", "AbortError")
+    request.abort(error)
+    timeout.abort(new DOMException("The operation timed out", "TimeoutError"))
+
+    expect(normalizeTimeoutError(error, "request", timeout.signal)).toBe(error)
+  })
+
+  test("records the first abort source instead of inspecting final signal state", () => {
+    const request = new AbortController()
+    const timeout = new AbortController()
+    const timeoutFirst = trackAbortSource(request.signal, [timeout.signal])
+    timeout.abort()
+    request.abort()
+    expect(timeoutFirst.source()).toBe("timeout")
+    expect(timeoutFirst.winner()).toBe(timeout.signal)
+    timeoutFirst.dispose()
+
+    const request2 = new AbortController()
+    const timeout2 = new AbortController()
+    const requestFirst = trackAbortSource(request2.signal, [timeout2.signal])
+    request2.abort()
+    timeout2.abort()
+    expect(requestFirst.source()).toBe("request")
+    expect(requestFirst.winner()).toBe(request2.signal)
+    requestFirst.dispose()
+  })
+
+  test("inherits Request.signal unless init supplies one", () => {
+    const request = new AbortController()
+    const override = new AbortController()
+    const input = new Request("https://example.com", { signal: request.signal })
+
+    expect(requestSignal(input)).toBe(request.signal)
+    expect(requestSignal(input, { signal: override.signal })).toBe(override.signal)
+  })
+
+  test("keeps the request timeout active while the response body is streaming", async () => {
+    const timeout = new AbortController()
+    let clearCount = 0
+    let cancelled = false
+    const response = wrapRequestTimeout(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("first"))
+          },
+          cancel() {
+            cancelled = true
+          },
+        }),
+      ),
+      undefined,
+      timeout.signal,
+      () => clearCount++,
+    )
+    const reader = response.body?.getReader()
+    if (!reader) throw new Error("expected response body")
+
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe("first")
+    expect(clearCount).toBe(0)
+    timeout.abort(new DOMException("The operation timed out", "TimeoutError"))
+
+    const error = await reader.read().catch((error) => error)
+    expect((error as Error & { code?: string }).code).toBe("ETIMEDOUT")
+    expect(clearCount).toBe(1)
+    await Bun.sleep(0)
+    expect(cancelled).toBe(true)
+  })
+
+  test("keeps caller cancellation terminal while the response body is streaming", async () => {
+    const request = new AbortController()
+    const timeout = new AbortController()
+    let cancelled = false
+    const response = wrapRequestTimeout(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          cancel() {
+            cancelled = true
+          },
+        }),
+      ),
+      request.signal,
+      timeout.signal,
+      () => {},
+    )
+    const reader = response.body?.getReader()
+    if (!reader) throw new Error("expected response body")
+    const pending = reader.read().catch((error) => error)
+
+    request.abort(new DOMException("The user aborted the request", "AbortError"))
+
+    const error = await pending
+    expect(error).toBeInstanceOf(DOMException)
+    expect((error as DOMException).name).toBe("AbortError")
+    expect((error as Error & { code?: string | number }).code).not.toBe("ETIMEDOUT")
+    await Bun.sleep(0)
+    expect(cancelled).toBe(true)
+  })
+})

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -785,19 +785,25 @@ describe("session.llm.stream", () => {
     })
   })
 
-  test("aborts an OpenAI request that stalls before response headers", async () => {
+  test("retries an OpenAI request that times out before response headers", async () => {
     const server = state.server
     if (!server) throw new Error("Server not initialized")
 
     const source = await loadFixture("openai", "gpt-5.2")
-    const request = deferred<Capture>()
+    const first = deferred<Capture>()
+    const second = deferred<Capture>()
     state.queue.push({
       path: "/responses",
-      resolve: request.resolve,
+      resolve: first.resolve,
       response: async () => {
         await Bun.sleep(500)
         return createEventResponse([], true)
       },
+    })
+    state.queue.push({
+      path: "/responses",
+      resolve: second.resolve,
+      response: createEventResponse([], true),
     })
 
     await using tmp = await tmpdir({
@@ -854,17 +860,18 @@ describe("session.llm.stream", () => {
               system: ["You are a helpful assistant."],
               messages: [{ role: "user", content: "Hello" }],
               tools: {},
-              retries: 0,
+              retries: 1,
             })
             .pipe(Stream.runCollect),
         )
 
-        expect(Date.now() - started).toBeLessThan(400)
-        expect(Array.from(events).some((event) => event.type === "error")).toBe(true)
-        expect((await request.promise).url.pathname.endsWith("/responses")).toBe(true)
+        expect(Date.now() - started).toBeLessThan(3_000)
+        expect(Array.from(events).some((event) => event.type === "error")).toBe(false)
+        expect((await first.promise).url.pathname.endsWith("/responses")).toBe(true)
+        expect((await second.promise).url.pathname.endsWith("/responses")).toBe(true)
       },
     })
-  })
+  }, 15_000)
 
   test("accepts user image attachments as data URLs for OpenAI models", async () => {
     const server = state.server

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -309,6 +309,26 @@ describe("session.retry.retryable", () => {
 })
 
 describe("session.message-v2.fromError", () => {
+  test("treats a normalized provider timeout as retryable", () => {
+    const result = MessageV2.fromError(Object.assign(new Error("Request timed out"), { code: "ETIMEDOUT" }), {
+      providerID,
+    })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+    expect((result as MessageV2.APIError).data.metadata?.code).toBe("ETIMEDOUT")
+    expect(SessionRetry.retryable(result as ReturnType<NamedError["toObject"]>)).toBeTruthy()
+  })
+
+  test("keeps AbortError terminal", () => {
+    const result = MessageV2.fromError(new DOMException("The user aborted the request", "AbortError"), {
+      providerID,
+    })
+
+    expect(MessageV2.AbortedError.isInstance(result)).toBe(true)
+    expect(SessionRetry.retryable(result as ReturnType<NamedError["toObject"]>)).toBeUndefined()
+  })
+
   test.concurrent(
     "converts ECONNRESET socket errors to retryable APIError",
     async () => {


### PR DESCRIPTION
## Summary

- distinguish provider-owned request/header timeouts from caller-initiated aborts
- normalize internal timeout aborts to retryable `ETIMEDOUT` errors while keeping user cancellation terminal
- preserve `Request.signal`, response metadata, and whole-response streaming deadlines
- actively cancel stalled response readers even when a custom fetch implementation ignores abort signals

## Why

Provider timeout signals were combined with the caller signal, so the AI SDK only observed a generic `AbortError`. It treats aborts as user cancellation and bypasses its retry loop; the session layer then classified the same error as terminal. Tracking the first abort source keeps genuine cancellation non-retryable while allowing internal deadlines to use the existing SDK and session retry layers.

## Verification

- `bun test test/provider/provider-timeout.test.ts test/session/retry.test.ts test/session/llm-retry.test.ts test/session/llm.test.ts` (82 pass)
- `bun typecheck`
- `git diff --check origin/main...HEAD`