### PR TITLE
fix(mcp): trust lifecycle metadata for session scope

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -295,16 +295,26 @@ function isMcpConfigured(entry: McpEntry): entry is ConfigMCP.Info {
 }
 
 const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, "_")
+// Negotiated lifecycle metadata is host-controlled; model arguments cannot replace that identity.
+const LEGACY_TURN_IDENTITY_ARGUMENTS = new Set(["session_id", "turn_id"])
 
 // Convert MCP tool definition to AI SDK Tool type
 function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number, context?: TurnContext): Tool {
   const inputSchema = mcpTool.inputSchema
+  const lifecycle = supportsTurnLifecycle(client)
 
   // Spread first, then override type to ensure it's always "object"
   const schema: JSONSchema7 = {
     ...(inputSchema as JSONSchema7),
     type: "object",
-    properties: (inputSchema.properties ?? {}) as JSONSchema7["properties"],
+    properties: lifecycle
+      ? Object.fromEntries(
+          Object.entries(inputSchema.properties ?? {}).filter(([key]) => !LEGACY_TURN_IDENTITY_ARGUMENTS.has(key)),
+        )
+      : (inputSchema.properties ?? {}) as JSONSchema7["properties"],
+    ...(lifecycle && Array.isArray(inputSchema.required)
+      ? { required: inputSchema.required.filter((key) => !LEGACY_TURN_IDENTITY_ARGUMENTS.has(key)) }
+      : {}),
     additionalProperties: false,
   }
 
@@ -312,13 +322,14 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
     description: mcpTool.description ?? "",
     inputSchema: jsonSchema(schema),
     execute: async (args: unknown, options) => {
-      const metadata =
-        context && supportsTurnLifecycle(client) ? { _meta: { [TURN_LIFECYCLE_CAPABILITY]: context } } : {}
+      const values = (args || {}) as Record<string, unknown>
       return client.callTool(
         {
           name: mcpTool.name,
-          arguments: (args || {}) as Record<string, unknown>,
-          ...metadata,
+          arguments: lifecycle
+            ? Object.fromEntries(Object.entries(values).filter(([key]) => !LEGACY_TURN_IDENTITY_ARGUMENTS.has(key)))
+            : values,
+          ...(context && lifecycle ? { _meta: { [TURN_LIFECYCLE_CAPABILITY]: context } } : {}),
         },
         CallToolResultSchema,
         {

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, mock, beforeEach } from "bun:test"
 import { Effect, Fiber } from "effect"
+import { asSchema } from "ai"
 import type { MCP as MCPNS } from "../../src/mcp/index"
 
 // --- Mock infrastructure ---
@@ -336,21 +337,39 @@ test(
     Effect.gen(function* () {
       lastCreatedClientName = "legacy-server"
       const serverState = getOrCreateClientState("legacy-server")
+      serverState.tools = [
+        {
+          name: "test_tool",
+          description: "A legacy tool",
+          inputSchema: {
+            type: "object",
+            properties: { session_id: { type: "string" }, turn_id: { type: "string" } },
+          },
+        },
+      ]
       yield* mcp.add("legacy-server", {
         type: "local",
         command: ["echo", "test"],
       })
 
       const tools = yield* mcp.tools({ sessionId: "ses_1", turnId: "turn_1", actorId: "main" })
-      const execute = tools["legacy-server_test_tool"]?.execute
+      const tool = tools["legacy-server_test_tool"]
+      const execute = tool?.execute
       expect(execute).toBeDefined()
+      const schema = yield* Effect.promise(() => Promise.resolve(asSchema(tool!.inputSchema).jsonSchema))
+      expect(schema.properties).toEqual({ session_id: { type: "string" }, turn_id: { type: "string" } })
       yield* Effect.promise(() =>
         Promise.resolve(
-          execute?.({}, { toolCallId: "call_1", messages: [], abortSignal: new AbortController().signal }),
+          execute?.(
+            { session_id: "legacy-session", turn_id: "legacy-turn" },
+            { toolCallId: "call_1", messages: [], abortSignal: new AbortController().signal },
+          ),
         ),
       )
 
-      expect(serverState.toolCalls).toEqual([{ name: "test_tool", arguments: {} }])
+      expect(serverState.toolCalls).toEqual([
+        { name: "test_tool", arguments: { session_id: "legacy-session", turn_id: "legacy-turn" } },
+      ])
     }),
   ),
 )
@@ -393,6 +412,62 @@ test(
         {
           name: "test_tool",
           arguments: { index: 2 },
+          _meta: { "com.xiaomi.mimo/turn-lifecycle": context },
+        },
+      ])
+    }),
+  ),
+)
+
+// [TP-IAB-R10-05] The host runtime context, never model arguments, owns lifecycle scope.
+test(
+  "lifecycle metadata is the only session identity exposed and forwarded",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "lifecycle-server"
+      const serverState = getOrCreateClientState("lifecycle-server")
+      serverState.serverCapabilities = {
+        experimental: { "com.xiaomi.mimo/turn-lifecycle": { version: 1 } },
+      }
+      serverState.tools = [
+        {
+          name: "browser_js",
+          description: "execute browser code",
+          inputSchema: {
+            type: "object",
+            required: ["code"],
+            properties: {
+              code: { type: "string" },
+              session_id: { type: "string" },
+              turn_id: { type: "string" },
+            },
+          },
+        },
+      ]
+      yield* mcp.add("lifecycle-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      const context = { sessionId: "trusted-session", turnId: "trusted-turn", actorId: "main" }
+      const execute = (yield* mcp.tools(context))["lifecycle-server_browser_js"]
+      expect(execute).toBeDefined()
+      const schema = yield* Effect.promise(() => Promise.resolve(asSchema(execute!.inputSchema).jsonSchema))
+      expect(schema.properties).toEqual({ code: { type: "string" } })
+
+      yield* Effect.promise(() =>
+        Promise.resolve(
+          execute!.execute?.(
+            { code: "1 + 1", session_id: "forged-session", turn_id: "forged-turn" },
+            { toolCallId: "call_1", messages: [], abortSignal: new AbortController().signal },
+          ),
+        ),
+      )
+
+      expect(serverState.toolCalls).toEqual([
+        {
+          name: "browser_js",
+          arguments: { code: "1 + 1" },
           _meta: { "com.xiaomi.mimo/turn-lifecycle": context },
         },
       ])


### PR DESCRIPTION
## Summary

- treat negotiated turn-lifecycle metadata as the sole MCP session/turn identity
- hide legacy `session_id` / `turn_id` inputs from lifecycle-aware tool schemas
- strip spoofed legacy identity fields again at the `tools/call` boundary
- preserve legacy arguments for servers that do not advertise lifecycle v1

## Why

MiMo Desktop's Browser Runtime accepts legacy model-facing `session_id` before lifecycle metadata. Even when the engine sends trusted metadata, a model argument could therefore select the Provider scope. Lifecycle-aware servers must receive identity only from the engine's internal turn context.

## Verification

- `bun test test/mcp/lifecycle.test.ts` (32 passed)
- `bun typecheck` from `packages/opencode`
- push hook `bun turbo typecheck` (12 packages passed)
