### PR TITLE
fix(session): honor the configured context limit

### DIFF
--- a/docs/compose/spec/context-budget-control.md
+++ b/docs/compose/spec/context-budget-control.md
@@ -1,8 +1,8 @@
 ---
 feature: context-budget-control
 status: delivered
-updated: 2026-07-27
-branch: feat/context-budget-control
+updated: 2026-07-31
+branch: fix/context-limit-threshold-rebuild
 commits: 028f3178..3b15062d
 ---
 
@@ -12,18 +12,22 @@ commits: 028f3178..3b15062d
 
 **What was built** — `compaction.max_context` lets a user compact earlier than the model's own window, expressed as a token count, a `"300K"` / `"1M"` / `"50%"` shorthand, or a map keyed by `"<providerID>/<modelID>"` with wildcards. `Overflow.contextWindow()` is the single place that resolves the provider cap (`limit.input || limit.context`), applies the budget as a clamp, and subtracts the reserves; `usable()` is now a thin wrapper over it, so the compaction trigger, checkpoint thresholds, and pruning all follow the budget without further plumbing. With no budget configured the arithmetic reduces to the previous expression for both model shapes.
 
-The three TUI surfaces that previously divided by the raw `limit.context` (prompt footer, subagent footer, sidebar) now divide by the trigger and mark a configured budget with `↓`, `/status` gained a Context block (window, budget + source, reserved, compact-at, used), and `mimocode models <provider>` prints the same numbers without `--verbose`. `/context-limit` opens a preset picker (Model default / 200K / 300K / 500K / 1M / Custom…) that writes only the current model's key into the global config, refusing while a session is busy because a config write disposes the instance and cancels in-flight runners.
+The prompt and subagent footers divide usage by the internal trigger and mark a configured budget with `↓`; the sidebar instead shows usage against the user-controlled active limit and compares that setting with the provider cap. `/status` gained a diagnostic Context block (window, budget + source, reserved, compact-at, used), and `mimocode models <provider>` prints the same underlying values without `--verbose`. `/context-limit` opens a preset picker (Model default / 200K / 300K / 500K / 1M / Custom…) that writes only the current model's key into the global config, refusing while a session is busy because a config write disposes the instance and cancels in-flight runners.
+
+The 2026-07-31 follow-up makes `usable()` the only automatic context-switch boundary. Checkpoint thresholds continue to keep the checkpoint fresh, but their final 80%/90% rung no longer triggers an early rebuild. The sidebar presents the user-controlled limit relative to the provider cap, so a 300K budget on a 922K model renders `limit 300K of 922K`; the reserve-adjusted trigger remains an internal detail available in `/status`.
 
 Separately, the merged PR #1926 was corrected: it assigned `limit.context = 300_000` for every `gpt-*` model under Codex OAuth, which *raised* the window for gpt-4o (128K) and gpt-3.5-turbo (16K), broke the `limit.context === 0` sentinel for image models, and never moved the compaction trigger for the 1M-class models it targeted because `usable()` reads `limit.input` when the catalog publishes one. It is now a clamp on both fields at **372,000** — the capacity OpenAI's Codex registry declares and that a 350,317-token request demonstrably reaches — applied only when a window exists and only when `limit.input` already exists. The 272K figure circulating for Codex is the 2x-input billing boundary, not capacity, so it ships as a documented `compaction.max_context` recipe (see S2.5).
 
 **Verification**
 
 - `bun typecheck` (packages/opencode) — PASS, post-rebase.
+- `bun typecheck` (packages/opencode) — PASS for the 2026-07-31 follow-up.
+- `bun test test/session/auto-overflow-writer-first.test.ts test/session/prune.test.ts test/session/prompt-rebuild-reset.test.ts test/session/overflow.test.ts test/session/checkpoint-thresholds.test.ts test/cli/tui/sidebar-context.test.tsx` — 94 pass / 0 fail for the 2026-07-31 follow-up.
 - `bun test test/session/overflow.test.ts test/plugin/codex.test.ts test/session/checkpoint-thresholds.test.ts test/session/prune.test.ts` — 96 pass / 0 fail.
 - `bun test test/config test/session/checkpoint-thresholds.test.ts` — 188 pass / 4 skip / 0 fail.
 - Full `bun test` before the review fixes — 4359 pass / 4 fail; every failure reproduced at base or passed in isolation (`test/util/ssrf.test.ts` DNS fail-closed fails at base; `test/workflow/runtime.test.ts` has 2 fails at base vs 1 here; `test/session/checkpoint-rebuild-unify.test.ts` passes in isolation in both trees). CI runs the full suite.
 - CLI: `MIMOCODE_CONFIG_CONTENT='{"compaction":{"max_context":{"openai/gpt-5*":"300K","openai/gpt-5.6":200000}}}' bun run src/index.ts models openai` → `gpt-5.6` window 922K / budget 200K / compacts at 180K; `gpt-5.6-sol` budget 300K / 280K; `gpt-5.3-codex` (272K cap) shows no budget because 300K clamps away; `gpt-4o` and `o3` unchanged.
