### PR TITLE
fix(checkpoint): hide disabled lifecycle prompt copy

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -90,8 +90,9 @@ export const Flag = {
   MIMOCODE_DISABLE_DEFAULT_PLUGINS: truthy("MIMOCODE_DISABLE_DEFAULT_PLUGINS"),
   MIMOCODE_DISABLE_LSP_DOWNLOAD: truthy("MIMOCODE_DISABLE_LSP_DOWNLOAD"),
   MIMOCODE_ENABLE_EXPERIMENTAL_MODELS: truthy("MIMOCODE_ENABLE_EXPERIMENTAL_MODELS"),
-  // Defaults to false. When enabled, checkpoint writers and checkpoint-based
-  // context rebuilds are disabled; context overflow falls back to compaction.
+  // Defaults to false. When enabled, checkpoint writers, checkpoint-based
+  // context rebuilds, and checkpoint copy in the system prompt and tool
+  // schemas are disabled; context overflow falls back to compaction.
   // Read lazily so tests and in-process embedders can toggle it at runtime.
   get MIMOCODE_DISABLE_CHECKPOINT() {
     return truthy("MIMOCODE_DISABLE_CHECKPOINT")

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -35,6 +35,7 @@ import { isRetryableTransientError } from "./retry"
 import { MCP_TOOL_SEARCH_ID } from "@/tool/mcp-tool-search"
 import { deriveLiveness } from "@/actor/schema"
 import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
+import { Flag } from "@/flag/flag"
 
 const log = Log.create({ service: "llm" })
 export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
@@ -140,37 +141,58 @@ export const persistentRetrySchedule = Schedule.exponential("500 millis", 2).pip
  * files already present in the rebuild dump, and the Subagent return
  * format contract.
  *
+ * When `MIMOCODE_DISABLE_CHECKPOINT` is on, the checkpoint.md / writer /
+ * Active-recall sections are omitted so the prompt does not teach a
+ * lifecycle that is not running. MEMORY.md, notes.md, and global memory
+ * instructions stay.
+ *
  * `memoryRoot` is the same absolute root returned by Memory.root(), so these
  * paths match the files used by checkpoint restore and memory/task detection.
  */
 function buildMemoryInstructions(sessionID: SessionID, projectID: ProjectID, memoryRoot: string): string {
   const memoryFile = path.join(memoryRoot, "projects", projectID, "MEMORY.md")
-  const checkpointFile = path.join(memoryRoot, "sessions", sessionID, "checkpoint.md")
   const sessionMemoryDir = path.join(memoryRoot, "sessions", sessionID)
   const globalMemoryFile = path.join(memoryRoot, "global", "MEMORY.md")
-  return `# Memory system
+  const notesFile = path.join(sessionMemoryDir, "notes.md")
+  const checkpointEnabled = !Flag.MIMOCODE_DISABLE_CHECKPOINT
 
-You have a persistent file-based memory system. Four file types:
+  const files = [
+    `- Project memory at \`${memoryFile}\` — persistent across all sessions in this project. Contains: project context, rules, architecture decisions, durable cross-task knowledge.`,
+    ...(checkpointEnabled
+      ? [
+          `- Session checkpoint at \`${path.join(sessionMemoryDir, "checkpoint.md")}\` — current session's structured state, written ONLY by the checkpoint-writer subagent. 11 sections covering active intent, next action, directives, task tree, current work, files, learnings, errors, live resources, design decisions, and open notes. Task content lives inside §4 Task tree and §5 Current work.`,
+          `- Per-task progress at \`${path.join(sessionMemoryDir, "tasks", "<id>", "progress.md")}\` — writer-derived splitover from session-level progress.md (not LLM-written). When you spawn a subagent on a task, the subagent may be handed this path for reading; you do not maintain it.`,
+        ]
+      : []),
+    `- Global memory at \`${globalMemoryFile}\` — user-level preferences and cross-project feedback that persist across all projects.${checkpointEnabled ? ` Auto-injected into rebuild context under the "## Global memory" header when present.` : ""}`,
+  ]
 
-- Project memory at \`${memoryFile}\` — persistent across all sessions in this project. Contains: project context, rules, architecture decisions, durable cross-task knowledge.
-- Session checkpoint at \`${checkpointFile}\` — current session's structured state, written ONLY by the checkpoint-writer subagent. 11 sections covering active intent, next action, directives, task tree, current work, files, learnings, errors, live resources, design decisions, and open notes. Task content lives inside §4 Task tree and §5 Current work.
-- Per-task progress at \`${path.join(sessionMemoryDir, "tasks", "<id>", "progress.md")}\` — writer-derived splitover from session-level progress.md (not LLM-written). When you spawn a subagent on a task, the subagent may be handed this path for reading; you do not maintain it.
-- Global memory at \`${globalMemoryFile}\` — user-level preferences and cross-project feedback that persist across all projects. Auto-injected into rebuild context under the "## Global memory" header when present.
+  const sections = [
+    `# Memory system
 
-The checkpoint writer is the sole curator of the structured files. You don't maintain them mid-task — the writer extracts everything from the conversation at checkpoint events.
+You have a persistent file-based memory system. ${checkpointEnabled ? "Four" : "Two"} file types:
 
-## When to Edit MEMORY.md directly
+${files.join("\n")}`,
+    ...(checkpointEnabled
+      ? [
+          "The checkpoint writer is the sole curator of the structured files. You don't maintain them mid-task — the writer extracts everything from the conversation at checkpoint events.",
+        ]
+      : []),
+    `## When to Edit MEMORY.md directly
 
 You may Edit MEMORY.md when:
 - User states a project-level rule that should hold across sessions → ## Rules
 - User states a project-level architectural decision → ## Architecture decisions
-- A clearly durable cross-session fact emerges that you want available immediately, before the next checkpoint → ## Discovered durable knowledge
+- A clearly durable cross-session fact emerges that you want available immediately${checkpointEnabled ? ", before the next checkpoint" : ""} → ## Discovered durable knowledge${
+      checkpointEnabled
+        ? `
 
-These are exceptions, not the norm. The writer covers most extraction at checkpoint time.
+These are exceptions, not the norm. The writer covers most extraction at checkpoint time.`
+        : ""
+    }`,
+    `## Notes scratchpad
 
-## Notes scratchpad
-
-You have a single legal scratchpad at \`${path.join(sessionMemoryDir, "notes.md")}\`. Append entries to it when you want to record:
+You have a single legal scratchpad at \`${notesFile}\`. Append entries to it when you want to record:
 
 - A quote (from the user, an article, a known engineer) that has lasting value but isn't a task-specific decision
 - An unresolved question — something you noticed but won't answer this turn
@@ -179,11 +201,10 @@ You have a single legal scratchpad at \`${path.join(sessionMemoryDir, "notes.md"
 
 Format each entry as:
   ## [turn N · YYYY-MM-DDTHH:MM:SSZ]
-  Free-form body. The writer reorganizes structured content at checkpoint time.
+  Free-form body.${checkpointEnabled ? " The writer reorganizes structured content at checkpoint time." : ""}
 
-This is your ONLY legal scratchpad — don't create \`learning.md\`, \`scratch.md\`, or any other ad-hoc memory file.
-
-## Subagent return format
+This is your ONLY legal scratchpad — don't create \`learning.md\`, \`scratch.md\`, or any other ad-hoc memory file.`,
+    `## Subagent return format
 
 When you (as a subagent) finish your task, your final assistant message will be delivered to the spawning agent. If the spawn machinery added a "Return format (required)" section to your prompt, follow it exactly:
 
@@ -195,15 +216,17 @@ When you (as a subagent) finish your task, your final assistant message will be 
   **Files touched**: <comma-separated paths or "(none)">
   **Findings worth promoting**: <bullet list, or "(none)">
 
-If your spawn prompt didn't include this format (e.g., explore/title/summary agents have their own contracts), follow whatever your prompt specifies.
+If your spawn prompt didn't include this format (e.g., explore/title/summary agents have their own contracts), follow whatever your prompt specifies.`,
+    `## What NOT to do
 
-## What NOT to do
-
-- Don't Edit checkpoint.md — that's the writer's domain.
-- Don't create memory files other than notes.md (no learning.md, no scratch.md). Use notes.md for any free-form entry.
-- Don't ask the user about something memory may already record — search first via Grep / Read.
-
-## Active recall protocol
+${[
+  ...(checkpointEnabled ? ["- Don't Edit checkpoint.md — that's the writer's domain."] : []),
+  "- Don't create memory files other than notes.md (no learning.md, no scratch.md). Use notes.md for any free-form entry.",
+  "- Don't ask the user about something memory may already record — search first via Grep / Read.",
+].join("\n")}`,
+    ...(checkpointEnabled
+      ? [
+          `## Active recall protocol
 
 After a checkpoint rebuild, the following dumps may be already in your context (look for the "Summary of previous conversation from checkpoint files:" header followed by these dumps):
 
@@ -222,8 +245,12 @@ If a dump shows "⚠️ Truncated at ~N tokens. Read(<path>, offset=L) for the r
 
 Memory entries name functions, files, flags, paths — those are CLAIMS about a point in time when they were written. Verify before acting on a specific name.
 
-Don't ask the user about something memory may already record.
-`
+Don't ask the user about something memory may already record.`,
+        ]
+      : []),
+  ]
+
+  return sections.join("\n\n")
 }
 
 export type StreamInput = {
@@ -307,16 +334,18 @@ const live: Layer.Layer<
       )
 
       // v5: memory-instructions section. Teaches the agent how/where/when to
