### PR TITLE
feat(provider): surface free-tier opencode models when authenticated

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -303,12 +303,10 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         Boolean(yield* dep.auth(input.id)) ||
         Boolean((yield* dep.config()).provider?.["opencode"]?.options?.apiKey)
 
-      // Never surface the free/public tier (cost.input === 0). Without a
-      // subscription/key, hide the remaining (paid) models too — they can't be
-      // used unauthenticated. So: authenticated -> subscription models only,
-      // unauthenticated -> nothing.
+      // Without a subscription/key, hide all models — they can't be used
+      // unauthenticated. Authenticated users see both free and paid models.
       for (const [key, value] of Object.entries(input.models)) {
-        if (!ok || value.cost.input === 0) delete input.models[key]
+        if (!ok) delete input.models[key]
       }
 
       return {


### PR DESCRIPTION
Closes #2006

## What

Show free-tier opencode models (mimo-v2.5-free, deepseek-v4-flash-free, etc.) when the user is authenticated.

## Why

The current filter hides ALL free models (cost.input === 0) even with a valid API key. Users must manually define free models as a custom provider to use them, and miss out on automatic model metadata (reasoning capability, variants, pricing).

## Changes

Remove the cost-based filter. Unauthenticated users still see no models.

## Verification

- 458 provider tests pass
- TypeScript typecheck passes
- Change is minimal: 1 file, 3 lines added, 5 removed