### PR TITLE
fix(mcp): patch @ai-sdk/openai-compatible to stop dropping multi-arg tool calls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -636,6 +636,7 @@
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "@opentui/core@0.1.101": "patches/@opentui%2Fcore@0.1.101.patch",
+    "@ai-sdk/openai-compatible@2.0.41": "patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch",
   },
   "overrides": {
     "@types/bun": "catalog:",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "@npmcli/agent@4.0.0": "patches/@npmcli%2Fagent@4.0.0.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
-    "@opentui/core@0.1.101": "patches/@opentui%2Fcore@0.1.101.patch"
+    "@opentui/core@0.1.101": "patches/@opentui%2Fcore@0.1.101.patch",
+    "@ai-sdk/openai-compatible@2.0.41": "patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch"
   }
 }

--- a/packages/opencode/test/mcp/openai-compatible-args-patch.test.ts
+++ b/packages/opencode/test/mcp/openai-compatible-args-patch.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test"
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
+import { streamText, tool } from "ai"
+import z from "zod"
+
+// Independent reproduction of the `@ai-sdk/openai-compatible@2.0.41` patch
+// (`patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch`, branch
+// fix/mcp-tool-args-stream). Exercises the REAL patched stream parser
+// end-to-end: mock SSE → provider `doStream` → `ai` core tool execution.
+//
+// Defect being fixed: a provider that emits OVERLAPPING complete-JSON argument
+// snapshots (OpenRouter buffered mode) triggered the parser's premature
+// finalize on the FIRST parseable snapshot (`{}`), so the tool `execute`
+// received an empty object. The patch tracks `lastValidDelta` = the LAST
+// complete snapshot and falls back to it at flush when the concatenated
+// accumulator is not parseable.
+
+interface Captured {
+  name: string
+  input: unknown
+}
+
+function chunk(delta: Record<string, unknown>, finishReason?: string): string {
+  const payload = {
+    id: "chatcmpl-stub",
+    object: "chat.completion.chunk",
+    choices: [{ delta, ...(finishReason ? { finish_reason: finishReason } : {}) }],
+  }
+  return `data: ${JSON.stringify(payload)}\n\n`
+}
+
+function sseResponse(lines: string[]) {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) controller.enqueue(new TextEncoder().encode(line))
+      controller.close()
+    },
+  })
+  return new Response(body, { headers: { "content-type": "text/event-stream" } })
+}
+
+const FULL_ARGS = JSON.stringify({
+  p0: "a",
+  p1: "b",
+  p2: "c",
+  p3: "d",
+  p4: "e",
+  p5: "f",
+})
+
+function overlappingSnapshotsLines(): string[] {
+  const snapshots = [
+    "{}",
+    JSON.stringify({ p0: "a" }),
+    JSON.stringify({ p0: "a", p1: "b" }),
+    JSON.stringify({ p0: "a", p1: "b", p2: "c" }),
+    JSON.stringify({ p0: "a", p1: "b", p2: "c", p3: "d" }),
+    JSON.stringify({ p0: "a", p1: "b", p2: "c", p3: "d", p4: "e" }),
+    FULL_ARGS,
+  ]
+  return [
+    chunk({ role: "assistant" }),
+    chunk({
+      tool_calls: [
+        { index: 0, id: "call_1", type: "function", function: { name: "calc", arguments: snapshots[0] } },
+      ],
+    }),
+    ...snapshots.slice(1).map((args) =>
+      chunk({ tool_calls: [{ index: 0, function: { arguments: args } }] }),
+    ),
+    chunk({}, "stop"),
+    "data: [DONE]\n\n",
+  ]
+}
+
+function incrementalPrefixLines(): string[] {
+  return [
+    chunk({ role: "assistant" }),
+    chunk({
+      tool_calls: [
+        { index: 0, id: "call_1", type: "function", function: { name: "calc", arguments: '{"p0":"a"' } },
+      ],
+    }),
+    chunk({ tool_calls: [{ index: 0, function: { arguments: ',"p1":"b"' } }] }),
+    chunk({ tool_calls: [{ index: 0, function: { arguments: ',"p2":"c"' } }] }),
+    chunk({ tool_calls: [{ index: 0, function: { arguments: ',"p3":"d"' } }] }),
+    chunk({ tool_calls: [{ index: 0, function: { arguments: ',"p4":"e"' } }] }),
+    chunk({ tool_calls: [{ index: 0, function: { arguments: ',"p5":"f"}' } }] }),
+    chunk({}, "stop"),
+    "data: [DONE]\n\n",
+  ]
+}
+
+async function run(lines: string[]): Promise<Captured> {
+  const captured: Captured = { name: "", input: null }
+  const provider = createOpenAICompatible({
+    baseURL: "http://mock/v1",
+    name: "mock",
+    apiKey: "test-key",
+    fetch: (async () => sseResponse(lines)) as any,
+  })
+  const model = provider.languageModel("mock-model")
+
+  const result = streamText({
+    model,
+    prompt: "run calc",
+    toolChoice: "required",
+    tools: {
+      calc: tool({
+        description: "Calc",
+        inputSchema: z.object({
+          p0: z.string(),
+          p1: z.string(),
+          p2: z.string(),
+          p3: z.string(),
+          p4: z.string(),
+          p5: z.string(),
+        }),
+        execute: async (input) => {
+          captured.name = "calc"
+          captured.input = input
+          return "ok"
+        },
+      }),
+    },
+  })
+
+  // Consume the full stream so the tool loop runs to completion.
+  await result.toolResults
+  expect(captured.name).toBe("calc")
+  return captured
+}
+
+describe("openai-compatible patch: lastValidDelta", () => {
+  test("OVERLAPPING complete-JSON snapshots → execute receives ALL 6 args", async () => {
+    const captured = await run(overlappingSnapshotsLines())
+    expect(captured.input).toEqual({
+      p0: "a",
+      p1: "b",
+      p2: "c",
+      p3: "d",
+      p4: "e",
+      p5: "f",
+    })
+  })
+
+  test("incremental-prefix streaming still works → execute receives ALL 6 args", async () => {
+    const captured = await run(incrementalPrefixLines())
+    expect(captured.input).toEqual({
+      p0: "a",
+      p1: "b",
+      p2: "c",
+      p3: "d",
+      p4: "e",
+      p5: "f",
+    })
+  })
+})