-- Live TUI (tmux, isolated `MIMOCODE_HOME`, `xiaomi/mimo-v2.5`): picking 300K wrote `"xiaomi/mimo-v2.5": 300000` to the global `mimocode.jsonc`, footer became `33.0K/260K↓ (13%)`, sidebar `compact at 260K of 1.05M`, `/status` `window 1.05M · budget 300K · compacts at 260K`. Custom `"50%"` wrote 524288 (`compacts at 484K`). "Model default" wrote `0` and restored `compacts at 1.01M`. Selecting a tier mid-stream left the config untouched and kept the dialog open; the same action once idle wrote 200000.
+- Live TUI (tmux, isolated `MIMOCODE_HOME`, `xiaomi/mimo-v2.5`): picking 300K wrote `"xiaomi/mimo-v2.5": 300000` to the global `mimocode.jsonc`, footer became `33.0K/260K↓ (13%)`, and `/status` showed `window 1.05M · budget 300K · compacts at 260K`. The sidebar follow-up renders the user setting against the model limit (`limit 300K of 1.05M`) and covers it with a TUI render test. Custom `"50%"` wrote 524288 (`compacts at 484K`). "Model default" wrote `0` and restored `compacts at 1.01M`. Selecting a tier mid-stream left the config untouched and kept the dialog open; the same action once idle wrote 200000.
 
 **Journey log**
 
@@ -84,13 +88,17 @@ Defect 3 — **not overridable and not per-plan.** The plugin auth loader runs a
 
 Defect 4 — **wrong layer for the general need.** Even a correct provider-layer clamp only serves "the provider lies about its window". It does not serve "I want to compact at 200K on a 1M model" for cost, latency, cache-churn or answer-quality reasons — a request already filed as issue #1837 ("Context occupancy meter (% + tokens) and adjustable auto-compact threshold"), and adjacent to #1840 (switching to a smaller-window model mid-session).
 
-### S1.3 Existing knobs and why they are insufficient
+### S1.3 Checkpoint thresholds apply a second context-limit discount
+
+Checkpoint percentages use `usable()` as their denominator, and the final 80%/90% threshold also signals the prompt loop to rebuild. A configured 300K active limit therefore reports a 280K trigger but rebuilds at 252K, while a configured `"90%"` budget rebuilds at roughly `90% × 90%` of the provider cap. Checkpoint thresholds are snapshot scheduling policy, not a second context limit, so they must not trigger an active-context rebuild.
+
+### S1.4 Existing knobs and why they are insufficient
 
 - `compaction.reserved` (`config.ts:254`) can be abused as an early-compact dial (`reserved = context - target`), but it is global across all models, is also consumed by `compaction.ts:49-54` and `prune.ts:274-292` as a *safety* buffer, and produces a nonsensical number for anyone reading the config.
 - `provider.<id>.models.<id>.limit.input` (`config/provider.ts:40-46`) *does* already move the trigger, but it is per-model JSON archaeology, it lies about the provider's real cap, and for the Codex case it is overwritten by the plugin (Defect 3).
 - `MIMOCODE_DISABLE_AUTOCOMPACT` is all-or-nothing.
 
-### S1.4 Requirement summary
+### S1.5 Requirement summary
 
 1. A user-settable working budget, distinct from the provider cap, expressible in common tiers (200K / 300K / 500K / 1M) plus "model default" and a custom value.
 2. Never exceeds the provider's effective cap — the setting clamps, it never raises.
