### PR TITLE
fix(memory): stop promising memory loads itself while writing is off

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -343,7 +343,7 @@ const InfoSchema = Schema.Struct({
     Schema.Struct({
       disable_write: Schema.optional(Schema.Boolean).annotate({
         description:
-          "Stop WRITING new memory. Default: false (memory is written). When true, no new memory is produced — session checkpoint.md, project MEMORY.md, notes.md and per-task progress.md are never written, the high-pressure 'save your learnings to memory' nudge is suppressed, and automatic dream/distill runs are skipped. READING is deliberately unaffected: existing memory still loads into session-rebuild context and the builtin `memory` search tool keeps working. Nothing is ever deleted — set it back to false to resume writing on top of the existing files.",
+          "Stop WRITING new memory. Default: false (memory is written). When true, no new memory is produced — session checkpoint.md, project MEMORY.md, notes.md and per-task progress.md are never written, the high-pressure 'save your learnings to memory' nudge is suppressed, and automatic dream/distill runs are skipped. Existing memory stays READABLE on demand: the builtin `memory` search tool keeps working and the files can still be read directly. What does stop is the AUTOMATIC injection — checkpoint rebuild is short-circuited to compaction while writing is off, and the memory dumps that a rebuild would have placed in context are only produced by that rebuild, so nothing is loaded on its own; an agent that wants memory has to search or read for it. Nothing is ever deleted — set it back to false to resume writing on top of the existing files.",
       }),
       cc_index: Schema.optional(Schema.Boolean).annotate({
         description:

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -563,14 +563,23 @@ export const layer = Layer.effect(
      * What the user is told when a rebuild degrades to compaction *because the
      * memory write switch is off* — not because anything failed.
      *
-     * With `memory.disable_write` on, no checkpoint can ever exist for the
-     * session, so `rebuildEnsuringCheckpoint` returns "memory-write-off" on the
-     * spot and every overflow degrades to compaction. That is the switch working
-     * as asked, but the only trace of it was a log line ("memory writing
-     * disabled, skipping checkpoint") no user reads — and the one message that IS
-     * surfaced, `compactedInsteadMsg`, blames "the checkpoint writer failed",
-     * which reads like a bug worth reporting. So the two causes get two texts:
-     * this one names the switch.
+     * With `memory.disable_write` on, no *new* checkpoint can be written, and
+     * `rebuildEnsuringCheckpoint` returns "memory-write-off" at step 0 — before
+     * `rebuildFromCheckpoint` — so every overflow degrades to compaction. Note
+     * what that means and why it is deliberate: a checkpoint written *before* the
+     * switch was turned on can still be sitting on disk, and it is deliberately
+     * NOT rebuilt from either. The switch is "memory is inert", not merely "no new
+     * files": rebuilding would resume the checkpoint lifecycle the switch exists to
+     * stop, and it is the rebuild that injects the memory dumps into context. Do
+     * not "improve" this into a probe for an existing checkpoint — that is a
+     * behaviour change, not a bug fix. On-demand reads are the supported path while
+     * the switch is on (the `memory` search tool, or reading the files).
+     *
+     * That is the switch working as asked, but the only trace of it was a log line
+     * ("memory writing disabled, skipping checkpoint") no user reads — and the one
+     * message that IS surfaced, `compactedInsteadMsg`, blames "the checkpoint
+     * writer failed", which reads like a bug worth reporting. So the two causes get
+     * two texts: this one names the switch.
      *
      * Single-language English, deliberately: this text is persisted into the
      * session record, which the TUI, headless `run --format json`, and every

--- a/packages/opencode/src/tool/memory-path-guard.ts
+++ b/packages/opencode/src/tool/memory-path-guard.ts
@@ -177,15 +177,19 @@ export function assertMemoryWriteAllowed(input: {
   // Memory write switch. Deliberately worded so the refusal cannot be mistaken
   // for a path/permission problem — a model that reads "not allowed here" tends to
   // retry a different memory path, which would just loop. Says WRITING is off, not
-  // that memory is off: reads still work. English only, like every other message
-  // this module throws: it has no locale to consult, and the consuming client
-  // that surfaces it carries its own translations.
+  // that memory is off: existing memory is still readable. But it must not promise
+  // AUTOMATIC availability — while writing is off, checkpoint rebuild short-circuits
+  // to compaction, and the memory dumps only a rebuild produces never appear. So the
+  // reader is told to go get it, not that it will arrive. English only, like every
+  // other message this module throws: it has no locale to consult, and the consuming
+  // client that surfaces it carries its own translations.
   if (input.writeEnabled === false) {
     throw new Error(
       `Memory WRITING is disabled: config \`memory.disable_write\` is true, so no new memory may be written.\n` +
         `Refused: ${target}.\n` +
         `Do NOT retry with another memory path — every path under ${memoryRoot} is refused while writing is off.\n` +
-        `Reading is unaffected: existing memory still loads into session context and the \`memory\` search tool still works.\n` +
+        `Existing memory is still READABLE: the \`memory\` search tool works and you can read files under ${memoryRoot} directly.\n` +
+        `It is NOT loaded for you automatically while writing is off — checkpoint rebuild falls back to compaction, so search or read it explicitly when you need it.\n` +
         `To re-enable, set \`memory.disable_write: false\` in config.`,
     )
   }

--- a/packages/opencode/test/tool/memory-write-gate.test.ts
+++ b/packages/opencode/test/tool/memory-write-gate.test.ts
@@ -52,8 +52,18 @@ describe("assertWriteAllowed × memory write switch (W5)", () => {
           expect(message).not.toMatch(/[\u4e00-\u9fff]/)
           // Must not read as a path/permission problem, or the model retries elsewhere.
           expect(message).toContain("Do NOT retry with another memory path")
-          // Must not claim memory as a whole is off — reads still work.
-          expect(message).toContain("Reading is unaffected")
+          // Must not claim memory as a whole is off — existing memory stays readable.
+          expect(message).toContain("READABLE")
+          // ...but must NOT promise it arrives on its own. While writing is off,
+          // checkpoint rebuild short-circuits to compaction, and the memory dumps only a
+          // rebuild produces never appear — so a message that says memory "still loads
+          // into context" sends the reader to wait for something that will not come.
+          // Negative invariant, not a swapped literal: any future rewording that
+          // reintroduces the automatic-availability promise fails here.
+          expect(message).not.toMatch(/loads? into (session|context)/i)
+          expect(message).not.toMatch(/reading is unaffected/i)
+          // And it must say what to do instead.
+          expect(message).toMatch(/search or read it explicitly/i)
         }),
       { outsideGit: true, config: { memory: { disable_write: true } } },
     ),


### PR DESCRIPTION
## Problem

`memory.disable_write` is documented — and its refusal message worded — as:

> READING is deliberately unaffected: existing memory still loads into session-rebuild context and the builtin `memory` search tool keeps working.

The second half of that sentence is false, and it names the exact channel that does not run:

- the memory dumps are placed in context by a **checkpoint rebuild**;
- while writing is off, `rebuildEnsuringCheckpoint` returns `memory-write-off` at **step 0**, before `rebuildFromCheckpoint` is ever reached.

So the one mechanism the copy promised is precisely the one that is short-circuited. The switch also skips rebuilding from a checkpoint that already exists on disk from before the switch was turned on. That is intended — no new checkpoint can be written, so rebuild degrades to compaction and says so — but it means nothing is loaded on its own.

The `memory` search tool half is true, and nothing is deleted. The claim that needed correcting is *automatic availability*.

## Evidence

Measured with a control arm, on an isolated `MIMOCODE_HOME` sandbox with `MIMOCODE_PURE=true` and a pinned models file:

- switch **on**, all tools denied, model asked for a sentinel string held only in project memory → it answered that no project memory was in its context;
- switch **off**, same prompt → **identical answer**.

The control arm is the load-bearing half: it shows the injection channel is inert in both states rather than being broken by the switch, which is what localises the defect to the copy rather than to the guard.

## Change

Three strings and one test, no behaviour change.

- **`config/config.ts`** — the `disable_write` schema description. Now separates what stays available on demand (search tool, reading the files) from what stops (the automatic injection), and says why: rebuild short-circuits to compaction, and only a rebuild produces the dumps.
- **`tool/memory-path-guard.ts`** — the write-refusal thrown at the model. `Reading is unaffected: … still loads into session context` becomes an explicit two-liner: existing memory is READABLE via the search tool or by reading files, and it is **not** loaded automatically, so search or read it explicitly. This matters more than doc accuracy: the reader is a model deciding what to do next, and the old wording told it to expect context that will not arrive.
- **`session/prompt.ts`** — a comment that asserted a false invariant: *"With `memory.disable_write` on, no checkpoint can ever exist for the session."* One can exist, written before the switch was flipped; it is deliberately not rebuilt from. Left as-is, that comment invites a future reader to "fix" the guard into probing for an existing checkpoint — a behaviour change dressed as a bug fix. The comment now states the real invariant and says not to do that. The user-facing `MEMORY_WRITE_OFF_FALLBACK_NOTICE` next to it was already accurate and is untouched.

## Test

`memory-write-gate.test.ts` pinned the old wording with `expect(message).toContain("Reading is unaffected")`. It is re-pinned as a **negative invariant** rather than swapped to the new literal:

    expect(message).not.toMatch(/loads? into (session|context)/i)
    expect(message).not.toMatch(/reading is unaffected/i)
    expect(message).toMatch(/search or read it explicitly/i)

Re-anchoring to the new literal would pin only today's bytes and let a future edit quietly reintroduce the promise. The negative form fails on any rewording that brings it back.

## Verification

- `bun run --cwd packages/opencode typecheck` — clean
- `bun test test/tool/memory-write-gate.test.ts` — 5 pass / 0 fail (13 `expect()` calls)
- prettier drift compared per-file against the unmodified `HEAD`: `config.ts` 1 hunk both sides, `prompt.ts` 1 both sides, `memory-path-guard.ts` clean both sides — **no new drift introduced**; `prettier --write` was not run (known hazard on these files)

## Not verified

- **No E2E in this PR.** The behaviour is unchanged, and the measurement that motivates the wording was taken separately (described above) rather than re-run here.
- **The "checkpoint existed before the switch was flipped" case is a code-reading conclusion**, not an observed run — the guard sits before `rebuildFromCheckpoint`, so an existing checkpoint cannot be reached, but forcing a real overflow to demonstrate it was not attempted.
- Only the two overclaiming strings were changed; other `disable_write` prose (the fallback notice, the log line) was read and found accurate, but the audit was a grep for this specific claim, not a full copy review.