### PR TITLE
chore(sdk): sync generated types missed by earlier commits

### DIFF
--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2299,6 +2299,10 @@ export type Config = {
   }
   memory?: {
     /**
+     * Stop WRITING new memory. Default: false (memory is written). When true, no new memory is produced — session checkpoint.md, project MEMORY.md, notes.md and per-task progress.md are never written, the high-pressure 'save your learnings to memory' nudge is suppressed, and automatic dream/distill runs are skipped. Existing memory stays READABLE on demand: the builtin `memory` search tool keeps working and the files can still be read directly. What does stop is the AUTOMATIC injection — checkpoint rebuild is short-circuited to compaction while writing is off, and the memory dumps that a rebuild would have placed in context are only produced by that rebuild, so nothing is loaded on its own; an agent that wants memory has to search or read for it. Nothing is ever deleted — set it back to false to resume writing on top of the existing files.
+     */
+    disable_write?: boolean
+    /**
      * Index Claude Code memory (~/.claude/projects/<slug>/memory) and expose under scope='cc'. Default: false. Note: when enabled, every mimocode agent (build/explore/subagents) can search these memories via the builtin `memory` tool — including CC's `type: user` (your role/preferences) and `type: feedback` (your guidance) categories. CC originally writes them for future CC sessions; flipping this on widens the consumer set to mimocode agents on the same machine. Leave disabled (default) if you don't want personal context recallable from a prompt-injection-vulnerable agent.
      */
     cc_index?: boolean
@@ -2954,6 +2958,7 @@ export type Agent = {
   modelRef?: string
   variant?: string
   prompt?: string
+  completionGate?: boolean
   options: {
     [key: string]: unknown
   }


### PR DESCRIPTION
## Summary

Earlier commits changed the server config/agent schemas but landed without regenerating the JavaScript SDK, so `packages/sdk/js/src/v2/gen/types.gen.ts` drifted from the OpenAPI spec. This is the missing sync — no hand-written changes.

Two fields were missing:

- `Config.memory.disable_write` — added in #2040 (`bce8bccf`), description later reworded in #2071 (`27f65465`)
- `Agent.completionGate` — added in `db4f4a76`

## How it was produced

Regenerated in a clean worktree off `main` (`192938ef`):

```
bun ci
./packages/sdk/js/script/build.ts
```

The result is exactly the two additions above — no other generated file changed.

## Verification

- `./packages/sdk/js/script/build.ts` — PASS (includes its own `bun tsc` step)
- `bun typecheck` in `packages/sdk/js` — PASS (clean, no output)