### PR TITLE
fix(id): extend identifier timestamps to 64 bits before v1 wraps

### DIFF
--- a/packages/app/src/utils/id.ts
+++ b/packages/app/src/utils/id.ts
@@ -9,7 +9,11 @@ const prefixes = {
   pty: "pty",
 } as const
 
+// Payload after `{prefix}_` is always 26 chars.
+// v1: 12 hex + 14 base62 (48-bit, wraps every 2^36 ms).
+// v2: `{g|-}` + 16 hex + 9 base62. `g` > `f`, `-` < `0` vs v1 hex.
 const LENGTH = 26
+const TIME_BYTES = 8
 let lastTimestamp = 0
 let counter = 0
 
@@ -56,12 +60,13 @@ function create(prefix: Prefix, descending: boolean, timestamp?: number): string
     now = ~now
   }
 
-  const timeBytes = new Uint8Array(6)
-  for (let i = 0; i < 6; i += 1) {
-    timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff))
+  const timeBytes = new Uint8Array(TIME_BYTES)
+  for (let i = 0; i < TIME_BYTES; i += 1) {
+    timeBytes[i] = Number((now >> BigInt(56 - 8 * i)) & BigInt(0xff))
   }
 
-  return prefixes[prefix] + "_" + bytesToHex(timeBytes) + randomBase62(LENGTH - 12)
+  const mark = descending ? "-" : "g"
+  return prefixes[prefix] + "_" + mark + bytesToHex(timeBytes) + randomBase62(LENGTH - 1 - TIME_BYTES * 2)
 }
 
 function bytesToHex(bytes: Uint8Array): string {

--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -20,7 +20,15 @@ export function schema(prefix: keyof typeof prefixes) {
   return z.string().startsWith(prefixes[prefix])
 }
 
+// Payload after `{prefix}_` is always 26 chars.
+// v1 (legacy): 12 hex (48-bit time*4096+counter) + 14 base62.
+//   Date.now()*4096 is now 53 bits, so v1 kept only the low 48 and wrapped
+//   every 2^36 ms (~795 days). The 26th wrap was 2026-08-14T19:19:55.136Z.
+// v2: `{g|-}` + 16 hex (64-bit) + 9 base62.
+//   `g` > `f` so ascending v2 sorts after every v1 id.
+//   `-` < `0` so descending v2 sorts before every v1 id.
 const LENGTH = 26
+const TIME_BYTES = 8
 
 // State for monotonic ID generation
 let lastTimestamp = 0
@@ -68,20 +76,26 @@ export function create(prefix: string, direction: "descending" | "ascending", ti
 
   now = direction === "descending" ? ~now : now
 
-  const timeBytes = Buffer.alloc(6)
-  for (let i = 0; i < 6; i++) {
-    timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff))
+  const timeBytes = Buffer.alloc(TIME_BYTES)
+  for (let i = 0; i < TIME_BYTES; i++) {
+    timeBytes[i] = Number((now >> BigInt(56 - 8 * i)) & BigInt(0xff))
   }
 
-  return prefix + "_" + timeBytes.toString("hex") + randomBase62(LENGTH - 12)
+  const mark = direction === "descending" ? "-" : "g"
+  return prefix + "_" + mark + timeBytes.toString("hex") + randomBase62(LENGTH - 1 - TIME_BYTES * 2)
 }
 
 /** Extract timestamp from an ascending ID. Does not work with descending IDs. */
