### PR TITLE
fix(tui): hide runtime-spawned agent hosts from the Sessions list

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -11,6 +11,7 @@ import { useSDK } from "../context/sdk"
 import { useLanguage } from "../context/language"
 import { Flag } from "@/flag/flag"
 import { isSystemSession } from "@/session/auto-dream"
+import { classifySession } from "@/session/visibility"
 import { DialogSessionRename } from "./dialog-session-rename"
 import { Keybind } from "@/util"
 import { createDebouncedSignal } from "../util/signal"
@@ -112,15 +113,40 @@ export function DialogSessionList() {
     ))
   }
 
+  // A child session is listed only if the render prohibition would allow it to be
+  // opened. The actor rows come from the sync store rather than a fetch on
+  // purpose: a host is only ever IN that store because it was created during this
+  // TUI's lifetime (bootstrap loads roots only, and sync.sync() loads children
+  // with `visible: true`), and the same lifetime delivers its `actor.registered`
+  // event — so the rows this reads are present for exactly the population that
+  // can leak. `undefined` means "no rows", which classifySession renders.
+  const listable = (x: { id: string; parentID?: string }) =>
+    classifySession(x, sync.data.actor?.[x.id]).renderable
+
   const options = createMemo(() => {
     const today = new Date().toDateString()
     const current = currentSessionID()
     // Top-level sessions, plus the CURRENT session's children (e.g. Orchestrator
     // child sessions) so the user can discover and switch into them. Other
     // sessions' children stay hidden to keep the list focused.
+    //
+    // The child arm needs the visibility predicate on top of the parent test.
+    // `sync.data.session` is NOT already filtered: sync.sync() merges children
+    // fetched with `visible: true` (sync.tsx), but `session.updated` inserts
+    // EVERY session it sees (sync.tsx, "session.updated" arm) — and a
+    // checkpoint-writer host is created with its title already set
+    // (`title: "checkpoint-writer: …"`, session/checkpoint.ts), so it arrives on
+    // that path and lands in the store. Filtering only on `parentID === current`
+    // therefore listed one `↳ checkpoint-writer: …` row per checkpoint.
+    //
+    // classifySession is the same predicate the route's render gate uses, so the
+    // list cannot disagree with what opening the entry would do. It fails OPEN
+    // (no actor rows ⇒ listed), which is what keeps orchestrator `session create`
+    // children — including the `[topic:…]` ones — listed: they own a mode "peer"
+    // row and are returned renderable outright.
     const isChildOfCurrent = (x: { parentID?: string }) => current !== undefined && x.parentID === current
     return sessions()
-      .filter((x) => x.parentID === undefined || isChildOfCurrent(x))
+      .filter((x) => x.parentID === undefined || (isChildOfCurrent(x) && listable(x)))
       .toSorted((a, b) => {
         const updatedDay = new Date(b.time.updated).setHours(0, 0, 0, 0) - new Date(a.time.updated).setHours(0, 0, 0, 0)
         if (updatedDay !== 0) return updatedDay

--- a/packages/opencode/test/cli/tui/session-list-visibility.test.ts
+++ b/packages/opencode/test/cli/tui/session-list-visibility.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, setDefaultTimeout } from "bun:test"
+import { Effect, Layer } from "effect"
+
+setDefaultTimeout(30_000)
+
+import { Agent } from "../../../src/agent/agent"
+import { Actor } from "../../../src/actor/spawn"
+import { ActorRegistry } from "../../../src/actor/registry"
+import { Bus } from "../../../src/bus"
+import { Config } from "../../../src/config"
+import { Git } from "../../../src/git"
+import { Instance } from "../../../src/project/instance"
+import { Provider } from "../../../src/provider"
+import { Session } from "../../../src/session"
+import { classifySession } from "../../../src/session/visibility"
+import { SessionID } from "../../../src/session/schema"
+import { Truncate } from "../../../src/tool"
+import { Worktree } from "../../../src/worktree"
+import * as CrossSpawnSpawner from "../../../src/effect/cross-spawn-spawner"
+import { Log } from "../../../src/util"
+import { provideTmpdirInstance } from "../../fixture/fixture"
+import { testEffect } from "../../lib/effect"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const env = Layer.mergeAll(
+  Session.defaultLayer,
+  ActorRegistry.defaultLayer,
+  Provider.defaultLayer,
+  Truncate.defaultLayer,
+  Agent.defaultLayer,
+  CrossSpawnSpawner.defaultLayer,
+  Bus.defaultLayer,
+  Config.defaultLayer,
+  Worktree.defaultLayer,
+  Git.defaultLayer,
+  Actor.defaultLayer,
+)
+
+const it = testEffect(env)
+
+const DIALOG = new URL("../../../src/cli/cmd/tui/component/dialog-session-list.tsx", import.meta.url).pathname
+
+/**
+ * The populations the Sessions dialog has to tell apart, as the user actually
+ * sees them. Both are children of the SAME parent, both were created by
+ * `session.create({ parentID })`, and the only thing that separates them is the
+ * actor row — which is exactly why the list may not discriminate on the title.
+ *
+ *   - orchestrator peer children (`actor/spawn.ts`, `mode: "peer"`) — the
+ *     `Orchestrator` / `[topic:…]` rows in the user's list. MUST stay listed.
+ *   - the checkpoint-writer host (`session/checkpoint.ts`, `mode: "subagent"`,
+ *     `agent: "checkpoint-writer"`) — the `↳ checkpoint-writer: …` rows. MUST go.
+ */
+const scaffold = Effect.gen(function* () {
+  const sessions = yield* Session.Service
+  const actorReg = yield* ActorRegistry.Service
+
+  const root = yield* sessions.create({ title: "Orchestrator" })
+
+  const registerPeer = (sessionID: string) =>
+    actorReg.register({
+      sessionID: SessionID.make(sessionID),
+      actorID: sessionID,
+      mode: "peer",
+      agent: "build",
+      description: "orchestrator child",
+      contextMode: "none",
+      contextWatermark: undefined,
+      background: true,
+      lifecycle: "persistent",
+      tools: undefined,
+    })
+
+  // Titled exactly as the user's screenshot shows them.
+  const topic = yield* sessions.create({
+    parentID: root.id as SessionID,
+    title: "[topic:memory-switch] memory 开关方案调研",
+  })
+  yield* registerPeer(topic.id)
+
+  const plain = yield* sessions.create({
+    parentID: root.id as SessionID,
+    title: "build: 在 mimocode 引擎侧实现「memory 写入开关」",
+  })
+  yield* registerPeer(plain.id)
+
+  // checkpoint.ts creates this with the title ALREADY set, before it registers
+  // the actor row — which is how it reaches the TUI store via `session.updated`.
+  const writerHost = yield* sessions.create({
+    parentID: root.id as SessionID,
+    title: "checkpoint-writer: Previous checkpoint: /Users/mi/.local/share/mimocode/memory/sessions/ses_x/checkpoint.md",
+  })
+  yield* actorReg.register({
+    sessionID: writerHost.id as SessionID,
+    actorID: "checkpoint-writer-1",
+    mode: "subagent",
+    agent: "checkpoint-writer",
+    description: "writer",
+    contextMode: "none",
+    contextWatermark: undefined,
+    background: true,
+    lifecycle: "ephemeral",
+    tools: undefined,
+  })
+
+  return { sessions, actorReg, root, topic, plain, writerHost }
+})
+
+/** The dialog reads rows out of the sync store; over the API that is listBySession. */
+const rowsOf = (actorReg: ActorRegistry.Interface, sessionID: string) =>
+  actorReg.listBySession(SessionID.make(sessionID)).pipe(
+    Effect.map((rows) => rows.map((row) => ({ mode: row.mode, agent: row.agent }))),
+  )
+
+describe("the Sessions dialog lists orchestrator children and not machinery hosts", () => {
+  it.live("admits orchestrator peer children (including [topic:…]) and refuses the writer host", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const { actorReg, root, topic, plain, writerHost } = yield* scaffold
+
+        const verdict = (s: { id: string; parentID?: string | null }) =>
+          rowsOf(actorReg, s.id).pipe(Effect.map((rows) => classifySession(s, rows)))
+
+        // ⚠️The regression this test exists for. These are user-visible sessions
+        // the orchestrator created with `session create`; a filter that drops them
+        // is worse than the bug it was written to fix.
+        expect((yield* verdict(topic)).renderable).toBe(true)
+        expect((yield* verdict(plain)).renderable).toBe(true)
+
+        // The parent itself is a root and is listed without consulting rows.
+        expect((yield* verdict(root)).renderable).toBe(true)
+
+        const writer = yield* verdict(writerHost)
+        expect(writer.renderable).toBe(false)
+        if (!writer.renderable) expect(writer.reason).toContain("checkpoint-writer")
+      }),
+    ),
+  )
+
+  // The two populations differ ONLY by actor row: same parent, same creation call.
+  // The writer's title is the one thing a tempting shortcut would key on, so the
+  // titles are swapped here. If either verdict follows the title, the rule has
+  // drifted and a user session named "checkpoint-writer: …" would vanish.
+  it.live("the verdict follows the actor row, not the title", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const actorReg = yield* ActorRegistry.Service
+        const root = yield* sessions.create({ title: "Orchestrator" })
+
+        // Peer row wearing the writer's title.
+        const decoy = yield* sessions.create({
+          parentID: root.id as SessionID,
+          title: "checkpoint-writer: Previous checkpoint: /tmp/decoy.md",
+        })
+        yield* actorReg.register({
+          sessionID: decoy.id as SessionID,
+          actorID: decoy.id,
+          mode: "peer",
+          agent: "build",
+          description: "orchestrator child that named itself confusingly",
+          contextMode: "none",
+          contextWatermark: undefined,
+          background: true,
+          lifecycle: "persistent",
+          tools: undefined,
+        })
+
+        // Writer row wearing a friendly topic title.
+        const disguised = yield* sessions.create({
+          parentID: root.id as SessionID,
+          title: "[topic:memory-switch] memory 开关方案调研",
+        })
+        yield* actorReg.register({
+          sessionID: disguised.id as SessionID,
+          actorID: "checkpoint-writer-1",
+          mode: "subagent",
+          agent: "checkpoint-writer",
+          description: "writer",
+          contextMode: "none",
+          contextWatermark: undefined,
+          background: true,
+          lifecycle: "ephemeral",
+          tools: undefined,
+        })
+
+        const verdict = (s: { id: string; parentID?: string | null }) =>
+          rowsOf(actorReg, s.id).pipe(Effect.map((rows) => classifySession(s, rows)))
+
+        expect((yield* verdict(decoy)).renderable).toBe(true)
+        expect((yield* verdict(disguised)).renderable).toBe(false)
+      }),
+    ),
+  )
+})
+
+// There is no Solid render harness for the dialog, so the wiring is asserted at
+// the source level — the same reason and the same shape as the route guard's
+// assertion in test/session/internal-session-prohibition.test.ts. Without this,
+// deleting the filter would restore the bug while both behavioural tests above
+// still passed, because they exercise classifySession rather than the dialog.
+describe("the Sessions dialog wires the visibility predicate into its child arm", () => {
+  it.live("filters children through classifySession", () =>
+    Effect.promise(async () => {
+      const src = await Bun.file(DIALOG).text()
+      expect(src).toContain('from "@/session/visibility"')
+      expect(src).toContain("classifySession(x, sync.data.actor?.[x.id]).renderable")
+      // The root arm must stay unconditional and the child arm must be gated:
+      // this is the exact expression, so a future edit that drops `listable(x)`
+      // fails here.
+      expect(src).toContain("x.parentID === undefined || (isChildOfCurrent(x) && listable(x))")
+    }),
+  )
+
+  it.live("does not discriminate on the checkpoint-writer title", () =>
+    Effect.promise(async () => {
+      const src = await Bun.file(DIALOG).text()
+      const code = src
+        .split("\n")
+        .filter((line) => !line.trimStart().startsWith("//") && !line.trimStart().startsWith("*"))
+        .join("\n")
+      expect(code).not.toContain('"checkpoint-writer')
+      expect(code).not.toContain("startsWith(")
+    }),
+  )
+})


