### PR TITLE
docs: remove free MiMo Auto API mentions from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 MiMoCode is a terminal-native AI coding assistant. It can read and write code, run commands, manage Git, and use a persistent memory system to keep a deep understanding of your project across sessions while continuously improving itself.
 
-MiMo Auto is built in as a free-for-limited-time channel, so you can start with zero configuration. MiMoCode also supports connecting to any mainstream LLM provider API.
+MiMoCode supports connecting to any mainstream LLM provider API.
 
 ---
 
@@ -39,7 +39,6 @@ mimo
 ```
 
 The first launch guides you through configuration automatically. Supported options:
-- **MiMo Auto (free for a limited time)** — anonymous channel, zero configuration
 - **Xiaomi MiMo Platform** — OAuth login
 - **Codex (ChatGPT Pro/Plus)** — OpenAI OAuth login
 - **Import from Claude Code** — migrate existing authentication in one step

--- a/README.zh.md
+++ b/README.zh.md
@@ -18,7 +18,7 @@
 
 MiMoCode 是一个终端原生的 AI 编程助手。它能读写代码、执行命令、管理 Git，通过持久化记忆系统，在多次会话间保持对你项目的深度理解，并自我进化。
 
-内置 MiMo Auto 限时免费通道——零配置即可开始使用。也支持接入各家主流 LLM 厂商 API。
+支持接入各家主流 LLM 厂商 API。
 
 ---
 
@@ -39,7 +39,6 @@ mimo
 ```
 
 首次启动自动引导配置。支持：
-- **MiMo Auto（限时免费）** — 匿名通道，零配置
 - **小米 MiMo 平台** — OAuth 登录
 - **Codex（ChatGPT Pro/Plus）** — OpenAI OAuth 登录
 - **从 Claude Code 导入** — 一键迁移已有认证


### PR DESCRIPTION
## Summary
- Remove MiMo Auto limited-time free channel wording from the intro and first-launch config options in `README.md` and `README.zh.md`.

## Test plan
- [ ] Spot-check both READMEs for remaining free-API / MiMo Auto free mentions
- [ ] Confirm supported auth options list still reads correctly