-export function timestamp(id: string): number {
+export function timestamp(id: string, now = Date.now()): number {
   const prefix = id.split("_")[0]
-  const hex = id.slice(prefix.length + 1, prefix.length + 13)
-  const encoded = BigInt("0x" + hex)
-  return Number(encoded / BigInt(0x1000))
+  const body = id.slice(prefix.length + 1)
+  const v2 = body[0] === "g" || body[0] === "-"
+  const raw = Number(BigInt("0x" + (v2 ? body.slice(1, 17) : body.slice(0, 12))) / BigInt(0x1000))
+  if (v2) return raw
+  // v1 stored ts % 2^36. Restore the latest cycle that does not exceed `now`.
+  const cycle = 2 ** 36
+  const recovered = Math.floor(now / cycle) * cycle + raw
+  return recovered > now ? recovered - cycle : recovered
 }
 
 export * as Identifier from "./id"

--- a/packages/opencode/src/server/routes/instance/workflows.ts
+++ b/packages/opencode/src/server/routes/instance/workflows.ts
@@ -8,13 +8,13 @@ import { jsonRequest } from "./trace"
 import type { SessionID } from "@/session/schema"
 
 // Read-only routes (transcript/structure) accept BOTH runID shapes: a top-level
-// run is `wf_` + 26 base62 (Identifier.descending), a nested child workflow is
-// `wf_` + 64 hex (sha256 of parent runID + key, see runtime.ts). The resume route
-// keeps the strict 26-char form because only top-level runs are resumable AND it
-// builds a filesystem path from the id; these read routes only do an in-memory
-// runtime map lookup, so the wider (still traversal-proof — no `.`/`/`) charset is
-// safe here.
-const READ_RUN_ID = /^wf_(?:[0-9A-Za-z]{26}|[0-9a-f]{64})$/
+// run is `wf_` + 26-char Identifier payload (v1 hex+base62, or v2 `-`/hex+base62),
+// a nested child workflow is `wf_` + 64 hex (sha256 of parent runID + key, see
+// runtime.ts). The resume route keeps the strict 26-char form because only
+// top-level runs are resumable AND it builds a filesystem path from the id; these
+// read routes only do an in-memory runtime map lookup, so the wider (still
+// traversal-proof — no `.`/`/`) charset is safe here.
+const READ_RUN_ID = /^wf_(?:[0-9A-Za-z-]{26}|[0-9a-f]{64})$/
 
 export const WorkflowRoutes = lazy(() =>
   new Hono()
@@ -63,11 +63,11 @@ export const WorkflowRoutes = lazy(() =>
           // Strict shape, NOT just startsWith("wf"): runID flows into
           // scriptPath = join(scriptDir, runID + ".js"), so a value like
           // `wf_../../../etc/passwd` (which startsWith "wf") would escape scriptDir.
-          // Identifier mints `wf_` + 26 base62 chars; this charset has no `.` or `/`,
-          // so it is traversal-proof by construction. The `{26}` tracks
-          // Identifier.LENGTH — if that constant ever changes, widen this too (the
-          // in-depth persistence guard uses `+`, so it stays correct regardless).
-          runID: z.string().regex(/^wf_[0-9A-Za-z]{26}$/, "invalid workflow runID"),
+          // Identifier mints `wf_` + 26 payload chars (`[0-9A-Za-z-]`). This charset
+          // has no `.` or `/`, so it is traversal-proof by construction. The `{26}`
+          // tracks Identifier.LENGTH — if that constant ever changes, widen this too
+          // (the in-depth persistence guard uses `+`, so it stays correct regardless).
+          runID: z.string().regex(/^wf_[0-9A-Za-z-]{26}$/, "invalid workflow runID"),
         }),
       ),
       async (c) =>

--- a/packages/opencode/src/workflow/persistence.ts
+++ b/packages/opencode/src/workflow/persistence.ts
@@ -84,7 +84,7 @@ const scriptDir = () => path.join(Global.Path.data, "workflow")
 // or dot-dot (`../../../etc/passwd`, `wf_../x`, an absolute path) would escape
 // scriptDir. The HTTP route already rejects these, but resume()/journal IO are also
 // reachable from the workflow tool and the TUI, so we re-enforce the minted shape
-// here (`wf_` + base62 — a charset with no `.` or `/`). A throw here surfaces as an
+// here (`wf_` + `[0-9A-Za-z-]` — a charset with no `.` or `/`). A throw here surfaces as an
 // Effect defect: on the async IO paths (readScript/loadJournal) resume() captures it
 // via Effect.exit and treats it as not-resumable; on the synchronous journal appends
 // it fails as a defect BEFORE any appendFileSync (the caller Effect.ignore's it), so
