### PR TITLE
fix(tui): stop the sidebar surviving a shrink, and stop scrollbar drags firing adjacent controls

### DIFF
--- a/docs/compose/spec/sidebar-shrink-and-press-gate.md
+++ b/docs/compose/spec/sidebar-shrink-and-press-gate.md
@@ -1,14 +1,68 @@
 ---
 feature: sidebar-shrink-and-press-gate
-status: in-progress
+status: delivered
 updated: 2026-08-03
 branch: fix/sidebar-shrink-and-press-gate
-commits: <base-sha>..<head-sha>
+commits: ce124cbd..95ecd9ab
 ---
 
 # Sidebar state model & press-gated mouse controls
 
 ## Report
+
+**What was built** — The right sidebar's two overlapping state variables collapse into one
+persisted tri-state `SidebarPreference`, normalised on every toggle so that a result the
+terminal width would have chosen anyway is stored as `auto`. The sticky state that kept a
+manually-expanded sidebar visible in terminals too narrow to dock it is now
+unrepresentable, rather than cleared by a resize handler. An expanded sidebar always offers
+a collapse control — the narrow-terminal overlay used to paint over the only one — while a
+collapsed sidebar offers an expand control only where it can dock, and a subagent view
+offers neither and cannot write the preference. `contentWidth` stops reserving the
+sidebar's columns in overlay mode, where the sidebar takes no layout space.
+
+Mouse activation for the sidebar toggle and the voice control moves behind
+`ui/press.ts`'s `createPress`, which takes a **stable click** only: press and release on
+the element with no `out` in between. This replaces `onMouseUp`-only handling, which
+opentui fires on whatever sits under the cursor when a drag captured elsewhere ends there —
+the scrollbar-drag mis-fire that prompted the work. The gate is a narrow opt-in, not a
+migration target: plain `onMouseUp` remains correct for the other ~127 call sites, and its
+entry criterion is a control where an accidental activation is itself the defect.
+
+**Verification** — `bun typecheck` in `packages/opencode` passes. `bun test
+test/cli/tui/press-gate.test.tsx test/cli/tui/sidebar-state.test.ts` — 16 pass. `bun test
+test/cli/tui test/cli/cmd/tui` — 261 pass, 1 fail, 1 error; the same command on base `main`
+gives 245 pass, 1 fail, 1 error, so that failure is `PRE-EXISTING` (`thread.test.ts`,
+independently root-caused: the workflow builtin `.js` files are function bodies with a
+top-level `return`, imported as raw text via `with { type: "text" }`, and Bun sometimes
+loads one through the ESM parser instead; minimal repro `bun test
+test/cli/tui/plugin-toggle.test.ts test/cli/tui/thread.test.ts`, each file green alone).
+Each fix was reproduced as a failing assertion before being made to pass, including the
+baseline mis-fire against a plain `onMouseUp` button and the `zIndex` layering, both proven
+with throwaway `testRender` probes.
+
+**Journey log**
+
+- Three review rounds each found a real CRITICAL, and the third one found a defect the
+  second round's own fix had introduced. When a fix keeps reopening its own area, the
+  problem is usually the model, not the patch: this gate was accumulating disarm hooks to
+  approximate browser click semantics against a dispatcher that does not supply the events
+  for it.
+- The product owner cut that knot by naming the contract instead of the mechanism —
+  stable click, `out` discards, don't care about the rest. That reverted a fix
+  (`d0bb626b` → `50fee2d1`) and turned a reviewer's CRITICAL into an asserted contract.
+  The asymmetry is the whole point: a dropped click is a non-event the user repeats, an
+  unintended one is the bug. Encode such a rule as a test, or the next contributor
+  "fixes" it.
+- Two hypotheses died to cheap experiments. Unrestored `spyOn`s looked like the obvious
+  cause of the pre-existing failure until reading the file showed `mockRestore()` in a
+  `finally`; a static-plus-dynamic double import of a text-loaded module looked like the
+  Bun bug until a 4-file standalone repro refused to reproduce. Both cost minutes and
+  saved a wrong fix.
+- `rg -rn` is `--replace`, not recursive — it silently rewrote match output mid-investigation
+  and briefly made `builtin.ts` look like it imported `./builtin/n.js`.
+- The upstream-facing half of that failure (a Bun text-import/ESM loader collision) is
+  parked with a worktree and no commits; CI is green because it shards test files across
+  four processes, so the two files that collide rarely share one.
 
 ## [S1] Problem
 
@@ -104,19 +158,29 @@ update and the `batch` it needed.
 
 - Expanded → a collapse control at **any** width.
 - Collapsed → an expand control only when wide enough to dock.
+- Subagent views → no control at all, and the `sidebar_toggle` command disabled.
 
-The render condition `sidebarVisible() || wide()` already expresses this; what was
-missing is that the narrow overlay painted over it. The button gets `zIndex={1}` so it
+The render condition `sidebarVisible() || wide()` already expresses the first two; what
+was missing is that the narrow overlay painted over the button. It gets `zIndex={1}` so it
 floats above the overlay, landing on the sidebar's right padding column. Verified both
 visually (`captureCharFrame`) and for hit-testing (`mockMouse` click at the raised
 button's cell).
 
+The third rule is new. `sidebarVisible()` was already gated on `currentAgentID() === "main"`
+while `sidebarToggle` is width-only, so on a subagent view the control offered "expand"
+and a click wrote `"hide"` — persisting a hidden sidebar for the main view. That gate is
+now a named `sidebarAllowed()` memo used by the panel, the button's `Show`, and the
+command's `enabled`. `main` rendered a dead button there (it mutated state but the agent
+gate suppressed any visible effect); the control is removed rather than made to work,
+since the sidebar itself cannot appear on a subagent view.
+
 `contentWidth` now subtracts the sidebar only when docked (`sidebarVisible() && wide()`),
 using a shared `SIDEBAR_WIDTH` constant exported from `sidebar.tsx` instead of a second
-hardcoded `42`. This removes the overlay-mode reflow and, because nothing is subtracted
-on narrow terminals, removes the non-positive-width case without needing a floor. The
-sidebar itself clamps to `Math.min(SIDEBAR_WIDTH, dimensions().width)` so it cannot
-overflow a terminal narrower than itself.
+hardcoded `42`. This removes the overlay-mode reflow and lifts the non-positive-width
+threshold from "below 46 columns" to "4 columns or fewer" — not a floor, just narrow
+enough to be unreachable; no clamp was added for a terminal that small. The sidebar itself
+clamps to `Math.min(SIDEBAR_WIDTH, dimensions().width)` so it cannot overflow a terminal
+narrower than itself.
 
 ### [S2.3] Stable-click gate
 
@@ -175,5 +239,7 @@ transcript text) whose action the user cannot casually undo.
 ## Tasks
 - [x] T1: Replace the two-signal sidebar state with `sidebarVisibleFor`/`sidebarToggle` in `routes/session/sidebar-state.ts` and wire both toggle sites — acceptance: a wide collapse/expand round-trip normalises to `auto` so a later shrink hides the sidebar; an explicit narrow expand persists (covers: S2.1)
 - [x] T2: Add `createPress` in `ui/press.ts` — acceptance: press outside + release inside does not fire; press inside + release inside fires exactly once; press inside + release outside does not fire (covers: S2.3)
-- [x] T3: Raise the toggle above the overlay, share `SIDEBAR_WIDTH`, clamp the sidebar, and adopt `createPress` in the toggle and the voice control — acceptance: the collapse glyph renders and is clickable with the overlay up; `contentWidth` stays positive at any width (covers: S2.2; S2.4; depends: T2)
+- [x] T3: Raise the toggle above the overlay, share `SIDEBAR_WIDTH`, clamp the sidebar, and adopt `createPress` in the toggle and the voice control — acceptance: the collapse glyph renders and is clickable with the overlay up; `contentWidth` stays positive at every reachable width (covers: S2.2; S2.4; depends: T2)
 - [x] T4: Regression tests plus typecheck — acceptance: `testRender` + `mockMouse` proves the captured-drag mis-fire is gated out, the state model is covered by pure tests, and `bun typecheck` passes (covers: S2.1; S2.3; depends: T1, T3)
+- [x] T5: Gate the control and the `sidebar_toggle` command on `sidebarAllowed()` — acceptance: a subagent view offers no sidebar affordance and cannot write the preference (covers: S2.2)
+- [x] T6: Fix the arm leak and the selection-drag release path, then settle the stable-click contract and record its entry criterion — acceptance: a foreign drag or selection released over a control never fires it; a drifted press is dropped and asserted as contract (covers: S2.3; S2.4; depends: T2)

--- a/docs/compose/spec/sidebar-shrink-and-press-gate.md
+++ b/docs/compose/spec/sidebar-shrink-and-press-gate.md
@@ -3,7 +3,7 @@ feature: sidebar-shrink-and-press-gate
 status: delivered
 updated: 2026-08-03
 branch: fix/sidebar-shrink-and-press-gate
-commits: 6853935c..PLACEHOLDER
+commits: 6853935c..6dff0b1a
 ---
 
 # Sidebar state model & press-gated mouse controls

--- a/docs/compose/spec/sidebar-shrink-and-press-gate.md
+++ b/docs/compose/spec/sidebar-shrink-and-press-gate.md
@@ -3,7 +3,7 @@ feature: sidebar-shrink-and-press-gate
 status: delivered
 updated: 2026-08-03
 branch: fix/sidebar-shrink-and-press-gate
-commits: ce124cbd..95ecd9ab
+commits: 6853935c..e796a77a
 ---
 
 # Sidebar state model & press-gated mouse controls

