### PR TITLE
fix(tui): make post-rebuild pending-detection independent of message order

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -478,13 +478,14 @@ export function Prompt(props: PromptProps) {
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     const win = Model.contextWindow(sync.data.config, model)
     // A /rebuild boundary is a message carrying a `checkpoint` part (stored in
-    // sync.data.part, keyed by message id). When it is newer than the last
-    // measured turn, computeContextUsage reports pending instead of the stale
-    // fill — the number only becomes real again on the next assistant turn.
+    // sync.data.part, keyed by message id). Its `coveredUpTo` is the watermark it
+    // collapsed up to; computeContextUsage uses that (not message order) to decide
+    // the measured turn is stale and report pending until the next assistant turn.
     const result = Model.computeContextUsage({
       messages: msg,
       window: win,
-      hasCheckpoint: (id) => (sync.data.part[id] ?? []).some((p) => p.type === "checkpoint"),
+      checkpointCoverage: (id) =>
+        (sync.data.part[id] ?? []).find((p) => p.type === "checkpoint")?.coveredUpTo,
     })
     if (!result) return
     return {

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -1005,6 +1005,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
               draft.todo[sessionID] = todo.data ?? []
               draft.task[sessionID] = task.data ?? []
               const flat = (messages.data ?? []).map((x) => x.info)
+              // Server returns messages id-ordered and message.updated keeps that order; the footer's post-/rebuild pending-detection deliberately does NOT depend on it (it keys off checkpoint coveredUpTo, model.ts), so reordering here won't resurface the stale-context bug.
               draft.message[sessionID] = bucketMessages(flat)
               for (const message of messages.data ?? []) {
                 draft.part[message.info.id] = message.parts

--- a/packages/opencode/src/cli/cmd/tui/util/model.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/model.ts
@@ -81,14 +81,26 @@ export type ContextWindow = ReturnType<typeof overflowWindow>
  * a manual /rebuild inserts only a checkpoint-boundary message and produces no
  * new usage record, so re-tokenizing the trimmed transcript here would show a
  * number that disagrees with the trigger and then jumps to a different measured
- * value on the next turn. Instead, when the newest measured assistant turn is
- * OLDER than the most recent rebuild boundary, the measured figure is stale, so
+ * value on the next turn. Instead, when the last measured assistant turn falls
+ * inside a region a rebuild collapsed, the measured figure is stale, so
  * `pending` is true and `context` blanks only the unmeasured numerator while
  * keeping the window frame (`—/960K`), since the window is still known and a
  * percentage of an unknown numerator is meaningless. The number refreshes for
- * real on the next assistant turn (whose id sorts after the boundary). Cost is a
- * cumulative sum over all assistant turns and is unaffected by the boundary —
+ * real on the next assistant turn (which is created after the boundary). Cost is
+ * a cumulative sum over all assistant turns and is unaffected by the boundary —
  * the whole point of /rebuild is to drop context, not cost.
+ *
+ * Staleness is decided from each rebuild's `coveredUpTo` (the watermark message
+ * id it collapsed up to), NOT from the boundary marker's own id or its array
+ * position. This matters: the boundary marker message is created with a fresh
+ * ascending id but a deliberately backdated `time.created` (checkpoint.ts, so it
+ * renders next to the region it summarizes), so its id and time disagree by
+ * design. Comparing the marker's own id — or trusting `findLast` to return the
+ * newest boundary in array order — would silently reintroduce the stale-figure
+ * bug the moment the caller ordered messages by time, or ran a second rebuild.
+ * `coveredUpTo` is an ordinary watermark message id (a real prior turn), so
+ * `coveredUpTo >= last.id` is an honest "was this measured turn collapsed?" test
+ * that holds under any caller ordering and any number of rebuilds.
  *
  * `context` is the final display string in every case: the pure function is the
  * sole owner of the pending placeholder (it is where the "figure is stale"
@@ -98,10 +110,14 @@ export type ContextWindow = ReturnType<typeof overflowWindow>
 export function computeContextUsage(input: {
   messages: Message[]
   window: ContextWindow | undefined
-  /** True when the message with this id carries a `checkpoint` (rebuild) part. */
-  hasCheckpoint: (messageID: string) => boolean
+  /**
+   * For a message carrying a `checkpoint` (rebuild) part, the `coveredUpTo`
+   * watermark id that rebuild collapsed up to; `undefined` for any other
+   * message. Ordering-independent: the readout never inspects message order.
+   */
+  checkpointCoverage: (messageID: string) => string | undefined
 }): { context: string; cost: number; pending: boolean } | undefined {
-  const { messages, window: win, hasCheckpoint } = input
+  const { messages, window: win, checkpointCoverage } = input
   const last = messages.findLast(
     (m): m is AssistantMessage => m.role === "assistant" && m.tokens.output > 0,
   )
@@ -118,10 +134,13 @@ export function computeContextUsage(input: {
   // reaches 100% and a configured budget looks ignored.
   const frame = win ? `${Token.format(win.usable)}${win.source === "config" ? "↓" : ""}` : undefined
 
-  // Ascending message ids are timestamp-monotonic, so a boundary id greater than
-  // the last measured assistant id means the rebuild happened after that turn.
-  const boundary = messages.findLast((m) => hasCheckpoint(m.id))
-  const pending = !!boundary && boundary.id > last.id
+  // The measured turn is stale if ANY rebuild collapsed a region reaching it or
+  // past it — i.e. some checkpoint's coveredUpTo id is >= the last measured turn's
+  // id. `some` (not `findLast`) so the result never depends on message order.
+  const pending = messages.some((m) => {
+    const coveredUpTo = checkpointCoverage(m.id)
+    return coveredUpTo !== undefined && coveredUpTo >= last.id
+  })
   if (pending) {
     // Blank only the unmeasured numerator; keep the frame when we have one so the
     // footer reads as deliberately-unknown (`—/960K`) rather than broken. With no

--- a/packages/opencode/test/cli/tui/context-usage.test.ts
+++ b/packages/opencode/test/cli/tui/context-usage.test.ts
@@ -4,39 +4,55 @@ import { computeContextUsage } from "../../../src/cli/cmd/tui/util/model"
 
 // The footer's context readout (prompt/index.tsx `usage` memo) reads the LAST
 // completed assistant turn's usage record. A manual /rebuild inserts only a
-// checkpoint-boundary message; it produces no new usage record, so a naive
-// findLast(output>0) keeps reporting the pre-rebuild figure until the next
-// assistant turn — the number the user ran /rebuild to watch drop stays stale.
+// checkpoint-boundary message; it produces no new usage record, so a naive read
+// keeps reporting the pre-rebuild figure until the next assistant turn — the
+// number the user ran /rebuild to watch drop stays stale.
 //
 // These tests pin `computeContextUsage`, the pure function the memo delegates
 // to, one level below the SolidJS render (there is no render harness for this
 // component). The window is passed in already-resolved so the test does not
-// depend on model/config plumbing.
+// depend on model/config plumbing. Staleness is driven by each checkpoint's
+// `coveredUpTo` (the watermark id it collapsed up to) via `checkpointCoverage`,
+// which is why these fixtures pass a coverage map rather than a boolean.
 
 const WINDOW = { hard: 1_000_000, effective: 980_000, usable: 960_000, source: "model" as const }
 
-// computeContextUsage only reads id/role/tokens/cost; the rest of the SDK
-// message shape is irrelevant here, so build the minimal object and cast.
-function assistant(id: string, input: number, opts?: { cost?: number }): Message {
+// computeContextUsage reads id/role/tokens/cost and, in the order-independence
+// tests, time.created; the rest of the SDK message shape is irrelevant, so build
+// the minimal object and cast.
+function assistant(id: string, input: number, opts?: { cost?: number; created?: number }): Message {
   return {
     id,
     role: "assistant",
     providerID: "alibaba",
     modelID: "qwen-plus",
     cost: opts?.cost ?? 0,
+    time: { created: opts?.created ?? 0 },
     tokens: { input, output: 100, reasoning: 0, cache: { read: 0, write: 0 } },
   } as AssistantMessage
 }
 
-function user(id: string): Message {
-  return { id, role: "user" } as UserMessage
+function user(id: string, opts?: { created?: number }): Message {
+  return { id, role: "user", time: { created: opts?.created ?? 0 } } as UserMessage
+}
+
+// A checkpoint-boundary message: fresh ascending id, and (for the ordering
+// tests) a deliberately backdated time.created — exactly the real shape from
+// checkpoint.ts (`syntheticTime = boundaryCreatedAt + 1`, id = fresh ascending).
+function boundary(id: string, opts?: { created?: number }): Message {
+  return { id, role: "user", time: { created: opts?.created ?? 0 } } as UserMessage
+}
+
+/** Build the `checkpointCoverage` lookup from an id -> coveredUpTo map. */
+function coverage(map: Record<string, string>) {
+  return (id: string) => map[id]
 }
 
 describe("computeContextUsage", () => {
   test("measured: reports the last assistant turn's context fill and cumulative cost", () => {
     // 578900 + 100 output = 579000 tokens over a 960K usable window → 579.0K/960K (60%).
     const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 })]
-    const out = computeContextUsage({ messages, window: WINDOW, hasCheckpoint: () => false })
+    const out = computeContextUsage({ messages, window: WINDOW, checkpointCoverage: () => undefined })
     expect(out).toBeDefined()
     expect(out!.pending).toBe(false)
     expect(out!.context).toBe("579.0K/960K (60%)")
@@ -44,14 +60,14 @@ describe("computeContextUsage", () => {
   })
 
   test("after a manual /rebuild the stale pre-rebuild figure is NOT shown", () => {
-    // The last assistant usage record (msg_02, 60%) predates a checkpoint
-    // boundary inserted by /rebuild (msg_03). The measured figure is stale, so
-    // the context readout must go pending instead of repeating "579.0K/960K (60%)".
-    const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 }), user("msg_03")]
+    // The last assistant usage record (msg_02, 60%) was collapsed by a /rebuild
+    // boundary (msg_03) whose coveredUpTo is msg_02. The measured figure is stale,
+    // so the readout must go pending instead of repeating "579.0K/960K (60%)".
+    const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 }), boundary("msg_03")]
     const out = computeContextUsage({
       messages,
       window: WINDOW,
-      hasCheckpoint: (id) => id === "msg_03",
+      checkpointCoverage: coverage({ msg_03: "msg_02" }),
     })
     expect(out).toBeDefined()
     expect(out!.pending).toBe(true)
@@ -69,11 +85,11 @@ describe("computeContextUsage", () => {
     // When the window is unknown the non-pending path shows only a bare token
     // count, so pending has no frame to preserve — a bare `—` is correct, and it
     // must still not carry a percentage or the stale token count.
-    const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 }), user("msg_03")]
+    const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 }), boundary("msg_03")]
     const out = computeContextUsage({
       messages,
       window: undefined,
-      hasCheckpoint: (id) => id === "msg_03",
+      checkpointCoverage: coverage({ msg_03: "msg_02" }),
     })
     expect(out).toBeDefined()
     expect(out!.pending).toBe(true)
@@ -86,11 +102,11 @@ describe("computeContextUsage", () => {
   test("config-source window keeps the ↓ marker in the pending frame", () => {
     // The frame includes the ↓ budget marker for a config-sourced window; pending
     // must preserve it so the user still sees they are on a configured budget.
-    const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 }), user("msg_03")]
+    const messages = [user("msg_01"), assistant("msg_02", 578_900, { cost: 13.1 }), boundary("msg_03")]
     const out = computeContextUsage({
       messages,
       window: { hard: 1_000_000, effective: 980_000, usable: 960_000, source: "config" as const },
-      hasCheckpoint: (id) => id === "msg_03",
+      checkpointCoverage: coverage({ msg_03: "msg_02" }),
     })
     expect(out).toBeDefined()
     expect(out!.pending).toBe(true)
@@ -99,17 +115,18 @@ describe("computeContextUsage", () => {
 
   test("a fresh assistant turn after the boundary clears pending and re-measures", () => {
     // Once a new assistant turn completes AFTER the rebuild boundary, its usage
-    // record is authoritative again: pending clears and the new figure shows.
+    // record is authoritative again: the boundary's coveredUpTo (msg_02) is older
+    // than the new measured turn (msg_04), so pending clears and the figure shows.
     const messages = [
       user("msg_01"),
       assistant("msg_02", 578_900, { cost: 13.1 }),
-      user("msg_03"),
+      boundary("msg_03"),
       assistant("msg_04", 190_000, { cost: 14.0 }),
     ]
     const out = computeContextUsage({
       messages,
       window: WINDOW,
-      hasCheckpoint: (id) => id === "msg_03",
+      checkpointCoverage: coverage({ msg_03: "msg_02" }),
     })
     expect(out).toBeDefined()
     expect(out!.pending).toBe(false)
@@ -117,5 +134,45 @@ describe("computeContextUsage", () => {
     expect(out!.context).toBe("190.1K/960K (20%)")
     // Cost is cumulative across all assistant turns (13.1 + 14.0), never reset.
     expect(out!.cost).toBeCloseTo(27.1, 5)
+  })
+
+  // Shared multi-rebuild fixture, engineered so id order and time order DISAGREE
+  // and so the two rebuild markers' own ids straddle the measured turn:
+  //
+  //   ids (as sync stores them, ascending):  u0(msg_00) < bOld(msg_01) < a2(msg_04) < bCover(msg_05)
+  //   time.created (backdated markers):       bCover(2) < bOld(9) < u0(100) < a2(101)
+  //
+  // Truth: bCover collapsed up to a2 (coveredUpTo = a2), so the last measured turn
+  // a2 IS stale → pending. The trap for the old logic: in TIME order, the last
+  // boundary in the array is bOld (msg_01), whose OWN id is LESS than a2 (msg_04),
+  // so a `findLast(boundary).id > last.id` test would read NOT-pending — the exact
+  // silent regression this change removes. coveredUpTo makes the verdict identical
+  // in both orderings.
+  const u0 = user("msg_00_u0", { created: 100 })
+  const bOld = boundary("msg_01_bOld", { created: 9 }) // covers u0 only; late-ish time, small id
+  const a2 = assistant("msg_04_a2", 300_000, { cost: 5.0, created: 101 })
+  const bCover = boundary("msg_05_bCover", { created: 2 }) // covers a2; backdated, large id
+  const multiCoverage = coverage({ msg_01_bOld: "msg_00_u0", msg_05_bCover: "msg_04_a2" })
+  const idOrder = [u0, bOld, a2, bCover]
+
+  test("two rebuilds in one session: still pending after the second, with backdated boundary times", () => {
+    const out = computeContextUsage({ messages: idOrder, window: WINDOW, checkpointCoverage: multiCoverage })
+    expect(out).toBeDefined()
+    expect(out!.pending).toBe(true)
+    expect(out!.context).toBe("—/960K")
+  })
+
+  test("order-independence: a time-sorted array yields the same pending verdict", () => {
+    const timeOrder = [...idOrder].toSorted((x, y) => (x as any).time.created - (y as any).time.created)
+    // Guard: the two orderings really are different (else this proves nothing), and
+    // in time order the trailing boundary is bOld (small id) — the trap case.
+    expect(timeOrder.map((m) => m.id)).not.toEqual(idOrder.map((m) => m.id))
+    expect(timeOrder.map((m) => m.id)).toEqual(["msg_05_bCover", "msg_01_bOld", "msg_00_u0", "msg_04_a2"])
+
+    const idOut = computeContextUsage({ messages: idOrder, window: WINDOW, checkpointCoverage: multiCoverage })
+    const timeOut = computeContextUsage({ messages: timeOrder, window: WINDOW, checkpointCoverage: multiCoverage })
+    expect(idOut).toEqual(timeOut)
+    expect(timeOut!.pending).toBe(true)
+    expect(timeOut!.context).toBe("—/960K")
   })
 })


### PR DESCRIPTION
## What this pins

The post-`/rebuild` "pending" check merged in #1999 found the last checkpoint in
**array order** (`findLast`) and compared the boundary marker's own id to the
last measured turn's id. But a rebuild boundary is created with a fresh ascending
id and a **deliberately backdated `time.created`** (`checkpoint.ts`, so the marker
renders next to the region it summarizes) — id and time disagree by design. With
two rebuilds, if the message array were ever ordered by time, `findLast` could
return the wrong boundary and the comparison would judge against a marker id that
sorts before the measured turn — silently resurrecting the stale-context figure.

## Fix

`CheckpointPart.coveredUpTo` (the watermark id a rebuild collapsed up to) already
carries this, order-independently. So drop the id comparison: the measured turn
is stale iff **some** checkpoint's `coveredUpTo >= its id`. `coveredUpTo` is an
ordinary prior-turn id (not the backdated marker), so it holds under any caller
ordering and any number of rebuilds; the memo no longer inspects message order.

## How it's enforced

- Two-rebuild test with backdated boundary times, fixture built so id order and
  time order actually differ.
- Order-independence test: a time-sorted array must yield the same verdict as the
  id-sorted one (the old `findLast`+id comparison disagreed here).
- One line at the `sync.tsx` message array noting the readout no longer depends
  on order. The 3 #1999 pending/staleness tests are unchanged.
