### PR TITLE
fix(provider): auto-detect reasoning models from reasoningEffort option

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1318,7 +1318,7 @@ const layer: Layer.Layer<
               providerID: ProviderID.make(providerID),
               capabilities: {
                 temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
-                reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
+                reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? (model.options?.reasoningEffort ? true : false),
                 attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
                 toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,
                 input: {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2695,6 +2695,48 @@ test("custom model with variants enabled and disabled", async () => {
   })
 })
 
+test("reasoning capability is auto-detected from reasoningEffort option", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "zen-free": {
+              name: "Zen Free",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "mimo-v2.5-free": {
+                  name: "MiMo V2.5 Free",
+                  limit: { context: 128000, output: 16000 },
+                  options: {
+                    reasoningEffort: "high",
+                  },
+                },
+              },
+              options: { apiKey: "test-key" },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const model = providers[ProviderID.make("zen-free")].models["mimo-v2.5-free"]
+      expect(model.capabilities.reasoning).toBe(true)
+      expect(model.variants).toBeDefined()
+      expect(model.variants!["low"]).toBeDefined()
+      expect(model.variants!["medium"]).toBeDefined()
+      expect(model.variants!["high"]).toBeDefined()
+    },
+  })
+})
+
 test("Google Vertex: retains baseURL for custom proxy", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
Closes #2003

## What

Auto-detect reasoning models by checking if reasoningEffort is set in model options.

## Why

When users define custom providers with reasoningEffort in options, they must also manually set reasoning: true. Otherwise, the variants() function returns empty and Ctrl+T toggle doesn't appear. This is the scenario for Zen code models (mimo-v2.5-free, deepseek-v4-flash-free, etc.) and any other custom OpenAI-compatible provider.

## Changes

Check if reasoningEffort is set in model options when determining the reasoning capability flag.

## Verification

- New regression test: reasoning capability auto-detected from reasoningEffort (verified it fails without the fix)
- 84 provider tests pass
- TypeScript typecheck passes
- Change is minimal: 2 files (1 source line + 1 regression test)