### PR TITLE
fix(mcp): reap MCP child processes on process exit

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -67,12 +67,11 @@ function registerExitCleanup() {
   if (exitCleanupRegistered) return
   exitCleanupRegistered = true
   process.on("exit", reapMcpChildren)
+  // Deliberate tradeoff: reap synchronously before exiting so a child spawned on
+  // the crash path can never survive the parent, and exit(0) masks the signal's
+  // non-zero code for supervisors. SIGINT is intentionally NOT hooked so the TUI
+  // Ctrl+C path still uses graceful Effect teardown (which also runs the finalizer).
   process.on("SIGTERM", () => { reapMcpChildren(); process.exit(0) })
-}
-
-/** Test hook: expose the registry size (readonly). */
-export function mcpChildCount() {
-  return mcpChildPids.size
 }
 
 /** Test hook: register a pid for reap (used by tests; production uses connectLocal). */
@@ -797,11 +796,26 @@ export const layer = Layer.effect(
       const client = s.clients[name]
       delete s.defs[name]
       if (!client) return Effect.void
+      // Capture the pid before close: StdioClientTransport.close() clears its
+      // process handle, so transport.pid would be undefined afterwards.
+      const pid = client.transport instanceof StdioClientTransport ? client.transport.pid : null
       // Interrupt sampling still running for this client first: once the
       // transport is gone its response can never be delivered, so the fiber
       // would otherwise keep a model call alive with nowhere to send the result.
       return McpSampling.cancelAll(client).pipe(
-        Effect.andThen(Effect.tryPromise(() => client.close()).pipe(Effect.ignore)),
+        Effect.andThen(
+          Effect.tryPromise(() => client.close()).pipe(
+            // StdioClientTransport.close() terminates the child, so it's safe to
+            // drop the pid here — this prunes stale pids on disconnect/reconnect
+            // so the exit handler can never SIGTERM a recycled pid.
+            Effect.tap(
+              Effect.sync(() => {
+                if (typeof pid === "number") mcpChildPids.delete(pid)
+              }),
+            ),
+            Effect.ignore,
+          ),
+        ),
       )
     }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -32,9 +32,53 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import { McpSampling } from "./sampling"
 import { SessionID } from "@/session/schema"
+import { spawnSync } from "node:child_process"
 
 const log = Log.create({ service: "mcp" })
 const DEFAULT_TIMEOUT = 30_000
