### PR TITLE
fix(tui): harden collapse.lines against non-string content

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/collapse.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/collapse.ts
@@ -8,8 +8,8 @@
 // therefore an approximate ceiling, not a hard bound — see the follow-up note in
 // docs/compose/spec/exec-tool-view.md.
 
-export function lines(content: string) {
-  if (!content) return []
+export function lines(content: unknown) {
+  if (typeof content !== "string" || content === "") return []
   return content.replace(/\n$/, "").split("\n")
 }
 

--- a/packages/opencode/test/cli/tui/collapse.test.ts
+++ b/packages/opencode/test/cli/tui/collapse.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, test } from "bun:test"
 import * as Collapse from "../../../src/cli/cmd/tui/util/collapse"
 
+describe("collapse.lines", () => {
+  test("returns [] for non-string truthy values", () => {
+    expect(Collapse.lines(42 as any)).toEqual([])
+    expect(Collapse.lines({} as any)).toEqual([])
+  })
+
+  test("returns [] for undefined / null / empty string", () => {
+    expect(Collapse.lines(undefined as any)).toEqual([])
+    expect(Collapse.lines(null as any)).toEqual([])
+    expect(Collapse.lines("")).toEqual([])
+  })
+
+  test("still splits strings", () => {
+    expect(Collapse.lines("a\nb\n")).toEqual(["a", "b"])
+    expect(Collapse.lines("x")).toEqual(["x"])
+  })
+})
+
 describe("collapse.rows", () => {
   test("counts wrapped height, not source lines", () => {
     expect(Collapse.rows("a".repeat(250), 100)).toBe(3)


### PR DESCRIPTION
## Summary

Fixes #1952. `TypeError: A.replace is not a function` (minified `A` = `content`) when `collapse.lines` receives a truthy non-string value.

**Root cause:** `packages/opencode/src/cli/cmd/tui/util/collapse.ts` `lines()` guard `if (!content) return []` only catches falsy values — a truthy non-string (number/object) passes and `content.replace` is undefined → crash. Tool output / patch content rendered in the TUI can be a non-string under unusual model output.

**Fix:** tighten the guard to reject any non-string while preserving the empty-string → `[]` behavior (which `rows("")` depends on):

```ts
export function lines(content: unknown) {
  if (typeof content !== "string" || content === "") return []
  return content.replace(/\n$/, "").split("\n")
}
```

## Test Plan

- [x] New `collapse.lines` tests: non-string truthy → `[]`; `undefined`/`null`/`""` → `[]`; strings still split with trailing newline stripped.
- [x] `bun test test/cli/tui/collapse.test.ts` — 19 pass.
- [x] `bun typecheck` — clean.