### PR TITLE
fix(provider): send prompt_cache_key for every @ai-sdk/openai provider

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1648,7 +1648,21 @@ export function options(input: {
     }
   }
 
-  if (input.model.providerID === "openai" || input.model.api.npm === "@ai-sdk/xai" || input.providerOptions?.setCacheKey) {
+  // Cache-affinity key. Providers that speak the real OpenAI protocol route a
+  // request to the machine holding its cached prefix by hashing the prompt head
+  // plus this key; without it a gateway fronting several upstream instances
+  // scatters the turns of one session and the prefix cache misses outright
+  // (observed on a custom @ai-sdk/openai provider: cached reads of 0 even for
+  // consecutive steps of the SAME turn, whose prefix is identical by
+  // construction). Scoped to `@ai-sdk/openai` on purpose — `openai-compatible`
+  // proxies (LiteLLM et al.) reject unknown parameters, same reason
+  // `reasoningSummary` below is gated that way.
+  if (
+    input.model.providerID === "openai" ||
+    input.model.api.npm === "@ai-sdk/openai" ||
+    input.model.api.npm === "@ai-sdk/xai" ||
+    input.providerOptions?.setCacheKey
+  ) {
     result["promptCacheKey"] = input.sessionID
   }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -83,6 +83,37 @@ describe("ProviderTransform.options - setCacheKey", () => {
     expect(result.promptCacheKey).toBe(sessionID)
   })
 
+  test("should set promptCacheKey for a custom provider that speaks the OpenAI protocol", () => {
+    // A user-configured provider (e.g. a gateway fronting several upstream
+    // instances) still needs the cache-affinity key, or its turns scatter across
+    // machines and the prefix cache misses even for identical prefixes.
+    const gatewayModel = {
+      ...mockModel,
+      providerID: "codex",
+      api: {
+        id: "gpt-5.6-sol",
+        url: "http://gateway.internal/v1",
+        npm: "@ai-sdk/openai",
+      },
+    }
+    const result = ProviderTransform.options({ model: gatewayModel, sessionID, providerOptions: {} })
+    expect(result.promptCacheKey).toBe(sessionID)
+  })
+
+  test("should not set promptCacheKey for openai-compatible proxies that reject unknown params", () => {
+    const litellmModel = {
+      ...mockModel,
+      providerID: "litellm",
+      api: {
+        id: "gpt-5.2",
+        url: "http://litellm.internal/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    }
+    const result = ProviderTransform.options({ model: litellmModel, sessionID, providerOptions: {} })
+    expect(result.promptCacheKey).toBeUndefined()
+  })
+
   test("should set store=false for openai provider", () => {
     const openaiModel = {
       ...mockModel,


### PR DESCRIPTION
## Problem

`promptCacheKey` is the **cache-affinity** key, not a cache switch: a provider speaking the real OpenAI protocol routes a request to the machine holding its cached prefix by hashing the prompt head plus this key. Behind a gateway that fronts several upstream instances, omitting it scatters the turns of one session and the prefix cache misses **even when the prefix is byte-identical**.

The condition only matched `providerID` `"openai"` / `"xai"` / azure / venice / openrouter / `opencode*`. Any user-configured provider on the OpenAI SDK fell through and sent no key at all.

Observed on such a provider (`providerID: "codex"`, `npm: "@ai-sdk/openai"`, `gpt-5.6-sol` behind an internal gateway) — cached reads for three consecutive steps of the **same turn**, whose prefix is identical by construction:

```
inp 199,941   cache.read 0
inp 200,055   cache.read 0     (+114 tokens vs previous step)
inp 201,438   cache.read 0
```

150k–200k input tokens re-billed per step, purely because the steps landed on different upstream instances.

## Change

Extend the existing condition to `input.model.api.npm === "@ai-sdk/openai"`, so every provider on the real OpenAI SDK gets the session-scoped key that `providerID: "openai"` already got.

Deliberately **not** extended to `@ai-sdk/openai-compatible`: those proxies (LiteLLM et al.) reject unknown parameters — the same reason `reasoningSummary` is gated to the native SDK a few lines below. Providers can still force it on through the existing `options.setCacheKey` escape hatch.

The value stays `input.sessionID`, matching the five existing call sites in this file. (Nuance for a follow-up, not this PR: subagents share the parent's `sessionID` while carrying a different prefix, so a `sessionID + agentID` key would isolate them better. Worth doing only once there is eviction data to justify it.)

## Tests

Two cases added next to the existing `setCacheKey` suite:

- a custom provider on `@ai-sdk/openai` (mirrors the reported config) **does** get `promptCacheKey`
- an `@ai-sdk/openai-compatible` proxy still does **not**

```
bun typecheck                            → clean
bun test test/provider/transform.test.ts → 246 pass / 0 fail
```
