### PR TITLE
fix(session): bound /btw side-question snapshot to recent messages

### DIFF
--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -50,6 +50,19 @@ function SIDE_QUESTION_PROMPT(question: string): string {
   ].join("\n")
 }
 
+/** Cap the /btw side-question snapshot to this many recent messages. */
+export const MAX_FORK_QUERY_MESSAGES = 12
+
+/**
+ * Bound a side-question snapshot to the most recent `max` messages. A side
+ * question needs recent context, not the whole session (which can be hundreds
+ * of thousands of tokens on long sessions). The caller keeps the session
+ * boundary/watermark from the full set; only the snapshot content is bounded.
+ */
+export function sliceSideQuestionContext<T>(msgs: readonly T[], max: number): T[] {
+  return msgs.slice(-max)
+}
+
 // One-shot, READ-ONLY fork-query: ask a (possibly running) target session a
 // side question over a FROZEN snapshot of its history without disturbing its
 // turn, and return the answer text. Mechanism mirrors tryStartCheckpointWriter
@@ -111,7 +124,7 @@ export function forkQuery(deps: {
       agentName,
       providerID,
       modelID,
-      msgs,
+      msgs: sliceSideQuestionContext(msgs, MAX_FORK_QUERY_MESSAGES),
     })
     const forkCtx = {
       system: prefix.system,

--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -58,9 +58,21 @@ export const MAX_FORK_QUERY_MESSAGES = 12
  * question needs recent context, not the whole session (which can be hundreds
  * of thousands of tokens on long sessions). The caller keeps the session
  * boundary/watermark from the full set; only the snapshot content is bounded.
+ *
+ * With `mustInclude`, the window is extended to also cover the last element
+ * matching it (e.g. the last user message) even when it falls outside the tail
+ * window — `buildLLMRequestPrefix` dies if its msgs have no user message.
  */
-export function sliceSideQuestionContext<T>(msgs: readonly T[], max: number): T[] {
-  return msgs.slice(-max)
+export function sliceSideQuestionContext<T>(
+  msgs: readonly T[],
+  max: number,
+  /** Predicate for an element that must survive in the window (e.g. the last user message). */
+  mustInclude?: (m: T) => boolean,
+): T[] {
+  if (!mustInclude) return msgs.slice(-max)
+  const lastIdx = msgs.findLastIndex(mustInclude)
+  if (lastIdx < 0) return msgs.slice(-max)
+  return msgs.slice(Math.min(msgs.length - max, lastIdx))
 }
 
 // One-shot, READ-ONLY fork-query: ask a (possibly running) target session a
@@ -124,7 +136,7 @@ export function forkQuery(deps: {
       agentName,
       providerID,
       modelID,
-      msgs: sliceSideQuestionContext(msgs, MAX_FORK_QUERY_MESSAGES),
+      msgs: sliceSideQuestionContext(msgs, MAX_FORK_QUERY_MESSAGES, (m) => m.info.role === "user"),
     })
     const forkCtx = {
       system: prefix.system,

--- a/packages/opencode/test/tool/session-side-question.test.ts
+++ b/packages/opencode/test/tool/session-side-question.test.ts
@@ -19,4 +19,19 @@ describe("sliceSideQuestionContext", () => {
     const msgs = [1, 2, 3, 4, 5]
     expect(sliceSideQuestionContext(msgs, 3)).toEqual([3, 4, 5])
   })
+
+  test("extends the window to include a matching message when the tail has none", () => {
+    const msgs = Array.from({ length: 100 }, (_, i) => ({ id: i, role: i === 50 ? "user" : "assistant" }))
+    const out = sliceSideQuestionContext(msgs, 12, (m) => m.role === "user")
+    expect(out).toContainEqual({ id: 50, role: "user" })
+    expect(out.at(-1)).toEqual({ id: 99, role: "assistant" })
+    expect(out[0]?.id).toBeLessThanOrEqual(50)
+  })
+
+  test("stays bounded to max when the tail already contains a match", () => {
+    const msgs = Array.from({ length: 100 }, (_, i) => ({ id: i, role: i >= 90 ? "user" : "assistant" }))
+    const out = sliceSideQuestionContext(msgs, 12, (m) => m.role === "user")
+    expect(out).toHaveLength(12)
+    expect(out.some((m) => m.role === "user")).toBe(true)
+  })
 })

--- a/packages/opencode/test/tool/session-side-question.test.ts
+++ b/packages/opencode/test/tool/session-side-question.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { sliceSideQuestionContext } from "../../src/tool/session"
+
+describe("sliceSideQuestionContext", () => {
+  test("bounds to the most recent max messages", () => {
+    const msgs = Array.from({ length: 100 }, (_, i) => ({ id: i }))
+    const out = sliceSideQuestionContext(msgs, 12)
+    expect(out).toHaveLength(12)
+    expect(out[0]).toEqual({ id: 88 })
+    expect(out.at(-1)).toEqual({ id: 99 })
+  })
+
+  test("keeps all messages when under the cap", () => {
+    const msgs = Array.from({ length: 5 }, (_, i) => ({ id: i }))
+    expect(sliceSideQuestionContext(msgs, 12)).toHaveLength(5)
+  })
+
+  test("preserves order", () => {
+    const msgs = [1, 2, 3, 4, 5]
+    expect(sliceSideQuestionContext(msgs, 3)).toEqual([3, 4, 5])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1855. `/btw <question>` is marketed as a "side question without context cost", but `forkQuery` (`packages/opencode/src/tool/session.ts`) passed the **entire** session history to `buildPrefix`, so the fork's prompt was the full session (observed 1M+ input tokens on ~300k-token sessions → empty answer / hang).

**Fix:** bound the side-question snapshot to the most recent `MAX_FORK_QUERY_MESSAGES` (12) messages, while guaranteeing the last user message stays in the window (`buildLLMRequestPrefix` dies without a user message — an uncatchable defect).

- `sliceSideQuestionContext(msgs, max, mustInclude?)` — new helper: normally the last `max` messages; extends to include the last matching element (the last user message) if it would otherwise be cut off.
- `forkQuery` passes `(m) => m.info.role === "user"` as the predicate.
- `watermark` (session boundary) and agent identity stay computed from the full session — only the snapshot content is bounded.
- Covers all side-ask paths (`session.ask` route + `session ask` tool op both call `forkQuery`).

The fork's prompt is `[...forkCtx.inheritedMessages, ...ownNewModelMsgs]` and does not re-pull history, so bounding `inheritedMessages` bounds the fork.

## Test Plan

- [x] New unit tests: `sliceSideQuestionContext` bounds to last `max`; keeps all under cap; preserves order; extends window to include the last user message when the tail has none; stays bounded when the tail already contains a user message.
- [x] `bun test test/tool/session-side-question.test.ts` — 5 pass.
- [x] `bun typecheck` — clean.