### PR DESCRIPTION
## Symptom

In the TUI's Sessions dialog, every checkpoint adds one more internal-machinery session, with a title of the form:

```
↳ checkpoint-writer: Previous checkpoint: /Users/mi/.local/s…
```

The user's feedback was "this was supposedly already fixed, why is it still here".

## Relationship to #1964: two paths, and the guard cannot substitute for the list

What #1964 fixed was the **navigation guard** — `routes/session/index.tsx` uses `verifySessionRenderable` to refuse a machinery host before rendering, so *opening* one gets rejected. But **the list itself** was never filtered, so those hosts kept getting *listed*. These are two independent paths, and the former cannot substitute for the latter.

The file comment in `visibility.ts` in fact already spells out this distinction:

> Being absent here means "not offered in a list"; what may never be RENDERED is narrower and lives in `session/visibility.ts`

The server-side capability is complete as well: `Session.children(parentID, { visible: true })` filters by the peer actor row, `GET /session/:id/children?visible=` exposes it, and `sync.sync()` does fetch child sessions with `visible: true`.

**The leak path is elsewhere**: the `session.updated` arm in `sync.tsx` unconditionally inserts **any** session it receives into `store.session`, bypassing that `visible: true` fetch. And when `session/checkpoint.ts` creates the writer host, **the title is already set** (`title: "checkpoint-writer: ${rangeDesc}"`), and this happens **before** the actor row is registered — so it enters the store via `session.updated` carrying a directly displayable title, and is waved straight through by the filter in `dialog-session-list.tsx`, which only looks at the parent/child relationship:

```ts
.filter((x) => x.parentID === undefined || isChildOfCurrent(x))
```

## Not just a noisy list: it pollutes the orchestrator's session inventory

These hosts are registered as **real child sessions**. Measured on one orchestrator fleet: **13 of 19 child sessions were `checkpoint-writer`, all with a turn count of 0**. So the impact goes beyond a dirty TUI list — the orchestrator's own session inventory is drowned in these empty shells.

## The change

The child-session arm gains a `listable(x)` check, using **the very same** `classifySession` predicate as the guard:

```ts
const listable = (x: { id: string; parentID?: string }) =>
  classifySession(x, sync.data.actor?.[x.id]).renderable
```

**Why reuse `classifySession` instead of writing a new rule**: with the list and the guard sharing one predicate, the self-contradictory "it's in the list but opening it is refused" state becomes impossible. The rule has exactly one home.

The actor row is taken from the sync store rather than from an additional network request, because the two populations line up exactly: a host can only *be* in the store if it was created within this TUI lifecycle (bootstrap loads only roots, and `sync.sync()` loads child sessions with `visible: true`), and that same lifecycle also delivers its `actor.registered` event — so for exactly the set that can leak, the row read here necessarily exists.

## The fail-open choice

`classifySession` **judges a session displayable when there is no actor row**. This is deliberate, and it is the reason #1964 narrowed the rule down from `mode !== "peer"` in the first place: the old fail-closed proxy over-blocked 28 sessions (11 `ask:` forks + 17 pre-registry `@explore`/`@general` transcripts), none of which were machinery. Over-hiding real sessions is the more expensive mistake.

