### PR TITLE
fix(provider): replay empty signed Anthropic thinking blocks

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -69,13 +69,18 @@ function stripsEmptyParts(model: Provider.Model): boolean {
   ].includes(model.api.npm)
 }
 
+function record(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  return value as Record<string, unknown>
+}
+
 function normalizeMessages(
   msgs: ModelMessage[],
   model: Provider.Model,
   _options: Record<string, unknown>,
 ): ModelMessage[] {
-  // Anthropic rejects messages with empty content - filter out empty string messages
-  // and remove empty text/reasoning parts from array content
+  // Anthropic rejects messages with empty content. Signed thinking is the exception:
+  // its text may be empty, but its signature/redacted data must survive for replay.
   if (stripsEmptyParts(model)) {
     msgs = msgs
       .map((msg) => {
@@ -85,8 +90,14 @@ function normalizeMessages(
         }
         if (!Array.isArray(msg.content)) return msg
         const filtered = msg.content.filter((part) => {
-          if (part.type === "text" || part.type === "reasoning") {
-            return part.text !== ""
+          if (part.type === "text") return part.text !== ""
+          if (part.type === "reasoning") {
+            if (part.text !== "") return true
+            const metadata = record(part.providerOptions?.anthropic ?? part.providerOptions?.[model.providerID])
+            return (
+              (typeof metadata?.signature === "string" && metadata.signature !== "") ||
+              (typeof metadata?.redactedData === "string" && metadata.redactedData !== "")
+            )
           }
           return true
         })
@@ -622,11 +633,6 @@ function normalizeContentArray(msgs: ModelMessage[]): ModelMessage[] {
     if (msg.role === "user") return { ...msg, content: [{ type: "text", text: EMPTY_CONTENT_PLACEHOLDER }] } as ModelMessage
     return msg
   })
-}
-
-function record(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
-  return value as Record<string, unknown>
 }
 
 // Anthropic's SDK discards historical reasoning without a signature or redacted

--- a/packages/opencode/test/provider/empty-content-wire.test.ts
+++ b/packages/opencode/test/provider/empty-content-wire.test.ts
@@ -112,3 +112,36 @@ describe("the trailing continuation turn reaches the wire with non-empty content
     expect(empty).toEqual([])
   })
 })
+
+describe("signed empty Anthropic reasoning reaches the wire", () => {
+  test("preserves the thinking block and signature", async () => {
+    const signature = "signed-empty-thinking"
+    const body = await outbound(
+      ProviderTransform.message(
+        [
+          { role: "user", content: [{ type: "text", text: "hi" }] },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "reasoning",
+                text: "",
+                providerOptions: { anthropic: { signature } },
+              },
+              { type: "text", text: "done" },
+            ],
+          },
+          { role: "user", content: [{ type: "text", text: "next" }] },
+        ] as any,
+        model,
+        {},
+      ),
+    )
+
+    expect(body.messages[1].content[0]).toEqual({
+      type: "thinking",
+      thinking: "",
+      signature,
+    })
+  })
+})

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1736,6 +1736,53 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     expect(result[0].content[0]).toEqual({ type: "text", text: "Answer" })
   })
 
+  test("preserves empty Anthropic reasoning with a signature", () => {
+    const reasoning = {
+      type: "reasoning" as const,
+      text: "",
+      providerOptions: { anthropic: { signature: "signed-thinking" } },
+    }
+    const msgs = [
+      {
+        role: "assistant",
+        content: [reasoning, { type: "text", text: "Answer" }],
+      },
+      { role: "user", content: [{ type: "text", text: "next" }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {})
+
+    expect(result).toHaveLength(2)
+    expect(result[0].content).toEqual([reasoning, { type: "text", text: "Answer" }])
+  })
+
+  test("preserves signed empty reasoning from a custom Anthropic route", () => {
+    const result = ProviderTransform.message(
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "reasoning",
+              text: "",
+              providerOptions: { prod: { signature: "prod-signature" } },
+            },
+            { type: "text", text: "Answer" },
+          ],
+        },
+        { role: "user", content: [{ type: "text", text: "next" }] },
+      ] as any[],
+      { ...anthropicModel, providerID: "prod" },
+      {},
+    )
+
+    expect(result[0].content[0]).toEqual({
+      type: "reasoning",
+      text: "",
+      providerOptions: { anthropic: { signature: "prod-signature" } },
+    })
+  })
+
   test("removes entire message when all parts are empty", () => {
     const msgs = [
       { role: "user", content: "Hello" },


### PR DESCRIPTION
### Issue / context (if applicable)

Prod Anthropic route with thinking enabled. Gateway first-round response:

```json
{"type":"thinking","thinking":"","signature":"EsYCC..."}
```

Thinking body is empty (intentional), signature is complete. The next-turn replay (req6/req7) dropped the whole thinking block, so the assistant message arrived as `[text, tool_use]` and the signature disappeared with it.

`MIMOCODE_FORCE_ANTHROPIC_REASONING_CONTENT` cannot fix this: it only fills a missing signature on a block that still exists. Here the block itself was gone.

### Type of change

Bug fix

### What does this PR do?

`ProviderTransform.normalizeMessages` used to strip every empty `text`/`reasoning` part. That is correct for empty text, and for unsigned empty reasoning, but it is wrong for signed thinking: Anthropic requires the signature to stay inside the corresponding thinking block, even when `thinking` is `""`.

Empty reasoning is now kept when it still carries a non-empty `signature` or `redactedData`, read from `providerOptions.anthropic` or `providerOptions[providerID]` (prod / custom Anthropic routes). The signature stays on that same reasoning part; it is not sent separately.

### How did you verify your code works?

From `packages/opencode`:

- `bun test test/provider/empty-content-wire.test.ts test/provider/transform.test.ts` — **249 pass, 0 fail**
- Unit: empty signed reasoning is preserved, including a custom `prod` providerID remapped to the Anthropic SDK key
- Unit: unsigned empty reasoning is still stripped
- Wire: `@ai-sdk/anthropic` emits `{type:"thinking", thinking:"", signature}` on the outbound HTTP body

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR