### PR TITLE
fix(skill-search): blacklist reminder models

### DIFF
--- a/packages/opencode/src/skill/search.ts
+++ b/packages/opencode/src/skill/search.ts
@@ -17,6 +17,8 @@ export type SkillSearchModel = {
   api?: { id?: string }
 }
 
+const SKILL_SEARCH_MODEL_BLACKLIST = ["claude", "gpt", "kimi"]
+
 function isComposeSkill(skill: Pick<Skill.Info, "name">) {
   return skill.name.startsWith("compose:")
 }
@@ -24,7 +26,11 @@ function isComposeSkill(skill: Pick<Skill.Info, "name">) {
 export function isSkillSearchDisabled(model: SkillSearchModel) {
   return [model.id, model.modelID, model.api?.id, model.name, model.family]
     .filter((value) => value !== undefined)
-    .some((value) => /(^|[^a-z0-9])(claude|gpt)($|[^a-z0-9])/i.test(value))
+    .some((value) =>
+      SKILL_SEARCH_MODEL_BLACKLIST.some((blocked) =>
+        new RegExp(`(^|[^a-z0-9])${blocked}($|[^a-z0-9])`, "i").test(value),
+      ),
+    )
 }
 
 function normalize(value: string) {

--- a/packages/opencode/src/skill/search.ts
+++ b/packages/opencode/src/skill/search.ts
@@ -17,7 +17,7 @@ export type SkillSearchModel = {
   api?: { id?: string }
 }
 
-const SKILL_SEARCH_MODEL_BLACKLIST = ["claude", "gpt", "kimi"]
+const SKILL_SEARCH_MODEL_BLACKLIST = ["claude", "gpt", "kimi", "mimo"]
 
 function isComposeSkill(skill: Pick<Skill.Info, "name">) {
   return skill.name.startsWith("compose:")

--- a/packages/opencode/test/session/skill-search-reminder.test.ts
+++ b/packages/opencode/test/session/skill-search-reminder.test.ts
@@ -128,10 +128,10 @@ describe("skillSearchReminder", () => {
     }
   })
 
-  test("does not inject for Claude or GPT models", () => {
+  test("does not inject first-query or twelve-hour reminders for blacklisted models", () => {
     const enabled = Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER
     Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER = true
-    const input = {
+    const firstQuery = {
       session: {},
       agent: { name: "build", mode: "primary" as const },
       messages: [
@@ -141,20 +141,28 @@ describe("skillSearchReminder", () => {
         },
       ],
     }
+    const twelveHoursLater = {
+      ...firstQuery,
+      messages: [
+        firstQuery.messages[0],
+        {
+          info: { role: "user", id: "user-2", time: { created: 43_201_000 } },
+          parts: [{ type: "text", text: "Build another report" }],
+        },
+      ],
+    }
+    const models = [
+      { id: "claude-sonnet-4", api: { id: "claude-sonnet-4" } },
+      { id: "custom-openai-model", api: { id: "gpt-5.4" } },
+      { id: "kimi-k2.5", api: { id: "kimi-k2.5" } },
+      { id: "k2p5", family: "kimi-thinking", api: { id: "k2p5" } },
+    ]
 
     try {
-      expect(
-        skillSearchReminderForSession({
-          ...input,
-          model: { id: "claude-sonnet-4", api: { id: "claude-sonnet-4" } },
-        }),
-      ).toBeUndefined()
-      expect(
-        skillSearchReminderForSession({
-          ...input,
-          model: { id: "custom-openai-model", api: { id: "gpt-5.4" } },
-        }),
-      ).toBeUndefined()
+      for (const model of models) {
+        expect(skillSearchReminderForSession({ ...firstQuery, model })).toBeUndefined()
+        expect(skillSearchReminderForSession({ ...twelveHoursLater, model })).toBeUndefined()
+      }
     } finally {
       Flag.MIMOCODE_ENABLE_SKILL_SEARCH_REMINDER = enabled
     }

--- a/packages/opencode/test/session/skill-search-reminder.test.ts
+++ b/packages/opencode/test/session/skill-search-reminder.test.ts
@@ -7,7 +7,7 @@ import {
 import { Flag } from "../../src/flag/flag"
 
 describe("skillSearchReminder", () => {
-  const model = { id: "mimo-v2", name: "MiMo V2", api: { id: "mimo-v2" } }
+  const model = { id: "deepseek-v3.2", name: "DeepSeek V3.2", api: { id: "deepseek-v3.2" } }
 
   test("prompts skill search on the first user query", () => {
     const reminder = skillSearchReminder({ currentUserAt: 1_000 })
@@ -156,6 +156,7 @@ describe("skillSearchReminder", () => {
       { id: "custom-openai-model", api: { id: "gpt-5.4" } },
       { id: "kimi-k2.5", api: { id: "kimi-k2.5" } },
       { id: "k2p5", family: "kimi-thinking", api: { id: "k2p5" } },
+      { id: "mimo-v2", api: { id: "mimo-v2" } },
     ]
 
     try {

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -330,6 +330,7 @@ description: ${description}
               system.skills(build!, { id: "kimi-k2.5" }),
               system.skills(build!, { id: "k2p5", family: "kimi-thinking" }),
               system.skills(build!, { id: "mimo-v2" }),
+              system.skills(build!, { id: "deepseek-v3.2" }),
             ])
           }).pipe(Effect.provide(SystemPrompt.defaultLayer)),
         )
@@ -338,7 +339,8 @@ description: ${description}
         expect(prompts[1]).not.toContain("skill_search")
         expect(prompts[2]).not.toContain("skill_search")
         expect(prompts[3]).not.toContain("skill_search")
-        expect(prompts[4]).toContain("skill_search")
+        expect(prompts[4]).not.toContain("skill_search")
+        expect(prompts[5]).toContain("skill_search")
       },
     })
   })

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -314,7 +314,7 @@ description: ${description}
     }
   })
 
-  test("does not prompt GPT or Claude models to use skill_search", async () => {
+  test("does not prompt blacklisted models to use skill_search", async () => {
     await using tmp = await tmpdir({ git: true })
 
     await Instance.provide({
@@ -327,6 +327,8 @@ description: ${description}
             return yield* Effect.all([
               system.skills(build!, { id: "gpt-5.4" }),
               system.skills(build!, { id: "claude-sonnet-4-6" }),
+              system.skills(build!, { id: "kimi-k2.5" }),
+              system.skills(build!, { id: "k2p5", family: "kimi-thinking" }),
               system.skills(build!, { id: "mimo-v2" }),
             ])
           }).pipe(Effect.provide(SystemPrompt.defaultLayer)),
@@ -334,7 +336,9 @@ description: ${description}
 
         expect(prompts[0]).not.toContain("skill_search")
         expect(prompts[1]).not.toContain("skill_search")
-        expect(prompts[2]).toContain("skill_search")
+        expect(prompts[2]).not.toContain("skill_search")
+        expect(prompts[3]).not.toContain("skill_search")
+        expect(prompts[4]).toContain("skill_search")
       },
     })
   })

--- a/packages/opencode/test/skill/search.test.ts
+++ b/packages/opencode/test/skill/search.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Skill } from "../../src/skill"
-import { searchSkills } from "../../src/skill/search"
+import { isSkillSearchDisabled, searchSkills } from "../../src/skill/search"
 
 const skill = (name: string, description: string, aliases?: string[]): Skill.Info => ({
   name,
@@ -11,6 +11,13 @@ const skill = (name: string, description: string, aliases?: string[]): Skill.Inf
 })
 
 describe("skill.search", () => {
+  test("disables skill search prompts for blacklisted model families", () => {
+    expect(isSkillSearchDisabled({ id: "gpt-5.4" })).toBe(true)
+    expect(isSkillSearchDisabled({ api: { id: "claude-sonnet-4-6" } })).toBe(true)
+    expect(isSkillSearchDisabled({ id: "k2p5", family: "kimi-thinking" })).toBe(true)
+    expect(isSkillSearchDisabled({ id: "mimo-v2" })).toBe(false)
+  })
+
   test("ranks an exact alias match above BM25 matches", () => {
     const results = searchSkills("quarterly-review", [
       skill("spreadsheet-analysis", "Analyze quarterly sales spreadsheets and business metrics."),

--- a/packages/opencode/test/skill/search.test.ts
+++ b/packages/opencode/test/skill/search.test.ts
@@ -15,7 +15,8 @@ describe("skill.search", () => {
     expect(isSkillSearchDisabled({ id: "gpt-5.4" })).toBe(true)
     expect(isSkillSearchDisabled({ api: { id: "claude-sonnet-4-6" } })).toBe(true)
     expect(isSkillSearchDisabled({ id: "k2p5", family: "kimi-thinking" })).toBe(true)
-    expect(isSkillSearchDisabled({ id: "mimo-v2" })).toBe(false)
+    expect(isSkillSearchDisabled({ id: "mimo-v2" })).toBe(true)
+    expect(isSkillSearchDisabled({ id: "deepseek-v3.2" })).toBe(false)
   })
 
   test("ranks an exact alias match above BM25 matches", () => {


### PR DESCRIPTION
## Summary

- replace the GPT/Claude reminder special case with a shared model blacklist
- add Kimi model IDs and families to the blacklist
- skip both first-query and 12-hour skill-search reminders for blacklisted models
- keep skill-search guidance enabled for non-blacklisted models such as MiMo

## Testing

- `bun test test/session/skill-search-reminder.test.ts test/session/system.test.ts test/skill/search.test.ts test/flag/skill-search-reminder-flag.test.ts`
- `bun typecheck`
- `git diff --check`
