### PR TITLE
fix(memory): parse Windows backslash paths in memory/cc path locators

### DIFF
--- a/packages/opencode/src/memory/paths.ts
+++ b/packages/opencode/src/memory/paths.ts
@@ -43,7 +43,9 @@ function detectType(key: string): MemoryType {
 }
 
 export function parsePath(absPath: string): MemoryLocator | null {
-  const m = absPath.match(/\/memory\/(global|projects|sessions)(?:\/([^/]+))?\/(.+)\.md$/)
+  // Windows paths use backslashes; normalize so the forward-slash regex matches.
+  const normalized = absPath.replace(/\\/g, "/")
+  const m = normalized.match(/\/memory\/(global|projects|sessions)(?:\/([^/]+))?\/(.+)\.md$/)
   if (!m) return null
   const [, scope, idMaybe, keyRaw] = m
   const scope_id = scope === "global" ? "" : (idMaybe ?? "")
@@ -57,7 +59,7 @@ export function parsePath(absPath: string): MemoryLocator | null {
 const CC_PATH_RE = /\/\.claude\/projects\/([^/]+)\/memory\/(.+)\.md$/
 
 export function parseCcPath(absPath: string): MemoryLocator | null {
-  const m = absPath.match(CC_PATH_RE)
+  const m = absPath.replace(/\\/g, "/").match(CC_PATH_RE)
   if (!m) return null
   const [, slug, keyRaw] = m
   return {

--- a/packages/opencode/test/memory/cc-paths.test.ts
+++ b/packages/opencode/test/memory/cc-paths.test.ts
@@ -57,4 +57,13 @@ describe("parseCcPath", () => {
   test("non-md file returns null", () => {
     expect(parseCcPath("/home/u/.claude/projects/-foo/memory/x.txt")).toBeNull()
   })
+
+  test("CC memory with backslash separators", () => {
+    expect(parseCcPath("C:\\Users\\me\\.claude\\projects\\slug\\memory\\notes.md")).toEqual({
+      scope: "cc",
+      scope_id: "slug",
+      type: "free",
+      key: "notes",
+    })
+  })
 })

--- a/packages/opencode/test/memory/paths.test.ts
+++ b/packages/opencode/test/memory/paths.test.ts
@@ -150,6 +150,35 @@ describe("parsePath", () => {
   })
 })
 
+describe("parsePath (Windows backslash paths)", () => {
+  test("global scope with backslash separators", () => {
+    expect(parsePath("C:\\data\\memory\\global\\tooling-prefs.md")).toEqual({
+      scope: "global",
+      scope_id: "",
+      type: "free",
+      key: "tooling-prefs",
+    })
+  })
+
+  test("project MEMORY.md with backslash separators", () => {
+    expect(parsePath("C:\\data\\memory\\projects\\uuid-1\\MEMORY.md")).toEqual({
+      scope: "projects",
+      scope_id: "uuid-1",
+      type: "memory",
+      key: "MEMORY",
+    })
+  })
+
+  test("session checkpoint with backslash separators", () => {
+    expect(parsePath("C:\\data\\memory\\sessions\\ses_abc\\checkpoint.md")).toEqual({
+      scope: "sessions",
+      scope_id: "ses_abc",
+      type: "checkpoint",
+      key: "checkpoint",
+    })
+  })
+})
+
 describe("buildPath", () => {
   test("session checkpoint", () => {
     expect(


### PR DESCRIPTION
## Summary

Fixes #2012 (Issues 1 & 2). The memory system is non-functional on Windows: `parsePath()` in `packages/opencode/src/memory/paths.ts` matches `/memory/...` with a forward-slash-only regex, but Windows returns backslash paths (`\memory\...`). Every file fails to parse → `reconcileMemory()` skips all → `memory_fts` stays empty → the `memory` tool always returns "No matches".

**Fix:** normalize `\` → `/` before the forward-slash regex match in both `parsePath()` and `parseCcPath()` (which has the same Windows failure). No-op for POSIX paths.

```ts
const normalized = absPath.replace(/\\/g, "/")
const m = normalized.match(/\/memory\/(global|projects|sessions).../)
```

## Test Plan

- [x] New Windows (backslash) tests: `parsePath` global/project-MEMORY/session-checkpoint; `parseCcPath` CC notes.
- [x] `bun test test/memory/paths.test.ts test/memory/cc-paths.test.ts` — 38 pass (existing forward-slash tests green).
- [x] `bun typecheck` — clean.

## Notes

- Issue #2012's Issue 3 (all sessions share `project_id = "global"`, no project isolation) is a separate architectural concern (#902) — out of scope here.