@@ -92,7 +92,7 @@ const scriptDir = () => path.join(Global.Path.data, "workflow")
 // The `+` form (not the route's fixed `{26}`) is deliberate: this in-depth guard only
 // needs the traversal-proof property (no `.`/`/`), so it stays correct even if the
 // minted ID length changes; the strict length check lives at the route trust boundary.
-const RUN_ID = /^wf_[0-9A-Za-z]+$/
+const RUN_ID = /^wf_[0-9A-Za-z-]+$/
 const safeRunID = (runID: string) => {
   if (!RUN_ID.test(runID)) throw new Error(`invalid workflow runID: ${JSON.stringify(runID)}`)
   return runID

--- a/packages/opencode/test/id/id.test.ts
+++ b/packages/opencode/test/id/id.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+import { Identifier } from "../../src/id/id"
+
+const WRAP_MS = 2 ** 36
+const WRAP_26 = 26 * WRAP_MS
+
+function v1(prefix: string, hex12: string) {
+  return `${prefix}_${hex12}${"0".repeat(14)}`
+}
+
+function v1At(prefix: string, ts: number) {
+  const hex = ((BigInt(ts) * 0x1000n + 1n) & 0xffffffffffffn).toString(16).padStart(12, "0")
+  return `${prefix}_${hex}${"0".repeat(14)}`
+}
+
+describe("Identifier", () => {
+  test("payload after prefix is still 26 chars", () => {
+    const id = Identifier.ascending("message")
+    expect(id.startsWith("msg_")).toBe(true)
+    expect(id.slice(4).length).toBe(26)
+  })
+
+  test("ascending v2 starts with g so it sorts after every v1 id", () => {
+    const next = Identifier.ascending("message")
+    expect(next[4]).toBe("g")
+    expect(v1("msg", "ffffffffffff") < next).toBe(true)
+    expect(v1("msg", "000000000000") < next).toBe(true)
+    expect("msg_fd708d21e001JXYNUE1Jba3VEW" < next).toBe(true)
+  })
+
+  test("descending v2 starts with - so it sorts before every v1 id", () => {
+    const next = Identifier.descending("session")
+    expect(next[4]).toBe("-")
+    expect(next < v1("ses", "000000000000")).toBe(true)
+    expect(next < v1("ses", "ffffffffffff")).toBe(true)
+  })
+
+  test("ascending ids stay ordered across the old 48-bit wrap", () => {
+    const before = Identifier.create("msg", "ascending", WRAP_26 - 1)
+    const after = Identifier.create("msg", "ascending", WRAP_26)
+    expect(before < after).toBe(true)
+    expect(Identifier.timestamp(before)).toBe(WRAP_26 - 1)
+    expect(Identifier.timestamp(after)).toBe(WRAP_26)
+  })
+
+  test("same-millisecond ascending ids are ordered by counter", () => {
+    const a = Identifier.create("msg", "ascending", 1_700_000_000_000)
+    const b = Identifier.create("msg", "ascending", 1_700_000_000_000)
+    expect(a < b).toBe(true)
+    expect(Identifier.timestamp(a)).toBe(1_700_000_000_000)
+    expect(Identifier.timestamp(b)).toBe(1_700_000_000_000)
+  })
+
+  test("timestamp() unwraps a v1 id onto the current 2^36 cycle", () => {
+    const threeDaysAgo = Date.now() - 3 * 24 * 60 * 60 * 1000
+    expect(Identifier.timestamp(v1At("msg", threeDaysAgo))).toBe(threeDaysAgo)
+  })
+
+  test("timestamp() keeps a pre-wrap v1 id in the previous cycle", () => {
+    expect(Identifier.timestamp(v1At("msg", WRAP_26 - 1000), WRAP_26 + 1000)).toBe(WRAP_26 - 1000)
+  })
+
+  test("a 3-day-old v1 id is newer than a 7-day v2 cutoff", () => {
+    const now = Date.now()
+    const cutoff = Identifier.timestamp(Identifier.create("tool", "ascending", now - 7 * 24 * 60 * 60 * 1000), now)
+    expect(Identifier.timestamp(v1At("tool", now - 3 * 24 * 60 * 60 * 1000), now)).toBeGreaterThanOrEqual(cutoff)
+  })
+
+  test("schema accepts both v1 and v2", () => {
+    const schema = Identifier.schema("message")
+    expect(schema.safeParse("msg_f4c12734b001QCMNgJEWL8E2J3").success).toBe(true)
+    expect(schema.safeParse(Identifier.ascending("message")).success).toBe(true)
+    expect(schema.safeParse("prt_g00").success).toBe(false)
+  })
+})

--- a/packages/opencode/test/server/workflows-route.test.ts
+++ b/packages/opencode/test/server/workflows-route.test.ts
@@ -4,6 +4,7 @@ import { Log } from "../../src/util"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
 import { Session } from "../../src/session"
+import { Identifier } from "../../src/id/id"
 import { WorkflowPersistence } from "../../src/workflow/persistence"
 import { WorkflowRuntime } from "../../src/workflow/runtime"
 import { workflowRef } from "../../src/workflow/runtime-ref"
@@ -46,13 +47,27 @@ describe("workflows routes", () => {
         // #given the workflow runtime layer is not running
         workflowRef.current = undefined
 
-        // #when — a real minted-shape runID (wf_ + 26 base62) with no persisted run
+        // #when — a real minted-shape runID (wf_ + 26-char payload) with no persisted run
         const app = Server.Default().app
         const response = await app.request("/workflows/wf_16ec185f2ffexEGkbWeMqWSucv/resume", { method: "POST" })
 
         // #then
         expect(response.status).toBe(200)
         expect(await response.json()).toEqual({ runID: "wf_16ec185f2ffexEGkbWeMqWSucv", resumed: false })
+      },
+    })
+  })
+
+  test("POST /workflows/:runID/resume accepts a minted v2 descending runID", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        workflowRef.current = undefined
+        const runID = Identifier.descending("workflow")
+        const response = await Server.Default().app.request(`/workflows/${runID}/resume`, { method: "POST" })
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ runID, resumed: false })
       },
     })
   })
