### PR TITLE
fix(tui): stop context readout showing a stale figure after /rebuild

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -32,7 +32,7 @@ import * as Clipboard from "../../util/clipboard"
 import type { AssistantMessage, FilePart, UserMessage } from "@mimo-ai/sdk/v2"
 import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
-import { Locale, Token } from "@/util"
+import { Locale } from "@/util"
 import { formatDuration } from "@/util/format"
 import { SessionRetry } from "@/session/retry"
 import { createColors, createFrames } from "../../ui/spinner.ts"
@@ -471,25 +471,28 @@ export function Prompt(props: PromptProps) {
   const usage = createMemo(() => {
     if (!props.sessionID) return
     const msg = sync.data.message[props.sessionID]?.["main"] ?? []
+    // Resolve the window from the last measured assistant turn's model, matching
+    // the record `computeContextUsage` reads for the token count.
     const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
     if (!last) return
-
-    const tokens =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
-    if (tokens <= 0) return
-
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     const win = Model.contextWindow(sync.data.config, model)
-    const cost = msg.reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0)
+    // A /rebuild boundary is a message carrying a `checkpoint` part (stored in
+    // sync.data.part, keyed by message id). When it is newer than the last
+    // measured turn, computeContextUsage reports pending instead of the stale
+    // fill — the number only becomes real again on the next assistant turn.
+    const result = Model.computeContextUsage({
+      messages: msg,
+      window: win,
+      hasCheckpoint: (id) => (sync.data.part[id] ?? []).some((p) => p.type === "checkpoint"),
+    })
+    if (!result) return
     return {
-      // Denominator is the compaction trigger, not the raw window — otherwise the
-      // percentage never reaches 100% and a configured budget looks ignored.
-      context: win
-        ? `${Locale.number(tokens)}/${Token.format(win.usable)}${win.source === "config" ? "↓" : ""} (${Math.round(
-            (tokens / win.usable) * 100,
-          )}%)`
-        : Locale.number(tokens),
-      cost: cost > 0 ? money.format(cost) : undefined,
+      // Pending renders an em dash so the footer visibly stops asserting the
+      // pre-rebuild fill (which is exactly why the user ran /rebuild) without
+      // inventing an estimate that would disagree with the compaction trigger.
+      context: result.pending ? "—" : result.context,
+      cost: result.cost > 0 ? money.format(result.cost) : undefined,
     }
   })
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -488,10 +488,10 @@ export function Prompt(props: PromptProps) {
     })
     if (!result) return
     return {
-      // Pending renders an em dash so the footer visibly stops asserting the
-      // pre-rebuild fill (which is exactly why the user ran /rebuild) without
-      // inventing an estimate that would disagree with the compaction trigger.
-      context: result.pending ? "—" : result.context,
+      // computeContextUsage owns the pending placeholder (it renders `—/<win>`
+      // so the footer stops asserting the pre-rebuild fill while keeping the
+      // frame), so `context` is the final string in every case — render it as-is.
+      context: result.context,
       cost: result.cost > 0 ? money.format(result.cost) : undefined,
     }
   })

--- a/packages/opencode/src/cli/cmd/tui/util/model.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/model.ts
@@ -1,5 +1,6 @@
-import type { Config, Model, Provider } from "@mimo-ai/sdk/v2"
+import type { AssistantMessage, Config, Message, Model, Provider } from "@mimo-ai/sdk/v2"
 import { contextWindow as overflowWindow } from "@/session/overflow"
