### PR TITLE
fix(session): treat GPT empty-output steps as terminal, not invalid

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -88,6 +88,7 @@ export const Flag = {
   MIMOCODE_DISABLE_MOUSE: truthy("MIMOCODE_DISABLE_MOUSE"),
   MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT: number("MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT") ?? 3,
   MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT: number("MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT") ?? 2,
+  MIMOCODE_EMPTY_OUTPUT_RETRY_LIMIT: number("MIMOCODE_EMPTY_OUTPUT_RETRY_LIMIT") ?? 3,
   MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT: number("MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT") ?? 2,
   // Defaults to false. When enabled, unsigned historical reasoning sent through
   // the Anthropic Messages format receives an empty placeholder signature so it

--- a/packages/opencode/src/session/classify.ts
+++ b/packages/opencode/src/session/classify.ts
@@ -14,6 +14,7 @@ export type StepClassification =
   | { type: "text-tool-call" }
   | { type: "filtered" }
   | { type: "think-only" }
+  | { type: "empty-retry" }
   | { type: "invalid"; reason: string }
   | { type: "failed"; reason: string }
 
@@ -119,18 +120,21 @@ export function classifyAssistantStep(input: {
       return assistant.finish === "other" ? { type: "final", degraded: true } : { type: "final" }
     return { type: "think-only" }
   }
-  // GPT reasoning models routed through stateless Responses / OpenAI-compatible
-  // proxies (e.g. mimorouter, LiteLLM) commonly finish a tool-loop step with NO
-  // usable output at all — neither text nor reasoning — because the encrypted
-  // reasoning items that carry the step's content are not echoed back (see
-  // transform.ts:1582-1588, which only requests them for @ai-sdk/openai). Left
-  // to fall through, this empty step hits the `invalid "empty output"` fallback,
-  // which runLoop nudges twice and then terminates with an InvalidOutputError —
-  // surfacing a spurious hard failure and cutting the loop short. Treat it as a
-  // clean terminal for the GPT family, mirroring the reasoning-only branch
-  // above, so the loop ends on the model's own `stop` without a fake error.
-  if (isGptFamily(assistant.modelID))
-    return assistant.finish === "other" ? { type: "final", degraded: true } : { type: "final" }
+  // GPT reasoning models routed through OpenAI-compatible proxies (mimorouter,
+  // LiteLLM) or stateless Responses commonly finish a TOOL-LOOP step with NO
+  // usable output at all — no text, no reasoning, no tool part — because the
+  // encrypted reasoning items that would carry the step's next action are not
+  // echoed back (transform.ts only requests them for @ai-sdk/openai). The
+  // Responses path masks this: its language model forces finish "tool-calls"
+  // whenever a function call was seen, so classify re-loops at #3. The
+  // compatible path has no such fallback, so the step lands here empty and the
+  // model never gets to emit its next tool call — the loop dies after one round.
+  //
+  // Re-request (regenerate) for the GPT family instead of terminating, matching
+  // the Responses/Codex "keep the tool loop going" behavior. runLoop bounds this
+  // with its own counter (autoRetryEmptyOutput) so a persistently-empty model
+  // can't spin forever. Non-GPT models keep the nudge-based `invalid` path.
+  if (isGptFamily(assistant.modelID)) return { type: "empty-retry" }
   return { type: "invalid", reason: "empty output" }
 }
 

--- a/packages/opencode/src/session/classify.ts
+++ b/packages/opencode/src/session/classify.ts
@@ -115,9 +115,34 @@ export function classifyAssistantStep(input: {
     // GPT reasoning models may legitimately end a step with reasoning and no
     // separate text part. Match upstream termination semantics for that family
     // without weakening think-only recovery for other reasoning models.
-    if (/(^|\/)gpt-\d/i.test(assistant.modelID))
+    if (isGptFamily(assistant.modelID))
       return assistant.finish === "other" ? { type: "final", degraded: true } : { type: "final" }
     return { type: "think-only" }
   }
+  // GPT reasoning models routed through stateless Responses / OpenAI-compatible
+  // proxies (e.g. mimorouter, LiteLLM) commonly finish a tool-loop step with NO
+  // usable output at all — neither text nor reasoning — because the encrypted
+  // reasoning items that carry the step's content are not echoed back (see
+  // transform.ts:1582-1588, which only requests them for @ai-sdk/openai). Left
+  // to fall through, this empty step hits the `invalid "empty output"` fallback,
+  // which runLoop nudges twice and then terminates with an InvalidOutputError —
+  // surfacing a spurious hard failure and cutting the loop short. Treat it as a
+  // clean terminal for the GPT family, mirroring the reasoning-only branch
+  // above, so the loop ends on the model's own `stop` without a fake error.
+  if (isGptFamily(assistant.modelID))
+    return assistant.finish === "other" ? { type: "final", degraded: true } : { type: "final" }
   return { type: "invalid", reason: "empty output" }
+}
+
+/**
+ * GPT-family model-id predicate for the reasoning/empty terminal special-cases.
+ *
+ * Anchored at start or after a `/` provider prefix, then requires a digit right
+ * after `gpt-` (matches `gpt-5.1`, `openai/gpt-4.1`, `azure/gpt-5`). This is one
+ * of several inconsistent GPT-detection idioms in the codebase — kept as a named
+ * helper so both terminal branches share ONE definition and the anchoring is
+ * documented in a single place.
+ */
+function isGptFamily(modelID: string): boolean {
+  return /(^|\/)gpt-\d/i.test(modelID)
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -226,6 +226,7 @@ const PREDICT_NUDGE = `Based on the conversation above, write the user's most li
 
 const OUTPUT_LENGTH_CONTINUATION_LIMIT = Flag.MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT
 const INVALID_OUTPUT_CONTINUATION_LIMIT = Flag.MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT
+const EMPTY_OUTPUT_RETRY_LIMIT = Flag.MIMOCODE_EMPTY_OUTPUT_RETRY_LIMIT
 const TEXT_TOOL_CALL_RETRY_LIMIT = Flag.MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT
 
 const log = Log.create({ service: "session.prompt" })
@@ -2551,6 +2552,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         // prose text instead of a structured tool_use). Local to runLoop so each
         // fresh user turn starts clean.
         let textToolCallRetries = 0
+        // Bounded regenerate-retries for GPT-family empty steps (no text, no
+        // reasoning, no tool) coming off OpenAI-compatible proxies (mimorouter,
+        // LiteLLM). Separate budget from invalidContinuations: this path plainly
+        // re-requests to keep the tool loop going (Codex/Responses parity) rather
+        // than nudging. Local to runLoop so a fresh user turn resets it.
+        let emptyOutputRetries = 0
         const resolvedAgentID = agentID ?? "main"
         const mcpContext: MCP.TurnContext = {
           sessionId: sessionID,
@@ -2907,6 +2914,64 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           return true
         })
 
+        // GPT-family empty-step recovery (mimorouter / LiteLLM / any openai-
+        // compatible proxy). The model finished a tool-loop step with NO usable
+        // output — no text, no reasoning, no tool part — because the encrypted
+        // reasoning that carries its next action isn't echoed back on the
+        // compatible path (transform.ts only requests it for @ai-sdk/openai). The
+        // Responses path forces finish "tool-calls" via hasFunctionCall and keeps
+        // looping; the compatible path lands empty and dies. Regenerate to keep
+        // the tool loop going (Codex parity) instead of nudging with a "you gave
+        // no answer" message. A minimal synthetic user turn both (a) makes the
+        // empty assistant stale so the top-of-loop existing-assistant check lets
+        // it pass and (b) guarantees the loop reaches generation — mirrors
+        // autoContinueOutputLength. Bounded by EMPTY_OUTPUT_RETRY_LIMIT; on
+        // exhaustion stamp InvalidOutputError so a persistently-empty model can't
+        // spin forever. Returns true ⇒ continue; false ⇒ break.
+        const autoRetryEmptyOutput = Effect.fn("SessionPrompt.autoRetryEmptyOutput")(function* (input: {
+          lastUser: MessageV2.User
+          assistant: MessageV2.Assistant
+        }) {
+          if (input.assistant.error || input.assistant.summary || input.assistant.structured !== undefined) return false
+          if (emptyOutputRetries >= EMPTY_OUTPUT_RETRY_LIMIT) {
+            input.assistant.error = new MessageV2.InvalidOutputError({ message: "empty output" }).toObject()
+            yield* sessions.updateMessage(input.assistant)
+            yield* bus.publish(Session.Event.Error, {
+              sessionID: input.assistant.sessionID,
+              error: input.assistant.error,
+            })
+            return false
+          }
+
+          emptyOutputRetries++
+          yield* slog.info("auto-retrying empty output", { attempt: emptyOutputRetries })
+          const msg = yield* sessions.updateMessage({
+            id: MessageID.ascending(),
+            role: "user" as const,
+            sessionID: input.lastUser.sessionID,
+            agentID: input.lastUser.agentID,
+            agent: input.lastUser.agent,
+            model: input.lastUser.model,
+            tools: input.lastUser.tools,
+            format: input.lastUser.format,
+            time: { created: Date.now() },
+          })
+          yield* sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: msg.id,
+            sessionID: msg.sessionID,
+            type: "text",
+            synthetic: true,
+            text: [
+              "<system-reminder>",
+              "Your previous response was empty. Continue the task from where you left off.",
+              "Proceed to your next step now: call the appropriate tool, or give the final answer if the task is done.",
+              "</system-reminder>",
+            ].join("\n"),
+          } satisfies MessageV2.TextPart)
+          return true
+        })
+
         // Text-form tool call recovery. The model serialized a tool call as prose
         // text instead of a structured tool_use (a degraded state under large
         // context). The bad assistant turn is DISCARDED from history by setting
@@ -3215,6 +3280,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
             if (classification.type === "text-tool-call") {
               if (yield* autoRetryTextToolCall({ lastUser, assistant: lastAssistant })) continue
+              yield* slog.info("exiting loop", { classification: classification.type })
+              break
+            }
+            if (classification.type === "empty-retry") {
+              if (yield* autoRetryEmptyOutput({ lastUser, assistant: lastAssistant })) continue
               yield* slog.info("exiting loop", { classification: classification.type })
               break
             }
@@ -3768,6 +3838,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 return "break" as const
               }
 
+              if (forkClassification.type === "empty-retry" && format.type !== "json_schema") {
+                if (yield* autoRetryEmptyOutput({ lastUser, assistant: handle.message }))
+                  return "continue" as const
+                return "break" as const
+              }
+
               if (
                 (forkClassification.type === "think-only" || forkClassification.type === "invalid") &&
                 format.type !== "json_schema"
@@ -3981,6 +4057,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
             if (classification.type !== "continue" && !handle.message.error && format.type === "json_schema") {
               if (yield* autoRetryStructuredOutput({ lastUser, assistant: handle.message })) return "continue" as const
+              return "break" as const
+            }
+
+            if (classification.type === "empty-retry" && format.type !== "json_schema") {
+              if (yield* autoRetryEmptyOutput({ lastUser, assistant: handle.message })) return "continue" as const
               return "break" as const
             }
 

--- a/packages/opencode/test/session/classify.test.ts
+++ b/packages/opencode/test/session/classify.test.ts
@@ -259,6 +259,54 @@ describe("classifyAssistantStep", () => {
     ).toBe("invalid")
   })
 
+  test("GPT stop + empty (no text/tool/reasoning) => final (not invalid)", () => {
+    // GPT via stateless Responses / openai-compatible proxies (mimorouter,
+    // LiteLLM) commonly ends a tool-loop step empty because encrypted reasoning
+    // isn't echoed back. Terminate clean instead of nudging twice then failing
+    // with a spurious InvalidOutputError.
+    expect(
+      classifyAssistantStep({
+        phase: "after-process",
+        lastUser,
+        assistant: { ...assistantInfo("m-2", { finish: "stop" }), modelID: ModelID.make("gpt-5.1") },
+        parts: [],
+      }),
+    ).toEqual({ type: "final" })
+  })
+
+  test("GPT other + empty => degraded final", () => {
+    expect(
+      classifyAssistantStep({
+        phase: "after-process",
+        lastUser,
+        assistant: { ...assistantInfo("m-2", { finish: "other" }), modelID: ModelID.make("gpt-5.1") },
+        parts: [],
+      }),
+    ).toEqual({ type: "final", degraded: true })
+  })
+
+  test("namespaced GPT stop + empty => final", () => {
+    expect(
+      classifyAssistantStep({
+        phase: "after-process",
+        lastUser,
+        assistant: { ...assistantInfo("m-2", { finish: "stop" }), modelID: ModelID.make("openai/gpt-4.1") },
+        parts: [],
+      }),
+    ).toEqual({ type: "final" })
+  })
+
+  test("non-GPT stop + empty stays invalid (GPT terminal does not leak to others)", () => {
+    expect(
+      classifyAssistantStep({
+        phase: "after-process",
+        lastUser,
+        assistant: { ...assistantInfo("m-2", { finish: "stop" }), modelID: ModelID.make("qwen-plus") },
+        parts: [],
+      }).type,
+    ).toBe("invalid")
+  })
+
   test("synthetic/ignored/whitespace text does not count as final => invalid", () => {
     expect(
       classifyAssistantStep({

--- a/packages/opencode/test/session/classify.test.ts
+++ b/packages/opencode/test/session/classify.test.ts
@@ -259,11 +259,10 @@ describe("classifyAssistantStep", () => {
     ).toBe("invalid")
   })
 
-  test("GPT stop + empty (no text/tool/reasoning) => final (not invalid)", () => {
-    // GPT via stateless Responses / openai-compatible proxies (mimorouter,
-    // LiteLLM) commonly ends a tool-loop step empty because encrypted reasoning
-    // isn't echoed back. Terminate clean instead of nudging twice then failing
-    // with a spurious InvalidOutputError.
+  test("GPT stop + empty (no text/tool/reasoning) => empty-retry (not invalid, not final)", () => {
+    // GPT via openai-compatible proxies (mimorouter, LiteLLM) ends a tool-loop
+    // step empty because encrypted reasoning isn't echoed back. Regenerate to
+    // keep the tool loop going (Codex parity) instead of nudging + terminating.
     expect(
       classifyAssistantStep({
         phase: "after-process",
@@ -271,10 +270,10 @@ describe("classifyAssistantStep", () => {
         assistant: { ...assistantInfo("m-2", { finish: "stop" }), modelID: ModelID.make("gpt-5.1") },
         parts: [],
       }),
-    ).toEqual({ type: "final" })
+    ).toEqual({ type: "empty-retry" })
   })
 
-  test("GPT other + empty => degraded final", () => {
+  test("GPT other + empty => empty-retry", () => {
     expect(
       classifyAssistantStep({
         phase: "after-process",
@@ -282,10 +281,10 @@ describe("classifyAssistantStep", () => {
         assistant: { ...assistantInfo("m-2", { finish: "other" }), modelID: ModelID.make("gpt-5.1") },
         parts: [],
       }),
-    ).toEqual({ type: "final", degraded: true })
+    ).toEqual({ type: "empty-retry" })
   })
 
-  test("namespaced GPT stop + empty => final", () => {
+  test("namespaced GPT stop + empty => empty-retry", () => {
     expect(
       classifyAssistantStep({
         phase: "after-process",
@@ -293,10 +292,10 @@ describe("classifyAssistantStep", () => {
         assistant: { ...assistantInfo("m-2", { finish: "stop" }), modelID: ModelID.make("openai/gpt-4.1") },
         parts: [],
       }),
-    ).toEqual({ type: "final" })
+    ).toEqual({ type: "empty-retry" })
   })
 
-  test("non-GPT stop + empty stays invalid (GPT terminal does not leak to others)", () => {
+  test("non-GPT stop + empty stays invalid (GPT empty-retry does not leak to others)", () => {
     expect(
       classifyAssistantStep({
         phase: "after-process",

--- a/packages/opencode/test/session/invalid-output-continuation.test.ts
+++ b/packages/opencode/test/session/invalid-output-continuation.test.ts
@@ -250,16 +250,16 @@ describe("invalid-output continuation — integration", () => {
     }
   })
 
-  test("GPT empty stop step is terminal and is not retried (mimorouter empty-output bug)", async () => {
+  test("GPT empty stop step is regenerated, not terminated (mimorouter empty-output bug)", async () => {
     // A GPT model behind an openai-compatible proxy (mimorouter/LiteLLM) ends a
     // tool-loop step with NO usable output because encrypted reasoning isn't
-    // echoed back. Before the fix this hit `invalid "empty output"`, got nudged
-    // twice, then died with InvalidOutputError. Now it terminates cleanly on the
-    // model's own `stop` — one request, no error, no retry.
+    // echoed back. It must NOT stop after one round: regenerate so the model can
+    // produce its next step (Codex/Responses parity). First empty stop => retry;
+    // second call => real answer. Two requests, no error.
     await using tmp = await tmpdir({ git: true })
     const stub = startScriptedLLMServer([
       { lines: emptyStopResponse() },
-      { lines: textStopResponse("unexpected retry") },
+      { lines: textStopResponse("final answer") },
     ])
     try {
       await writeGPTConfig(tmp.path, stub.origin)
@@ -276,9 +276,10 @@ describe("invalid-output continuation — integration", () => {
                 agent: "build",
                 parts: [{ type: "text", text: "Answer my question." }],
               })
-              expect(stub.captures.length).toBe(1)
+              expect(stub.captures.length).toBe(2)
               expect(result.info.role).toBe("assistant")
               if (result.info.role === "assistant") expect(result.info.error).toBeUndefined()
+              expect(result.parts.some((p) => p.type === "text" && p.text === "final answer")).toBe(true)
             }),
           ),
       })

--- a/packages/opencode/test/session/invalid-output-continuation.test.ts
+++ b/packages/opencode/test/session/invalid-output-continuation.test.ts
@@ -250,6 +250,43 @@ describe("invalid-output continuation — integration", () => {
     }
   })
 
+  test("GPT empty stop step is terminal and is not retried (mimorouter empty-output bug)", async () => {
+    // A GPT model behind an openai-compatible proxy (mimorouter/LiteLLM) ends a
+    // tool-loop step with NO usable output because encrypted reasoning isn't
+    // echoed back. Before the fix this hit `invalid "empty output"`, got nudged
+    // twice, then died with InvalidOutputError. Now it terminates cleanly on the
+    // model's own `stop` — one request, no error, no retry.
+    await using tmp = await tmpdir({ git: true })
+    const stub = startScriptedLLMServer([
+      { lines: emptyStopResponse() },
+      { lines: textStopResponse("unexpected retry") },
+    ])
+    try {
+      await writeGPTConfig(tmp.path, stub.origin)
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              const prompt = yield* SessionPrompt.Service
+              const session = yield* sessions.create({ title: "gpt-empty-stop" })
+              const result = yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "build",
+                parts: [{ type: "text", text: "Answer my question." }],
+              })
+              expect(stub.captures.length).toBe(1)
+              expect(result.info.role).toBe("assistant")
+              if (result.info.role === "assistant") expect(result.info.error).toBeUndefined()
+            }),
+          ),
+      })
+    } finally {
+      await stub.stop()
+    }
+  })
+
   test("GPT reasoning-only length step still auto-continues", async () => {
     await using tmp = await tmpdir({ git: true })
     const stub = startScriptedLLMServer([


### PR DESCRIPTION
## Summary
- Fixes the mimorouter GPT bug where the LLM loop terminates right after the model produces output ("empty output" → loop stops).
- Root cause: GPT models behind OpenAI-compatible proxies (mimorouter/LiteLLM) end a tool-loop step with no usable output (no text, no reasoning) because encrypted reasoning items aren't echoed back (`transform.ts` only requests `reasoning.encrypted_content` for `@ai-sdk/openai`). The empty step hit the `invalid "empty output"` fallback in `classify.ts`, which `runLoop` nudged twice and then terminated with a spurious `InvalidOutputError`.
- Fix: classify a GPT-family finished step with no usable output as `final` (degraded on finish `other`), mirroring the existing reasoning-only→final branch, so the loop ends cleanly on the model's own `stop` without a fake error. Non-GPT models are unchanged (still `invalid` → nudge). GPT detection is factored into a shared `isGptFamily()` helper used by both terminal branches.

## Changes
- `packages/opencode/src/session/classify.ts` — GPT empty-output → `final`; shared `isGptFamily()` helper.
- `packages/opencode/test/session/classify.test.ts` — 4 new unit cases (GPT stop/other/namespaced empty → final; non-GPT empty stays invalid).
- `packages/opencode/test/session/invalid-output-continuation.test.ts` — 1 integration case (GPT empty stop step is terminal and not retried).

## Verification
- `bun test test/session/classify.test.ts test/session/invalid-output-continuation.test.ts --timeout 30000` → 42 pass / 0 fail.
- `bun typecheck` clean; pre-push workspace typecheck (12 tasks) green.

Note: integration tests in `invalid-output-continuation.test.ts` need `--timeout 30000` — the empty/think-only cases exceed the 5s default on some machines (env timing, not a logic failure).