### PR TITLE
fix(runtime): use Node APIs for hashing and FTS queries in core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,9 @@ Our core development focus is the **TUI** (terminal UI) implementation in `packa
 - Keep things in one function unless composable or reusable
 - Avoid `try`/`catch` where possible
 - Avoid using the `any` type
-- Use Bun APIs when possible, like `Bun.file()`
+- Use Bun APIs where the runtime is Bun-only, like `Bun.file()` in the TUI (`src/cli/cmd/tui/`); build-time macros are fine anywhere, as they never reach the shipped runtime
+- In core code reachable from `src/node.ts`, prefer the Node equivalent when one exists — `createHash` over `Bun.CryptoHasher`, `prepare()` over bun:sqlite's `query()` — as that code also ships through `script/build-node.ts` and must run on plain Node
+- Bun-only calls in core escape both `typecheck` and `bun test`, which run on Bun; existing usage needs no urgent removal, and APIs with no Node equivalent may stay until a runtime seam exists
 - Rely on type inference when possible; avoid explicit type annotations or interfaces unless necessary for exports or clarity
 - Prefer functional array methods (flatMap, filter, map) over for loops; use type guards on filter to maintain type inference downstream
 - In `src/config`, follow the existing self-export pattern at the top of the file (for example `export * as ConfigAgent from "./agent"`) when adding a new config module.

--- a/packages/opencode/src/history/service.ts
+++ b/packages/opencode/src/history/service.ts
@@ -133,7 +133,10 @@ export const layer = Layer.effect(
         ORDER BY score
         LIMIT ?
       `
-      const rows = Database.Client().$client.query(sqlText).all(ftsQuery, ...params, limit) as Row[]
+      // `prepare` rather than `query`: both bun:sqlite and node:sqlite expose it with the same
+      // `.all(...positionalParams)` shape, so this path works under either driver (`#db`
+      // resolves to node:sqlite outside Bun). See the same note in memory/service.ts.
+      const rows = Database.Client().$client.prepare(sqlText).all(ftsQuery, ...params, limit) as Row[]
       return rows.map((r) => ({
         part_id: r.part_id,
         session_id: r.session_id,

--- a/packages/opencode/src/memory/service.ts
+++ b/packages/opencode/src/memory/service.ts
@@ -114,7 +114,11 @@ export const layer: Layer.Layer<Service, never, Config.Service> = Layer.effect(
       // Over-fetch (3x, capped) so the relative floor can trim common-word
       // noise without starving the list when there ARE enough real hits.
       const fetchLimit = Math.min(limit * 3, 50)
-      const rows = Database.Client().$client.query(sql).all(ftsQuery, ...params, fetchLimit) as SearchRow[]
+      // `prepare` rather than `query`: both bun:sqlite and node:sqlite expose it with the
+      // same `.all(...positionalParams)` shape, so this path works under either driver
+      // (`#db` resolves to node:sqlite outside Bun). `query`'s statement cache is Bun-only,
+      // and caching buys little here — the SQL varies with the filter clause.
+      const rows = Database.Client().$client.prepare(sql).all(ftsQuery, ...params, fetchLimit) as SearchRow[]
 
       // FTS5 bm25() returns lower = better; convert to higher = better for caller
       const mapped = rows.map((r) => ({

--- a/packages/opencode/src/tool/mcp-tool-search.ts
+++ b/packages/opencode/src/tool/mcp-tool-search.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import type { JSONObject } from "@ai-sdk/provider"
 import { Effect } from "effect"
 import z from "zod"
@@ -167,7 +168,7 @@ function index(entries: McpToolSearchEntry[]) {
 
 export function createMcpToolSearchCatalog(entries: McpToolSearchEntry[]): McpToolSearchCatalog {
   return {
-    key: new Bun.CryptoHasher("sha256").update(JSON.stringify(entries)).digest("hex"),
+    key: createHash("sha256").update(JSON.stringify(entries)).digest("hex"),
     entries,
   }
 }


### PR DESCRIPTION
### Issue / context (if applicable)

None — found while checking what the Node bundle (`script/build-node.ts`, entry `src/node.ts`) still depends on at runtime.

### Type of change

Bug fix / Documentation

### What does this PR do?

Two call sites in core were Bun-only, so they threw under the Node bundle:

- `tool/mcp-tool-search.ts` hashed the MCP tool catalog with `Bun.CryptoHasher`. `createMcpToolSearchCatalog` is called from `SessionPrompt.resolveTools` on **every turn** and is not wrapped in an `Effect.try`, so on Node the throw took the whole turn down instead of degrading.
- `memory/service.ts` and `history/service.ts` ran their FTS5 search through bun:sqlite's `$client.query()`. Outside Bun, `#db` resolves to node:sqlite, whose `DatabaseSync` only exposes `prepare()` — so every memory and history search failed.

Both now use APIs that exist on either runtime: `node:crypto`'s `createHash` and `prepare()`. `createHash("sha256")` returns the same digest as `Bun.CryptoHasher` for the same input, so catalog keys are unchanged. `query()`'s statement cache is Bun-only and buys little here, since the SQL varies with the filter clause.

`AGENTS.md` carried "Use Bun APIs when possible", which reads as repo-wide advice and is what invites this class of bug. It is now scoped by where the code runs: the TUI stays Bun-first, build-time macros are fine anywhere (they are evaluated during bundling), and core reachable from `src/node.ts` prefers the Node equivalent when one exists. Existing Bun usage in core is left alone, and APIs with no Node equivalent (`Bun.Transpiler`, `Bun.build`, `HTMLRewriter`) stay until someone adds a runtime seam like the existing `imports` conditional exports.

### How did you verify your code works?

From `packages/opencode`:

- `bun typecheck` — clean
- `bun lint` — 0 errors
- `bun test test/memory/ test/history/ test/tool/` — **1025 pass, 0 fail, 10 skip** across 76 files

`test/tool/mcp-tool-search.test.ts` already asserts the catalog key is 64 hex chars and changes when entries change, so the hash swap is covered by existing assertions rather than a new test.

One limitation worth stating plainly: every one of those runs executes on Bun, where the replaced APIs also exist. They show the swap is behaviour-preserving, but they cannot prove the Node path — that is exactly why this slipped in. The digest equivalence was checked directly rather than assumed.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR