### PR TITLE
feat(permission): make the delete-ask exemption instance-scoped, not process-global

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -2,6 +2,7 @@ import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
 import { ConfigPermission } from "@/config/permission"
 import { InstanceState } from "@/effect"
+import { Flag } from "@/flag/flag"
 import { ProjectID } from "@/project/schema"
 import { MessageID, SessionID } from "@/session/schema"
 import { PermissionTable } from "@/session/session.sql"
@@ -165,6 +166,8 @@ export interface Interface {
   readonly list: () => Effect.Effect<ReadonlyArray<Request>>
   readonly skipAll: () => Effect.Effect<boolean>
   readonly setSkipAll: (enabled: boolean) => Effect.Effect<void>
+  readonly autoApproveDelete: () => Effect.Effect<boolean>
+  readonly setAutoApproveDelete: (enabled: boolean) => Effect.Effect<void>
 }
 
 interface PendingEntry {
@@ -179,6 +182,17 @@ interface State {
   // instead. Explicit "deny" rules still win (they return before this check).
   // Runtime-only, instance-scoped: subagents in the same project inherit it.
   skipAll: boolean
+  // When true, the bash tool skips the extra bash_delete confirmation for
+  // irreversible deletes. Separate from skipAll because forced-ask permissions
+  // deliberately survive it (see FORCED_ASK) — trusting the model with deletes
+  // is its own, louder decision.
+  // Instance-scoped for the same reason every other approval state is: one
+  // server process serves many directories, each with independent permission
+  // state, so a process-global carrier (e.g. an env var) would let a permissive
+  // directory silently auto-approve deletes in a strict one.
+  // Defaults to the MIMOCODE_AUTO_APPROVE_DELETE env var so the CLI/TUI keeps
+  // its documented opt-out; an embedder can override it per instance at runtime.
+  autoApproveDelete: boolean
 }
 
 export function evaluate(permission: string, pattern: string, ...rulesets: Ruleset[]): Rule {
@@ -209,6 +223,7 @@ export const layer = Layer.effect(
           pending: new Map<PermissionID, PendingEntry>(),
           approved: row?.data ?? [],
           skipAll: false,
+          autoApproveDelete: Flag.MIMOCODE_AUTO_APPROVE_DELETE,
         }
 
         yield* Effect.addFinalizer(() =>
@@ -593,7 +608,20 @@ export const layer = Layer.effect(
       }
     })
 
-    return Service.of({ ask, reply, list, skipAll, setSkipAll })
+    const autoApproveDelete = Effect.fn("Permission.autoApproveDelete")(function* () {
+      return (yield* InstanceState.get(state)).autoApproveDelete
+    })
+
+    // No pending flush here, unlike setSkipAll: a bash_delete ask that is already
+    // waiting was raised while deletes still required a human, and the command it
+    // guards is irreversible. Enabling the exemption applies to later commands.
+    const setAutoApproveDelete = Effect.fn("Permission.setAutoApproveDelete")(function* (enabled: boolean) {
+      const s = yield* InstanceState.get(state)
+      s.autoApproveDelete = enabled
+      log.info("auto-approve-delete set", { enabled })
+    })
+
+    return Service.of({ ask, reply, list, skipAll, setSkipAll, autoApproveDelete, setAutoApproveDelete })
   }),
 )
 

--- a/packages/opencode/src/server/routes/instance/permission.ts
+++ b/packages/opencode/src/server/routes/instance/permission.ts
@@ -120,5 +120,56 @@ export const PermissionRoutes = lazy(() =>
           yield* svc.setSkipAll(c.req.valid("json").enabled)
           return yield* svc.skipAll()
         }),
+    )
+    .get(
+      "/auto-approve-delete",
+      describeRoute({
+        summary: "Get auto-approve-delete state",
+        description:
+          "Whether irreversible deletes skip the extra bash_delete confirmation. Instance-scoped; defaults to the MIMOCODE_AUTO_APPROVE_DELETE env var.",
+        operationId: "permission.autoApproveDelete",
+        responses: {
+          200: {
+            description: "Current auto-approve-delete state",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) =>
+        jsonRequest("PermissionRoutes.autoApproveDelete", c, function* () {
+          const svc = yield* Permission.Service
+          return yield* svc.autoApproveDelete()
+        }),
+    )
+    .post(
+      "/auto-approve-delete",
+      describeRoute({
+        summary: "Set auto-approve-delete state",
+        description:
+          "Trust the model with irreversible deletes, skipping the extra bash_delete confirmation. Distinct from skip-all, which deliberately does NOT cover forced-ask permissions. Applies instance-wide (this directory only, so other directories served by the same process are unaffected) and subagents inherit it. Explicit `bash: deny` rules still block. Already-pending delete asks are left for a human — the command they guard is irreversible.",
+        operationId: "permission.setAutoApproveDelete",
+        responses: {
+          200: {
+            description: "Updated auto-approve-delete state",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("json", z.object({ enabled: z.boolean().describe("Whether auto-approve-delete is enabled") })),
+      async (c) =>
+        jsonRequest("PermissionRoutes.setAutoApproveDelete", c, function* () {
+          const svc = yield* Permission.Service
+          yield* svc.setAutoApproveDelete(c.req.valid("json").enabled)
+          return yield* svc.autoApproveDelete()
+        }),
     ),
 )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1329,6 +1329,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               options.abortSignal,
             )
             .pipe(Effect.orDie),
+        // Instance-scoped delete exemption (see Tool.Context.autoApproveDelete):
+        // read through the Permission service the caller already holds, so it can
+        // never be confused across the directories one process serves.
+        autoApproveDelete: () => permission.autoApproveDelete(),
       })
 
       for (const item of yield* registry.tools({

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -951,14 +951,19 @@ export const BashTool = Tool.define(
               // paths it touches), so a separate bash/external_directory
               // prompt would just be a second confirmation of the same thing.
               // Two bypasses fall back to the regular ask (where a `bash: deny`
-              // rule still blocks): MIMOCODE_AUTO_APPROVE_DELETE trusts every
-              // delete, and `tmpOnlyDelete` trusts one whose every target is
-              // provably inside a temp root — scratch space holds no durable
-              // user work, and that check fails closed on anything it cannot
-              // resolve.
+              // rule still blocks): the instance's auto-approve-delete state
+              // trusts every delete (defaults to MIMOCODE_AUTO_APPROVE_DELETE,
+              // and an embedder may flip it per instance at runtime), and
+              // `tmpOnlyDelete` trusts one whose every target is provably inside
+              // a temp root — scratch space holds no durable user work, and that
+              // check fails closed on anything it cannot resolve.
+              // Instance-scoped, NOT a process-global: one server process serves
+              // many directories with independent permission state, so a global
+              // carrier would let a permissive directory silently auto-approve
+              // deletes in a strict one. Absent accessor ⇒ not exempt (ask).
               const skipDeleteAsk =
                 scan.deletes.size === 0 ||
-                Flag.MIMOCODE_AUTO_APPROVE_DELETE ||
+                (ctx.autoApproveDelete ? yield* ctx.autoApproveDelete() : false) ||
                 (yield* tmpOnlyDelete(root, cwd, ps, shell))
               if (!skipDeleteAsk) {
                 yield* askDelete(ctx, scan, params.command)

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -26,6 +26,15 @@ export type Context<M extends Metadata = Metadata> = {
   messages: MessageV2.WithParts[]
   metadata(input: { title?: string; metadata?: M }): Effect.Effect<void>
   ask(input: Omit<Permission.Request, "id" | "sessionID" | "tool">): Effect.Effect<void>
+  // Whether this instance currently exempts irreversible deletes from the extra
+  // bash_delete confirmation. Supplied by the caller (which holds the Permission
+  // service) instead of read from a process-global, so it stays instance-scoped:
+  // one server process serves many directories with independent permission state,
+  // and a global carrier would let a permissive directory silently auto-approve
+  // deletes in a strict one.
+  // Optional so the handful of synthetic contexts need not care; absent means
+  // "not exempt" — i.e. keep asking, which is the fail-closed direction.
+  autoApproveDelete?(): Effect.Effect<boolean>
 }
 
 export interface ExecuteResult<M extends Metadata = Metadata> {

--- a/packages/opencode/test/permission/auto-approve-delete.test.ts
+++ b/packages/opencode/test/permission/auto-approve-delete.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Fiber, Layer } from "effect"
+import { Bus } from "../../src/bus"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { provideInstance, provideTmpdirInstance, tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { Log } from "../../src/util"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const bus = Bus.layer
+const env = Layer.mergeAll(Permission.layer.pipe(Layer.provide(bus)), bus, CrossSpawnSpawner.defaultLayer)
+const it = testEffect(env)
+
+const waitForPending = (count: number) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    for (let i = 0; i < 100; i++) {
+      const list = yield* permission.list()
+      if (list.length === count) return list
+      yield* Effect.sleep("10 millis")
+    }
+    return yield* Effect.fail(new Error(`timed out waiting for ${count} pending permission request(s)`))
+  })
+
+describe("Permission auto-approve-delete runtime toggle", () => {
+  it.live(
+    "defaults to off so irreversible deletes keep asking",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        expect(yield* perm.autoApproveDelete()).toBe(false)
+      }),
+    ),
+  )
+
+  it.live(
+    "reflects the value it was set to",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        yield* perm.setAutoApproveDelete(true)
+        expect(yield* perm.autoApproveDelete()).toBe(true)
+        // Must be two-way: leaving it on after the caller drops back to a stricter
+        // approval mode would keep deletes silently approved.
+        yield* perm.setAutoApproveDelete(false)
+        expect(yield* perm.autoApproveDelete()).toBe(false)
+      }),
+    ),
+  )
+
+  it.live(
+    "is independent of skip-all in both directions",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        // skip-all deliberately does NOT cover forced-ask permissions, so turning
+        // it on must not imply the delete exemption.
+        yield* perm.setSkipAll(true)
+        expect(yield* perm.autoApproveDelete()).toBe(false)
+        // ...and trusting deletes must not silently turn on blanket auto-allow.
+        yield* perm.setSkipAll(false)
+        yield* perm.setAutoApproveDelete(true)
+        expect(yield* perm.skipAll()).toBe(false)
+      }),
+    ),
+  )
+
+  // The reason this state is instance-scoped rather than a process-global (e.g. an
+  // env var): one server process serves many directories, each with its own
+  // permission state. A global carrier would let a permissive directory silently
+  // auto-approve `rm -rf` / `git reset --hard` in a strict one — the exact opposite
+  // of what a per-directory approval mode promises.
+  it.live("does not leak across the directories one process serves", () =>
+    Effect.gen(function* () {
+      const permissive = yield* tmpdirScoped()
+      const strict = yield* tmpdirScoped()
+
+      yield* Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        yield* perm.setAutoApproveDelete(true)
+        expect(yield* perm.autoApproveDelete()).toBe(true)
+      }).pipe(provideInstance(permissive))
+
+      yield* Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        expect(yield* perm.autoApproveDelete()).toBe(false)
+      }).pipe(provideInstance(strict))
+
+      // And the permissive one keeps its own value — isolation, not last-write-wins.
+      yield* Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        expect(yield* perm.autoApproveDelete()).toBe(true)
+      }).pipe(provideInstance(permissive))
+    }),
+  )
+
+  it.live(
+    "leaves an already-pending delete ask for a human",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        const fiber = yield* perm
+          .ask({
+            sessionID: "ses_test" as never,
+            permission: "bash_delete" as never,
+            patterns: ["rm -rf important"],
+            metadata: {},
+            always: [],
+            ruleset: [],
+          })
+          .pipe(Effect.exit, Effect.forkScoped)
+
+        // Let the ask register as pending before flipping the exemption.
+        yield* waitForPending(1)
+        yield* perm.setAutoApproveDelete(true)
+        yield* Effect.sleep("50 millis")
+
+        // Unlike setSkipAll, enabling this does NOT flush waiting asks: the command
+        // already in flight is irreversible, so it still needs an explicit answer.
+        const pending = yield* perm.list()
+        expect(pending.some((r) => r.permission === "bash_delete")).toBe(true)
+
+        yield* perm.reply({ requestID: pending[0]!.id, reply: "reject" })
+        yield* Fiber.await(fiber)
+      }),
+    ),
+  )
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -86,12 +86,15 @@ import type {
   PartUpdateErrors,
   PartUpdateResponses,
   PathGetResponses,
+  PermissionAutoApproveDeleteResponses,
   PermissionListResponses,
   PermissionReplyErrors,
   PermissionReplyResponses,
   PermissionRespondErrors,
   PermissionRespondResponses,
   PermissionRuleset,
+  PermissionSetAutoApproveDeleteErrors,
+  PermissionSetAutoApproveDeleteResponses,
   PermissionSetSkipAllErrors,
   PermissionSetSkipAllResponses,
   PermissionSkipAllResponses,
@@ -3090,6 +3093,77 @@ export class Permission extends HeyApiClient {
       ThrowOnError
     >({
       url: "/permission/skip-all",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Get auto-approve-delete state
+   *
+   * Whether irreversible deletes skip the extra bash_delete confirmation. Instance-scoped; defaults to the MIMOCODE_AUTO_APPROVE_DELETE env var.
+   */
+  public autoApproveDelete<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<PermissionAutoApproveDeleteResponses, unknown, ThrowOnError>({
+      url: "/permission/auto-approve-delete",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Set auto-approve-delete state
+   *
+   * Trust the model with irreversible deletes, skipping the extra bash_delete confirmation. Distinct from skip-all, which deliberately does NOT cover forced-ask permissions. Applies instance-wide (this directory only, so other directories served by the same process are unaffected) and subagents inherit it. Explicit `bash: deny` rules still block. Already-pending delete asks are left for a human — the command they guard is irreversible.
+   */
+  public setAutoApproveDelete<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      enabled?: boolean
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "enabled" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      PermissionSetAutoApproveDeleteResponses,
+      PermissionSetAutoApproveDeleteErrors,
+      ThrowOnError
+    >({
+      url: "/permission/auto-approve-delete",
       ...options,
       ...params,
       headers: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5428,6 +5428,61 @@ export type PermissionSetSkipAllResponses = {
 
 export type PermissionSetSkipAllResponse = PermissionSetSkipAllResponses[keyof PermissionSetSkipAllResponses]
 
+export type PermissionAutoApproveDeleteData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/permission/auto-approve-delete"
+}
+
+export type PermissionAutoApproveDeleteResponses = {
+  /**
+   * Current auto-approve-delete state
+   */
+  200: boolean
+}
+
+export type PermissionAutoApproveDeleteResponse =
+  PermissionAutoApproveDeleteResponses[keyof PermissionAutoApproveDeleteResponses]
+
+export type PermissionSetAutoApproveDeleteData = {
+  body?: {
+    /**
+     * Whether auto-approve-delete is enabled
+     */
+    enabled: boolean
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/permission/auto-approve-delete"
+}
+
+export type PermissionSetAutoApproveDeleteErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionSetAutoApproveDeleteError =
+  PermissionSetAutoApproveDeleteErrors[keyof PermissionSetAutoApproveDeleteErrors]
+
+export type PermissionSetAutoApproveDeleteResponses = {
+  /**
+   * Updated auto-approve-delete state
+   */
+  200: boolean
+}
+
+export type PermissionSetAutoApproveDeleteResponse =
+  PermissionSetAutoApproveDeleteResponses[keyof PermissionSetAutoApproveDeleteResponses]
+
 export type WorkflowListData = {
   body?: never
   path?: never


### PR DESCRIPTION
MIMOCODE_AUTO_APPROVE_DELETE is read from process.env, which is fine for the CLI (one process, one directory) but wrong for an embedder that hosts the server in-process: one process serves many directories, each with its own instance and independent permission state. A process-global carrier cannot express "exempt in A, still ask in B" — whichever directory wrote last decides for all of them, so a permissive directory silently auto-approves `rm -rf` / `git reset --hard` in a strict one. That inverts what a per-directory approval mode promises, and it does so for exactly the irreversible operations the forced-ask path exists to protect.

Move the state into the Permission instance, alongside skipAll:
  - State.autoApproveDelete, seeded from the env var so the CLI/TUI keeps its documented opt-out unchanged
  - autoApproveDelete() / setAutoApproveDelete() on the service
  - GET/POST /permission/auto-approve-delete, mirroring /permission/skip-all
  - Tool.Context.autoApproveDelete(), supplied by the caller that holds the service; bash.ts reads it instead of Flag

Kept deliberately separate from skipAll: skip-all explicitly does NOT cover forced-ask permissions, so folding deletes into it would quietly widen that contract. Enabling it also does not flush already-pending delete asks — that command is already in flight and irreversible, so it still needs an answer.

The context field is optional and absence means "not exempt", so the synthetic tool contexts keep asking; the fail-closed direction.