+import { Locale, Token } from "@/util"
 
 type Selection = {
   providerID: string
@@ -63,4 +64,62 @@ export function contextWindow(config: Config | undefined, model: Model | undefin
   // usable can legitimately reach 0 (window smaller than the reserves, or a large
   // compaction.reserved). Callers divide by it, so treat that as "unknown window".
   return result.hard === 0 || result.usable === 0 ? undefined : result
+}
+
+/** Window shape from `contextWindow` / the server's overflow arithmetic. */
+export type ContextWindow = ReturnType<typeof overflowWindow>
+
+/**
+ * Compute the footer's context-fill readout and cumulative cost from the main
+ * message list. Pure and render-free so it can be unit-tested below the SolidJS
+ * memo in prompt/index.tsx (which has no render harness).
+ *
+ * The context number reads the LAST completed assistant turn's usage record —
+ * the same source the server's overflow/compaction TRIGGER uses
+ * (session/overflow.ts `isOverflow` over `MessageV2.Assistant["tokens"]`, fed by
+ * prompt.ts `lastFinished.tokens`). There is deliberately no second estimator:
+ * a manual /rebuild inserts only a checkpoint-boundary message and produces no
+ * new usage record, so re-tokenizing the trimmed transcript here would show a
+ * number that disagrees with the trigger and then jumps to a different measured
+ * value on the next turn. Instead, when the newest measured assistant turn is
+ * OLDER than the most recent rebuild boundary, the measured figure is stale, so
+ * we report `pending: true` rather than repeat the pre-rebuild fill. The number
+ * refreshes for real on the next assistant turn (whose id sorts after the
+ * boundary). Cost is a cumulative sum over all assistant turns and is unaffected
+ * by the boundary — the whole point of /rebuild is to drop context, not cost.
+ */
+export function computeContextUsage(input: {
+  messages: Message[]
+  window: ContextWindow | undefined
+  /** True when the message with this id carries a `checkpoint` (rebuild) part. */
+  hasCheckpoint: (messageID: string) => boolean
+}): { context: string; cost: number; pending: boolean } | undefined {
+  const { messages, window: win, hasCheckpoint } = input
+  const last = messages.findLast(
+    (m): m is AssistantMessage => m.role === "assistant" && m.tokens.output > 0,
+  )
+  if (!last) return undefined
+
+  const tokens =
+    last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
+  if (tokens <= 0) return undefined
+
+  const cost = messages.reduce((sum, m) => sum + (m.role === "assistant" ? m.cost : 0), 0)
+
+  // Ascending message ids are timestamp-monotonic, so a boundary id greater than
+  // the last measured assistant id means the rebuild happened after that turn.
+  const boundary = messages.findLast((m) => hasCheckpoint(m.id))
+  const pending = !!boundary && boundary.id > last.id
+  if (pending) {
+    return { context: "…", cost, pending: true }
+  }
+
+  const context = win
+    ? // Denominator is the compaction trigger, not the raw window — otherwise the
+      // percentage never reaches 100% and a configured budget looks ignored.
+      `${Locale.number(tokens)}/${Token.format(win.usable)}${win.source === "config" ? "↓" : ""} (${Math.round(
+        (tokens / win.usable) * 100,
+      )}%)`
+    : Locale.number(tokens)
+  return { context, cost, pending: false }
 }

--- a/packages/opencode/src/cli/cmd/tui/util/model.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/model.ts
@@ -83,10 +83,17 @@ export type ContextWindow = ReturnType<typeof overflowWindow>
  * number that disagrees with the trigger and then jumps to a different measured
  * value on the next turn. Instead, when the newest measured assistant turn is
  * OLDER than the most recent rebuild boundary, the measured figure is stale, so
- * we report `pending: true` rather than repeat the pre-rebuild fill. The number
- * refreshes for real on the next assistant turn (whose id sorts after the
- * boundary). Cost is a cumulative sum over all assistant turns and is unaffected
- * by the boundary — the whole point of /rebuild is to drop context, not cost.
+ * `pending` is true and `context` blanks only the unmeasured numerator while
+ * keeping the window frame (`—/960K`), since the window is still known and a
+ * percentage of an unknown numerator is meaningless. The number refreshes for
+ * real on the next assistant turn (whose id sorts after the boundary). Cost is a
+ * cumulative sum over all assistant turns and is unaffected by the boundary —
+ * the whole point of /rebuild is to drop context, not cost.
+ *
+ * `context` is the final display string in every case: the pure function is the
+ * sole owner of the pending placeholder (it is where the "figure is stale"
+ * decision is made and where the tests live), so the renderer shows `context`
+ * unconditionally and never has to reinterpret `pending`.
  */
 export function computeContextUsage(input: {
   messages: Message[]
@@ -106,20 +113,23 @@ export function computeContextUsage(input: {
 
   const cost = messages.reduce((sum, m) => sum + (m.role === "assistant" ? m.cost : 0), 0)
 
+  // The window frame is `<usable>` plus the `↓` config-budget marker. Denominator
+  // is the compaction trigger, not the raw window — otherwise the percentage never
+  // reaches 100% and a configured budget looks ignored.
+  const frame = win ? `${Token.format(win.usable)}${win.source === "config" ? "↓" : ""}` : undefined
+
   // Ascending message ids are timestamp-monotonic, so a boundary id greater than
   // the last measured assistant id means the rebuild happened after that turn.
   const boundary = messages.findLast((m) => hasCheckpoint(m.id))
   const pending = !!boundary && boundary.id > last.id
   if (pending) {
-    return { context: "…", cost, pending: true }
+    // Blank only the unmeasured numerator; keep the frame when we have one so the
+    // footer reads as deliberately-unknown (`—/960K`) rather than broken. With no
+    // window there is no frame to keep, so a bare placeholder is correct. No
+    // percentage either way — a percentage of an unknown numerator is meaningless.
+    return { context: frame ? `—/${frame}` : "—", cost, pending: true }
   }
 
-  const context = win
-    ? // Denominator is the compaction trigger, not the raw window — otherwise the
-      // percentage never reaches 100% and a configured budget looks ignored.
-      `${Locale.number(tokens)}/${Token.format(win.usable)}${win.source === "config" ? "↓" : ""} (${Math.round(
-        (tokens / win.usable) * 100,
-      )}%)`
-    : Locale.number(tokens)
+  const context = frame ? `${Locale.number(tokens)}/${frame} (${Math.round((tokens / win!.usable) * 100)}%)` : Locale.number(tokens)
   return { context, cost, pending: false }
 }

--- a/packages/opencode/test/cli/tui/context-usage.test.ts
+++ b/packages/opencode/test/cli/tui/context-usage.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import type { AssistantMessage, Message, UserMessage } from "@mimo-ai/sdk/v2"
+import { computeContextUsage } from "../../../src/cli/cmd/tui/util/model"
+
+// The footer's context readout (prompt/index.tsx `usage` memo) reads the LAST
+// completed assistant turn's usage record. A manual /rebuild inserts only a
+// checkpoint-boundary message; it produces no new usage record, so a naive
+// findLast(output>0) keeps reporting the pre-rebuild figure until the next
+// assistant turn — the number the user ran /rebuild to watch drop stays stale.
+//
+// These tests pin `computeContextUsage`, the pure function the memo delegates
+// to, one level below the SolidJS render (there is no render harness for this
+// component). The window is passed in already-resolved so the test does not
+// depend on model/config plumbing.
+
+const WINDOW = { hard: 1_000_000, effective: 980_000, usable: 960_000, source: "model" as const }
+
+// computeContextUsage only reads id/role/tokens/cost; the rest of the SDK
+// message shape is irrelevant here, so build the minimal object and cast.
+function assistant(id: string, input: number, opts?: { cost?: number }): Message {
+  return {
+    id,
+    role: "assistant",
+    providerID: "alibaba",
+    modelID: "qwen-plus",
+    cost: opts?.cost ?? 0,
+    tokens: { input, output: 100, reasoning: 0, cache: { read: 0, write: 0 } },
+  } as AssistantMessage
+}
+
+function user(id: string): Message {
+  return { id, role: "user" } as UserMessage
+}
+
+describe("computeContextUsage", () => {
+  test("measured: reports the last assistant turn's context fill and cumulative cost", () => {
+    // 578900 + 100 output = 579000 tokens over a 960K usable window → 579.0K/960K (60%).
+    const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 })]
+    const out = computeContextUsage({ messages, window: WINDOW, hasCheckpoint: () => false })
+    expect(out).toBeDefined()
+    expect(out!.pending).toBe(false)
+    expect(out!.context).toBe("579.0K/960K (60%)")
+    expect(out!.cost).toBe(13.1)
+  })
+
+  test("after a manual /rebuild the stale pre-rebuild figure is NOT shown", () => {
+    // The last assistant usage record (msg_02, 60%) predates a checkpoint
+    // boundary inserted by /rebuild (msg_03). The measured figure is stale, so
+    // the context readout must go pending instead of repeating "579.0K/960K (60%)".
+    const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 }), user("msg_03")]
+    const out = computeContextUsage({
+      messages,
+      window: WINDOW,
+      hasCheckpoint: (id) => id === "msg_03",
+    })
+    expect(out).toBeDefined()
+    expect(out!.pending).toBe(true)
+    expect(out!.context).not.toBe("579.0K/960K (60%)")
+    // Cost is cumulative and independent of the context figure — it must survive.
+    expect(out!.cost).toBe(13.1)
+  })
+
+  test("a fresh assistant turn after the boundary clears pending and re-measures", () => {
+    // Once a new assistant turn completes AFTER the rebuild boundary, its usage
+    // record is authoritative again: pending clears and the new figure shows.
+    const messages = [
+      user("msg_01"),
+      assistant("msg_02", 578_900, { cost: 13.1 }),
+      user("msg_03"),
+      assistant("msg_04", 190_000, { cost: 14.0 }),
+    ]
+    const out = computeContextUsage({
+      messages,
+      window: WINDOW,
+      hasCheckpoint: (id) => id === "msg_03",
+    })
+    expect(out).toBeDefined()
+    expect(out!.pending).toBe(false)
+    // 190000 + 100 = 190100 over 960K → 20%.
+    expect(out!.context).toBe("190.1K/960K (20%)")
+    // Cost is cumulative across all assistant turns (13.1 + 14.0), never reset.
+    expect(out!.cost).toBeCloseTo(27.1, 5)
+  })
+})