@@ -191,6 +206,19 @@ describe("workflows routes", () => {
         const runID = "wf_16ec185f2ffexEGkbWeMqWSucv"
         await Effect.runPromise(WorkflowPersistence.writeScript(runID, "export const meta = {}\n"))
         // #then — the guard does NOT break the legit path
+        const body = await Effect.runPromise(WorkflowPersistence.readScript(runID))
+        expect(body).toContain("export const meta")
+      },
+    })
+  })
+
+  test("WorkflowPersistence.readScript reads a minted v2 descending runID", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const runID = Identifier.descending("workflow")
+        await Effect.runPromise(WorkflowPersistence.writeScript(runID, "export const meta = {}\n"))
         const body = await Effect.runPromise(WorkflowPersistence.readScript(runID))
         expect(body).toContain("export const meta")
       },

--- a/packages/opencode/test/tool/truncation.test.ts
+++ b/packages/opencode/test/tool/truncation.test.ts
@@ -250,15 +250,25 @@ describe("Truncate", () => {
 
         yield* fs.makeDirectory(Truncate.DIR, { recursive: true })
 
+        const v1Name = (ts: number) => {
+          const hex = ((BigInt(ts) * 0x1000n + 1n) & 0xffffffffffffn).toString(16).padStart(12, "0")
+          return `tool_${hex}${"0".repeat(14)}`
+        }
         const old = path.join(Truncate.DIR, Identifier.create("tool", "ascending", Date.now() - 10 * DAY_MS))
         const recent = path.join(Truncate.DIR, Identifier.create("tool", "ascending", Date.now() - 3 * DAY_MS))
+        const oldV1 = path.join(Truncate.DIR, v1Name(Date.now() - 10 * DAY_MS))
+        const recentV1 = path.join(Truncate.DIR, v1Name(Date.now() - 3 * DAY_MS))
 
         yield* writeFileStringScoped(old, "old content")
         yield* writeFileStringScoped(recent, "recent content")
+        yield* writeFileStringScoped(oldV1, "old v1")
+        yield* writeFileStringScoped(recentV1, "recent v1")
         yield* svc.cleanup()
 
         expect(yield* fs.exists(old)).toBe(false)
         expect(yield* fs.exists(recent)).toBe(true)
+        expect(yield* fs.exists(oldV1)).toBe(false)
+        expect(yield* fs.exists(recentV1)).toBe(true)
       }),
     )
   })

