### PR TITLE
feat(bash): exempt temp-scoped deletes from the forced-ask confirmation

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -1,6 +1,6 @@
 import z from "zod"
 import os from "os"
-import { createWriteStream, existsSync, readFileSync } from "node:fs"
+import { createWriteStream, existsSync, readFileSync, realpathSync } from "node:fs"
 import * as Tool from "./tool"
 import path from "path"
 import DESCRIPTION from "./bash.txt"
@@ -32,6 +32,43 @@ import * as BashTokenEfficientHeuristic from "./bash_token_efficient_heuristic"
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.MIMOCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
 const PS = new Set(["powershell", "pwsh"])
+// Delete targets under the OS temp dir are exempt from the forced-ask
+// confirmation: scratch space is where an agent legitimately churns files, and
+// nothing there is the user's durable work. The exemption is deliberately
+// narrow — see `tmpOnlyDelete`, which grants it ONLY when every path argument
+// of every delete command resolves, unambiguously, inside a temp root.
+//
+// macOS reports /tmp and /var as symlinks into /private, so containment must be
+// checked on REALPATHS: a lexical check would reject the literal "/tmp/x" even
+// though it lives inside the canonical os.tmpdir() jail. "/tmp" is listed
+// alongside os.tmpdir() because on macOS they are DIFFERENT directories
+// (/private/tmp vs /private/var/folders/...). Mirrors tool-script.ts's jail.
+function tmpRoots() {
+  return [os.tmpdir(), ...(process.platform === "win32" ? [] : ["/tmp"])]
+}
+
+function realpathBestEffort(p: string) {
+  let cur = p
+  let suffix = ""
+  while (true) {
+    try {
+      return path.join(realpathSync.native(cur), suffix)
+    } catch {
+      suffix = suffix ? path.join(path.basename(cur), suffix) : path.basename(cur)
+      const parent = path.dirname(cur)
+      if (parent === cur) return p
+      cur = parent
+    }
+  }
+}
+
+function insideTmp(resolved: string) {
+  const abs = realpathBestEffort(resolved)
+  return tmpRoots()
+    .map(realpathBestEffort)
+    .some((root) => abs !== root && abs.startsWith(root + path.sep))
+}
+
 const CWD = new Set(["cd", "push-location", "set-location"])
 const FILES = new Set([
   ...CWD,
@@ -536,6 +573,45 @@ export const BashTool = Tool.define(
       return yield* resolvePath(next, cwd, shell)
     })
 
+    // Whether EVERY delete in this command line is a plain removal confined to a
+    // temp root — the one case where the forced-ask confirmation is skipped.
+    //
+    // Fails closed on purpose, in four ways. Any single miss means "ask":
+    //   1. Only DELETE_COMMANDS qualify. Destructive git subcommands
+    //      (reset --hard, push --force, stash drop, …) act on repository state,
+    //      not on a path in tmp, so they can never earn the exemption.
+    //   2. A delete with no path arguments cannot be shown to be tmp-scoped.
+    //   3. An argument `argPath` declines to resolve — a glob, a `$VAR`, a `$(…)`
+    //      substitution (see `dynamic`) — is UNKNOWN, and unknown is not tmp.
+    //      This is the load-bearing case: `rm -rf $BUILD_DIR/*` must still ask.
+    //   4. A resolved path outside a temp root, including a root itself
+    //      (`insideTmp` requires a strict descendant, so `rm -rf /tmp` asks).
+    //   5. A path inside the PROJECT, even when the project itself lives under a
+    //      temp root (a real configuration — the test fixtures do exactly this).
+    //      Scratch space earns the exemption because it holds no durable work;
+    //      a checkout's own files are durable wherever they happen to sit.
+    const tmpOnlyDelete = Effect.fn("BashTool.tmpOnlyDelete")(function* (
+      root: Node,
+      cwd: string,
+      ps: boolean,
+      shell: string,
+    ) {
+      for (const node of commands(root)) {
+        const command = parts(node)
+        const tokens = command.map((item) => item.text)
+        if (!isDelete(tokens, ps)) continue
+        const head = ps ? tokens[0]?.toLowerCase() : tokens[0]
+        if (!head || !DELETE_COMMANDS.has(head)) return false
+        const args = pathArgs(command, ps)
+        if (args.length === 0) return false
+        for (const arg of args) {
+          const resolved = yield* argPath(arg, cwd, ps, shell)
+          if (!resolved || !insideTmp(resolved) || Instance.containsPath(resolved)) return false
+        }
+      }
+      return true
+    })
+
     const collect = Effect.fn("BashTool.collect")(function* (root: Node, cwd: string, ps: boolean, shell: string) {
       const scan: Scan = {
         dirs: new Set<string>(),
@@ -872,9 +948,17 @@ export const BashTool = Tool.define(
               // the delete UI shows the full command (including any external
               // paths it touches), so a separate bash/external_directory
               // prompt would just be a second confirmation of the same thing.
-              // MIMOCODE_AUTO_APPROVE_DELETE trusts deletes and falls back to
-              // the regular ask (where a `bash: deny` rule still blocks).
-              if (scan.deletes.size > 0 && !Flag.MIMOCODE_AUTO_APPROVE_DELETE) {
+              // Two bypasses fall back to the regular ask (where a `bash: deny`
+              // rule still blocks): MIMOCODE_AUTO_APPROVE_DELETE trusts every
+              // delete, and `tmpOnlyDelete` trusts one whose every target is
+              // provably inside a temp root — scratch space holds no durable
+              // user work, and that check fails closed on anything it cannot
+              // resolve.
+              const skipDeleteAsk =
+                scan.deletes.size === 0 ||
+                Flag.MIMOCODE_AUTO_APPROVE_DELETE ||
+                (yield* tmpOnlyDelete(root, cwd, ps, shell))
+              if (!skipDeleteAsk) {
                 yield* askDelete(ctx, scan, params.command)
               } else {
                 yield* ask(ctx, scan)

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -488,6 +488,149 @@ describe("tool.bash permissions", () => {
     })
   })
 
+  // The temp-scoped delete exemption. The interesting assertions are the
+  // fail-closed ones: an exemption that mis-fires silently authorizes an
+  // irreversible action, so every case it CANNOT prove must still ask.
+  each("skips bash_delete for a delete confined to the OS temp dir", async () => {
+    await using tmp = await tmpdir()
+    const scratch = await fs.mkdtemp(path.join(os.tmpdir(), "mimocode-bash-tmpdel-"))
+    await Bun.write(path.join(scratch, "scratch.txt"), "x")
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await Effect.runPromise(
+          bash.execute(
+            { command: `rm ${path.join(scratch, "scratch.txt")}`, description: "Remove scratch file" },
+            capture(requests),
+          ),
+        )
+        expect(requests.find((r) => r.permission === "bash_delete")).toBeUndefined()
+      },
+    })
+    await fs.rm(scratch, { recursive: true, force: true })
+  })
+
+  each("still asks for bash_delete when a temp path cannot be resolved", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const err = new Error("stop after permission")
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await expect(
+          Effect.runPromise(
+            bash.execute(
+              // $BUILD_DIR is unresolvable, so the target is UNKNOWN — and
+              // unknown must never be treated as temp-scoped.
+              { command: "rm -rf $BUILD_DIR/*", description: "Remove build dir" },
+              capture(requests, err),
+            ),
+          ),
+        ).rejects.toThrow(err.message)
+        expect(requests.find((r) => r.permission === "bash_delete")).toBeDefined()
+      },
+    })
+  })
+
+  each("still asks for bash_delete when one target of several is outside temp", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "victim.txt"), "x")
+      },
+    })
+    const scratch = await fs.mkdtemp(path.join(os.tmpdir(), "mimocode-bash-tmpdel-"))
+    await Bun.write(path.join(scratch, "scratch.txt"), "x")
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const err = new Error("stop after permission")
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await expect(
+          Effect.runPromise(
+            bash.execute(
+              {
+                command: `rm ${path.join(scratch, "scratch.txt")} ${path.join(tmp.path, "victim.txt")}`,
+                description: "Remove two files",
+              },
+              capture(requests, err),
+            ),
+          ),
+        ).rejects.toThrow(err.message)
+        expect(requests.find((r) => r.permission === "bash_delete")).toBeDefined()
+      },
+    })
+    await fs.rm(scratch, { recursive: true, force: true })
+  })
+
+  each("still asks for bash_delete for a project file even when the project is under temp", async () => {
+    // A project genuinely living under os.tmpdir() would be exempted by a naive
+    // "is it under temp?" test, taking the checkout's own files with it. The
+    // shared fixture roots tmpdirs under cwd, so this case has to build the
+    // project inside os.tmpdir() explicitly or it proves nothing.
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), "mimocode-bash-tmpproj-"))
+    const project = await fs.realpath(projectRoot)
+    await Bun.write(path.join(project, "victim.txt"), "x")
+    await Instance.provide({
+      directory: project,
+      fn: async () => {
+        const bash = await initBash()
+        const err = new Error("stop after permission")
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await expect(
+          Effect.runPromise(
+            bash.execute({ command: "rm victim.txt", description: "Remove victim" }, capture(requests, err)),
+          ),
+        ).rejects.toThrow(err.message)
+        expect(requests.find((r) => r.permission === "bash_delete")).toBeDefined()
+      },
+    })
+    await fs.rm(project, { recursive: true, force: true })
+  })
+
+  each("still asks for bash_delete on a destructive git subcommand run from temp", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const err = new Error("stop after permission")
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await expect(
+          Effect.runPromise(
+            bash.execute(
+              // Acts on repository state, not on a path in temp — never exempt.
+              { command: "git stash drop", description: "Drop stash" },
+              capture(requests, err),
+            ),
+          ),
+        ).rejects.toThrow(err.message)
+        expect(requests.find((r) => r.permission === "bash_delete")).toBeDefined()
+      },
+    })
+  })
+
+  each("still asks for bash_delete when the target is a temp root itself", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const err = new Error("stop after permission")
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        await expect(
+          Effect.runPromise(
+            bash.execute({ command: `rm -rf ${os.tmpdir()}`, description: "Remove temp root" }, capture(requests, err)),
+          ),
+        ).rejects.toThrow(err.message)
+        expect(requests.find((r) => r.permission === "bash_delete")).toBeDefined()
+      },
+    })
+  })
+
   if (process.platform === "win32") {
     if (bash) {
       test(


### PR DESCRIPTION
Deleting scratch files under the OS temp dir made an agent stall on a confirmation that protects nothing: temp holds no durable user work. Skip askDelete when every target of every delete provably resolves inside a temp root.

The exemption fails closed in five ways, because a mis-firing exemption silently authorizes an irreversible action:
  - only direct removal commands qualify; destructive git subcommands (reset --hard, stash drop, push --force) act on repository state, not a path in temp, so they are never exempt
  - a delete with no path arguments cannot be shown to be temp-scoped
  - an argument the resolver declines (glob, $VAR, $(...) substitution) is UNKNOWN, and unknown is not temp — 'rm -rf $BUILD_DIR/*' still asks
  - a resolved path outside temp, including a root itself, still asks
  - a path inside the PROJECT still asks even when the project itself lives under temp, which the test fixtures' own layout would otherwise have exempted

Containment is checked on realpaths so macOS's /tmp -> /private/tmp symlink resolves, mirroring the tool-script sandbox jail.

Each of the six tests was verified to go red with its guard removed.