@@ -105,6 +113,7 @@ Defect 4 — **wrong layer for the general need.** Even a correct provider-layer
 - `budget(cfg, model, …)` = user-requested working budget, or `undefined`.
 - `effectiveCap` = `hardCap === 0 ? 0 : min(hardCap, budget ?? hardCap)`.
 - `usable()` keeps its current meaning: `effectiveCap` minus reserves. It stays the single source of truth for "when do we compact".
+- Checkpoint thresholds only schedule checkpoint writers. Crossing the final threshold does not rebuild or compact; `usable()` remains the only automatic context-switch boundary.
 
 ### S2.2 `Overflow.usable()` becomes budget-aware
 
@@ -197,8 +206,8 @@ Three surfaces compute `%` independently against raw `limit.context` today, and 
 | Surface | Today | After |
 | --- | --- | --- |
 | prompt footer `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx:469-486` | `162,000 (15%)` vs raw context | `162.0K/300K (54%)` vs `usable`, with a `↓` marker when a budget is active |
-| sidebar context widget `.../feature-plugins/sidebar/context.tsx:67-95` | `% used` vs raw context | same denominator + `compact at 300K` line |
-| subagent footer `.../routes/session/subagent-footer.tsx:54-63` | raw context | same denominator |
+| sidebar context widget `.../feature-plugins/sidebar/context.tsx:67-95` | `% used` vs raw context | `% used` vs active limit + `limit 300K of 922K` when a 300K budget is active on a 922K model |
+| subagent footer `.../routes/session/subagent-footer.tsx:54-63` | raw context | usage vs internal `usable` trigger, matching the prompt footer |
 | `/status` dialog `.../component/dialog-status.tsx` | no context info at all | new **Context** block: model, provider window, budget + its source, reserved, compact-at, current tokens + `%` |
 | CLI | `mimo models openai --verbose` dumps the whole model JSON | add a `context` column to non-verbose output, or a `--context` flag printing `hard / effective / usable` |
 
@@ -283,6 +292,8 @@ Route B (UI writer):
 
 Display (needed by any route):
 
-- [x] T9: Switch the prompt footer, sidebar context widget, and subagent footer to `Overflow.contextWindow()` and show `used/compact-at (%)` — acceptance: on a model with an active budget all three show the same denominator, and it equals the value at which compaction actually fires (covers: S2.6; depends: T5)
+- [x] T9: Switch the prompt footer, sidebar context widget, and subagent footer to `Overflow.contextWindow()` — acceptance: prompt/subagent usage uses the internal trigger, while sidebar usage uses the active setting and compares it with the provider cap (covers: S2.6; depends: T5)
 - [x] T10: Add a Context block to the `/status` dialog showing provider window, budget + source, reserved, compact-at, current tokens and `%` — acceptance: with and without a configured budget the block renders correct numbers and the correct `source` label (covers: S2.6; depends: T5)
 - [x] T11: Surface the context window in the `models` CLI command without `--verbose` — acceptance: `mimocode models openai` prints each model's provider window and compact-at (covers: S2.6; depends: T5)
+- [x] T12: Decouple the final checkpoint threshold from the prompt-loop rebuild condition — acceptance: crossing the final checkpoint threshold below `usable()` writes a checkpoint but inserts no rebuild or compaction boundary; reaching `usable()` still follows the existing rebuild path (covers: S1.3, S2.1; depends: T5)
+- [x] T13: Show the configured active limit relative to the provider hard cap in the sidebar — acceptance: a 300K budget on a 922K model renders `limit 300K of 922K`, while the reserve-adjusted trigger remains internal and available in `/status` (covers: S2.6; depends: T5)

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -13,7 +13,7 @@ const money = new Intl.NumberFormat("en-US", {
   currency: "USD",
 })
 
-function View(props: { api: TuiPluginApi; session_id: string }) {
+export function ContextSidebar(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const cost = createMemo(() => msg().reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0))
@@ -82,7 +82,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
     const win = Model.contextWindow(props.api.state.config, model)
     return {
       tokens,
-      percent: win ? Math.round((tokens / win.usable) * 100) : null,
+      percent: win ? Math.round((tokens / win.effective) * 100) : null,
       limit: win,
     }
   })
@@ -97,7 +97,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       <Show when={state().limit}>
         {(win) => (
           <text fg={theme().textMuted}>
-            compact at {Token.format(win().usable)}
+            limit {Token.format(win().effective)}
             {win().source === "config" ? ` of ${Token.format(win().hard)}` : ""}
           </text>
         )}
