### PR TITLE
fix(provider): stop treating unknown modalities as unsupported for BYOK models

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1630,6 +1630,13 @@ function UserMessage(props: {
       return origin?.kind === "checkpoint-off" ? [x.text] : []
     })[0]
   })
+  const withheldInputNotice = createMemo(() => {
+    return props.parts.flatMap((x) => {
+      if (x.type !== "text" || !x.synthetic || !x.ignored) return []
+      const origin = (x.metadata as { origin?: { kind?: string } } | undefined)?.origin
+      return origin?.kind === "withheld-input" ? [x.text] : []
+    })[0]
+  })
   // A context rebuild (`/rebuild`) inserts a single user message carrying a
   // `checkpoint` part plus `synthetic: true` text parts (the rendered context
   // and index). Neither renders — `checkpoint` has no PART_MAPPING entry and
@@ -1711,6 +1718,16 @@ function UserMessage(props: {
           <box id={props.message.id} marginTop={props.index === 0 ? 0 : 1} paddingLeft={2} flexDirection="row" gap={1}>
             <text fg={theme.textMuted}>
               <span style={{ bg: theme.backgroundElement, fg: theme.warning, bold: true }}> checkpoint off </span>
+              <span style={{ fg: theme.text }}> {notice()}</span>
+            </text>
+          </box>
+        )}
+      </Show>
+      <Show when={withheldInputNotice()}>
+        {(notice) => (
+          <box id={props.message.id} marginTop={props.index === 0 ? 0 : 1} paddingLeft={2} flexDirection="row" gap={1}>
+            <text fg={theme.textMuted}>
+              <span style={{ bg: theme.backgroundElement, fg: theme.warning, bold: true }}> input withheld </span>
               <span style={{ fg: theme.text }}> {notice()}</span>
             </text>
           </box>

--- a/packages/opencode/src/provider/capability-registry.ts
+++ b/packages/opencode/src/provider/capability-registry.ts
@@ -1,4 +1,5 @@
 import type { Provider } from "@/provider"
+import { ModalityInference } from "./modality-inference"
 
 /**
  * Model Capability Registry.
@@ -131,7 +132,7 @@ const ADAPTERS: Record<string, AdapterDeclaration> = {
     text: TEXT_SUPPORTED,
     image: IMAGE_SUPPORTED,
     audio: absent(),
-    evidence: "tool-attachment.ts:49-53,69-71 exclude @ai-sdk/amazon-bedrock from every audio route",  // no direct wire probe; routing logic is the evidence
+    evidence: "tool-attachment.ts:49-53,69-71 exclude @ai-sdk/amazon-bedrock from every audio route", // no direct wire probe; routing logic is the evidence
   },
 }
 
@@ -158,10 +159,10 @@ export function declaredAdapters(): ReadonlyArray<string> {
   return Object.keys(ADAPTERS)
 }
 
-function modelGate(model: Provider.Model, modality: Modality): boolean {
-  if (modality === "text") return model.capabilities.input.text
-  if (modality === "image") return model.capabilities.input.image
-  return model.capabilities.input.audio
+function modelGate(model: Provider.Model, modality: Modality): Support {
+  if (!ModalityInference.acceptsInput(model.capabilities, modality)) return "unsupported"
+  if (!ModalityInference.hasEvidencedInput(model.capabilities, modality)) return "unknown"
+  return "supported"
 }
 
 /**
@@ -171,9 +172,8 @@ function modelGate(model: Provider.Model, modality: Modality): boolean {
  */
 export function modelDeclaration(model: Provider.Model, modality: Modality): ModalityDeclaration {
   const adapter = adapterDeclaration(model.api.npm)[modality]
-  if (!modelGate(model, modality)) {
-    return { support: "unsupported", mimeTypes: [], maxBytes: 0 }
-  }
+  const support = modelGate(model, modality)
+  if (support !== "supported") return { support, mimeTypes: [], maxBytes: 0 }
   return adapter
 }
 

--- a/packages/opencode/src/provider/modality-inference.ts
+++ b/packages/opencode/src/provider/modality-inference.ts
@@ -11,27 +11,70 @@ import type * as ModelsDev from "./models"
  * The answer is resolved in strict precedence order:
  *
  *  1. DECLARED     — the user wrote `modalities` in config. Always authoritative.
- *  2. PROVIDER-ENTRY — the same-named models.dev provider already lists this
+ *  2. BUILTIN      — this repo ships the answer for one of its own aliases that
+ *                    no catalog documents. See `BUILTIN_INPUT`.
+ *  3. PROVIDER-ENTRY — the same-named models.dev provider already lists this
  *                    model id, so its metadata is inherited.
- *  3. DIRECTORY    — the model id alone is looked up across the whole models.dev
+ *  4. DIRECTORY    — the model id alone is looked up across the whole models.dev
  *                    directory and the FIRST-PARTY entry is used. This is the
  *                    tier that a user-invented provider id needs: `mimo-v2.5`
  *                    served through a provider called `mimo` matches nothing in
- *                    tier 2, but the model itself is documented under `xiaomi`.
- *  4. ASSUMED      — nothing is known. This is UNKNOWN, and unknown is not the
+ *                    tier 3, but the model itself is documented under `xiaomi`.
+ *  5. ASSUMED      — nothing is known. This is UNKNOWN, and unknown is not the
  *                    same as unsupported (see `assumedInput` for why unknown
  *                    resolves permissively).
  *
- * Tiers 3 and 4 are the new ones. Before them, an unmatched model fell straight
+ * Tiers 4 and 5 are the new ones. Before them, an unmatched model fell straight
  * to a hardcoded `false` for every non-text modality, which turned "we never
  * looked this up" into the much stronger claim "we know it cannot do this".
+ *
+ * Only tiers 1 and 2 are STATED by someone who knows (see `isStated`); the rest
+ * are worked out from metadata that may not describe this deployment.
  */
 
 export type InputModality = "text" | "audio" | "image" | "video" | "pdf"
 
-export type ModalityProvenance = "declared" | "provider-entry" | "directory" | "assumed"
+export type ModalityProvenance = "declared" | "builtin" | "provider-entry" | "directory" | "assumed"
 
 export type ModalityMap = Record<InputModality, boolean>
+
+/**
+ * Input modalities this repo itself ships the answer for, keyed `providerID/modelID`.
+ *
+ * `mimo-auto` is a free-tier routing ALIAS rather than a model: no vendor
+ * publishes it, so no catalog tier can ever match it, and it dispatches to a
+ * vision-capable model. Its image support is therefore not something to infer —
+ * it is a fact this repo owns, and stating it here puts it at the same standing
+ * as a user's own `modalities` declaration.
+ *
+ * It has to enter the pipeline HERE, as part of the verdict, and not be patched
+ * onto the finished model afterwards. Assigning `capabilities.input.image = true`
+ * after the fact leaves the verdict's own provenance saying `assumed`, and every
+ * consumer that asks for EVIDENCE of image support (`Provider.hasEvidencedImageInput`)
+ * then reads the alias as unknown and passes over it — which is how the only
+ * vision channel a free-tier user has got excluded from automatic vision-model
+ * selection while its `input.image` said `true` the whole time.
+ *
+ * Entries are COMPLETE input maps: an unlisted modality is `false`, not unknown.
+ * The permissive `assumed` tier exists for models nobody looked up, which is the
+ * opposite of these.
+ */
+const BUILTIN_INPUT: Record<string, readonly InputModality[]> = {
+  "mimo/mimo-auto": ["text", "image"],
+}
+
+/**
+ * Whether a provenance means the answer was STATED by someone who knows — the
+ * user's own config, or this repo's own catalog of its aliases — as opposed to
+ * worked out from third-party metadata or defaulted.
+ *
+ * Callers that warn "this verdict may be wrong" or log it as inferred should ask
+ * this rather than compare against `"declared"`, so that a stated fact is not
+ * reported to the model as a guess.
+ */
+export function isStated(provenance: ModalityProvenance): boolean {
+  return provenance === "declared" || provenance === "builtin"
+}
 
 export interface InputModalityVerdict {
   readonly modalities: ModalityMap
@@ -157,15 +200,24 @@ export function directoryIndex(database: Record<string, ModelsDev.Provider>): Di
 export interface ResolveInput {
   /** `modalities.input` as written in config, when the user wrote it. */
   readonly declared?: readonly string[]
-  /** Tier 2: input modalities of the same-named provider's existing entry. */
+  /** Tier 3: input modalities of the same-named provider's existing entry. */
   readonly inherited?: ModalityMap
-  /** Tier 3 lookup key — the id actually sent upstream. */
+  /** Tier 4 lookup key — the id actually sent upstream. */
   readonly apiID: string
   readonly directory: DirectoryIndex
+  /**
+   * Tier 2 lookup key — the CONFIG-side identity, because that is what the
+   * engine's own aliases are named by. `apiID` is what goes upstream and a user
+   * may point any local id at it.
+   */
+  readonly providerID: string
+  readonly modelID: string
 }
 
 export function resolveInput(input: ResolveInput): InputModalityVerdict {
   if (input.declared) return { modalities: mapOf(input.declared, false), provenance: "declared" }
+  const builtin = BUILTIN_INPUT[`${input.providerID}/${input.modelID}`]
+  if (builtin) return { modalities: mapOf(builtin, false), provenance: "builtin" }
   if (input.inherited) return { modalities: { ...input.inherited }, provenance: "provider-entry" }
   const official = input.directory.official(input.apiID)
   if (official?.model.modalities?.input) {
@@ -179,12 +231,14 @@ export function resolveInput(input: ResolveInput): InputModalityVerdict {
 }
 
 /**
- * Output modalities get tiers 1-3 but NOT the permissive tier 4.
+ * Output modalities get the catalog tiers but NOT the permissive `assumed` one,
+ * and no `builtin` tier either.
  *
  * Nothing decides whether to send content based on output modalities, so an
  * unknown carries no silent-drop risk to correct for; claiming a model emits
  * video would be an invention with no upside. Unknown therefore keeps the
- * long-standing text-only shape.
+ * long-standing text-only shape — which is already what the engine's own
+ * aliases emit, so there is nothing for a builtin entry to state.
  */
 export function resolveOutput(input: ResolveInput): InputModalityVerdict {
   if (input.declared) return { modalities: mapOf(input.declared, false), provenance: "declared" }

--- a/packages/opencode/src/provider/modality-inference.ts
+++ b/packages/opencode/src/provider/modality-inference.ts
@@ -1,0 +1,203 @@
+import type * as ModelsDev from "./models"
+
+/**
+ * Input-modality inference for models the user declares themselves.
+ *
+ * A model configured under `provider.<id>.models.<id>` may say nothing about
+ * `modalities`. Something still has to answer "can this model read an image?",
+ * because `provider/transform.ts` uses that answer to decide whether to forward
+ * an image part or replace it with an error sentence addressed to the model.
+ *
+ * The answer is resolved in strict precedence order:
+ *
+ *  1. DECLARED     — the user wrote `modalities` in config. Always authoritative.
+ *  2. PROVIDER-ENTRY — the same-named models.dev provider already lists this
+ *                    model id, so its metadata is inherited.
+ *  3. DIRECTORY    — the model id alone is looked up across the whole models.dev
+ *                    directory and the FIRST-PARTY entry is used. This is the
+ *                    tier that a user-invented provider id needs: `mimo-v2.5`
+ *                    served through a provider called `mimo` matches nothing in
+ *                    tier 2, but the model itself is documented under `xiaomi`.
+ *  4. ASSUMED      — nothing is known. This is UNKNOWN, and unknown is not the
+ *                    same as unsupported (see `assumedInput` for why unknown
+ *                    resolves permissively).
+ *
+ * Tiers 3 and 4 are the new ones. Before them, an unmatched model fell straight
+ * to a hardcoded `false` for every non-text modality, which turned "we never
+ * looked this up" into the much stronger claim "we know it cannot do this".
+ */
+
+export type InputModality = "text" | "audio" | "image" | "video" | "pdf"
+
+export type ModalityProvenance = "declared" | "provider-entry" | "directory" | "assumed"
+
+export type ModalityMap = Record<InputModality, boolean>
+
+export interface InputModalityVerdict {
+  readonly modalities: ModalityMap
+  readonly provenance: ModalityProvenance
+  /** models.dev ref the verdict came from. Only set for `"directory"`. */
+  readonly source?: string
+}
+
+function mapOf(list: readonly string[] | undefined, fallback: boolean): ModalityMap {
+  const has = (modality: InputModality) => (list ? list.includes(modality) : fallback)
+  return {
+    text: has("text"),
+    audio: has("audio"),
+    image: has("image"),
+    video: has("video"),
+    pdf: has("pdf"),
+  }
+}
+
+/**
+ * The verdict for a model nothing is known about: every input modality is
+ * permitted.
+ *
+ * This is a deliberate bias, and the reason is that the two ways of being wrong
+ * do not cost the same. Guess "supported" wrongly and the request goes out and
+ * the provider answers with an explicit 4xx naming the media it rejected —
+ * loud, attributable, and fixable by declaring `modalities` in config. Guess
+ * "unsupported" wrongly and the image is replaced, before the request is built,
+ * by a sentence only the model can see: the model then truthfully reports that
+ * it received no image, the image is sitting in the session record the whole
+ * time, and there is nothing anywhere that says the engine chose to drop it.
+ *
+ * The scope of this bias is narrow on purpose. It applies only to models the
+ * user declared in config AND that no models.dev entry covers; catalog-sourced
+ * models keep answering strictly from their metadata.
+ */
+export function assumedInput(): ModalityMap {
+  return mapOf(undefined, true)
+}
+
+/**
+ * Bare-model-id index over the models.dev directory.
+ *
+ * Built once per provider-state init and then queried per configured model, so
+ * the full directory walk happens a single time rather than per lookup.
+ */
+export interface DirectoryIndex {
+  /**
+   * The first-party models.dev entry for a bare model id, or `undefined` when
+   * there is no single unambiguous one.
+   */
+  official(modelID: string): { readonly ref: string; readonly model: ModelsDev.Model } | undefined
+}
+
+/**
+ * models.dev publishes no "first party" flag, so first-partyness is derived from
+ * the shape of the directory itself.
+ *
+ * Aggregators list a resold model under the VENDOR NAMESPACE they bought it
+ * from — `xiaomi/mimo-v2.5`, `openai/gpt-5`, `anthropic/claude-sonnet-4-5`. The
+ * vendor's own provider entry, in contrast, lists the model under its bare id.
+ * So the namespace that aggregators agree on names the vendor provider, and
+ * intersecting those namespaces with the providers that carry the bare id yields
+ * the vendor's own entry.
+ *
+ * Requiring EXACTLY ONE survivor is what keeps this from becoming a guess. No
+ * union of the aggregators' claims, no majority vote: either the directory
+ * points at one first-party entry or the lookup declines to answer and the
+ * caller falls through to `assumedInput`. A namespace that no provider serves
+ * (`xiaomimimo/…`, `gemini/…`) and an aggregator that namespaces under its own
+ * id both drop out of the intersection for free.
+ */
+export function directoryIndex(database: Record<string, ModelsDev.Provider>): DirectoryIndex {
+  /** bare model id -> providers whose own entry uses that exact id */
+  const holders = new Map<string, Set<string>>()
+  /** bare model id -> vendor namespaces some provider prefixes it with */
+  const namespaces = new Map<string, Set<string>>()
+
+  const add = (index: Map<string, Set<string>>, key: string, value: string) => {
+    const existing = index.get(key)
+    if (existing) existing.add(value)
+    else index.set(key, new Set([value]))
+  }
+
+  for (const [providerID, provider] of Object.entries(database)) {
+    for (const modelID of Object.keys(provider.models ?? {})) {
+      const slash = modelID.indexOf("/")
+      if (slash === -1) {
+        add(holders, modelID, providerID)
+        continue
+      }
+      add(namespaces, modelID.slice(slash + 1), modelID.slice(0, slash))
+    }
+  }
+
+  const resolved = new Map<string, { ref: string; model: ModelsDev.Model } | undefined>()
+
+  function lookup(providerID: string, modelID: string) {
+    const model = database[providerID]?.models?.[modelID]
+    if (!model) return undefined
+    return { ref: `${providerID}/${modelID}`, model }
+  }
+
+  return {
+    official(modelID) {
+      if (resolved.has(modelID)) return resolved.get(modelID)
+      const answer = (() => {
+        // An id the user already wrote namespaced names its own vendor provider.
+        const slash = modelID.indexOf("/")
+        if (slash !== -1) return lookup(modelID.slice(0, slash), modelID.slice(slash + 1))
+        const owners = holders.get(modelID)
+        if (!owners) return undefined
+        const candidates = [...(namespaces.get(modelID) ?? [])].filter((ns) => owners.has(ns))
+        if (candidates.length !== 1) return undefined
+        return lookup(candidates[0], modelID)
+      })()
+      resolved.set(modelID, answer)
+      return answer
+    },
+  }
+}
+
+export interface ResolveInput {
+  /** `modalities.input` as written in config, when the user wrote it. */
+  readonly declared?: readonly string[]
+  /** Tier 2: input modalities of the same-named provider's existing entry. */
+  readonly inherited?: ModalityMap
+  /** Tier 3 lookup key — the id actually sent upstream. */
+  readonly apiID: string
+  readonly directory: DirectoryIndex
+}
+
+export function resolveInput(input: ResolveInput): InputModalityVerdict {
+  if (input.declared) return { modalities: mapOf(input.declared, false), provenance: "declared" }
+  if (input.inherited) return { modalities: { ...input.inherited }, provenance: "provider-entry" }
+  const official = input.directory.official(input.apiID)
+  if (official?.model.modalities?.input) {
+    return {
+      modalities: mapOf(official.model.modalities.input, false),
+      provenance: "directory",
+      source: official.ref,
+    }
+  }
+  return { modalities: assumedInput(), provenance: "assumed" }
+}
+
+/**
+ * Output modalities get tiers 1-3 but NOT the permissive tier 4.
+ *
+ * Nothing decides whether to send content based on output modalities, so an
+ * unknown carries no silent-drop risk to correct for; claiming a model emits
+ * video would be an invention with no upside. Unknown therefore keeps the
+ * long-standing text-only shape.
+ */
+export function resolveOutput(input: ResolveInput): InputModalityVerdict {
+  if (input.declared) return { modalities: mapOf(input.declared, false), provenance: "declared" }
+  if (input.inherited) return { modalities: { ...input.inherited }, provenance: "provider-entry" }
+  const official = input.directory.official(input.apiID)
+  if (official?.model.modalities?.output) {
+    return {
+      modalities: mapOf(official.model.modalities.output, false),
+      provenance: "directory",
+      source: official.ref,
+    }
+  }
+  return { modalities: { ...mapOf(undefined, false), text: true }, provenance: "assumed" }
+}
+
+export * as ModalityInference from "./modality-inference"

--- a/packages/opencode/src/provider/modality-inference.ts
+++ b/packages/opencode/src/provider/modality-inference.ts
@@ -38,6 +38,11 @@ export type ModalityProvenance = "declared" | "builtin" | "provider-entry" | "di
 
 export type ModalityMap = Record<InputModality, boolean>
 
+export interface InputCapabilities {
+  readonly input: ModalityMap
+  readonly inferred?: { readonly input?: ModalityProvenance }
+}
+
 /**
  * Input modalities this repo itself ships the answer for, keyed `providerID/modelID`.
  *
@@ -76,6 +81,14 @@ export function isStated(provenance: ModalityProvenance): boolean {
   return provenance === "declared" || provenance === "builtin"
 }
 
+export function acceptsInput(capabilities: InputCapabilities, modality: InputModality): boolean {
+  return capabilities.input[modality]
+}
+
+export function hasEvidencedInput(capabilities: InputCapabilities, modality: InputModality): boolean {
+  return acceptsInput(capabilities, modality) && (modality === "text" || capabilities.inferred?.input !== "assumed")
+}
+
 export interface InputModalityVerdict {
   readonly modalities: ModalityMap
   readonly provenance: ModalityProvenance
@@ -83,7 +96,7 @@ export interface InputModalityVerdict {
   readonly source?: string
 }
 
-function mapOf(list: readonly string[] | undefined, fallback: boolean): ModalityMap {
+export function mapOf(list: readonly string[] | undefined, fallback: boolean): ModalityMap {
   const has = (modality: InputModality) => (list ? list.includes(modality) : fallback)
   return {
     text: has("text"),
@@ -155,20 +168,23 @@ export function directoryIndex(database: Record<string, ModelsDev.Provider>): Di
 
   const add = (index: Map<string, Set<string>>, key: string, value: string) => {
     const existing = index.get(key)
-    if (existing) existing.add(value)
-    else index.set(key, new Set([value]))
+    if (existing) {
+      existing.add(value)
+      return
+    }
+    index.set(key, new Set([value]))
   }
 
-  for (const [providerID, provider] of Object.entries(database)) {
-    for (const modelID of Object.keys(provider.models ?? {})) {
+  Object.entries(database)
+    .flatMap(([providerID, provider]) => Object.keys(provider.models ?? {}).map((modelID) => ({ providerID, modelID })))
+    .forEach(({ providerID, modelID }) => {
       const slash = modelID.indexOf("/")
       if (slash === -1) {
         add(holders, modelID, providerID)
-        continue
+        return
       }
       add(namespaces, modelID.slice(slash + 1), modelID.slice(0, slash))
-    }
-  }
+    })
 
   const resolved = new Map<string, { ref: string; model: ModelsDev.Model } | undefined>()
 
@@ -215,10 +231,16 @@ export interface ResolveInput {
 }
 
 export function resolveInput(input: ResolveInput): InputModalityVerdict {
-  if (input.declared) return { modalities: mapOf(input.declared, false), provenance: "declared" }
-  const builtin = BUILTIN_INPUT[`${input.providerID}/${input.modelID}`]
+  if (input.declared !== undefined) return { modalities: mapOf(input.declared, false), provenance: "declared" }
+  const builtin = BUILTIN_INPUT[input.providerID + "/" + input.modelID]
   if (builtin) return { modalities: mapOf(builtin, false), provenance: "builtin" }
-  if (input.inherited) return { modalities: { ...input.inherited }, provenance: "provider-entry" }
+  if (input.inherited) {
+    return {
+      modalities: { ...input.inherited },
+      provenance: "provider-entry",
+      source: input.providerID + "/" + input.modelID,
+    }
+  }
   const official = input.directory.official(input.apiID)
   if (official?.model.modalities?.input) {
     return {
@@ -241,8 +263,14 @@ export function resolveInput(input: ResolveInput): InputModalityVerdict {
  * aliases emit, so there is nothing for a builtin entry to state.
  */
 export function resolveOutput(input: ResolveInput): InputModalityVerdict {
-  if (input.declared) return { modalities: mapOf(input.declared, false), provenance: "declared" }
-  if (input.inherited) return { modalities: { ...input.inherited }, provenance: "provider-entry" }
+  if (input.declared !== undefined) return { modalities: mapOf(input.declared, false), provenance: "declared" }
+  if (input.inherited) {
+    return {
+      modalities: { ...input.inherited },
+      provenance: "provider-entry",
+      source: input.providerID + "/" + input.modelID,
+    }
+  }
   const official = input.directory.official(input.apiID)
   if (official?.model.modalities?.output) {
     return {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -30,6 +30,7 @@ import { isFreeApiModel, isFreeApiSunset } from "@/util/free-api-sunset"
 import { usesMimoCodexMode } from "../tool/gpt"
 
 import * as ProviderTransform from "./transform"
+import { ModalityInference } from "./modality-inference"
 import { ModelID, ProviderID } from "./schema"
 
 const log = Log.create({ service: "provider" })
@@ -991,6 +992,26 @@ const ProviderInterleaved = Schema.Union([
   }),
 ])
 
+/**
+ * Provenance of a model's modality verdict, present only when the verdict was
+ * INFERRED rather than declared.
+ *
+ * Its whole job is attribution. A modality verdict can be wrong, and when it is,
+ * the difference between "the user's config says so" and "we inherited this from
+ * a models.dev entry for a different provider" is the difference between a
+ * one-line fix and an afternoon of bisecting. `source` names the exact entry the
+ * verdict was inherited from so the guess is auditable, not anonymous.
+ *
+ * `"assumed"` additionally marks a verdict that is a POLICY, not a fact — see
+ * `ModalityInference.assumedInput`. Callers that autonomously pick a model by
+ * capability must not treat it as evidence.
+ */
+const ProviderModalityInference = Schema.Struct({
+  input: Schema.Literals(["declared", "provider-entry", "directory", "assumed"]),
+  output: Schema.Literals(["declared", "provider-entry", "directory", "assumed"]),
+  source: Schema.optional(Schema.String),
+})
+
 const ProviderCapabilities = Schema.Struct({
   temperature: Schema.Boolean,
   reasoning: Schema.Boolean,
@@ -1010,6 +1031,7 @@ const ProviderCapabilities = Schema.Struct({
   input: ProviderModalities,
   output: ProviderModalities,
   interleaved: ProviderInterleaved,
+  inferred: Schema.optional(ProviderModalityInference),
 })
 
 const ProviderCacheCost = Schema.Struct({
@@ -1124,6 +1146,21 @@ export function sortVisionModels(models: Model[]): Model[] {
     if (a.cost.input !== b.cost.input) return a.cost.input - b.cost.input
     return `${a.providerID}/${a.id}`.localeCompare(`${b.providerID}/${b.id}`)
   })
+}
+
+/**
+ * Whether a model's image-input verdict is EVIDENCE rather than policy.
+ *
+ * `assumed` image support exists so that a user who attaches an image to their
+ * own BYOK model gets it sent instead of silently swapped out. It is not a
+ * reason for the engine to go and pick that model on the user's behalf: doing so
+ * would trade the silent drop this fixes for a new silent failure, where a
+ * text-only model gets auto-selected to look at a screenshot. So autonomous
+ * capability-based SELECTION requires evidence, while honouring what the user
+ * explicitly attached does not.
+ */
+export function hasEvidencedImageInput(model: Model): boolean {
+  return model.capabilities.input.image === true && model.capabilities.inferred?.input !== "assumed"
 }
 
 function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
@@ -1278,6 +1315,11 @@ const layer: Layer.Layer<
 
         log.info("init")
 
+        // Indexed over the RAW models.dev directory, not `database`: `database`
+        // is rewritten below by every config provider, and the index must keep
+        // describing the catalog rather than the user's overrides of it.
+        const modalityDirectory = ModalityInference.directoryIndex(modelsDev)
+
         function mergeProvider(providerID: ProviderID, provider: Partial<Info>) {
           const existing = providers[providerID]
           if (existing) {
@@ -1331,6 +1373,25 @@ const layer: Layer.Layer<
               if (model.id && model.id !== modelID) return modelID
               return existingModel?.name ?? modelID
             })
+            // Modality resolution is factored out because its precedence is no
+            // longer expressible as a `??` chain: past the user's own
+            // declaration and the same-named provider's entry there is a
+            // directory lookup by bare model id, and past THAT an explicit
+            // "unknown" that must not collapse into `false`. See
+            // provider/modality-inference.ts for the ordering and for why
+            // unknown resolves permissively.
+            const inputModalities = ModalityInference.resolveInput({
+              declared: model.modalities?.input,
+              inherited: existingModel?.capabilities.input,
+              apiID,
+              directory: modalityDirectory,
+            })
+            const outputModalities = ModalityInference.resolveOutput({
+              declared: model.modalities?.output,
+              inherited: existingModel?.capabilities.output,
+              apiID,
+              directory: modalityDirectory,
+            })
             const parsedModel: Model = {
               id: ModelID.make(modelID),
               api: {
@@ -1346,23 +1407,8 @@ const layer: Layer.Layer<
                 reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
                 attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
                 toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,
-                input: {
-                  text: model.modalities?.input?.includes("text") ?? existingModel?.capabilities.input.text ?? true,
-                  audio: model.modalities?.input?.includes("audio") ?? existingModel?.capabilities.input.audio ?? false,
-                  image: model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? false,
-                  video: model.modalities?.input?.includes("video") ?? existingModel?.capabilities.input.video ?? false,
-                  pdf: model.modalities?.input?.includes("pdf") ?? existingModel?.capabilities.input.pdf ?? false,
-                },
-                output: {
-                  text: model.modalities?.output?.includes("text") ?? existingModel?.capabilities.output.text ?? true,
-                  audio:
-                    model.modalities?.output?.includes("audio") ?? existingModel?.capabilities.output.audio ?? false,
-                  image:
-                    model.modalities?.output?.includes("image") ?? existingModel?.capabilities.output.image ?? false,
-                  video:
-                    model.modalities?.output?.includes("video") ?? existingModel?.capabilities.output.video ?? false,
-                  pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
-                },
+                input: inputModalities.modalities,
+                output: outputModalities.modalities,
                 // Declared per model, never derived: design is indistinguishable from plain
                 // TTS by modality, and a sample-taking model could be speech-to-speech
                 // conversion. `existingModel` carries the value forward when a config entry
@@ -1375,6 +1421,17 @@ const layer: Layer.Layer<
                   (!existingModel && apiNpm === "@ai-sdk/openai-compatible" && apiID.includes("deepseek")
                     ? { field: "reasoning_content" }
                     : false),
+                ...(inputModalities.provenance === "declared" && outputModalities.provenance === "declared"
+                  ? {}
+                  : {
+                      inferred: {
+                        input: inputModalities.provenance,
+                        output: outputModalities.provenance,
+                        ...((inputModalities.source ?? outputModalities.source)
+                          ? { source: inputModalities.source ?? outputModalities.source }
+                          : {}),
+                      },
+                    }),
               },
               cost: {
                 input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,
@@ -1423,6 +1480,20 @@ const layer: Layer.Layer<
             // vision-capable model, so image input is supported.
             if (providerID === "mimo" && modelID === "mimo-auto") {
               parsedModel.capabilities.input.image = true
+            }
+            if (inputModalities.provenance !== "declared") {
+              log.info("input modalities inferred", {
+                providerID,
+                modelID,
+                apiID,
+                provenance: inputModalities.provenance,
+                source: inputModalities.source,
+                image: parsedModel.capabilities.input.image,
+                fix:
+                  inputModalities.provenance === "assumed"
+                    ? `Declare modalities.input in mimocode.json under provider.${providerID}.models.${modelID} to make this exact`
+                    : undefined,
+              })
             }
             const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
             parsedModel.variants = mapValues(
@@ -1976,7 +2047,7 @@ const layer: Layer.Layer<
       const providers = yield* list()
       const vision = Object.values(providers)
         .flatMap((info) => Object.values(info.models))
-        .filter((m) => m.capabilities.input.image === true)
+        .filter(hasEvidencedImageInput)
       return sortVisionModels(vision)[0]
     })
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1007,9 +1007,11 @@ const ProviderInterleaved = Schema.Union([
  * capability must not treat it as evidence.
  */
 const ProviderModalityInference = Schema.Struct({
-  input: Schema.Literals(["declared", "builtin", "provider-entry", "directory", "assumed"]),
-  output: Schema.Literals(["declared", "builtin", "provider-entry", "directory", "assumed"]),
+  input: Schema.optional(Schema.Literals(["declared", "builtin", "provider-entry", "directory", "assumed"])),
+  output: Schema.optional(Schema.Literals(["declared", "builtin", "provider-entry", "directory", "assumed"])),
   source: Schema.optional(Schema.String),
+  inputSource: Schema.optional(Schema.String),
+  outputSource: Schema.optional(Schema.String),
 })
 
 const ProviderCapabilities = Schema.Struct({
@@ -1148,6 +1150,14 @@ export function sortVisionModels(models: Model[]): Model[] {
   })
 }
 
+export function acceptsInput(model: Model, modality: ModalityInference.InputModality): boolean {
+  return ModalityInference.acceptsInput(model.capabilities, modality)
+}
+
+export function hasEvidencedInput(model: Model, modality: ModalityInference.InputModality): boolean {
+  return ModalityInference.hasEvidencedInput(model.capabilities, modality)
+}
+
 /**
  * "Can an image be handed to THIS model?" — the permissive of the two image
  * questions, and the one to ask about a model the user has already chosen.
@@ -1163,7 +1173,7 @@ export function sortVisionModels(models: Model[]): Model[] {
  * the author meant, and the two silently drifted apart once already.
  */
 export function acceptsImageInput(model: Model): boolean {
-  return model.capabilities.input.image === true
+  return acceptsInput(model, "image")
 }
 
 /**
@@ -1187,7 +1197,7 @@ export function acceptsImageInput(model: Model): boolean {
  * default and only an explicit unknown is excluded.
  */
 export function hasEvidencedImageInput(model: Model): boolean {
-  return model.capabilities.input.image === true && model.capabilities.inferred?.input !== "assumed"
+  return hasEvidencedInput(model, "image")
 }
 
 function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
@@ -1240,18 +1250,10 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
       voiceDesign: model.voice_design ?? false,
       voiceClone: model.voice_clone ?? false,
       input: {
-        text: model.modalities?.input?.includes("text") ?? false,
-        audio: model.modalities?.input?.includes("audio") ?? false,
-        image: model.modalities?.input?.includes("image") ?? false,
-        video: model.modalities?.input?.includes("video") ?? false,
-        pdf: model.modalities?.input?.includes("pdf") ?? false,
+        ...ModalityInference.mapOf(model.modalities?.input, false),
       },
       output: {
-        text: model.modalities?.output?.includes("text") ?? false,
-        audio: model.modalities?.output?.includes("audio") ?? false,
-        image: model.modalities?.output?.includes("image") ?? false,
-        video: model.modalities?.output?.includes("video") ?? false,
-        pdf: model.modalities?.output?.includes("pdf") ?? false,
+        ...ModalityInference.mapOf(model.modalities?.output, false),
       },
       interleaved: model.interleaved ?? false,
     },
@@ -1452,17 +1454,30 @@ const layer: Layer.Layer<
                   (!existingModel && apiNpm === "@ai-sdk/openai-compatible" && apiID.includes("deepseek")
                     ? { field: "reasoning_content" }
                     : false),
-                ...(inputModalities.provenance === "declared" && outputModalities.provenance === "declared"
-                  ? {}
-                  : {
-                      inferred: {
-                        input: inputModalities.provenance,
-                        output: outputModalities.provenance,
-                        ...((inputModalities.source ?? outputModalities.source)
-                          ? { source: inputModalities.source ?? outputModalities.source }
-                          : {}),
-                      },
-                    }),
+                ...(() => {
+                  const inputInferred = !ModalityInference.isStated(inputModalities.provenance)
+                  const outputInferred = !ModalityInference.isStated(outputModalities.provenance)
+                  if (!inputInferred && !outputInferred) return {}
+                  const inputSource = inputInferred ? inputModalities.source : undefined
+                  const outputSource = outputInferred ? outputModalities.source : undefined
+                  const sharedSource =
+                    inputSource && outputSource && inputSource === outputSource
+                      ? inputSource
+                      : inputInferred && !outputInferred
+                        ? inputSource
+                        : !inputInferred && outputInferred
+                          ? outputSource
+                          : undefined
+                  return {
+                    inferred: {
+                      ...(inputInferred ? { input: inputModalities.provenance } : {}),
+                      ...(outputInferred ? { output: outputModalities.provenance } : {}),
+                      ...(inputSource ? { inputSource } : {}),
+                      ...(outputSource ? { outputSource } : {}),
+                      ...(sharedSource ? { source: sharedSource } : {}),
+                    },
+                  }
+                })(),
               },
               cost: {
                 input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,
@@ -1780,7 +1795,7 @@ const layer: Layer.Layer<
         const headerTimeout = options["headerTimeout"]
         const chunkTimeout =
           typeof userChunkTimeout === "number"
-            ? userChunkTimeout  // user-set value (incl. 0 / negative to disable)
+            ? userChunkTimeout // user-set value (incl. 0 / negative to disable)
             : DEFAULT_CHUNK_TIMEOUT
         delete options["chunkTimeout"]
         delete options["headerTimeout"]
@@ -2119,7 +2134,18 @@ const layer: Layer.Layer<
       }
     })
 
-    return Service.of({ list, getProvider, getModel, getLanguage, getSpeech, closest, getSmallModel, getVisionModel, defaultModel, resolveModelRef })
+    return Service.of({
+      list,
+      getProvider,
+      getModel,
+      getLanguage,
+      getSpeech,
+      closest,
+      getSmallModel,
+      getVisionModel,
+      defaultModel,
+      resolveModelRef,
+    })
   }),
 )
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1007,8 +1007,8 @@ const ProviderInterleaved = Schema.Union([
  * capability must not treat it as evidence.
  */
 const ProviderModalityInference = Schema.Struct({
-  input: Schema.Literals(["declared", "provider-entry", "directory", "assumed"]),
-  output: Schema.Literals(["declared", "provider-entry", "directory", "assumed"]),
+  input: Schema.Literals(["declared", "builtin", "provider-entry", "directory", "assumed"]),
+  output: Schema.Literals(["declared", "builtin", "provider-entry", "directory", "assumed"]),
   source: Schema.optional(Schema.String),
 })
 
@@ -1149,7 +1149,26 @@ export function sortVisionModels(models: Model[]): Model[] {
 }
 
 /**
- * Whether a model's image-input verdict is EVIDENCE rather than policy.
+ * "Can an image be handed to THIS model?" — the permissive of the two image
+ * questions, and the one to ask about a model the user has already chosen.
+ *
+ * A verdict of `assumed` counts here. The whole point of assuming permissively
+ * is that a user who attaches an image to their own BYOK model gets it sent
+ * rather than silently swapped out, so this must not require evidence.
+ *
+ * Not the question to ask when the ENGINE is choosing or recommending a model —
+ * use `hasEvidencedImageInput` for that. The two answers differ, so the choice
+ * between them is a policy decision and both are named to keep it visible: a
+ * bare `capabilities.input.image` at a call site says nothing about which one
+ * the author meant, and the two silently drifted apart once already.
+ */
+export function acceptsImageInput(model: Model): boolean {
+  return model.capabilities.input.image === true
+}
+
+/**
+ * "May the engine PICK or RECOMMEND this model to look at an image?" — the
+ * evidence-requiring counterpart to `acceptsImageInput`.
  *
  * `assumed` image support exists so that a user who attaches an image to their
  * own BYOK model gets it sent instead of silently swapped out. It is not a
@@ -1158,6 +1177,14 @@ export function sortVisionModels(models: Model[]): Model[] {
  * text-only model gets auto-selected to look at a screenshot. So autonomous
  * capability-based SELECTION requires evidence, while honouring what the user
  * explicitly attached does not.
+ *
+ * This includes telling the MODEL which refs to pass to `--model`: a ref the
+ * engine advertises is one it will be dispatched to, so advertising and picking
+ * have to answer the same way.
+ *
+ * The test is against `assumed` specifically, not for a whitelist of good
+ * provenances, so a newly added source of knowledge counts as evidence by
+ * default and only an explicit unknown is excluded.
  */
 export function hasEvidencedImageInput(model: Model): boolean {
   return model.capabilities.input.image === true && model.capabilities.inferred?.input !== "assumed"
@@ -1375,9 +1402,9 @@ const layer: Layer.Layer<
             })
             // Modality resolution is factored out because its precedence is no
             // longer expressible as a `??` chain: past the user's own
-            // declaration and the same-named provider's entry there is a
-            // directory lookup by bare model id, and past THAT an explicit
-            // "unknown" that must not collapse into `false`. See
+            // declaration, this repo's own aliases and the same-named provider's
+            // entry there is a directory lookup by bare model id, and past THAT
+            // an explicit "unknown" that must not collapse into `false`. See
             // provider/modality-inference.ts for the ordering and for why
             // unknown resolves permissively.
             const inputModalities = ModalityInference.resolveInput({
@@ -1385,12 +1412,16 @@ const layer: Layer.Layer<
               inherited: existingModel?.capabilities.input,
               apiID,
               directory: modalityDirectory,
+              providerID,
+              modelID,
             })
             const outputModalities = ModalityInference.resolveOutput({
               declared: model.modalities?.output,
               inherited: existingModel?.capabilities.output,
               apiID,
               directory: modalityDirectory,
+              providerID,
+              modelID,
             })
             const parsedModel: Model = {
               id: ModelID.make(modelID),
@@ -1476,12 +1507,10 @@ const layer: Layer.Layer<
               cachePromptTTL: model.cachePromptTTL ?? existingModel?.cachePromptTTL,
               variants: {},
             }
-            // mimo-auto is a free-tier routing alias absent from models.dev; it routes to a
-            // vision-capable model, so image input is supported.
-            if (providerID === "mimo" && modelID === "mimo-auto") {
-              parsedModel.capabilities.input.image = true
-            }
-            if (inputModalities.provenance !== "declared") {
+            // mimo/mimo-auto's image support is stated in the BUILTIN tier of
+            // provider/modality-inference.ts, not patched on here: overwriting a
+            // finished model leaves its provenance saying the verdict was assumed.
+            if (!ModalityInference.isStated(inputModalities.provenance)) {
               log.info("input modalities inferred", {
                 providerID,
                 modelID,

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -723,7 +723,7 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
       const name = filename ? `"${filename}"` : modality
       return {
         type: "text" as const,
-        text: `ERROR: Cannot read ${name} (this model does not support ${modality} input). Inform the user.`,
+        text: `ERROR: Cannot read ${name} (this model does not support ${modality} input; the attachment was omitted).`,
       }
     })
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -24,6 +24,22 @@ function mimeToModality(mime: string): Modality | undefined {
   return undefined
 }
 
+/**
+ * The modality `unsupportedParts` would refuse to forward for this mime, or
+ * `undefined` when the content passes through.
+ *
+ * Exported so a caller holding a user-facing channel can announce the decision
+ * BEFORE `unsupportedParts` acts on it. That substitution happens inside an AI
+ * SDK middleware, where the replacement text is addressed to the model and the
+ * user sees nothing; this predicate is the same verdict, computed from the same
+ * two inputs, reachable from somewhere that can write to the transcript.
+ */
+export function withheldModality(mime: string, model: Provider.Model): Modality | undefined {
+  const modality = mimeToModality(mime)
+  if (!modality) return undefined
+  return model.capabilities.input[modality] ? undefined : modality
+}
+
 export const OUTPUT_TOKEN_MAX = Flag.MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
 export const LARGE_MODEL_OUTPUT_TOKEN_MAX = 128_000
 
@@ -701,10 +717,8 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
 
       const mime = part.type === "image" ? String(part.image).split(";")[0].replace("data:", "") : part.mediaType
       const filename = part.type === "file" ? part.filename : undefined
-      const modality = mimeToModality(mime)
+      const modality = withheldModality(mime, model)
       if (!modality) return part
-      const supported = model.capabilities.input[modality]
-      if (supported) return part
 
       const name = filename ? `"${filename}"` : modality
       return {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -12,6 +12,7 @@ import { decideAskRouting, hasActorTool, resolveInvalidOutputPolicy, SYSTEM_SPAW
 import { renderActorNotification } from "@/inbox/render"
 import { parseReturnHeader } from "@/actor/return-header"
 import { Provider } from "../provider"
+import { ModalityInference } from "../provider/modality-inference"
 import { ModelID, ProviderID } from "../provider/schema"
 import {
   type Tool as AITool,
@@ -2579,7 +2580,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       if (withheld.length > 0) {
         const capabilities = withheld[0].model.capabilities
         const provenance =
-          capabilities.inferred?.input && capabilities.inferred.input !== "declared"
+          capabilities.inferred?.input && !ModalityInference.isStated(capabilities.inferred.input)
             ? ` This model's input modalities were not declared in config — they were inferred (${capabilities.inferred.input}` +
               `${capabilities.inferred.source ? ` from ${capabilities.inferred.source}` : ""}), so the verdict may be wrong.`
             : ""

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2592,6 +2592,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             type: "text",
             synthetic: true,
             ignored: true,
+            metadata: { origin: { kind: "withheld-input" } },
             time: { start: now, end: now },
             text:
               `Not sent to ${model.providerID}/${model.modelID}: ` +

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2579,10 +2579,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
       if (withheld.length > 0) {
         const capabilities = withheld[0].model.capabilities
+        const inputSource = capabilities.inferred?.inputSource ?? capabilities.inferred?.source
         const provenance =
           capabilities.inferred?.input && !ModalityInference.isStated(capabilities.inferred.input)
             ? ` This model's input modalities were not declared in config — they were inferred (${capabilities.inferred.input}` +
-              `${capabilities.inferred.source ? ` from ${capabilities.inferred.source}` : ""}), so the verdict may be wrong.`
+              `${inputSource ? ` from ${inputSource}` : ""}), so the verdict may be wrong.`
             : ""
         const now = Date.now()
         parts.push(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2548,6 +2548,67 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         return { info, parts: [] }
       }
 
+      // Announce media this turn will send WITHOUT, before the send path silently
+      // does it.
+      //
+      // `ProviderTransform.unsupportedParts` replaces an unsupported file part
+      // with "ERROR: Cannot read … Inform the user." That text is addressed to
+      // the MODEL, from inside an AI SDK middleware, and nothing about the
+      // substitution reaches the transcript: the user sees a model claiming it
+      // received no image while the image sits in the session record, which reads
+      // like the client corrupted the attachment. A component that decides to do
+      // less has to be able to say so.
+      //
+      // Same shape as `noticeMemoryWriteOffFallback` above and for the same
+      // reasons: `ignored: true` keeps a user-addressed notice out of the model's
+      // context, `synthetic: true` marks it as not-user-authored, and `time.end`
+      // is what makes the CLI emit it. Single-language English, because the
+      // engine does not know the reader's locale and the consuming client does.
+      const withheld = yield* Effect.gen(function* () {
+        const files = parts.filter((p): p is Extract<typeof p, { type: "file" }> => p.type === "file")
+        if (files.length === 0) return []
+        const full = yield* provider
+          .getModel(model.providerID, model.modelID)
+          .pipe(Effect.catchDefect(() => Effect.succeed(undefined)))
+        if (!full) return []
+        return files.flatMap((file) => {
+          const modality = ProviderTransform.withheldModality(file.mime, full)
+          return modality ? [{ filename: file.filename ?? file.mime, modality, model: full }] : []
+        })
+      })
+      if (withheld.length > 0) {
+        const capabilities = withheld[0].model.capabilities
+        const provenance =
+          capabilities.inferred?.input && capabilities.inferred.input !== "declared"
+            ? ` This model's input modalities were not declared in config — they were inferred (${capabilities.inferred.input}` +
+              `${capabilities.inferred.source ? ` from ${capabilities.inferred.source}` : ""}), so the verdict may be wrong.`
+            : ""
+        const now = Date.now()
+        parts.push(
+          assign({
+            messageID: info.id,
+            sessionID: input.sessionID,
+            type: "text",
+            synthetic: true,
+            ignored: true,
+            time: { start: now, end: now },
+            text:
+              `Not sent to ${model.providerID}/${model.modelID}: ` +
+              withheld.map((item) => `${item.filename} (${item.modality})`).join(", ") +
+              `. The model is recorded as not accepting ${[...new Set(withheld.map((i) => i.modality))].join("/")} ` +
+              `input, so the attachment was replaced with a note to the model rather than uploaded.${provenance} ` +
+              `To send it anyway, set modalities.input for this model in config, or switch to a model that accepts it.`,
+          }),
+        )
+        log.info("withheld unsupported input media", {
+          sessionID: input.sessionID,
+          messageID: info.id,
+          model: `${model.providerID}/${model.modelID}`,
+          withheld: withheld.map((item) => `${item.filename}:${item.modality}`),
+          inferred: capabilities.inferred?.input,
+        })
+      }
+
       const prompt = yield* sessions.resolvePrompt({
         sessionID: input.sessionID,
         ...(parts.some((part) => !("synthetic" in part) || !part.synthetic)

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -18,7 +18,7 @@ import PROMPT_GLM from "./prompt/glm.txt"
 import PROMPT_MINIMAX from "./prompt/minimax.txt"
 import PROMPT_TRINITY from "./prompt/trinity.txt"
 import { Provider } from "@/provider"
-import { sortVisionModels } from "@/provider/provider"
+import { sortVisionModels, acceptsImageInput, hasEvidencedImageInput } from "@/provider/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
@@ -138,7 +138,11 @@ export const layer = Layer.effect(
         const maskVisionCapability = [model.id, model.api.id, model.providerID].some((id) =>
           /(^|[^a-z0-9])(gpt|claude|gemini)($|[^a-z0-9])/i.test(id),
         )
-        if (!model.capabilities.input.image && !maskVisionCapability) {
+        // Two different image questions, one line apart. The GATE asks whether the
+        // model the user chose can be handed an image, so an assumed verdict counts.
+        // The LIST is handed to the model as `--model` targets it may dispatch to,
+        // which is the engine recommending a model, so that one needs evidence.
+        if (!acceptsImageInput(model) && !maskVisionCapability) {
           // NOTE: vision models are resolved per-call (lazy). If provider list changes
           // mid-session, this block may differ between turns and break cached system prefix.
           // In practice provider config is stable within a session.
@@ -150,7 +154,7 @@ export const layer = Layer.effect(
                 sortVisionModels(
                   Object.values(providers)
                     .flatMap((info) => Object.values(info.models))
-                    .filter((m) => m.capabilities.input.image === true),
+                    .filter(hasEvidencedImageInput),
                 )
                   .map((m) => `${m.providerID}/${m.id}`)
                   .slice(0, 3),

--- a/packages/opencode/src/session/tool-attachment.ts
+++ b/packages/opencode/src/session/tool-attachment.ts
@@ -1,4 +1,4 @@
-import type { Provider } from "@/provider"
+import { Provider } from "@/provider"
 
 export type ToolAttachment = {
   mime: string
@@ -32,11 +32,11 @@ function isRemoteURL(url: string) {
 }
 
 function modelAcceptsMime(model: Provider.Model, mime: string) {
-  if (mime.startsWith("image/")) return SAFE_IMAGE_MIMES.has(mime) && model.capabilities.input.image
-  if (mime === "application/pdf") return model.capabilities.input.pdf
-  if (mime.startsWith("audio/")) return model.capabilities.input.audio
-  if (mime.startsWith("video/")) return model.capabilities.input.video
-  if (mime.startsWith("text/")) return model.capabilities.input.text
+  if (mime.startsWith("image/")) return SAFE_IMAGE_MIMES.has(mime) && Provider.acceptsInput(model, "image")
+  if (mime === "application/pdf") return Provider.acceptsInput(model, "pdf")
+  if (mime.startsWith("audio/")) return Provider.acceptsInput(model, "audio")
+  if (mime.startsWith("video/")) return Provider.acceptsInput(model, "video")
+  if (mime.startsWith("text/")) return Provider.acceptsInput(model, "text")
   return false
 }
 

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -11,7 +11,7 @@ import { SessionID, MessageID, PartID } from "../session/schema"
 import { MessageV2 } from "../session/message-v2"
 import { Agent } from "../agent/agent"
 import { Provider } from "../provider"
-import { sortVisionModels } from "../provider/provider"
+import { sortVisionModels, hasEvidencedImageInput } from "../provider/provider"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "../config"
 import { ActorRegistry } from "@/actor/registry"
@@ -690,13 +690,16 @@ export const ActorTool = Tool.define(
         if (op.action === "models") {
           const providers = yield* provider.list()
           const allModels = Object.values(providers).flatMap((info) => Object.values(info.models))
-          const filtered = op.vision ? allModels.filter((m) => m.capabilities.input.image === true) : allModels
+          // `actor models --vision` is the list the model is told to consult before
+          // passing `--model`, so it has to answer the same way as the engine's own
+          // vision-model selection: evidence, not an assumed verdict.
+          const filtered = op.vision ? allModels.filter(hasEvidencedImageInput) : allModels
           const ordered = op.vision
             ? sortVisionModels(filtered)
             : [...filtered].sort((a, b) => `${a.providerID}/${a.id}`.localeCompare(`${b.providerID}/${b.id}`))
           const limit = op.limit ?? 50
           const shown = ordered.slice(0, limit)
-          const lines = shown.map((m) => `${m.providerID}/${m.id}${m.capabilities.input.image ? " (vision)" : ""}`)
+          const lines = shown.map((m) => `${m.providerID}/${m.id}${hasEvidencedImageInput(m) ? " (vision)" : ""}`)
           const header = op.vision ? `Vision-capable models` : `Available models`
           const more = ordered.length > shown.length ? `\n… and ${ordered.length - shown.length} more (raise --limit)` : ""
           const output = shown.length === 0

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -229,7 +229,9 @@ export const ReadTool = Tool.define(
                 .getModel(messageModelRef.providerID, messageModelRef.modelID)
                 .pipe(Effect.catchDefect(() => Effect.succeed(undefined)))
             : undefined)
-        const supportsImage = model?.capabilities.input.image ?? false
+        // The user already chose this model, so an assumed image verdict counts —
+        // unlike the vision model recommended below, which the engine picks.
+        const supportsImage = model ? Provider.acceptsImageInput(model) : false
         if (!supportsImage) {
         const preferred = yield* provider.getVisionModel().pipe(Effect.orElseSucceed(() => undefined))
         const preferredRef = preferred ? `${preferred.providerID}/${preferred.id}` : undefined

--- a/packages/opencode/src/tool/view-image.ts
+++ b/packages/opencode/src/tool/view-image.ts
@@ -2,7 +2,7 @@ import path from "path"
 import z from "zod"
 import { Effect } from "effect"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
-import type { Provider } from "@/provider"
+import { Provider } from "@/provider"
 import { Instance } from "@/project/instance"
 import { isImageAttachment, sniffAttachmentMime } from "@/util/media"
 import { assertExternalDirectoryEffect } from "./external-directory"
@@ -31,7 +31,8 @@ export const ViewImageTool = Tool.define(
       execute: (params: z.infer<typeof parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
           const model = (ctx.extra as { model?: Provider.Model } | undefined)?.model
-          if (!model?.capabilities.input.image) {
+          // Honouring the model the user is already on, so an assumed verdict counts.
+          if (!model || !Provider.acceptsImageInput(model)) {
             return yield* Effect.fail(new Error("view_image is not allowed because you do not support image inputs"))
           }
 

--- a/packages/opencode/test/fake/provider.ts
+++ b/packages/opencode/test/fake/provider.ts
@@ -1,5 +1,6 @@
 import { Effect, Layer } from "effect"
 import { Provider } from "../../src/provider"
+import { hasEvidencedImageInput } from "../../src/provider/provider"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 
 export namespace ProviderTest {
@@ -83,7 +84,9 @@ export namespace ProviderTest {
             Effect.succeed(providerID === row.id ? mdl : undefined),
           ),
           getVisionModel: Effect.fn("TestProvider.getVisionModel")(() =>
-            Effect.succeed(mdl.capabilities.input.image ? mdl : undefined),
+            // The real one requires evidence; a fake that answered from the raw
+            // capability would let a test pass on a model production would skip.
+            Effect.succeed(hasEvidencedImageInput(mdl) ? mdl : undefined),
           ),
           defaultModel: Effect.fn("TestProvider.defaultModel")(() =>
             Effect.succeed({ providerID: row.id, modelID: mdl.id }),

--- a/packages/opencode/test/provider/capability-registry.test.ts
+++ b/packages/opencode/test/provider/capability-registry.test.ts
@@ -12,6 +12,7 @@ function model(input: {
   text?: boolean
   image?: boolean
   audio?: boolean
+  inferredInput?: "declared" | "builtin" | "provider-entry" | "directory" | "assumed"
 }): Provider.Model {
   return {
     id: input.id,
@@ -31,6 +32,7 @@ function model(input: {
         pdf: false,
       },
       output: { text: true, audio: false, image: false, video: false, pdf: false },
+      ...(input.inferredInput ? { inferred: { input: input.inferredInput } } : {}),
     },
     cost: { input: 1, output: 1, cache: { read: 0, write: 0 } },
     limit: { context: 8000, output: 2000 },
@@ -80,6 +82,11 @@ describe("adapter declarations", () => {
 })
 
 describe("model declaration ANDs the model gate with the adapter gate", () => {
+  test("assumed non-text support is unknown for autonomous sampling selection", () => {
+    const subject = model({ id: "unknown-vision", image: true, inferredInput: "assumed" })
+    expect(ModelCapability.modelDeclaration(subject, "image").support).toBe("unknown")
+  })
+
   test("adapter can carry audio but model does not declare it → unsupported", () => {
     const subject = model({ id: "g", npm: "@ai-sdk/google", audio: false })
     expect(ModelCapability.modelDeclaration(subject, "audio").support).toBe("unsupported")
@@ -109,9 +116,7 @@ describe("rejectionFor", () => {
 
   test("rejects an audio MIME the adapter does not accept", () => {
     const subject = model({ id: "mimo-v2.5", audio: true })
-    const reason = ModelCapability.rejectionFor(subject, [
-      { modality: "audio", mimeType: "audio/flac", bytes: 1000 },
-    ])
+    const reason = ModelCapability.rejectionFor(subject, [{ modality: "audio", mimeType: "audio/flac", bytes: 1000 }])
     expect(reason).toEqual({ kind: "mime-unsupported", modality: "audio", mimeType: "audio/flac" })
   })
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -7,6 +7,7 @@ import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin/index"
 import { ModelsDev } from "../../src/provider"
 import { Provider } from "../../src/provider"
+import { ModalityInference } from "../../src/provider/modality-inference"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import { Env } from "../../src/env"
 import { Effect } from "effect"
@@ -1090,6 +1091,56 @@ test("model modalities default correctly", async () => {
       expect(model.capabilities.output.text).toBe(true)
     },
   })
+})
+
+test("an explicitly empty input modality list stays authoritative", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "test-provider": {
+              name: "Test",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "test-model": {
+                  name: "Test Model",
+                  limit: { context: 8000, output: 2000 },
+                  modalities: { input: [], output: ["text"] },
+                },
+              },
+              options: { apiKey: "test" },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const model = providers[ProviderID.make("test-provider")].models["test-model"]
+      expect(model.capabilities.input).toEqual({ text: false, audio: false, image: false, video: false, pdf: false })
+      expect(model.capabilities.inferred).toBeUndefined()
+    },
+  })
+})
+
+test("provider-entry provenance identifies the catalog ref", () => {
+  const directory = ModalityInference.directoryIndex({})
+  const verdict = ModalityInference.resolveInput({
+    inherited: ModalityInference.mapOf(["text"], false),
+    apiID: "gpt-5",
+    directory,
+    providerID: "openai",
+    modelID: "gpt-5",
+  })
+  expect(verdict.provenance).toBe("provider-entry")
+  expect(verdict.source).toBe("openai/gpt-5")
 })
 
 test("model with custom cost values", async () => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1432,6 +1432,107 @@ test("getVisionModel falls back to smart default when vision_model is misconfigu
   })
 })
 
+// Regression: mimo-auto is the only vision channel a free-tier user has, and it is
+// absent from models.dev, so its image support is stated in the BUILTIN tier. It used
+// to be assigned onto the finished model instead, which left the verdict's provenance
+// saying "assumed" and got the alias filtered straight back out of vision selection.
+//
+// The invariant is negative on purpose: the bug was not "mimo-auto is missing from a
+// list", it was "the verdict was recorded as unknown". Pinning the absence of the
+// cause survives a rewrite of how the list is built.
+const freeTierConfig = (autoModel: Record<string, unknown>) => ({
+  $schema: "https://opencode.ai/config.json",
+  provider: {
+    mimo: {
+      name: "MiMo",
+      npm: "@ai-sdk/openai-compatible",
+      env: [],
+      api: "https://example.invalid/v1",
+      models: { "mimo-auto": { name: "MiMo Auto", limit: { context: 32000, output: 8000 }, ...autoModel } },
+      options: { apiKey: "test-key" },
+    },
+    acme: {
+      name: "Acme",
+      npm: "@ai-sdk/openai-compatible",
+      env: [],
+      api: "https://example.invalid/v1",
+      // No modalities and no catalog entry anywhere: the ASSUMED tier.
+      models: { "mystery-1": { name: "Mystery 1", limit: { context: 32000, output: 8000 } } },
+      options: { apiKey: "test-key" },
+    },
+  },
+  enabled_providers: ["mimo", "acme"],
+})
+
+test("mimo-auto's image verdict is never recorded as assumed", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "mimocode.json"), JSON.stringify(freeTierConfig({})))
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const auto = providers[ProviderID.make("mimo")].models[ModelID.make("mimo-auto")]
+
+      // The cause of the regression, pinned as an absence.
+      expect(auto.capabilities.inferred?.input).not.toBe("assumed")
+      // And therefore the engine may pick it.
+      expect(Provider.hasEvidencedImageInput(auto)).toBe(true)
+
+      const chosen = await getVisionModel()
+      expect(chosen && `${chosen.providerID}/${chosen.id}`).toBe("mimo/mimo-auto")
+    },
+  })
+})
+
+// The two image predicates answer differently on purpose. This pins the difference
+// so that collapsing them back into one shared `capabilities.input.image` read — in
+// either direction — fails here rather than in a user's session.
+test("an assumed image verdict is honoured for the user's own model but not selectable", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "mimocode.json"), JSON.stringify(freeTierConfig({})))
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const mystery = providers[ProviderID.make("acme")].models[ModelID.make("mystery-1")]
+
+      expect(mystery.capabilities.inferred?.input).toBe("assumed")
+      // An image the user attached is still forwarded...
+      expect(Provider.acceptsImageInput(mystery)).toBe(true)
+      // ...but the engine must not go and choose this model to look at one.
+      expect(Provider.hasEvidencedImageInput(mystery)).toBe(false)
+    },
+  })
+})
+
+test("a user's own modalities declaration still overrides the builtin verdict", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify(freeTierConfig({ modalities: { input: ["text"], output: ["text"] } })),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const auto = providers[ProviderID.make("mimo")].models[ModelID.make("mimo-auto")]
+
+      expect(auto.capabilities.input.image).toBe(false)
+      expect(auto.capabilities.inferred?.input).toBeUndefined()
+      expect(Provider.hasEvidencedImageInput(auto)).toBe(false)
+    },
+  })
+})
+
 test("provider.sort prioritizes preferred models", () => {
   const models = [
     { id: "random-model", name: "Random" },

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -321,6 +321,82 @@ describe("session.system", () => {
     })
   })
 
+  // The refs in this block are handed to the model as `--model` targets it may
+  // dispatch a subagent to, so the block is the engine RECOMMENDING a model. It
+  // therefore has to answer the same way as the engine's own vision-model
+  // selection. It used to filter on the raw capability instead, which let a model
+  // whose image support is merely ASSUMED be advertised as a vision target — and
+  // hid the mimo-auto exclusion, because the same list happened to supply the
+  // fallback ref that selection had dropped.
+  test("advertises only vision models the engine would itself select", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "mimocode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            provider: {
+              mimo: {
+                name: "MiMo",
+                npm: "@ai-sdk/openai-compatible",
+                env: [],
+                api: "https://example.invalid/v1",
+                models: { "mimo-auto": { name: "MiMo Auto", limit: { context: 32000, output: 8000 } } },
+                options: { apiKey: "test-key" },
+              },
+              acme: {
+                name: "Acme",
+                npm: "@ai-sdk/openai-compatible",
+                env: [],
+                api: "https://example.invalid/v1",
+                // No modalities, no catalog entry: image support is ASSUMED.
+                models: {
+                  "mystery-1": { name: "Mystery 1", limit: { context: 32000, output: 8000 } },
+                  "text-1": {
+                    name: "Text 1",
+                    limit: { context: 32000, output: 8000 },
+                    modalities: { input: ["text"], output: ["text"] },
+                  },
+                },
+                options: { apiKey: "test-key" },
+              },
+            },
+            enabled_providers: ["mimo", "acme"],
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const prompt = await Effect.runPromise(
+          Effect.gen(function* () {
+            const system = yield* SystemPrompt.Service
+            return yield* system.environment(
+              ProviderTest.model({
+                id: ModelID.make("text-1"),
+                providerID: ProviderID.make("acme"),
+                api: { id: "text-1" } as never,
+              }),
+              Date.now(),
+            )
+          }).pipe(Effect.provide(SystemPrompt.defaultLayer)),
+        ).then((lines) => lines.join("\n"))
+
+        expect(prompt).toContain("<vision-capability>")
+        // A model whose image support is only assumed must never be advertised as a
+        // dispatch target, however the list comes to be built.
+        expect(prompt).not.toContain("acme/mystery-1")
+        // And the free-tier alias must not be missing, which is what leaves the
+        // model with nothing to dispatch to.
+        expect(prompt).toContain("mimo/mimo-auto")
+        expect(prompt).not.toContain("No vision-capable model is currently configured")
+      },
+    })
+  })
+
   test("skill catalog does not include invocation reminders", async () => {
     await using tmp = await tmpdir({ git: true })
     const home = process.env.HOME
@@ -343,6 +419,39 @@ describe("session.system", () => {
           expect(prompt).not.toContain("first user query")
           expect(prompt).not.toContain("skill_search")
           expect(prompt).not.toContain("Use the skill tool")
+        },
+      })
+    } finally {
+      process.env.HOME = home
+      process.env.USERPROFILE = userProfile
+    }
+  })
+
+  test("prompts the model to search skills from the first user query", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const home = process.env.HOME
+    const userProfile = process.env.USERPROFILE
+    process.env.HOME = tmp.path
+    process.env.USERPROFILE = tmp.path
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const build = await load(tmp.path, (svc) => svc.get("build"))
+          const prompt = await Effect.runPromise(
+            Effect.gen(function* () {
+              return yield* (yield* SystemPrompt.Service).skills(build!)
+            }).pipe(Effect.provide(SystemPrompt.defaultLayer)),
+          )
+
+          expect(prompt).toContain("first user query")
+          expect(prompt).toContain("might benefit from a specialized workflow")
+          expect(prompt).toContain("skill_search")
+          expect(prompt).toContain("action")
+          expect(prompt).toContain("input")
+          expect(prompt).toContain("output")
+          expect(prompt).toContain("audience")
         },
       })
     } finally {
@@ -408,6 +517,31 @@ description: ${description}
       process.env.HOME = home
       process.env.USERPROFILE = userProfile
     }
+  })
+
+  test("does not prompt GPT or Claude models to use skill_search", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const build = await load(tmp.path, (svc) => svc.get("build"))
+        const prompts = await Effect.runPromise(
+          Effect.gen(function* () {
+            const system = yield* SystemPrompt.Service
+            return yield* Effect.all([
+              system.skills(build!, { id: "gpt-5.4" }),
+              system.skills(build!, { id: "claude-sonnet-4-6" }),
+              system.skills(build!, { id: "mimo-v2" }),
+            ])
+          }).pipe(Effect.provide(SystemPrompt.defaultLayer)),
+        )
+
+        expect(prompts[0]).not.toContain("skill_search")
+        expect(prompts[1]).not.toContain("skill_search")
+        expect(prompts[2]).toContain("skill_search")
+      },
+    })
   })
 
 })

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -427,39 +427,6 @@ describe("session.system", () => {
     }
   })
 