--- a/packages/opencode/test/cli/tui/context-usage.test.ts
+++ b/packages/opencode/test/cli/tui/context-usage.test.ts
@@ -55,9 +55,46 @@ describe("computeContextUsage", () => {
     })
     expect(out).toBeDefined()
     expect(out!.pending).toBe(true)
+    // Must not repeat the stale pre-rebuild fill (this is the whole point).
     expect(out!.context).not.toBe("579.0K/960K (60%)")
+    // Keep the frame, blank only the unmeasured numerator, and drop the percentage
+    // (a percentage of an unknown numerator is meaningless).
+    expect(out!.context).toBe("—/960K")
+    expect(out!.context).not.toContain("%")
     // Cost is cumulative and independent of the context figure — it must survive.
     expect(out!.cost).toBe(13.1)
+  })
+
+  test("pending with no known window shows a bare placeholder (no frame to keep)", () => {
+    // When the window is unknown the non-pending path shows only a bare token
+    // count, so pending has no frame to preserve — a bare `—` is correct, and it
+    // must still not carry a percentage or the stale token count.
+    const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 }), user("msg_03")]
+    const out = computeContextUsage({
+      messages,
+      window: undefined,
+      hasCheckpoint: (id) => id === "msg_03",
+    })
+    expect(out).toBeDefined()
+    expect(out!.pending).toBe(true)
+    expect(out!.context).toBe("—")
+    expect(out!.context).not.toContain("%")
+    expect(out!.context).not.toContain("579")
+    expect(out!.cost).toBe(13.1)
+  })
+
+  test("config-source window keeps the ↓ marker in the pending frame", () => {
+    // The frame includes the ↓ budget marker for a config-sourced window; pending
+    // must preserve it so the user still sees they are on a configured budget.
+    const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 }), user("msg_03")]
+    const out = computeContextUsage({
+      messages,
+      window: { hard: 1_000_000, effective: 980_000, usable: 960_000, source: "config" as const },
+      hasCheckpoint: (id) => id === "msg_03",
+    })
+    expect(out).toBeDefined()
+    expect(out!.pending).toBe(true)
+    expect(out!.context).toBe("—/960K↓")
   })
 
   test("a fresh assistant turn after the boundary clears pending and re-measures", () => {


### PR DESCRIPTION
## Symptom
After a manual `/rebuild`, the transcript clears and the boundary marker
renders, but the footer keeps showing the pre-rebuild context fill (e.g.
`579.0K/960K (60%)`) until the next assistant turn. Since that number is the
whole observable outcome of `/rebuild`, the command looks like it did nothing.
(Cost is cumulative and is left untouched.)

## Cause
The footer's `usage` memo (`prompt/index.tsx`) reads the last completed
assistant turn's usage record via `findLast(output>0)`. A `/rebuild` inserts
only a checkpoint-boundary message and produces no new usage record, so the
figure is stale. This is (i) never-recomputed, not (ii) a stale render: the memo
does re-run when the boundary arrives, but resolves to the same old record.

## Why not recompute a live number
The server's own overflow/compaction trigger (`session/overflow` `isOverflow`)
reads the very same last-assistant record and has no independent live estimator.
Recomputing here would produce a second number that disagrees with the trigger
and then jumps to a different measured value next turn. So instead of inventing
an estimate, when the last measured turn predates the newest rebuild boundary we
show a pending em dash — measured-vs-unknown, never estimated. The real figure
returns on the next assistant turn.

## Enforcement
Logic extracted to a pure `computeContextUsage` (`tui/util/model.ts`) and pinned
in `test/cli/tui/context-usage.test.ts` (no render harness for the memo, so
tested one level below it). A test fails if the footer reverts to the
pre-rebuild figure after a boundary.
