### PR TITLE
fix(release): widen npmmirror sync window, drop auto-retry, exit non-zero on failure

### DIFF
--- a/script/sync-registry.ts
+++ b/script/sync-registry.ts
@@ -40,7 +40,7 @@ type RegistryKey = keyof typeof REGISTRIES
 
 const CONCURRENCY = 5
 const POLL_INTERVAL = 10000
-const POLL_TIMEOUT = 120000
+const POLL_TIMEOUT = 600000
 
 async function syncNpmmirror(packageName: string) {
   const encoded = encodeURIComponent(packageName)
@@ -101,10 +101,13 @@ async function runConcurrent<T>(items: T[], concurrency: number, fn: (item: T) =
   await Promise.all(workers)
 }
 
-async function syncPass(packages: string[]) {
+async function syncToNpmmirror() {
+  console.log(`\n▶ Syncing to npmmirror (${REGISTRIES.npmmirror.syncUrl})`)
+  console.log(`  Triggering sync for ${PACKAGES.length} packages...\n`)
+
   const tasks: { pkg: string; taskId: string }[] = []
   const failed: string[] = []
-  await runConcurrent(packages, CONCURRENCY, async (name) => {
+  await runConcurrent(PACKAGES, CONCURRENCY, async (name) => {
     const taskId = await syncNpmmirror(name)
     if (!taskId) {
       failed.push(name)
@@ -121,25 +124,15 @@ async function syncPass(packages: string[]) {
     console.log(`  ${icon} ${task.pkg}: ${result}`)
     if (result !== "success") failed.push(task.pkg)
   })
-  return failed
-}
 
-async function syncToNpmmirror() {
-  console.log(`\n▶ Syncing to npmmirror (${REGISTRIES.npmmirror.syncUrl})`)
-  console.log(`  Triggering sync for ${PACKAGES.length} packages...\n`)
-
-  const failed = await syncPass(PACKAGES)
-  if (failed.length === 0) return
-
-  console.log(`\n  ⟳ Retrying ${failed.length} failed/timed-out packages...\n`)
-  const stillFailed = await syncPass(failed)
-  if (stillFailed.length === 0) {
-    console.log(`\n  ✓ All packages synced after retry.`)
+  if (failed.length === 0) {
+    console.log(`\n  ✓ All packages synced.`)
     return
   }
 
-  console.log(`\n  ⚠️  ${stillFailed.length}/${PACKAGES.length} packages NOT synced after retry:`)
-  for (const pkg of stillFailed) console.log(`     ✗ ${pkg}`)
+  console.log(`\n  ⚠️  ${failed.length}/${PACKAGES.length} packages NOT synced:`)
+  for (const pkg of failed) console.log(`     ✗ ${pkg}`)
+  console.log(`\n  ↳ Re-run \`./script/sync-registry.ts npmmirror\` to retry.`)
 }
 
 async function syncToProxy(key: RegistryKey) {

--- a/script/sync-registry.ts
+++ b/script/sync-registry.ts
@@ -127,12 +127,13 @@ async function syncToNpmmirror() {
 
   if (failed.length === 0) {
     console.log(`\n  ✓ All packages synced.`)
-    return
+    return failed
   }
 
   console.log(`\n  ⚠️  ${failed.length}/${PACKAGES.length} packages NOT synced:`)
   for (const pkg of failed) console.log(`     ✗ ${pkg}`)
   console.log(`\n  ↳ Re-run \`./script/sync-registry.ts npmmirror\` to retry.`)
+  return failed
 }
 
 async function syncToProxy(key: RegistryKey) {
@@ -154,14 +155,17 @@ console.log("═══ MiMoCode Registry Sync ═══")
 console.log(`Version: ${Script.version} (${Script.channel})`)
 console.log(`Packages: ${PACKAGES.length}`)
 
-if (!target || target === "all" || target === "npmmirror") {
-  await syncToNpmmirror()
-}
+const failed = !target || target === "all" || target === "npmmirror" ? await syncToNpmmirror() : []
 if (!target || target === "all" || target === "tencent") {
   await syncToProxy("tencent")
 }
 if (!target || target === "all" || target === "huawei") {
   await syncToProxy("huawei")
+}
+
+if (failed.length > 0) {
+  console.log(`\n═══ Failed: ${failed.length} package(s) not synced to npmmirror ═══`)
+  process.exit(1)
 }
 
 console.log("\n═══ Done ═══")


### PR DESCRIPTION
## Summary

`script/sync-registry.ts` mirrors a freshly published release to the Chinese registries. Three changes to the npmmirror path:

- **Poll window 2 min → 10 min** (`POLL_TIMEOUT` 120000 → 600000, interval still 10s). The old window was short enough that healthy-but-slow syncs were reported as failures.
- **Auto-retry removed.** The retry pass re-issued `PUT /-/package/{name}/syncs` for packages that had merely not finished in time, so a slow sync got queued twice and still reported as failed. Now a single pass, and the summary prints the exact re-run command — recovery is an operator decision.
- **Non-zero exit when packages are left behind.** The script used to report failures on stdout and exit 0, so a release flow chaining `publish` and `sync` could not distinguish a partial mirror sync from a clean one. With auto-retry gone, that signal matters. Tencent/Huawei are cache warming only and deliberately stay out of the exit code.

Docs for this flow live in the internal repo and are updated there separately.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit --skipLibCheck --strict --types bun` on the file | PASS, 0 errors |
| `oxlint -c .oxlintrc.json script/sync-registry.ts` | 3 warnings / 0 errors — identical to the pre-change baseline (pre-existing) |
| `prettier` (run from inside the worktree) | no new violations; the one remaining diff at `syncNpmmirror`'s sibling `fetch` call predates this branch |
| Failure path: `syncUrl` pointed at a local server returning 503, target `npmmirror` | 13/13 reported failed, `═══ Failed: 13 package(s) not synced to npmmirror ═══`, **exit 1** |
| Success path: `sync-registry.ts tencent` (read-only proxy warming) | 13/13 warmed, `═══ Done ═══`, **exit 0** |
| Bad argument: `sync-registry.ts bogus` | usage message, **exit 1** (unchanged) |

The real npmmirror sync API was never invoked during verification — the failure path used a local mock, since `PUT .../syncs` is a live side effect on a public mirror.

## Notes for reviewers

- Worst-case runtime grows roughly 2.3× (13 packages at concurrency 5 ⇒ 3 per busiest worker; ~13 min before with the retry pass, ~30 min now). This script is not invoked by any workflow in `.github/`, so it is an operator wait, not a CI timeout.
- `pollSyncStatus` checks its deadline *before* sleeping, so the true per-package ceiling is `POLL_TIMEOUT + POLL_INTERVAL` ≈ 610s.
- The poll-failure branch of the exit code (a package that queues successfully but then polls to `error`/`timeout`) was confirmed by reading the code — `if (result !== "success")` covers both — not by direct observation; the mock fails at the trigger stage, which skips polling.
- Pre-existing and untouched: a *thrown* fetch error in `warmProxy` (DNS/ECONNREFUSED, as opposed to a non-2xx response) still surfaces as an unhandled rejection and a non-zero exit, so the "proxy failures never affect the exit code" rule holds for HTTP status, not network-level errors.