### PR TITLE
fix(provider): send function tools to OpenAI Responses with explicit strict: false

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1039,17 +1039,37 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
 //
 // An explicit per-tool `strict` is preserved, so a tool that has been made
 // strict-compatible can still opt in.
+//
+// Azure's `useCompletionUrls` branch sends the same tools to Chat Completions
+// instead, where the field lands as `function.strict: false` — a documented
+// boolean whose default is already false, so that path is unaffected.
 const EXPLICIT_NON_STRICT_TOOL_SDKS = ["@ai-sdk/openai", "@ai-sdk/azure"]
 
-// Place a cache breakpoint on the tool definitions. The cache hierarchy is
-// `tools` → `system` → `messages`, so marking the LAST tool caches the entire
-// tool-schema block (often several KB) as a stable prefix that sits in front of
-// the system + message caches. Tools are passed to the SDK separately from
-// `message()` and never go through its providerID→SDK-key remap, so we resolve
-// the SDK-keyed marker via `cacheMarkerFor`. Tool registration order is stable
-// (insertion order of the tools record), so "last tool" is deterministic.
+// The single choke point for the outbound tool set (session/llm.ts passes the
+// result straight to `streamText`). Two responsibilities:
+//
+// 1. Pin `strict: false` for EXPLICIT_NON_STRICT_TOOL_SDKS — see above for why
+//    omitting the field breaks the Codex backend mid-stream.
+// 2. Place a cache breakpoint on the tool definitions. The cache hierarchy is
+//    `tools` → `system` → `messages`, so marking the LAST tool caches the entire
+//    tool-schema block (often several KB) as a stable prefix that sits in front
+//    of the system + message caches. Tools are passed to the SDK separately from
+//    `message()` and never go through its providerID→SDK-key remap, so we
+//    resolve the SDK-keyed marker via `cacheMarkerFor`. Tool registration order
+//    is stable (insertion order of the tools record), so "last tool" is
+//    deterministic.
+//
+// Both mutate in place. That is safe because the record and every tool object in
+// it are rebuilt per request: `resolveTools` allocates a fresh record and calls
+// `tool()` per entry, and MCP entries come from `convertMcpTool`, which returns
+// a new `dynamicTool()` on every `MCP.tools()` call. Nothing here outlives the
+// request, so a model switch between steps cannot carry `strict` over to a
+// provider that would reject or warn on it.
 export function tools<T extends Record<string, any>>(tools: T, model: Provider.Model): T {
   if (EXPLICIT_NON_STRICT_TOOL_SDKS.includes(model.api.npm)) {
+    // Guarded because this walks every entry; the single `last` lookup below can
+    // assume a well-formed record, but a loop over N values is cheaper to make
+    // safe than to debug as a crash in the request path.
     for (const tool of Object.values(tools)) {
       if (tool && tool.strict == null) tool.strict = false
     }
@@ -1064,6 +1084,45 @@ export function tools<T extends Record<string, any>>(tools: T, model: Provider.M
   const last = tools[names[names.length - 1]]
   last.providerOptions = mergeDeep(last.providerOptions ?? {}, marker)
   return tools
+}
+
+// The `response_format` / `text.format` sibling of the tool `strict` problem
+// above. `generateObject`/`streamObject` ship our zod schema as a `json_schema`
+// response format, and there the OpenAI SDKs default `strictJsonSchema` to TRUE
+// — `@ai-sdk/openai` on both the chat and responses paths, and
+// `@ai-sdk/openai-compatible` — so `strict: true` goes out EXPLICITLY rather
+// than being omitted.
+//
+// Our judge schema is not strict-compatible: `SessionGoal.Verdict` marks
+// `impossible` optional, so `required` ships 2 of its 3 properties and OpenAI
+// rejects the request (strict mode requires every key in `properties` to appear
+// in `required`). Verified on the wire: `text.format` goes out as `strict: true`
+// with `required: ["ok", "reason"]`. Because `goal.ts` judges with the SESSION's
+// model, this breaks the stop-condition judge on every OpenAI-backed model.
+//
+// Unlike the tool case this fails cleanly at validation instead of mid-stream, so
+// it is a separate, visible bug — but the root cause is the same: a strict
+// default meeting a deliberately non-strict schema.
+//
+// Making the schema strict-compatible is the wrong trade here. `impossible` is
+// optional BY DESIGN — JUDGE_SYSTEM tells the judge to return `{"ok": false}`
+// WITHOUT `impossible` when in doubt — so forcing it into `required` would change
+// what the judge is asked to produce. State `strict: false` instead, exactly as
+// for tools.
+//
+// Scoped to the SDKs that read `strictJsonSchema` AND default it to true.
+// `@ai-sdk/openai-compatible` is included: it looks up provider options under the
+// name it was constructed with, which provider.ts sets to `model.providerID` —
+// the same key `providerOptions()` falls back to when `sdkKey()` has no mapping.
+//
+// Schemas that ARE strict-compatible (e.g. the agent-config schema in
+// agent/agent.ts) are deliberately left alone so they keep constrained decoding.
+const DEFAULT_STRICT_SCHEMA_SDKS = ["@ai-sdk/openai", "@ai-sdk/azure", "@ai-sdk/openai-compatible"]
+
+// Feed through `providerOptions()` before handing to generateObject/streamObject.
+export function structuredOutputOptions(model: Provider.Model) {
+  if (!DEFAULT_STRICT_SCHEMA_SDKS.includes(model.api.npm)) return {}
+  return { strictJsonSchema: false }
 }
 
 export function temperature(model: Provider.Model) {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1027,15 +1027,32 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
 // the same schema gets a clean 502 instead, which is why this read as random
 // upstream flakiness rather than a deterministic schema problem.
 //
-// So state the intent explicitly. Scoped to the SDKs that reach an OpenAI
-// Responses endpoint AND forward `tool.strict`:
-//   - `@ai-sdk/openai`
-//   - `@ai-sdk/azure`, which builds `OpenAIResponsesLanguageModel` from
-//     `@ai-sdk/openai/internal`
-// The vendored Copilot Responses SDK (`provider/sdk/copilot/responses`) already
-// always emits `strict`, and every other SDK is left alone on purpose:
-// `@ai-sdk/anthropic` warns ("strict mode is not supported by this provider")
-// for any non-null `strict`, so a blanket default would spam warnings there.
+// So state the intent explicitly.
+//
+// This list is keyed by npm package, but the Responses-vs-Chat decision is made
+// per PROVIDER in `provider.ts` `getModel`. Those two can drift, so here is the
+// full set of `sdk.responses()` call sites and why each is or is not listed:
+//
+//   provider.ts:323  openai                    @ai-sdk/openai  → LISTED
+//   provider.ts:359  azure                     @ai-sdk/azure   → LISTED, builds
+//                    `OpenAIResponsesLanguageModel` from `@ai-sdk/openai/internal`
+//   provider.ts:379  azure-cognitive-services  @ai-sdk/azure   → covered by the above
+//                    (catalog pins the provider's npm to `@ai-sdk/azure`)
+//   provider.ts:340  github-copilot            → the npm id resolves to the VENDORED
+//                    `./sdk/copilot`, whose prepare-tools already always emits
+//                    `strict`, so it is immune and must stay out of this list
+//   provider.ts:331  xai                       @ai-sdk/xai     → NOT listed. It
+//                    forwards `tool.strict` with the same omit-when-null guard, but
+//                    its prepare-tools runs every tool schema through
+//                    `removeAdditionalPropertiesFalse` (xai/dist:319). Strict mode
+//                    REQUIRES `additionalProperties: false`, so a strict-by-default
+//                    xAI would reject every tool call the SDK makes. It therefore
+//                    cannot be strict by default, and forcing the field here would
+//                    assert a constraint xAI has not been shown to honour.
+//
+// Everything else is left alone on purpose: `@ai-sdk/anthropic` warns ("strict mode
+// is not supported by this provider") for any non-null `strict`, so a blanket
+// default would spam warnings on every Anthropic request.
 //
 // An explicit per-tool `strict` is preserved, so a tool that has been made
 // strict-compatible can still opt in.
@@ -1120,8 +1137,11 @@ export function tools<T extends Record<string, any>>(tools: T, model: Provider.M
 const DEFAULT_STRICT_SCHEMA_SDKS = ["@ai-sdk/openai", "@ai-sdk/azure", "@ai-sdk/openai-compatible"]
 
 // Feed through `providerOptions()` before handing to generateObject/streamObject.
+// Returns undefined — not `{}` — for SDKs that do not default strict on, so
+// callers can skip attaching a provider-options bag entirely rather than sending
+// an empty one to every other provider.
 export function structuredOutputOptions(model: Provider.Model) {
-  if (!DEFAULT_STRICT_SCHEMA_SDKS.includes(model.api.npm)) return {}
+  if (!DEFAULT_STRICT_SCHEMA_SDKS.includes(model.api.npm)) return undefined
   return { strictJsonSchema: false }
 }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1009,6 +1009,38 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
   return msgs
 }
 
+// OpenAI's Responses API treats a function tool that OMITS `strict` as strict,
+// and `@ai-sdk/openai` only emits the field when the tool sets it
+// (`...tool.strict != null ? { strict: tool.strict } : {}`) — so by default we
+// were opting into constrained decoding by accident.
+//
+// Our tool schemas are deliberately NOT strict-compatible: optional parameters
+// stay out of `required`, not every object carries `additionalProperties: false`,
+// and discriminated unions keep an `anyOf`. Rather than reject the request, the
+// Codex backend auto-patches such a schema (observed on the wire: all 17 tools
+// came back tagged `strict: true`, `bash.required` grew from 2 entries to 5, and
+// `task.parameters.properties.operation` gained `additionalProperties: false`)
+// and then fails to compile the resulting decoding grammar. Because the failure
+// happens at GENERATION time, the 200 is already committed and the error can
+// only arrive mid-stream as `event: error` (`server_error`) + `response.failed` —
+// i.e. "the answer stops half-written". Sending `strict: true` explicitly with
+// the same schema gets a clean 502 instead, which is why this read as random
+// upstream flakiness rather than a deterministic schema problem.
+//
+// So state the intent explicitly. Scoped to the SDKs that reach an OpenAI
+// Responses endpoint AND forward `tool.strict`:
+//   - `@ai-sdk/openai`
+//   - `@ai-sdk/azure`, which builds `OpenAIResponsesLanguageModel` from
+//     `@ai-sdk/openai/internal`
+// The vendored Copilot Responses SDK (`provider/sdk/copilot/responses`) already
+// always emits `strict`, and every other SDK is left alone on purpose:
+// `@ai-sdk/anthropic` warns ("strict mode is not supported by this provider")
+// for any non-null `strict`, so a blanket default would spam warnings there.
+//
+// An explicit per-tool `strict` is preserved, so a tool that has been made
+// strict-compatible can still opt in.
+const EXPLICIT_NON_STRICT_TOOL_SDKS = ["@ai-sdk/openai", "@ai-sdk/azure"]
+
 // Place a cache breakpoint on the tool definitions. The cache hierarchy is
 // `tools` → `system` → `messages`, so marking the LAST tool caches the entire
 // tool-schema block (often several KB) as a stable prefix that sits in front of
@@ -1017,6 +1049,12 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
 // the SDK-keyed marker via `cacheMarkerFor`. Tool registration order is stable
 // (insertion order of the tools record), so "last tool" is deterministic.
 export function tools<T extends Record<string, any>>(tools: T, model: Provider.Model): T {
+  if (EXPLICIT_NON_STRICT_TOOL_SDKS.includes(model.api.npm)) {
+    for (const tool of Object.values(tools)) {
+      if (tool && tool.strict == null) tool.strict = false
+    }
+  }
+
   if (!supportsCacheMarkers(model)) return tools
   const marker = cacheMarkerFor(model)
   if (!marker) return tools

--- a/packages/opencode/src/session/goal.ts
+++ b/packages/opencode/src/session/goal.ts
@@ -188,6 +188,12 @@ export const layer = Layer.effect(
         messages: JSON.stringify(fullMessages, clip),
       })
 
+      // `Verdict.impossible` is optional by design, which strict mode rejects.
+      // See ProviderTransform.structuredOutputOptions for the full reasoning.
+      // undefined for SDKs that don't default json_schema strict on, so those
+      // models keep sending no provider options at all.
+      const structuredOutput = ProviderTransform.structuredOutputOptions(resolved)
+
       const params = {
         experimental_telemetry: {
           isEnabled: cfg.experimental?.openTelemetry,
@@ -205,12 +211,7 @@ export const layer = Layer.effect(
         ],
         model: language,
         schema: Verdict,
-        // `Verdict.impossible` is optional by design, which strict mode rejects.
-        // See ProviderTransform.structuredOutputOptions for the full reasoning.
-        providerOptions: ProviderTransform.providerOptions(
-          resolved,
-          ProviderTransform.structuredOutputOptions(resolved),
-        ),
+        providerOptions: structuredOutput && ProviderTransform.providerOptions(resolved, structuredOutput),
       } satisfies Parameters<typeof generateObject>[0]
 
       if (isOpenaiOauth) {
@@ -220,7 +221,7 @@ export const layer = Layer.effect(
             providerOptions: ProviderTransform.providerOptions(resolved, {
               instructions: JUDGE_SYSTEM,
               store: false,
-              ...ProviderTransform.structuredOutputOptions(resolved),
+              ...structuredOutput,
             }),
             onError: () => {},
           })

--- a/packages/opencode/src/session/goal.ts
+++ b/packages/opencode/src/session/goal.ts
@@ -205,6 +205,12 @@ export const layer = Layer.effect(
         ],
         model: language,
         schema: Verdict,
+        // `Verdict.impossible` is optional by design, which strict mode rejects.
+        // See ProviderTransform.structuredOutputOptions for the full reasoning.
+        providerOptions: ProviderTransform.providerOptions(
+          resolved,
+          ProviderTransform.structuredOutputOptions(resolved),
+        ),
       } satisfies Parameters<typeof generateObject>[0]
 
       if (isOpenaiOauth) {
@@ -214,6 +220,7 @@ export const layer = Layer.effect(
             providerOptions: ProviderTransform.providerOptions(resolved, {
               instructions: JUDGE_SYSTEM,
               store: false,
+              ...ProviderTransform.structuredOutputOptions(resolved),
             }),
             onError: () => {},
           })

--- a/packages/opencode/test/provider/strict-schema-wire.test.ts
+++ b/packages/opencode/test/provider/strict-schema-wire.test.ts
@@ -241,11 +241,13 @@ describe("non-OpenAI SDKs are left alone", () => {
   // The premise the exclusion above rests on, asserted rather than cited.
   //
   // @ai-sdk/xai runs every tool schema through `removeAdditionalPropertiesFalse`
-  // (xai/dist:319, called from prepareResponsesTools). OpenAI strict mode REQUIRES
-  // `additionalProperties: false` on every object, so a strict-by-default xAI
-  // would reject every tool call its own SDK makes — self-contradictory. That is
-  // why forcing `strict: false` there would assert a constraint xAI has not been
-  // shown to honour.
+  // (xai/dist:319, called from prepareResponsesTools; verified against the pinned
+  // @ai-sdk/xai 3.0.102 — note bun.lock also records a TRANSITIVE xai 3.0.82 under
+  // ai-gateway-provider that predates the stripping, so check the direct dependency
+  // when re-verifying). OpenAI strict mode REQUIRES `additionalProperties: false`
+  // on every object, so a strict-by-default xAI would reject every tool call its
+  // own SDK makes — self-contradictory. That is why forcing `strict: false` there
+  // would assert a constraint xAI has not been shown to honour.
   //
   // If xai ever stops stripping the field, this test fails and the exclusion is
   // due for re-evaluation — which is the whole point of asserting it here.

--- a/packages/opencode/test/provider/strict-schema-wire.test.ts
+++ b/packages/opencode/test/provider/strict-schema-wire.test.ts
@@ -225,19 +225,53 @@ describe("non-OpenAI SDKs are left alone", () => {
 
   // xai also reaches a Responses endpoint (provider.ts:331) and forwards
   // `tool.strict` with the same omit-when-null guard, so it looks like it belongs
-  // in the list. It does not: its prepare-tools strips `additionalProperties:
-  // false` from every schema, which strict mode REQUIRES — a strict-by-default xAI
-  // would reject every tool call the SDK makes, so it cannot be strict by default.
-  // Pinned so the exclusion reads as a decision rather than an oversight.
-  test("xai is excluded — its SDK strips additionalProperties, so it cannot be strict by default", async () => {
+  // in the list. It does not — see the next test for the reason. Pinned so the
+  // exclusion reads as a decision rather than an oversight.
+  test("xai tools are left untouched, so nothing reaches the wire", async () => {
     const tools = ProviderTransform.tools(toolset(), model("@ai-sdk/xai"))
     for (const entry of Object.values(tools)) expect(entry).not.toHaveProperty("strict")
 
-    const stripped = await outbound(tools, responsesReply, (fetch) =>
+    const body = await outbound(tools, responsesReply, (fetch) =>
       createXai({ apiKey: "test-key", fetch }).responses("grok-4"),
     )
-    expect(stripped.tools).toHaveLength(2)
-    for (const entry of stripped.tools) expect(entry).not.toHaveProperty("strict")
+    expect(body.tools).toHaveLength(2)
+    for (const entry of body.tools) expect(entry).not.toHaveProperty("strict")
+  })
+
+  // The premise the exclusion above rests on, asserted rather than cited.
+  //
+  // @ai-sdk/xai runs every tool schema through `removeAdditionalPropertiesFalse`
+  // (xai/dist:319, called from prepareResponsesTools). OpenAI strict mode REQUIRES
+  // `additionalProperties: false` on every object, so a strict-by-default xAI
+  // would reject every tool call its own SDK makes — self-contradictory. That is
+  // why forcing `strict: false` there would assert a constraint xAI has not been
+  // shown to honour.
+  //
+  // If xai ever stops stripping the field, this test fails and the exclusion is
+  // due for re-evaluation — which is the whole point of asserting it here.
+  test("xai strips additionalProperties: false, which strict mode requires", async () => {
+    const withAdditionalProperties = () => ({
+      query: dynamicTool({
+        description: "Query a server",
+        inputSchema: jsonSchema<any>({
+          type: "object",
+          properties: { q: { type: "string" } },
+          required: ["q"],
+          additionalProperties: false,
+        }),
+        execute: async () => "ok",
+      }),
+    })
+
+    const viaXai = await outbound(withAdditionalProperties(), responsesReply, (fetch) =>
+      createXai({ apiKey: "test-key", fetch }).responses("grok-4"),
+    )
+    expect(viaXai.tools[0].parameters).not.toHaveProperty("additionalProperties")
+
+    // CONTRAST: the OpenAI SDK ships the same schema with the field intact, so the
+    // stripping is xai-specific and not something `ai` core does upstream.
+    const viaOpenai = await openaiResponses(withAdditionalProperties())
+    expect(viaOpenai.tools[0].parameters.additionalProperties).toBe(false)
   })
 })
 

--- a/packages/opencode/test/provider/strict-schema-wire.test.ts
+++ b/packages/opencode/test/provider/strict-schema-wire.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { createAnthropic } from "@ai-sdk/anthropic"
 import { createOpenAI } from "@ai-sdk/openai"
-import { generateText, jsonSchema, tool } from "ai"
+import { dynamicTool, generateObject, generateText, jsonSchema, tool } from "ai"
+import z from "zod"
 import { ProviderTransform } from "../../src/provider"
 
 // WIRE-LEVEL proof that function tools ship with an explicit `strict: false` to
@@ -117,9 +118,7 @@ async function outbound(tools: Record<string, any>, reply: unknown, build: (fetc
 }
 
 const openaiResponses = (tools: Record<string, any>) =>
-  outbound(tools, responsesReply, (fetch) =>
-    createOpenAI({ apiKey: "test-key", fetch }).responses("gpt-5.1-codex"),
-  )
+  outbound(tools, responsesReply, (fetch) => createOpenAI({ apiKey: "test-key", fetch }).responses("gpt-5.1-codex"))
 
 const anthropicMessages = (tools: Record<string, any>) =>
   outbound(tools, anthropicReply, (fetch) => createAnthropic({ apiKey: "test-key", fetch })("claude-sonnet-4"))
@@ -167,6 +166,28 @@ describe("function tools reach the OpenAI Responses API with an explicit strict:
       ["read", false],
     ])
   })
+
+  // MCP tools are built by `convertMcpTool` as `dynamicTool()`, i.e.
+  // `type: "dynamic"` rather than a plain function tool. `ai`'s
+  // `prepareToolsAndToolChoice` funnels `dynamic` through the same
+  // `case "function"` branch, so `strict` must survive for them too — MCP tool
+  // schemas are server-supplied and the least likely to be strict-compatible.
+  test("dynamic (MCP) tools also ship `strict: false`", async () => {
+    const tools = {
+      mcp_server_query: dynamicTool({
+        description: "Query a server",
+        inputSchema: jsonSchema<any>({
+          type: "object",
+          properties: { q: { type: "string" }, page: { type: "number" } },
+          required: ["q"],
+          additionalProperties: false,
+        }),
+        execute: async () => "ok",
+      }),
+    }
+    const body = await openaiResponses(ProviderTransform.tools(tools, model("@ai-sdk/openai")))
+    expect(body.tools.map((entry: any) => [entry.name, entry.strict])).toEqual([["mcp_server_query", false]])
+  })
 })
 
 describe("non-OpenAI SDKs are left alone", () => {
@@ -199,5 +220,73 @@ describe("non-OpenAI SDKs are left alone", () => {
   test("openai-compatible proxies are untouched", () => {
     const tools = ProviderTransform.tools(toolset(), model("@ai-sdk/openai-compatible"))
     for (const entry of Object.values(tools)) expect(entry).not.toHaveProperty("strict")
+  })
+})
+
+// The `response_format` sibling of the above. Here the SDKs default
+// `strictJsonSchema` to TRUE, so `strict: true` goes out EXPLICITLY — the
+// opposite direction from the tool case, and it fails cleanly at validation
+// rather than mid-stream.
+describe("structured output declares strict: false for non-strict-compatible schemas", () => {
+  // `SessionGoal.Verdict`. `impossible` is optional BY DESIGN — JUDGE_SYSTEM
+  // tells the judge to omit it when in doubt.
+  const Verdict = z.object({ ok: z.boolean(), impossible: z.boolean().optional(), reason: z.string() })
+
+  async function format(schema: any, options: Record<string, unknown>) {
+    let captured: any
+    const openai = createOpenAI({
+      apiKey: "test-key",
+      fetch: (async (_url: any, init: any) => {
+        captured = JSON.parse(init.body as string)
+        return new Response("{}", { headers: { "content-type": "application/json" } })
+      }) as any,
+    })
+    await generateObject({
+      model: openai.responses("gpt-5.1-codex"),
+      prompt: "hi",
+      schema,
+      providerOptions: options as any,
+    }).catch(() => {})
+    return captured?.text?.format
+  }
+
+  test("CONTROL: Verdict would ship strict: true with an incomplete `required` (the defect)", async () => {
+    const sent = await format(Verdict, {})
+    expect(sent.strict).toBe(true)
+    // 3 properties, 2 required — exactly what OpenAI's strict mode rejects.
+    expect(Object.keys(sent.schema.properties)).toEqual(["ok", "impossible", "reason"])
+    expect(sent.schema.required).toEqual(["ok", "reason"])
+  })
+
+  test("structuredOutputOptions turns strict off for the openai SDK", async () => {
+    const sent = await format(
+      Verdict,
+      ProviderTransform.providerOptions(model("@ai-sdk/openai"), {
+        ...ProviderTransform.structuredOutputOptions(model("@ai-sdk/openai")),
+      }),
+    )
+    expect(sent.strict).toBe(false)
+    // The schema is untouched — `impossible` stays optional.
+    expect(sent.schema.required).toEqual(["ok", "reason"])
+  })
+
+  test("azure and openai-compatible are covered; anthropic is not", () => {
+    expect(ProviderTransform.structuredOutputOptions(model("@ai-sdk/openai"))).toEqual({ strictJsonSchema: false })
+    expect(ProviderTransform.structuredOutputOptions(model("@ai-sdk/azure"))).toEqual({ strictJsonSchema: false })
+    expect(ProviderTransform.structuredOutputOptions(model("@ai-sdk/openai-compatible"))).toEqual({
+      strictJsonSchema: false,
+    })
+    expect(ProviderTransform.structuredOutputOptions(model("@ai-sdk/anthropic"))).toEqual({})
+  })
+
+  // agent.ts's schema is deliberately NOT opted out: it is strict-compatible, so
+  // it still gets constrained decoding. This pins that property — adding an
+  // optional field there would silently reintroduce the Verdict bug, and this
+  // test is the tripwire that points at structuredOutputOptions.
+  test("the agent-config schema stays strict-compatible, so strict decoding is kept", async () => {
+    const sent = await format(z.object({ identifier: z.string(), whenToUse: z.string(), systemPrompt: z.string() }), {})
+    expect(sent.strict).toBe(true)
+    expect(sent.schema.required).toEqual(Object.keys(sent.schema.properties))
+    expect(sent.schema.additionalProperties).toBe(false)
   })
 })

--- a/packages/opencode/test/provider/strict-schema-wire.test.ts
+++ b/packages/opencode/test/provider/strict-schema-wire.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { createAnthropic } from "@ai-sdk/anthropic"
 import { createOpenAI } from "@ai-sdk/openai"
+import { createXai } from "@ai-sdk/xai"
 import { dynamicTool, generateObject, generateText, jsonSchema, tool } from "ai"
 import z from "zod"
 import { ProviderTransform } from "../../src/provider"
@@ -221,6 +222,23 @@ describe("non-OpenAI SDKs are left alone", () => {
     const tools = ProviderTransform.tools(toolset(), model("@ai-sdk/openai-compatible"))
     for (const entry of Object.values(tools)) expect(entry).not.toHaveProperty("strict")
   })
+
+  // xai also reaches a Responses endpoint (provider.ts:331) and forwards
+  // `tool.strict` with the same omit-when-null guard, so it looks like it belongs
+  // in the list. It does not: its prepare-tools strips `additionalProperties:
+  // false` from every schema, which strict mode REQUIRES — a strict-by-default xAI
+  // would reject every tool call the SDK makes, so it cannot be strict by default.
+  // Pinned so the exclusion reads as a decision rather than an oversight.
+  test("xai is excluded — its SDK strips additionalProperties, so it cannot be strict by default", async () => {
+    const tools = ProviderTransform.tools(toolset(), model("@ai-sdk/xai"))
+    for (const entry of Object.values(tools)) expect(entry).not.toHaveProperty("strict")
+
+    const stripped = await outbound(tools, responsesReply, (fetch) =>
+      createXai({ apiKey: "test-key", fetch }).responses("grok-4"),
+    )
+    expect(stripped.tools).toHaveLength(2)
+    for (const entry of stripped.tools) expect(entry).not.toHaveProperty("strict")
+  })
 })
 
 // The `response_format` sibling of the above. Here the SDKs default
@@ -276,7 +294,10 @@ describe("structured output declares strict: false for non-strict-compatible sch
     expect(ProviderTransform.structuredOutputOptions(model("@ai-sdk/openai-compatible"))).toEqual({
       strictJsonSchema: false,
     })
-    expect(ProviderTransform.structuredOutputOptions(model("@ai-sdk/anthropic"))).toEqual({})
+    // undefined, not {} — so goal.ts attaches no provider-options bag at all for
+    // SDKs that don't default json_schema strict on.
+    expect(ProviderTransform.structuredOutputOptions(model("@ai-sdk/anthropic"))).toBeUndefined()
+    expect(ProviderTransform.structuredOutputOptions(model("@ai-sdk/xai"))).toBeUndefined()
   })
 
   // agent.ts's schema is deliberately NOT opted out: it is strict-compatible, so

--- a/packages/opencode/test/provider/tool-strict-wire.test.ts
+++ b/packages/opencode/test/provider/tool-strict-wire.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "bun:test"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { createOpenAI } from "@ai-sdk/openai"
+import { generateText, jsonSchema, tool } from "ai"
+import { ProviderTransform } from "../../src/provider"
+
+// WIRE-LEVEL proof that function tools ship with an explicit `strict: false` to
+// the OpenAI Responses API.
+//
+// The Responses API treats a function tool that OMITS `strict` as strict, and
+// `@ai-sdk/openai` only emits the field when the tool sets it
+// (`...tool.strict != null ? { strict: tool.strict } : {}`). Our schemas are not
+// strict-compatible — optional parameters stay out of `required` and objects do
+// not all carry `additionalProperties: false` — so the Codex backend auto-patched
+// them, failed to compile the decoding grammar, and returned `server_error`
+// MID-STREAM after the 200 was already committed (the answer stopped
+// half-written). Explicit `strict: false` is the fix.
+//
+// Asserting on `ProviderTransform.tools`' return value alone is two layers short
+// of the wire: `ai`'s `prepareToolsAndToolChoice` has the same
+// `tool.strict != null` guard, so a field that fails to survive it never reaches
+// the provider. These tests capture the real outbound HTTP body instead.
+
+function model(npm: string, overrides: Partial<any> = {}) {
+  return {
+    id: `test/${npm}`,
+    providerID: "test",
+    api: { id: "gpt-5.1-codex", url: "https://api.openai.com/v1", npm },
+    name: "Test Model",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
+    limit: { context: 200_000, output: 64_000 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2025-01-01",
+    ...overrides,
+  } as any
+}
+
+// `ProviderTransform.tools` mutates the record in place, so every test needs a
+// fresh set. Mirrors the real shape that broke: `timeout` is optional (absent
+// from `required`) and no object declares `additionalProperties: false`.
+const toolset = () => ({
+  bash: tool({
+    description: "Run a shell command",
+    inputSchema: jsonSchema<any>({
+      type: "object",
+      properties: {
+        command: { type: "string", description: "The command to run" },
+        timeout: { type: "number", description: "Timeout in ms" },
+      },
+      required: ["command"],
+    }),
+    execute: async () => "ok",
+  }),
+  read: tool({
+    description: "Read a file",
+    inputSchema: jsonSchema<any>({
+      type: "object",
+      properties: { path: { type: "string" }, limit: { type: "number" } },
+      required: ["path"],
+    }),
+    execute: async () => "ok",
+  }),
+})
+
+const responsesReply = {
+  id: "resp_1",
+  object: "response",
+  created_at: 1_755_000_000,
+  status: "completed",
+  model: "gpt-5.1-codex",
+  output: [
+    {
+      id: "msg_1",
+      type: "message",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "ok", annotations: [] }],
+    },
+  ],
+  usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+  incomplete_details: null,
+}
+
+const anthropicReply = {
+  id: "msg_1",
+  type: "message",
+  role: "assistant",
+  model: "claude-sonnet-4",
+  content: [{ type: "text", text: "ok" }],
+  stop_reason: "end_turn",
+  usage: { input_tokens: 1, output_tokens: 1 },
+}
+
+// Runs the tool set through the real `ai` core + real provider and returns the
+// parsed outbound HTTP body.
+async function outbound(tools: Record<string, any>, reply: unknown, build: (fetch: any) => any) {
+  let captured: any
+  const languageModel = build((async (_url: any, init: any) => {
+    captured = JSON.parse(init.body as string)
+    return new Response(JSON.stringify(reply), { headers: { "content-type": "application/json" } })
+  }) as any)
+  // The reply is a text answer, so the tool loop never runs; a validation
+  // mismatch on the stub is irrelevant because the body is already captured.
+  await generateText({ model: languageModel, prompt: "hi", tools }).catch(() => {})
+  return captured
+}
+
+const openaiResponses = (tools: Record<string, any>) =>
+  outbound(tools, responsesReply, (fetch) =>
+    createOpenAI({ apiKey: "test-key", fetch }).responses("gpt-5.1-codex"),
+  )
+
+const anthropicMessages = (tools: Record<string, any>) =>
+  outbound(tools, anthropicReply, (fetch) => createAnthropic({ apiKey: "test-key", fetch })("claude-sonnet-4"))
+
+describe("function tools reach the OpenAI Responses API with an explicit strict: false", () => {
+  test("CONTROL: untransformed tools omit `strict` entirely (the defect)", async () => {
+    const body = await openaiResponses(toolset())
+    expect(body.tools).toHaveLength(2)
+    // Proof of the mechanism, and proof this test would catch a regression:
+    // omitting the field is what made the backend treat these as strict.
+    for (const entry of body.tools) expect(entry).not.toHaveProperty("strict")
+  })
+
+  test("every tool ships `strict: false` after ProviderTransform.tools", async () => {
+    const body = await openaiResponses(ProviderTransform.tools(toolset(), model("@ai-sdk/openai")))
+    expect(body.tools.map((entry: any) => [entry.name, entry.strict])).toEqual([
+      ["bash", false],
+      ["read", false],
+    ])
+  })
+
+  test("the schemas themselves are untouched — only `strict` is added", async () => {
+    const before = await openaiResponses(toolset())
+    const after = await openaiResponses(ProviderTransform.tools(toolset(), model("@ai-sdk/openai")))
+    expect(after.tools.map((entry: any) => entry.parameters)).toEqual(
+      before.tools.map((entry: any) => entry.parameters),
+    )
+    // The shape that the backend auto-patched survives verbatim: `timeout`
+    // stays optional and no `additionalProperties: false` is invented.
+    expect(after.tools[0].parameters.required).toEqual(["command"])
+    expect(after.tools[0].parameters).not.toHaveProperty("additionalProperties")
+  })
+
+  test("@ai-sdk/azure gets the same treatment — it builds OpenAI's responses model", () => {
+    const tools = ProviderTransform.tools(toolset(), model("@ai-sdk/azure"))
+    expect(Object.values(tools).map((entry: any) => entry.strict)).toEqual([false, false])
+  })
+
+  test("an explicit per-tool `strict` is preserved, not overwritten", async () => {
+    const tools = toolset()
+    ;(tools.bash as any).strict = true
+    const body = await openaiResponses(ProviderTransform.tools(tools, model("@ai-sdk/openai")))
+    expect(body.tools.map((entry: any) => [entry.name, entry.strict])).toEqual([
+      ["bash", true],
+      ["read", false],
+    ])
+  })
+})
+
+describe("non-OpenAI SDKs are left alone", () => {
+  // @ai-sdk/anthropic emits an "unsupported feature" warning for ANY non-null
+  // `strict`, so defaulting it there would spam warnings on every request.
+  test("anthropic tools keep `strict` unset and nothing reaches the wire", async () => {
+    const tools = ProviderTransform.tools(toolset(), model("@ai-sdk/anthropic"))
+    for (const entry of Object.values(tools)) expect(entry).not.toHaveProperty("strict")
+
+    const body = await anthropicMessages(tools)
+    expect(body.tools).toHaveLength(2)
+    for (const entry of body.tools) expect(entry).not.toHaveProperty("strict")
+  })
+
+  test("anthropic requests emit no strict-mode warning", async () => {
+    const warnings = await generateText({
+      model: createAnthropic({
+        apiKey: "test-key",
+        fetch: (async () =>
+          new Response(JSON.stringify(anthropicReply), {
+            headers: { "content-type": "application/json" },
+          })) as any,
+      })("claude-sonnet-4"),
+      prompt: "hi",
+      tools: ProviderTransform.tools(toolset(), model("@ai-sdk/anthropic")),
+    }).then((result) => result.warnings)
+    expect(warnings?.filter((warning: any) => warning.feature === "strict")).toEqual([])
+  })
+
+  test("openai-compatible proxies are untouched", () => {
+    const tools = ProviderTransform.tools(toolset(), model("@ai-sdk/openai-compatible"))
+    for (const entry of Object.values(tools)) expect(entry).not.toHaveProperty("strict")
+  })
+})


### PR DESCRIPTION
## Problem

MiMo Code requests to a Codex backend failed **mid-stream** at a 5–17% rate: HTTP 200, some tokens already delivered, then `event: error` (`server_error`) + `response.failed`. To the user the answer just stops half-written. The official `codex` client on the same upstream failed at 0.2–0.9%, and for unrelated reasons (`server_is_overloaded`, context limits).

The official client is immune because **it sends no tools** — its built-ins are provided by the backend. Every client that ships its own tools hits this.

## Root cause

OpenAI's Responses API treats a function tool that **omits** `strict` as strict, and `@ai-sdk/openai` only emits the field when the tool sets it:

```js
// node_modules/@ai-sdk/openai/dist/index.mjs:4446
...tool.strict != null ? { strict: tool.strict } : {},
```

`ai` core has the same guard (`ai/dist/index.mjs:1806`). So we were opting into constrained decoding by accident, never having stated an intent.

Our schemas are deliberately **not** strict-compatible — optional parameters stay out of `required`, not every object carries `additionalProperties: false`, and discriminated unions keep an `anyOf`. Rather than reject the request, the backend auto-patches the schema and then fails to compile the resulting decoding grammar. Observed in the `response.created` echo: all 17 tools came back tagged `strict: true`, `bash.required` grew from 2 entries to 5 (`timeout`/`workdir`/`interactive` all became mandatory), and `task.parameters.properties.operation` gained `additionalProperties: false`.

Because that failure happens at **generation** time, the 200 is already committed, so the error can only surface mid-stream.

What made this expensive to diagnose is the asymmetry: the *same* invalid schema sent with an explicit `strict: true` gets a clean 502 (no partial output, no billing), while omitting the field passes validation and then 500s mid-generation. It reads as random upstream flakiness rather than a deterministic schema problem.

## Fix

State the intent explicitly. **No schema changes** — `anyOf` unions and optional parameters stay exactly as they are.

`ProviderTransform.tools()` is the single choke point for the outbound tool set (`session/llm.ts:733`), so one place covers built-in, MCP, and `StructuredOutput` tools:

```ts
if (EXPLICIT_NON_STRICT_TOOL_SDKS.includes(model.api.npm)) {
  for (const tool of Object.values(tools)) {
    if (tool && tool.strict == null) tool.strict = false
  }
}
```

Scoped to the SDKs that reach an OpenAI Responses endpoint **and** forward `tool.strict`:

- `@ai-sdk/openai`
- `@ai-sdk/azure` — builds `OpenAIResponsesLanguageModel` from `@ai-sdk/openai/internal`

Deliberately **not** applied elsewhere: the vendored Copilot Responses SDK already always emits `strict` (`sdk/copilot/responses/openai-responses-prepare-tools.ts:50`), and `@ai-sdk/anthropic` warns for *any* non-null `strict` (`dist/index.mjs:1505`), so a blanket default would spam warnings on every Anthropic request. An explicit per-tool `strict` is preserved so a tool that is made strict-compatible can still opt in.

## Second commit: the same bug class on the structured-output path

While verifying the scope I found the `response_format` sibling. `generateObject`/`streamObject` default `strictJsonSchema` to **true** (`@ai-sdk/openai` chat + responses, and `@ai-sdk/openai-compatible`), so `strict: true` goes out *explicitly*.

`SessionGoal.Verdict` marks `impossible` optional, so `required` ships 2 of its 3 properties. Captured from the wire:

```
strict: true
properties: ["ok", "impossible", "reason"]
required:   ["ok",               "reason"]   ← strict mode rejects this
```

`goal.ts` judges with the **session's** model, so the stop-condition judge (`/goal`) was broken on every OpenAI-backed model. This one fails cleanly at validation rather than mid-stream, so it is a separate, visible bug — but the root cause is identical.

Fixed the same way rather than by rewriting the schema: `impossible` is optional *by design* (JUDGE_SYSTEM tells the judge to return `{"ok": false}` **without** `impossible` when in doubt), so forcing it into `required` would change what the judge is asked to produce. `.default(false)` does not help — it still lands outside `required`.

The agent-config schema in `agent/agent.ts` is deliberately **not** opted out: it is already strict-compatible (all fields required, `additionalProperties: false`), so it keeps constrained decoding. A test pins that so adding an optional field there fails loudly instead of silently reintroducing this bug.

## Testing

`test/provider/strict-schema-wire.test.ts` (13 tests) follows the existing `empty-content-wire.test.ts` pattern: inject `fetch` and assert on the **real outbound HTTP body**, driven through the full chain (`ToolSet` → `ai` core → provider → wire). Asserting on `ProviderTransform.tools()`'s return value alone would be two layers short — `ai`'s `prepareToolsAndToolChoice` has the same `tool.strict != null` guard, so a field that failed to survive it would never reach the provider.

Includes **CONTROL** cases proving the defect mechanism (and therefore that these tests would catch a regression): untransformed tools ship with no `strict` field at all, and `Verdict` ships `strict: true` with an incomplete `required`.

Also covered:
- schemas byte-identical before/after — only `strict` is added
- MCP tools (`dynamicTool`, `type: "dynamic"`, which `ai` funnels through the same `case "function"` branch) — server-supplied schemas are the least likely to be strict-compatible
- Anthropic keeps `strict` unset **and** emits no `feature: "strict"` warning
- an explicit `strict: true` survives

Results:
- `bun test test/provider/` → **471 pass, 0 fail**
- `bun test test/session/` → **898 pass, 25 skip, 0 fail**
- `bun typecheck` → clean

## Notes for reviewers

Both transforms **mutate in place**. That is safe because the record and every tool object in it are rebuilt per request: `resolveTools` allocates a fresh record and calls `tool()` per entry, and MCP entries come from `convertMcpTool`, which returns a new `dynamicTool()` on every `MCP.tools()` call. Nothing outlives the request, so a mid-turn model switch cannot carry `strict` over to a provider that would reject or warn on it. This is documented at the function, since it is the correctness precondition for the approach.

Azure's `useCompletionUrls` branch sends the same tools to Chat Completions, where the field lands as `function.strict: false` — a documented boolean whose default is already false, so that path is unaffected.

Not a regression: `transform.ts` and the pinned `@ai-sdk/openai@3.0.53` both date to the initial open-source commit. It is the interaction of three individually-reasonable behaviours (the SDK not inventing an intent, OpenAI defaulting to strict, our schemas being intentionally non-strict) that only becomes visible when tools are sent to a Codex backend.

**Known remaining gap:** the vendored Copilot Responses SDK defaults `strictJsonSchema` to `false` (`openai-responses-language-model.ts:212`) while the npm packages default it to `true`, so structured output behaves differently across providers. Left alone here to keep this PR scoped; worth unifying separately.
