### PR TITLE
fix(session): prune tool outputs before serializing compaction request

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -37,8 +37,33 @@ export const Event = {
 
 export const PRUNE_MINIMUM = 20_000
 export const PRUNE_PROTECT = 40_000
-const PRUNE_PROTECTED_TOOLS = ["skill"]
+export const PRUNE_PROTECTED_TOOLS = ["skill"]
 const DEFAULT_TAIL_TURNS = 2
+
+// Strip the OUTPUT of old completed tool parts on an in-memory message array
+// (used before building the compaction modelMessages). Mirrors the DB `prune()`
+// thresholds (PRUNE_PROTECT / PRUNE_MINIMUM / PRUNE_PROTECTED_TOOLS) but
+// operates on the in-memory copy and never touches the DB — the compaction
+// summary doesn't need full old tool bodies, so this bounds the compaction
+// request size so it can't exceed the model window (#1661).
+export function pruneToolOutputs(messages: MessageV2.WithParts[]): void {
+  let total = 0
+  let turns = 0
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    if (msg.info.role === "user") turns++
+    if (turns < 2) continue
+    if (msg.info.role === "assistant" && msg.info.summary) break
+    for (const part of msg.parts) {
+      if (part.type !== "tool" || part.state.status !== "completed") continue
+      if (PRUNE_PROTECTED_TOOLS.includes(part.tool)) continue
+      const est = Token.estimate(part.state.output)
+      total += est
+      if (total > PRUNE_PROTECT) part.state.output = ""
+    }
+  }
+}
+
 const MIN_PRESERVE_RECENT_TOKENS = 2_000
 const MAX_PRESERVE_RECENT_TOKENS = 8_000
 type Turn = {
@@ -331,6 +356,7 @@ export const layer: Layer.Layer<
 
       const prompt = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
       const msgs = structuredClone(selected.head)
+      pruneToolOutputs(msgs)
       yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
       const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, { stripMedia: true })
       const ctx = yield* InstanceState.context

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -42,10 +42,12 @@ const DEFAULT_TAIL_TURNS = 2
 
 // Strip the OUTPUT of old completed tool parts on an in-memory message array
 // (used before building the compaction modelMessages). Mirrors the DB `prune()`
-// thresholds (PRUNE_PROTECT / PRUNE_MINIMUM / PRUNE_PROTECTED_TOOLS) but
-// operates on the in-memory copy and never touches the DB — the compaction
-// summary doesn't need full old tool bodies, so this bounds the compaction
-// request size so it can't exceed the model window (#1661).
+// thresholds (PRUNE_PROTECT / PRUNE_PROTECTED_TOOLS) but operates on the
+// in-memory copy and never touches the DB. Unlike the DB version it never gates
+// on PRUNE_MINIMUM — that threshold only decides whether to persist the pruned
+// state, whereas here the compaction summary doesn't need full old tool bodies,
+// so it always strips past PRUNE_PROTECT to bound the request size so it can't
+// exceed the model window (#1661).
 export function pruneToolOutputs(messages: MessageV2.WithParts[]): void {
   let total = 0
   let turns = 0
@@ -59,7 +61,10 @@ export function pruneToolOutputs(messages: MessageV2.WithParts[]): void {
       if (PRUNE_PROTECTED_TOOLS.includes(part.tool)) continue
       const est = Token.estimate(part.state.output)
       total += est
-      if (total > PRUNE_PROTECT) part.state.output = ""
+      if (total > PRUNE_PROTECT) {
+        part.state.output = ""
+        part.state.providerOutput = undefined
+      }
     }
   }
 }

--- a/packages/opencode/test/session/compaction-prune.test.ts
+++ b/packages/opencode/test/session/compaction-prune.test.ts
@@ -63,4 +63,26 @@ describe("pruneToolOutputs", () => {
     const toolParts = msgs.flatMap((m: any) => m.parts).filter((p: any) => p.type === "tool")
     expect(toolParts[0].state.output).toBe("tiny")
   })
+
+  test("stops the walk at a summary message, leaving pre-summary parts untouched", () => {
+    const big = "x".repeat(PRUNE_PROTECT * 5)
+    const msgs = [
+      userMsg("old"),
+      assistantMsg([toolPart("read", big)]),                      // pre-summary, would be stripped if reached
+      assistantMsg([{ type: "text", text: "summarized" }], true), // summary boundary
+      userMsg("mid"),
+      assistantMsg([toolPart("grep", big)]),                       // post-summary, outside the protected tail
+      userMsg("recent"),
+      assistantMsg([toolPart("edit", "small")]),                   // recent tail, protected
+      userMsg("last"),
+    ]
+    pruneToolOutputs(msgs)
+    const toolParts = msgs.flatMap((m: any) => m.parts).filter((p: any) => p.type === "tool")
+    // The walk broke at the summary, so the pre-summary read output is untouched.
+    expect(toolParts[0].state.output).toBe(big)
+    // The post-summary grep output is old enough to be stripped.
+    expect(toolParts[1].state.output).toBe("")
+    // The recent tail keeps its output.
+    expect(toolParts[2].state.output).toBe("small")
+  })
 })