--- a/packages/shared/src/util/identifier.ts
+++ b/packages/shared/src/util/identifier.ts
@@ -1,7 +1,11 @@
 import { randomBytes } from "crypto"
 
 export namespace Identifier {
+  // Payload is always 26 chars. v1 was 12 hex + 14 base62 (48-bit, wraps
+  // every 2^36 ms). v2 is `{g|-}` + 16 hex + 9 base62 so lexicographic order
+  // stays compatible with existing v1 ids: `g` > `f`, `-` < `0`.
   const LENGTH = 26
+  const TIME_BYTES = 8
 
   // State for monotonic ID generation
   let lastTimestamp = 0
@@ -38,11 +42,12 @@ export namespace Identifier {
 
     now = descending ? ~now : now
 
-    const timeBytes = Buffer.alloc(6)
-    for (let i = 0; i < 6; i++) {
-      timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff))
+    const timeBytes = Buffer.alloc(TIME_BYTES)
+    for (let i = 0; i < TIME_BYTES; i++) {
+      timeBytes[i] = Number((now >> BigInt(56 - 8 * i)) & BigInt(0xff))
     }
 
-    return timeBytes.toString("hex") + randomBase62(LENGTH - 12)
+    const mark = descending ? "-" : "g"
+    return mark + timeBytes.toString("hex") + randomBase62(LENGTH - 1 - TIME_BYTES * 2)
   }
 }

--- a/packages/shared/test/util/identifier.test.ts
+++ b/packages/shared/test/util/identifier.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { Identifier } from "../../src/util/identifier"
+
+const WRAP_MS = 2 ** 36
+const WRAP_26 = 26 * WRAP_MS
+
+describe("Identifier", () => {
+  test("payload is still 26 chars", () => {
+    expect(Identifier.ascending().length).toBe(26)
+    expect(Identifier.descending().length).toBe(26)
+  })
+
+  test("ascending v2 sorts after a max v1 id", () => {
+    const next = Identifier.ascending()
+    expect(next[0]).toBe("g")
+    expect("f".repeat(12) + "0".repeat(14) < next).toBe(true)
+  })
+
+  test("descending v2 sorts before a min v1 id", () => {
+    const next = Identifier.descending()
+    expect(next[0]).toBe("-")
+    expect(next < "0".repeat(26)).toBe(true)
+  })
+
+  test("ascending ids stay ordered across the old 48-bit wrap", () => {
+    const before = Identifier.create(false, WRAP_26 - 1)
+    const after = Identifier.create(false, WRAP_26)
+    expect(before < after).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- v1 IDs kept only the low 48 bits of `Date.now()*4096`, wrapping every 2^36 ms (~795 days); the 26th wrap lands **2026-08-14**.
- v2 payload: `{g|-}` + 16 hex (64-bit time) + 9 base62, keeping the 26-char length; `g` > `f` and `-` < `0` preserve lexicographic order against existing v1 IDs.
- `Identifier.timestamp()` now recovers the latest v1 cycle not exceeding `now`, so legacy IDs stay sortable/deletable.
- Workflow runID regexes (`workflows.ts` route, `persistence.ts`) accept the new `-` mark; charset still traversal-proof.
- Applies the v2 format in `packages/app`, `packages/opencode`, and `packages/shared`; new tests for id round-trip/order and truncation of v1 vs v2 files.

## Verification
- `bun test` on `test/id`, `test/tool/truncation`, `test/server/workflows-route` (opencode): 46 pass; one pre-existing test (`GET /workflows returns []` without runtime) timed out at 5s — unrelated to these changes, flaky under load.
- `bun test test/util/identifier.test.ts` (shared): 4 pass.
- `bun turbo typecheck`: 12/12 packages pass.