### PR TITLE
fix(server): stop emitting a dangling $ref, unbreaking SDK codegen

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -325,7 +325,7 @@ export const ToolStateCompleted = z
     status: z.literal("completed"),
     input: z.record(z.string(), z.any()),
     output: z.string(),
-    providerOutput: z.json().optional(),
+    providerOutput: z.unknown().optional(),
     providerMetadata: z.record(z.string(), z.any()).optional(),
     title: z.string(),
     metadata: z.record(z.string(), z.any()),

--- a/packages/opencode/test/server/openapi-refs.test.ts
+++ b/packages/opencode/test/server/openapi-refs.test.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "bun:test"
+import { Server } from "../../src/server/server"
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null
+
+// zod-openapi rewrites every local `#/$defs/<name>` reference to
+// `#/components/schemas/<name>` but only hoists the definitions it knows by
+// name, so a recursive zod schema — `z.json()`, `z.lazy()`, any self-reference —
+// emits a $ref to a component that was never written. Nothing in the running
+// server notices; the failure surfaces only when someone regenerates the SDK,
+// where openapi-ts dies with `Missing $ref pointer`. That is how the spec stayed
+// broken for four days after `fc74c539` shipped `providerOutput: z.json()`.
+// Resolving every pointer here turns that into a test failure instead.
+test("every $ref in the generated OpenAPI document resolves", async () => {
+  const doc = await Server.openapi()
+
+  const refs = new Set<string>()
+  const collect = (node: unknown) => {
+    if (Array.isArray(node)) return node.forEach(collect)
+    if (!isRecord(node)) return
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$ref" && typeof value === "string") refs.add(value)
+      collect(value)
+    }
+  }
+  collect(doc)
+  expect(refs.size).toBeGreaterThan(0)
+
+  // JSON Pointer walk, with RFC 6901 token unescaping.
+  const resolve = (node: unknown, tokens: string[]): unknown => {
+    if (tokens.length === 0) return node
+    if (!isRecord(node)) return undefined
+    return resolve(node[tokens[0].replaceAll("~1", "/").replaceAll("~0", "~")], tokens.slice(1))
+  }
+
+  const dangling = [...refs].filter(
+    (ref) => !ref.startsWith("#/") || resolve(doc, ref.slice(2).split("/")) === undefined,
+  )
+  expect(dangling).toEqual([])
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -125,7 +125,7 @@ export type EventActorStalled = {
     sessionID: string
     actorID: string
     description: string
-    lastTurnTime: number
+    lastActivityTime: number
     stalledDuration: number
   }
 }
@@ -1195,6 +1195,10 @@ export type ToolStateCompleted = {
     [key: string]: unknown
   }
   output: string
+  providerOutput?: unknown
+  providerMetadata?: {
+    [key: string]: unknown
+  }
   title: string
   metadata: {
     [key: string]: unknown
@@ -1883,6 +1887,11 @@ export type ProviderConfig = {
   only_configured_models?: boolean
 }
 
+/**
+ * Policy for MCP client-side sampling (`sampling/createMessage`) from this server: deny, ask (default), or allow.
+ */
+export type McpSamplingPolicy = "deny" | "ask" | "allow"
+
 export type McpLocalConfig = {
   /**
    * Type of MCP server connection
@@ -1906,6 +1915,7 @@ export type McpLocalConfig = {
    * Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified.
    */
   timeout?: number
+  sampling?: McpSamplingPolicy
 }
 
 export type McpOAuthConfig = {
@@ -1954,6 +1964,7 @@ export type McpRemoteConfig = {
    * Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified.
    */
   timeout?: number
+  sampling?: McpSamplingPolicy
 }
 
 /**
@@ -2193,6 +2204,15 @@ export type Config = {
      * Token buffer for compaction. Leaves enough window to avoid overflow during compaction.
      */
     reserved?: number
+    /**
+     * Compact earlier than the model window. A token count (300000), a shorthand string ("300K", "1M", "50%"), or a map keyed by "<providerID>/<modelID>" with wildcards ("openai/gpt-5*"). Always clamped to the model's real window — it can only lower the compaction trigger, never raise it. 0 means no budget.
+     */
+    max_context?:
+      | number
+      | string
+      | {
+          [key: string]: number | string
+        }
   }
   checkpoint?: {
     /**
@@ -2294,7 +2314,7 @@ export type Config = {
   }
   dream?: {
     /**
-     * Auto-trigger dream memory consolidation on new session start. Default: true.
+     * Auto-trigger dream memory consolidation on new session start. Default: false.
      */
     auto?: boolean
     /**
@@ -2304,7 +2324,7 @@ export type Config = {
   }
   distill?: {
     /**
-     * Auto-trigger distill workflow packaging on new session start. Default: true.
+     * Auto-trigger distill workflow packaging on new session start. Default: false.
      */
     auto?: boolean
     /**


### PR DESCRIPTION
## Summary

`./packages/sdk/js/script/build.ts` has been failing since `fc74c539` (2026-07-26) with:

```
Missing $ref pointer "#/components/schemas/__schema0". Token "__schema0" does not exist.
```

So the generated SDK has been frozen for four days. Evidence: the committed `types.gen.ts` had no `providerOutput` — the very field whose schema broke the generator.

**Cause.** `providerOutput: z.json()` (`message-v2.ts:328`) is a *recursive* schema. zod names its anonymous definition `__schema0` under a local `$defs`; zod-openapi then rewrites every `#/$defs/<name>` reference to `#/components/schemas/<name>` but only hoists the definitions it knows by name (`zod-openapi/dist/components-DiNDbisK.mjs:369-428`). The definition stays nested — in 7 places: `Event`, `GlobalEvent`, and 5 route response schemas — while the reference points at a component that was never written. Naming the schema explicitly (`.meta({ id })`) does not help; it just yields a *second* dangling ref.

**Fix.** `z.json()` is the only occurrence in `src`, so drop it instead of building `$defs` hoisting machinery. `z.unknown()` carries the same "opaque JSON blob" intent without the recursion.

No validation is lost: the only producer already round-trips through `JSON.stringify`/`JSON.parse` and maps anything non-serializable to `null` (`processor.ts:53-56`), so the value is JSON by construction and `z.json()`'s check was redundant on the write path.

## Why `unknown` and not an object type

`z.record(z.string(), z.unknown())` — or anything else that pins the value to an object — would also dodge the recursion, but it would be a downgrade:

1. **Upstream types it `unknown`.** AI SDK 6.0.168 `index.d.ts:1931-1933` declares the `output-available` variant as `{ state: 'output-available'; input: unknown; output: unknown }`. This field is a pure pass-through of exactly that payload — in at `processor.ts:536` (`case "tool-result": value.output`), out at `message-v2.ts:838-840` — so `z.unknown()` mirrors the upstream signature one-for-one.
2. **Nothing introspects it.** `rg "providerOutput\."` returns zero hits across `packages/opencode/src` and `packages/app/src`. A narrower type buys no type safety at any call site.
3. **It legitimately may not be an object.** It is only populated for provider-executed tools (`structured = !result && part.metadata?.providerExecuted`, `processor.ts:350`), i.e. the provider's own raw tool result. Those return arrays (a search result set) or bare strings depending on the provider. The sibling branches of the very expression that consumes it already yield a bare string (`message-v2.ts:841-846`), so the slot is not object-only by construction.
4. **The cost of over-constraining is asymmetric.** `MessageV2.Part` is validated on the way through: `prompt.ts:2371` logs `invalid user part before save` on a `safeParse` failure, and `cli/cmd/import.ts:187` uses `.parse()`, which throws. A provider returning an array against an object-shaped schema would therefore break saving or importing session history — in exchange for zero runtime guarantee, since `jsonToolOutput` has already round-tripped the value through JSON.

A middle option — a hand-rolled non-recursive one-level JSON union `z.union([z.record(z.string(), z.unknown()), z.array(z.unknown()), z.string(), z.number(), z.boolean(), z.null()])` — was considered and rejected: it only adds "reject `undefined`/functions/symbols", which the JSON round-trip already makes impossible, and pays for it with an awkward union in the SDK type and an `anyOf` in the spec.

If a future call site needs to read fields off this value, the right move is a zod parse at *that* read point, narrowing to the shape it needs, rather than tightening the storage contract for every provider.

## Regression test

`packages/opencode/test/server/openapi-refs.test.ts` resolves every JSON Pointer in the document `Server.openapi()` produces. This class of defect now fails in CI rather than lying dormant until someone regenerates the SDK. Confirmed to fail on the `z.json()` version (3 unresolvable refs) and pass after the fix.

## Verification

- `./packages/sdk/js/script/build.ts` — now exits 0 (was: `Missing $ref pointer`)
- Dangling refs in the generated document: 1 → 0; nested `$defs`: 7 → 0
- `bun typecheck` (opencode, sdk/js) — PASS
- `bun test test/server test/session/message-v2.test.ts` — 87 pass, 0 fail
- `bun test test/mcp test/tool/mcp*.test.ts` — 119 pass, 0 fail
- `bunx oxlint` on both changed files — 0 warnings, 0 errors
- `git diff --check` — clean

## Note on the SDK diff

The regenerated `types.gen.ts` carries four days of accumulated drift, not just this fix: `providerOutput`, `providerMetadata`, `McpSamplingPolicy`, `max_context`, `lastActivityTime`, and two default-value doc corrections.

If #2026 lands first, its one hand-edited field (`disable_model_invocation` in `AppSkillsResponses`, added because regeneration was impossible) will be superseded by a clean regeneration on top of this.