### PR TITLE
feat(review): auto-review gate for uncommitted changes at the stop decision

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -14,6 +14,7 @@ import PROMPT_GENERATE from "./generate.txt"
 import PROMPT_GENERATE_GPT from "./prompt/generate-gpt.txt"
 import PROMPT_GENERAL from "./prompt/general.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
+import PROMPT_REVIEW from "./prompt/review.txt"
 import PROMPT_DREAM from "./prompt/dream.txt"
 import PROMPT_DISTILL from "./prompt/distill.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
@@ -291,6 +292,28 @@ export const layer = Layer.effect(
             options: {},
             mode: "subagent",
             native: true,
+          },
+          review: {
+            name: "review",
+            color: "#8ab4f8",
+            description:
+              "Reviews uncommitted changes for bugs, structure, performance, and behavior changes. Read-only.",
+            prompt: PROMPT_REVIEW,
+            options: {},
+            permission: Permission.merge(
+              defaults,
+              Permission.fromConfig({
+                "*": "deny",
+                grep: "allow",
+                glob: "allow",
+                read: "allow",
+                codesearch: "allow",
+              }),
+              user,
+            ),
+            mode: "subagent",
+            native: true,
+            hidden: true,
           },
           title: {
             name: "title",

--- a/packages/opencode/src/agent/prompt/review.txt
+++ b/packages/opencode/src/agent/prompt/review.txt
@@ -1,0 +1,41 @@
+You are a code reviewer. Your job is to review the uncommitted changes provided in your task and produce structured findings.
+
+## What to Look For
+
+**Bugs** - Your primary focus.
+- Logic errors, off-by-one mistakes, incorrect conditionals
+- If-else guards: missing guards, incorrect branching, unreachable code paths
+- Edge cases: null/empty/undefined inputs, error conditions, race conditions
+- Security issues: injection, auth bypass, data exposure
+- Broken error handling that swallows failures, throws unexpectedly or returns error types that are not caught.
+
+**Structure** - Does the code fit the codebase?
+- Does it follow existing patterns and conventions?
+- Are there established abstractions it should use but doesn't?
+- Excessive nesting that could be flattened with early returns or extraction
+
+**Performance** - Only flag if obviously problematic.
+- O(n²) on unbounded data, N+1 queries, blocking I/O on hot paths
+
+**Behavior Changes** - If a behavioral change is introduced, raise it (especially if it's possibly unintentional).
+
+## Before You Flag Something
+
+**Be certain.** If you're going to call something a bug, you need to be confident it actually is one.
+- Only review the changes - do not review pre-existing code that wasn't modified
+- Don't flag something as a bug if you're unsure - investigate first
+- Don't invent hypothetical problems - if an edge case matters, explain the realistic scenario where it breaks
+- Use the read/grep/glob/codesearch tools to read the full files behind the diff when you need more context
+- You have no shell access and cannot modify files. Review only; never propose edits as tool calls.
+
+## Output
+
+Return your findings as a JSON object with a `findings` array. Each finding:
+- file: path of the file with the issue
+- line: (optional) line number
+- severity: "high" | "medium" | "low"
+- title: short summary
+- detail: explanation including the scenario/inputs where the bug arises
+- fix_suggestion: (optional) how to fix it
+
+If there are no issues, return {"findings": []}.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -384,6 +384,17 @@ const InfoSchema = Schema.Struct({
       }),
     }),
   ).annotate({ description: "Voice input provider and model configuration." }),
