### PR TITLE
fix(flag): read MIMOCODE_AUTO_APPROVE_DELETE lazily so embedders can toggle it at runtime

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -75,7 +75,14 @@ export const Flag = {
   // normal bash-permission ask so it can't be silently pre-approved by a broad
   // `bash: allow` rule. Set MIMOCODE_AUTO_APPROVE_DELETE=true to trust the
   // model with deletes and skip the second confirmation.
-  MIMOCODE_AUTO_APPROVE_DELETE: truthy("MIMOCODE_AUTO_APPROVE_DELETE"),
+  // Read lazily (getter, not an eagerly-evaluated literal) so an embedder can
+  // flip it at runtime: the desktop app runs the server in-process, so its
+  // approval mode — switchable mid-session, like the TUI's /skip-permissions —
+  // has no process boundary at which to re-read env. A literal would freeze
+  // this at module-evaluation time and make every later write a no-op.
+  get MIMOCODE_AUTO_APPROVE_DELETE() {
+    return truthy("MIMOCODE_AUTO_APPROVE_DELETE")
+  },
   // Set by the TUI's --dangerously-skip-permissions flag. When truthy, an
   // allow-all base ruleset is injected UNDER the user's config permission so
   // every tool auto-approves unless the user explicitly denied it.

--- a/packages/opencode/test/flag/auto-approve-delete-flag.test.ts
+++ b/packages/opencode/test/flag/auto-approve-delete-flag.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Flag } from "../../src/flag/flag"
+
+const original = process.env.MIMOCODE_AUTO_APPROVE_DELETE
+
+function set(value?: string) {
+  if (value === undefined) delete process.env.MIMOCODE_AUTO_APPROVE_DELETE
+  else process.env.MIMOCODE_AUTO_APPROVE_DELETE = value
+}
+
+afterEach(() => set(original))
+
+describe("MIMOCODE_AUTO_APPROVE_DELETE", () => {
+  test("keeps the forced-ask confirmation by default", () => {
+    set(undefined)
+    expect(Flag.MIMOCODE_AUTO_APPROVE_DELETE).toBe(false)
+  })
+
+  // The value must be read on ACCESS, not at module-evaluation time. An embedder
+  // that hosts the server in-process (the desktop app) toggles its approval mode
+  // mid-session and has no process boundary at which to re-read env, so a frozen
+  // literal would silently ignore every write after the first import. Flipping
+  // within a single process is what distinguishes a getter from a literal —
+  // spawning a fresh process per read would pass either way.
+  test("tracks env writes made after the module was first imported", () => {
+    set("true")
+    expect(Flag.MIMOCODE_AUTO_APPROVE_DELETE).toBe(true)
+    set("false")
+    expect(Flag.MIMOCODE_AUTO_APPROVE_DELETE).toBe(false)
+    set("true")
+    expect(Flag.MIMOCODE_AUTO_APPROVE_DELETE).toBe(true)
+  })
+
+  test("treats 1/0 as the truthy/falsy aliases", () => {
+    set("1")
+    expect(Flag.MIMOCODE_AUTO_APPROVE_DELETE).toBe(true)
+    set("0")
+    expect(Flag.MIMOCODE_AUTO_APPROVE_DELETE).toBe(false)
+  })
+})


### PR DESCRIPTION
The flag was an eagerly-evaluated object literal, so `truthy()` ran once at module-evaluation time and froze the value for the process lifetime. Any later write to process.env was silently a no-op.

That makes the documented opt-out unreachable for an embedder that hosts the server in-process rather than as a child process: the desktop app imports the server module directly, and its approval mode is switchable mid-session (the same state the TUI's /skip-permissions drives), so there is no process boundary at which env could be re-read.

Convert the property to a getter, matching the idiom already used elsewhere in this object (MIMOCODE_PURE, MIMOCODE_CONFIG_DIR, ...) and the lazy read in permission/index.ts. Behaviour is unchanged for existing callers — unset still means false, so the forced-ask delete confirmation stays on by default.

The regression test flips env within a single process, which is what actually distinguishes a getter from a literal; spawning a fresh process per read (as the neighbouring flag test does) would pass against the frozen literal too.