### PR TITLE
fix(permission): let yolo auto-approve deletes

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -35,6 +35,23 @@ type ToolProps<T> = {
   part: ToolPart
 }
 
+async function enableDangerousDeleteApproval(
+  sdk: Pick<OpencodeClient, "permission">,
+  enabled: boolean,
+) {
+  if (!enabled) return async () => {}
+  const previous = (await sdk.permission.autoApproveDelete(undefined, { throwOnError: true })).data === true
+  if (previous) return async () => {}
+
+  await sdk.permission.setAutoApproveDelete({ enabled: true }, { throwOnError: true })
+  const state = { restored: false }
+  return async () => {
+    if (state.restored) return
+    await sdk.permission.setAutoApproveDelete({ enabled: false }, { throwOnError: true })
+    state.restored = true
+  }
+}
+
 function props<T>(part: ToolPart): ToolProps<T> {
   const state = part.state
   return {
@@ -430,7 +447,7 @@ export const RunCommand = cmd({
       const events = await sdk.event.subscribe()
       let error: string | undefined
 
-      async function loop(tracker: CompletionTracker) {
+      async function loop(tracker: CompletionTracker, restoreDangerousDeleteApproval: () => Promise<void>) {
         const toggles = new Map<string, boolean>()
         const log = Log.create({ service: "cli.run" })
 
@@ -561,6 +578,7 @@ export const RunCommand = cmd({
         } finally {
           tracker.stop()
           await iter.return?.(undefined).catch(() => {})
+          await restoreDangerousDeleteApproval()
         }
       }
 
@@ -649,33 +667,43 @@ export const RunCommand = cmd({
         },
       })
 
-      loop(tracker).catch(async (e) => {
+      const restoreDangerousDeleteApproval = await enableDangerousDeleteApproval(
+        sdk,
+        args["dangerously-skip-permissions"],
+      )
+
+      loop(tracker, restoreDangerousDeleteApproval).catch(async (e) => {
         console.error(e)
         await Log.exit(1)
       })
 
-      if (args.command) {
-        await sdk.session.command({
-          sessionID,
-          agent,
-          model: args.model,
-          command: args.command,
-          arguments: message,
-          variant: args.variant,
-        })
-      } else {
-        const model = args.model ? Provider.parseModel(args.model) : undefined
-        const params = {
-          sessionID,
-          agent,
-          model,
-          variant: args.variant,
-          role: args.role as "user" | "assistant" | undefined,
-          parts: [...files, { type: "text" as const, text: message }],
+      try {
+        if (args.command) {
+          await sdk.session.command({
+            sessionID,
+            agent,
+            model: args.model,
+            command: args.command,
+            arguments: message,
+            variant: args.variant,
+          })
+        } else {
+          const model = args.model ? Provider.parseModel(args.model) : undefined
+          const params = {
+            sessionID,
+            agent,
+            model,
+            variant: args.variant,
+            role: args.role as "user" | "assistant" | undefined,
+            parts: [...files, { type: "text" as const, text: message }],
+          }
+          await sdk.session.prompt(params as typeof params & Record<string, unknown>)
         }
-        await sdk.session.prompt(params as typeof params & Record<string, unknown>)
+        tracker.markStarted()
+      } catch (error) {
+        await restoreDangerousDeleteApproval()
+        throw error
       }
-      tracker.markStarted()
     }
 
     if (args.attach) {

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -190,8 +190,9 @@ interface State {
   // server process serves many directories, each with independent permission
   // state, so a process-global carrier (e.g. an env var) would let a permissive
   // directory silently auto-approve deletes in a strict one.
-  // Defaults to the MIMOCODE_AUTO_APPROVE_DELETE env var so the CLI/TUI keeps
-  // its documented opt-out; an embedder can override it per instance at runtime.
+  // Defaults to the dedicated delete opt-out or dangerous startup mode so
+  // --yolo truly skips every non-denied approval; an embedder can override it
+  // per instance at runtime.
   autoApproveDelete: boolean
 }
 
@@ -204,8 +205,8 @@ export function evaluate(permission: string, pattern: string, ...rulesets: Rules
 // pattern:"*", action:"allow"}` approval) MUST NOT be able to pre-authorize
 // these — the whole point of a forced-ask permission is that the intent to
 // perform an irreversible action must be recorded in-band, not inherited from
-// a broad blanket rule. Explicit deny still wins; the tool-side env opt-out
-// (e.g. MIMOCODE_AUTO_APPROVE_DELETE for bash_delete) is the only bypass.
+// a broad blanket rule. Explicit deny still wins; the tool-side delete exemption
+// (dedicated or enabled by dangerous startup mode) is the only bypass.
 const FORCED_ASK = new Set(["bash_delete"])
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Permission") {}
@@ -223,7 +224,7 @@ export const layer = Layer.effect(
           pending: new Map<PermissionID, PendingEntry>(),
           approved: row?.data ?? [],
           skipAll: false,
-          autoApproveDelete: Flag.MIMOCODE_AUTO_APPROVE_DELETE,
+          autoApproveDelete: Flag.MIMOCODE_AUTO_APPROVE_DELETE || Flag.MIMOCODE_DANGEROUSLY_SKIP_PERMISSIONS,
         }
 
         yield* Effect.addFinalizer(() =>
@@ -275,6 +276,17 @@ export const layer = Layer.effect(
         if (ruleAction === "allow") continue
         if (evaluate(request.permission, pattern, approved).action === "allow") continue
         needsAsk = true
+      }
+
+      // Dangerous startup mode and the dedicated delete exemption may bypass
+      // the human confirmation, but only after every explicit bash_delete deny
+      // above has had a chance to reject the request.
+      if (needsAsk && forced && s.autoApproveDelete) {
+        log.info("auto-approve-delete active, auto-allowing", {
+          permission: request.permission,
+          patterns: request.patterns,
+        })
+        return
       }
 
       // Runtime skip-all: auto-allow anything that would block for approval.

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -946,27 +946,24 @@ export const BashTool = Tool.define(
               }
               const scan = yield* collect(root, cwd, ps, shell)
               if (!Instance.containsPath(cwd)) scan.dirs.add(cwd)
-              // Delete-containing commands are authorized by askDelete alone —
-              // the delete UI shows the full command (including any external
-              // paths it touches), so a separate bash/external_directory
-              // prompt would just be a second confirmation of the same thing.
-              // Two bypasses fall back to the regular ask (where a `bash: deny`
-              // rule still blocks): the instance's auto-approve-delete state
-              // trusts every delete (defaults to MIMOCODE_AUTO_APPROVE_DELETE,
-              // and an embedder may flip it per instance at runtime), and
+              // Delete-containing commands normally use askDelete alone — the
+              // delete UI shows the full command, so another bash prompt would
+              // duplicate the confirmation. Auto-approved deletes still pass
+              // through askDelete so an explicit `bash_delete: deny` wins, then
+              // fall back to the regular ask so `bash: deny` wins too.
               // `tmpOnlyDelete` trusts one whose every target is provably inside
-              // a temp root — scratch space holds no durable user work, and that
+              // a temp root; scratch space holds no durable user work, and that
               // check fails closed on anything it cannot resolve.
               // Instance-scoped, NOT a process-global: one server process serves
               // many directories with independent permission state, so a global
               // carrier would let a permissive directory silently auto-approve
               // deletes in a strict one. Absent accessor ⇒ not exempt (ask).
-              const skipDeleteAsk =
-                scan.deletes.size === 0 ||
-                (ctx.autoApproveDelete ? yield* ctx.autoApproveDelete() : false) ||
-                (yield* tmpOnlyDelete(root, cwd, ps, shell))
+              const autoApproveDelete =
+                scan.deletes.size > 0 && ctx.autoApproveDelete ? yield* ctx.autoApproveDelete() : false
+              const skipDeleteAsk = scan.deletes.size === 0 || (yield* tmpOnlyDelete(root, cwd, ps, shell))
               if (!skipDeleteAsk) {
                 yield* askDelete(ctx, scan, params.command)
+                if (autoApproveDelete) yield* ask(ctx, scan)
               } else {
                 yield* ask(ctx, scan)
               }

--- a/packages/opencode/test/permission/auto-approve-delete.test.ts
+++ b/packages/opencode/test/permission/auto-approve-delete.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect } from "bun:test"
+import { afterEach, beforeEach, describe, expect } from "bun:test"
 import { Effect, Fiber, Layer } from "effect"
 import { Bus } from "../../src/bus"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Flag } from "../../src/flag/flag"
 import { Permission } from "../../src/permission"
 import { Instance } from "../../src/project/instance"
 import { provideInstance, provideTmpdirInstance, tmpdirScoped } from "../fixture/fixture"
@@ -10,7 +11,14 @@ import { Log } from "../../src/util"
 
 void Log.init({ print: false })
 
+const originalDangerouslySkipPermissions = Flag.MIMOCODE_DANGEROUSLY_SKIP_PERMISSIONS
+
+beforeEach(() => {
+  Flag.MIMOCODE_DANGEROUSLY_SKIP_PERMISSIONS = false
+})
+
 afterEach(async () => {
+  Flag.MIMOCODE_DANGEROUSLY_SKIP_PERMISSIONS = originalDangerouslySkipPermissions
   await Instance.disposeAll()
 })
 
@@ -29,13 +37,24 @@ const waitForPending = (count: number) =>
     return yield* Effect.fail(new Error(`timed out waiting for ${count} pending permission request(s)`))
   })
 
-describe("Permission auto-approve-delete runtime toggle", () => {
+describe.serial("Permission auto-approve-delete runtime toggle", () => {
   it.live(
     "defaults to off so irreversible deletes keep asking",
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const perm = yield* Permission.Service
         expect(yield* perm.autoApproveDelete()).toBe(false)
+      }),
+    ),
+  )
+
+  it.live(
+    "enables delete approval bypass in dangerous startup mode",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        Flag.MIMOCODE_DANGEROUSLY_SKIP_PERMISSIONS = true
+        const perm = yield* Permission.Service
+        expect(yield* perm.autoApproveDelete()).toBe(true)
       }),
     ),
   )
@@ -51,6 +70,35 @@ describe("Permission auto-approve-delete runtime toggle", () => {
         // approval mode would keep deletes silently approved.
         yield* perm.setAutoApproveDelete(false)
         expect(yield* perm.autoApproveDelete()).toBe(false)
+      }),
+    ),
+  )
+
+  it.live(
+    "auto-approves bash_delete only after explicit deny rules are checked",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        yield* perm.setAutoApproveDelete(true)
+        const request = {
+          sessionID: "ses_test" as never,
+          permission: "bash_delete" as never,
+          patterns: ["rm important"],
+          metadata: {},
+          always: [],
+          interactive: false,
+        }
+
+        const allowed = yield* perm.ask({ ...request, ruleset: [] }).pipe(Effect.exit)
+        expect(allowed._tag).toBe("Success")
+
+        const denied = yield* perm
+          .ask({
+            ...request,
+            ruleset: [{ permission: "bash_delete", pattern: "*", action: "deny" }],
+          })
+          .pipe(Effect.exit)
+        expect(denied._tag).toBe("Failure")
       }),
     ),
   )

--- a/packages/opencode/test/permission/skip-all.test.ts
+++ b/packages/opencode/test/permission/skip-all.test.ts
@@ -80,6 +80,9 @@ describe("Permission skip-all runtime toggle", () => {
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const perm = yield* Permission.Service
+        // Isolate skip-all from a process started in dangerous mode, which now
+        // seeds the separate delete exemption by design.
+        yield* perm.setAutoApproveDelete(false)
         yield* perm.setSkipAll(true)
         let asked = 0
         const unsub = Bus.subscribe(Permission.Event.Asked, () => {


### PR DESCRIPTION
## Summary

- make `--yolo` / `--dangerously-skip-permissions` initialize instance-scoped delete auto-approval
- preserve explicit `bash_delete` and `bash` deny rules before bypassing confirmation
- scope headless/attached run delete approval to the command lifetime so subagents inherit it without leaving the instance permissive
- keep runtime `/skip-permissions` behavior independent

## Verification

- pre-push hook: `bun turbo typecheck` (12/12 tasks passed)
- no additional manual test run after the requested cleanup