### PR TITLE
feat(checkpoint): add disable switch

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1551,6 +1551,16 @@ function UserMessage(props: {
       return parsed ? [parsed] : []
     })[0]
   })
+  // Checkpoint-off notices stay synthetic + ignored so undo, title prediction,
+  // and model context never treat them as user input. Render the engine's
+  // stable notice text explicitly instead of exposing it through text().
+  const checkpointOffNotice = createMemo(() => {
+    return props.parts.flatMap((x) => {
+      if (x.type !== "text" || !x.synthetic || !x.ignored) return []
+      const origin = (x.metadata as { origin?: { kind?: string } } | undefined)?.origin
+      return origin?.kind === "checkpoint-off" ? [x.text] : []
+    })[0]
+  })
   // A context rebuild (`/rebuild`) inserts a single user message carrying a
   // `checkpoint` part plus `synthetic: true` text parts (the rendered context
   // and index). Neither renders — `checkpoint` has no PART_MAPPING entry and
@@ -1626,6 +1636,16 @@ function UserMessage(props: {
             </box>
           )
         }}
+      </Show>
+      <Show when={checkpointOffNotice()}>
+        {(notice) => (
+          <box id={props.message.id} marginTop={props.index === 0 ? 0 : 1} paddingLeft={2} flexDirection="row" gap={1}>
+            <text fg={theme.textMuted}>
+              <span style={{ bg: theme.backgroundElement, fg: theme.warning, bold: true }}> checkpoint off </span>
+              <span style={{ fg: theme.text }}> {notice()}</span>
+            </text>
+          </box>
+        )}
       </Show>
       <Show when={rebuildBoundary()}>
         <box id={props.message.id} marginTop={props.index === 0 ? 0 : 1} paddingLeft={2} flexDirection="row" gap={1}>

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -90,6 +90,12 @@ export const Flag = {
   MIMOCODE_DISABLE_DEFAULT_PLUGINS: truthy("MIMOCODE_DISABLE_DEFAULT_PLUGINS"),
   MIMOCODE_DISABLE_LSP_DOWNLOAD: truthy("MIMOCODE_DISABLE_LSP_DOWNLOAD"),
   MIMOCODE_ENABLE_EXPERIMENTAL_MODELS: truthy("MIMOCODE_ENABLE_EXPERIMENTAL_MODELS"),
+  // Defaults to false. When enabled, checkpoint writers and checkpoint-based
+  // context rebuilds are disabled; context overflow falls back to compaction.
+  // Read lazily so tests and in-process embedders can toggle it at runtime.
+  get MIMOCODE_DISABLE_CHECKPOINT() {
+    return truthy("MIMOCODE_DISABLE_CHECKPOINT")
+  },
   MIMOCODE_DISABLE_AUTOCOMPACT: truthy("MIMOCODE_DISABLE_AUTOCOMPACT"),
   MIMOCODE_DISABLE_MODELS_FETCH: truthy("MIMOCODE_DISABLE_MODELS_FETCH"),
   MIMOCODE_DISABLE_MOUSE: truthy("MIMOCODE_DISABLE_MOUSE"),

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -3,6 +3,7 @@ import path from "path"
 import { Global } from "@/global"
 import { Bus } from "@/bus"
 import { Config } from "@/config"
+import { Flag } from "@/flag/flag"
 import { Memory } from "@/memory"
 import { isMemoryWriteEnabled } from "@/memory/write-gate"
 import { MemoryFtsTable } from "@/memory/fts.sql"
@@ -589,6 +590,11 @@ export const layer: Layer.Layer<
     ) => Effect.Effect<TryStartCheckpointWriterResult> = Effect.fn("SessionCheckpoint.tryStartCheckpointWriter")(function* (
       input: TryStartCheckpointWriterInput,
     ) {
+      if (Flag.MIMOCODE_DISABLE_CHECKPOINT) {
+        log.info("checkpointing disabled, skipping checkpoint", { sessionID: input.sessionID })
+        return "skipped" as const
+      }
+
       // Memory writing disabled — stop producing NEW memory. This is the single
       // gate for the whole write side of checkpointing: template bootstrap
       // (ensureCheckpointTemplate / ensureMemoryTemplate / ensureNotesTemplate),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -682,9 +682,9 @@ export const layer = Layer.effect(
           sessionID,
           type: "text",
           text: CHECKPOINT_OFF_FALLBACK_NOTICE,
-          // Visible in the TUI transcript; ignored still keeps it out of model
-          // context and session classification.
+          synthetic: true,
           ignored: true,
+          metadata: { origin: { kind: "checkpoint-off" } },
           time: { start: now, end: now },
         })
         .pipe(Effect.ignore)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -440,8 +440,11 @@ export const layer = Layer.effect(
      *                   switched off, so a checkpoint cannot exist and cannot be
      *                   produced. Callers may compact, and MUST say the switch is
      *                   why — never that a writer failed.
+     * - "checkpoint-off" nothing was attempted because checkpointing is
+     *                   explicitly disabled. Callers may compact and must name
+     *                   the switch rather than reporting a writer failure.
      */
-    type RebuildAttempt = "rebuilt" | "writer-failed" | "insert-failed" | "memory-write-off"
+    type RebuildAttempt = "rebuilt" | "writer-failed" | "insert-failed" | "memory-write-off" | "checkpoint-off"
 
     // The single place that decides whether a rebuild may degrade to
     // compaction. Every caller — both auto context-overflow sites and the
@@ -467,6 +470,8 @@ export const layer = Layer.effect(
       /** Run once, immediately before the wait begins, to explain the stall. */
       onWaitingForWriter?: Effect.Effect<void>
     }) {
+      if (Flag.MIMOCODE_DISABLE_CHECKPOINT) return "checkpoint-off" as const
+
       // 0. Memory writing off → there is nothing to try. Bail out BEFORE any of
       //    the work below, because with the switch on every step of it is
       //    predetermined to be useless: no checkpoint can exist (the writer has
@@ -596,6 +601,12 @@ export const layer = Layer.effect(
       "and the session keeps working — to get checkpoint rebuilds back, set `memory.disable_write` to false in " +
       "config."
 
+    const CHECKPOINT_OFF_FALLBACK_NOTICE =
+      "Checkpointing is off, so the context was compacted instead of rebuilt from a checkpoint. Earlier turns " +
+      "leave the model's view without a checkpoint summary, which can weaken continuity on long-running work. " +
+      "Nothing is broken — to enable checkpoint writers and checkpoint rebuilds again, unset " +
+      "`MIMOCODE_DISABLE_CHECKPOINT` or set it to false."
+
     // Sessions that have already been told once, this process.
     //
     // The notice describes a CONFIG STATE, not an event: it says exactly the
@@ -607,6 +618,7 @@ export const layer = Layer.effect(
     // still shapes that run — so this is deliberately in-memory rather than a
     // durable "already warned" flag.
     const memoryWriteOffNoticed = new Set<SessionID>()
+    const checkpointOffNoticed = new Set<SessionID>()
 
     /**
      * Surface the memory-write-off degradation, and return the notice text so a
@@ -652,6 +664,31 @@ export const layer = Layer.effect(
         })
         .pipe(Effect.ignore)
       return MEMORY_WRITE_OFF_FALLBACK_NOTICE
+    })
+
+    const noticeCheckpointOffFallback = Effect.fn("SessionPrompt.noticeCheckpointOffFallback")(function* (
+      sessionID: SessionID,
+    ) {
+      if (checkpointOffNoticed.has(sessionID)) return CHECKPOINT_OFF_FALLBACK_NOTICE
+      checkpointOffNoticed.add(sessionID)
+      const msgs = yield* sessions.messages({ sessionID, agentID: "main" })
+      const anchor = msgs.findLast((m) => m.parts.some((p) => p.type === "compaction")) ?? msgs[msgs.length - 1]
+      if (!anchor) return CHECKPOINT_OFF_FALLBACK_NOTICE
+      const now = Date.now()
+      yield* sessions
+        .updatePart({
+          id: PartID.ascending(),
+          messageID: anchor.info.id,
+          sessionID,
+          type: "text",
+          text: CHECKPOINT_OFF_FALLBACK_NOTICE,
+          // Visible in the TUI transcript; ignored still keeps it out of model
+          // context and session classification.
+          ignored: true,
+          time: { start: now, end: now },
+        })
+        .pipe(Effect.ignore)
+      return CHECKPOINT_OFF_FALLBACK_NOTICE
     })
 
     const resolvePromptParts = Effect.fn("SessionPrompt.resolvePromptParts")(function* (template: string) {
@@ -3617,7 +3654,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // A writer was started and awaited above (AUTO_WRITER_WAIT_MS) and
             // still produced nothing — or memory writing is off, so nothing was
             // attempted at all. Either way this is the ONE state that may compact.
-            if (attempt === "writer-failed" || attempt === "memory-write-off") {
+            if (
+              attempt === "writer-failed" ||
+              attempt === "memory-write-off" ||
+              attempt === "checkpoint-off"
+            ) {
               // THE single compaction fallback: no checkpoint existed AND the
               // writer failed / never ran / the bound expired / was never
               // allowed to run at all. Note this is a bare boundary insert, not
@@ -3640,6 +3681,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               // existing behaviour untouched.
               if (attempt === "memory-write-off")
                 yield* noticeMemoryWriteOffFallback(sessionID).pipe(Effect.ignore)
+              if (attempt === "checkpoint-off")
+                yield* noticeCheckpointOffFallback(sessionID).pipe(Effect.ignore)
               skipOverflowCheck = true
               continue
             }
@@ -4205,7 +4248,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
               // Same as above: the writer ran and failed — not "no checkpoint" —
               // or memory writing is off and nothing was attempted.
-              if (attempt2 === "writer-failed" || attempt2 === "memory-write-off") {
+              if (
+                attempt2 === "writer-failed" ||
+                attempt2 === "memory-write-off" ||
+                attempt2 === "checkpoint-off"
+              ) {
                 // THE single compaction fallback (see the token-threshold site).
                 yield* compaction
                   .create({
@@ -4220,6 +4267,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 // Same reason-split as the token-threshold site.
                 if (attempt2 === "memory-write-off")
                   yield* noticeMemoryWriteOffFallback(sessionID).pipe(Effect.ignore)
+                if (attempt2 === "checkpoint-off")
+                  yield* noticeCheckpointOffFallback(sessionID).pipe(Effect.ignore)
                 skipOverflowCheck = true
               }
               // "insert-failed" → a checkpoint exists; must not compact.
@@ -4491,7 +4540,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         // still produced nothing — or memory writing is off, so no writer was
         // started at all. Only in those two states may /rebuild degrade to
         // compaction.
-        if (attempt === "writer-failed" || attempt === "memory-write-off") {
+        if (
+          attempt === "writer-failed" ||
+          attempt === "memory-write-off" ||
+          attempt === "checkpoint-off"
+        ) {
           // No checkpoint AND the writer genuinely failed / never ran / the bound
           // expired / was never allowed to run — the ONE fallback condition,
           // shared with the auto overflow paths. An earlier revision of this
@@ -4524,7 +4577,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               ? yield* noticeMemoryWriteOffFallback(input.sessionID).pipe(
                   Effect.catch(() => Effect.succeed(MEMORY_WRITE_OFF_FALLBACK_NOTICE)),
                 )
-              : compactedInsteadMsg
+              : attempt === "checkpoint-off"
+                ? yield* noticeCheckpointOffFallback(input.sessionID).pipe(
+                    Effect.catch(() => Effect.succeed(CHECKPOINT_OFF_FALLBACK_NOTICE)),
+                  )
+                : compactedInsteadMsg
           yield* settle(msg)
           return lastUser ?? msgs[msgs.length - 1]!
         }

--- a/packages/opencode/src/session/prune.ts
+++ b/packages/opencode/src/session/prune.ts
@@ -5,6 +5,7 @@ import { MessageV2 } from "./message-v2"
 import { Token } from "../util"
 import { Log } from "../util"
 import { Config } from "@/config"
+import { Flag } from "@/flag/flag"
 import { NotFoundError } from "@/storage"
 import { Effect, Layer, Context } from "effect"
 import { pressureLevel, usable } from "./overflow"
@@ -258,6 +259,11 @@ export const layer: Layer.Layer<
       // (no agentID / unregistered / race) → servesCheckpoint fails open and fires:
       // main and peer must never silently lose checkpoints.
       if (!(yield* actorReg.servesCheckpoint(input.sessionID, input.agentID))) return
+
+      // Do not consume crossed thresholds while checkpointing is disabled.
+      // If an in-process embedder re-enables the flag, the next invocation must
+      // still be able to fire every threshold already crossed by the session.
+      if (Flag.MIMOCODE_DISABLE_CHECKPOINT) return
 
       // Lock: skip if a writer is already running for this session.
       // crossed Set is NOT incremented here — when the in-flight writer

--- a/packages/opencode/test/flag/disable-checkpoint-flag.test.ts
+++ b/packages/opencode/test/flag/disable-checkpoint-flag.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Flag } from "../../src/flag/flag"
+
+const original = process.env.MIMOCODE_DISABLE_CHECKPOINT
+
+function set(value?: string) {
+  if (value === undefined) delete process.env.MIMOCODE_DISABLE_CHECKPOINT
+  else process.env.MIMOCODE_DISABLE_CHECKPOINT = value
+}
+
+afterEach(() => set(original))
+
+describe("MIMOCODE_DISABLE_CHECKPOINT", () => {
+  test("keeps checkpointing enabled by default", () => {
+    set(undefined)
+    expect(Flag.MIMOCODE_DISABLE_CHECKPOINT).toBe(false)
+  })
+
+  test("tracks runtime env changes", () => {
+    set("true")
+    expect(Flag.MIMOCODE_DISABLE_CHECKPOINT).toBe(true)
+    set("false")
+    expect(Flag.MIMOCODE_DISABLE_CHECKPOINT).toBe(false)
+  })
+
+  test("accepts 1 as the truthy alias", () => {
+    set("1")
+    expect(Flag.MIMOCODE_DISABLE_CHECKPOINT).toBe(true)
+    set("0")
+    expect(Flag.MIMOCODE_DISABLE_CHECKPOINT).toBe(false)
+  })
+})

--- a/packages/opencode/test/session/checkpoint-memory-write.test.ts
+++ b/packages/opencode/test/session/checkpoint-memory-write.test.ts
@@ -108,6 +108,38 @@ const seedSession = Effect.fn("seedSession")(function* () {
 
 describe("memory write gate (W1)", () => {
   it.live(
+    "MIMOCODE_DISABLE_CHECKPOINT=true → skipped without affecting the memory config",
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          yield* reset
+          const previous = process.env["MIMOCODE_DISABLE_CHECKPOINT"]
+          process.env["MIMOCODE_DISABLE_CHECKPOINT"] = "true"
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              if (previous === undefined) delete process.env["MIMOCODE_DISABLE_CHECKPOINT"]
+              else process.env["MIMOCODE_DISABLE_CHECKPOINT"] = previous
+            }),
+          )
+          const cp = yield* SessionCheckpoint.Service
+          const info = yield* seedSession()
+
+          const outcome = yield* cp.tryStartCheckpointWriter({
+            sessionID: info.id,
+            model: { providerID: "test", modelID: "test-model" },
+            promptOps: {} as never,
+          })
+
+          expect(outcome).toBe("skipped")
+          expect(spawnLog.count).toBe(0)
+          expect(yield* Effect.promise(() => Bun.file(checkpointPath(info.id)).exists())).toBe(false)
+          expect(yield* Effect.promise(() => Bun.file(notesPath(info.id)).exists())).toBe(false)
+        }),
+      { outsideGit: true },
+    ),
+  )
+
+  it.live(
     "absent config → writer starts and memory files are bootstrapped (today's behavior)",
     provideTmpdirInstance(
       () =>

--- a/packages/opencode/test/session/prune.test.ts
+++ b/packages/opencode/test/session/prune.test.ts
@@ -305,6 +305,36 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
     cache: { read: 0, write: 0 },
   })
 
+  test("disabled thresholds remain eligible after checkpointing is re-enabled", async () => {
+    const previous = process.env.MIMOCODE_DISABLE_CHECKPOINT
+    const harness = makeRetryHarness()
+    const promptOps = {} as any
+
+    try {
+      await runWithHarness(
+        harness,
+        Effect.gen(function* () {
+          const svc = yield* SessionPrune.Service
+          const ssn = yield* SessionNs.Service
+          const info = yield* ssn.create({})
+          const model = createModel({ context: 100_000, output: 32_000 })
+
+          process.env.MIMOCODE_DISABLE_CHECKPOINT = "true"
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(35_000), promptOps })
+          expect(harness.state.enqueueCount).toBe(0)
+
+          process.env.MIMOCODE_DISABLE_CHECKPOINT = "false"
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(35_000), promptOps })
+          expect(harness.state.enqueueCount).toBe(1)
+        }),
+        { checkpoint: { thresholds: ["30K", "45K"] } },
+      )
+    } finally {
+      if (previous === undefined) delete process.env.MIMOCODE_DISABLE_CHECKPOINT
+      else process.env.MIMOCODE_DISABLE_CHECKPOINT = previous
+    }
+  })
+
   // These cases replace the six that pinned the deleted accounting
   // (writerFailures / MAX_WRITER_FAILURES / MAX_WRITER_WAIT_EXTENSIONS). What
   // they used to assert, and why it is no longer the requirement:

--- a/packages/opencode/test/session/rebuild-on-the-spot.test.ts
+++ b/packages/opencode/test/session/rebuild-on-the-spot.test.ts
@@ -701,8 +701,9 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
                     )
                   expect(notice?.type).toBe("text")
                   if (notice?.type !== "text") throw new Error("expected checkpoint-off notice")
-                  expect(notice.synthetic).not.toBe(true)
+                  expect(notice.synthetic).toBe(true)
                   expect(notice.ignored).toBe(true)
+                  expect(notice.metadata).toEqual({ origin: { kind: "checkpoint-off" } })
                   expect(llm.calls).toBe(0)
                 }),
               ),

--- a/packages/opencode/test/session/rebuild-on-the-spot.test.ts
+++ b/packages/opencode/test/session/rebuild-on-the-spot.test.ts
@@ -625,6 +625,99 @@ describe("Manual /rebuild: on-the-spot rebuild driven through SessionPrompt.comm
     { timeout: 30_000 },
   )
 
+  test(
+    "MIMOCODE_DISABLE_CHECKPOINT=true → compacts immediately without starting or waiting for a writer",
+    async () => {
+      const previous = process.env.MIMOCODE_DISABLE_CHECKPOINT
+      process.env.MIMOCODE_DISABLE_CHECKPOINT = "true"
+      const llm = startLLM("should-not-be-used-as-a-reply")
+      const writer = countingSpawn(writerThatWritesCheckpoint("SHOULD_NEVER_BE_WRITTEN"))
+      const seen: Array<string | undefined> = []
+      const onEvent = (e: {
+        payload?: { type?: string; properties?: { status?: { type?: string; message?: string } } }
+      }) => {
+        if (e?.payload?.type === "session.status" && e.payload.properties?.status?.type === "busy") {
+          seen.push(e.payload.properties.status.message)
+        }
+      }
+      GlobalBus.on("event", onEvent)
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
+        })
+
+        await withSpawnRef(writer.impl, () =>
+          Instance.provide({
+            directory: tmp.path,
+            fn: () =>
+              run(
+                Effect.gen(function* () {
+                  const prompt = yield* SessionPrompt.Service
+                  const sessions = yield* Session.Service
+                  const info = yield* sessions.create({ title: "rebuild-checkpoint-off" })
+                  const boundary = yield* Effect.promise(() =>
+                    seedUserMessage(info.id, "turn one with checkpointing off"),
+                  )
+                  yield* Effect.promise(() =>
+                    fs.mkdir(path.dirname(checkpointPath(info.id)), { recursive: true }),
+                  )
+                  yield* Effect.promise(() =>
+                    fs.writeFile(
+                      checkpointPath(info.id),
+                      "# Session checkpoint\n\n## §1 Active intent\nThis existing checkpoint must not be rebuilt.\n",
+                    ),
+                  )
+                  yield* Effect.sync(() =>
+                    Database.use((db) =>
+                      db
+                        .update(SessionTable)
+                        .set({ last_checkpoint_message_id: boundary.id })
+                        .where(eq(SessionTable.id, info.id))
+                        .run(),
+                    ),
+                  )
+
+                  yield* prompt.command({
+                    sessionID: info.id,
+                    command: Command.Default.REBUILD,
+                    arguments: "",
+                    agent: "build",
+                  })
+
+                  const after = yield* sessions.messages({ sessionID: info.id })
+                  expect(after.filter((m) => m.parts.some((p) => p.type === "compaction")).length).toBe(1)
+                  expect(after.filter((m) => m.parts.some((p) => p.type === "checkpoint")).length).toBe(0)
+                  expect(writer.calls).toBe(0)
+                  expect(seen).not.toContain("Writing checkpoint\u2026")
+                  expect(yield* Effect.promise(() => Bun.file(checkpointPath(info.id)).exists())).toBe(true)
+                  const notice = after
+                    .flatMap((m) => m.parts)
+                    .find(
+                      (p) =>
+                        p.type === "text" &&
+                        p.text.includes("Checkpointing is off") &&
+                        p.text.includes("MIMOCODE_DISABLE_CHECKPOINT"),
+                    )
+                  expect(notice?.type).toBe("text")
+                  if (notice?.type !== "text") throw new Error("expected checkpoint-off notice")
+                  expect(notice.synthetic).not.toBe(true)
+                  expect(notice.ignored).toBe(true)
+                  expect(llm.calls).toBe(0)
+                }),
+              ),
+          }),
+        )
+      } finally {
+        if (previous === undefined) delete process.env.MIMOCODE_DISABLE_CHECKPOINT
+        else process.env.MIMOCODE_DISABLE_CHECKPOINT = previous
+        GlobalBus.off("event", onEvent)
+        await llm.stop()
+      }
+    },
+    { timeout: 30_000 },
+  )
+
   // `memory.disable_write: true` means no checkpoint can ever be written for the
   // session, so every rebuild degrades to compaction for the whole life of that
   // session. That is the switch doing its job, but it used to leave the user with


### PR DESCRIPTION
## Summary

- add the runtime `MIMOCODE_DISABLE_CHECKPOINT` flag
- skip checkpoint writers and checkpoint rebuilds while preserving other memory writes
- fall back to compaction with a TUI-visible, model-ignored notice
- preserve crossed thresholds so runtime re-enabling can trigger checkpointing

## Testing

- `bun test test/flag/disable-checkpoint-flag.test.ts test/session/checkpoint-memory-write.test.ts test/session/rebuild-on-the-spot.test.ts test/session/prune.test.ts`
- `bun typecheck` from `packages/opencode`
- push hook: `bun turbo typecheck`