-  test("prompts the model to search skills from the first user query", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const home = process.env.HOME
-    const userProfile = process.env.USERPROFILE
-    process.env.HOME = tmp.path
-    process.env.USERPROFILE = tmp.path
-
-    try {
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const build = await load(tmp.path, (svc) => svc.get("build"))
-          const prompt = await Effect.runPromise(
-            Effect.gen(function* () {
-              return yield* (yield* SystemPrompt.Service).skills(build!)
-            }).pipe(Effect.provide(SystemPrompt.defaultLayer)),
-          )
-
-          expect(prompt).toContain("first user query")
-          expect(prompt).toContain("might benefit from a specialized workflow")
-          expect(prompt).toContain("skill_search")
-          expect(prompt).toContain("action")
-          expect(prompt).toContain("input")
-          expect(prompt).toContain("output")
-          expect(prompt).toContain("audience")
-        },
-      })
-    } finally {
-      process.env.HOME = home
-      process.env.USERPROFILE = userProfile
-    }
-  })
-
   test("skills output is sorted by name and stable across calls", async () => {
     await using tmp = await tmpdir({
       git: true,
@@ -517,31 +484,6 @@ description: ${description}
       process.env.HOME = home
       process.env.USERPROFILE = userProfile
     }
-  })
-
-  test("does not prompt GPT or Claude models to use skill_search", async () => {
-    await using tmp = await tmpdir({ git: true })
-
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const build = await load(tmp.path, (svc) => svc.get("build"))
-        const prompts = await Effect.runPromise(
-          Effect.gen(function* () {
-            const system = yield* SystemPrompt.Service
-            return yield* Effect.all([
-              system.skills(build!, { id: "gpt-5.4" }),
-              system.skills(build!, { id: "claude-sonnet-4-6" }),
-              system.skills(build!, { id: "mimo-v2" }),
-            ])
-          }).pipe(Effect.provide(SystemPrompt.defaultLayer)),
-        )
-
-        expect(prompts[0]).not.toContain("skill_search")
-        expect(prompts[1]).not.toContain("skill_search")
-        expect(prompts[2]).toContain("skill_search")
-      },
-    })
   })
 
 })


