### PR TITLE
fix(session): prevent duplicate context rebuilds

### DIFF
--- a/docs/compose/spec/context-budget-control.md
+++ b/docs/compose/spec/context-budget-control.md
@@ -1,8 +1,8 @@
 ---
 feature: context-budget-control
-status: delivered
-updated: 2026-07-31
-branch: fix/context-limit-threshold-rebuild
+status: in-progress
+updated: 2026-08-05
+branch: investigate/context-limit-double-rebuild
 commits: 028f3178..3b15062d
 ---
 
@@ -104,6 +104,12 @@ Checkpoint percentages use `usable()` as their denominator, and the final 80%/90
 2. Never exceeds the provider's effective cap — the setting clamps, it never raises.
 3. Discoverable from the TUI without editing JSON, and the resulting number must be printable ("what is my current context window, and where will it compact?").
 4. The provider-layer Codex bug fixed correctly and independently of (1)–(3).
+
+### S1.6 A completed high-usage turn is rebuilt twice
+
+`SessionProcessor` marks a successfully completed model turn as `"overflow"` when its reported usage reaches `Overflow.usable()`. The post-process overflow handler rebuilds immediately, but the same completed assistant usage remains visible to later prompt loops. The next user turn can therefore consume that usage again in the preflight overflow check, insert a second checkpoint boundary, re-arm checkpoint thresholds, and run tail microcompaction again.
+
+For a configured 372K budget with the default 20K reserve, the first trigger is 352K (`94.6%` of the configured limit). This is the intended trigger. The defect is processing that one high-water usage record twice, not the trigger percentage.
 
 ## [S2] Design — route-independent core
 
@@ -215,6 +221,14 @@ The TUI may import `Overflow.window` directly — TUI modules already import fro
 
 Note this intentionally changes an existing user-visible number: the footer `%` will read higher than before for models whose reserves are large, because it is now measured against the value that actually triggers compaction. That is the point of the change and must be called out in the PR description.
 
+### S2.7 One recovery per assistant usage record
+
+Every overflow recovery path that successfully frees context in the post-process phase sets `skipOverflowCheck` before continuing the current run loop. Across run loops, a checkpoint or compaction boundary with an ascending message ID newer than the completed assistant marks that usage as already recovered. Boundary timestamps are backdated to the checkpoint watermark, so this comparison uses message IDs rather than timestamps.
+
+The next iteration or user turn may call the model on the rebuilt or compacted context, but must not run checkpoint scheduling, preflight overflow, or exit-time pruning against the same completed assistant usage. This applies to main-agent checkpoint rebuilds and subagent/fork compaction paths. If recovery inserts nothing (`insert-failed`), no marker exists and the usage remains eligible because no context was freed.
+
+The invariant is behavioral, not time-based: no cooldown or percentage margin is introduced. A later assistant turn with newly measured high usage may still trigger its own recovery.
+
 ## [S3] Routes — decision required
 
 Storage location for the user's budget. All routes share S2.1–S2.2 and S2.6; they differ in where the value lives and therefore in scope, persistence, and cost.
@@ -297,3 +311,5 @@ Display (needed by any route):
 - [x] T11: Surface the context window in the `models` CLI command without `--verbose` — acceptance: `mimocode models openai` prints each model's provider window and compact-at (covers: S2.6; depends: T5)
 - [x] T12: Decouple the final checkpoint threshold from the prompt-loop rebuild condition — acceptance: crossing the final checkpoint threshold below `usable()` writes a checkpoint but inserts no rebuild or compaction boundary; reaching `usable()` still follows the existing rebuild path (covers: S1.3, S2.1; depends: T5)
 - [x] T13: Show the configured active limit relative to the provider hard cap in the sidebar — acceptance: a 300K budget on a 922K model renders `limit 300K of 922K`, while the reserve-adjusted trigger remains internal and available in `/status` (covers: S2.6; depends: T5)
