### PR TITLE
fix(session): retry OpenAI overload stream errors

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -145,14 +145,20 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   const responseBody = JSON.stringify(body)
   if (body.type !== "error") return
 
+  if (
+    body?.error?.code === "server_error" ||
+    body?.error?.code === "server_is_overloaded" ||
+    body?.error?.type === "service_unavailable_error"
+  ) {
+    return {
+      type: "api_error",
+      message: typeof body?.error?.message === "string" ? body.error.message : "OpenAI server error",
+      isRetryable: true,
+      responseBody,
+    }
+  }
+
   switch (body?.error?.code) {
-    case "server_error":
-      return {
-        type: "api_error",
-        message: typeof body?.error?.message === "string" ? body.error.message : "OpenAI server error",
-        isRetryable: true,
-        responseBody,
-      }
     case "context_length_exceeded":
       return {
         type: "context_overflow",

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -179,4 +179,24 @@ describe("provider stream error", () => {
       responseBody: JSON.stringify(input),
     })
   })
+
+  test("marks OpenAI service_unavailable_error events as retryable", () => {
+    const input = {
+      type: "error",
+      sequence_number: 2,
+      error: {
+        type: "service_unavailable_error",
+        code: "server_is_overloaded",
+        message: "Our servers are currently overloaded. Please try again later.",
+        param: null,
+      },
+    }
+
+    expect(parseStreamError(input)).toStrictEqual({
+      type: "api_error",
+      message: input.error.message,
+      isRetryable: true,
+      responseBody: JSON.stringify(input),
+    })
+  })
 })

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -148,6 +148,30 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error)).toBe(input.error.message)
   })
 
+  test("retries OpenAI service_unavailable_error stream events", () => {
+    const input = {
+      type: "error",
+      sequence_number: 2,
+      error: {
+        type: "service_unavailable_error",
+        code: "server_is_overloaded",
+        message: "Our servers are currently overloaded. Please try again later.",
+        param: null,
+      },
+    }
+    const error = MessageV2.fromError(input, { providerID })
+
+    expect(error).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: input.error.message,
+        isRetryable: true,
+        responseBody: JSON.stringify(input),
+      },
+    })
+    expect(SessionRetry.retryable(error)).toBe(input.error.message)
+  })
+
   test("maps too_many_requests json messages", () => {
     const error = wrap(JSON.stringify({ type: "error", error: { type: "too_many_requests" } }))
     expect(SessionRetry.retryable(error)).toBe("Too Many Requests")


### PR DESCRIPTION
### Issue for this PR

Closes #2083

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI Responses can report transient capacity failures as `service_unavailable_error` / `server_is_overloaded` stream events. Classify those events as retryable so they enter MiMoCode's existing retry policy instead of terminating the session with the raw provider event.

Adds parser-level and end-to-end retry regression coverage using the observed event shape.

### How did you verify your code works?

- Focused provider/session retry tests: 65 passed
- All four CI unit-test shards passed with Bun 1.3.14
- `bun lint`: 0 errors
- Full repository typecheck: passed

Shard 1 initially hit an unrelated workflow timing flake; the test passed in isolation and the full shard passed on rerun.

### Screenshots / recordings

Not applicable; no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