--- a/patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
+++ b/patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
@@ -1,0 +1,150 @@
+diff --git a/dist/index.js b/dist/index.js
+index dca128d3a790378c51a24a16d92585178343b278..84f21b064e487c62377241fb0737321cd0968e76 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -791,6 +791,7 @@
+                       arguments: (_e = toolCallDelta.function.arguments) != null ? _e : ""
+                     },
+                     hasFinished: false,
++                    lastValidDelta: undefined,
+                     thoughtSignature: (_h = (_g = (_f = toolCallDelta.extra_content) == null ? void 0 : _f.google) == null ? void 0 : _g.thought_signature) != null ? _h : void 0
+                   };
+                   const toolCall2 = toolCalls[index];
+@@ -803,24 +804,7 @@
+                       });
+                     }
+                     if ((0, import_provider_utils2.isParsableJson)(toolCall2.function.arguments)) {
+-                      controller.enqueue({
+-                        type: "tool-input-end",
+-                        id: toolCall2.id
+-                      });
+-                      controller.enqueue({
+-                        type: "tool-call",
+-                        toolCallId: (_k = toolCall2.id) != null ? _k : (0, import_provider_utils2.generateId)(),
+-                        toolName: toolCall2.function.name,
+-                        input: toolCall2.function.arguments,
+-                        ...toolCall2.thoughtSignature ? {
+-                          providerMetadata: {
+-                            [providerOptionsName]: {
+-                              thoughtSignature: toolCall2.thoughtSignature
+-                            }
+-                          }
+-                        } : {}
+-                      });
+-                      toolCall2.hasFinished = true;
++                      toolCall2.lastValidDelta = toolCall2.function.arguments;
+                     }
+                   }
+                   continue;
+@@ -837,25 +821,8 @@
+                   id: toolCall.id,
+                   delta: (_o = toolCallDelta.function.arguments) != null ? _o : ""
+                 });
+-                if (((_p = toolCall.function) == null ? void 0 : _p.name) != null && ((_q = toolCall.function) == null ? void 0 : _q.arguments) != null && (0, import_provider_utils2.isParsableJson)(toolCall.function.arguments)) {
+-                  controller.enqueue({
+-                    type: "tool-input-end",
+-                    id: toolCall.id
+-                  });
+-                  controller.enqueue({
+-                    type: "tool-call",
+-                    toolCallId: (_r = toolCall.id) != null ? _r : (0, import_provider_utils2.generateId)(),
+-                    toolName: toolCall.function.name,
+-                    input: toolCall.function.arguments,
+-                    ...toolCall.thoughtSignature ? {
+-                      providerMetadata: {
+-                        [providerOptionsName]: {
+-                          thoughtSignature: toolCall.thoughtSignature
+-                        }
+-                      }
+-                    } : {}
+-                  });
+-                  toolCall.hasFinished = true;
++                if (((_p = toolCallDelta.function) == null ? void 0 : _p.arguments) != null && (0, import_provider_utils2.isParsableJson)(toolCallDelta.function.arguments)) {
++                  toolCall.lastValidDelta = toolCallDelta.function.arguments;
+                 }
+               }
+             }
+@@ -879,7 +846,7 @@
+                 type: "tool-call",
+                 toolCallId: (_a2 = toolCall.id) != null ? _a2 : (0, import_provider_utils2.generateId)(),
+                 toolName: toolCall.function.name,
+-                input: toolCall.function.arguments,
++                input: (0, import_provider_utils2.isParsableJson)(toolCall.function.arguments) ? toolCall.function.arguments : (toolCall.lastValidDelta != null ? toolCall.lastValidDelta : toolCall.function.arguments),
+                 ...toolCall.thoughtSignature ? {
+                   providerMetadata: {
+                     [providerOptionsName]: {
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..6a926f818251fd1f046e3aa816842d9517332ca9 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -778,6 +778,7 @@
+                       arguments: (_e = toolCallDelta.function.arguments) != null ? _e : ""
+                     },
+                     hasFinished: false,
++                    lastValidDelta: undefined,
+                     thoughtSignature: (_h = (_g = (_f = toolCallDelta.extra_content) == null ? void 0 : _f.google) == null ? void 0 : _g.thought_signature) != null ? _h : void 0
+                   };
+                   const toolCall2 = toolCalls[index];
+@@ -790,24 +791,7 @@
+                       });
+                     }
+                     if (isParsableJson(toolCall2.function.arguments)) {
+-                      controller.enqueue({
+-                        type: "tool-input-end",
+-                        id: toolCall2.id
+-                      });
+-                      controller.enqueue({
+-                        type: "tool-call",
+-                        toolCallId: (_k = toolCall2.id) != null ? _k : generateId(),
+-                        toolName: toolCall2.function.name,
+-                        input: toolCall2.function.arguments,
+-                        ...toolCall2.thoughtSignature ? {
+-                          providerMetadata: {
+-                            [providerOptionsName]: {
+-                              thoughtSignature: toolCall2.thoughtSignature
+-                            }
+-                          }
+-                        } : {}
+-                      });
+-                      toolCall2.hasFinished = true;
++                      toolCall2.lastValidDelta = toolCall2.function.arguments;
+                     }
+                   }
+                   continue;
+@@ -824,25 +808,8 @@
+                   id: toolCall.id,
+                   delta: (_o = toolCallDelta.function.arguments) != null ? _o : ""
+                 });
+-                if (((_p = toolCall.function) == null ? void 0 : _p.name) != null && ((_q = toolCall.function) == null ? void 0 : _q.arguments) != null && isParsableJson(toolCall.function.arguments)) {
+-                  controller.enqueue({
+-                    type: "tool-input-end",
+-                    id: toolCall.id
+-                  });
+-                  controller.enqueue({
+-                    type: "tool-call",
+-                    toolCallId: (_r = toolCall.id) != null ? _r : generateId(),
+-                    toolName: toolCall.function.name,
+-                    input: toolCall.function.arguments,
+-                    ...toolCall.thoughtSignature ? {
+-                      providerMetadata: {
+-                        [providerOptionsName]: {
+-                          thoughtSignature: toolCall.thoughtSignature
+-                        }
+-                      }
+-                    } : {}
+-                  });
+-                  toolCall.hasFinished = true;
++                if (((_p = toolCallDelta.function) == null ? void 0 : _p.arguments) != null && isParsableJson(toolCallDelta.function.arguments)) {
++                  toolCall.lastValidDelta = toolCallDelta.function.arguments;
+                 }
+               }
+             }
+@@ -866,7 +833,7 @@
+                 type: "tool-call",
+                 toolCallId: (_a2 = toolCall.id) != null ? _a2 : generateId(),
+                 toolName: toolCall.function.name,
+-                input: toolCall.function.arguments,
++                input: isParsableJson(toolCall.function.arguments) ? toolCall.function.arguments : (toolCall.lastValidDelta != null ? toolCall.lastValidDelta : toolCall.function.arguments),
+                 ...toolCall.thoughtSignature ? {
+                   providerMetadata: {
+                     [providerOptionsName]: {


### PR DESCRIPTION
## Summary

Fixes #2025. MCP tools with >2 parameters lost their arguments — the server received empty/partial args even though the model generated correct tool calls.

**Root cause (reproduction-confirmed):** `@ai-sdk/openai-compatible`'s stream parser prematurely finalized a tool call the moment the accumulated `function.arguments` string parsed as valid JSON (`isParsableJson`). Providers that buffer args as complete-JSON snapshots (e.g. OpenRouter default) emit the first parseable fragment (`{}` or `{"p0":"a","p1":"b"}`) and then drop all later fragments → `tool-call.input` was truncated/empty. The full args are unrecoverable from stream parts.

**Fix:** patch `@ai-sdk/openai-compatible@2.0.41` via the repo's `patches/` + `patchedDependencies` mechanism (the repo already patches 4 other deps):
- Remove the two premature `isParsableJson` finalize blocks.
- Track `lastValidDelta` (the last delta that is itself valid JSON).
- At `flush`, emit `input: isParsableJson(accumulated) ? accumulated : (lastValidDelta ?? accumulated)` — full args for incremental-prefix streams, and the last complete snapshot (the full args) for overlapping-snapshot providers.
- Covers both `dist/index.js` and `dist/index.mjs` (the ESM build is what bun loads).

**Regression test** (`test/mcp/openai-compatible-args-patch.test.ts`): mock-SSE `streamText` through the real patched parser — overlapping snapshots now deliver all 6 args (was `{}`), incremental-prefix streaming unaffected.

## Test Plan

- [x] Regression test: overlapping complete-JSON snapshots → `execute` gets all 6 args; incremental-prefix → all 6 args.
- [x] Verified the test FAILS with the patch reverted (proves it catches the bug).
- [x] `bun typecheck` clean; affected suites (provider/mcp/session-tool) 645 pass.
- [x] `bun install` applies the patch cleanly (fresh-install verified).

## Known limitations (out of scope)

- `@openrouter/ai-sdk-provider` and the repo's own Copilot provider (`src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts`) have the same premature-finalize bug; not covered by this patch (separate follow-ups / upstream SDK fixes).