### PR TITLE
fix(session): persist missing-model assistant errors

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1956,17 +1956,40 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       providerID: ProviderID,
       modelID: ModelID,
       sessionID: SessionID,
+      terminalUser?: MessageV2.User,
     ) {
       const exit = yield* provider.getModel(providerID, modelID).pipe(Effect.exit)
       if (Exit.isSuccess(exit)) return exit.value
       const err = Cause.squash(exit.cause)
       if (Provider.ModelNotFoundError.isInstance(err)) {
         const hint = err.data.suggestions?.length ? ` Did you mean: ${err.data.suggestions.join(", ")}?` : ""
+        const error = new NamedError.Unknown({
+          message: `Model not found: ${err.data.providerID}/${err.data.modelID}.${hint}`,
+        }).toObject()
+        if (terminalUser) {
+          const ctx = yield* InstanceState.context
+          const now = Date.now()
+          yield* sessions.updateMessage({
+            id: MessageID.ascending(),
+            sessionID,
+            parentID: terminalUser.id,
+            agentID: terminalUser.agentID,
+            role: "assistant",
+            mode: terminalUser.agent,
+            agent: terminalUser.agent,
+            variant: terminalUser.model.variant,
+            path: { cwd: ctx.directory, root: ctx.worktree },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID,
+            providerID,
+            time: { created: now, completed: now },
+            error,
+          })
+        }
         yield* bus.publish(Session.Event.Error, {
           sessionID,
-          error: new NamedError.Unknown({
-            message: `Model not found: ${err.data.providerID}/${err.data.modelID}.${hint}`,
-          }).toObject(),
+          error,
         })
       }
       return yield* Effect.failCause(exit.cause)
@@ -3296,7 +3319,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
           }
 
-          const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
+          const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID, lastUser)
           lastModelForPrune = model
           lastFinishedForPrune = lastFinished
           const task = tasks.pop()

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2,7 +2,7 @@ import path from "path"
 import { describe, expect, test } from "bun:test"
 import { NamedError } from "@mimo-ai/shared/util/error"
 import { fileURLToPath } from "url"
-import { Effect, Layer } from "effect"
+import { Effect, Exit, Layer } from "effect"
 import { Instance } from "../../src/project/instance"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session"
@@ -128,6 +128,48 @@ function hanging(ready: () => void) {
     },
   })
 }
+
+describe("session.prompt terminal model errors", () => {
+  test("persists an assistant error before a missing model fails the prompt", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Effect.gen(function* () {
+            const prompt = yield* SessionPrompt.Service
+            const sessions = yield* Session.Service
+            const session = yield* sessions.create({ title: "Missing model" })
+            const providerID = ProviderID.make("missing-provider")
+            const modelID = ModelID.make("missing-model")
+
+            const exit = yield* prompt
+              .prompt({
+                sessionID: session.id,
+                agent: "build",
+                model: { providerID, modelID },
+                parts: [{ type: "text", text: "hello" }],
+              })
+              .pipe(Effect.exit)
+
+            expect(Exit.isFailure(exit)).toBe(true)
+            const messages = yield* sessions.messages({ sessionID: session.id, agentID: "*" })
+            expect(messages).toHaveLength(2)
+            expect(messages[0]?.info.role).toBe("user")
+            const assistant = messages[1]?.info
+            expect(assistant?.role).toBe("assistant")
+            if (assistant?.role !== "assistant") return
+            expect(assistant.parentID).toBe(messages[0]?.info.id)
+            expect(assistant.providerID).toBe(providerID)
+            expect(assistant.modelID).toBe(modelID)
+            expect(assistant.error?.data.message).toContain("Model not found: missing-provider/missing-model")
+            expect(assistant.time.completed).toBeNumber()
+          }),
+        ),
+    })
+  })
+})
 
 describe("session.prompt missing file", () => {
   test("does not fail the prompt when a file part is missing", async () => {


### PR DESCRIPTION
## Summary
- persist a terminal assistant message when the selected model cannot be resolved
- write the structured error to SQLite before publishing `session.error`
- cover the real prompt/session persistence path with a regression test

## Tests
- `bun test test/session/prompt.test.ts --timeout 30000`
- `bun typecheck` (from `packages/opencode`)
- repository pre-push `bun turbo typecheck`