+
+// Global registry so MCP children can be reaped on process exit even when the
+// Effect teardown path doesn't run (crash, SIGTERM, abrupt quit).
+const mcpChildPids = new Set<number>()
+
+/** Synchronous recursive kill (pgrep -P) — usable from process.on("exit"). */
+export function reapMcpChildren() {
+  for (const pid of mcpChildPids) {
+    const stack = [pid]
+    const seen = new Set<number>()
+    while (stack.length > 0) {
+      const current = stack.pop()!
+      if (seen.has(current)) continue
+      seen.add(current)
+      try { process.kill(current, "SIGTERM") } catch {}
+      try {
+        const r = spawnSync("pgrep", ["-P", String(current)], { encoding: "utf-8" })
+        for (const tok of (r.stdout ?? "").split("\n")) {
+          const c = parseInt(tok, 10)
+          if (!isNaN(c)) stack.push(c)
+        }
+      } catch {}
+    }
+  }
+}
+
+let exitCleanupRegistered = false
+function registerExitCleanup() {
+  if (exitCleanupRegistered) return
+  exitCleanupRegistered = true
+  process.on("exit", reapMcpChildren)
+  process.on("SIGTERM", () => { reapMcpChildren(); process.exit(0) })
+}
+
+/** Test hook: expose the registry size (readonly). */
+export function mcpChildCount() {
+  return mcpChildPids.size
+}
+
+/** Test hook: register a pid for reap (used by tests; production uses connectLocal). */
+export function registerMcpChildForTest(pid: number) {
+  mcpChildPids.add(pid)
+}
 
 export const Resource = z
   .object({
@@ -596,6 +640,13 @@ export const layer = Layer.effect(
 
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
       return yield* connectTransport(transport, connectTimeout).pipe(
+        Effect.tap(
+          Effect.sync(() => {
+            const pid = transport.pid
+            if (typeof pid === "number") mcpChildPids.add(pid)
+            registerExitCleanup()
+          }),
+        ),
         Effect.map((client): { client: MCPClient | undefined; status: Status } => ({
           client,
           status: { status: "connected" },
@@ -727,6 +778,7 @@ export const layer = Layer.effect(
                         process.kill(dpid, "SIGTERM")
                       } catch {}
                     }
+                    mcpChildPids.delete(pid)
                   }
                   yield* McpSampling.cancelAll(client)
                   yield* Effect.tryPromise(() => client.close()).pipe(Effect.ignore)

--- a/packages/opencode/test/mcp/reap.test.ts
+++ b/packages/opencode/test/mcp/reap.test.ts
@@ -14,17 +14,48 @@ function alive(pid: number): boolean {
   }
 }
 
+function kill(pid: number) {
+  try {
+    process.kill(pid, "SIGKILL")
+  } catch {}
+}
+
 describe("reapMcpChildren", () => {
-  test.skipIf(process.platform === "win32")("kills a registered process tree", () => {
+  test.skipIf(process.platform === "win32")("kills a registered process", () => {
     // `sh -c 'sleep 300 & echo $!'` spawns a child `sleep` whose PID is printed.
     // Register the sleep PID via the test hook; reap must terminate it.
     const out = spawnSync("sh", ["-c", "sleep 300 & echo $!"], { encoding: "utf-8" })
     const pid = parseInt((out.stdout ?? "").trim(), 10)
     expect(Number.isNaN(pid)).toBe(false)
     expect(alive(pid)).toBe(true)
-    registerMcpChildForTest(pid)
-    reapMcpChildren()
-    expect(alive(pid)).toBe(false)
+    try {
+      registerMcpChildForTest(pid)
+      reapMcpChildren()
+      expect(alive(pid)).toBe(false)
+    } finally {
+      // Cleanup on assertion failure so the long-lived sleep never leaks.
+      kill(pid)
+    }
+  })
+
+  test.skipIf(process.platform === "win32")("kills a registered non-leaf process", () => {
+    // `sh -c 'sh -c "sleep 300" & echo $!'` spawns an inner shell running a
+    // foreground `sleep 300`; the printed PID is the inner shell. Register it so
+    // reap has to SIGTERM a process that still owns a child (exercises the tree
+    // path rather than a leaf). Only the registered pid is asserted dead — the
+    // grandchild may reparent before pgrep runs, so its liveness is not a
+    // reliable assertion here.
+    const out = spawnSync("sh", ["-c", 'sh -c "sleep 300" & echo $!'], { encoding: "utf-8" })
+    const pid = parseInt((out.stdout ?? "").trim(), 10)
+    expect(Number.isNaN(pid)).toBe(false)
+    expect(alive(pid)).toBe(true)
+    try {
+      registerMcpChildForTest(pid)
+      reapMcpChildren()
+      expect(alive(pid)).toBe(false)
+    } finally {
+      kill(pid)
+    }
   })
 
   test("does not throw on empty registry", () => {

--- a/packages/opencode/test/mcp/reap.test.ts
+++ b/packages/opencode/test/mcp/reap.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { reapMcpChildren, registerMcpChildForTest } from "../../src/mcp/index"
+import { Log } from "../../src/util"
+
+void Log.init({ print: false })
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe("reapMcpChildren", () => {
+  test.skipIf(process.platform === "win32")("kills a registered process tree", () => {
+    // `sh -c 'sleep 300 & echo $!'` spawns a child `sleep` whose PID is printed.
+    // Register the sleep PID via the test hook; reap must terminate it.
+    const out = spawnSync("sh", ["-c", "sleep 300 & echo $!"], { encoding: "utf-8" })
+    const pid = parseInt((out.stdout ?? "").trim(), 10)
+    expect(Number.isNaN(pid)).toBe(false)
+    expect(alive(pid)).toBe(true)
+    registerMcpChildForTest(pid)
+    reapMcpChildren()
+    expect(alive(pid)).toBe(false)
+  })
+
+  test("does not throw on empty registry", () => {
+    expect(() => reapMcpChildren()).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1892. MCP child processes were orphaned when MiMoCode exited/restarted (reparented to PID 1, ~2 procs/~81MB leaked per restart; 22 shell+MCP pairs = 1.7GB observed).

**Root cause:** `packages/opencode/src/mcp/index.ts` already kills MCP server children + descendants in an `addFinalizer` (on Effect teardown). But the app's exit path does NOT dispose the instance — the TUI's `onExit` doesn't call `instance.dispose()`, and crash/SIGTERM never runs Effect teardown. So MCP children survived the process.

**Fix:** a module-level `mcpChildPids` registry + process-level exit handlers:
- Populated with `transport.pid` on each local MCP connect (success path only).
- Pruned in `closeClient` (disconnect/reconnect) so the exit handler can never SIGTERM a recycled PID.
- `process.on("exit")` + `SIGTERM` run `reapMcpChildren()` — a synchronous recursive `pgrep -P` kill of each tracked PID and its descendants (the graceful finalizer stays for Effect teardown).
- SIGINT deliberately NOT hooked so TUI Ctrl+C still uses graceful teardown.

## Test Plan

- [x] Real-process test: `reapMcpChildren` terminates a registered process; a two-level tree test covers a non-leaf PID; `finally` cleanup prevents leaked `sleep` processes.
- [x] `bun test test/mcp/reap.test.ts` — 3 pass (10× stable); `bun typecheck` clean; MCP suite 115 pass no regression.

## Notes

- Best-effort POSIX fix (uses `pgrep`); no-op/degraded on Windows.
- The SIGTERM handler deliberately `exit(0)` after reaping (masks the signal's non-zero code for supervisors); documented in code.