### PR TITLE
fix(session): scope diffs to requested message

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -314,7 +314,7 @@ export const layer = Layer.effect(
             ([exportName, v]) => typeof v === "function" && exportName.endsWith("Plugin"),
           )?.[1] as PluginInstance | undefined
           if (!overlay) continue
-          log.info("loading extension", { name })
+          // log.info("loading extension", { name })
           const init = yield* Effect.tryPromise({
             try: () => overlay(input),
             catch: (err) => log.error("failed to load extension", { name, error: err }),

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -129,6 +129,21 @@ export const layer = Layer.effect(
     })
 
     const diff = Effect.fn("SessionSummary.diff")(function* (input: { sessionID: SessionID; messageID?: MessageID }) {
+      if (input.messageID) {
+        const all = yield* sessions.messages({ sessionID: input.sessionID, agentID: "*" })
+        const target = all.find((item) => item.info.id === input.messageID)
+        if (!target || target.info.role !== "user") return []
+        const diffs =
+          target.info.summary?.diffs ??
+          (yield* computeDiff({
+            messages: all.filter(
+              (item) =>
+                item.info.id === input.messageID ||
+                (item.info.role === "assistant" && item.info.parentID === input.messageID),
+            ),
+          }))
+        return diffs.map((item) => ({ ...item, file: unquoteGitPath(item.file) }))
+      }
       const diffs = yield* storage
         .read<Snapshot.FileDiff[]>(["session_diff", input.sessionID])
         .pipe(Effect.catch(() => Effect.succeed([] as Snapshot.FileDiff[])))


### PR DESCRIPTION
## Summary
- scope message-specific session diffs to the requested user message and its direct assistant reply
- reuse stored message summaries when available and normalize returned git paths
- silence the noisy extension-loading log line

## Verification
- `bun test test/session/summary-main-slice.test.ts`
- `bun typecheck`
- push hook: repository-wide turbo typecheck passed