### PR TITLE
fix(session): retry GPT server overload errors

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -146,6 +146,7 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   if (body.type !== "error") return
 
   switch (body?.error?.code) {
+    case "server_is_overloaded":
     case "server_error":
       return {
         type: "api_error",

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -833,6 +833,8 @@ export const layer: Layer.Layer<
             Effect.retry(
               SessionRetry.policy({
                 parse,
+                silentRetry: (error) =>
+                  SessionRetry.isGptModel(input.model) && SessionRetry.isGptServerOverloadedError(error),
                 set: (info) =>
                   isMain
                     ? status.set(ctx.sessionID, {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -30,6 +30,7 @@ export const RETRY_INITIAL_DELAY = 2000
 export const RETRY_BACKOFF_FACTOR = 2
 export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
 export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
+export const GPT_OVERLOAD_RETRIES = 3
 
 const NETWORK_ERROR_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT"])
 const SSE_TIMEOUT_MESSAGE = "SSE read timed out"
@@ -202,15 +203,43 @@ export function retryable(error: Err) {
   return undefined
 }
 
+export function isGptServerOverloadedError(error: Err): boolean {
+  if (!MessageV2.APIError.isInstance(error) || !error.data.responseBody) return false
+  const responseBody = error.data.responseBody
+
+  const body = iife(() => {
+    try {
+      return JSON.parse(responseBody)
+    } catch {
+      return undefined
+    }
+  })
+
+  return (
+    body?.type === "error" &&
+    body?.error?.type === "service_unavailable_error" &&
+    body?.error?.code === "server_is_overloaded"
+  )
+}
+
+export function isGptModel(model: { id: string; api: { id: string } }): boolean {
+  return [model.id, model.api.id].some((id) => id.toLowerCase().startsWith("gpt-"))
+}
+
 export function policy(opts: {
   parse: (error: unknown) => Err
   set: (input: { attempt: number; message: string; next: number }) => Effect.Effect<void>
+  silentRetry?: (error: Err) => boolean
 }) {
   return Schedule.fromStepWithMetadata(
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
       const error = opts.parse(meta.input)
       const message = retryable(error)
       if (!message) return Cause.done(meta.attempt)
+      if (opts.silentRetry?.(error)) {
+        if (meta.attempt > GPT_OVERLOAD_RETRIES) return Cause.done(meta.attempt)
+        return Effect.succeed([meta.attempt, Duration.zero] as [number, Duration.Duration])
+      }
       return Effect.gen(function* () {
         const wait = delay(meta.attempt, MessageV2.APIError.isInstance(error) ? error : undefined)
         const now = yield* Clock.currentTimeMillis

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -160,6 +160,26 @@ describe("provider error message", () => {
 })
 
 describe("provider stream error", () => {
+  test("marks OpenAI server overload events as retryable", () => {
+    const input = {
+      type: "error",
+      sequence_number: 2,
+      error: {
+        type: "service_unavailable_error",
+        code: "server_is_overloaded",
+        message: "Our servers are currently overloaded. Please try again later.",
+        param: null,
+      },
+    }
+
+    expect(parseStreamError(input)).toStrictEqual({
+      type: "api_error",
+      message: input.error.message,
+      isRetryable: true,
+      responseBody: JSON.stringify(input),
+    })
+  })
+
   test("marks OpenAI server_error events as retryable", () => {
     const input = {
       type: "error",

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -124,6 +124,70 @@ describe("session.retry.delay", () => {
 })
 
 describe("session.retry.retryable", () => {
+  test("recognizes GPT models by configured or API model ID", () => {
+    expect(SessionRetry.isGptModel({ id: "gpt-5.2", api: { id: "gpt-5.2" } })).toBe(true)
+    expect(SessionRetry.isGptModel({ id: "coding-model", api: { id: "gpt-5.2" } })).toBe(true)
+    expect(SessionRetry.isGptModel({ id: "claude-sonnet-4", api: { id: "claude-sonnet-4" } })).toBe(false)
+  })
+
+  test("identifies the GPT server overloaded stream error exactly", () => {
+    const body = {
+      type: "error",
+      sequence_number: 2,
+      error: {
+        type: "service_unavailable_error",
+        code: "server_is_overloaded",
+        message: "Our servers are currently overloaded. Please try again later.",
+        param: null,
+      },
+    }
+    const error = new MessageV2.APIError({
+      message: body.error.message,
+      isRetryable: true,
+      responseBody: JSON.stringify(body),
+    }).toObject() as MessageV2.APIError
+
+    expect(SessionRetry.isGptServerOverloadedError(error)).toBe(true)
+    expect(
+      SessionRetry.isGptServerOverloadedError({
+        ...error,
+        data: { ...error.data, responseBody: JSON.stringify({ ...body, error: { ...body.error, code: "server_error" } }) },
+      }),
+    ).toBe(false)
+  })
+
+  test("silently retries GPT overload three times before stopping", async () => {
+    const error = new MessageV2.APIError({
+      message: "Our servers are currently overloaded. Please try again later.",
+      isRetryable: true,
+      responseBody: JSON.stringify({
+        type: "error",
+        error: { type: "service_unavailable_error", code: "server_is_overloaded" },
+      }),
+    }).toObject() as MessageV2.APIError
+    const visible: number[] = []
+    let attempts = 0
+
+    await expect(
+      Effect.runPromise(
+        Effect.suspend(() => {
+          attempts++
+          return Effect.fail(error)
+        }).pipe(
+          Effect.retry(
+            SessionRetry.policy({
+              parse: (input) => input as MessageV2.APIError,
+              silentRetry: SessionRetry.isGptServerOverloadedError,
+              set: (info) => Effect.sync(() => visible.push(info.attempt)),
+            }),
+          ),
+        ),
+      ),
+    ).rejects.toBe(error)
+    expect(attempts).toBe(4)
+    expect(visible).toEqual([])
+  })
+
   test("retries OpenAI server_error stream events", () => {
     const input = {
       type: "error",


### PR DESCRIPTION
## Summary
- recognize OpenAI `server_is_overloaded` stream events as retryable API errors
- silently retry matching GPT overload failures up to three times without delay
- add coverage for stream parsing, GPT model detection, and retry limits

## Testing
- `bun test test/provider/error.test.ts test/session/retry.test.ts`
- `bun typecheck`