@@ -113,7 +113,7 @@ const tui: TuiPlugin = async (api) => {
     order: 100,
     slots: {
       sidebar_content(_ctx, props) {
-        return <View api={api} session_id={props.session_id} />
+        return <ContextSidebar api={api} session_id={props.session_id} />
       },
     },
   })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3467,9 +3467,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             agent?.native === true && agent?.hidden === true
 
           // Fire background checkpoint writers for any newly-crossed thresholds
-          // based on the latest completed assistant message's tokens. Must run
-          // BEFORE the overflow/maxThreshold check below so maxCrossed flag is
-          // set in time to trigger rebuild on this same iteration.
+          // based on the latest completed assistant message's tokens. These
+          // thresholds only keep the checkpoint fresh; `overflowCheck` below is
+          // the single trigger for rebuilding the active context.
           if (!skipOverflowCheck && !isBoundedComputation && lastFinished && lastFinished.tokens) {
             const fireOps = yield* ops()
             yield* prune
@@ -3488,8 +3488,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             !isBoundedComputation &&
             lastFinished &&
             lastFinished.summary !== true &&
-            (overflowCheck({ cfg: yield* config.get(), tokens: lastFinished.tokens, model }) ||
-              (yield* prune.maxThresholdCrossed(sessionID)))
+            overflowCheck({ cfg: yield* config.get(), tokens: lastFinished.tokens, model })
           ) {
             // Subagent overflow → per-actor compaction (lossy LLM summarization
             // scoped to the actor's (sessionID, agent_id) slice). Subagents

--- a/packages/opencode/src/session/prune.ts
+++ b/packages/opencode/src/session/prune.ts
@@ -152,8 +152,6 @@ export interface Interface {
     promptOps: ActorPromptOps
     agentID?: string
   }) => Effect.Effect<void>
-  /** True when the current tokens have just crossed the max checkpoint threshold. */
-  readonly maxThresholdCrossed: (sessionID: SessionID) => Effect.Effect<boolean>
   /** Clear the crossed-threshold state for a session (e.g. after discard+rebuild). */
   readonly resetThresholds: (sessionID: SessionID) => Effect.Effect<void>
 }
@@ -176,9 +174,6 @@ export const layer: Layer.Layer<
     // (and had a checkpoint writer enqueued). Prevents re-firing on the same
     // threshold every turn.
     const crossed = new Map<SessionID, Set<number>>()
-    // Per-session signal: the max threshold was just crossed; prompt.ts should
-    // trigger discard+rebuild on the next loop iteration.
-    const maxCrossed = new Set<SessionID>()
     // Per-session RECOVERY GATE: the token count at or above which the FINAL
     // threshold is allowed to fire a second time, armed only when that
     // threshold's writer settled with a TRANSIENT failure.
@@ -348,14 +343,9 @@ export const layer: Layer.Layer<
           //
           // WHAT THAT ARGUMENT DOES NOT COVER — the FINAL threshold. "The next
           // threshold is the retry" presumes a next threshold; the last one has
-          // none. Its only would-be successor is the discard+rebuild that
-          // maxThresholdCrossed triggers, because a successful rebuild calls
-          // resetThresholds (prompt.ts:428) and re-arms the whole ladder. But
-          // rebuildFromCheckpoint returns false when lastBoundary is unset
-          // (prompt.ts:413), and the watermark is unset precisely when no
-          // writer has EVER succeeded — so in the one case that needs recovery
-          // most, there is no reset, no further crossing, and the session never
-          // checkpoints again until overflow.
+          // none. Without a recovery gate, a transient failure there would
+          // leave the checkpoint stale until the actual context trigger causes
+          // a rebuild and re-arms the ladder.
           //
           // So the final threshold gets a gate, on two conditions that between
           // them replace the deleted counter:
@@ -421,8 +411,6 @@ export const layer: Layer.Layer<
 
         already.add(t)
         log.info("checkpoint triggered", { threshold: t, currentTokens })
-
-        if (t === maxThreshold) maxCrossed.add(input.sessionID)
       }
 
       crossed.set(input.sessionID, already)
@@ -520,22 +508,15 @@ export const layer: Layer.Layer<
       }
     })
 
-    const maxThresholdCrossed = Effect.fn("SessionPrune.maxThresholdCrossed")(function* (
-      sessionID: SessionID,
-    ) {
-      return maxCrossed.has(sessionID)
-    })
-
     const resetThresholds = Effect.fn("SessionPrune.resetThresholds")(function* (sessionID: SessionID) {
       crossed.delete(sessionID)
-      maxCrossed.delete(sessionID)
       // A rebuild re-arms the whole ladder, which supersedes any pending
       // recovery gate — leaving it set would let the (now re-armable) final
       // threshold fire out of order.
       finalRetryAt.delete(sessionID)
     })
 
-    return Service.of({ prune, fireCheckpoints, maxThresholdCrossed, resetThresholds })
+    return Service.of({ prune, fireCheckpoints, resetThresholds })
   }),
 )
 

--- a/packages/opencode/test/cli/tui/sidebar-context.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-context.test.tsx
@@ -1,0 +1,45 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { ContextSidebar } from "../../../src/cli/cmd/tui/feature-plugins/sidebar/context"
+import { createTuiPluginApi } from "../../fixture/tui-plugin"
+
+test("sidebar compares the configured context limit with the model limit", async () => {
+  const api = createTuiPluginApi({
+    state: {
+      config: { compaction: { max_context: { "test/gpt": 300_000 } } } as never,
+      provider: [
+        {
+          id: "test",
+          models: {
+            gpt: {
+              id: "gpt",
+              providerID: "test",
+              limit: { context: 922_000, input: 922_000, output: 128_000 },
+            },
+          },
+        },
+      ] as never,
+      session: {
+        messages: () =>
+          [
+            {
+              id: "msg",
+              role: "assistant",
+              providerID: "test",
+              modelID: "gpt",
+              cost: 0,
+              tokens: { input: 100_000, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+              time: { created: 1, completed: 2 },
+            },
+          ] as never,
+      },
+    },
+  })
+
+  const app = await testRender(() => <ContextSidebar api={api} session_id="ses" />)
+  await app.renderOnce()
+
+  expect(app.captureCharFrame()).toContain("33% used")
+  expect(app.captureCharFrame()).toContain("limit 300K of 922K")
+})

--- a/packages/opencode/test/session/auto-overflow-writer-first.test.ts
+++ b/packages/opencode/test/session/auto-overflow-writer-first.test.ts
@@ -106,12 +106,13 @@ function withSpawnRef<T>(impl: SpawnImpl | undefined, body: () => Promise<T>): P
  * instant-success stub would have already advanced the watermark by then, so the
  * old code would have rebuilt too and the test would prove nothing.
  */
-function writerThatWritesCheckpointAfter(marker: string, delayMs: number): SpawnImpl {
+function writerThatWritesCheckpointAfter(marker: string, delayMs: number, onSpawn?: () => void): SpawnImpl {
   let counter = 0
   return {
     spawn: (input) =>
       Effect.gen(function* () {
         counter += 1
+        onSpawn?.()
         const parent = (input.parentSessionID ?? input.sessionID) as SessionID
         const outcome = yield* Deferred.make<AgentOutcome>()
         yield* Effect.forkDetach(
@@ -176,13 +177,14 @@ function writerThatFails(): SpawnImpl {
 // usable > 13_000, or SessionPrune.resolveThresholds refuses the window
 // ("too small for checkpoints"). 40_000 satisfies both: usable = 40_000 -
 // 20_100 = 19_900, against the seeded 50_000 tokens.
-function mimocodeConfig(baseURL: string) {
+function mimocodeConfig(baseURL: string, maxContext = 40_000, checkpoint?: { thresholds: string[]; reserved: number }) {
   return JSON.stringify({
     $schema: "https://opencode.ai/config.json",
     enabled_providers: ["alibaba"],
     provider: { alibaba: { options: { apiKey: "test-key", baseURL: `${baseURL}/v1` } } },
     agent: { build: { model: "alibaba/qwen-plus" } },
-    compaction: { reserved: 100, max_context: 40000 },
+    compaction: { reserved: 100, max_context: maxContext },
+    checkpoint,
   })
 }
 
@@ -252,8 +254,8 @@ async function seedFinishedAssistant(sessionID: SessionID, parentID: MessageID, 
 }
 
 // These tests drive the REAL main-agent context-overflow path inside
-// SessionPrompt's runLoop (prompt.ts, the `overflowCheck(...) ||
-// maxThresholdCrossed(...)` branch) against a scripted LLM stub, and assert on
+// SessionPrompt's runLoop (prompt.ts, the `overflowCheck(...)` branch) against
+// a scripted LLM stub, and assert on
 // what the session ends up containing: a `checkpoint` boundary part (rebuild) vs
 // a `compaction` boundary part (degradation).
 //
@@ -271,6 +273,98 @@ async function seedFinishedAssistant(sessionID: SessionID, parentID: MessageID, 
 // with no summary at all. Degrading is therefore a real loss, not a cheaper
 // summary.
 describe("Auto context overflow: write a checkpoint before degrading to compaction", () => {
+  test(
+    "crossing the final checkpoint threshold below the configured context trigger does not rebuild",
+    async () => {
+      const llm = startLLM("reply-before-context-trigger")
+      let writerCalls = 0
+      const writer = writerThatWritesCheckpointAfter("CHECKPOINT_WITHOUT_REBUILD", 400, () => writerCalls++)
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) =>
+            Bun.write(
+              path.join(dir, "mimocode.json"),
+              mimocodeConfig(llm.origin, 50_000, { thresholds: ["24K"], reserved: 100 }),
+            ),
+        })
+
+        await Instance.provide({
+          directory: tmp.path,
+          fn: () =>
+            run(
+              Effect.gen(function* () {
+                const prompt = yield* SessionPrompt.Service
+                const sessions = yield* Session.Service
+                const info = yield* sessions.create({ title: "checkpoint-without-early-rebuild" })
+
+                // Resolve SessionPrompt's actor layer before replacing the
+                // late-bound writer implementation below.
+                yield* prompt.prompt({
+                  sessionID: info.id,
+                  parts: [{ type: "text", text: "initialize the actor layer" }],
+                  agent: "build",
+                })
+
+                // usable = 50K - 20.1K reserves = 29.9K. The single 24K
+                // checkpoint threshold is below it, so 25K must write a
+                // checkpoint without rebuilding before the 29.9K trigger.
+                const first = yield* Effect.promise(() => seedUserMessage(info.id, "earlier question"))
+                yield* Effect.promise(() => seedFinishedAssistant(info.id, first.id, 25_000))
+
+                // SessionPrompt's layer initialization installs the real
+                // actor implementation into spawnRef, so bind the writer
+                // double after resolving the service and for this call only.
+                const previous = spawnRef.current
+                spawnRef.current = writer
+                yield* prompt
+                  .prompt({
+                    sessionID: info.id,
+                    parts: [{ type: "text", text: "continue below the configured trigger" }],
+                    agent: "build",
+                  })
+                  .pipe(
+                    Effect.ensuring(
+                      Effect.sync(() => {
+                        spawnRef.current = previous
+                      }),
+                    ),
+                  )
+                yield* Effect.sleep(500)
+
+                const after = yield* sessions.messages({ sessionID: info.id })
+                expect(writerCalls).toBe(1)
+                expect(yield* Effect.promise(() => Bun.file(checkpointPath(info.id)).text())).toContain(
+                  "CHECKPOINT_WITHOUT_REBUILD",
+                )
+                const watermark = yield* Effect.sync(() =>
+                  Database.use((db) =>
+                    db
+                      .select({ id: SessionTable.last_checkpoint_message_id })
+                      .from(SessionTable)
+                      .where(eq(SessionTable.id, info.id))
+                      .get(),
+                  ),
+                )
+                expect(watermark?.id).toBeTruthy()
+                expect(after.some((m) => m.parts.some((p) => p.type === "checkpoint"))).toBe(false)
+                expect(after.some((m) => m.parts.some((p) => p.type === "compaction"))).toBe(false)
+                expect(
+                  after.some((m) =>
+                    m.parts.some((p) => p.type === "text" && p.text === "reply-before-context-trigger"),
+                  ),
+                ).toBe(true)
+                expect(llm.calls).toBe(2)
+              }),
+            ),
+        })
+      } finally {
+        await llm.stop()
+      }
+    },
+    { timeout: 60_000 },
+  )
+
   test(
     "no checkpoint + writer succeeds → inserts a checkpoint boundary and does NOT compact",
     async () => {

--- a/packages/opencode/test/session/prompt-rebuild-reset.test.ts
+++ b/packages/opencode/test/session/prompt-rebuild-reset.test.ts
@@ -31,24 +31,7 @@ const it = testEffect(
   ),
 )
 
-describe("F1 — prune resetThresholds clears sticky maxCrossed", () => {
-  it.live("resetThresholds clears maxThresholdCrossed flag", () =>
-    provideTmpdirInstance(() =>
-      Effect.gen(function* () {
-        const prune = yield* SessionPrune.Service
-        const session = yield* Session.Service
-        const sess = yield* session.create({ title: "t1" })
-
-        // Initially false (never crossed)
-        expect(yield* prune.maxThresholdCrossed(sess.id)).toBe(false)
-
-        // resetThresholds is a no-op when state is empty
-        yield* prune.resetThresholds(sess.id)
-        expect(yield* prune.maxThresholdCrossed(sess.id)).toBe(false)
-      }),
-    ),
-  )
-
+describe("F1 — rebuild resets checkpoint thresholds", () => {
   it.live("prompt.ts rebuild path resets thresholds and sets skipOverflowCheck before continue", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
@@ -59,8 +42,8 @@ describe("F1 — prune resetThresholds clears sticky maxCrossed", () => {
         // the /rebuild command). Assert BOTH halves of the invariant: (a) the
         // shared helper resets thresholds after a successful insert; (b) site-1
         // sets skipOverflowCheck=true then continue on a successful rebuild — so
-        // the loop can't immediately re-trigger overflow on the same crossed
-        // thresholds.
+        // the loop can't immediately re-trigger overflow on the same token
+        // count.
         //
         // DELIBERATE UPDATE: (b)'s pattern used to be
         //   const inserted = yield* rebuildFromCheckpoint(…)

--- a/packages/opencode/test/session/prune.test.ts
+++ b/packages/opencode/test/session/prune.test.ts
@@ -368,36 +368,6 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
     )
   })
 
-  test("a failed writer at the max threshold leaves maxThresholdCrossed set", async () => {
-    const harness = makeRetryHarness()
-    const promptOps = {} as any
-
-    await runWithHarness(
-      harness,
-      Effect.gen(function* () {
-        const svc = yield* SessionPrune.Service
-        const ssn = yield* SessionNs.Service
-        const info = yield* ssn.create({})
-        const model = createModel({ context: 100_000, output: 32_000 })
-
-        harness.outcomes.push({ outcome: "failure" }, { outcome: "failure" })
-
-        // Cross BOTH thresholds in one fire so the max threshold is crossed and
-        // the observed outcome is a failure.
-        yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(50_000), promptOps })
-        yield* Effect.sleep(150)
-
-        // The old watcher paired `crossed.delete` with `maxCrossed.delete` on a
-        // sub-cap failure, which withdrew the already-raised discard+rebuild
-        // signal that prompt.ts consumes. Overflow readiness must not depend on
-        // whether the checkpoint writer happened to succeed, so the signal
-        // stands: under the old code this read false.
-        expect(yield* svc.maxThresholdCrossed(info.id)).toBe(true)
-      }),
-      { checkpoint: { thresholds: ["30K", "45K"] } },
-    )
-  })
-
   test("the next threshold crossing still fires after a failure", async () => {
     const harness = makeRetryHarness()
     const promptOps = {} as any


### PR DESCRIPTION
## Summary

- make `Overflow.usable()` the only automatic context rebuild boundary
- keep checkpoint percentage thresholds responsible only for refreshing checkpoint state
- remove the obsolete max-threshold rebuild signal and its tests
- show the configured context limit relative to the model limit in the sidebar
- add run-loop and TUI rendering regressions for both behaviors

## Context

This is a follow-up to #1930. Checkpoint percentages were resolved against the already reserve-adjusted usable window, then the final percentage threshold also triggered a rebuild. A configured working limit could therefore be discounted a second time before the actual context trigger.

The sidebar now presents the user-controlled relationship (`limit 300K of 922K`) while reserve-adjusted trigger details remain available through `/status`.

## Tests

- `bun test test/session/auto-overflow-writer-first.test.ts test/session/prune.test.ts test/session/prompt-rebuild-reset.test.ts test/session/overflow.test.ts test/session/checkpoint-thresholds.test.ts test/cli/tui/sidebar-context.test.tsx` (94 pass)
- `bun typecheck` from `packages/opencode`
- pre-push monorepo typecheck