--- a/docs/compose/spec/sidebar-shrink-and-press-gate.md
+++ b/docs/compose/spec/sidebar-shrink-and-press-gate.md
@@ -1,0 +1,179 @@
+---
+feature: sidebar-shrink-and-press-gate
+status: in-progress
+updated: 2026-08-03
+branch: fix/sidebar-shrink-and-press-gate
+commits: <base-sha>..<head-sha>
+---
+
+# Sidebar state model & press-gated mouse controls
+
+## Report
+
+## [S1] Problem
+
+Two independent mouse/layout defects in the session TUI.
+
+**S1.1 — sidebar survives a shrink it cannot fit into, with no way to close it.**
+`routes/session/index.tsx` carried two overlapping pieces of sidebar state: a persisted
+`sidebar: "auto" | "hide"` (index.tsx:199) and an in-memory `sidebarOpen` signal
+(index.tsx:200). Visibility was
+
+```
+sidebarVisible = agent === "main" && (sidebarOpen || (sidebar === "auto" && wide))
+```
+
+`sidebarOpen` short-circuited ahead of the `wide` term and nothing ever cleared it.
+Collapsing then re-expanding on a wide terminal left `sidebarOpen === true` for the rest
+of the session, so shrinking below the `width > 120` threshold no longer auto-hid the
+sidebar: it flipped to the narrow full-area overlay branch (index.tsx:1497-1509), which
+paints over the 3-column toggle button (index.tsx:1480-1491) because the overlay is the
+later sibling with no `zIndex`. The user saw a sidebar that pops out with no visible
+control. Reproducible every time after one collapse/expand cycle; a fresh session reset
+`sidebarOpen` and looked fine, which is why it read as intermittent.
+
+The overlay buried the toggle in *every* narrow case, not just the sticky one — opening
+via `Ctrl+X B` on a narrow terminal produced the same unclosable-by-mouse sidebar. A
+throwaway `testRender` probe confirmed the layering: without `zIndex` the button's glyph
+is absent from the captured frame entirely.
+
+`contentWidth` (index.tsx:239) also subtracted the sidebar's hardcoded 42 columns even in
+overlay mode, where the sidebar takes no layout space. Below 46 columns that drove it
+non-positive.
+
+**S1.2 — scrollbar drags mis-trigger neighbouring buttons.** The sidebar toggle
+(index.tsx:155) and the voice control (component/prompt/index.tsx:1834-1851) fired on
+`onMouseUp` alone, with no record of where the press began. `@opentui/core`'s renderer
+dispatches a bare `up` to the renderable under the cursor *in addition to* delivering
+`drag-end`/`up` to the captured renderable, because the captured-`up` branch has no
+`return` before the generic dispatch at the end of `handleMouseEvent`. Dragging the
+transcript scrollbar — which becomes the captured renderable via `SliderRenderable`'s
+`onMouseDown`/`onMouseDrag` — and releasing with the cursor drifted onto an adjacent
+button therefore activated that button. The button also receives `over` during the drag,
+so its hover highlight lights up and the mis-fire looks intentional. Confirmed with a
+baseline `testRender` + `mockMouse` probe: an `onMouseUp`-only button fires when a drag
+captured on a neighbour is released over it.
+
+Two dispatch details constrain any fix:
+
+- Releasing inside a captured renderable delivers `up` **twice** (once from the captured
+  branch, once from the generic dispatch), so a press gate must consume its armed state
+  exactly once.
+- A captured renderable never receives `out` (the dispatcher guards with
+  `lastOverRenderable !== capturedRenderable`), so "press the button, drag away, release
+  outside" cannot be detected by hover tracking alone and needs a geometric bounds check
+  at release time.
+
+## [S2] Design
+
+### [S2.1] One tri-state preference, normalised on toggle
+
+`sidebarOpen` is deleted. The persisted preference widens to
+`SidebarPreference = "auto" | "show" | "hide"` and all logic moves into two pure
+functions in `routes/session/sidebar-state.ts`:
+
+```ts
+export function sidebarVisibleFor(preference: SidebarPreference, wide: boolean) {
+  if (preference === "auto") return wide
+  return preference === "show"
+}
+
+export function sidebarToggle(preference: SidebarPreference, wide: boolean): SidebarPreference {
+  const next = !sidebarVisibleFor(preference, wide)
+  if (next === wide) return "auto"
+  return next ? "show" : "hide"
+}
+```
+
+The normalisation is the fix for S1.1: a toggle whose resulting visibility matches what
+the width would have picked anyway stores `auto` rather than an override. A
+collapse/expand round-trip on a wide terminal therefore ends at `auto`, and a later
+shrink hides the sidebar again. No resize effect is needed — the sticky state cannot be
+represented.
+
+An explicit expand on a narrow terminal still yields `show`, which deliberately survives
+further shrinking: the user asked for it, so it stays until they collapse it. Collapsing
+it lands back on `auto` by the same rule. Existing `"auto"` / `"hide"` values on disk
+remain valid, so no kv migration is required.
+
+Both toggle call sites (`sidebar_toggle` command and the button) collapse to
+`setSidebar(() => sidebarToggle(sidebar(), wide()))`, removing the duplicated two-signal
+update and the `batch` it needed.
+
+### [S2.2] Toggle affordance rules
+
+- Expanded → a collapse control at **any** width.
+- Collapsed → an expand control only when wide enough to dock.
+
+The render condition `sidebarVisible() || wide()` already expresses this; what was
+missing is that the narrow overlay painted over it. The button gets `zIndex={1}` so it
+floats above the overlay, landing on the sidebar's right padding column. Verified both
+visually (`captureCharFrame`) and for hit-testing (`mockMouse` click at the raised
+button's cell).
+
+`contentWidth` now subtracts the sidebar only when docked (`sidebarVisible() && wide()`),
+using a shared `SIDEBAR_WIDTH` constant exported from `sidebar.tsx` instead of a second
+hardcoded `42`. This removes the overlay-mode reflow and, because nothing is subtracted
+on narrow terminals, removes the non-positive-width case without needing a floor. The
+sidebar itself clamps to `Math.min(SIDEBAR_WIDTH, dimensions().width)` so it cannot
+overflow a terminal narrower than itself.
+
+### [S2.3] Stable-click gate
+
+New `ui/press.ts` exporting `createPress(onPress: () => void)`, returning a `hover`
+accessor plus a spreadable prop bag. The contract is a **stable click**: press and release
+on the element with no `out` in between, once per press. Anything less is dropped.
+
+That asymmetry is the design. A dropped click is a non-event the user repeats; an
+unintended activation is the defect this exists to prevent, so every ambiguity resolves
+toward not firing. Browser semantics — where the pointer may leave the element and return
+and still produce a click — are explicitly not the goal. `out` also arrives on
+intra-element hit changes, because a child glyph and the box's own cells are separate hit
+targets, so a press that drifts one cell is discarded too. Asserted as such in the tests.
+
+- `onMouseDown` arms only if the press coordinates fall inside the element's rect.
+- `onMouseOut` disarms unconditionally; `onMouseDrag` disarms when the drag lands outside;
+  `onMouseDrop` disarms because a `drop` means a drag captured elsewhere ended here.
+- `onMouseUp` returns early when unarmed, disarms before anything else (the duplicate `up`
+  delivered inside a captured renderable is then inert), rejects releases carrying
+  `isDragging` (opentui sets that only on its two selection dispatches, so it identifies a
+  release closing a text selection — which never gets a preceding `drop`), and re-checks
+  the release coordinates against the rect.
+- `onMouseOver`/`onMouseOut` also drive the returned `hover` accessor, because the gate
+  must own `onMouseOut` and callers cannot register a second handler for it.
+
+Consumers must render unselectable content (`selectable={false}` on any `<text>`).
+Otherwise the element's own press starts a text selection, every release arrives with
+`isDragging`, and the control is silently dead. Stated in the exported doc comment.
+
+Bounds come from the renderable captured through `ref`; `Renderable` exposes absolute
+`x`/`y`/`width`/`height` in the same coordinate space as `MouseEvent`'s `x`/`y`.
+
+### [S2.4] Adoption, and where this must NOT spread
+
+`SidebarToggleButton` and the voice control consume `createPress`. The voice control's
+five `Match` branches share one gate instance created outside the `Switch`; the
+non-interactive `finishing` branch keeps no handlers. Both render unselectable glyphs.
+
+The gate is deliberately **not** a general replacement for `onMouseUp`, and the remaining
+~127 `onMouseUp` sites are not queued for migration. Handling only `up` is correct for the
+great majority of controls; routing one of them through the gate buys nothing and costs it
+dropped clicks. The entry criterion is a control where an accidental activation is itself
+the defect — in practice, one adjacent to a drag surface (a scrollbar, selectable
+transcript text) whose action the user cannot casually undo.
+
+## [S3] Out of Scope
+
+- Migrating the other ~127 `onMouseUp` handlers to the press gate. Not a backlog item: see
+  [S2.4] — most controls should keep plain `onMouseUp`.
+- Subtracting the toggle button's 3 columns from `contentWidth` — a pre-existing
+  discrepancy; changing it would reflow every transcript.
+- Patching the upstream `@opentui/core` dispatch bug.
+- The pre-existing `test/cli/tui/thread.test.ts` failure and the workflow-builtin `.js`
+  load error it surfaces when the suite runs as a batch.
+
+## Tasks
+- [x] T1: Replace the two-signal sidebar state with `sidebarVisibleFor`/`sidebarToggle` in `routes/session/sidebar-state.ts` and wire both toggle sites — acceptance: a wide collapse/expand round-trip normalises to `auto` so a later shrink hides the sidebar; an explicit narrow expand persists (covers: S2.1)
+- [x] T2: Add `createPress` in `ui/press.ts` — acceptance: press outside + release inside does not fire; press inside + release inside fires exactly once; press inside + release outside does not fire (covers: S2.3)
+- [x] T3: Raise the toggle above the overlay, share `SIDEBAR_WIDTH`, clamp the sidebar, and adopt `createPress` in the toggle and the voice control — acceptance: the collapse glyph renders and is clickable with the overlay up; `contentWidth` stays positive at any width (covers: S2.2; S2.4; depends: T2)
+- [x] T4: Regression tests plus typecheck — acceptance: `testRender` + `mockMouse` proves the captured-drag mis-fire is gated out, the state model is covered by pure tests, and `bun typecheck` passes (covers: S2.1; S2.3; depends: T1, T3)

--- a/docs/compose/spec/sidebar-shrink-and-press-gate.md
+++ b/docs/compose/spec/sidebar-shrink-and-press-gate.md
@@ -3,7 +3,7 @@ feature: sidebar-shrink-and-press-gate
 status: delivered
 updated: 2026-08-03
 branch: fix/sidebar-shrink-and-press-gate
-commits: 6853935c..fceb9f50
+commits: 6853935c..PLACEHOLDER
 ---
 
 # Sidebar state model & press-gated mouse controls
@@ -37,8 +37,9 @@ top-level `return`, imported as raw text via `with { type: "text" }`, and Bun so
 loads one through the ESM parser instead; minimal repro `bun test
 test/cli/tui/plugin-toggle.test.ts test/cli/tui/thread.test.ts`, each file green alone).
 Each fix was reproduced as a failing assertion before being made to pass, including the
-baseline mis-fire against a plain `onMouseUp` button and the `zIndex` layering, both proven
-with throwaway `testRender` probes.
+baseline mis-fire against a plain `onMouseUp` button, the dropped intra-element click, and
+the toggle's position parity between docked and overlay modes, all proven with throwaway
+`testRender` probes.
 
 **Journey log**
 
@@ -166,11 +167,15 @@ update and the `batch` it needed.
 - Collapsed → an expand control only when wide enough to dock.
 - Subagent views → no control at all, and the `sidebar_toggle` command disabled.
 
-The render condition `sidebarVisible() || wide()` already expresses the first two; what
-was missing is that the narrow overlay painted over the button. It gets `zIndex={1}` so it
-floats above the overlay, landing on the sidebar's right padding column. Verified both
-visually (`captureCharFrame`) and for hit-testing (`mockMouse` click at the raised
-button's cell).
+The render condition `sidebarVisible() || wide()` already expressed the first two; what was
+missing is that the narrow overlay painted over the button. Rather than raise the button
+above the overlay, it now rides *inside* it as a right-aligned row sibling placed before the
+panel. That keeps one invariant across both modes — the control sits immediately to the left
+of the sidebar — instead of the control appearing left of the panel when docked and on the
+panel's right edge when overlaid. It also removes the `zIndex` the raised version needed, and
+simplifies the in-flow gate to `sidebarAllowed() && wide()` since the overlay now owns its
+own control. Verified by comparing captured frames: the glyph occupies the same column and
+the sidebar starts at the same column in both modes, with exactly one control rendered.
 
 The third rule is new. `sidebarVisible()` was already gated on `currentAgentID() === "main"`
 while `sidebarToggle` is width-only, so on a subagent view the control offered "expand"

--- a/docs/compose/spec/sidebar-shrink-and-press-gate.md
+++ b/docs/compose/spec/sidebar-shrink-and-press-gate.md
@@ -3,7 +3,7 @@ feature: sidebar-shrink-and-press-gate
 status: delivered
 updated: 2026-08-03
 branch: fix/sidebar-shrink-and-press-gate
-commits: 6853935c..e796a77a
+commits: 6853935c..fceb9f50
 ---
 
 # Sidebar state model & press-gated mouse controls
@@ -47,12 +47,18 @@ with throwaway `testRender` probes.
   problem is usually the model, not the patch: this gate was accumulating disarm hooks to
   approximate browser click semantics against a dispatcher that does not supply the events
   for it.
-- The product owner cut that knot by naming the contract instead of the mechanism —
-  stable click, `out` discards, don't care about the rest. That reverted a fix
-  (`d0bb626b` → `50fee2d1`) and turned a reviewer's CRITICAL into an asserted contract.
-  The asymmetry is the whole point: a dropped click is a non-event the user repeats, an
-  unintended one is the bug. Encode such a rule as a test, or the next contributor
-  "fixes" it.
+- The product owner cut that knot by naming the contract instead of the mechanism — stable
+  click, leaving discards, don't care about the rest. That reverted a fix (`d0bb626b` →
+  `50fee2d1`) and turned a reviewer's CRITICAL into an asserted contract. The asymmetry is
+  the whole point: a dropped click is a non-event the user repeats, an unintended one is the
+  bug. Encode such a rule as a test, or the next contributor "fixes" it.
+- The contract then had to be read precisely, because "no `out`" and "never left" are not
+  the same predicate here. Reverting wholesale also discarded clicks that merely drifted
+  inside the control, which the contract never asked for. Restoring the geometric check
+  turned out to cost nothing: the mis-fire it had been reverted for only reproduces when a
+  press arrives with no preceding pointer motion, which no real pointer does. The lesson is
+  that the earlier revert leaned on a reviewer's synthetic repro without asking whether the
+  input sequence was reachable — measure the cost of a guard before paying for it.
 - Two hypotheses died to cheap experiments. Unrestored `spyOn`s looked like the obvious
   cause of the pre-existing failure until reading the file showed `mockRestore()` in a
   `finally`; a static-plus-dynamic double import of a text-loaded module looked like the
@@ -185,19 +191,27 @@ narrower than itself.
 ### [S2.3] Stable-click gate
 
 New `ui/press.ts` exporting `createPress(onPress: () => void)`, returning a `hover`
-accessor plus a spreadable prop bag. The contract is a **stable click**: press and release
-on the element with no `out` in between, once per press. Anything less is dropped.
+accessor plus a spreadable prop bag. The contract is a **stable click**: the press and the
+release both land on the element and the pointer never leaves its bounds in between, once
+per press. Movement within the element is fine.
 
 That asymmetry is the design. A dropped click is a non-event the user repeats; an
 unintended activation is the defect this exists to prevent, so every ambiguity resolves
 toward not firing. Browser semantics — where the pointer may leave the element and return
-and still produce a click — are explicitly not the goal. `out` also arrives on
-intra-element hit changes, because a child glyph and the box's own cells are separate hit
-targets, so a press that drifts one cell is discarded too. Asserted as such in the tests.
+and still produce a click — are explicitly not the goal.
+
+"Left the element" has to be decided geometrically rather than from the event name, because
+opentui raises `out` and `over` on intra-element hit-target changes as well: a child glyph
+and the box's own cells are separate hit targets, and both events bubble to the parent, so
+the parent sees `out` while the pointer is still inside it. `MouseEvent.target` does not
+settle it either, since an `out` is dispatched to the element being left — which is that
+same child both when the pointer merely crosses an internal boundary and when it exits the
+control entirely. The coordinates do settle it: `out` carries the pointer's new position.
 
 - `onMouseDown` arms only if the press coordinates fall inside the element's rect.
