### PR TITLE
fix(tui): keep agent on declined plan entry

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -100,6 +100,7 @@ import { DialogTokenPlan } from "../../component/dialog-token-plan"
 import { SessionRetry } from "@/session/retry"
 import { getRevertDiffFiles } from "../../util/revert-diff"
 import * as Collapse from "../../util/collapse"
+import { planSwitchTarget } from "./plan-switch"
 import {
   createFreeApiSunsetSignal,
   freeApiModelNameKey,
@@ -280,16 +281,12 @@ export function Session() {
     const part = evt.properties.part
     if (part.type !== "tool") return
     if (part.sessionID !== route.sessionID) return
-    if (part.state.status !== "completed") return
     if (part.id === lastSwitch) return
 
-    if (part.tool === "plan_exit" && part.state.metadata?.switched) {
-      local.agent.set("build")
-      lastSwitch = part.id
-    } else if (part.tool === "plan_enter") {
-      local.agent.set("plan")
-      lastSwitch = part.id
-    }
+    const agent = planSwitchTarget(part)
+    if (!agent) return
+    local.agent.set(agent)
+    lastSwitch = part.id
   })
 
   let seeded = false

--- a/packages/opencode/src/cli/cmd/tui/routes/session/plan-switch.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/plan-switch.ts
@@ -1,0 +1,9 @@
+import type { ToolPart } from "@mimo-ai/sdk/v2"
+
+export function planSwitchTarget(part: Pick<ToolPart, "tool" | "state">): "build" | "plan" | undefined {
+  if (part.state.status !== "completed") return undefined
+  if (part.state.metadata.switched !== true) return undefined
+  if (part.tool === "plan_exit") return "build"
+  if (part.tool === "plan_enter") return "plan"
+  return undefined
+}

--- a/packages/opencode/test/cli/tui/plan-switch.test.ts
+++ b/packages/opencode/test/cli/tui/plan-switch.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import type { ToolPart } from "../../../src/session/message-v2"
+import { planSwitchTarget } from "../../../src/cli/cmd/tui/routes/session/plan-switch"
+
+function completed(tool: string, switched?: boolean) {
+  return {
+    tool,
+    state: {
+      status: "completed",
+      input: {},
+      output: "",
+      title: "",
+      metadata: switched === undefined ? {} : { switched },
+      time: { start: 0, end: 1 },
+    },
+  } satisfies Pick<ToolPart, "tool" | "state">
+}
+
+describe("planSwitchTarget", () => {
+  test("switches only when a plan tool reports success", () => {
+    expect(planSwitchTarget(completed("plan_enter", true))).toBe("plan")
+    expect(planSwitchTarget(completed("plan_exit", true))).toBe("build")
+  })
+
+  test("does not switch when plan enter or exit is declined", () => {
+    expect(planSwitchTarget(completed("plan_enter", false))).toBeUndefined()
+    expect(planSwitchTarget(completed("plan_exit", false))).toBeUndefined()
+  })
+
+  test("does not switch without explicit switched metadata", () => {
+    expect(planSwitchTarget(completed("plan_enter"))).toBeUndefined()
+    expect(planSwitchTarget(completed("plan_exit"))).toBeUndefined()
+  })
+
+  test("ignores unfinished and unrelated tools", () => {
+    expect(
+      planSwitchTarget({
+        tool: "plan_enter",
+        state: { status: "running", input: {}, metadata: { switched: true }, time: { start: 0 } },
+      }),
+    ).toBeUndefined()
+    expect(planSwitchTarget(completed("question", true))).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- gate TUI plan agent changes on explicit `metadata.switched === true`
- keep the Input agent unchanged when `plan_enter` or `plan_exit` is declined
- add client-side regression coverage for accepted, declined, unfinished, and unrelated tool events

## Test plan

- `bun test test/cli/tui/plan-switch.test.ts`
- `bun test test/tool/plan.test.ts`
- `bun typecheck`
- targeted oxlint and Prettier checks
- `git diff --check`