+  review: Schema.optional(
+    Schema.Struct({
+      auto: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Auto-trigger an independent review of uncommitted changes at the main-loop stop decision. Default: true.",
+      }),
+      max_review_rounds: Schema.optional(NonNegativeInt).annotate({
+        description: "Maximum review-driven re-entry rounds per session. Default: 3.",
+      }),
+    }),
+  ),
   experimental: Schema.optional(
     Schema.Struct({
       disable_paste_summary: Schema.optional(Schema.Boolean),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2881,12 +2881,19 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           // SessionCheckpoint uses for checkpoint-writer. A missing Actor
           // (render-only/test paths) fails open so the reviewer can never trap.
           const actor = spawnRef.current
-          if (!actor) return false
+          if (!actor) {
+            slog.debug("review gate: actor unavailable, skipping auto-review")
+            return false
+          }
           const cfg = yield* config.get()
           return yield* ReviewGate.shouldReenter({
             sessionID,
             worktree: ctx.worktree,
-            agent: lastUser.agent,
+            // Pass the agent IDENTITY (`agentID`, e.g. "main"), not the agent
+            // TYPE name (`lastUser.agent`, e.g. "build") — ReviewGate.decide
+            // derives isMain from `agent === "main"`. Same expression as the
+            // main-agent guard above and the taskGate/goalGate guards.
+            agent: agentID ?? "main",
             lastUser,
             cfg,
             state: reviewGateState,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -119,6 +119,9 @@ import {
   type McpToolSearchMetadata,
 } from "@/tool/mcp-tool-search"
 import { isMcpToolSearchEnabled } from "@/tool/gpt"
+import { Git } from "@/git"
+import { ReviewGate } from "./review"
+import { ReviewGateState } from "./review-gate-state"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -278,7 +281,9 @@ export const layer = Layer.effect(
     const instruction = yield* Instruction.Service
     const state = yield* SessionRunState.Service
     const goal = yield* Goal.Service
-
+    const taskRegistry = yield* TaskRegistry.Service
+    const reviewGateState = yield* ReviewGateState.Service
+    const git = yield* Git.Service
     const revert = yield* SessionRevert.Service
     const summary = yield* SessionSummary.Service
     const sys = yield* SystemPrompt.Service
@@ -2863,6 +2868,35 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           return true
         })
 
+        // Auto-review stop gate (main agent only). Before honoring a stop, run
+        // an independent read-only review of uncommitted changes. Findings are
+        // injected as a synthetic user turn and the loop re-enters so the main
+        // agent fixes them. Runs AFTER taskGate/goalGate: work that isn't done
+        // (tasks open, goal unmet) shouldn't be reviewed yet. Fail-open on any
+        // reviewer error so a flaky reviewer can never trap the user.
+        const reviewGate = Effect.fn("SessionPrompt.reviewGate")(function* (lastUser: MessageV2.User) {
+          if ((agentID ?? "main") !== "main") return false
+          // Actor is late-bound via spawnRef (NOT `yield* Actor.Service`) to
+          // break the Actor → SessionPrompt → Actor layer cycle — same pattern
+          // SessionCheckpoint uses for checkpoint-writer. A missing Actor
+          // (render-only/test paths) fails open so the reviewer can never trap.
+          const actor = spawnRef.current
+          if (!actor) return false
+          const cfg = yield* config.get()
+          return yield* ReviewGate.shouldReenter({
+            sessionID,
+            worktree: ctx.worktree,
+            agent: lastUser.agent,
+            lastUser,
+            cfg,
+            state: reviewGateState,
+            taskReg: taskRegistry,
+            git,
+            actor,
+            sessions,
+          })
+        })
+
         // think-only (reasoning only) / empty (nothing at all) steps finish with
         // a non-tool stop but carry no usable answer. Without intervention the loop
         // breaks and hands the user an assistant with no final text. Nudge the model
@@ -3258,6 +3292,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               yield* slog.warn("degraded final on abnormal finish", { finish: lastAssistant.finish })
             if (classification.type !== "continue") {
               if (yield* goalGate(lastUser)) continue
+              if (yield* reviewGate(lastUser)) continue
               yield* slog.info("exiting loop", { classification: classification.type })
               break
             }
@@ -4589,6 +4624,8 @@ export const defaultLayer = Layer.suspend(() =>
         Inbox.defaultLayer,
         Goal.defaultLayer,
         TaskRegistry.defaultLayer,
+        ReviewGateState.defaultLayer,
+        Git.defaultLayer,
       ),
     ),
   ),

--- a/packages/opencode/src/session/review-gate-state.ts
+++ b/packages/opencode/src/session/review-gate-state.ts
@@ -1,0 +1,87 @@
+import { Context, Effect, Layer } from "effect"
+import { InstanceState } from "@/effect"
+import type { SessionID } from "@/session/schema"
+
+/**
+ * Per-session state for the auto-review stop gate. Mirrors TaskGateState
+ * (src/task/gate-state.ts) — same InstanceState-backed map pattern — plus a
+ * last-reviewed diff hash (dedup) and an in-flight marker (double-spawn guard).
+ * State lives in InstanceState (per project instance); cleared on teardown.
+ */
+
+export interface Interface {
+  readonly get: (sessionID: SessionID) => Effect.Effect<number>
+  /** Increment counter, return new value. */
+  readonly bump: (sessionID: SessionID) => Effect.Effect<number>
+  readonly clear: (sessionID: SessionID) => Effect.Effect<void>
+  readonly setLastReviewedHash: (sessionID: SessionID, hash: string) => Effect.Effect<void>
+  readonly getLastReviewedHash: (sessionID: SessionID) => Effect.Effect<string | undefined>
+  readonly setInFlight: (sessionID: SessionID, inFlight: boolean) => Effect.Effect<void>
+  readonly inFlight: (sessionID: SessionID) => Effect.Effect<boolean>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/ReviewGateState") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const state = yield* InstanceState.make(
+      Effect.fn("ReviewGateState.state")(function* () {
+        return {
+          counts: new Map<string, number>(),
+          hashes: new Map<string, string>(),
+          inflight: new Map<string, boolean>(),
+        }
+      }),
+    )
+
+    const get = Effect.fn("ReviewGateState.get")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      return data.counts.get(sessionID) ?? 0
+    })
+
+    const bump = Effect.fn("ReviewGateState.bump")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      const next = (data.counts.get(sessionID) ?? 0) + 1
+      data.counts.set(sessionID, next)
+      return next
+    })
+
+    const clear = Effect.fn("ReviewGateState.clear")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      data.counts.delete(sessionID)
+      data.hashes.delete(sessionID)
+      data.inflight.delete(sessionID)
+    })
+
+    const setLastReviewedHash = Effect.fn("ReviewGateState.setLastReviewedHash")(function* (
+      sessionID: SessionID,
+      hash: string,
+    ) {
+      const data = yield* InstanceState.get(state)
+      data.hashes.set(sessionID, hash)
+    })
+
+    const getLastReviewedHash = Effect.fn("ReviewGateState.getLastReviewedHash")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      return data.hashes.get(sessionID)
+    })
+
+    const setInFlight = Effect.fn("ReviewGateState.setInFlight")(function* (sessionID: SessionID, inFlight: boolean) {
+      const data = yield* InstanceState.get(state)
+      if (inFlight) data.inflight.set(sessionID, true)
+      else data.inflight.delete(sessionID)
+    })
+
+    const inFlight = Effect.fn("ReviewGateState.inFlight")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      return data.inflight.get(sessionID) ?? false
+    })
+
+    return Service.of({ get, bump, clear, setLastReviewedHash, getLastReviewedHash, setInFlight, inFlight })
+  }),
+)
+
+export const defaultLayer = layer
+
+export * as ReviewGateState from "./review-gate-state"

--- a/packages/opencode/src/session/review.ts
+++ b/packages/opencode/src/session/review.ts
@@ -92,14 +92,27 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null
 }
 
-/** Narrow an AgentOutcome's structured output to a Finding[]; malformed → []. */
+const VALID_SEVERITIES = new Set(["high", "medium", "low"])
+
+function isFinding(v: unknown): v is Finding {
+  if (!isRecord(v)) return false
+  return (
+    typeof v["file"] === "string" &&
+    typeof v["severity"] === "string" &&
+    VALID_SEVERITIES.has(v["severity"]) &&
+    typeof v["title"] === "string" &&
+    typeof v["detail"] === "string"
+  )
+}
+
+/** Narrow an AgentOutcome's structured output to a Finding[]; malformed → dropped. */
 export function extractFindings(outcome: AgentOutcome): Finding[] {
   if (outcome.status !== "success") return []
   const structured = outcome.structured
   if (!isRecord(structured)) return []
   const arr = structured["findings"]
   if (!Array.isArray(arr)) return []
-  return arr.filter(isRecord) as unknown as Finding[]
+  return arr.filter(isFinding)
 }
 
 export function findingsText(findings: Finding[]): string {
@@ -214,11 +227,15 @@ export const shouldReenter = Effect.fn("ReviewGate.shouldReenter")(function* (in
       background: false,
       format: { type: "json_schema", schema: FINDINGS_SCHEMA, retryCount: 2 },
     })
-    .pipe(Effect.catch((err) => {
-      log.warn("review spawn failed; allowing stop", { error: String(err) })
-      return Effect.succeed(null)
-    }))
-  yield* state.setInFlight(sessionID, false)
+    .pipe(
+      // Runs on success, failure, AND interruption so a cancelled review never
+      // leaves the in-flight marker stuck (which would silently disable the gate).
+      Effect.ensuring(state.setInFlight(sessionID, false)),
+      Effect.catch((err) => {
+        log.warn("review spawn failed; allowing stop", { error: String(err) })
+        return Effect.succeed(null)
+      }),
+    )
 
   if (!spawned) return false
 

--- a/packages/opencode/src/session/review.ts
+++ b/packages/opencode/src/session/review.ts
@@ -1,0 +1,262 @@
+import { createHash } from "node:crypto"
+import { Deferred, Effect } from "effect"
+import { Actor } from "@/actor/spawn"
+import { Config } from "@/config"
+import { Git } from "@/git"
+import { TaskRegistry } from "@/task/registry"
+import { MessageV2 } from "./message-v2"
+import { SessionID, MessageID, PartID } from "./schema"
+import * as Session from "./session"
+import { ReviewGateState } from "./review-gate-state"
+import { Log } from "@/util"
+import type { AgentOutcome } from "@/actor/spawn"
+
+const log = Log.create({ service: "session.review" })
+
+export const DEFAULT_MAX_REVIEW_ROUNDS = 3
+
+/** Tools the read-only reviewer may use. No shell, no edits. */
+export const REVIEW_TOOLS = ["read", "grep", "glob", "codesearch"] as const
+
+/** JSON Schema (not zod) — passed straight to the structured-output format. */
+export const FINDINGS_SCHEMA = {
+  type: "object",
+  properties: {
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          file: { type: "string" },
+          line: { type: "number" },
+          severity: { type: "string", enum: ["high", "medium", "low"] },
+          title: { type: "string" },
+          detail: { type: "string" },
+          fix_suggestion: { type: "string" },
+        },
+        required: ["file", "severity", "title", "detail"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["findings"],
+  additionalProperties: false,
+} as const
+
+export interface Finding {
+  file: string
+  line?: number
+  severity: "high" | "medium" | "low"
+  title: string
+  detail: string
+  fix_suggestion?: string
+}
+
+export type ReviewDecision =
+  | { needReentry: false; reason: "disabled" | "not-main" | "in-flight" | "no-diff" | "tasks-open" | "dedup" | "cap" }
+  | { needReentry: true }
+
+export interface DecideInput {
+  isMain: boolean
+  autoEnabled: boolean
+  inFlight: boolean
+  count: number
+  maxRounds: number
+  sessionHasTasks: boolean
+  allTasksTerminal: boolean
+  hasUncommittedChanges: boolean
+  diffHash: string
+  lastReviewedHash: string | undefined
+}
+
+/**
+ * Pure decision — unit-testable without any services. Mirrors TaskGate.decide's
+ * fail-open posture: every skip reason allows stop.
+ */
+export function decide(input: DecideInput): ReviewDecision {
+  if (!input.isMain) return { needReentry: false, reason: "not-main" }
+  if (!input.autoEnabled) return { needReentry: false, reason: "disabled" }
+  if (input.inFlight) return { needReentry: false, reason: "in-flight" }
+  if (input.sessionHasTasks && !input.allTasksTerminal) return { needReentry: false, reason: "tasks-open" }
+  if (!input.hasUncommittedChanges) return { needReentry: false, reason: "no-diff" }
+  if (input.diffHash === input.lastReviewedHash) return { needReentry: false, reason: "dedup" }
+  if (input.count >= input.maxRounds) return { needReentry: false, reason: "cap" }
+  return { needReentry: true }
+}
+
+export function hashDiff(diffText: string): string {
+  return createHash("sha1").update(diffText).digest("hex")
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null
+}
+
+/** Narrow an AgentOutcome's structured output to a Finding[]; malformed → []. */
+export function extractFindings(outcome: AgentOutcome): Finding[] {
+  if (outcome.status !== "success") return []
+  const structured = outcome.structured
+  if (!isRecord(structured)) return []
+  const arr = structured["findings"]
+  if (!Array.isArray(arr)) return []
+  return arr.filter(isRecord) as unknown as Finding[]
+}
+
+export function findingsText(findings: Finding[]): string {
+  const lines = findings.map(
+    (f) =>
+      `- **${f.severity.toUpperCase()}** \`${f.file}${f.line ? `:${f.line}` : ""}\`: ${f.title} — ${f.detail}` +
+      (f.fix_suggestion ? `\n  Fix: ${f.fix_suggestion}` : ""),
+  )
+  return [
+    "<system-reminder>",
+    "An independent reviewer found issues in your changes. Fix them before stopping:",
+    "",
+    ...lines,
+    "",
+    "If a finding is a false positive, address it explicitly (explain why) or make the fix.",
+    "Do not finish until the findings above are resolved.",
+    "</system-reminder>",
+  ].join("\n")
+}
+
+function buildReviewTask(input: { worktree: string; diffText: string }): string {
+  return [
+    "Review the following uncommitted changes for bugs, structure, performance, and behavior changes.",
+    "",
+    "Changed files & diff (git diff + git diff --cached):",
+    "```diff",
+    input.diffText || "(empty diff)",
+    "```",
+    "",
+    `Working directory: ${input.worktree}`,
+    "",
+    "Read the full files behind the diff with the read/grep/glob/codesearch tools when you need context.",
+    "Produce your findings as the structured output described in your instructions.",
+  ].join("\n")
+}
+
+function readDiff(git: Git.Interface, worktree: string) {
+  const runDiff = (args: string[]) =>
+    Effect.gen(function* () {
+      const result = yield* git.run(args, { cwd: worktree })
+      return result.exitCode === 0 ? result.text() : ""
+    }).pipe(Effect.orElseSucceed(() => ""))
+  return Effect.gen(function* () {
+    const unstaged = yield* runDiff(["diff", "--no-ext-diff", "--no-renames", "--", "."])
+    const staged = yield* runDiff(["diff", "--cached", "--no-ext-diff", "--no-renames", "--", "."])
+    return `${unstaged}\n${staged}`
+  })
+}
+
+export interface ShouldReenterInput {
+  sessionID: SessionID
+  worktree: string
+  agent: string
+  lastUser: MessageV2.User
+  cfg: Config.Info
+  state: ReviewGateState.Interface
+  taskReg: TaskRegistry.Interface
+  git: Git.Interface
+  actor: Actor.Interface
+  sessions: Session.Interface
+}
+
+/**
+ * Main gate body. Returns true when the loop must re-enter (findings injected),
+ * false when the agent may stop. Fail-open on every failure path.
+ */
+export const shouldReenter = Effect.fn("ReviewGate.shouldReenter")(function* (input: ShouldReenterInput) {
+  const { sessionID, worktree, agent, lastUser, cfg, state, taskReg, git, actor, sessions } = input
+
+  const allTasks = yield* taskReg
+    .list({ session_id: sessionID, include_terminal: true })
+    .pipe(Effect.orElseSucceed(() => []))
+  const nonTerminal = yield* taskReg
+    .list({ session_id: sessionID, include_terminal: false })
+    .pipe(Effect.orElseSucceed(() => []))
+  const sessionHasTasks = allTasks.length > 0
+  const allTasksTerminal = nonTerminal.length === 0
+
+  const diffText = yield* readDiff(git, worktree)
+  const hasUncommittedChanges = diffText.trim().length > 0
+  const diffHash = hashDiff(diffText)
+
+  const count = yield* state.get(sessionID)
+  const lastReviewedHash = yield* state.getLastReviewedHash(sessionID)
+  const inFlight = yield* state.inFlight(sessionID)
+
+  const decision = decide({
+    isMain: agent === "main",
+    autoEnabled: cfg.review?.auto !== false,
+    inFlight,
+    count,
+    maxRounds: cfg.review?.max_review_rounds ?? DEFAULT_MAX_REVIEW_ROUNDS,
+    sessionHasTasks,
+    allTasksTerminal,
+    hasUncommittedChanges,
+    diffHash,
+    lastReviewedHash,
+  })
+
+  if (!decision.needReentry) return false
+
+  yield* state.setInFlight(sessionID, true)
+  const spawned = yield* actor
+    .spawn({
+      mode: "subagent",
+      sessionID,
+      agentType: "review",
+      task: buildReviewTask({ worktree, diffText }),
+      description: "auto-review",
+      context: "none",
+      tools: REVIEW_TOOLS,
+      background: false,
+      format: { type: "json_schema", schema: FINDINGS_SCHEMA, retryCount: 2 },
+    })
+    .pipe(Effect.catch((err) => {
+      log.warn("review spawn failed; allowing stop", { error: String(err) })
+      return Effect.succeed(null)
+    }))
+  yield* state.setInFlight(sessionID, false)
+
+  if (!spawned) return false
+
+  const outcome = yield* Deferred.await(spawned.outcome).pipe(Effect.catch(() => Effect.succeed(null)))
+  if (!outcome) return false
+
+  const findings = extractFindings(outcome)
+  if (findings.length === 0) {
+    yield* state.clear(sessionID)
+    yield* state.setLastReviewedHash(sessionID, diffHash)
+    log.info("review clean; allowing stop", { sessionID })
+    return false
+  }
+
+  yield* state.bump(sessionID)
+  yield* state.setLastReviewedHash(sessionID, diffHash)
+
+  const reentry = yield* sessions.updateMessage({
+    id: MessageID.ascending(),
+    role: "user" as const,
+    sessionID,
+    agentID: lastUser.agentID,
+    agent: lastUser.agent,
+    model: lastUser.model,
+    tools: lastUser.tools,
+    format: lastUser.format,
+    time: { created: Date.now() },
+  })
+  yield* sessions.updatePart({
+    id: PartID.ascending(),
+    messageID: reentry.id,
+    sessionID,
+    type: "text",
+    synthetic: true,
+    text: findingsText(findings),
+  } satisfies MessageV2.TextPart)
+  log.info("review findings injected; re-entering", { sessionID, count: findings.length })
+  return true
+})
+
+export * as ReviewGate from "./review"

--- a/packages/opencode/test/actor/cancel-cascade.test.ts
+++ b/packages/opencode/test/actor/cancel-cascade.test.ts
@@ -26,6 +26,9 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -160,6 +163,9 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/actor/cancel-cascade.test.ts
+++ b/packages/opencode/test/actor/cancel-cascade.test.ts
@@ -26,7 +26,6 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
@@ -163,7 +162,6 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/actor/cancel-notification.test.ts
+++ b/packages/opencode/test/actor/cancel-notification.test.ts
@@ -28,6 +28,8 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -164,6 +166,8 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/actor/poststop-progress-write-permission.repro.test.ts
+++ b/packages/opencode/test/actor/poststop-progress-write-permission.repro.test.ts
@@ -26,7 +26,6 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
@@ -179,7 +178,6 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/actor/poststop-progress-write-permission.repro.test.ts
+++ b/packages/opencode/test/actor/poststop-progress-write-permission.repro.test.ts
@@ -26,6 +26,9 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -176,6 +179,9 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/actor/spawn-lifecycle.test.ts
+++ b/packages/opencode/test/actor/spawn-lifecycle.test.ts
@@ -26,6 +26,9 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -160,6 +163,9 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/actor/spawn-lifecycle.test.ts
+++ b/packages/opencode/test/actor/spawn-lifecycle.test.ts
@@ -26,7 +26,6 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
@@ -163,7 +162,6 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/actor/spawn-no-deadlock.test.ts
+++ b/packages/opencode/test/actor/spawn-no-deadlock.test.ts
@@ -27,7 +27,6 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
@@ -163,7 +162,6 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/actor/spawn-no-deadlock.test.ts
+++ b/packages/opencode/test/actor/spawn-no-deadlock.test.ts
@@ -27,6 +27,9 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -160,6 +163,9 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/actor/spawn-notification.test.ts
+++ b/packages/opencode/test/actor/spawn-notification.test.ts
@@ -29,7 +29,6 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
@@ -168,7 +167,6 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/actor/spawn-notification.test.ts
+++ b/packages/opencode/test/actor/spawn-notification.test.ts
@@ -29,6 +29,9 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -165,6 +168,9 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/actor/spawn-task-autostart.test.ts
+++ b/packages/opencode/test/actor/spawn-task-autostart.test.ts
@@ -26,6 +26,9 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -162,6 +165,9 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/actor/spawn-task-autostart.test.ts
+++ b/packages/opencode/test/actor/spawn-task-autostart.test.ts
@@ -26,7 +26,6 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
@@ -165,7 +164,6 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -27,7 +27,6 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
@@ -171,7 +170,6 @@ function makeLayer(opts?: { settledError: () => NonNullable<MessageV2.Assistant[
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -27,6 +27,9 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -168,6 +171,9 @@ function makeLayer(opts?: { settledError: () => NonNullable<MessageV2.Assistant[
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/actor/stall-watchdog.test.ts
+++ b/packages/opencode/test/actor/stall-watchdog.test.ts
@@ -27,6 +27,8 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -165,6 +167,8 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -918,7 +918,7 @@ test("defaultAgent throws when all primary agents are disabled", async () => {
   })
 })
 
-test("bounded computation agents are exactly title, summary, compaction, checkpoint-writer, dream, distill", async () => {
+test("bounded computation agents are exactly title, summary, compaction, checkpoint-writer, dream, distill, review", async () => {
   await using tmp = await tmpdir()
   await Instance.provide({
     directory: tmp.path,
@@ -928,7 +928,15 @@ test("bounded computation agents are exactly title, summary, compaction, checkpo
         .filter((a) => a.native === true && a.hidden === true)
         .map((a) => a.name)
         .sort()
-      expect(boundedComputations).toEqual(["checkpoint-writer", "compaction", "distill", "dream", "summary", "title"])
+      expect(boundedComputations).toEqual([
+        "checkpoint-writer",
+        "compaction",
+        "distill",
+        "dream",
+        "review",
+        "summary",
+        "title",
+      ])
 
       // Spot-check a few durable agents are NOT classified as bounded.
       const build = agents.find((a) => a.name === "build")
@@ -1061,3 +1069,24 @@ itTool.live("compose's tool list swaps GPT-specific file tools", () =>
     }),
   ),
 )
+
+test("review agent is registered, read-only, and subagent mode", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const review = await load(tmp.path, (svc) => svc.get("review"))
+      expect(review).toBeDefined()
+      expect(review?.mode).toBe("subagent")
+      expect(review?.native).toBe(true)
+      expect(evalPerm(review, "read")).toBe("allow")
+      expect(evalPerm(review, "grep")).toBe("allow")
+      expect(evalPerm(review, "glob")).toBe("allow")
+      expect(evalPerm(review, "codesearch")).toBe("allow")
+      expect(evalPerm(review, "bash")).toBe("deny")
+      expect(evalPerm(review, "edit")).toBe("deny")
+      expect(evalPerm(review, "write")).toBe("deny")
+      expect(evalPerm(review, "apply_patch")).toBe("deny")
+    },
+  })
+})

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -147,6 +147,25 @@ test("loads JSON config file", async () => {
   })
 })
 
+test("loads review config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        $schema: "https://opencode.ai/config.json",
+        review: { auto: false, max_review_rounds: 1 },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await load()
+      expect(config.review?.auto).toBe(false)
+      expect(config.review?.max_review_rounds).toBe(1)
+    },
+  })
+})
+
 test("loads Claude Code MCP servers from home and project config", async () => {
   await writeClaudeConfig(path.join(Global.Path.home, ".claude.json"), {
     mcpServers: {

--- a/packages/opencode/test/inbox/fork-agent-compat.test.ts
+++ b/packages/opencode/test/inbox/fork-agent-compat.test.ts
@@ -40,7 +40,6 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
@@ -179,7 +178,6 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/inbox/fork-agent-compat.test.ts
+++ b/packages/opencode/test/inbox/fork-agent-compat.test.ts
@@ -40,6 +40,9 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -176,6 +179,9 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -32,6 +32,9 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
@@ -263,6 +266,10 @@ function makeHttp(mcpService = mcp) {
     TestLLMServer.layer,
     SessionPrompt.layer.pipe(
       Layer.provide(Goal.defaultLayer),
+    Layer.provide(Goal.defaultLayer),
+      Layer.provide(TaskGateState.defaultLayer),
+      Layer.provide(ReviewGateState.defaultLayer),
+      Layer.provide(Git.defaultLayer),
       Layer.provide(TaskRegistry.defaultLayer),
       Layer.provide(SchedulerDefaultLayer),
       Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -32,7 +32,6 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
@@ -266,8 +265,6 @@ function makeHttp(mcpService = mcp) {
     TestLLMServer.layer,
     SessionPrompt.layer.pipe(
       Layer.provide(Goal.defaultLayer),
-    Layer.provide(Goal.defaultLayer),
-      Layer.provide(TaskGateState.defaultLayer),
       Layer.provide(ReviewGateState.defaultLayer),
       Layer.provide(Git.defaultLayer),
       Layer.provide(TaskRegistry.defaultLayer),

--- a/packages/opencode/test/session/review-gate-state.test.ts
+++ b/packages/opencode/test/session/review-gate-state.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the per-session auto-review gate state (session/review-gate-state.ts).
+ * Mirrors the TaskGateState test style: InstanceState-backed, per-session counters.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { SessionID } from "../../src/session/schema"
+import { Log } from "../../src/util"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const ses = SessionID.make("ses_review_state")
+
+function runState<A>(dir: string, fn: (svc: ReviewGateState.Interface) => Effect.Effect<A>) {
+  return Instance.provide({
+    directory: dir,
+    fn: () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const svc = yield* ReviewGateState.Service
+          return yield* fn(svc)
+        }).pipe(Effect.scoped, Effect.provide(ReviewGateState.defaultLayer)),
+      ),
+  })
+}
+
+describe("ReviewGateState", () => {
+  test("get returns 0 before any bump", async () => {
+    await using tmp = await tmpdir({})
+    const got = await runState(tmp.path, (svc) => svc.get(ses))
+    expect(got).toBe(0)
+  })
+
+  test("bump increments, clear resets", async () => {
+    await using tmp = await tmpdir({})
+    const got = await runState(tmp.path, (svc) =>
+      Effect.gen(function* () {
+        const a = yield* svc.bump(ses)
+        const b = yield* svc.bump(ses)
+        yield* svc.clear(ses)
+        const c = yield* svc.get(ses)
+        return { a, b, c }
+      }),
+    )
+    expect(got).toEqual({ a: 1, b: 2, c: 0 })
+  })
+
+  test("last-reviewed hash round-trips and clears", async () => {
+    await using tmp = await tmpdir({})
+    const got = await runState(tmp.path, (svc) =>
+      Effect.gen(function* () {
+        yield* svc.setLastReviewedHash(ses, "abc")
+        const before = yield* svc.getLastReviewedHash(ses)
+        yield* svc.clear(ses)
+        const after = yield* svc.getLastReviewedHash(ses)
+        return { before, after }
+      }),
+    )
+    expect(got).toEqual({ before: "abc", after: undefined })
+  })
+
+  test("in-flight marker round-trips and clears", async () => {
+    await using tmp = await tmpdir({})
+    const got = await runState(tmp.path, (svc) =>
+      Effect.gen(function* () {
+        yield* svc.setInFlight(ses, true)
+        const during = yield* svc.inFlight(ses)
+        yield* svc.setInFlight(ses, false)
+        const after = yield* svc.inFlight(ses)
+        return { during, after }
+      }),
+    )
+    expect(got).toEqual({ during: true, after: false })
+  })
+
+  test("per-session isolation", async () => {
+    await using tmp = await tmpdir({})
+    const other = SessionID.make("ses_other")
+    const got = await runState(tmp.path, (svc) =>
+      Effect.gen(function* () {
+        yield* svc.bump(ses)
+        yield* svc.setLastReviewedHash(ses, "x")
+        return {
+          otherCount: yield* svc.get(other),
+          otherHash: yield* svc.getLastReviewedHash(other),
+        }
+      }),
+    )
+    expect(got).toEqual({ otherCount: 0, otherHash: undefined })
+  })
+})

--- a/packages/opencode/test/session/review-gate.test.ts
+++ b/packages/opencode/test/session/review-gate.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Deferred, Effect, Layer } from "effect"
+import { spawnSync } from "node:child_process"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { Bus } from "../../src/bus"
+import { Session } from "../../src/session"
+import { TaskRegistry } from "../../src/task/registry"
+import { Instance } from "../../src/project/instance"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Actor } from "../../src/actor/spawn"
+import { Git } from "../../src/git"
+import { ReviewGate } from "../../src/session/review"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Config } from "../../src/config"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, SessionID } from "../../src/session/schema"
+import type { AgentOutcome } from "../../src/actor/spawn"
+import { Log } from "../../src/util"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const env = Layer.mergeAll(
+  CrossSpawnSpawner.defaultLayer,
+  Bus.defaultLayer,
+  Session.defaultLayer,
+  TaskRegistry.defaultLayer,
+  Git.defaultLayer,
+  ReviewGateState.defaultLayer,
+)
+
+const it = testEffect(env)
+
+function git(dir: string, args: string[]) {
+  const r = spawnSync("git", args, { cwd: dir, encoding: "utf-8" })
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`)
+  return r.stdout
+}
+
+/** Commits a file, then introduces an uncommitted change so `git diff` is non-empty. */
+async function seedDirty(dir: string) {
+  await fs.writeFile(path.join(dir, "a.ts"), "export const a = 1\n")
+  git(dir, ["add", "a.ts"])
+  git(dir, ["commit", "-q", "-m", "seed"])
+  await fs.writeFile(path.join(dir, "a.ts"), "export const a = 2\n")
+}
+
+/** Plain-object Actor fake passed as a parameter (shouldReenter takes deps as args). */
+function fakeActor(outcome: AgentOutcome): Actor.Interface {
+  return {
+    spawn: () =>
+      Effect.gen(function* () {
+        const d = yield* Deferred.make<AgentOutcome>()
+        yield* Deferred.succeed(d, outcome)
+        return { actorID: "review-1", sessionID: SessionID.make("unused"), outcome: d }
+      }),
+    cancel: () => Effect.void,
+    getForkContext: () => Effect.succeed(undefined),
+  }
+}
+
+function lastUser(sessionID: SessionID) {
+  return MessageV2.User.parse({
+    id: MessageID.ascending(),
+    sessionID,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "build",
+    agentID: "main",
+    model: { providerID: "test", modelID: "test-model" },
+  })
+}
+
+const cfg = { review: { auto: true, max_review_rounds: 3 } } as Config.Info
+
+describe("ReviewGate.shouldReenter", () => {
+  it.live("findings → returns true and injects a synthetic user turn", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => seedDirty(dir))
+          const state = yield* ReviewGateState.Service
+          const taskReg = yield* TaskRegistry.Service
+          const gitSvc = yield* Git.Service
+          const sessions = yield* Session.Service
+          const sess = yield* sessions.create({ title: "R" })
+          const actor = fakeActor({
+            status: "success",
+            structured: { findings: [{ file: "a.ts", severity: "high", title: "magic number", detail: "hard-coded" }] },
+          } satisfies AgentOutcome)
+
+          const reenter = yield* ReviewGate.shouldReenter({
+            sessionID: sess.id,
+            worktree: dir,
+            agent: "main",
+            lastUser: lastUser(sess.id),
+            cfg,
+            state,
+            taskReg,
+            git: gitSvc,
+            actor,
+            sessions,
+          })
+
+          expect(reenter).toBe(true)
+          const msgs = yield* sessions.messages({ sessionID: sess.id })
+          const synthetic = msgs.flatMap((m) => m.parts).filter((p) => p.type === "text" && p.synthetic === true)
+          expect(synthetic.length).toBeGreaterThan(0)
+          if (synthetic[0]?.type === "text") expect(synthetic[0].text).toContain("independent reviewer")
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("no findings → returns false and injects nothing", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => seedDirty(dir))
+          const state = yield* ReviewGateState.Service
+          const taskReg = yield* TaskRegistry.Service
+          const gitSvc = yield* Git.Service
+          const sessions = yield* Session.Service
+          const sess = yield* sessions.create({ title: "R" })
+          const actor = fakeActor({ status: "success", structured: { findings: [] } } satisfies AgentOutcome)
+
+          const reenter = yield* ReviewGate.shouldReenter({
+            sessionID: sess.id,
+            worktree: dir,
+            agent: "main",
+            lastUser: lastUser(sess.id),
+            cfg,
+            state,
+            taskReg,
+            git: gitSvc,
+            actor,
+            sessions,
+          })
+
+          expect(reenter).toBe(false)
+          const msgs = yield* sessions.messages({ sessionID: sess.id })
+          const synthetic = msgs.flatMap((m) => m.parts).filter((p) => p.type === "text" && p.synthetic === true)
+          expect(synthetic.length).toBe(0)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("empty diff → returns false without spawning the reviewer", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          // `git: true` fixture committed a root commit; no working-tree changes.
+          const state = yield* ReviewGateState.Service
+          const taskReg = yield* TaskRegistry.Service
+          const gitSvc = yield* Git.Service
+          const sessions = yield* Session.Service
+          const sess = yield* sessions.create({ title: "R" })
+          const actor = fakeActor({ status: "failure", error: "should never be called" } satisfies AgentOutcome)
+
+          const reenter = yield* ReviewGate.shouldReenter({
+            sessionID: sess.id,
+            worktree: dir,
+            agent: "main",
+            lastUser: lastUser(sess.id),
+            cfg,
+            state,
+            taskReg,
+            git: gitSvc,
+            actor,
+            sessions,
+          })
+
+          expect(reenter).toBe(false)
+        }),
+      { git: true },
+    ),
+  )
+})

--- a/packages/opencode/test/session/review-gate.test.ts
+++ b/packages/opencode/test/session/review-gate.test.ts
@@ -98,7 +98,7 @@ describe("ReviewGate.shouldReenter", () => {
           const reenter = yield* ReviewGate.shouldReenter({
             sessionID: sess.id,
             worktree: dir,
-            agent: "main",
+            agent: lastUser(sess.id).agentID ?? "main",
             lastUser: lastUser(sess.id),
             cfg,
             state,
@@ -133,7 +133,7 @@ describe("ReviewGate.shouldReenter", () => {
           const reenter = yield* ReviewGate.shouldReenter({
             sessionID: sess.id,
             worktree: dir,
-            agent: "main",
+            agent: lastUser(sess.id).agentID ?? "main",
             lastUser: lastUser(sess.id),
             cfg,
             state,
@@ -167,7 +167,45 @@ describe("ReviewGate.shouldReenter", () => {
           const reenter = yield* ReviewGate.shouldReenter({
             sessionID: sess.id,
             worktree: dir,
-            agent: "main",
+            agent: lastUser(sess.id).agentID ?? "main",
+            lastUser: lastUser(sess.id),
+            cfg,
+            state,
+            taskReg,
+            git: gitSvc,
+            actor,
+            sessions,
+          })
+
+          expect(reenter).toBe(false)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("type name agent (e.g. 'build') on a dirty repo → returns false (gate needs the identity)", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => seedDirty(dir))
+          const state = yield* ReviewGateState.Service
+          const taskReg = yield* TaskRegistry.Service
+          const gitSvc = yield* Git.Service
+          const sessions = yield* Session.Service
+          const sess = yield* sessions.create({ title: "R" })
+          const actor = fakeActor({
+            status: "success",
+            structured: { findings: [{ file: "a.ts", severity: "high", title: "magic number", detail: "hard-coded" }] },
+          } satisfies AgentOutcome)
+
+          // `lastUser.agent` is the agent TYPE name ("build"), NOT the identity
+          // ("main"). ReviewGate.decide derives isMain from `agent === "main"`,
+          // so passing the type name must fail closed — pinning the contract
+          // that the wrapper MUST pass `agentID` (or "main").
+          const reenter = yield* ReviewGate.shouldReenter({
+            sessionID: sess.id,
+            worktree: dir,
+            agent: lastUser(sess.id).agent,
             lastUser: lastUser(sess.id),
             cfg,
             state,

--- a/packages/opencode/test/session/review.test.ts
+++ b/packages/opencode/test/session/review.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test"
+import { ReviewGate } from "../../src/session/review"
+
+describe("ReviewGate.decide", () => {
+  const base = {
+    isMain: true,
+    autoEnabled: true,
+    inFlight: false,
+    count: 0,
+    maxRounds: 3,
+    sessionHasTasks: false,
+    allTasksTerminal: true,
+    hasUncommittedChanges: true,
+    diffHash: "h1",
+    lastReviewedHash: undefined,
+  }
+
+  test("fires when main, enabled, diff present, and not yet reviewed", () => {
+    expect(ReviewGate.decide(base)).toEqual({ needReentry: true })
+  })
+
+  test("skips when not the main agent", () => {
+    expect(ReviewGate.decide({ ...base, isMain: false })).toEqual({ needReentry: false, reason: "not-main" })
+  })
+
+  test("skips when disabled", () => {
+    expect(ReviewGate.decide({ ...base, autoEnabled: false })).toEqual({ needReentry: false, reason: "disabled" })
+  })
+
+  test("skips when a review is already in flight", () => {
+    expect(ReviewGate.decide({ ...base, inFlight: true })).toEqual({ needReentry: false, reason: "in-flight" })
+  })
+
+  test("skips when no uncommitted changes", () => {
+    expect(ReviewGate.decide({ ...base, hasUncommittedChanges: false })).toEqual({
+      needReentry: false,
+      reason: "no-diff",
+    })
+  })
+
+  test("skips when tasks exist but are not all terminal (task-mode)", () => {
+    expect(ReviewGate.decide({ ...base, sessionHasTasks: true, allTasksTerminal: false })).toEqual({
+      needReentry: false,
+      reason: "tasks-open",
+    })
+  })
+
+  test("fires in task-mode when all tasks are terminal", () => {
+    expect(ReviewGate.decide({ ...base, sessionHasTasks: true, allTasksTerminal: true })).toEqual({
+      needReentry: true,
+    })
+  })
+
+  test("dedup: skips when the diff was already reviewed", () => {
+    expect(ReviewGate.decide({ ...base, lastReviewedHash: "h1" })).toEqual({ needReentry: false, reason: "dedup" })
+  })
+
+  test("cap: skips when round count reached the max", () => {
+    expect(ReviewGate.decide({ ...base, count: 3, maxRounds: 3 })).toEqual({ needReentry: false, reason: "cap" })
+  })
+
+  test("fires below the cap", () => {
+    expect(ReviewGate.decide({ ...base, count: 2, maxRounds: 3 })).toEqual({ needReentry: true })
+  })
+})
+
+describe("ReviewGate.hashDiff", () => {
+  test("same input produces same hash, different input different hash", () => {
+    const a = ReviewGate.hashDiff("unchanged content")
+    const b = ReviewGate.hashDiff("unchanged content")
+    const c = ReviewGate.hashDiff("changed content")
+    expect(a).toBe(b)
+    expect(a).not.toBe(c)
+    expect(a).toMatch(/^[0-9a-f]{40}$/)
+  })
+})
+
+describe("ReviewGate.extractFindings", () => {
+  test("returns [] for non-success outcomes", () => {
+    expect(ReviewGate.extractFindings({ status: "failure", error: "boom" })).toEqual([])
+    expect(ReviewGate.extractFindings({ status: "cancelled" })).toEqual([])
+  })
+
+  test("returns [] when structured is missing or malformed", () => {
+    expect(ReviewGate.extractFindings({ status: "success" })).toEqual([])
+    expect(ReviewGate.extractFindings({ status: "success", structured: { nope: 1 } })).toEqual([])
+  })
+
+  test("returns the findings array", () => {
+    const findings: ReviewGate.Finding[] = [{ file: "a.ts", severity: "high", title: "bug", detail: "detail" }]
+    expect(ReviewGate.extractFindings({ status: "success", structured: { findings } })).toEqual(findings)
+  })
+})
+
+describe("ReviewGate.findingsText", () => {
+  test("renders findings as a system-reminder with severity, file, line, and fix", () => {
+    const text = ReviewGate.findingsText([
+      { file: "a.ts", line: 3, severity: "high", title: "null deref", detail: "crashes on null", fix_suggestion: "guard it" },
+      { file: "b.ts", severity: "low", title: "naming", detail: "confusing", fix_suggestion: "rename" },
+    ])
+    expect(text).toContain("<system-reminder>")
+    expect(text).toContain("**HIGH** `a.ts:3`: null deref")
+    expect(text).toContain("**LOW** `b.ts`: naming")
+    expect(text).toContain("Fix: guard it")
+    expect(text).toContain("independent reviewer found issues")
+  })
+
+  test("empty findings produces a generic message", () => {
+    const text = ReviewGate.findingsText([])
+    expect(text).toContain("<system-reminder>")
+    expect(text).toContain("independent reviewer")
+  })
+})

--- a/packages/opencode/test/session/review.test.ts
+++ b/packages/opencode/test/session/review.test.ts
@@ -90,6 +90,19 @@ describe("ReviewGate.extractFindings", () => {
     const findings: ReviewGate.Finding[] = [{ file: "a.ts", severity: "high", title: "bug", detail: "detail" }]
     expect(ReviewGate.extractFindings({ status: "success", structured: { findings } })).toEqual(findings)
   })
+
+  test("drops malformed findings (missing or invalid severity)", () => {
+    const structured = {
+      findings: [
+        { file: "a.ts", severity: "high", title: "bug", detail: "detail" },
+        { file: "b.ts", title: "missing severity", detail: "x" },
+        { file: "c.ts", severity: "critical", title: "bad severity", detail: "x" },
+      ],
+    }
+    expect(ReviewGate.extractFindings({ status: "success", structured })).toEqual([
+      { file: "a.ts", severity: "high", title: "bug", detail: "detail" },
+    ])
+  })
 })
 
 describe("ReviewGate.findingsText", () => {

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -50,7 +50,6 @@ import { SessionProcessor } from "../../src/session/processor"
 import { SessionCompaction } from "../../src/session/compaction"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
@@ -192,7 +191,6 @@ function makeHttp() {
     SessionSummary.defaultLayer,
     SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-      Layer.provide(TaskGateState.defaultLayer),
       Layer.provide(ReviewGateState.defaultLayer),
       Layer.provide(Git.defaultLayer),
       Layer.provide(TaskRegistry.defaultLayer),

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -50,6 +50,9 @@ import { SessionProcessor } from "../../src/session/processor"
 import { SessionCompaction } from "../../src/session/compaction"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { SessionCheckpoint } from "../../src/session/checkpoint"
 import { ActorRegistry } from "../../src/actor/registry"
@@ -189,6 +192,9 @@ function makeHttp() {
     SessionSummary.defaultLayer,
     SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+      Layer.provide(TaskGateState.defaultLayer),
+      Layer.provide(ReviewGateState.defaultLayer),
+      Layer.provide(Git.defaultLayer),
       Layer.provide(TaskRegistry.defaultLayer),
     Layer.provide(SchedulerDefaultLayer),
       Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/session/text-loop-integration.test.ts
+++ b/packages/opencode/test/session/text-loop-integration.test.ts
@@ -33,6 +33,8 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -188,6 +190,8 @@ function makeLayers() {
   const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
   return SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(TaskRegistry.defaultLayer),
     Layer.provide(SchedulerDefaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/tool/session-tool.test.ts
+++ b/packages/opencode/test/tool/session-tool.test.ts
@@ -20,6 +20,7 @@ import { Provider } from "../../src/provider"
 import { Session } from "../../src/session"
 import { Worktree } from "../../src/worktree"
 import { Git } from "../../src/git"
+import { ReviewGateState } from "../../src/session/review-gate-state"
 import { MessageID, SessionID, PartID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { TaskRegistry } from "../../src/task/registry"
@@ -1191,6 +1192,8 @@ function makeAskLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(askSummary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/tool/whitelist.test.ts
+++ b/packages/opencode/test/tool/whitelist.test.ts
@@ -29,7 +29,6 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
@@ -184,7 +183,6 @@ function makeLayer() {
   const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(TaskRegistry.defaultLayer),

--- a/packages/opencode/test/tool/whitelist.test.ts
+++ b/packages/opencode/test/tool/whitelist.test.ts
@@ -29,6 +29,9 @@ import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
 import { SystemPrompt } from "../../src/session/system"
@@ -181,6 +184,9 @@ function makeLayer() {
   const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(TaskRegistry.defaultLayer),
     Layer.provide(SchedulerDefaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/workflow/lib.ts
+++ b/packages/opencode/test/workflow/lib.ts
@@ -41,6 +41,8 @@ import { SessionCompaction } from "../../src/session/compaction"
 import { Goal } from "../../src/session/goal"
 import { TaskRegistry } from "../../src/task/registry"
 import { defaultLayer as SchedulerDefaultLayer } from "../../src/cron/scheduler"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { Auth } from "../../src/auth"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { Ripgrep } from "../../src/file/ripgrep"
@@ -153,6 +155,9 @@ export function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/workflow/lib.ts
+++ b/packages/opencode/test/workflow/lib.ts
@@ -155,7 +155,6 @@ export function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),

--- a/packages/opencode/test/workflow/tool.test.ts
+++ b/packages/opencode/test/workflow/tool.test.ts
@@ -41,6 +41,9 @@ import { Team } from "../../src/team"
 import { SessionCheckpoint } from "../../src/session/checkpoint"
 import { SessionCompaction } from "../../src/session/compaction"
 import { Goal } from "../../src/session/goal"
+import { TaskGateState } from "../../src/task/gate-state"
+import { ReviewGateState } from "../../src/session/review-gate-state"
+import { Git } from "../../src/git"
 import { TaskRegistry } from "../../src/task/registry"
 import { defaultLayer as SchedulerDefaultLayer } from "../../src/cron/scheduler"
 import { Auth } from "../../src/auth"
@@ -167,6 +170,9 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
+    Layer.provide(TaskGateState.defaultLayer),
+    Layer.provide(ReviewGateState.defaultLayer),
+    Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(summary),
     Layer.provide(checkpoint),

--- a/packages/opencode/test/workflow/tool.test.ts
+++ b/packages/opencode/test/workflow/tool.test.ts
@@ -41,7 +41,6 @@ import { Team } from "../../src/team"
 import { SessionCheckpoint } from "../../src/session/checkpoint"
 import { SessionCompaction } from "../../src/session/compaction"
 import { Goal } from "../../src/session/goal"
-import { TaskGateState } from "../../src/task/gate-state"
 import { ReviewGateState } from "../../src/session/review-gate-state"
 import { Git } from "../../src/git"
 import { TaskRegistry } from "../../src/task/registry"
@@ -170,7 +169,6 @@ function makeLayer() {
   const prune = SessionPrune.layer.pipe(Layer.provide(checkpoint), Layer.provideMerge(deps))
   const prompt = SessionPrompt.layer.pipe(
     Layer.provide(Goal.defaultLayer),
-    Layer.provide(TaskGateState.defaultLayer),
     Layer.provide(ReviewGateState.defaultLayer),
     Layer.provide(Git.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),


### PR DESCRIPTION
## Summary

- 在主循环停止决策点新增 `reviewGate`（`prompt.ts`），与 `goalGate` 同构：`goalGate` → `reviewGate` → stop。
- 门控在 main agent 想停止时，对未提交变更运行独立的只读 `review` 子代理（`"*": "deny"` + read/grep/glob/codesearch），产出结构化 findings。
- 有 findings 时注入为合成用户轮次并重新进入循环，让 main agent 修复后再停止；干净则放行。全路径 fail-open（评审失败永不阻塞用户）。
- 去重：同一批 diff 只审一次（sha1 hash），修复后 diff 变化才重审。上限：`review.max_review_rounds`（默认 3）。配置 `review.auto`（默认 true）。
- 新增模块：`review.ts`（decide/shouldReenter 核心）、`review-gate-state.ts`（计数+hash+in-flight）、`review` agent + 系统提示词。
- 关键实现点：`Effect.ensuring` 保证 in-flight 标记中断安全；`agentID`（非 agent 类型名）传入身份判断；`Actor` 经 `spawnRef` 延迟绑定规避 `Actor→SessionPrompt` 循环依赖；git diff 由门控预取，评审子代理无需 shell。

## Test Plan

- [x] 新功能测试 26 pass（decide 决策矩阵 + 状态服务 + 集成，集成用真实 git + fake actor）
- [x] `bun typecheck` 全量通过（含全部受影响测试文件层适配）
- [x] 17 个受影响测试文件 182 个测试通过，无新增失败
- [ ] 手动冒烟：真实会话中让 agent 改代码后停止，观察自动 review 触发、findings 注入与修复