+- [x] T14: Consume each assistant usage at most once during overflow recovery — acceptance: post-process recovery sets the current-loop skip guard; across user turns, a newer boundary prevents the recovered assistant from driving checkpoint scheduling, preflight overflow, or exit-time pruning; equivalent subagent/fork recovery paths set the same guard (covers: S1.6, S2.7; depends: T12)
+- [x] T15: Add regression coverage for duplicate recovery — acceptance: a low-usage initialization turn, a successful high-usage turn, and a following user turn produce two distinct checkpoint boundaries on current `main`, but exactly one boundary and one writer after T14; existing preflight and provider-overflow fallback tests remain green (covers: S1.6, S2.7; depends: T14)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3163,6 +3163,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
+          const usageRecovered =
+            !!lastFinished &&
+            msgs.some(
+              (msg) =>
+                msg.info.id > lastFinished.id &&
+                msg.parts.some((part) => part.type === "checkpoint" || part.type === "compaction"),
+            )
 
           // Per-user-message active recall reminder. Once the session has
           // any memory artifacts (memory dir populated OR tasks recorded),
@@ -3321,7 +3328,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID, lastUser)
           lastModelForPrune = model
-          lastFinishedForPrune = lastFinished
+          lastFinishedForPrune = usageRecovered ? undefined : lastFinished
           const task = tasks.pop()
 
           if (task?.type === "subtask") {
@@ -3412,7 +3419,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           // based on the latest completed assistant message's tokens. These
           // thresholds only keep the checkpoint fresh; `overflowCheck` below is
           // the single trigger for rebuilding the active context.
-          if (!skipOverflowCheck && !isBoundedComputation && lastFinished && lastFinished.tokens) {
+          if (!skipOverflowCheck && !usageRecovered && !isBoundedComputation && lastFinished && lastFinished.tokens) {
             const fireOps = yield* ops()
             yield* prune
               .fireCheckpoints({
@@ -3427,6 +3434,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           if (
             !skipOverflowCheck &&
+            !usageRecovered &&
             !isBoundedComputation &&
             lastFinished &&
             lastFinished.summary !== true &&
@@ -3817,6 +3825,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     agentID: lastUser.agentID,
                   })
                   .pipe(Effect.ignore)
+                skipOverflowCheck = true
               }
               return "continue" as const
             }
@@ -4037,6 +4046,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     agentID: lastUser.agentID,
                   })
                   .pipe(Effect.ignore)
+                skipOverflowCheck = true
                 return "continue" as const
               }
 
@@ -4055,7 +4065,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   .set(sessionID, { type: "busy", message: "Writing checkpoint\u2026" })
                   .pipe(Effect.catch(() => Effect.void)),
               })
-              if (attempt2 === "rebuilt") return "continue" as const
+              if (attempt2 === "rebuilt") {
+                skipOverflowCheck = true
+                return "continue" as const
+              }
 
               // Same as above: the writer ran and failed — not "no checkpoint".
               if (attempt2 === "writer-failed") {
@@ -4070,6 +4083,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     agentID: lastUser.agentID,
                   })
                   .pipe(Effect.ignore)
+                skipOverflowCheck = true
               }
               // "insert-failed" → a checkpoint exists; must not compact.
             }

--- a/packages/opencode/test/session/auto-overflow-writer-first.test.ts
+++ b/packages/opencode/test/session/auto-overflow-writer-first.test.ts
@@ -33,7 +33,7 @@ function run<A, E>(fx: Effect.Effect<A, E, SessionPrompt.Service | Session.Servi
   )
 }
 
-function chat(text: string): ReadableStream<Uint8Array> {
+function chat(text: string, promptTokens?: number): ReadableStream<Uint8Array> {
   const payload =
     [
       `data: ${JSON.stringify({
@@ -50,6 +50,10 @@ function chat(text: string): ReadableStream<Uint8Array> {
         id: "chatcmpl-1",
         object: "chat.completion.chunk",
         choices: [{ delta: {}, finish_reason: "stop" }],
+        usage:
+          promptTokens === undefined
+            ? undefined
+            : { prompt_tokens: promptTokens, completion_tokens: 1, total_tokens: promptTokens + 1 },
       })}`,
       "data: [DONE]",
     ].join("\n\n") + "\n\n"
@@ -60,6 +64,30 @@ function chat(text: string): ReadableStream<Uint8Array> {
       ctrl.close()
     },
   })
+}
+
+function startUsageLLM(replies: Array<{ text: string; promptTokens: number }>) {
+  let calls = 0
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url)
+      if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
+      const reply = replies[Math.min(calls, replies.length - 1)]!
+      calls++
+      return new Response(chat(reply.text, reply.promptTokens), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    },
+  })
+  return {
+    origin: server.url.origin,
+    get calls() {
+      return calls
+    },
+    stop: () => server.stop(true),
+  }
 }
 
 function startLLM(reply: string) {
@@ -273,6 +301,81 @@ async function seedFinishedAssistant(sessionID: SessionID, parentID: MessageID, 
 // with no summary at all. Degrading is therefore a real loss, not a cheaper
 // summary.
 describe("Auto context overflow: write a checkpoint before degrading to compaction", () => {
+  test(
+    "a completed high-usage turn is rebuilt exactly once",
+    async () => {
+      const llm = startUsageLLM([
+        { text: "initialized", promptTokens: 1_000 },
+        { text: "high-usage reply", promptTokens: 25_000 },
+        { text: "reply after rebuild", promptTokens: 1_000 },
+      ])
+      let writerCalls = 0
+      const writer = writerThatWritesCheckpointAfter("HIGH_USAGE_CHECKPOINT", 400, () => writerCalls++)
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
+        })
+
+        await Instance.provide({
+          directory: tmp.path,
+          fn: () =>
+            run(
+              Effect.gen(function* () {
+                const prompt = yield* SessionPrompt.Service
+                const sessions = yield* Session.Service
+                const info = yield* sessions.create({ title: "high-usage-single-rebuild" })
+
+                // The first prompt resolves the late-bound actor layer, which
+                // installs its real spawn implementation.
+                yield* prompt.prompt({
+                  sessionID: info.id,
+                  parts: [{ type: "text", text: "initialize the actor layer" }],
+                  agent: "build",
+                })
+
+                // Bind the deterministic writer after layer initialization.
+                const previous = spawnRef.current
+                spawnRef.current = writer
+                yield* prompt
+                  .prompt({
+                    sessionID: info.id,
+                    parts: [{ type: "text", text: "produce one high-usage turn" }],
+                    agent: "build",
+                  })
+                  .pipe(
+                    Effect.ensuring(
+                      Effect.sync(() => {
+                        spawnRef.current = previous
+                      }),
+                    ),
+                  )
+
+                yield* prompt.prompt({
+                  sessionID: info.id,
+                  parts: [{ type: "text", text: "continue after the automatic rebuild" }],
+                  agent: "build",
+                })
+
+                const after = yield* sessions.messages({ sessionID: info.id })
+                const checkpoints = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                expect(checkpoints).toHaveLength(1)
+                expect(new Set(checkpoints.map((m) => m.info.id)).size).toBe(1)
+                expect(writerCalls).toBe(1)
+                expect(llm.calls).toBe(3)
+                expect(
+                  after.some((m) => m.parts.some((p) => p.type === "text" && p.text === "reply after rebuild")),
+                ).toBe(true)
+              }),
+            ),
+        })
+      } finally {
+        await llm.stop()
+      }
+    },
+    { timeout: 60_000 },
+  )
+
   test(
     "crossing the final checkpoint threshold below the configured context trigger does not rebuild",
     async () => {


### PR DESCRIPTION
## Summary

- mark a completed assistant usage as recovered when a newer checkpoint or compaction boundary exists
- exclude recovered usage from checkpoint scheduling, preflight overflow handling, and exit-time pruning
- set the run-loop overflow skip guard after every successful post-process rebuild or compaction path
- add a cross-turn regression that reproduces two boundaries on `main` and one after the fix

## Root cause

A successful assistant response at the local usable-context threshold returns `overflow`. The post-process handler rebuilds context immediately, but the next user turn can still see the same completed assistant usage and consume it again in preflight, inserting a second boundary and pruning the rebuilt tail again.

For a 372K configured window with the default 20K reserve, triggering near 352K (94.6%) is expected. The bug was processing that one high-water usage record twice.

## Verification

- regression without the production fix: expected 1 boundary, received 2
- regression with the fix: 1 boundary, 1 writer, 3 model calls
- `bun test test/session/auto-overflow-writer-first.test.ts test/session/prompt-rebuild-reset.test.ts test/session/checkpoint-rebuild-unify.test.ts test/session/overflow.test.ts test/session/checkpoint-thresholds.test.ts test/session/prune.test.ts` (97 pass)
- `bun test test/session/prompt-effect.test.ts` (52 pass, 2 skip)
- `bun test test/session/run-state-tuple-key.test.ts` (4 pass)
- `bun typecheck` from `packages/opencode`
- push hook repository typecheck (12/12 tasks successful)

## Follow-up

Checkpoint file content and its covered watermark are not currently read as an atomic snapshot when waiting for an in-flight writer. That is a separate defensive race condition and is not required to merge this directly reproduced duplicate-consumption fix.