--- a/packages/opencode/test/session/compaction-prune.test.ts
+++ b/packages/opencode/test/session/compaction-prune.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import { pruneToolOutputs, PRUNE_PROTECT, PRUNE_PROTECTED_TOOLS } from "../../src/session/compaction"
+import { MessageID } from "../../src/session/schema"
+
+function toolPart(tool: string, output: string, completed = true) {
+  return {
+    type: "tool",
+    tool,
+    state: { status: completed ? "completed" : "pending", input: {}, output, time: { start: 0, end: 0 } },
+  } as any
+}
+
+function userMsg(text: string) {
+  return { info: { id: MessageID.ascending(), role: "user" }, parts: [{ type: "text", text }] } as any
+}
+
+function assistantMsg(parts: any[], summary = false) {
+  return { info: { id: MessageID.ascending(), role: "assistant", summary }, parts } as any
+}
+
+describe("pruneToolOutputs", () => {
+  test("strips old completed tool outputs past PRUNE_PROTECT", () => {
+    // est = len/4 => ~50K tokens, past the 40K protect budget.
+    const big = "x".repeat(PRUNE_PROTECT * 5)
+    // The read output sits more than the protected 2 turns back, so it's
+    // eligible for stripping; the edit output is inside the protected window.
+    const msgs = [
+      userMsg("first"),
+      assistantMsg([toolPart("read", big)]),   // large old output
+      userMsg("second"),
+      assistantMsg([toolPart("edit", "small")]),
+      userMsg("third"),
+    ]
+    pruneToolOutputs(msgs)
+    const toolParts = msgs.flatMap((m: any) => m.parts).filter((p: any) => p.type === "tool")
+    // The large old output (before the protected 2 turns) must be stripped.
+    expect(toolParts[0].state.output).toBe("")
+    // Recent turn (within protection) keeps its output.
+    expect(toolParts[1].state.output).toBe("small")
+  })
+
+  test("keeps protected tools' outputs", () => {
+    const big = "x".repeat(PRUNE_PROTECT * 5)
+    // The skill output is old enough to be stripped, but skill is protected.
+    const msgs = [
+      userMsg("first"),
+      assistantMsg([toolPart(PRUNE_PROTECTED_TOOLS[0], big)]),  // protected tool
+      userMsg("second"),
+      userMsg("third"),
+    ]
+    pruneToolOutputs(msgs)
+    const toolParts = msgs.flatMap((m: any) => m.parts).filter((p: any) => p.type === "tool")
+    expect(toolParts[0].state.output).toBe(big)  // not stripped
+  })
+
+  test("leaves small sessions untouched", () => {
+    const msgs = [
+      userMsg("hi"),
+      assistantMsg([toolPart("read", "tiny")]),
+      userMsg("bye"),
+    ]
+    pruneToolOutputs(msgs)
+    const toolParts = msgs.flatMap((m: any) => m.parts).filter((p: any) => p.type === "tool")
+    expect(toolParts[0].state.output).toBe("tiny")
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1661. Compaction fails with "context exceeds model limit" even when the thread's live token count is well under the model window (e.g. 100k used vs 1M window) — large tool outputs serialized into the compaction request inflate it past the limit.

**Root cause:** `packages/opencode/src/session/compaction.ts` has a DB `prune()` for tool outputs that is defined but **never called**. `compaction.process` builds its `modelMessages` from `selected.head` via `toModelMessagesEffect` WITHOUT pruning old tool outputs, so a session with big tool bodies (file reads, diffs) overflows the compaction model.

**Fix:** strip old tool outputs on the **in-memory copy** before serialization:
- New `pruneToolOutputs(messages)` mirrors the DB prune walk (protect last 2 user turns + summary boundary + `PRUNE_PROTECTED_TOOLS`, accumulate past `PRUNE_PROTECT`, strip `output` **and** `providerOutput`).
- Called in `compaction.process` after `structuredClone(selected.head)` and before `toModelMessagesEffect` — never touches the DB or the visible transcript.

## Test Plan

- [x] 4 focused tests: strips old outputs past `PRUNE_PROTECT`; keeps protected `skill` outputs; small sessions untouched; summary boundary stops the walk.
- [x] `bun typecheck` clean; session suite 913 pass no regression.

## Notes

- The in-memory strip is the right scope for #1661 (it bounds the compaction *request*). The DB `prune()` remains unwired (separate storage-savings enhancement).
- Known limitation (documented in review): tool `input` and non-provider-executed structured output are not bounded — the fix targets the common large-`output` case (read/bash/edit/write).