### PR TITLE
fix(tool): register lsp tool when LSP is configured, not behind experimental flag

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -232,9 +232,10 @@ export const layer = Layer.effect(
           }
         }
 
-        yield* config.get()
+        const cfg = yield* config.get()
         const questionEnabled =
           ["app", "cli", "desktop"].includes(Flag.MIMOCODE_CLIENT) || Flag.MIMOCODE_ENABLE_QUESTION_TOOL
+        const lspEnabled = Boolean(cfg.lsp) || Flag.MIMOCODE_EXPERIMENTAL_LSP_TOOL
 
         const tool = yield* Effect.all({
           invalid: Tool.init(invalid),
@@ -289,7 +290,7 @@ export const layer = Layer.effect(
             tool.skill,
             tool.patch,
             tool.changedir,
-            ...(Flag.MIMOCODE_EXPERIMENTAL_LSP_TOOL ? [tool.lsp] : []),
+            ...(lspEnabled ? [tool.lsp] : []),
             tool.planexit,
             tool.memory,
             tool.history,

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -174,13 +174,15 @@ describe("tool.registry", () => {
     ),
   )
 
-  it.live("does not register the lsp tool when LSP is not configured", () =>
-    provideTmpdirInstance((dir) =>
-      Effect.gen(function* () {
-        const registry = yield* ToolRegistry.Service
-        const ids = yield* registry.ids()
-        expect(ids).not.toContain("lsp")
-      }),
+  it.live("does not register the lsp tool when LSP is disabled", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const registry = yield* ToolRegistry.Service
+          const ids = yield* registry.ids()
+          expect(ids).not.toContain("lsp")
+        }),
+      { config: { lsp: false } },
     ),
   )
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -162,6 +162,28 @@ describe("tool.registry", () => {
     ),
   )
 
+  it.live("registers the lsp tool when LSP is configured", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const registry = yield* ToolRegistry.Service
+          const ids = yield* registry.ids()
+          expect(ids).toContain("lsp")
+        }),
+      { config: { lsp: true } },
+    ),
+  )
+
+  it.live("does not register the lsp tool when LSP is not configured", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const registry = yield* ToolRegistry.Service
+        const ids = yield* registry.ids()
+        expect(ids).not.toContain("lsp")
+      }),
+    ),
+  )
+
   it.live("keeps the reserved MCP search tool when a custom tool conflicts", () =>
     provideTmpdirInstance((dir) =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Fixes #2017. The `lsp` tool never appears in the agent tool list even when LSP servers are configured (e.g. `lsp.rust-analyzer`).

**Root cause:** `packages/opencode/src/tool/registry.ts` gated the `lsp` tool behind `Flag.MIMOCODE_EXPERIMENTAL_LSP_TOOL`, which defaults OFF. The tool was therefore never registered for normal users regardless of LSP configuration or server-launch timing.

**Fix:** register the `lsp` tool when LSP is configured — `lspEnabled = Boolean(cfg.lsp) || Flag.MIMOCODE_EXPERIMENTAL_LSP_TOOL`:
- `config.lsp` truthy (`true` or a server record) → `lsp` tool registered.
- `config.lsp` falsy (default) → not registered (no token overhead for non-LSP users).
- The experimental flag is retained as a force-enable override (backward compatible).

The `lsp` tool itself already handles "no server for this file type" at runtime via `lsp.hasClients`, so no change to the tool's execute path.

## Test Plan

- [x] New tests: `registry.ids()` contains `lsp` with `config: { lsp: true }`; does NOT contain `lsp` with `config: { lsp: false }`.
- [x] `bun test test/tool/registry.test.ts` — 7 pass.
- [x] `bun typecheck` — clean.