-- `onMouseOut` disarms unconditionally; `onMouseDrag` disarms when the drag lands outside;
-  `onMouseDrop` disarms because a `drop` means a drag captured elsewhere ended here.
+- `onMouseOut` and `onMouseOver` disarm only when the event's new position is outside the
+  rect; `onMouseDrag` disarms when the drag lands outside; `onMouseDrop` disarms because a
+  `drop` means a drag captured elsewhere ended here.
 - `onMouseUp` returns early when unarmed, disarms before anything else (the duplicate `up`
   delivered inside a captured renderable is then inert), rejects releases carrying
   `isDragging` (opentui sets that only on its two selection dispatches, so it identifies a
@@ -205,6 +219,14 @@ targets, so a press that drifts one cell is discarded too. Asserted as such in t
   the release coordinates against the rect.
 - `onMouseOver`/`onMouseOut` also drive the returned `hover` accessor, because the gate
   must own `onMouseOut` and callers cannot register a second handler for it.
+
+One limitation is accepted and documented rather than worked around: a press that arrives
+with no preceding pointer movement onto the element cannot be disarmed when it drags away,
+because opentui then delivers the element no event at all for that press — it is too narrow
+to become the capture target, and `lastOverRenderable` was never pointed at it. This was
+measured rather than assumed: with a realistic hover-then-press sequence the drag-off does
+deliver an `out` and disarms, and only a synthetic press with no prior motion reproduces the
+stale arm. Real pointers always generate that movement first.
 
 Consumers must render unselectable content (`selectable={false}` on any `<text>`).
 Otherwise the element's own press starts a text selection, every release arrives with

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -41,6 +41,7 @@ import { DialogProvider as DialogProviderConnect } from "../dialog-provider"
 import { DialogAlert } from "../../ui/dialog-alert"
 import { DialogPrompt } from "../../ui/dialog-prompt"
 import { useToast } from "../../ui/toast"
+import { createPress } from "../../ui/press"
 import { useKV } from "../../context/kv"
 import { createFadeIn } from "../../util/signal"
 import { useTextareaKeybindings } from "../textarea-keybindings"
@@ -366,6 +367,8 @@ export function Prompt(props: PromptProps) {
     activeVoice = av
     setVoiceState("listening")
   }
+
+  const voicePress = createPress(() => void voiceToggle())
 
   const list = createMemo(() => props.placeholders?.normal ?? [])
   const shell = createMemo(() => props.placeholders?.shell ?? [])
@@ -1831,22 +1834,22 @@ export function Prompt(props: PromptProps) {
                 <Show when={voiceEnabled()}>
                   <Switch>
                     <Match when={voiceState() === "idle"}>
-                      <text fg={theme.textMuted} selectable={false} onMouseUp={() => voiceToggle()}>
+                      <text fg={theme.textMuted} selectable={false} {...voicePress.props}>
                         {"[ 🎙  Voice ]"}
                       </text>
                     </Match>
                     <Match when={voiceState() === "listening"}>
-                      <text fg={theme.primary} selectable={false} onMouseUp={() => voiceToggle()}>
+                      <text fg={theme.primary} selectable={false} {...voicePress.props}>
                         {"[ 🎙  -:-- ]"}
                       </text>
                     </Match>
                     <Match when={voiceState() === "speaking"}>
-                      <text fg={theme.primary} selectable={false} onMouseUp={() => voiceToggle()}>
+                      <text fg={theme.primary} selectable={false} {...voicePress.props}>
                         {`[ 🎙  ${Math.floor(voiceElapsed() / 60)}:${String(voiceElapsed() % 60).padStart(2, "0")} ]`}
                       </text>
                     </Match>
                     <Match when={voiceState() === "processing"}>
-                      <text fg={theme.primary} selectable={false} onMouseUp={() => voiceToggle()}>
+                      <text fg={theme.primary} selectable={false} {...voicePress.props}>
                         {"[ 🎙  .... ]"}
                       </text>
                     </Match>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -150,9 +150,6 @@ function SidebarToggleButton(props: { visible: boolean; onToggle: () => void }) 
       height="100%"
       justifyContent="flex-start"
       alignItems="center"
-      // Above the narrow-terminal sidebar overlay, which would otherwise bury the only
-      // mouse affordance for collapsing it again.
-      zIndex={1}
       backgroundColor={press.hover() ? theme.backgroundElement : undefined}
       {...press.props}
     >
@@ -237,6 +234,7 @@ export function Session() {
   const sidebarVisible = createMemo(() => sidebarAllowed() && sidebarVisibleFor(sidebar(), wide()))
   // Only a docked sidebar consumes layout width; the narrow overlay floats above the transcript.
   const sidebarDocked = createMemo(() => sidebarVisible() && wide())
+  const toggleSidebar = () => setSidebar(() => sidebarToggle(sidebar(), wide()))
   const showTimestamps = createMemo(() => timestamps() === "show")
   const contentWidth = createMemo(() => dimensions().width - (sidebarDocked() ? SIDEBAR_WIDTH : 0) - 4)
   const providers = createMemo(() => Model.index(sync.data.provider))
@@ -795,7 +793,7 @@ export function Session() {
       category: "session",
       enabled: sidebarAllowed(),
       onSelect: (dialog) => {
-        setSidebar(() => sidebarToggle(sidebar(), wide()))
+        toggleSidebar()
         dialog.clear()
       },
     },
@@ -1476,11 +1474,8 @@ export function Session() {
           </Show>
           <Toast />
         </box>
-        <Show when={sidebarAllowed() && (sidebarVisible() || wide())}>
-          <SidebarToggleButton
-            visible={sidebarVisible()}
-            onToggle={() => setSidebar(() => sidebarToggle(sidebar(), wide()))}
-          />
+        <Show when={sidebarAllowed() && wide()}>
+          <SidebarToggleButton visible={sidebarVisible()} onToggle={toggleSidebar} />
         </Show>
         <Show when={sidebarVisible()}>
           <Switch>
@@ -1488,15 +1483,19 @@ export function Session() {
               <Sidebar sessionID={route.sessionID} />
             </Match>
             <Match when={!wide()}>
+              {/* The control rides inside the overlay so it keeps the same position
+                  relative to the sidebar as when docked: immediately to its left. */}
               <box
                 position="absolute"
                 top={0}
                 left={0}
                 right={0}
                 bottom={0}
-                alignItems="flex-end"
+                flexDirection="row"
+                justifyContent="flex-end"
                 backgroundColor={RGBA.fromInts(0, 0, 0, 70)}
               >
+                <SidebarToggleButton visible={sidebarVisible()} onToggle={toggleSidebar} />
                 <Sidebar sessionID={route.sessionID} />
               </box>
             </Match>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -156,7 +156,9 @@ function SidebarToggleButton(props: { visible: boolean; onToggle: () => void }) 
       backgroundColor={press.hover() ? theme.backgroundElement : undefined}
       {...press.props}
     >
-      <text fg={press.hover() ? theme.text : theme.textMuted}>{props.visible ? "▶" : "◀"}</text>
+      <text selectable={false} fg={press.hover() ? theme.text : theme.textMuted}>
+        {props.visible ? "▶" : "◀"}
+      </text>
     </box>
   )
 }
@@ -791,6 +793,7 @@ export function Session() {
       value: "session.sidebar.toggle",
       keybind: "sidebar_toggle",
       category: "session",
+      enabled: sidebarAllowed(),
       onSelect: (dialog) => {
         setSidebar(() => sidebarToggle(sidebar(), wide()))
         dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -230,10 +230,9 @@ export function Session() {
   const fromWorkflowRunID = createMemo(() => route.fromWorkflowRunID)
 
   const wide = createMemo(() => dimensions().width > 120)
-  const sidebarVisible = createMemo(() => {
-    if (currentAgentID() !== "main") return false
-    return sidebarVisibleFor(sidebar(), wide())
-  })
+  // Subagent views have no sidebar at all, so neither the panel nor its control belongs there.
+  const sidebarAllowed = createMemo(() => currentAgentID() === "main")
+  const sidebarVisible = createMemo(() => sidebarAllowed() && sidebarVisibleFor(sidebar(), wide()))
   // Only a docked sidebar consumes layout width; the narrow overlay floats above the transcript.
   const sidebarDocked = createMemo(() => sidebarVisible() && wide())
   const showTimestamps = createMemo(() => timestamps() === "show")
@@ -1474,7 +1473,7 @@ export function Session() {
           </Show>
           <Toast />
         </box>
-        <Show when={sidebarVisible() || wide()}>
+        <Show when={sidebarAllowed() && (sidebarVisible() || wide())}>
           <SidebarToggleButton
             visible={sidebarVisible()}
             onToggle={() => setSidebar(() => sidebarToggle(sidebar(), wide()))}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1,5 +1,4 @@
 import {
-  batch,
   createContext,
   createEffect,
   createMemo,
@@ -68,7 +67,9 @@ import { DialogPrompt } from "@tui/ui/dialog-prompt"
 import { DialogTimeline } from "./dialog-timeline"
 import { DialogForkFromTimeline } from "./dialog-fork-from-timeline"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
-import { Sidebar } from "./sidebar"
+import { Sidebar, SIDEBAR_WIDTH } from "./sidebar"
+import { sidebarToggle, sidebarVisibleFor, type SidebarPreference } from "./sidebar-state"
+import { createPress } from "../../ui/press"
 import { WorkflowTree } from "@tui/component/workflow-tree"
 import { SubagentFooter } from "./subagent-footer.tsx"
 import { DialogSubagent } from "./dialog-subagent.tsx"
@@ -142,19 +143,20 @@ function use() {
 
 function SidebarToggleButton(props: { visible: boolean; onToggle: () => void }) {
   const { theme } = useTheme()
-  const [hover, setHover] = createSignal(false)
+  const press = createPress(() => props.onToggle())
   return (
     <box
       width={3}
       height="100%"
       justifyContent="flex-start"
       alignItems="center"
-      backgroundColor={hover() ? theme.backgroundElement : undefined}
-      onMouseOver={() => setHover(true)}
-      onMouseOut={() => setHover(false)}
-      onMouseUp={() => props.onToggle()}
+      // Above the narrow-terminal sidebar overlay, which would otherwise bury the only
+      // mouse affordance for collapsing it again.
+      zIndex={1}
+      backgroundColor={press.hover() ? theme.backgroundElement : undefined}
+      {...press.props}
     >
-      <text fg={hover() ? theme.text : theme.textMuted}>{props.visible ? "▶" : "◀"}</text>
+      <text fg={press.hover() ? theme.text : theme.textMuted}>{props.visible ? "▶" : "◀"}</text>
     </box>
   )
 }
@@ -196,8 +198,7 @@ export function Session() {
   })
 
   const dimensions = useTerminalDimensions()
-  const [sidebar, setSidebar] = kv.signal<"auto" | "hide">("sidebar", "auto")
-  const [sidebarOpen, setSidebarOpen] = createSignal(false)
+  const [sidebar, setSidebar] = kv.signal<SidebarPreference>("sidebar", "auto")
   const [conceal, setConceal] = createSignal(true)
   const thinking = useThinkingMode()
   const thinkingMode = thinking.mode
@@ -231,12 +232,12 @@ export function Session() {
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
     if (currentAgentID() !== "main") return false
-    if (sidebarOpen()) return true
-    if (sidebar() === "auto" && wide()) return true
-    return false
+    return sidebarVisibleFor(sidebar(), wide())
   })
+  // Only a docked sidebar consumes layout width; the narrow overlay floats above the transcript.
+  const sidebarDocked = createMemo(() => sidebarVisible() && wide())
   const showTimestamps = createMemo(() => timestamps() === "show")
-  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+  const contentWidth = createMemo(() => dimensions().width - (sidebarDocked() ? SIDEBAR_WIDTH : 0) - 4)
   const providers = createMemo(() => Model.index(sync.data.provider))
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
@@ -792,11 +793,7 @@ export function Session() {
       keybind: "sidebar_toggle",
       category: "session",
       onSelect: (dialog) => {
-        batch(() => {
-          const isVisible = sidebarVisible()
-          setSidebar(() => (isVisible ? "hide" : "auto"))
-          setSidebarOpen(!isVisible)
-        })
+        setSidebar(() => sidebarToggle(sidebar(), wide()))
         dialog.clear()
       },
     },
@@ -1477,16 +1474,10 @@ export function Session() {
           </Show>
           <Toast />
         </box>
-        <Show when={wide() || sidebarVisible()}>
+        <Show when={sidebarVisible() || wide()}>
           <SidebarToggleButton
             visible={sidebarVisible()}
-            onToggle={() => {
-              batch(() => {
-                const isVisible = sidebarVisible()
-                setSidebar(() => (isVisible ? "hide" : "auto"))
-                setSidebarOpen(!isVisible)
-              })
-            }}
+            onToggle={() => setSidebar(() => sidebarToggle(sidebar(), wide()))}
           />
         </Show>
         <Show when={sidebarVisible()}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar-state.ts
@@ -1,0 +1,21 @@
+/**
+ * Sidebar visibility preference. `auto` follows the terminal width; `show`/`hide` are
+ * explicit user overrides that outlive a resize.
+ */
+export type SidebarPreference = "auto" | "show" | "hide"
+
+export function sidebarVisibleFor(preference: SidebarPreference, wide: boolean) {
+  if (preference === "auto") return wide
+  return preference === "show"
+}
+
+/**
+ * Toggling normalises back to `auto` whenever the requested state is what the width
+ * would have picked anyway. That keeps a collapse/expand round-trip on a wide terminal
+ * from leaving behind a `show` override that survives a shrink.
+ */
+export function sidebarToggle(preference: SidebarPreference, wide: boolean): SidebarPreference {
+  const next = !sidebarVisibleFor(preference, wide)
+  if (next === wide) return "auto"
+  return next ? "show" : "hide"
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -1,6 +1,7 @@
 import { useProject } from "@tui/context/project"
 import { useSync } from "@tui/context/sync"
 import { createMemo, Show } from "solid-js"
+import { useTerminalDimensions } from "@opentui/solid"
 import { useTheme } from "../../context/theme"
 import { useTuiConfig } from "../../context/tui-config"
 import { InstallationChannel, InstallationVersion } from "@/installation/version"
@@ -8,11 +9,14 @@ import { TuiPluginRuntime } from "../../plugin"
 
 import { getScrollAcceleration } from "../../util/scroll"
 
+export const SIDEBAR_WIDTH = 42
+
 export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const project = useProject()
   const sync = useSync()
   const { theme } = useTheme()
   const tuiConfig = useTuiConfig()
+  const dimensions = useTerminalDimensions()
   const session = createMemo(() => sync.session.get(props.sessionID))
   const workspaceStatus = () => {
     const workspaceID = session()?.workspaceID
@@ -32,7 +36,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
     <Show when={session()}>
       <box
         backgroundColor={theme.backgroundPanel}
-        width={42}
+        width={Math.min(SIDEBAR_WIDTH, dimensions().width)}
         height="100%"
         paddingTop={1}
         paddingBottom={1}

--- a/packages/opencode/src/cli/cmd/tui/ui/press.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/press.ts
@@ -21,10 +21,26 @@ export function createPress(onPress: () => void) {
   return {
     hover,
     props: {
-      ref: (r: Renderable) => (node = r),
-      onMouseOver: () => setHover(true),
+      ref: (r: Renderable) => {
+        node = r
+      },
+      // A press can end without this element ever seeing `out` or `up` (opentui only
+      // refreshes `lastOverRenderable` on a cross-element drag/move, and never sends
+      // `out` to the capture target), so every event that proves the pointer is no
+      // longer pressing us has to disarm.
+      onMouseOver: () => {
+        setHover(true)
+        armed = false
+      },
       onMouseOut: () => {
         setHover(false)
+        armed = false
+      },
+      onMouseDrag: (evt: MouseEvent) => {
+        if (inside(evt)) return
+        armed = false
+      },
+      onMouseDrop: () => {
         armed = false
       },
       onMouseDown: (evt: MouseEvent) => {

--- a/packages/opencode/src/cli/cmd/tui/ui/press.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/press.ts
@@ -4,18 +4,20 @@ import type { MouseEvent, Renderable } from "@opentui/core"
 /**
  * Click gate for controls where a mis-fire is costly — one sitting next to a drag surface
  * (a scrollbar, selectable transcript text) whose action the user cannot casually undo.
- * Fires only on a stable click: press and release on the element with no `out` in between.
+ * Fires only when the press and the release both land on the element and the pointer never
+ * left its bounds in between. Movement within the element is fine.
  *
  * NOT a general replacement for `onMouseUp`. Plain `onMouseUp` is correct for the great
  * majority of controls, and routing one through here only costs it dropped clicks. Adopt
  * this only when an accidental activation is the problem being solved.
  *
- * Anything less than a stable click is dropped, deliberately: a dropped click is a
- * non-event the user repeats, while an unintended one is the bug this exists to prevent.
- * `out` also arrives on intra-element hit changes (a child glyph and the box's own cells
- * are separate hit targets), so a press that drifts even one cell is discarded. That is
- * the intended trade — browser semantics, where the pointer may leave and return, are
- * explicitly not the goal here.
+ * Ambiguity resolves toward not firing: a dropped click is a non-event the user repeats,
+ * while an unintended one is the bug this exists to prevent. Leaving the element and
+ * returning does not produce a click — browser semantics are not the goal.
+ *
+ * Known limitation: a press that arrives with no preceding pointer movement onto the
+ * element cannot be disarmed when it drags away, because opentui then delivers the element
+ * no event at all for that press. Real pointers always generate that movement first.
  *
  * The element's own content must be unselectable (`selectable={false}` on any `<text>`),
  * otherwise its own press starts a text selection and every release is discarded as a
@@ -39,11 +41,16 @@ export function createPress(onPress: () => void) {
       ref: (r: Renderable) => {
         node = r
       },
-      onMouseOver: () => {
+      // opentui raises out/over on intra-element hit changes too — a child glyph and the
+      // box's own cells are separate hit targets, and both events bubble here — so only a
+      // pointer whose new position is outside our bounds counts as having left.
+      onMouseOver: (evt: MouseEvent) => {
         setHover(true)
+        if (inside(evt)) return
         armed = false
       },
-      onMouseOut: () => {
+      onMouseOut: (evt: MouseEvent) => {
+        if (inside(evt)) return
         setHover(false)
         armed = false
       },

--- a/packages/opencode/src/cli/cmd/tui/ui/press.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/press.ts
@@ -1,0 +1,42 @@
+import { createSignal } from "solid-js"
+import type { MouseEvent, Renderable } from "@opentui/core"
+
+/**
+ * Click gate: fires only when press and release both land on the element, once per press.
+ * Guards against opentui delivering a bare `up` to whatever sits under the cursor when a
+ * drag captured elsewhere (a scrollbar, a text selection) ends there.
+ */
+export function createPress(onPress: () => void) {
+  const [hover, setHover] = createSignal(false)
+  let node: Renderable | undefined
+  let armed = false
+
+  const inside = (evt: MouseEvent) =>
+    !!node &&
+    evt.x >= node.x &&
+    evt.x < node.x + node.width &&
+    evt.y >= node.y &&
+    evt.y < node.y + node.height
+
+  return {
+    hover,
+    props: {
+      ref: (r: Renderable) => (node = r),
+      onMouseOver: () => setHover(true),
+      onMouseOut: () => {
+        setHover(false)
+        armed = false
+      },
+      onMouseDown: (evt: MouseEvent) => {
+        armed = inside(evt)
+      },
+      onMouseUp: (evt: MouseEvent) => {
+        if (!armed) return
+        // Consume first: a release inside a captured renderable is dispatched twice.
+        armed = false
+        if (!inside(evt)) return
+        onPress()
+      },
+    },
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/ui/press.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/press.ts
@@ -2,9 +2,15 @@ import { createSignal } from "solid-js"
 import type { MouseEvent, Renderable } from "@opentui/core"
 
 /**
- * Click gate: fires only when press and release both land on the element, once per press.
- * Guards against opentui delivering a bare `up` to whatever sits under the cursor when a
- * drag captured elsewhere (a scrollbar, a text selection) ends there.
+ * Click gate for small controls: fires only on a stable click — press and release on the
+ * element with no `out` in between. Anything less is dropped, deliberately. Dropping a
+ * click is a non-event the user repeats; firing one they did not intend is not, and
+ * opentui hands a bare `up` to whatever sits under the cursor when a drag captured
+ * elsewhere (a scrollbar, a text selection) ends there.
+ *
+ * `out` arrives on intra-element hit changes too (a child glyph and the box's own cells
+ * are separate hit targets), so a press that drifts even one cell is discarded. That is
+ * the intended trade, not an oversight.
  *
  * The element's own content must be unselectable (`selectable={false}` on any `<text>`),
  * otherwise its own press starts a text selection and every release is discarded as a
@@ -28,15 +34,11 @@ export function createPress(onPress: () => void) {
       ref: (r: Renderable) => {
         node = r
       },
-      // opentui dispatches out/over on intra-element hit changes too (child glyph vs the
-      // box itself) and they bubble here, so only a pointer that actually left disarms.
-      onMouseOver: (evt: MouseEvent) => {
+      onMouseOver: () => {
         setHover(true)
-        if (inside(evt)) return
         armed = false
       },
-      onMouseOut: (evt: MouseEvent) => {
-        if (inside(evt)) return
+      onMouseOut: () => {
         setHover(false)
         armed = false
       },

--- a/packages/opencode/src/cli/cmd/tui/ui/press.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/press.ts
@@ -2,15 +2,20 @@ import { createSignal } from "solid-js"
 import type { MouseEvent, Renderable } from "@opentui/core"
 
 /**
- * Click gate for small controls: fires only on a stable click — press and release on the
- * element with no `out` in between. Anything less is dropped, deliberately. Dropping a
- * click is a non-event the user repeats; firing one they did not intend is not, and
- * opentui hands a bare `up` to whatever sits under the cursor when a drag captured
- * elsewhere (a scrollbar, a text selection) ends there.
+ * Click gate for controls where a mis-fire is costly — one sitting next to a drag surface
+ * (a scrollbar, selectable transcript text) whose action the user cannot casually undo.
+ * Fires only on a stable click: press and release on the element with no `out` in between.
  *
- * `out` arrives on intra-element hit changes too (a child glyph and the box's own cells
+ * NOT a general replacement for `onMouseUp`. Plain `onMouseUp` is correct for the great
+ * majority of controls, and routing one through here only costs it dropped clicks. Adopt
+ * this only when an accidental activation is the problem being solved.
+ *
+ * Anything less than a stable click is dropped, deliberately: a dropped click is a
+ * non-event the user repeats, while an unintended one is the bug this exists to prevent.
+ * `out` also arrives on intra-element hit changes (a child glyph and the box's own cells
  * are separate hit targets), so a press that drifts even one cell is discarded. That is
- * the intended trade, not an oversight.
+ * the intended trade — browser semantics, where the pointer may leave and return, are
+ * explicitly not the goal here.
  *
  * The element's own content must be unselectable (`selectable={false}` on any `<text>`),
  * otherwise its own press starts a text selection and every release is discarded as a

--- a/packages/opencode/src/cli/cmd/tui/ui/press.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/press.ts
@@ -5,6 +5,10 @@ import type { MouseEvent, Renderable } from "@opentui/core"
  * Click gate: fires only when press and release both land on the element, once per press.
  * Guards against opentui delivering a bare `up` to whatever sits under the cursor when a
  * drag captured elsewhere (a scrollbar, a text selection) ends there.
+ *
+ * The element's own content must be unselectable (`selectable={false}` on any `<text>`),
+ * otherwise its own press starts a text selection and every release is discarded as a
+ * selection drag — a silently dead control.
  */
 export function createPress(onPress: () => void) {
   const [hover, setHover] = createSignal(false)
@@ -24,13 +28,15 @@ export function createPress(onPress: () => void) {
       ref: (r: Renderable) => {
         node = r
       },
-      // A press can end without this element ever seeing `out` or `up`, so every event
-      // proving the pointer is no longer pressing us has to disarm.
-      onMouseOver: () => {
+      // opentui dispatches out/over on intra-element hit changes too (child glyph vs the
+      // box itself) and they bubble here, so only a pointer that actually left disarms.
+      onMouseOver: (evt: MouseEvent) => {
         setHover(true)
+        if (inside(evt)) return
         armed = false
       },
-      onMouseOut: () => {
+      onMouseOut: (evt: MouseEvent) => {
+        if (inside(evt)) return
         setHover(false)
         armed = false
       },
@@ -48,9 +54,8 @@ export function createPress(onPress: () => void) {
         if (!armed) return
         // Consume first: a release inside a captured renderable is dispatched twice.
         armed = false
-        // A release closing a text-selection drag arrives here with no preceding `drop`;
-        // it is never a click on us. Requires our own content to be unselectable, or our
-        // own press would start a selection and land in this branch too.
+        // A release closing a text-selection drag arrives with no preceding `drop`; it is
+        // never a click on us.
         if (evt.isDragging) return
         if (!inside(evt)) return
         onPress()

--- a/packages/opencode/src/cli/cmd/tui/ui/press.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/press.ts
@@ -24,10 +24,8 @@ export function createPress(onPress: () => void) {
       ref: (r: Renderable) => {
         node = r
       },
-      // A press can end without this element ever seeing `out` or `up` (opentui only
-      // refreshes `lastOverRenderable` on a cross-element drag/move, and never sends
-      // `out` to the capture target), so every event that proves the pointer is no
-      // longer pressing us has to disarm.
+      // A press can end without this element ever seeing `out` or `up`, so every event
+      // proving the pointer is no longer pressing us has to disarm.
       onMouseOver: () => {
         setHover(true)
         armed = false
@@ -50,6 +48,10 @@ export function createPress(onPress: () => void) {
         if (!armed) return
         // Consume first: a release inside a captured renderable is dispatched twice.
         armed = false
+        // A release closing a text-selection drag arrives here with no preceding `drop`;
+        // it is never a click on us. Requires our own content to be unselectable, or our
+        // own press would start a selection and land in this branch too.
+        if (evt.isDragging) return
         if (!inside(evt)) return
         onPress()
       },

--- a/packages/opencode/test/cli/tui/press-gate.test.tsx
+++ b/packages/opencode/test/cli/tui/press-gate.test.tsx
@@ -3,8 +3,9 @@ import { describe, expect, test } from "bun:test"
 import { testRender } from "@opentui/solid"
 import { createPress } from "../../../src/cli/cmd/tui/ui/press"
 
-// Left half is a drag capturer standing in for the transcript scrollbar; the 3-column
-// button on its right is the press-gated control.
+// Left half holds selectable text, standing in for the transcript (a left-press there
+// starts a text-selection drag); the 3-column button on its right is the press-gated
+// control, whose own glyph is unselectable exactly as the real one is.
 const NEIGHBOUR = { x: 4, y: 2 }
 const BUTTON = { x: 11, y: 2 }
 const OUTSIDE = { x: 20, y: 2 }
@@ -16,9 +17,11 @@ async function mount() {
       const press = createPress(() => (presses += 1))
       return (
         <box flexDirection="row">
-          <box width={10} height={5} />
+          <box width={10} height={5}>
+            <text>{"transcript text"}</text>
+          </box>
           <box width={3} height={5} {...press.props}>
-            <text>{"◀"}</text>
+            <text selectable={false}>{"◀"}</text>
           </box>
           <box width={10} height={5} />
         </box>
@@ -66,8 +69,8 @@ describe("createPress", () => {
 
   test("a press that drags off without an out event cannot fire a later foreign drag", async () => {
     const h = await mount()
-    // Press the button and drag straight off it. opentui sends the button no `out` here,
-    // so the arm has to be cleared by the drag or the over on the way back.
+    // Press the button and drag straight off it. The button is too narrow to become the
+    // capture target, so opentui sends it no out, drag, drop or up for this press.
     await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
     await h.mockMouse.moveTo(NEIGHBOUR.x, NEIGHBOUR.y)
     await h.mockMouse.release(NEIGHBOUR.x, NEIGHBOUR.y)
@@ -78,6 +81,30 @@ describe("createPress", () => {
     await h.mockMouse.moveTo(BUTTON.x, BUTTON.y)
     await h.mockMouse.release(BUTTON.x, BUTTON.y)
     expect(h.presses()).toBe(0)
+
+    // Positive control: the gate is disarmed, not dead.
+    await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
+    await h.mockMouse.release(BUTTON.x, BUTTON.y)
+    expect(h.presses()).toBe(1)
+  })
+
+  test("a text-selection drag released over the button does not fire it", async () => {
+    const h = await mount()
+    await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
+    await h.mockMouse.moveTo(NEIGHBOUR.x, NEIGHBOUR.y)
+    await h.mockMouse.release(NEIGHBOUR.x, NEIGHBOUR.y)
+
+    // Selecting transcript text takes opentui's selection path, which delivers a bare
+    // `up` with isDragging and no preceding `drop`.
+    await h.mockMouse.pressDown(2, 0)
+    await h.mockMouse.moveTo(5, 0)
+    await h.mockMouse.moveTo(BUTTON.x, BUTTON.y)
+    await h.mockMouse.release(BUTTON.x, BUTTON.y)
+    expect(h.presses()).toBe(0)
+
+    await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
+    await h.mockMouse.release(BUTTON.x, BUTTON.y)
+    expect(h.presses()).toBe(1)
   })
 
   // Mirrors the narrow-terminal sidebar: the collapse control is a raised flex child and
@@ -91,7 +118,7 @@ describe("createPress", () => {
           <box flexDirection="row">
             <box flexGrow={1} />
             <box width={3} height={5} zIndex={1} alignItems="center" {...press.props}>
-              <text>{"▶"}</text>
+              <text selectable={false}>{"▶"}</text>
             </box>
             <box position="absolute" top={0} left={0} right={0} bottom={0} alignItems="flex-end">
               <box width={20} height={5} backgroundColor="#333333" />

--- a/packages/opencode/test/cli/tui/press-gate.test.tsx
+++ b/packages/opencode/test/cli/tui/press-gate.test.tsx
@@ -109,13 +109,17 @@ describe("createPress", () => {
     expect(h.presses()).toBe(1)
   })
 
-  test("a click drifting across the inner glyph boundary still fires", async () => {
+  test("a click that drifts at all is dropped, by contract", async () => {
     const h = await mount()
-    // The glyph is its own hit target, so crossing from it to the box's own cells makes
-    // opentui dispatch out/over that bubble here mid-press.
+    // The glyph is its own hit target, so moving from it to the box's own cells raises
+    // `out`. These controls take stable clicks only — err toward dropping, never firing.
     await h.mockMouse.pressDown(GLYPH.x, GLYPH.y)
     await h.mockMouse.moveTo(GLYPH.x + 1, GLYPH.y)
     await h.mockMouse.release(GLYPH.x + 1, GLYPH.y)
+    expect(h.presses()).toBe(0)
+
+    await h.mockMouse.pressDown(GLYPH.x, GLYPH.y)
+    await h.mockMouse.release(GLYPH.x, GLYPH.y)
     expect(h.presses()).toBe(1)
   })
 

--- a/packages/opencode/test/cli/tui/press-gate.test.tsx
+++ b/packages/opencode/test/cli/tui/press-gate.test.tsx
@@ -122,32 +122,4 @@ describe("createPress", () => {
     await h.mockMouse.release(GLYPH.x + 1, GLYPH.y)
     expect(h.presses()).toBe(1)
   })
-
-  // Mirrors the narrow-terminal sidebar: the collapse control is a raised flex child and
-  // the sidebar is a later absolute sibling covering the whole row.
-  test("a raised gate stays visible and hit-testable under a later absolute sibling", async () => {
-    let presses = 0
-    const h = await testRender(
-      () => {
-        const press = createPress(() => (presses += 1))
-        return (
-          <box flexDirection="row">
-            <box flexGrow={1} />
-            <box width={3} height={5} zIndex={1} alignItems="center" {...press.props}>
-              <text selectable={false}>{"▶"}</text>
-            </box>
-            <box position="absolute" top={0} left={0} right={0} bottom={0} alignItems="flex-end">
-              <box width={20} height={5} backgroundColor="#333333" />
-            </box>
-          </box>
-        )
-      },
-      { width: 30, height: 6 },
-    )
-    await h.renderOnce()
-    expect(h.captureCharFrame()).toContain("▶")
-    await h.mockMouse.pressDown(28, 0)
-    await h.mockMouse.release(28, 0)
-    expect(presses).toBe(1)
-  })
 })

--- a/packages/opencode/test/cli/tui/press-gate.test.tsx
+++ b/packages/opencode/test/cli/tui/press-gate.test.tsx
@@ -1,0 +1,94 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { createPress } from "../../../src/cli/cmd/tui/ui/press"
+
+// Left half is a drag capturer standing in for the transcript scrollbar; the 3-column
+// button on its right is the press-gated control.
+const NEIGHBOUR = { x: 4, y: 2 }
+const BUTTON = { x: 11, y: 2 }
+const OUTSIDE = { x: 20, y: 2 }
+
+async function mount() {
+  let presses = 0
+  const harness = await testRender(
+    () => {
+      const press = createPress(() => (presses += 1))
+      return (
+        <box flexDirection="row">
+          <box width={10} height={5} />
+          <box width={3} height={5} {...press.props}>
+            <text>{"◀"}</text>
+          </box>
+          <box width={10} height={5} />
+        </box>
+      )
+    },
+    { width: 30, height: 8 },
+  )
+  await harness.renderOnce()
+  return { ...harness, presses: () => presses }
+}
+
+describe("createPress", () => {
+  test("a plain click fires once", async () => {
+    const h = await mount()
+    await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
+    await h.mockMouse.release(BUTTON.x, BUTTON.y)
+    expect(h.presses()).toBe(1)
+  })
+
+  test("a drag captured elsewhere and released on the button does not fire it", async () => {
+    const h = await mount()
+    await h.mockMouse.pressDown(NEIGHBOUR.x, NEIGHBOUR.y)
+    await h.mockMouse.moveTo(NEIGHBOUR.x + 2, NEIGHBOUR.y)
+    await h.mockMouse.moveTo(BUTTON.x, BUTTON.y)
+    await h.mockMouse.release(BUTTON.x, BUTTON.y)
+    expect(h.presses()).toBe(0)
+  })
+
+  test("pressing the button then releasing outside it does not fire", async () => {
+    const h = await mount()
+    await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
+    await h.mockMouse.moveTo(BUTTON.x, BUTTON.y)
+    await h.mockMouse.moveTo(OUTSIDE.x, OUTSIDE.y)
+    await h.mockMouse.release(OUTSIDE.x, OUTSIDE.y)
+    expect(h.presses()).toBe(0)
+  })
+
+  test("dragging within the button still fires exactly once on release", async () => {
+    const h = await mount()
+    await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
+    await h.mockMouse.moveTo(BUTTON.x + 1, BUTTON.y)
+    await h.mockMouse.release(BUTTON.x + 1, BUTTON.y)
+    expect(h.presses()).toBe(1)
+  })
+
+  // Mirrors the narrow-terminal sidebar: the collapse control is a raised flex child and
+  // the sidebar is a later absolute sibling covering the whole row.
+  test("a raised gate stays visible and hit-testable under a later absolute sibling", async () => {
+    let presses = 0
+    const h = await testRender(
+      () => {
+        const press = createPress(() => (presses += 1))
+        return (
+          <box flexDirection="row">
+            <box flexGrow={1} />
+            <box width={3} height={5} zIndex={1} alignItems="center" {...press.props}>
+              <text>{"▶"}</text>
+            </box>
+            <box position="absolute" top={0} left={0} right={0} bottom={0} alignItems="flex-end">
+              <box width={20} height={5} backgroundColor="#333333" />
+            </box>
+          </box>
+        )
+      },
+      { width: 30, height: 6 },
+    )
+    await h.renderOnce()
+    expect(h.captureCharFrame()).toContain("▶")
+    await h.mockMouse.pressDown(28, 0)
+    await h.mockMouse.release(28, 0)
+    expect(presses).toBe(1)
+  })
+})

--- a/packages/opencode/test/cli/tui/press-gate.test.tsx
+++ b/packages/opencode/test/cli/tui/press-gate.test.tsx
@@ -9,6 +9,8 @@ import { createPress } from "../../../src/cli/cmd/tui/ui/press"
 const NEIGHBOUR = { x: 4, y: 2 }
 const BUTTON = { x: 11, y: 2 }
 const OUTSIDE = { x: 20, y: 2 }
+// The centred glyph's own cell, on the row it occupies — a hit target distinct from the box.
+const GLYPH = { x: 11, y: 0 }
 
 async function mount() {
   let presses = 0
@@ -20,7 +22,7 @@ async function mount() {
           <box width={10} height={5}>
             <text>{"transcript text"}</text>
           </box>
-          <box width={3} height={5} {...press.props}>
+          <box width={3} height={5} alignItems="center" {...press.props}>
             <text selectable={false}>{"◀"}</text>
           </box>
           <box width={10} height={5} />
@@ -104,6 +106,16 @@ describe("createPress", () => {
 
     await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
     await h.mockMouse.release(BUTTON.x, BUTTON.y)
+    expect(h.presses()).toBe(1)
+  })
+
+  test("a click drifting across the inner glyph boundary still fires", async () => {
+    const h = await mount()
+    // The glyph is its own hit target, so crossing from it to the box's own cells makes
+    // opentui dispatch out/over that bubble here mid-press.
+    await h.mockMouse.pressDown(GLYPH.x, GLYPH.y)
+    await h.mockMouse.moveTo(GLYPH.x + 1, GLYPH.y)
+    await h.mockMouse.release(GLYPH.x + 1, GLYPH.y)
     expect(h.presses()).toBe(1)
   })
 

--- a/packages/opencode/test/cli/tui/press-gate.test.tsx
+++ b/packages/opencode/test/cli/tui/press-gate.test.tsx
@@ -69,15 +69,17 @@ describe("createPress", () => {
     expect(h.presses()).toBe(1)
   })
 
-  test("a press that drags off without an out event cannot fire a later foreign drag", async () => {
+  test("a press that drags off the button cannot fire a later foreign drag", async () => {
     const h = await mount()
-    // Press the button and drag straight off it. The button is too narrow to become the
-    // capture target, so opentui sends it no out, drag, drop or up for this press.
+    // Hover first: a real pointer always generates a move onto the element before the
+    // press, which is what lets opentui deliver the `out` that disarms us on the way off.
+    await h.mockMouse.moveTo(BUTTON.x, BUTTON.y)
     await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
     await h.mockMouse.moveTo(NEIGHBOUR.x, NEIGHBOUR.y)
     await h.mockMouse.release(NEIGHBOUR.x, NEIGHBOUR.y)
     expect(h.presses()).toBe(0)
 
+    await h.mockMouse.moveTo(NEIGHBOUR.x, NEIGHBOUR.y)
     await h.mockMouse.pressDown(NEIGHBOUR.x, NEIGHBOUR.y)
     await h.mockMouse.moveTo(NEIGHBOUR.x + 2, NEIGHBOUR.y)
     await h.mockMouse.moveTo(BUTTON.x, BUTTON.y)
@@ -92,6 +94,7 @@ describe("createPress", () => {
 
   test("a text-selection drag released over the button does not fire it", async () => {
     const h = await mount()
+    await h.mockMouse.moveTo(BUTTON.x, BUTTON.y)
     await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
     await h.mockMouse.moveTo(NEIGHBOUR.x, NEIGHBOUR.y)
     await h.mockMouse.release(NEIGHBOUR.x, NEIGHBOUR.y)
@@ -109,17 +112,14 @@ describe("createPress", () => {
     expect(h.presses()).toBe(1)
   })
 
-  test("a click that drifts at all is dropped, by contract", async () => {
+  test("a click drifting within the element still fires", async () => {
     const h = await mount()
     // The glyph is its own hit target, so moving from it to the box's own cells raises
-    // `out`. These controls take stable clicks only — err toward dropping, never firing.
+    // out/over that bubble here. The pointer never left the control, so this is a click.
+    await h.mockMouse.moveTo(GLYPH.x, GLYPH.y)
     await h.mockMouse.pressDown(GLYPH.x, GLYPH.y)
     await h.mockMouse.moveTo(GLYPH.x + 1, GLYPH.y)
     await h.mockMouse.release(GLYPH.x + 1, GLYPH.y)
-    expect(h.presses()).toBe(0)
-
-    await h.mockMouse.pressDown(GLYPH.x, GLYPH.y)
-    await h.mockMouse.release(GLYPH.x, GLYPH.y)
     expect(h.presses()).toBe(1)
   })
 

--- a/packages/opencode/test/cli/tui/press-gate.test.tsx
+++ b/packages/opencode/test/cli/tui/press-gate.test.tsx
@@ -64,6 +64,22 @@ describe("createPress", () => {
     expect(h.presses()).toBe(1)
   })
 
+  test("a press that drags off without an out event cannot fire a later foreign drag", async () => {
+    const h = await mount()
+    // Press the button and drag straight off it. opentui sends the button no `out` here,
+    // so the arm has to be cleared by the drag or the over on the way back.
+    await h.mockMouse.pressDown(BUTTON.x, BUTTON.y)
+    await h.mockMouse.moveTo(NEIGHBOUR.x, NEIGHBOUR.y)
+    await h.mockMouse.release(NEIGHBOUR.x, NEIGHBOUR.y)
+    expect(h.presses()).toBe(0)
+
+    await h.mockMouse.pressDown(NEIGHBOUR.x, NEIGHBOUR.y)
+    await h.mockMouse.moveTo(NEIGHBOUR.x + 2, NEIGHBOUR.y)
+    await h.mockMouse.moveTo(BUTTON.x, BUTTON.y)
+    await h.mockMouse.release(BUTTON.x, BUTTON.y)
+    expect(h.presses()).toBe(0)
+  })
+
   // Mirrors the narrow-terminal sidebar: the collapse control is a raised flex child and
   // the sidebar is a later absolute sibling covering the whole row.
   test("a raised gate stays visible and hit-testable under a later absolute sibling", async () => {

--- a/packages/opencode/test/cli/tui/sidebar-state.test.ts
+++ b/packages/opencode/test/cli/tui/sidebar-state.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import { sidebarToggle, sidebarVisibleFor } from "../../../src/cli/cmd/tui/routes/session/sidebar-state"
+
+const WIDE = true
+const NARROW = false
+
+describe("sidebarVisibleFor", () => {
+  test("auto follows the terminal width", () => {
+    expect(sidebarVisibleFor("auto", WIDE)).toBe(true)
+    expect(sidebarVisibleFor("auto", NARROW)).toBe(false)
+  })
+
+  test("explicit overrides ignore the terminal width", () => {
+    expect(sidebarVisibleFor("show", NARROW)).toBe(true)
+    expect(sidebarVisibleFor("hide", WIDE)).toBe(false)
+  })
+})
+
+describe("sidebarToggle", () => {
+  test("a collapse/expand round-trip on a wide terminal ends back at auto", () => {
+    const collapsed = sidebarToggle("auto", WIDE)
+    expect(collapsed).toBe("hide")
+    expect(sidebarVisibleFor(collapsed, WIDE)).toBe(false)
+
+    const expanded = sidebarToggle(collapsed, WIDE)
+    expect(expanded).toBe("auto")
+    // The regression: an expand used to leave a sticky override that survived a shrink.
+    expect(sidebarVisibleFor(expanded, NARROW)).toBe(false)
+  })
+
+  test("expanding on a narrow terminal is an explicit override that survives a shrink", () => {
+    const expanded = sidebarToggle("auto", NARROW)
+    expect(expanded).toBe("show")
+    expect(sidebarVisibleFor(expanded, NARROW)).toBe(true)
+  })
+
+  test("collapsing an override on a narrow terminal normalises to auto", () => {
+    expect(sidebarToggle("show", NARROW)).toBe("auto")
+  })
+
+  test("expanding a hidden sidebar on a narrow terminal is an override", () => {
+    expect(sidebarToggle("hide", NARROW)).toBe("show")
+  })
+
+  test("collapsing an override on a wide terminal stays explicit", () => {
+    expect(sidebarToggle("show", WIDE)).toBe("hide")
+  })
+
+  test("toggling always flips visibility at the current width", () => {
+    for (const preference of ["auto", "show", "hide"] as const) {
+      for (const wide of [WIDE, NARROW]) {
+        const before = sidebarVisibleFor(preference, wide)
+        expect(sidebarVisibleFor(sidebarToggle(preference, wide), wide)).toBe(!before)
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Two independent defects in the session TUI, reported together: the right sidebar could pop out in a terminal too narrow to hold it with no visible way to close it, and dragging the transcript scrollbar could activate the sidebar toggle or the voice control when the pointer drifted onto them before release.

## Sidebar state

The sidebar carried two overlapping pieces of state: a persisted `sidebar` preference and an ephemeral in-memory `sidebarOpen` signal that short-circuited the terminal-width check and was never cleared. One collapse-then-expand cycle on a wide terminal pinned the sidebar visible for the rest of the session, so a later shrink no longer auto-hid it; it flipped to the narrow full-area overlay, which is a later sibling with no `zIndex` and therefore painted over the three-column toggle button. The control remained in the tree but was neither visible nor hit-testable. A fresh session reset the ephemeral signal, which is why the fault presented as intermittent.

The two signals collapse into one persisted tri-state `SidebarPreference` of `auto`, `show` or `hide`, with the logic in two pure functions in `routes/session/sidebar-state.ts`. A toggle normalises back to `auto` whenever the requested visibility matches what the width would have selected anyway, so a collapse-and-expand round trip on a wide terminal leaves no override behind and a later shrink hides the sidebar again. The sticky state is no longer representable, so no resize handler is required. An explicit expand on a narrow terminal still records `show` and deliberately survives further shrinking until the user collapses it.

Affordance rules are now explicit: an expanded sidebar offers a collapse control at any width, a collapsed sidebar offers an expand control only where it can dock, and a subagent view offers neither. For the first rule to hold in practice the control now rides inside the narrow overlay as a right-aligned sibling placed before the panel, rather than remaining an in-flow child that the overlay painted over; that also keeps the control in one place across both modes, immediately to the left of the sidebar, instead of sitting left of the panel when docked and on the panel's right edge when overlaid. Subagent views previously rendered a control that mutated state while the agent gate suppressed any visible effect; it is removed rather than made to work, and the `sidebar_toggle` command is gated the same way so the keybind cannot write a preference whose result the user cannot see. Existing `auto` and `hide` values on disk remain valid, so no state migration is needed.

`contentWidth` now reserves the sidebar's columns only when the sidebar is docked, since the narrow overlay takes no layout space, and the width constant is shared rather than hardcoded in two files.

## Mouse activation

Both controls previously fired on `onMouseUp` alone, with no record of where the press began. The terminal UI library dispatches a bare `up` to the renderable under the cursor in addition to delivering `drag-end` and `up` to the renderable that captured the drag, so releasing a scrollbar drag with the pointer over a neighbouring control activated it. The control also receives an `over` event during the drag, so its hover highlight appeared and the activation looked intentional.

Activation moves behind a shared `createPress` gate in `ui/press.ts` which accepts a stable click only: the press and the release both land on the element and the pointer never leaves its bounds in between. Movement within the element is fine, which matters because the library raises `out` and `over` on intra-element hit-target changes as well — a child glyph and the box's own cells are separate hit targets and both events bubble to the parent — so the decision has to be geometric rather than taken from the event name. Leaving the element and returning does not produce a click; browser semantics are not the goal. The asymmetry is deliberate, because a discarded click is a non-event the user repeats whereas an unintended activation is the defect being fixed, so every ambiguity resolves toward not firing. Releases that close a text selection are rejected, and consumers must render unselectable content or their own press would start a selection and the control would never fire.

One limitation is documented rather than worked around: a press arriving with no preceding pointer movement onto the element cannot be disarmed when it drags away, because the library then delivers that element no event at all for the press. This was measured rather than assumed, and a realistic hover-then-press sequence does not reach it.

This gate is a narrow opt-in and not a general replacement for `onMouseUp`. Handling only `up` remains correct for the great majority of controls, and the remaining call sites are not queued for migration; routing an indifferent control through the gate buys nothing and costs it discarded clicks. The entry criterion, recorded in the exported documentation comment and in the design document, is a control for which an accidental activation is itself the defect, in practice one adjacent to a drag surface with an action the user cannot casually undo.

## Verification

`bun typecheck` in `packages/opencode` passes.

`bun test test/cli/tui/press-gate.test.tsx test/cli/tui/sidebar-state.test.ts` reports 15 passing tests. Every fix was first reproduced as a failing assertion, including the baseline misfire against a plain `onMouseUp` control, the discarded intra-element click, and the control's position parity between the docked and overlay modes, using the library's test renderer and mock mouse.

`bun test test/cli/tui test/cli/cmd/tui` reports 260 passing, with one failure and one error that reproduce identically on `main` at the same commit and are therefore pre-existing. They originate in `test/cli/tui/thread.test.ts` and are unrelated to this change: the built-in workflow scripts are function bodies imported as raw text through an import attribute, and the runtime occasionally loads one through the module parser instead. Each of the two files involved passes in isolation, and the continuous integration matrix shards test files across separate processes, which is why the pair rarely collides there. This is being tracked separately.

## Manual Verification

Resize a terminal wider than 120 columns, collapse the sidebar with the toggle, expand it again, then shrink below 120 columns: the sidebar hides rather than appearing as an overlay. Open it on a narrow terminal with the keybind: it appears as an overlay with the collapse control immediately to its left, in the same position it occupies when docked, and clicking that control closes it. Switch to a subagent view: no sidebar control is present and the keybind is inert. Drag the transcript scrollbar downward and release with the pointer over the toggle or the voice control: neither activates. Click either control, including a click that moves a cell within the control: it activates once. Move the pointer off the control and back before releasing: it does not activate.
