### PR TITLE
feat(tui): expose api.keymap to TUI plugins for OpenCode compatibility

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -69,6 +69,7 @@ import { PromptRefProvider, usePromptRef } from "./context/prompt"
 import { TuiConfigProvider, useTuiConfig } from "./context/tui-config"
 import { TuiConfig } from "@/cli/cmd/tui/config/tui"
 import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
+import { createPluginKeymap } from "./plugin/keymap"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 import { isPlainTerminal, isWindowsTerminal } from "./util/terminal"
 import {
@@ -262,8 +263,10 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     return routes.get(name)?.at(-1)?.render
   }
 
+  const keymap = createPluginKeymap({ command, keybind, dialog })
   const api = createTuiApi({
     command,
+    keymap,
     tuiConfig,
     dialog,
     keybind,

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
@@ -117,6 +117,12 @@ function init() {
   })
 
   const result = {
+    find(name: string) {
+      for (const option of entries()) {
+        if (option.value === name) return option
+      }
+      return undefined
+    },
     trigger(name: string) {
       for (const option of entries()) {
         if (option.value === name) {

--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -10,6 +10,7 @@ import type { useTheme } from "@tui/context/theme"
 import { Dialog as DialogUI, type useDialog } from "@tui/ui/dialog"
 import type { TuiConfig } from "@/cli/cmd/tui/config/tui"
 import { createPluginKeybind } from "../context/plugin-keybinds"
+import { createPluginKeymap } from "./keymap"
 import type { useKV } from "../context/kv"
 import { DialogAlert } from "../ui/dialog-alert"
 import { DialogConfirm } from "../ui/dialog-confirm"
@@ -29,6 +30,7 @@ export type RouteMap = Map<string, RouteEntry[]>
 
 type Input = {
   command: ReturnType<typeof useCommandDialog>
+  keymap: ReturnType<typeof createPluginKeymap>
   tuiConfig: TuiConfig.Info
   dialog: ReturnType<typeof useDialog>
   keybind: ReturnType<typeof useKeybind>
@@ -227,6 +229,7 @@ export function createTuiApi(input: Input): TuiPluginApi {
         input.command.show()
       },
     },
+    keymap: input.keymap,
     route: {
       register(list) {
         return routeRegister(input.routes, list, input.bump)

--- a/packages/opencode/src/cli/cmd/tui/plugin/keymap.ts
+++ b/packages/opencode/src/cli/cmd/tui/plugin/keymap.ts
@@ -21,15 +21,26 @@ type PluginCommand = Command<PluginTarget, KeyEvent>
 type PluginBinding = Binding<PluginTarget, KeyEvent>
 type PluginLayer = Layer<PluginTarget, KeyEvent>
 
-type RegistryEntry = {
+type CommandRegistryEntry = {
   command: PluginCommand
   binding?: PluginBinding
+}
+
+type FunctionBindingEntry = {
+  value: string
+  binding: PluginBinding & { cmd: (ctx: CommandContext<PluginTarget, KeyEvent>) => unknown }
 }
 
 type Input = {
   command: ReturnType<typeof useCommandDialog>
   keybind: ReturnType<typeof useKeybind>
   dialog: ReturnType<typeof useDialog>
+}
+
+type ContextOptions = {
+  command?: PluginCommand
+  event?: KeyEvent
+  payload?: unknown
 }
 
 function str(value: unknown): string | undefined {
@@ -60,29 +71,44 @@ function keyLikeToInfo(key: KeyLike): Keybind.Info | undefined {
   }
 }
 
+function removeEntry<Value>(list: Value[], entry: Value) {
+  const index = list.indexOf(entry)
+  if (index >= 0) list.splice(index, 1)
+}
+
 /**
  * Narrow `api.keymap` implementation bridging to the fork's command dialog
- * (`useCommandDialog`) and keybind system. `registerLayer` registers each
- * layer command as a command-palette entry; the existing keyboard loop matches
- * `option.keybind` and calls `onSelect`, so bindings work through the dialog
- * path. Known gaps vs upstream `@opentui/keymap`: no sequence keys, no layer
+ * (`useCommandDialog`) and keybind system. `registerLayer` registers each layer
+ * command as a command-palette entry and each function-valued binding as a
+ * hidden keybind option; the existing keyboard loop matches `option.keybind`
+ * and calls `onSelect`, so bindings fire through the dialog path.
+ * `dispatchCommand` runs keymap commands directly so it can thread
+ * `options.payload`/`options.event` into the command context, and falls back to
+ * the option's `onSelect` for commands registered outside the keymap.
+ *
+ * Known gaps vs upstream `@opentui/keymap`: no sequence keys, no layer
  * target/priority/targetMode semantics, no reactive `enabled`/`suggested`
  * subscriptions (evaluated once at registration), and `on`/`intercept` are
  * no-op stubs.
  */
 export function createPluginKeymap(input: Input): TuiKeymap {
-  const registry: RegistryEntry[] = []
+  const registry: CommandRegistryEntry[] = []
+  const functionBindings: FunctionBindingEntry[] = []
   const data = new Map<string, unknown>()
 
-  const buildCommandContext = (cmd: PluginCommand, keymap: TuiKeymap): CommandContext<PluginTarget, KeyEvent> => ({
+  const buildCommandContext = (
+    keymap: TuiKeymap,
+    commandInput: string,
+    opts?: ContextOptions,
+  ): CommandContext<PluginTarget, KeyEvent> => ({
     keymap,
-    event: undefined,
+    event: opts?.event,
     focused: null,
     target: null,
-    data: {},
-    command: cmd,
-    input: cmd.name,
-    payload: undefined,
+    data: Object.fromEntries(data),
+    command: opts?.command,
+    input: commandInput,
+    payload: opts?.payload,
   })
 
   const toActiveBinding = (binding: PluginBinding, keymap: TuiKeymap): ActiveBinding<PluginTarget, KeyEvent> => ({
@@ -93,7 +119,7 @@ export function createPluginKeymap(input: Input): TuiKeymap {
     fallthrough: binding.fallthrough ?? false,
   })
 
-  const commandOption = (entry: RegistryEntry, keymap: TuiKeymap): CommandOption => {
+  const commandOption = (entry: CommandRegistryEntry, keymap: TuiKeymap): CommandOption => {
     const { command: cmd, binding } = entry
     const slashName = str(cmd.slashName)
     const slashAliases = Array.isArray(cmd.slashAliases)
@@ -108,11 +134,22 @@ export function createPluginKeymap(input: Input): TuiKeymap {
       suggested: typeof cmd.suggested === "function" ? Boolean(cmd.suggested()) : (cmd.suggested as boolean | undefined),
       enabled: typeof cmd.enabled === "function" ? Boolean(cmd.enabled()) : (cmd.enabled as boolean | undefined),
       keybind: binding ? keyLikeToString(binding.key) : undefined,
-      onSelect: () => cmd.run(buildCommandContext(cmd, keymap)),
+      onSelect: () => cmd.run(buildCommandContext(keymap, cmd.name, { command: cmd })),
     }
   }
 
-  const filterCommands = (commands: PluginCommand[], query?: CommandQuery<PluginTarget, KeyEvent>): PluginCommand[] => {
+  const fnBindingOption = (entry: FunctionBindingEntry, keymap: TuiKeymap): CommandOption => ({
+    title: entry.value,
+    value: entry.value,
+    hidden: true,
+    keybind: keyLikeToString(entry.binding.key),
+    onSelect: () => entry.binding.cmd(buildCommandContext(keymap, entry.value, {})),
+  })
+
+  const filterCommands = (
+    commands: PluginCommand[],
+    query?: CommandQuery<PluginTarget, KeyEvent>,
+  ): PluginCommand[] => {
     let list = commands
     if (query?.search) {
       const searchIn = query.searchIn?.length ? query.searchIn : ["name"]
@@ -142,30 +179,51 @@ export function createPluginKeymap(input: Input): TuiKeymap {
     registerLayer(layer: PluginLayer) {
       const commands = layer.commands ?? []
       const bindings = layer.bindings ?? []
-      const entries = commands.map((command) => ({
+      const commandEntries = commands.map((command) => ({
         command,
         binding: bindings.find((b) => b.cmd === command.name),
       }))
-      for (const entry of entries) registry.push(entry)
-      const dispose = input.command.register(() => entries.map((entry) => commandOption(entry, keymap)))
+      const fnEntries = bindings
+        .filter(
+          (b): b is PluginBinding & { cmd: (ctx: CommandContext<PluginTarget, KeyEvent>) => unknown } =>
+            typeof b.cmd === "function",
+        )
+        .map((binding, index) => ({
+          value: `__keybind:${keyLikeToString(binding.key)}:${index}`,
+          binding,
+        }))
+      for (const entry of commandEntries) registry.push(entry)
+      for (const entry of fnEntries) functionBindings.push(entry)
+      const dispose = input.command.register(() => [
+        ...commandEntries.map((entry) => commandOption(entry, keymap)),
+        ...fnEntries.map((entry) => fnBindingOption(entry, keymap)),
+      ])
       return () => {
-        for (const entry of entries) {
-          const index = registry.indexOf(entry)
-          if (index >= 0) registry.splice(index, 1)
-        }
+        for (const entry of commandEntries) removeEntry(registry, entry)
+        for (const entry of fnEntries) removeEntry(functionBindings, entry)
         dispose()
       }
     },
-    dispatchCommand(name) {
+    dispatchCommand(name, options) {
       if (name === "command.palette.show") {
         input.command.show()
         return { ok: true }
       }
       const option = input.command.find(name)
       if (!option) return { ok: false, reason: "not-found" }
-      option.onSelect?.(input.dialog)
+      if (option.enabled === false) return { ok: false, reason: "disabled" }
       const command = registry.find((entry) => entry.command.name === name)?.command
-      return command ? { ok: true, command } : { ok: true }
+      if (command) {
+        command.run(buildCommandContext(keymap, name, { command, event: options?.event, payload: options?.payload }))
+        return { ok: true, command }
+      }
+      const fnBinding = functionBindings.find((entry) => entry.value === name)
+      if (fnBinding) {
+        fnBinding.binding.cmd(buildCommandContext(keymap, name, { event: options?.event, payload: options?.payload }))
+        return { ok: true }
+      }
+      option.onSelect?.(input.dialog)
+      return { ok: true }
     },
     runCommand(name, options) {
       return keymap.dispatchCommand(name, options)

--- a/packages/opencode/src/cli/cmd/tui/plugin/keymap.ts
+++ b/packages/opencode/src/cli/cmd/tui/plugin/keymap.ts
@@ -1,0 +1,231 @@
+import type { KeyEvent, Renderable } from "@opentui/core"
+import type {
+  ActiveBinding,
+  Binding,
+  Command,
+  CommandContext,
+  CommandEntry,
+  CommandQuery,
+  KeyLike,
+  KeySequencePart,
+  Layer,
+  TuiKeymap,
+} from "@mimo-ai/plugin/tui"
+import type { CommandOption, useCommandDialog } from "@tui/component/dialog-command"
+import type { useKeybind } from "@tui/context/keybind"
+import type { useDialog } from "@tui/ui/dialog"
+import { Keybind } from "@/util"
+
+type PluginTarget = Renderable
+type PluginCommand = Command<PluginTarget, KeyEvent>
+type PluginBinding = Binding<PluginTarget, KeyEvent>
+type PluginLayer = Layer<PluginTarget, KeyEvent>
+
+type RegistryEntry = {
+  command: PluginCommand
+  binding?: PluginBinding
+}
+
+type Input = {
+  command: ReturnType<typeof useCommandDialog>
+  keybind: ReturnType<typeof useKeybind>
+  dialog: ReturnType<typeof useDialog>
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined
+}
+
+function keyLikeToString(key: KeyLike): string {
+  if (typeof key === "string") return key
+  return Keybind.toString({
+    name: key.name,
+    ctrl: key.ctrl ?? false,
+    meta: key.meta ?? false,
+    shift: key.shift ?? false,
+    super: key.super ?? false,
+    leader: false,
+  })
+}
+
+function keyLikeToInfo(key: KeyLike): Keybind.Info | undefined {
+  if (typeof key === "string") return Keybind.parse(key).at(0)
+  return {
+    name: key.name,
+    ctrl: key.ctrl ?? false,
+    meta: key.meta ?? false,
+    shift: key.shift ?? false,
+    super: key.super ?? false,
+    leader: false,
+  }
+}
+
+/**
+ * Narrow `api.keymap` implementation bridging to the fork's command dialog
+ * (`useCommandDialog`) and keybind system. `registerLayer` registers each
+ * layer command as a command-palette entry; the existing keyboard loop matches
+ * `option.keybind` and calls `onSelect`, so bindings work through the dialog
+ * path. Known gaps vs upstream `@opentui/keymap`: no sequence keys, no layer
+ * target/priority/targetMode semantics, no reactive `enabled`/`suggested`
+ * subscriptions (evaluated once at registration), and `on`/`intercept` are
+ * no-op stubs.
+ */
+export function createPluginKeymap(input: Input): TuiKeymap {
+  const registry: RegistryEntry[] = []
+  const data = new Map<string, unknown>()
+
+  const buildCommandContext = (cmd: PluginCommand, keymap: TuiKeymap): CommandContext<PluginTarget, KeyEvent> => ({
+    keymap,
+    event: undefined,
+    focused: null,
+    target: null,
+    data: {},
+    command: cmd,
+    input: cmd.name,
+    payload: undefined,
+  })
+
+  const toActiveBinding = (binding: PluginBinding, keymap: TuiKeymap): ActiveBinding<PluginTarget, KeyEvent> => ({
+    sequence: keymap.parseKeySequence(binding.key),
+    command: binding.cmd,
+    event: binding.event ?? "press",
+    preventDefault: binding.preventDefault ?? true,
+    fallthrough: binding.fallthrough ?? false,
+  })
+
+  const commandOption = (entry: RegistryEntry, keymap: TuiKeymap): CommandOption => {
+    const { command: cmd, binding } = entry
+    const slashName = str(cmd.slashName)
+    const slashAliases = Array.isArray(cmd.slashAliases)
+      ? cmd.slashAliases.filter((x): x is string => typeof x === "string")
+      : undefined
+    return {
+      title: str(cmd.title) ?? cmd.name,
+      value: cmd.name,
+      description: str(cmd.desc) ?? str(cmd.description),
+      category: str(cmd.category),
+      slash: slashName ? { name: slashName, aliases: slashAliases } : undefined,
+      suggested: typeof cmd.suggested === "function" ? Boolean(cmd.suggested()) : (cmd.suggested as boolean | undefined),
+      enabled: typeof cmd.enabled === "function" ? Boolean(cmd.enabled()) : (cmd.enabled as boolean | undefined),
+      keybind: binding ? keyLikeToString(binding.key) : undefined,
+      onSelect: () => cmd.run(buildCommandContext(cmd, keymap)),
+    }
+  }
+
+  const filterCommands = (commands: PluginCommand[], query?: CommandQuery<PluginTarget, KeyEvent>): PluginCommand[] => {
+    let list = commands
+    if (query?.search) {
+      const searchIn = query.searchIn?.length ? query.searchIn : ["name"]
+      const needle = query.search.toLowerCase()
+      list = list.filter((cmd) =>
+        searchIn.some((field) => {
+          const value = cmd[field]
+          return typeof value === "string" && value.toLowerCase().includes(needle)
+        }),
+      )
+    }
+    if (typeof query?.filter === "function") list = list.filter(query.filter)
+    else if (query?.filter) {
+      for (const [field, expected] of Object.entries(query.filter)) {
+        list = list.filter((cmd) => {
+          if (typeof expected === "function") return Boolean(expected(cmd[field], cmd))
+          if (Array.isArray(expected)) return expected.includes(cmd[field])
+          return cmd[field] === expected
+        })
+      }
+    }
+    if (query?.limit != null) list = list.slice(0, query.limit)
+    return list
+  }
+
+  const keymap: TuiKeymap = {
+    registerLayer(layer: PluginLayer) {
+      const commands = layer.commands ?? []
+      const bindings = layer.bindings ?? []
+      const entries = commands.map((command) => ({
+        command,
+        binding: bindings.find((b) => b.cmd === command.name),
+      }))
+      for (const entry of entries) registry.push(entry)
+      const dispose = input.command.register(() => entries.map((entry) => commandOption(entry, keymap)))
+      return () => {
+        for (const entry of entries) {
+          const index = registry.indexOf(entry)
+          if (index >= 0) registry.splice(index, 1)
+        }
+        dispose()
+      }
+    },
+    dispatchCommand(name) {
+      if (name === "command.palette.show") {
+        input.command.show()
+        return { ok: true }
+      }
+      const option = input.command.find(name)
+      if (!option) return { ok: false, reason: "not-found" }
+      option.onSelect?.(input.dialog)
+      const command = registry.find((entry) => entry.command.name === name)?.command
+      return command ? { ok: true, command } : { ok: true }
+    },
+    runCommand(name, options) {
+      return keymap.dispatchCommand(name, options)
+    },
+    getCommands(query) {
+      return filterCommands(registry.map((entry) => entry.command), query)
+    },
+    getCommandEntries(query) {
+      return keymap.getCommands(query).map((command): CommandEntry<PluginTarget, KeyEvent> => {
+        const binding = registry.find((x) => x.command === command)?.binding
+        return { command, bindings: binding ? [toActiveBinding(binding, keymap)] : [] }
+      })
+    },
+    getCommandBindings(query) {
+      const map = new Map<string, readonly ActiveBinding<PluginTarget, KeyEvent>[]>()
+      for (const command of keymap.getCommands(query)) {
+        const binding = registry.find((x) => x.command === command)?.binding
+        if (!binding) continue
+        map.set(command.name, [toActiveBinding(binding, keymap)])
+      }
+      return map
+    },
+    setData(name, value) {
+      data.set(name, value)
+    },
+    getData(name) {
+      return data.get(name)
+    },
+    on() {
+      return () => {}
+    },
+    intercept() {
+      return () => {}
+    },
+    createKeyMatcher(key) {
+      const target = keyLikeToInfo(key)
+      return (input) => {
+        if (!input) return false
+        const info = keyLikeToInfo(input)
+        if (!info || !target) return false
+        return Keybind.match(target, info)
+      }
+    },
+    parseKeySequence(key) {
+      return Keybind.parse(keyLikeToString(key)).map((info): KeySequencePart => ({
+        stroke: {
+          name: info.name,
+          ctrl: info.ctrl,
+          shift: info.shift,
+          meta: info.meta,
+          super: info.super ?? false,
+        },
+        display: Keybind.toString(info),
+        match: Keybind.toString(info),
+      }))
+    },
+    formatKey(key) {
+      return Keybind.toString(keyLikeToInfo(key))
+    },
+  }
+
+  return keymap
+}

--- a/packages/opencode/src/cli/cmd/tui/plugin/runtime.ts
+++ b/packages/opencode/src/cli/cmd/tui/plugin/runtime.ts
@@ -533,6 +533,7 @@ function pluginApi(runtime: RuntimeState, plugin: PluginEntry, scope: PluginScop
   return {
     app: api.app,
     command,
+    keymap: api.keymap,
     route,
     ui: api.ui,
     keybind: api.keybind,

--- a/packages/opencode/test/cli/cmd/tui/plugin/keymap.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/plugin/keymap.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test"
+import type { KeyEvent } from "@opentui/core"
+import { createPluginKeymap } from "../../../../../src/cli/cmd/tui/plugin/keymap"
+
+type MockOption = {
+  title: string
+  value: string
+  enabled?: boolean
+  onSelect?: (dialog: unknown) => void
+}
+
+type Input = Parameters<typeof createPluginKeymap>[0]
+
+function mockCommandDialog() {
+  const registrations: (() => MockOption[])[] = []
+  const shown: number[] = []
+  const command = {
+    register(cb: () => MockOption[]) {
+      registrations.push(cb)
+      return () => {
+        const index = registrations.indexOf(cb)
+        if (index >= 0) registrations.splice(index, 1)
+      }
+    },
+    find(name: string) {
+      for (const reg of registrations) {
+        for (const option of reg()) {
+          if (option.value === name) return option
+        }
+      }
+      return undefined
+    },
+    trigger() {},
+    show() {
+      shown.push(shown.length + 1)
+    },
+  }
+  return {
+    command,
+    shown,
+    options() {
+      return registrations.flatMap((reg) => reg())
+    },
+  }
+}
+
+function makeKeymap() {
+  const mock = mockCommandDialog()
+  const keymap = createPluginKeymap({
+    command: mock.command as unknown as Input["command"],
+    keybind: {} as unknown as Input["keybind"],
+    dialog: {} as unknown as Input["dialog"],
+  })
+  return { keymap, mock }
+}
+
+describe("createPluginKeymap", () => {
+  test("registerLayer registers command options with title/value/slash", () => {
+    const { keymap, mock } = makeKeymap()
+    const dispose = keymap.registerLayer({
+      commands: [
+        {
+          name: "quota.show",
+          title: "Show quota",
+          desc: "Shows usage",
+          category: "OpenCode Quota",
+          slashName: "quota",
+          run: () => {},
+        },
+      ],
+      bindings: [],
+    })
+
+    expect(keymap.getCommands()).toHaveLength(1)
+    expect(mock.options()[0]).toMatchObject({
+      title: "Show quota",
+      value: "quota.show",
+      description: "Shows usage",
+      category: "OpenCode Quota",
+      slash: { name: "quota" },
+    })
+
+    dispose()
+    expect(keymap.getCommands()).toHaveLength(0)
+  })
+
+  test("dispatchCommand runs the command and returns ok", () => {
+    const { keymap, mock } = makeKeymap()
+    const ran: unknown[] = []
+    keymap.registerLayer({
+      commands: [{ name: "hello", run(ctx) { ran.push(ctx) } }],
+      bindings: [],
+    })
+
+    const result = keymap.dispatchCommand("hello")
+
+    expect(result).toMatchObject({ ok: true, command: { name: "hello" } })
+    expect(ran).toHaveLength(1)
+    expect(ran[0]).toMatchObject({ input: "hello", command: { name: "hello" } })
+    expect(mock.shown).toHaveLength(0)
+  })
+
+  test("dispatchCommand(command.palette.show) opens the dialog", () => {
+    const { keymap, mock } = makeKeymap()
+    expect(keymap.dispatchCommand("command.palette.show")).toEqual({ ok: true })
+    expect(mock.shown).toHaveLength(1)
+  })
+
+  test("dispatchCommand returns not-found for unknown commands", () => {
+    const { keymap } = makeKeymap()
+    expect(keymap.dispatchCommand("unknown.command")).toEqual({ ok: false, reason: "not-found" })
+  })
+
+  test("dispatchCommand respects the enabled gate", () => {
+    const { keymap } = makeKeymap()
+    const ran: string[] = []
+    keymap.registerLayer({
+      commands: [{ name: "hidden", enabled: false, run() { ran.push("hidden") } }],
+      bindings: [],
+    })
+
+    expect(keymap.dispatchCommand("hidden")).toEqual({ ok: false, reason: "disabled" })
+    expect(ran).toHaveLength(0)
+  })
+
+  test("setData/getData round-trip and ctx.data reflects the store", () => {
+    const { keymap } = makeKeymap()
+    const ctxs: Record<string, unknown>[] = []
+    keymap.setData("token", "abc")
+    keymap.registerLayer({
+      commands: [{ name: "read", run(ctx) { ctxs.push(ctx as Record<string, unknown>) } }],
+      bindings: [],
+    })
+
+    keymap.dispatchCommand("read")
+
+    expect(keymap.getData("token")).toBe("abc")
+    expect(ctxs[0].data).toEqual({ token: "abc" })
+  })
+
+  test("dispatchCommand threads payload and event through the context", () => {
+    const { keymap } = makeKeymap()
+    const ctxs: Record<string, unknown>[] = []
+    keymap.registerLayer({
+      commands: [{ name: "echo", run(ctx) { ctxs.push(ctx as Record<string, unknown>) } }],
+      bindings: [],
+    })
+
+    const event = { name: "x" } as unknown as KeyEvent
+    keymap.dispatchCommand("echo", { payload: 42, event })
+
+    expect(ctxs[0].payload).toBe(42)
+    expect(ctxs[0].event).toBe(event)
+  })
+
+  test("function-valued bindings fire via their synthetic command name", () => {
+    const { keymap, mock } = makeKeymap()
+    const ran: unknown[] = []
+    keymap.registerLayer({
+      commands: [],
+      bindings: [{ key: "ctrl+x", cmd(ctx) { ran.push(ctx) } }],
+    })
+
+    // function bindings are hidden keybind options, not palette commands
+    expect(keymap.getCommands()).toHaveLength(0)
+    expect(keymap.getCommandBindings().size).toBe(0)
+    expect(mock.options()[0]).toMatchObject({ value: "__keybind:ctrl+x:0", hidden: true })
+
+    const result = keymap.dispatchCommand("__keybind:ctrl+x:0")
+    expect(result).toEqual({ ok: true })
+    expect(ran).toHaveLength(1)
+    expect(ran[0]).toMatchObject({ input: "__keybind:ctrl+x:0", command: undefined })
+  })
+})

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -1,5 +1,6 @@
 import { createOpencodeClient } from "@mimo-ai/sdk/v2"
-import { RGBA, type CliRenderer } from "@opentui/core"
+import type { ActiveBinding } from "@mimo-ai/plugin/tui"
+import { RGBA, type CliRenderer, type KeyEvent, type Renderable } from "@opentui/core"
 import { createPluginKeybind } from "../../src/cli/cmd/tui/context/plugin-keybinds"
 import type { HostPluginApi } from "../../src/cli/cmd/tui/plugin/slots"
 
@@ -203,6 +204,21 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
       },
       trigger: () => {},
       show: () => {},
+    },
+    keymap: {
+      registerLayer: () => () => {},
+      dispatchCommand: () => ({ ok: false, reason: "not-found" as const }),
+      runCommand: () => ({ ok: false, reason: "not-found" as const }),
+      getCommands: () => [],
+      getCommandEntries: () => [],
+      getCommandBindings: () => new Map<string, readonly ActiveBinding<Renderable, KeyEvent>[]>(),
+      setData: () => {},
+      getData: () => undefined,
+      on: () => () => {},
+      intercept: () => () => {},
+      createKeyMatcher: () => () => false,
+      parseKeySequence: () => [],
+      formatKey: () => "",
     },
     route: {
       register: () => {

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -16,7 +16,7 @@ import type {
   TextPart,
   Config as SdkConfig,
 } from "@mimo-ai/sdk/v2"
-import type { CliRenderer, ParsedKey, RGBA, SlotMode } from "@opentui/core"
+import type { CliRenderer, KeyEvent, ParsedKey, Renderable, RGBA, SlotMode } from "@opentui/core"
 import type { JSX, SolidPlugin } from "@opentui/solid"
 import type { Config as PluginConfig, PluginOptions } from "./index.js"
 
@@ -76,6 +76,134 @@ export type TuiKeybindSet = {
   match: (name: string, evt: ParsedKey) => boolean
   print: (name: string) => string
 }
+
+// ---- api.keymap types ------------------------------------------------------
+// Narrow, type-compatible subset of upstream `@opentui/keymap` (mirrored so
+// OpenCode plugins using `api.keymap.registerLayer` compile against it). The
+// runtime value bridges to the fork's command dialog + keybind system — see
+// `packages/opencode/src/cli/cmd/tui/plugin/keymap.ts`.
+
+export type KeyStrokeInput = {
+  name: string
+  ctrl?: boolean
+  shift?: boolean
+  meta?: boolean
+  super?: boolean
+  hyper?: boolean
+}
+
+export type KeyLike = string | KeyStrokeInput
+
+export type KeySequencePart = {
+  stroke: KeyStrokeInput & { ctrl: boolean; shift: boolean; meta: boolean; super: boolean }
+  display: string
+  match: string
+  tokenName?: string
+  patternName?: string
+  payloadKey?: string
+}
+
+export type CommandContext<TTarget extends object = object, TEvent = KeyEvent, TPayload = unknown> = {
+  keymap: Keymap<TTarget, TEvent>
+  event: TEvent | undefined
+  focused: TTarget | null
+  target: TTarget | null
+  data: Readonly<Record<string, unknown>>
+  command?: Command<TTarget, TEvent, TPayload>
+  input: string
+  payload: TPayload
+}
+
+export type Command<TTarget extends object = object, TEvent = KeyEvent, TPayload = unknown> = {
+  name: string
+  run: (ctx: CommandContext<TTarget, TEvent, TPayload>) => unknown
+  [key: string]: unknown
+}
+
+export type RunCommandResult<TTarget extends object = object, TEvent = KeyEvent> =
+  | { ok: true; command?: Command<TTarget, TEvent> }
+  | { ok: false; reason: "not-found" }
+  | {
+      ok: false
+      reason: "inactive" | "disabled" | "invalid-args" | "rejected" | "error"
+      command?: Command<TTarget, TEvent>
+    }
+
+export type RunCommandOptions<TTarget extends object = object, TEvent = KeyEvent> = {
+  event?: TEvent
+  focused?: TTarget | null
+  target?: TTarget | null
+  includeCommand?: boolean
+  payload?: unknown
+}
+
+export type Binding<TTarget extends object = object, TEvent = KeyEvent> = {
+  key: KeyLike
+  cmd?: string | ((ctx: CommandContext<TTarget, TEvent>) => unknown)
+  event?: "press" | "release"
+  preventDefault?: boolean
+  fallthrough?: boolean
+  [key: string]: unknown
+}
+
+export type Layer<TTarget extends object = object, TEvent = KeyEvent> = {
+  target?: TTarget
+  priority?: number
+  bindings?: readonly Binding<TTarget, TEvent>[]
+  commands?: readonly Command<TTarget, TEvent, unknown>[]
+  targetMode?: "focus" | "focus-within"
+  [key: string]: unknown
+}
+
+export type CommandQuery<TTarget extends object = object, TEvent = KeyEvent> = {
+  visibility?: "reachable" | "active" | "registered"
+  focused?: TTarget | null
+  namespace?: string | readonly string[]
+  search?: string
+  searchIn?: readonly string[]
+  filter?: Readonly<Record<string, unknown>> | ((command: Command<TTarget, TEvent>) => boolean)
+  limit?: number
+}
+
+export type ActiveBinding<TTarget extends object = object, TEvent = KeyEvent> = {
+  sequence: readonly KeySequencePart[]
+  command?: string | ((ctx: CommandContext<TTarget, TEvent>) => unknown)
+  commandAttrs?: Readonly<Record<string, unknown>>
+  attrs?: Readonly<Record<string, unknown>>
+  event: "press" | "release"
+  preventDefault: boolean
+  fallthrough: boolean
+}
+
+export type CommandEntry<TTarget extends object = object, TEvent = KeyEvent> = {
+  command: Command<TTarget, TEvent>
+  bindings: readonly ActiveBinding<TTarget, TEvent>[]
+}
+
+/**
+ * The `api.keymap` surface. Only the methods the fork implements are declared;
+ * OpenCode plugins call `registerLayer`/`dispatchCommand` and the query/data
+ * accessors, which are all present. `on`/`intercept` are no-op stubs.
+ */
+export interface Keymap<TTarget extends object = object, TEvent = KeyEvent> {
+  registerLayer(layer: Layer<TTarget, TEvent>): () => void
+  dispatchCommand(name: string, options?: RunCommandOptions<TTarget, TEvent>): RunCommandResult<TTarget, TEvent>
+  runCommand(name: string, options?: RunCommandOptions<TTarget, TEvent>): RunCommandResult<TTarget, TEvent>
+  getCommands(query?: CommandQuery<TTarget, TEvent>): readonly Command<TTarget, TEvent>[]
+  getCommandEntries(query?: CommandQuery<TTarget, TEvent>): readonly CommandEntry<TTarget, TEvent>[]
+  getCommandBindings(
+    query?: CommandQuery<TTarget, TEvent>,
+  ): ReadonlyMap<string, readonly ActiveBinding<TTarget, TEvent>[]>
+  setData(name: string, value: unknown): void
+  getData(name: string): unknown
+  on(name: string, listener: (...args: unknown[]) => void): () => void
+  intercept(name: string, fn: (...args: unknown[]) => void): () => void
+  createKeyMatcher(key: KeyLike): (input: KeyLike | null | undefined) => boolean
+  parseKeySequence(key: KeyLike): readonly KeySequencePart[]
+  formatKey(key: KeyLike): string
+}
+
+export type TuiKeymap = Keymap<Renderable, KeyEvent>
 
 export type TuiDialogProps = {
   size?: "medium" | "large" | "xlarge"
@@ -478,6 +606,7 @@ export type TuiPluginApi = {
     trigger: (value: string) => void
     show: () => void
   }
+  keymap: TuiKeymap
   route: {
     register: (routes: TuiRouteDefinition[]) => () => void
     navigate: (name: string, params?: Record<string, unknown>) => void


### PR DESCRIPTION
## Summary

Fixes #2001. TUI plugins written against the upstream OpenCode plugin API (`api.keymap.registerLayer({ commands, bindings })`) failed to initialize on MiMoCode because `@mimo-ai/plugin`'s TUI API was missing the `keymap` module — the error killed the whole TUI plugin (sidebar slots included).

**Design:** reimplement a narrow, type-compatible subset of `api.keymap` in the fork (no `@opentui/keymap` dependency — it targets opentui 0.2.x, incompatible with the fork's 0.1.x). It bridges to the existing command dialog + keybind system.

- `packages/plugin/src/tui.ts`: keymap types (`TuiKeymap`, `Binding`, `Layer`, `Command`, `CommandContext`, `RunCommandResult`, …) + `TuiPluginApi.keymap`.
- `packages/opencode/src/cli/cmd/tui/plugin/keymap.ts` (new): `createPluginKeymap` — `registerLayer` (bridges commands into the command palette, keybind via existing dialog loop; function-valued `binding.cmd` handled as hidden keybind options), `dispatchCommand`/`runCommand` (thread `payload`/`event`, `command.palette.show` special case, `enabled` gate), `getCommands`/`getCommandEntries`/`getCommandBindings`, `setData`/`getData` (surfaced in `CommandContext.data`), `on`/`intercept` no-ops, key helpers.
- `useCommandDialog.find(name)`, wiring in `api.tsx`/`runtime.ts`/`app.tsx`.
- `api.command` (legacy) keeps working.

## Test Plan

- [x] Focused `createPluginKeymap` test (8 cases): registerLayer bridging, dispatch, palette.show, not-found, data round-trip + ctx.data, enabled gate, payload/event, function binding.
- [x] `bun typecheck` clean (both `packages/opencode` and `packages/plugin`); existing plugin/TUI suites 423 pass no regression.

## Known gaps (documented in code)

Sequence keys (`"g c"`), layer target/priority/targetMode semantics, reactive `enabled`/`suggested` (snapshot-evaluated), `api.lifecycle.onDispose` no-op, `api.mode` absent. These are the documented subset boundaries — the acceptance path (real plugin initializes + commands appear in palette + `run(ctx)` valid) holds.