### PR TITLE
fix(session): retry OpenAI stream server errors

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -134,7 +134,7 @@ export type ParsedStreamError =
   | {
       type: "api_error"
       message: string
-      isRetryable: false
+      isRetryable: boolean
       responseBody: string
     }
 
@@ -146,6 +146,13 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   if (body.type !== "error") return
 
   switch (body?.error?.code) {
+    case "server_error":
+      return {
+        type: "api_error",
+        message: typeof body?.error?.message === "string" ? body.error.message : "OpenAI server error",
+        isRetryable: true,
+        responseBody,
+      }
     case "context_length_exceeded":
       return {
         type: "context_overflow",

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { APICallError } from "ai"
-import { parseAPICallError } from "../../src/provider/error"
+import { parseAPICallError, parseStreamError } from "../../src/provider/error"
 import { ProviderID } from "../../src/provider/schema"
 
 const xiaomi = ProviderID.make("xiaomi")
@@ -156,5 +156,27 @@ describe("provider error message", () => {
       }),
     })
     expect(parsed.message).toBe("Insufficient account balance")
+  })
+})
+
+describe("provider stream error", () => {
+  test("marks OpenAI server_error events as retryable", () => {
+    const input = {
+      type: "error",
+      sequence_number: 3,
+      error: {
+        type: "server_error",
+        code: "server_error",
+        message: "An error occurred while processing your request. You can retry your request.",
+        param: null,
+      },
+    }
+
+    expect(parseStreamError(input)).toStrictEqual({
+      type: "api_error",
+      message: input.error.message,
+      isRetryable: true,
+      responseBody: JSON.stringify(input),
+    })
   })
 })

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -124,6 +124,30 @@ describe("session.retry.delay", () => {
 })
 
 describe("session.retry.retryable", () => {
+  test("retries OpenAI server_error stream events", () => {
+    const input = {
+      type: "error",
+      sequence_number: 3,
+      error: {
+        type: "server_error",
+        code: "server_error",
+        message: "An error occurred while processing your request. You can retry your request.",
+        param: null,
+      },
+    }
+    const error = MessageV2.fromError(input, { providerID })
+
+    expect(error).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: input.error.message,
+        isRetryable: true,
+        responseBody: JSON.stringify(input),
+      },
+    })
+    expect(SessionRetry.retryable(error)).toBe(input.error.message)
+  })
+
   test("maps too_many_requests json messages", () => {
     const error = wrap(JSON.stringify({ type: "error", error: { type: "too_many_requests" } }))
     expect(SessionRetry.retryable(error)).toBe("Too Many Requests")


### PR DESCRIPTION
## Summary
- classify OpenAI Responses API stream `server_error` events as retryable API errors
- preserve the provider error message and structured response body
- cover parsing and the session retry decision with regression tests

## Testing
- `bun test test/provider/error.test.ts test/session/retry.test.ts`
- `bun typecheck`
