### PR TITLE
fix(session): cap per-message summary diff size to prevent OOM bloat

### DIFF
--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -7,6 +7,23 @@ import * as Session from "./session"
 import { MessageV2 } from "./message-v2"
 import { SessionID, MessageID } from "./schema"
 
+/** Cap the per-message summary diff so a single huge file edit can't bloat a
+ * session message to hundreds of MB (issue #1854). The full session diff is
+ * still stored via session_diff; this bounds only the message-embedded copy. */
+export const MAX_SUMMARY_DIFF_BYTES = 1024 * 1024
+
+export function capSummaryDiffs(diffs: Snapshot.FileDiff[]): Snapshot.FileDiff[] {
+  let budget = MAX_SUMMARY_DIFF_BYTES
+  const capped: Snapshot.FileDiff[] = []
+  for (const d of diffs) {
+    if (budget <= 0) break
+    const patch = d.patch.slice(0, budget)
+    budget -= patch.length + d.file.length + 48
+    capped.push({ ...d, patch })
+  }
+  return capped
+}
+
 function unquoteGitPath(input: string) {
   if (!input.startsWith('"')) return input
   if (!input.endsWith('"')) return input
@@ -124,7 +141,7 @@ export const layer = Layer.effect(
       const target = messages.find((m) => m.info.id === input.messageID)
       if (!target || target.info.role !== "user") return
       const msgDiffs = yield* computeDiff({ messages })
-      target.info.summary = { ...target.info.summary, diffs: msgDiffs }
+      target.info.summary = { ...target.info.summary, diffs: capSummaryDiffs(msgDiffs) }
       yield* sessions.updateMessage(target.info)
     })
 

--- a/packages/opencode/test/session/summary-diffs-cap.test.ts
+++ b/packages/opencode/test/session/summary-diffs-cap.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { capSummaryDiffs, MAX_SUMMARY_DIFF_BYTES } from "../../src/session/summary"
+
+describe("capSummaryDiffs", () => {
+  test("caps a single huge patch to the budget", () => {
+    const huge = "x".repeat(MAX_SUMMARY_DIFF_BYTES * 2)
+    const out = capSummaryDiffs([{ file: "a.json", patch: huge, additions: 1, deletions: 1, status: "modified" as const }])
+    expect(out).toHaveLength(1)
+    expect(out[0].patch.length).toBeLessThanOrEqual(MAX_SUMMARY_DIFF_BYTES)
+    expect(out[0].patch.startsWith("x")).toBe(true)
+  })
+
+  test("keeps small diffs unchanged", () => {
+    const small = [{ file: "a.ts", patch: "diff --git a/a.ts", additions: 1, deletions: 1, status: "modified" as const }]
+    expect(capSummaryDiffs(small)).toEqual(small)
+  })
+
+  test("drops entries once the budget is exhausted", () => {
+    const big = "y".repeat(MAX_SUMMARY_DIFF_BYTES)
+    const out = capSummaryDiffs([
+      { file: "a", patch: big, additions: 1, deletions: 1 },
+      { file: "b", patch: big, additions: 1, deletions: 1 },
+    ])
+    expect(out.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1854 (part of it). `message.summary.diffs` grow unbounded — single messages reach tens–hundreds of MB because `Snapshot.FileDiff.patch` holds the full file content (diffFull uses full context). On resume, JSON → V8 heap ×copies → 10–20 GB process commit → OOM / Windows Event 2004.

**Root cause:** `packages/opencode/src/session/summary.ts` `summarize()` stores the full per-message diff into the message summary with no size cap.

**Fix:** cap the per-message summary diff at `MAX_SUMMARY_DIFF_BYTES` (1 MB):
- `capSummaryDiffs()` slices each `FileDiff.patch` to the remaining byte budget and drops entries once exhausted, so a single huge patch can never bloat a message beyond ~1 MB.
- Applied only to the message-embedded copy. The full session diff (`session_diff`) and the revert path are untouched — they use the unbounded diff.

## Test Plan

- [x] New tests: huge patch capped to budget; small diffs unchanged; budget exhaustion drops entries.
- [x] `bun test test/session/summary-diffs-cap.test.ts` — 3 pass; full session suite 913 pass no regression.
- [x] `bun typecheck` — clean.

## Notes

- Tradeoff: the `messageID`-scoped diff API returns truncated (structurally-invalid) diffs for huge single-file edits. No in-repo consumer uses the messageID variant (the TUI uses the session-level diff); the cap solves the OOM at the cost of per-message diff fidelity for pathological edits.
- The other #1854 acceptance items (prune deferral, history.backfill, process memory budget, fork slim-history, metrics) are separate fixes; this addresses the single largest lever (unbounded per-message diff JSON).