The cost is that a writer host that was just created and has not yet registered its actor row shows up briefly once; it has zero messages and disappears a moment later. Compared to the current "one permanent row per checkpoint" that is an order-of-magnitude improvement, and if you do click into it, the guard still refuses.

## Regression risk and the test that holds it

**The biggest risk is collateral damage to legitimate child sessions.** Child sessions the orchestrator creates via `session create` (`actor/spawn.ts`, `mode: "peer"`, including the ones prefixed with `[topic:…]`) **must remain visible**. They hold a `mode: "peer"` row and are judged renderable directly by the peer arm of `classifySession`, so this filter cannot catch them by association.

Adds `test/cli/tui/session-list-visibility.test.ts` (4 cases), built from real sessions plus real actor rows, pinning:

1. Constructed from the real titles in the user's list — `[topic:memory-switch] memory 开关方案调研` and `build: 在 mimocode 引擎侧实现「memory 写入开关」` — asserting they **must** be renderable, while the writer host must be refused.
2. **The title-swap case**: a peer row wearing the writer's title → still displayed; a writer row wearing a `[topic:…]` title → still hidden. This case exists specifically to prevent someone later taking the shortcut of filtering by title prefix — under which a user session that happens to be named `checkpoint-writer: …` would vanish into thin air.
3. A source-level assertion (the dialog has no Solid rendering fixture; same approach and same reasoning as #1964's assertion on the route guard): that the filter expression really does take `listable(x)`, and that no `"checkpoint-writer` literal and no `startsWith(` appears in the code.

## Verification

Baseline `8061d5fa0` (latest main).

```
$ bun typecheck
$ tsgo --noEmit                                                    <- no output, passes

$ bun test test/cli/tui/session-list-visibility.test.ts            -> 4 pass,  0 fail
$ bun test test/session/internal-session-prohibition.test.ts       -> 19 pass, 0 fail
$ bun test test/cli/tui/select-messages.test.ts                    -> 8 pass,  0 fail
```

**Mutation testing** (proving the regression pin actually fires): reverting the filter expression to its original form and re-running → `3 pass, 1 fail`, reporting

```
(fail) the Sessions dialog wires the visibility predicate into its child arm
       > filters children through classifySession
Expected to contain: "x.parentID === undefined || (isChildOfCurrent(x) && listable(x))"
```

That was subsequently restored from git, and `git status` is clean.

## Follow-up notes (unrelated to this PR, but reviewers should know)

The user hit this on `npm exec @mimo-ai/cli@latest`, which at the time gave them **0.1.9 (released 2026-07-24)**, whereas #1964 landed on **2026-07-31** — so that binary did not even have the navigation guard, which explains the "it was fixed but it's still here".

**0.1.10 was released today** (`2026-08-05T09:17:36Z`, version bump `8061d5fa0 chore: bump version to 0.1.10 (#2034)`), and `85a7faca4` (#1964) is confirmed to be one of its ancestors. So **0.1.10 does carry the navigation guard and only lacks this PR's list filter**: after upgrading to 0.1.10 the user will be refused when opening one, but they will still be listed until this PR reaches the next release.