### PR DESCRIPTION
## Problem

A model declared under `provider.<id>.models.<id>` without `modalities` had its non-text input capabilities resolved by a two-step `??` chain ending in a hardcoded `false`:

    image: model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? false

The middle step consults models.dev, but only within the **same provider id**. A user-invented provider id matches nothing there, so a model whose catalog entry plainly lists `["text","image","audio","video"]` still resolved to `image: false`. `provider/transform.ts` then replaced the user's image part with `ERROR: Cannot read "<file>" (this model does not support image input).` — text addressed to the *model*, written from inside an AI SDK middleware.

The observable result: the model truthfully reports it received no image, the image is sitting in the session record the whole time (a single `file` part's data URL measured 456,955 chars in the wild), and nothing anywhere says the engine chose to drop it. It reads like the consuming client corrupted the attachment.

`?? false` turned "we never looked this up" into "we know it cannot do this".

## Resolution order

1. **declared** — `modalities` in config. Always authoritative.
2. **provider-entry** — the same-named provider's existing catalog entry (prior behaviour).
3. **directory** — *new*: the bare model id looked up across the whole models.dev directory, taking the first-party entry.
4. **assumed** — nothing is known, and that is recorded as unknown rather than collapsed to `false`.

### Deriving first-partyness without a vendor table

models.dev publishes no "first party" flag, so tier 3 reads the directory's own shape: aggregators list a resold model under the **vendor namespace** (`xiaomi/mimo-v2.5`, `openai/gpt-5`), while the vendor lists it under the bare id. Intersecting the namespaces providers agree on with the providers holding the bare id names the vendor's entry.

**Exactly one survivor is required** — no union of aggregator claims, no majority vote. A namespace no provider serves and an aggregator namespacing under its own id both drop out for free. Against the real directory:

| bare id | providers holding it | first-party candidate | verdict |
|---|---|---|---|
| `mimo-v2.5` | 6 | `xiaomi` | `text,image,audio,video` |
| `mimo-v2.5-pro` | 8 | `xiaomi` | `text` |
| `gpt-5` | 12 | `openai` | `text,image` |
| `claude-sonnet-4-5` | 11 | `anthropic` | `text,image,pdf` |
| `gemini-2.5-pro` | 15 | `google` | `text,image,audio,video,pdf` |
| `deepseek-v3` | 5 | *none* | tier 4 |
| `mimo-1000` | 0 | *none* | tier 4 |

Note `mimo-v2.5` is multimodal while `mimo-v2.5-pro` is text-only — which is exactly why there is no family-name fallback here.

### Unknown resolves permissively

The two ways of being wrong do not cost the same:

- Guess "supported" wrongly → the request goes out and the provider answers with an explicit 4xx naming the media it rejected. Loud, attributable, fixable by declaring `modalities`.
- Guess "unsupported" wrongly → the content is replaced before the request exists, by a sentence only the model can see, and there is no record of the decision.

Scope is narrow: config-declared models that no catalog entry covers. Catalog-sourced models (`fromModelsDevModel`) still answer strictly from metadata. Output modalities get tiers 1–3 but not tier 4's permissiveness — nothing decides whether to *send* based on them, so there is no silent-drop risk to correct for.

### Inference is marked and attributable

`capabilities.inferred` (new, optional) records the tier and the exact models.dev ref a verdict was inherited from, so a wrong verdict is attributable to the inheritance instead of anonymous. It is absent when the user declared the modalities.

### Autonomous selection does not trust `assumed`

`getVisionModel()` ranks by cheapest, and a BYOK model defaults to `cost.input = 0` — so a blanket permissive default would have made a possibly-text-only BYOK model the systematic first pick for "the vision model". That would trade this bug's silent drop for a new silent failure. `getVisionModel` now filters through `hasEvidencedImageInput`, which rejects `assumed`.

The asymmetry: **honouring what the user explicitly attached** is permissive; **the engine picking a model on the user's behalf** requires evidence.

## Second commit: the withhold decision is now reportable

`unsupportedParts` still substitutes when a modality genuinely is unsupported — but the decision is no longer invisible. It is announced on the user's own channel using the mechanism already in the repo for this (`MEMORY_WRITE_OFF_FALLBACK_NOTICE`): a synthetic text part with `ignored: true` so it stays out of the model's context, and `time.end` set so the CLI emits it. Single-language English, matching that precedent — the engine cannot know the reader's locale and the consuming client already carries its own translations.

The notice names the file, the modality, the model, and — when the verdict was inferred — the tier and the entry it came from:

> Not sent to acme-byok/mimo-v2.5-pro: probe.png (image). The model is recorded as not accepting image input, so the attachment was replaced with a note to the model rather than uploaded. This model's input modalities were not declared in config — they were inferred (directory from xiaomi/mimo-v2.5-pro), so the verdict may be wrong. To send it anyway, set modalities.input for this model in config, or switch to a model that accepts it.

The verdict is factored into `ProviderTransform.withheldModality`, which `unsupportedParts` now calls, so the announcement and the substitution cannot drift apart.

## Verification

End-to-end against a fake OpenAI-compatible upstream that records request bodies verbatim, with a custom provider id absent from models.dev, a pinned `models.json`, and a real 64×64 PNG. Baseline is the same tree at `HEAD~1`, materialised with `git archive` + symlinked `node_modules`.

| Scenario | Model | Baseline | This PR |
|---|---|---|---|
| the defect | `acme-byok/mimo-v2.5`, no `modalities` | `image_url=0`; "no vision support" | `image_url=1`, 12,570-char data URL |
| tier 3 negative | `mimo-v2.5-pro` (catalog: text-only) | `image_url=0` | `image_url=0` — correctly withheld |
| tier 4 unknown | `acme-private-9000` (absent) | `image_url=0` | `image_url=1` |
| tier 1 authority | `mimo-v2.5` + `modalities.input:["text"]` | `image_url=0` | `image_url=0` — config wins over catalog |
| reportable notice | raw file part via `POST /session/:id/message` | 0 notice parts | 1 `ignored: true` notice |

The baseline run's own advice is worth quoting, because it is the bug in one line — it suggested dispatching a subagent with `--model xiaomi/mimo-v2.5`, i.e. the directory knew perfectly well that this exact model has vision, while the instance under a custom provider id was marked blind.

Every inference emits a log line carrying its provenance:

    service=provider providerID=acme-byok modelID=mimo-v2.5 apiID=mimo-v2.5
      provenance=directory source=xiaomi/mimo-v2.5 image=true  input modalities inferred

    service=provider providerID=acme-byok modelID=acme-private-9000 provenance=assumed image=true
      fix=Declare modalities.input in mimocode.json under provider.acme-byok.models.acme-private-9000 ...

`bun test test/provider` 474 pass / 0 fail. `bun test test/session` 910 pass / 0 fail, identical counts to the baseline tree. Repo-wide `turbo typecheck` clean. `capabilities.inferred` is optional, so the change is schema-compatible.

## Not verified

- **No real provider was contacted.** Every run went to a local fake upstream. "A wrong permissive guess produces a clean upstream 4xx" is reasoning from the asymmetry, not an observation.
- **`hasEvidencedImageInput` inside `getVisionModel` is not covered end-to-end** — it typechecks and the predicate is trivial, but no run exercised an `assumed` model being excluded from vision auto-selection.
- **Only `image` was exercised.** The code path is modality-generic, but `audio` / `video` / `pdf` tier-4 permissiveness was not observed.
- **The notice fires only for `file` parts on the user message.** The `read`-tool path pre-checks and emits its own user-visible text, so it never reaches the transform. Reachability was verified through the server route; other client entry points were not audited.
- **`inferred.output` is written but nothing reads it** — recorded for attribution only.
- **Directory-index cost not profiled.** One pass over ~180 providers at provider-state init, memoized per bare id.
- **`prettier --write` was never run** (known hazard on this repo). `provider.ts` / `prompt.ts` / `transform.ts` remain prettier-dirty in exactly the hunks that were already dirty at HEAD; `modality-inference.ts` is clean.
- **`test/session` flakiness is asserted, not root-caused.** 9 failures appeared on one run and did not reproduce on rerun or on the baseline tree.