### PR TITLE
feat(cli): add --yolo permission bypass alias

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -290,6 +290,7 @@ export const RunCommand = cmd({
         describe: "role for the injected message (assistant injects text as model output then triggers continuation)",
       })
       .option("dangerously-skip-permissions", {
+        alias: ["yolo"],
         type: "boolean",
         describe: "auto-approve permissions that are not explicitly denied (dangerous!)",
         default: false,

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -202,6 +202,7 @@ export const TuiThreadCommand = cmd({
         default: false,
       })
       .option("dangerously-skip-permissions", {
+        alias: ["yolo"],
         type: "boolean",
         describe: "auto-approve permissions that are not explicitly denied (dangerous!)",
         default: false,

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/commands.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/commands.md
@@ -29,7 +29,7 @@ Invoked from the shell. `mimo` with no command opens the TUI.
 
 Run `mimo <command> --help` for flags on any command.
 
-Notable TUI flags: `--continue`/`-c` (resume last session), `--session`/`-s`, `--model`/`-m`, `--agent`, `--never-ask`, `--trust`, and `--dangerously-skip-permissions` (auto-approve everything not explicitly denied; prompts once for confirmation — see permissions.md).
+Notable TUI flags: `--continue`/`-c` (resume last session), `--session`/`-s`, `--model`/`-m`, `--agent`, `--never-ask`, `--trust`, and `--dangerously-skip-permissions`/`--yolo` (auto-approve everything not explicitly denied; prompts once for confirmation — see permissions.md).
 
 For terminal compatibility, TUI rendering or lag, and local rendering over SSH with `mimo serve` + `mimo attach`, see @guide.md.
 

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/permissions.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/permissions.md
@@ -79,9 +79,9 @@ For trusted, disposable environments (containers, sandboxes, CI) you can auto-ap
 
 | Surface | How |
 |---------|-----|
-| TUI (`mimo`) | `mimo --dangerously-skip-permissions` |
+| TUI (`mimo`) | `mimo --dangerously-skip-permissions` or `mimo --yolo` |
 | TUI at runtime | `/skip-permissions` — toggle mid-session, instance-wide, inherited by subagents |
-| Headless (`mimo run`) | `mimo run --dangerously-skip-permissions "<prompt>"` |
+| Headless (`mimo run`) | `mimo run --dangerously-skip-permissions "<prompt>"` or `mimo run --yolo "<prompt>"` |
 | Any surface (env) | `MIMOCODE_PERMISSION='"allow"'` or `MIMOCODE_DANGEROUSLY_SKIP_PERMISSIONS=1` |
 
 The `/skip-permissions` toggle auto-allows permission asks but keeps `deny` rules in force; forced-ask operations (e.g. destructive bash) still prompt and auto-reject after 60s (`MIMOCODE_SKIP_ALL_FORCED_ASK_TIMEOUT_MS`) with feedback the model can act on, so unattended runs don't hang.

--- a/packages/opencode/test/cli/yolo.test.ts
+++ b/packages/opencode/test/cli/yolo.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import yargs from "yargs/yargs"
+import { RunCommand } from "../../src/cli/cmd/run"
+import { TuiThreadCommand } from "../../src/cli/cmd/tui/thread"
+
+describe("--yolo", () => {
+  test.each([
+    ["tui", TuiThreadCommand],
+    ["run", RunCommand],
+  ])("aliases --dangerously-skip-permissions for %s", async (_name, command) => {
+    if (typeof command.builder !== "function") throw new Error("command builder is not a function")
+
+    const args = await (await command.builder(yargs([]))).parseAsync(["--yolo"])
+
+    expect(args.yolo).toBe(true)
+    expect(args["dangerously-skip-permissions"]).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- add `--yolo` as an alias for `--dangerously-skip-permissions` in both TUI and headless run modes
- document the alias in the bundled MiMoCode command and permission references
- add parser coverage confirming the alias sets the canonical permission bypass flag

## Testing

- `bun test test/cli/yolo.test.ts test/cli/tui/thread.test.ts`
- `bun typecheck`
- pre-push repository-wide `bun turbo typecheck`