### PR TITLE
fix(session): use idle framing when a checkpoint rebuild follows a completed stop

### DIFF
--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -91,17 +91,13 @@ function autonomousLoopReminder(): string {
   ].join("\n")
 }
 
-function stopReminder(focusTaskID: string | undefined): string {
-  const taskHint = focusTaskID
-    ? `Consult this session's tasks/${focusTaskID}/progress.md head section.`
-    : "Consult the most recently active task's progress.md head section."
+function idleReminder(): string {
   return [
     "<system-reminder>",
-    "The previous assistant turn ended with a stop. Before stopping again,",
-    taskHint,
-    "Compare the Task spec to the latest Progress entries. If the task is",
-    "incomplete, proceed to the next concrete step. Only stop when the spec",
-    "is genuinely satisfied or you need user input you cannot infer.",
+    "The previous assistant turn ended with a stop. If it fulfilled the user's request,",
+    "do not reopen or re-verify completed work — wait for the user's next input.",
+    "Only continue if you were genuinely mid-task: consult the most recently active task's",
+    "progress.md head section and proceed only when a concrete next step is required.",
     "</system-reminder>",
   ].join("\n")
 }
@@ -1504,21 +1500,24 @@ export const layer: Layer.Layer<
         "Recent messages are preserved verbatim below — the assistant turn (and any tool results) you'll see is real history, not pseudo-content. Continue your task by responding to the most recent state.",
       )
       lines.push("")
+      const info = opts?.lastMessageInfo
+      const done = info?.role === "assistant" && info.finish === "stop"
       lines.push(
-        "Resume directly. Do not acknowledge this memory dump, do not recap, do not preface with \"I'll continue\" or similar. Pick up the last task as if the break never happened.",
+        done
+          ? "The last assistant turn ended with a stop. If it fulfilled the user's request, do not reopen or re-verify completed work — wait for the user's next input."
+          : 'Resume directly. Do not acknowledge this memory dump, do not recap, do not preface with "I\'ll continue" or similar. Pick up the last task as if the break never happened.',
       )
 
       // Section 11: tail-aware system reminder. Picks the appropriate nudge
       // based on how the preserved tail ends: tool-calls → continue loop,
