### PR TITLE
fix(auth): stop handing user credentials to child processes

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -8,6 +8,23 @@ export const OAUTH_DUMMY_KEY = "mimocode-oauth-dummy-key"
 
 const file = path.join(Global.Path.data, "auth.json")
 
+/**
+ * Credentials supplied by an embedding host (the desktop app runs the engine in-process).
+ *
+ * Kept in memory on purpose: the previous channel was `MIMOCODE_AUTH_CONTENT`, and anything in
+ * the environment is readable by every child the engine spawns — the bash tool alone turns
+ * `echo $MIMOCODE_AUTH_CONTENT` into a credential dump, and a sibling can still read
+ * `/proc/<pid>/environ` even after the child's own env is scrubbed. A module-level value has no
+ * such surface. The env var is still honored so workspace children keep working (they receive it
+ * explicitly), but hosts should prefer `inject`.
+ */
+let injected: string | undefined
+
+/** Set (or clear, with `undefined`) the in-process credentials. Read on every `all()`. */
+export function inject(content: string | undefined) {
+  injected = content
+}
+
 const fail = (message: string) => (cause: unknown) => new AuthError({ message, cause })
 
 export class Oauth extends Schema.Class<Oauth>("OAuth")({
@@ -56,9 +73,10 @@ export const layer = Layer.effect(
     const decode = Schema.decodeUnknownOption(Info)
 
     const all = Effect.fn("Auth.all")(function* () {
-      if (process.env.MIMOCODE_AUTH_CONTENT) {
+      const raw = injected ?? process.env.MIMOCODE_AUTH_CONTENT
+      if (raw) {
         try {
-          return JSON.parse(process.env.MIMOCODE_AUTH_CONTENT)
+          return JSON.parse(raw)
         } catch (err) {}
       }
 

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -1,4 +1,5 @@
 import type { Argv } from "yargs"
+import { withoutCredentials } from "@/util/credential-env"
 import { UI } from "../ui"
 import * as prompts from "@clack/prompts"
 import { AppRuntime } from "@/effect/app-runtime"
@@ -377,7 +378,7 @@ async function cleanWindowsPath() {
   `
   const result = await Process.run(["powershell", "-ep", "Bypass", "-c", script], {
     nothrow: true,
-    env: { ...process.env, MIMOCODE_UNINSTALL_DIR: installDir },
+    env: { ...withoutCredentials(process.env), MIMOCODE_UNINSTALL_DIR: installDir },
   })
   if (result.code !== 0) throw new Error(result.stderr.toString() || "Failed to clean User PATH")
 }

--- a/packages/opencode/src/effect/cross-spawn-spawner.ts
+++ b/packages/opencode/src/effect/cross-spawn-spawner.ts
@@ -1,4 +1,5 @@
 import type * as Arr from "effect/Array"
+import { withoutCredentials } from "@/util/credential-env"
 import { NodeFileSystem, NodeSink, NodeStream } from "@effect/platform-node"
 import * as NodePath from "@effect/platform-node/NodePath"
 import * as Deferred from "effect/Deferred"
@@ -104,8 +105,11 @@ export const make = Effect.gen(function* () {
     return path.resolve(opts.cwd)
   })
 
+  // withoutCredentials on the *inherited* half only: every `extendEnv: true` caller funnels
+  // through here, including the agent-controlled shell part in session/prompt.ts. A caller that
+  // passes credentials in `opts.env` on purpose (control-plane workspaces) is left alone.
   const env = (opts: ChildProcess.CommandOptions) =>
-    opts.extendEnv ? { ...globalThis.process.env, ...opts.env } : opts.env
+    opts.extendEnv ? { ...withoutCredentials(globalThis.process.env), ...opts.env } : opts.env
 
   const input = (x: ChildProcess.CommandInput | undefined): NodeChildProcess.IOType | undefined =>
     Stream.isStream(x) ? "pipe" : x

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import { withoutCredentials } from "@/util/credential-env"
 import z from "zod"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { Cause, Context, Effect, Fiber, Layer, Queue, Stream } from "effect"
@@ -143,7 +144,9 @@ export interface Interface {
 export class Service extends Context.Service<Service, Interface>()("@opencode/Ripgrep") {}
 
 function env() {
-  const env = sanitizedProcessEnv()
+  // sanitizedProcessEnv only drops undefined values — it does not drop credentials, and ripgrep
+  // has no use for them.
+  const env = withoutCredentials(sanitizedProcessEnv())
   delete env.RIPGREP_CONFIG_PATH
   return env
 }

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -1,4 +1,5 @@
 import { BusEvent } from "@/bus/bus-event"
+import { withoutCredentials } from "@/util/credential-env"
 import { Bus } from "@/bus"
 import { Log } from "../util"
 import * as LSPClient from "./client"
@@ -192,7 +193,7 @@ export const layer = Layer.effect(
                 spawn: async (root) => ({
                   process: lspspawn(item.command[0], item.command.slice(1), {
                     cwd: root,
-                    env: { ...process.env, ...item.env },
+                    env: { ...withoutCredentials(process.env), ...item.env },
                   }),
                   initialization: item.initialization,
                 }),

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1,4 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from "child_process"
+import { withoutCredentials } from "@/util/credential-env"
 import path from "path"
 import os from "os"
 import { Global } from "../global"
@@ -107,7 +108,7 @@ export const Typescript: Info = {
     const proc = spawn(bin, ["--stdio"], {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
     return {
@@ -138,7 +139,7 @@ export const Vue: Info = {
     const proc = spawn(binary, args, {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
     return {
@@ -197,7 +198,7 @@ export const ESLint: Info = {
     const proc = spawn("node", [serverPath, "--stdio"], {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
 
@@ -332,7 +333,7 @@ export const Biome: Info = {
     const proc = spawn(bin, args, {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
 
@@ -358,7 +359,7 @@ export const Gopls: Info = {
 
       log.info("installing gopls")
       const proc = Process.spawn(["go", "install", "golang.org/x/tools/gopls@latest"], {
-        env: { ...process.env, GOBIN: Global.Path.bin },
+        env: { ...withoutCredentials(process.env), GOBIN: Global.Path.bin },
         stdout: "pipe",
         stderr: "pipe",
         stdin: "pipe",
@@ -515,7 +516,7 @@ export const Pyright: Info = {
     const proc = spawn(binary, args, {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
     return {
@@ -569,7 +570,7 @@ export const ElixirLS: Info = {
         })
 
         const cwd = path.join(Global.Path.bin, "elixir-ls-master")
-        const env = { MIX_ENV: "prod", ...process.env }
+        const env = { MIX_ENV: "prod", ...withoutCredentials(process.env) }
         await Process.run(["mix", "deps.get"], { cwd, env })
         await Process.run(["mix", "compile"], { cwd, env })
         await Process.run(["mix", "elixir_ls.release2", "-o", "release"], { cwd, env })
@@ -1017,7 +1018,7 @@ export const Svelte: Info = {
     const proc = spawn(binary, args, {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
     return {
@@ -1051,7 +1052,7 @@ export const Astro: Info = {
     const proc = spawn(binary, args, {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
     return {
@@ -1302,7 +1303,7 @@ export const YamlLS: Info = {
     const proc = spawn(binary, args, {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
     return {
@@ -1469,7 +1470,7 @@ export const PHPIntelephense: Info = {
     const proc = spawn(binary, args, {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
     return {
@@ -1553,7 +1554,7 @@ export const BashLS: Info = {
     const proc = spawn(binary, args, {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
     return {
@@ -1748,7 +1749,7 @@ export const DockerfileLS: Info = {
     const proc = spawn(binary, args, {
       cwd: root,
       env: {
-        ...process.env,
+        ...withoutCredentials(process.env),
       },
     })
     return {
@@ -1820,7 +1821,7 @@ export const Nixd: Info = {
       process: spawn(nixd, [], {
         cwd: root,
         env: {
-          ...process.env,
+          ...withoutCredentials(process.env),
         },
       }),
     }

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -1,4 +1,5 @@
 import { dynamicTool, type Tool, jsonSchema, type JSONSchema7 } from "ai"
+import { withoutCredentials } from "@/util/credential-env"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
@@ -584,8 +585,12 @@ export const layer = Layer.effect(
         command: cmd,
         args,
         cwd,
+        // withoutCredentials: MCP servers are third-party binaries running as the user.
+        // Note for `opencode` configured as its own MCP server: that nested engine no longer
+        // inherits the host's credentials or config content, and falls back to reading auth.json
+        // and the config file from disk — which is what a plain CLI invocation does anyway.
         env: {
-          ...process.env,
+          ...withoutCredentials(process.env),
           ...(cmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
           ...mcp.environment,
         },

--- a/packages/opencode/src/node.ts
+++ b/packages/opencode/src/node.ts
@@ -1,3 +1,4 @@
+export { Auth } from "./auth"
 export { Config } from "./config"
 export { Server } from "./server/server"
 export { bootstrap } from "./cli/bootstrap"

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -1,4 +1,5 @@
 import { BusEvent } from "@/bus/bus-event"
+import { withoutCredentials } from "@/util/credential-env"
 import { Bus } from "@/bus"
 import { InstanceState } from "@/effect"
 import { Instance } from "@/project/instance"
@@ -182,8 +183,9 @@ export const layer = Layer.effect(
 
       const cwd = input.cwd || s.dir
       const shell = yield* plugin.trigger("shell.env", { cwd }, { env: {} })
+      // withoutCredentials: a terminal is a shell the user (or agent) types into.
       const env = {
-        ...process.env,
+        ...withoutCredentials(process.env),
         ...input.env,
         ...shell.env,
         TERM: "xterm-256color",

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { withoutCredentials } from "@/util/credential-env"
 import os from "os"
 import { createWriteStream, existsSync, readFileSync, realpathSync } from "node:fs"
 import * as Tool from "./tool"
@@ -661,8 +662,9 @@ export const BashTool = Tool.define(
       if (identity.email && !process.env["GIT_AUTHOR_EMAIL"]) gitFloor["GIT_AUTHOR_EMAIL"] = identity.email
       if (identity.name && !process.env["GIT_COMMITTER_NAME"]) gitFloor["GIT_COMMITTER_NAME"] = identity.name
       if (identity.email && !process.env["GIT_COMMITTER_EMAIL"]) gitFloor["GIT_COMMITTER_EMAIL"] = identity.email
+      // withoutCredentials: this env goes to agent-authored commands.
       return {
-        ...process.env,
+        ...withoutCredentials(process.env),
         // Python ignores the console code page when stdout is a pipe and falls
         // back to the ANSI code page (GBK on zh-CN), producing mojibake. Force
         // UTF-8 for child Python processes on Windows.

--- a/packages/opencode/src/util/credential-env.ts
+++ b/packages/opencode/src/util/credential-env.ts
@@ -1,0 +1,34 @@
+/**
+ * Env vars that carry the user's credentials in cleartext.
+ *
+ * `MIMOCODE_AUTH_CONTENT` is the whole `auth.json` (model provider keys, OAuth refresh tokens);
+ * `MIMOCODE_CONFIG_CONTENT` can embed MCP `environment` values and request `headers`.
+ *
+ * Neither may reach a child process the engine spawns. The bash tool and the shell part run
+ * agent-authored commands, local MCP servers are third-party binaries, and both run as the user —
+ * so plain inheritance means `echo $MIMOCODE_AUTH_CONTENT` exfiltrates the provider key.
+ *
+ * Scrub the *inherited* environment only, so a caller that puts credentials in an explicit `env` is
+ * still honored — `control-plane/workspace.ts` builds its own env that way. The TUI worker keeps a
+ * full copy (via `sanitizedProcessEnv`) because it is itself an engine process.
+ */
+const CREDENTIAL_ENV = new Set(["MIMOCODE_AUTH_CONTENT", "MIMOCODE_CONFIG_CONTENT"])
+
+/**
+ * Copy of `env` with the credential vars removed.
+ *
+ * Always hand the result to `spawn` explicitly: leaving `env` undefined makes the child inherit
+ * the parent's environment wholesale, credentials included.
+ *
+ * This closes inheritance, not every path: a child running as the same user can still read
+ * `/proc/<parent-pid>/environ`, so a credential that must not leak should not be in the
+ * environment at all — see `Auth.inject`.
+ */
+export function withoutCredentials(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return Object.fromEntries(Object.entries(env).filter(([key]) => !CREDENTIAL_ENV.has(key)))
+}
+
+/** Credential var names, for tests and diagnostics that must not hardcode the list. */
+export function credentialEnvKeys() {
+  return [...CREDENTIAL_ENV]
+}

--- a/packages/opencode/src/util/process.ts
+++ b/packages/opencode/src/util/process.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess } from "child_process"
+import { withoutCredentials } from "@/util/credential-env"
 import launch from "cross-spawn"
 import { buffer } from "node:stream/consumers"
 import { errorMessage } from "./error"
@@ -62,7 +63,9 @@ export function spawn(cmd: string[], opts: Options = {}): Child {
   const proc = launch(cmd[0], cmd.slice(1), {
     cwd: opts.cwd,
     shell: opts.shell,
-    env: opts.env === null ? {} : opts.env ? { ...process.env, ...opts.env } : undefined,
+    // Explicit env even when the caller passed none: an omitted `env` makes the child inherit
+    // the parent's wholesale, credentials included. Only the inherited half is scrubbed.
+    env: opts.env === null ? {} : { ...withoutCredentials(process.env), ...opts.env },
     stdio: [opts.stdin ?? "ignore", opts.stdout ?? "ignore", opts.stderr ?? "ignore"],
     windowsHide: process.platform === "win32",
   })

--- a/packages/opencode/test/auth/auth.test.ts
+++ b/packages/opencode/test/auth/auth.test.ts
@@ -83,4 +83,33 @@ describe("Auth", () => {
       }),
     ),
   )
+
+  // Auth.inject is the in-process channel for an embedding host (the desktop runs the engine
+  // in-process). It exists so credentials never have to sit in MIMOCODE_AUTH_CONTENT, which every
+  // child the engine spawns would inherit.
+  it.live("inject supplies credentials without touching the environment", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        Auth.inject(JSON.stringify({ xiaomi: { type: "api", key: "sk-injected" } }))
+        const data = yield* (yield* Auth.Service).all()
+        expect(data["xiaomi"]).toEqual({ type: "api", key: "sk-injected" })
+        expect(process.env.MIMOCODE_AUTH_CONTENT).toBeUndefined()
+        Auth.inject(undefined)
+      }),
+    ),
+  )
+
+  it.live("inject wins over the env channel, and clearing it falls back", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        process.env.MIMOCODE_AUTH_CONTENT = JSON.stringify({ xiaomi: { type: "api", key: "sk-env" } })
+        Auth.inject(JSON.stringify({ xiaomi: { type: "api", key: "sk-injected" } }))
+        const auth = yield* Auth.Service
+        expect((yield* auth.all())["xiaomi"]).toEqual({ type: "api", key: "sk-injected" })
+        Auth.inject(undefined)
+        expect((yield* auth.all())["xiaomi"]).toEqual({ type: "api", key: "sk-env" })
+        delete process.env.MIMOCODE_AUTH_CONTENT
+      }),
+    ),
+  )
 })

--- a/packages/opencode/test/util/credential-env.test.ts
+++ b/packages/opencode/test/util/credential-env.test.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "bun:test"
+import path from "path"
+import { credentialEnvKeys, withoutCredentials } from "../../src/util/credential-env"
+
+const SRC = path.join(import.meta.dir, "..", "..", "src")
+
+// Bun.Glob yields posix-separated relative paths on every platform, so exemptions are spelled that way.
+const lines = async (file: string) => (await Bun.file(path.join(SRC, file)).text()).split("\n")
+const files = () => [...new Bun.Glob("**/*.ts").scanSync(SRC)]
+
+async function scan(pattern: RegExp, skip: Set<string>) {
+  const hits = await Promise.all(
+    files()
+      .filter((file) => !skip.has(file))
+      .map(async (file) =>
+        (await lines(file)).flatMap((line, index) =>
+          pattern.test(line) && !line.includes("withoutCredentials") ? [`${file}:${index + 1}`] : [],
+        ),
+      ),
+  )
+  return hits.flat()
+}
+
+test("withoutCredentials drops every credential var and keeps the rest", () => {
+  const secrets = Object.fromEntries(credentialEnvKeys().map((key) => [key, "sk-secret"]))
+  const env = withoutCredentials({ PATH: "/usr/bin", HOME: "/home/user", ...secrets })
+
+  expect(Object.keys(env).sort()).toEqual(["HOME", "PATH"])
+  expect(JSON.stringify(env)).not.toContain("sk-secret")
+})
+
+test("withoutCredentials leaves non-credential keys alone", () => {
+  const env = withoutCredentials({ PATH: "/usr/bin", EMPTY: undefined })
+  expect(env.PATH).toBe("/usr/bin")
+  expect("EMPTY" in env).toBe(true)
+})
+
+// Every child process must get a scrubbed copy of the inherited environment. Asserting at the call
+// sites (not just on the helper) is the point: the regression this catches is a *new* spawn site
+// handing the environment over untouched, which no behavioral test of the helper would notice.
+//
+// The pattern covers `globalThis.process.env` and `env: process.env`, not just `...process.env` — the
+// spawner funnel every `extendEnv: true` caller goes through is written the first way, and a narrower
+// pattern reports a clean tree while the widest leak path stays open.
+//
+// Known limit: a call that omits `env` entirely inherits by default and matches nothing here. Those
+// spawn either fixed tooling with no attacker-controlled command (taskkill, gh, sqlite3) or go through
+// the wrappers below; a structural rule ("only wrappers may import child_process") would close it and
+// is the natural next step if the list grows.
+test("no spawn site hands the inherited environment over without scrubbing credentials", async () => {
+  // In-process snapshot for the Env service, not an environment handed to a child.
+  const offenders = await scan(
+    /\.\.\.\s*(?:globalThis\.)?process\.env|env:\s*(?:globalThis\.)?process\.env\b/,
+    new Set(["env/index.ts"]),
+  )
+  expect(offenders).toEqual([])
+})
+
+// `sanitizedProcessEnv` only filters undefined values (it exists to satisfy `Record<string, string>`),
+// so it is a full copy of the environment. That is legitimate for the TUI worker — itself an engine
+// process that needs the credentials — so the function stays; this pins down who else may use it.
+test("sanitizedProcessEnv is only used where the child is an engine process, or scrubbed at the call site", async () => {
+  const unscrubbed = await scan(/sanitizedProcessEnv\(/, new Set(["util/mimo-process.ts", "cli/cmd/tui/thread.ts"]))
+  expect(unscrubbed).toEqual([])
+})


### PR DESCRIPTION
`MIMOCODE_AUTH_CONTENT` (the whole auth.json: provider keys, OAuth refresh tokens) and `MIMOCODE_CONFIG_CONTENT` (can embed MCP `environment` values and request `headers`) travelled in the environment, and every child the engine spawns inherited them wholesale. An agent does not even need to know where auth.json lives — `echo $MIMOCODE_AUTH_CONTENT` from the bash tool is enough.

Affected spawn paths:

- `tool/bash.ts` and the shell part in `session/prompt.ts` — agent-authored commands;
- local MCP servers (`mcp/index.ts`) — third-party binaries the user installed;
- LSP servers, the PTY, ripgrep, formatters, the worktree start command, git/snapshot helpers;
- `effect/cross-spawn-spawner.ts`, the funnel every `extendEnv: true` caller goes through;
- `util/process.ts`, which inherited implicitly whenever no env was passed.

Two changes:

1. `withoutCredentials()` scrubs both vars from the *inherited* half of any env handed to a child. A caller that passes credentials explicitly is left alone, so control-plane workspaces (`control-plane/workspace.ts` builds its own env) and the TUI worker keep working.

2. `Auth.inject()` gives an embedding host an in-process channel so credentials need not be in the environment at all. Scrubbing the child's own env is not sufficient by itself: a child running as the same user can read `/proc/<parent-pid>/environ`. The env var stays as a fallback.

Behavior change worth noting: `opencode` configured as its own MCP server no longer inherits the host's credentials or config content; that nested engine falls back to reading auth.json and the config file from disk, which is what a plain CLI invocation does.

Tests (`test/util/credential-env.test.ts`): the helper, plus two source scans — one that no spawn site hands the inherited env over unscrubbed, one that `sanitizedProcessEnv` (a full copy of the environment despite the name) is only used where the child is an engine process. The scan pattern covers `...globalThis.process.env`, not just `...process.env`: the spawner funnel is written that way, and a narrower pattern reports a clean tree while the widest leak path stays open. Flip-verified: reverting the funnel or the ripgrep call site turns the scans red at the exact line. `test/auth/auth.test.ts` covers inject precedence and fallback.

### Issue / context (if applicable)

<!--
Link any relevant issue or discussion. For an external contribution that introduces a new feature or significant design change, include the issue where the direction was agreed. Use `Fixes #123` or `Closes #123` only when this PR fully resolves that issue.
-->

### Type of change

Bug fix / New feature / Refactor / Documentation — keep the ones that apply and delete the rest.

### What does this PR do?

Briefly describe the problem, what changed, and why this approach works.

### How did you verify your code works?

What did you test, and how can a reviewer reproduce the result?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR
