### PR TITLE
refactor(mcp): share one process-wide client layer

### DIFF
--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -1096,12 +1096,12 @@ export const layer = Layer.effect(
 // "Cannot access 'defaultLayer' before initialization", breaking every
 // it.live test harness. Same pattern session/prompt, session/checkpoint,
 // tool/registry, provider, etc. already use.
-export const defaultLayer = Layer.suspend(() =>
+/** App composition variant with SessionPrompt supplied by the root graph. */
+export const appLayer = Layer.suspend(() =>
   layer.pipe(
     Layer.provide(Session.defaultLayer),
     Layer.provide(ActorRegistry.defaultLayer),
     Layer.provide(Agent.defaultLayer),
-    Layer.provide(SessionPrompt.defaultLayer),
     Layer.provide(SessionRunState.defaultLayer),
     Layer.provide(Inbox.defaultLayer),
     Layer.provide(Plugin.defaultLayer),
@@ -1109,5 +1109,7 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(TaskRegistry.defaultLayer),
   ),
 )
+
+export const defaultLayer = appLayer.pipe(Layer.provide(SessionPrompt.defaultLayer))
 
 export * as Actor from "./spawn"

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -296,10 +296,16 @@ export const layer = Layer.effect(
   }),
 )
 
-export const defaultLayer = layer.pipe(
+/**
+ * Application composition variant. The process-wide AppLayer supplies the
+ * MCP service so Command and SessionPrompt share one client set instead of
+ * each hiding a separately scoped transport layer.
+ */
+export const appLayer = layer.pipe(
   Layer.provide(Config.defaultLayer),
-  Layer.provide(MCP.defaultLayer),
   Layer.provide(Skill.defaultLayer),
 )
+
+export const defaultLayer = appLayer.pipe(Layer.provide(MCP.defaultLayer))
 
 export * as Command from "."

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -95,15 +95,12 @@ export const AppLayer = Layer.suspend(() =>
     SessionPrune.defaultLayer,
     SessionRevert.defaultLayer,
     SessionSummary.defaultLayer,
-    SessionPrompt.defaultLayer,
     CronBridgeDefaultLayer,
     SessionCheckpoint.defaultLayer,
     Instruction.defaultLayer,
     LLM.defaultLayer,
     LSP.defaultLayer,
-    MCP.defaultLayer,
     McpAuth.defaultLayer,
-    Command.defaultLayer,
     Truncate.defaultLayer,
     ToolRegistry.defaultLayer,
     Format.defaultLayer,
@@ -116,11 +113,18 @@ export const AppLayer = Layer.suspend(() =>
     SessionShare.defaultLayer,
     ActorRegistry.defaultLayer,
     ActorWaiter.defaultLayer,
-    Actor.defaultLayer,
     TaskRegistry.defaultLayer,
     WorkflowRuntime.defaultLayer,
     Memory.defaultLayer,
     History.defaultLayer,
+    // MCP, Command, SessionPrompt, and Actor form one ownership chain. Their
+    // standalone default layers remain convenient for focused tests, while
+    // the application graph deliberately provides each stateful service once.
+    Actor.appLayer.pipe(
+      Layer.provideMerge(SessionPrompt.appLayer.pipe(
+        Layer.provideMerge(Command.appLayer.pipe(Layer.provideMerge(MCP.defaultLayer))),
+      )),
+    ),
   ).pipe(Layer.provideMerge(Observability.layer), Layer.provideMerge(BashInteractive.defaultLayer)),
 )
 

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -62,7 +62,7 @@ import * as BashInteractive from "@/tool/bash-interactive"
 import { memoMap } from "./memo-map"
 
 // Wrapped in Layer.suspend so the cross-module `.defaultLayer` reads defer to
-// first use instead of running at module load — same TDZ fix as Actor.defaultLayer.
+// first use instead of running at module load — same TDZ fix as Actor.appLayer.
 export const AppLayer = Layer.suspend(() =>
   Layer.mergeAll(
     Npm.defaultLayer,

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -732,7 +732,7 @@ export const SessionRoutes = lazy(() =>
           const actor = spawnRef.current
           if (!actor)
             return yield* Effect.fail(
-              new Error("Actor service unavailable — Actor.defaultLayer must be running to ask a side question"),
+              new Error("Actor service unavailable — Actor.appLayer must be running to ask a side question"),
             )
           const selectedModel =
             body.providerID && body.modelID ? { providerID: body.providerID, modelID: body.modelID } : undefined

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -1703,8 +1703,9 @@ export const layer: Layer.Layer<
 // the Actor implementation through the late-bound `spawnRef` (see
 // `actor/spawn-ref.ts`). This deliberately breaks the otherwise-unresolvable
 // layer cycle Actor → SessionPrompt → SessionCheckpoint → Actor. The AppLayer
-// constructs `Actor.defaultLayer` separately; its initialiser populates
-// `spawnRef`, which `tryStartCheckpointWriter` reads at call time.
+// constructs `Actor.appLayer` separately; that variant wraps the same
+// `Actor.layer`, whose initialiser populates `spawnRef` (see
+// `actor/spawn.ts`), and `tryStartCheckpointWriter` reads the ref at call time.
 export const defaultLayer = Layer.suspend(() =>
   layer.pipe(
     Layer.provide(Session.defaultLayer),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4555,7 +4555,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
   }),
 )
 
-export const defaultLayer = Layer.suspend(() =>
+/** App composition variant with MCP supplied by the process-wide layer. */
+export const appLayer = Layer.suspend(() =>
   layer.pipe(
     Layer.provide(SessionRunState.defaultLayer),
     Layer.provide(SessionStatus.defaultLayer),
@@ -4563,9 +4564,8 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(SessionCheckpoint.defaultLayer),
     Layer.provide(SessionCompaction.defaultLayer),
     Layer.provide(SessionProcessor.defaultLayer),
-    Layer.provide(Command.defaultLayer),
+    Layer.provide(Command.appLayer),
     Layer.provide(Permission.defaultLayer),
-    Layer.provide(MCP.defaultLayer),
     Layer.provide(LSP.defaultLayer),
     Layer.provide(ToolRegistry.defaultLayer),
     Layer.provide(Truncate.defaultLayer),
@@ -4593,6 +4593,8 @@ export const defaultLayer = Layer.suspend(() =>
     ),
   ),
 )
+
+export const defaultLayer = appLayer.pipe(Layer.provide(MCP.defaultLayer))
 /**
  * Returns true when at least one resolved user-message part carries substantive
  * content that will survive the send-side filter (message-v2.ts).  Used by

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -318,7 +318,7 @@ export const ActorTool = Tool.define(
       if (!a) {
         return Effect.fail(
           new Error(
-            "Actor service unavailable — Actor.defaultLayer must be running for the actor tool to spawn or cancel actors",
+            "Actor service unavailable — Actor.appLayer must be running for the actor tool to spawn or cancel actors",
           ),
         )
       }

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -641,7 +641,7 @@ export const SessionTool = Tool.define<typeof parameters, Metadata, Deps>(
       if (!a) {
         return Effect.fail(
           new Error(
-            "Actor service unavailable — Actor.defaultLayer must be running for the session tool to spawn or cancel sessions",
+            "Actor service unavailable — Actor.appLayer must be running for the session tool to spawn or cancel sessions",
           ),
         )
       }

--- a/packages/opencode/test/effect/app-runtime-mcp-singleton.test.ts
+++ b/packages/opencode/test/effect/app-runtime-mcp-singleton.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+
+import { Actor } from "../../src/actor/spawn"
+import { Command } from "../../src/command"
+import { AppLayer } from "../../src/effect/app-runtime"
+import { MCP } from "../../src/mcp"
+import { SessionPrompt } from "../../src/session/prompt"
+
+test("AppLayer composes one shared MCP ownership chain", () => {
+  expect(AppLayer).toBeDefined()
+  expect(MCP.defaultLayer).toBeDefined()
+  expect(Command.appLayer).toBeDefined()
+  expect(SessionPrompt.appLayer).toBeDefined()
+  expect(Actor.appLayer).toBeDefined()
+
+  // Standalone layers remain available for focused service tests, while the
+  // process graph has explicit dependency-injected variants for the four
+  // services that otherwise each start their own MCP transport scope.
+  expect(Command.defaultLayer).not.toBe(Command.appLayer)
+  expect(SessionPrompt.defaultLayer).not.toBe(SessionPrompt.appLayer)
+  expect(Actor.defaultLayer).not.toBe(Actor.appLayer)
+})

--- a/packages/opencode/test/effect/app-runtime-mcp-singleton.test.ts
+++ b/packages/opencode/test/effect/app-runtime-mcp-singleton.test.ts
@@ -12,10 +12,15 @@ import { SessionPrompt } from "../../src/session/prompt"
 //   Actor.appLayer <- SessionPrompt.appLayer <- Command.appLayer <- MCP.defaultLayer
 //
 // Before that chain existed, MCP, Command, SessionPrompt and Actor were four
-// independent AppLayer leaves and each one provided its own MCP.defaultLayer,
-// so the process started one MCP subprocess set per leaf. The regression this
-// file exists to catch is someone re-adding a self-provided MCP inside any of
-// the three `appLayer` variants, or adding a second MCP.defaultLayer leaf.
+// independent AppLayer leaves, three of which provided MCP.defaultLayer
+// themselves. That shape still built only ONE MCP instance, because Layer.effect
+// memoises on the layer's own identity and every ManagedRuntime here shares the
+// single memo map from src/effect/memo-map.ts — so single-instance behaviour was
+// incidental, resting on memo identity rather than on the graph. The chain makes
+// the ownership explicit instead. The regressions this file exists to catch are
+// someone re-adding a self-provided MCP inside any of the three `appLayer`
+// variants, or adding a second MCP.defaultLayer leaf — either of which would
+// break the memo assumption the old shape silently depended on.
 //
 // These tests deliberately never build the real MCP.defaultLayer and never build
 // the full AppLayer: booting real MCP is precisely the behaviour under guard.

--- a/packages/opencode/test/effect/app-runtime-mcp-singleton.test.ts
+++ b/packages/opencode/test/effect/app-runtime-mcp-singleton.test.ts
@@ -1,22 +1,112 @@
 import { expect, test } from "bun:test"
+import path from "path"
+import { Cause, Context, Effect, Exit, Layer, Option } from "effect"
 
 import { Actor } from "../../src/actor/spawn"
 import { Command } from "../../src/command"
-import { AppLayer } from "../../src/effect/app-runtime"
 import { MCP } from "../../src/mcp"
 import { SessionPrompt } from "../../src/session/prompt"
 
-test("AppLayer composes one shared MCP ownership chain", () => {
-  expect(AppLayer).toBeDefined()
-  expect(MCP.defaultLayer).toBeDefined()
-  expect(Command.appLayer).toBeDefined()
-  expect(SessionPrompt.appLayer).toBeDefined()
-  expect(Actor.appLayer).toBeDefined()
+// Guards the MCP single-instance ownership chain built in src/effect/app-runtime.ts:
+//
+//   Actor.appLayer <- SessionPrompt.appLayer <- Command.appLayer <- MCP.defaultLayer
+//
+// Before that chain existed, MCP, Command, SessionPrompt and Actor were four
+// independent AppLayer leaves and each one provided its own MCP.defaultLayer,
+// so the process started one MCP subprocess set per leaf. The regression this
+// file exists to catch is someone re-adding a self-provided MCP inside any of
+// the three `appLayer` variants, or adding a second MCP.defaultLayer leaf.
+//
+// These tests deliberately never build the real MCP.defaultLayer and never build
+// the full AppLayer: booting real MCP is precisely the behaviour under guard.
+// Layer.build below also intentionally does NOT reuse the process-wide memoMap
+// from src/effect/memo-map.ts — a fresh memo map per build keeps this test from
+// resolving against (or polluting) instances another test already memoized.
 
-  // Standalone layers remain available for focused service tests, while the
-  // process graph has explicit dependency-injected variants for the four
-  // services that otherwise each start their own MCP transport scope.
-  expect(Command.defaultLayer).not.toBe(Command.appLayer)
-  expect(SessionPrompt.defaultLayer).not.toBe(SessionPrompt.appLayer)
-  expect(Actor.defaultLayer).not.toBe(Actor.appLayer)
+/**
+ * Stand-in for MCP.Service. Every property access throws, so if any layer in the
+ * chain calls an MCP method while merely *building*, this test fails loudly
+ * instead of silently letting a real transport get established later.
+ */
+function makeCountingMcpLayer() {
+  let built = 0
+  const layer = Layer.effect(
+    MCP.Service,
+    Effect.sync(() => {
+      built++
+      return MCP.Service.of(
+        new Proxy(
+          {},
+          {
+            get(_target, property) {
+              throw new Error(`stub MCP.Service.${String(property)} used during layer build`)
+            },
+          },
+        ) as never,
+      )
+    }),
+  )
+  return { layer, builds: () => built }
+}
+
+test("app graph's MCP chain composes, and one MCP instance serves all three consumers", async () => {
+  const mcp = makeCountingMcpLayer()
+
+  // Same shape as src/effect/app-runtime.ts, with only MCP.defaultLayer swapped
+  // for the counting stub.
+  const chain = Actor.appLayer.pipe(
+    Layer.provideMerge(
+      SessionPrompt.appLayer.pipe(Layer.provideMerge(Command.appLayer.pipe(Layer.provideMerge(mcp.layer)))),
+    ),
+  )
+
+  const context = await Effect.runPromise(Effect.scoped(Layer.build(chain)))
+
+  // Exactly one MCP construction for Command + SessionPrompt + Actor together.
+  expect(mcp.builds()).toBe(1)
+
+  // provideMerge (not provide) keeps MCP.Service in the AppLayer output so
+  // server routes can still resolve it, alongside the three consumers.
+  // getOption is used rather than get so the throwing stub is never dereferenced.
+  expect(Option.isSome(Context.getOption(context, MCP.Service))).toBe(true)
+  expect(Option.isSome(Context.getOption(context, Command.Service))).toBe(true)
+  expect(Option.isSome(Context.getOption(context, SessionPrompt.Service))).toBe(true)
+  expect(Option.isSome(Context.getOption(context, Actor.Service))).toBe(true)
+})
+
+// Each appLayer must leave its MCP-bearing dependency *unmet* so the root graph
+// supplies it once. Asserting the specific missing service is what makes this a
+// real guard: if someone re-adds Layer.provide(MCP.defaultLayer) to Command or
+// SessionPrompt, or Layer.provide(SessionPrompt.defaultLayer) to Actor, the
+// layer becomes self-sufficient, the build succeeds, and this test fails.
+//
+// Actor is listed against SessionPrompt rather than MCP because Actor never
+// consumes MCP.Service directly; it reaches MCP only through SessionPrompt, so
+// SessionPrompt.defaultLayer is the edge that would smuggle a second MCP in.
+const unmetDependency = [
+  { name: "Command.appLayer", layer: Command.appLayer, missing: "@opencode/MCP" },
+  { name: "SessionPrompt.appLayer", layer: SessionPrompt.appLayer, missing: "@opencode/MCP" },
+  { name: "Actor.appLayer", layer: Actor.appLayer, missing: "@opencode/SessionPrompt" },
+] as const
+
+for (const { name, layer, missing } of unmetDependency) {
+  test(`${name} does not provide its own ${missing}`, async () => {
+    // The cast is load-bearing: these layers legitimately still declare an unmet
+    // requirement, which is exactly the property asserted here.
+    const build = Layer.build(layer as unknown as Layer.Layer<never, never, never>)
+    const exit = await Effect.runPromiseExit(Effect.scoped(build))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toInclude(`Service not found: ${missing}`)
+  })
+}
+
+test("app-runtime.ts wires MCP.defaultLayer exactly once", async () => {
+  // Structural companion to the behavioural tests above: they cannot see an
+  // extra independent `MCP.defaultLayer` leaf added to AppLayer's mergeAll,
+  // because building the real AppLayer is off-limits here.
+  const source = await Bun.file(path.join(import.meta.dir, "../../src/effect/app-runtime.ts")).text()
+  const occurrences = source.match(/MCP\.defaultLayer/g) ?? []
+
+  expect(occurrences).toHaveLength(1)
 })


### PR DESCRIPTION
### Issue for this PR

Makes the single-MCP-instance property structural rather than incidental.

Before this change `AppLayer` reached `MCP.defaultLayer` through four independent
leaves (`MCP`, `Command`, `SessionPrompt`, `Actor`), three of which provided it
themselves. That shape already built only **one** MCP instance, but only because
`Layer.effect` memoises on the layer's own identity and every `ManagedRuntime` in
the process shares the single memo map from `src/effect/memo-map.ts`. In other
words the graph *said* four provisions and was correct by memoisation, not by
construction — anything that broke memo identity (wrapping `MCP.defaultLayer` in
a factory, a duplicated module instance) would have silently produced real
duplicate client sets.

This PR removes that implicit dependency: MCP is provided in exactly one place,
so the ownership is visible in the graph, and a source-level assertion in the
accompanying test prevents a genuinely independent second leaf from being added
later.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Composes MCP, Command, SessionPrompt, and Actor through one application-owned
dependency chain via `provideMerge`, so `MCP.Service` stays in `AppLayer`'s
output and server routes still resolve it. Standalone `defaultLayer` exports
remain for focused tests.

Measured: MCP build count is 1 both before and after, and finaliser order is
unchanged (`Actor -> SessionPrompt -> Command -> MCP`). There is deliberately no
behavioural delta — the value is that the invariant is now expressed in the code.

### How did you verify your code works?

- `bun test test/effect/app-runtime-mcp-singleton.test.ts`
- `bun typecheck`
- `bun run build --single`
- Repository push hook: full Turbo typecheck
- Mutation-tested the new guard: re-adding `Layer.provide(MCP.defaultLayer)` to
  `Command.appLayer` turns it red (`Command.appLayer does not provide its own
  @opencode/MCP`), and adding a second `MCP.defaultLayer` leaf to `AppLayer`
  turns the source assertion red. Both revert to green.

### Screenshots / recordings

Not applicable; no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Known duplication mechanisms this PR does NOT address

An earlier draft of this description claimed the old shape started "one MCP
subprocess set per leaf" and proposed a 24h duplicate-subprocess watch. That was
a misdiagnosis and both have been removed: the layer graph never produced
duplicates, so rolling this PR back would not affect duplicate subprocesses
either way. The two mechanisms that genuinely can produce more than one client
set are unrelated to layer composition and remain open:

1. `InstanceState` is a `ScopedCache` keyed by `directory`
   (`src/effect/instance-state.ts:43-49,65`), so one process serving several
   instances/directories holds one client set per directory.
2. `MemoMapImpl` deletes a memo entry once its observers reach zero
   (`Layer.ts:330-333`), so disposing every runtime and then rebuilding spawns a
   fresh set.

Both deserve their own investigation; neither is in scope here.
