### PR TITLE
fix(cli): normalize command output newlines

### DIFF
--- a/packages/opencode/src/cli/cmd/generate.ts
+++ b/packages/opencode/src/cli/cmd/generate.ts
@@ -1,5 +1,6 @@
 import { Server } from "../../server/server"
 import type { CommandModule } from "yargs"
+import { UI } from "../ui"
 
 export const GenerateCommand = {
   command: "generate",
@@ -41,7 +42,7 @@ export const GenerateCommand = {
 
     // Wait for stdout to finish writing before process.exit() is called
     await new Promise<void>((resolve, reject) => {
-      process.stdout.write(json, (err) => {
+      process.stdout.write(UI.withTrailingEOL(json), (err) => {
         if (err) reject(err)
         else resolve()
       })

--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -39,6 +39,10 @@ export function print(...message: string[]) {
   process.stderr.write(message.join(" "))
 }
 
+export function withTrailingEOL(text: string) {
+  return text.replace(/[\r\n]+$/, "") + EOL
+}
+
 let blank = false
 export function empty() {
   if (blank) return

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -64,10 +64,10 @@ function show(out: string) {
   const text = out.trimStart()
   if (!text.startsWith("mimo ")) {
     process.stderr.write(UI.logo() + EOL + EOL)
-    process.stderr.write(text)
+    process.stderr.write(UI.withTrailingEOL(text))
     return
   }
-  process.stderr.write(out)
+  process.stderr.write(UI.withTrailingEOL(out))
 }
 
 const cli = yargs(args)

--- a/packages/opencode/test/cli/ui.test.ts
+++ b/packages/opencode/test/cli/ui.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { EOL } from "os"
+import { UI } from "../../src/cli/ui"
+
+describe("cli.ui", () => {
+  test("adds one trailing EOL when output is missing one", () => {
+    expect(UI.withTrailingEOL("help")).toBe("help" + EOL)
+  })
+
+  test("does not duplicate an existing trailing EOL", () => {
+    expect(UI.withTrailingEOL("help" + EOL)).toBe("help" + EOL)
+  })
+
+  test("normalizes multiple and mixed trailing line endings", () => {
+    expect(UI.withTrailingEOL("help\n\r\n\n")).toBe("help" + EOL)
+  })
+
+  test("returns one EOL for empty output", () => {
+    expect(UI.withTrailingEOL("")).toBe(EOL)
+  })
+})


### PR DESCRIPTION
## Summary

- Ensure yargs help and error output ends with exactly one platform newline.
- Normalize generated OpenAPI JSON output with the same shared helper.
- Add regression coverage for missing, duplicate, mixed, and empty trailing line endings.

## Verification

- `bun test test/cli/ui.test.ts` from `packages/opencode`: 4 passed
- `bun typecheck` from `packages/opencode`: passed
- `mimo --help` smoke test: output ends with a newline
- CLI output scan confirmed ACP and TUI control streams remain unchanged