-      // maintain `MEMORY.md` and `checkpoint.md` directly via Edit. Project ID is
-      // resolved from the ALS-bound Instance with a safe fallback to
-      // `ProjectID.global` (mirrors the pattern in session/checkpoint.ts so the
+      // maintain `MEMORY.md` and (when checkpointing is on) `checkpoint.md`.
+      // Project ID is resolved from the ALS-bound Instance with a safe fallback
+      // to `ProjectID.global` (mirrors the pattern in session/checkpoint.ts so the
       // path the prompt advertises matches the path the writer actually writes).
       // Injected only for actors whose context the checkpoint flow serves —
       // main + peer. Subagents (explore/general/compose) use per-actor compaction
       // and have no checkpoint duty; system-spawned actors (checkpoint-writer et al.)
       // are the writers themselves. Shares the exact `servesCheckpoint` judgement
       // with SessionPrune.fireCheckpoints so the "who owns a checkpoint" and "who is
-      // taught about it" sets can never drift apart.
+      // taught about it" sets can never drift apart. MIMOCODE_DISABLE_CHECKPOINT
+      // still injects this block, but strips the checkpoint.md / writer / recall
+      // sections so the prompt does not describe a disabled lifecycle.
       const servesCheckpoint = yield* actorReg.servesCheckpoint(SessionID.make(input.sessionID), input.agentID)
       if (servesCheckpoint) {
         const projectID =

--- a/packages/opencode/src/tool/actor.checkpoint.txt
+++ b/packages/opencode/src/tool/actor.checkpoint.txt
@@ -1,0 +1,4 @@
+## Checkpoint integration
+
+- `context="state"`: subagent gets checkpoint summaries injected (background knowledge, no full detail).
+- Findings captured to `tasks/<TID>/progress.md` are reconciled into the next checkpoint. After the subagent finishes writing that file, the checkpoint writer reads it and integrates verbatim commands, outcome, and discoveries into the main checkpoint.

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -1,7 +1,9 @@
 import * as Tool from "./tool"
 import { RecoverableError } from "./recoverable"
 import DESCRIPTION from "./actor.txt"
+import DESCRIPTION_CHECKPOINT from "./actor.checkpoint.txt"
 import SHELL_DESCRIPTION from "./actor.shell.txt"
+import { withCheckpointDescription, withCheckpointClause } from "./checkpoint-description"
 import { tokenize } from "./shell-tokenize"
 import z from "zod"
 import { Session } from "../session"
@@ -361,6 +363,16 @@ export const ActorTool = Tool.define(
         .optional()
         .describe("(optional) Milliseconds to wait before returning { status: 'timeout' }. Default 600000 (10 min).")
 
+      const contextField = z
+        .enum(["none", "state", "full"])
+        .optional()
+        .describe(
+          withCheckpointClause(
+            "(optional) Context inheritance. 'none' (default): child sees only prompt. 'full': child sees parent conversation (prefix cache sharing).",
+            "'state': child gets checkpoint summary.",
+          ),
+        )
+
       const runSchema = z.strictObject({
         action: z
           .literal("run")
@@ -384,12 +396,7 @@ export const ActorTool = Tool.define(
           ),
         timeout_ms: timeoutField,
         command: z.string().min(1).optional().describe("(optional) The command that triggered this task."),
-        context: z
-          .enum(["none", "state", "full"])
-          .optional()
-          .describe(
-            "(optional) Context inheritance. 'none' (default): child sees only prompt. 'full': child sees parent conversation (prefix cache sharing). 'state': child gets checkpoint summary.",
-          ),
+        context: contextField,
         task_id: z
           .string()
           .min(1)
@@ -427,10 +434,7 @@ export const ActorTool = Tool.define(
             "(optional) If set, resume the specified prior actor session instead of creating a new one.",
           ),
         command: z.string().min(1).optional().describe("(optional) The command that triggered this task."),
-        context: z
-          .enum(["none", "state", "full"])
-          .optional()
-          .describe("(optional) Context inheritance. Default 'none'."),
+        context: contextField,
         task_id: z
           .string()
           .min(1)
@@ -859,7 +863,7 @@ export const ActorTool = Tool.define(
       })
 
       return {
-        description: DESCRIPTION,
+        description: withCheckpointDescription(DESCRIPTION, DESCRIPTION_CHECKPOINT),
         parameters,
         execute: (input: z.infer<typeof parameters>, ctx: Tool.Context) => run(input, ctx).pipe(Effect.orDie),
         shell: {

--- a/packages/opencode/src/tool/actor.txt
+++ b/packages/opencode/src/tool/actor.txt
@@ -52,7 +52,7 @@ THE EXCEPTION — `run` blocks the conversation; only for a tiny lookup that gat
 - **Isolate heavy lifting**: `spawn` a subagent for 10+ file reads; you get only the synthesis.
 - **Specialized search**: use `explore` for read-only code discovery (finding definitions, callers).
 - **Custom review**: `general` subagent verifies implementation against spec without bias.
-- **Working on a tracked task**: when you spawn a subagent to do work for one of your active tasks (T1, T2, …) — investigation, focused review, dedicated implementation — pass `task_id` so the subagent's verbatim findings get captured to `tasks/<TID>/progress.md` and reconciled into the next checkpoint. Pass ONLY a task ID the `task` tool returned this session; never invent one. If you haven't created the task yet, create it with the `task` tool first, or omit `task_id` and spawn ad-hoc.
+- **Working on a tracked task**: when you spawn a subagent to do work for one of your active tasks (T1, T2, …) — investigation, focused review, dedicated implementation — pass `task_id` so the subagent's verbatim findings get captured to `tasks/<TID>/progress.md`. Pass ONLY a task ID the `task` tool returned this session; never invent one. If you haven't created the task yet, create it with the `task` tool first, or omit `task_id` and spawn ad-hoc.
 - **Don't delegate at all for**: trivial single-file lookups, answers already in your context, or decisions on partial outputs.
 
 ## Collecting spawned work
@@ -81,7 +81,6 @@ You are the subagent's only briefing — it hasn't seen this conversation.
 ## Context inheritance
 
 - `context="full"`: subagent sees your full conversation history (for state writers, evaluators).
-- `context="state"`: subagent gets checkpoint summaries injected (background knowledge, no full detail).
 - `context="none"` (default): clean context, only the prompt.
 
 ## Actor ID vs Task ID
@@ -95,8 +94,7 @@ specific task, pass the task's TID via `task_id` (e.g. `task_id: "T4"`) — but 
 a TID the `task` tool actually returned this session. After the subagent finishes,
 the system checks that `tasks/<task_id>/progress.md` exists with the required
 structure — if not, the subagent gets one more chance to write it before
-terminating. The next checkpoint writer then reads that file and integrates
-verbatim commands, outcome, and discoveries into the main checkpoint.
+terminating.
 
 If `task_id` is malformed or names no existing task, the binding is dropped —
 the subagent's findings won't be captured to that task, and the tool result
@@ -131,7 +129,7 @@ assistant: All three are running. I'll fold their results in as they report; if 
 
 <example>
 user: "investigate T4's failing tests in the type checker"
-assistant: T4 is an active task in my tracker. I'll spawn an explore subagent bound to T4 so its findings end up in tasks/T4/progress.md and the next checkpoint can integrate them.
+assistant: T4 is an active task in my tracker. I'll spawn an explore subagent bound to T4 so its findings end up in tasks/T4/progress.md.
 [actor({"operation":{"action":"spawn","subagent_type":"explore","description":"Investigate T4 type checker failures","prompt":"Run `bun test src/types.test.ts` and report each failing case. For each failure: file:line of the assertion, the expected vs actual values, and the most likely root-cause hypothesis based on reading src/types.ts. Don't fix anything.","task_id":"T4"}})]
 </example>
 

--- a/packages/opencode/src/tool/checkpoint-description.ts
+++ b/packages/opencode/src/tool/checkpoint-description.ts
@@ -1,0 +1,11 @@
+import { Flag } from "@/flag/flag"
+
+export function withCheckpointDescription(base: string, extra: string) {
+  if (Flag.MIMOCODE_DISABLE_CHECKPOINT) return base
+  return `${base}\n\n${extra}`
+}
+
+export function withCheckpointClause(base: string, extra: string) {
+  if (Flag.MIMOCODE_DISABLE_CHECKPOINT) return base
+  return `${base} ${extra}`
+}

--- a/packages/opencode/src/tool/memory.checkpoint.txt
+++ b/packages/opencode/src/tool/memory.checkpoint.txt
@@ -1,0 +1,2 @@
+Session checkpoints (`sessions/<sid>/checkpoint.md`) written by the
+checkpoint-writer subagent are also indexed.

--- a/packages/opencode/src/tool/memory.ts
+++ b/packages/opencode/src/tool/memory.ts
@@ -2,6 +2,8 @@ import { Effect } from "effect"
 import z from "zod"
 import { Memory } from "@/memory"
 import DESCRIPTION from "./memory.txt"
+import DESCRIPTION_CHECKPOINT from "./memory.checkpoint.txt"
+import { withCheckpointDescription } from "./checkpoint-description"
 import * as Tool from "./tool"
 
 const parameters = z.object({
@@ -24,7 +26,7 @@ export const MemoryTool = Tool.define(
   Effect.gen(function* () {
     const memory = yield* Memory.Service
     return {
-      description: DESCRIPTION,
+      description: withCheckpointDescription(DESCRIPTION, DESCRIPTION_CHECKPOINT),
       parameters,
       execute: (args: z.infer<typeof parameters>) =>
         Effect.gen(function* () {

--- a/packages/opencode/src/tool/memory.txt
+++ b/packages/opencode/src/tool/memory.txt
@@ -1,8 +1,7 @@
 Search session/project/global memory using BM25 over markdown
-bodies. Use this to recall content the agent or writer subagent
-persisted previously: project memory, session checkpoints, task
-narratives (under sessions/<sid>/tasks/), project notes, global
-preferences.
+bodies. Use this to recall content persisted previously: project
+memory, task narratives (under sessions/<sid>/tasks/), project
+notes, global preferences.
 
 Memory layout: <data>/memory/<scope>/<scope_id>/<key>.md
 Scopes: global | projects | sessions | cc (opt-in, see below)

--- a/packages/opencode/src/tool/task.shell.txt
+++ b/packages/opencode/src/tool/task.shell.txt
@@ -46,11 +46,9 @@ open ⇄ in_progress, either → blocked → open, either → done | abandoned.
 Status values for `task list <status>`: open | in_progress | blocked | done | abandoned
 
 # Removed verbs (use the listed equivalents instead):
-#   progress       — progress is maintained by the checkpoint writer in the
-#                    session-level progress.md; you do not journal events
+#   progress       — not a verb; task progress is not journaled through this tool
 #   approve        — proposed state was removed; new tasks start in 'open'
-#   revise         — task is rename-only; long descriptions belong in §1
-#                    Active intent or main progress.md sections
+#   revise         — task is rename-only; long descriptions belong in the task summary
 #   create_sub     — use 'create' with parent_id
 
 # Don't repeat the task tree in your reply — the UI already shows it.

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -20,7 +20,7 @@ JSON calls always wrap the action in an `operation` object — see examples belo
 
 Status lifecycle: open ⇄ in_progress, either → blocked → open, either → done | abandoned.
 Mark a task `start` before working it; `done` immediately after finishing.
-Terminal states clean up automatically after `checkpoint.task_archive_days` (default 7 days).
+Terminal states clean up automatically after 7 days.
 
 ## JSON examples
 

--- a/packages/opencode/test/session/llm-system-prompt.test.ts
+++ b/packages/opencode/test/session/llm-system-prompt.test.ts
@@ -478,4 +478,79 @@ describe("session.llm system prompt — memory-instructions guard", () => {
       },
     })
   })
+
+  test("MIMOCODE_DISABLE_CHECKPOINT=true — checkpoint sections omitted, MEMORY.md kept", async () => {
+    const previous = process.env.MIMOCODE_DISABLE_CHECKPOINT
+    process.env.MIMOCODE_DISABLE_CHECKPOINT = "true"
+    const server = queueState.server!
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hi"), { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+    )
+
+    try {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(path.join(dir, "mimocode.json"), tmpConfig(providerID, `${server.url.origin}/v1`))
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const resolved = await getModel(ProviderID.make(providerID), ModelID.make(fixture.model.id))
+          const sessionRt = ManagedRuntime.make(SessionNs.defaultLayer)
+          let sessionID: SessionID
+          try {
+            const info = await sessionRt.runPromise(SessionNs.Service.use((svc) => svc.create({})))
+            sessionID = info.id
+          } finally {
+            await sessionRt.dispose()
+          }
+          const rt = ManagedRuntime.make(Layer.mergeAll(LLM.defaultLayer))
+          try {
+            await rt.runPromise(
+              LLM.Service.use((svc) =>
+                svc
+                  .stream({
+                    user: makeBaseUser(sessionID, providerID, resolved.id),
+                    sessionID,
+                    model: resolved,
+                    agent: makeAgent(),
+                    system: ["You are a helpful assistant."],
+                    messages: [{ role: "user", content: "Hello" }],
+                    tools: {},
+                  })
+                  .pipe(Stream.runDrain),
+              ),
+            )
+          } finally {
+            await rt.dispose()
+          }
+          const capture = await request
+          const allSys = (capture.body.messages as Array<{ role: string; content: string }>)
+            .filter((m) => m.role === "system")
+            .map((m) => m.content)
+            .join("\n")
+
+          expect(allSys).toContain("# Memory system")
+          expect(allSys).toContain("MEMORY.md")
+          expect(allSys).toContain("Notes scratchpad")
+          expect(allSys).toContain("Subagent return format")
+          expect(allSys).toContain(path.join(Global.Path.data, "memory", "projects", Instance.current.project.id, "MEMORY.md"))
+
+          expect(allSys).not.toContain("checkpoint.md")
+          expect(allSys).not.toContain("Active recall protocol")
+          expect(allSys).not.toContain("sole curator")
+          expect(allSys).not.toContain("Session checkpoint")
+        },
+      })
+    } finally {
+      if (previous === undefined) delete process.env.MIMOCODE_DISABLE_CHECKPOINT
+      else process.env.MIMOCODE_DISABLE_CHECKPOINT = previous
+    }
+  })
 })

--- a/packages/opencode/test/tool/checkpoint-tool-description.test.ts
+++ b/packages/opencode/test/tool/checkpoint-tool-description.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import ACTOR_DESCRIPTION from "../../src/tool/actor.txt"
+import ACTOR_CHECKPOINT from "../../src/tool/actor.checkpoint.txt"
+import ACTOR_SHELL from "../../src/tool/actor.shell.txt"
+import MEMORY_DESCRIPTION from "../../src/tool/memory.txt"
+import MEMORY_CHECKPOINT from "../../src/tool/memory.checkpoint.txt"
+import TASK_DESCRIPTION from "../../src/tool/task.txt"
+import TASK_SHELL from "../../src/tool/task.shell.txt"
+import { withCheckpointClause, withCheckpointDescription } from "../../src/tool/checkpoint-description"
+
+const original = process.env.MIMOCODE_DISABLE_CHECKPOINT
+
+function set(value?: string) {
+  if (value === undefined) delete process.env.MIMOCODE_DISABLE_CHECKPOINT
+  else process.env.MIMOCODE_DISABLE_CHECKPOINT = value
+}
+
+afterEach(() => set(original))
+
+describe("tool schema checkpoint copy is composed, not always-on", () => {
+  test("base actor/memory/task descriptions do not mention checkpoint", () => {
+    expect(ACTOR_DESCRIPTION).not.toMatch(/checkpoint/i)
+    expect(ACTOR_SHELL).not.toMatch(/checkpoint/i)
+    expect(MEMORY_DESCRIPTION).not.toMatch(/checkpoint/i)
+    expect(TASK_DESCRIPTION).not.toMatch(/checkpoint/i)
+    expect(TASK_SHELL).not.toMatch(/checkpoint/i)
+  })
+
+  test("checkpoint fragments teach the disabled lifecycle", () => {
+    expect(ACTOR_CHECKPOINT).toMatch(/checkpoint/i)
+    expect(ACTOR_CHECKPOINT).toContain('context="state"')
+    expect(MEMORY_CHECKPOINT).toMatch(/checkpoint/i)
+  })
+
+  test("withCheckpointDescription omits the extra section when the flag is on", () => {
+    set("true")
+    expect(withCheckpointDescription(ACTOR_DESCRIPTION, ACTOR_CHECKPOINT)).toBe(ACTOR_DESCRIPTION)
+    expect(withCheckpointDescription(MEMORY_DESCRIPTION, MEMORY_CHECKPOINT)).toBe(MEMORY_DESCRIPTION)
+    expect(withCheckpointDescription(ACTOR_DESCRIPTION, ACTOR_CHECKPOINT)).not.toMatch(/checkpoint/i)
+  })
+
+  test("withCheckpointDescription appends the extra section when the flag is off", () => {
+    set(undefined)
+    const actor = withCheckpointDescription(ACTOR_DESCRIPTION, ACTOR_CHECKPOINT)
+    const memory = withCheckpointDescription(MEMORY_DESCRIPTION, MEMORY_CHECKPOINT)
+    expect(actor).toContain(ACTOR_DESCRIPTION.trim())
+    expect(actor).toContain(ACTOR_CHECKPOINT.trim())
+    expect(memory).toContain("Session checkpoints")
+  })
+
+  test("actor context clause mentions state only when checkpointing is on", () => {
+    const base =
+      "(optional) Context inheritance. 'none' (default): child sees only prompt. 'full': child sees parent conversation (prefix cache sharing)."
+    const extra = "'state': child gets checkpoint summary."
+    set("true")
+    expect(withCheckpointClause(base, extra)).toBe(base)
+    expect(withCheckpointClause(base, extra)).not.toMatch(/checkpoint/i)
+    set("false")
+    expect(withCheckpointClause(base, extra)).toContain("checkpoint summary")
+  })
+})


### PR DESCRIPTION
## Summary

- omit checkpoint-only sections from memory system instructions when `MIMOCODE_DISABLE_CHECKPOINT` is enabled
- conditionally compose checkpoint integration details into actor and memory tool schemas
- keep project memory, global memory, notes, and subagent return guidance available while checkpointing is disabled

## Verification

- `bun test --timeout 20000 test/session/llm-system-prompt.test.ts`
- `bun test --timeout 20000 test/session/system.test.ts`
- `bun test test/tool/checkpoint-tool-description.test.ts`
- `bun typecheck` from `packages/opencode`
- repository push hook: `bun turbo typecheck`

## Known blockers

- `session/system.ts` still returns the unfiltered default/GPT provider templates, so disabling checkpointing does not yet remove all checkpoint lifecycle copy from the system prompt.
- `tool/task.txt` currently describes terminal cleanup as a fixed seven-day interval even though `checkpoint.task_archive_days` is configurable.

This PR is intentionally marked draft until those review findings are resolved.