-      // stop → check task spec before stopping again, tool → process results,
-      // user → no addendum needed.
-      const info = opts?.lastMessageInfo
+      // stop → idle framing (do not reopen completed work), tool → process
+      // results, user → no addendum needed.
       if (info) {
         const reminder = (() => {
           switch (info.role) {
             case "assistant":
               if (info.finish === "tool-calls") return autonomousLoopReminder()
-              return stopReminder(undefined)
+              return idleReminder()
             case "tool":
               return toolResultContinueReminder()
             case "user":

--- a/packages/opencode/test/session/checkpoint-rebuild-v3.test.ts
+++ b/packages/opencode/test/session/checkpoint-rebuild-v3.test.ts
@@ -175,7 +175,7 @@ describe("renderRebuildContext v3", () => {
     ),
   )
 
-  it.live("appends stopReminder when lastMessageInfo is assistant+stop", () =>
+  it.live("uses idle framing when lastMessageInfo is assistant+stop", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const cp = yield* SessionCheckpoint.Service
@@ -186,6 +186,7 @@ describe("renderRebuildContext v3", () => {
 
         const out = yield* cp.renderRebuildContext(sess.id, { lastMessageInfo: { role: "assistant", finish: "stop" } })
         expect(out).toContain("The previous assistant turn ended with a stop")
+        expect(out).toContain("wait for the user")
         expect(out).toContain("progress.md head section")
       }),
     ),

--- a/packages/opencode/test/session/checkpoint-render-verify.test.ts
+++ b/packages/opencode/test/session/checkpoint-render-verify.test.ts
@@ -292,6 +292,62 @@ Next: implement renderRebuildContext 9-section render in src/session/checkpoint.
     ),
   )
 
+  it.live("renderRebuildContext uses idle framing when lastMessageInfo is assistant/stop", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const cp = yield* SessionCheckpoint.Service
+        const session = yield* Session.Service
+        const memory = yield* Memory.Service
+
+        const sess = yield* session.create({ title: "idle framing stop" })
+
+        const root = yield* memory.root()
+        const sessDir = path.join(root, "sessions", sess.id)
+
+        yield* Effect.promise(async () => {
+          await fs.mkdir(sessDir, { recursive: true })
+          await fs.writeFile(
+            path.join(sessDir, "checkpoint.md"),
+            `Topic: Idle framing fixture\n\n### Execution context\n- minimal seed\n`,
+          )
+        })
+
+        const out = yield* cp.renderRebuildContext(sess.id, { lastMessageInfo: { role: "assistant", finish: "stop" } })
+
+        expect(out).not.toContain("Pick up the last task as if the break never happened")
+        expect(out).toContain("wait for the user")
+      }),
+    ),
+  )
+
+  it.live("renderRebuildContext keeps resume framing for assistant/tool-calls", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const cp = yield* SessionCheckpoint.Service
+        const session = yield* Session.Service
+        const memory = yield* Memory.Service
+
+        const sess = yield* session.create({ title: "resume framing tool-calls" })
+
+        const root = yield* memory.root()
+        const sessDir = path.join(root, "sessions", sess.id)
+
+        yield* Effect.promise(async () => {
+          await fs.mkdir(sessDir, { recursive: true })
+          await fs.writeFile(
+            path.join(sessDir, "checkpoint.md"),
+            `Topic: Resume framing fixture\n\n### Execution context\n- minimal seed\n`,
+          )
+        })
+
+        const out = yield* cp.renderRebuildContext(sess.id, { lastMessageInfo: { role: "assistant", finish: "tool-calls" } })
+
+        expect(out).toContain("Pick up the last task as if the break never happened")
+        expect(out).toContain("autonomous task")
+      }),
+    ),
+  )
+
   it.live("renderRebuildContext omits autonomous addendum when opts undefined", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Fixes #1915 (part 1). After a finite task completes, a checkpoint rebuild unconditionally reinjected "Pick up the last task as if the break never happened" plus resume reminders, so the main agent re-verified already-finished work → token growth → repeated writers/rebuilds → keep-alive loop.

**Root cause:** `packages/opencode/src/session/checkpoint.ts` `renderRebuildContext()` Section 10 always appended the hard resume text, and Section 11 used a resume-oriented `stopReminder()` for `assistant` + `finish === "stop"`. No idle/done branch.

**Fix:** gate the resume framing on the tail:
- Compute `done = lastMessageInfo?.role === "assistant" && lastMessageInfo.finish === "stop"`.
- Section 10: when done, use an idle framing ("if it fulfilled the user's request, do not reopen or re-verify completed work — wait for the user's next input"); otherwise keep the resume text.
- Section 11: `assistant`/`stop` → new `idleReminder()` (do-not-reopen + progress.md guidance so a genuinely mid-task / truncated / cancelled agent still knows where to judge); `tool-calls` → `autonomousLoopReminder()` (unchanged); `tool` → `toolResultContinueReminder()` (unchanged).
- Removed the now-unused `stopReminder`.

## Test Plan

- [x] New tests: `assistant/stop` → no "Pick up the last task", contains "wait for the user"; `assistant/tool-calls` → keeps resume framing.
- [x] Updated `checkpoint-rebuild-v3.test.ts` (its old assertion referenced the removed `stopReminder` text).
- [x] `bun test test/session/checkpoint-render-verify.test.ts test/session/checkpoint-rebuild-v3.test.ts` — 22 pass; `bun typecheck` clean.

## Notes

- Issue's suggested parts 2 (writer idle/done rules) and 3 (LastMessageInfo/rebuildMode) are follow-ups; part 1 alone stops the reopen loop per the issue.