### PR TITLE
docs(readme): fix 404 blog link in README and README_npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <a href="https://mimo.xiaomi.com/coder">Website</a> | <a href="https://mimo.xiaomi.com/en/blog/mimo-code-long-horizon">Blog</a>
+  <a href="https://mimo.xiaomi.com/coder">Website</a> | <a href="https://mimo.xiaomi.com/blog/mimo-code-long-horizon">Blog</a>
 </p>
 
 ---

--- a/README_npm.md
+++ b/README_npm.md
@@ -3,7 +3,7 @@
 <p align="center"><strong>MiMo Code: Where Models and Agents Co-Evolve</strong></p>
 
 <p align="center">
-  <a href="https://mimo.xiaomi.com/coder">Website</a> | <a href="https://mimo.xiaomi.com/en/blog/mimo-code-long-horizon">Blog</a> | <a href="https://github.com/XiaomiMiMo/MiMo-Code">GitHub</a>
+  <a href="https://mimo.xiaomi.com/coder">Website</a> | <a href="https://mimo.xiaomi.com/blog/mimo-code-long-horizon">Blog</a> | <a href="https://github.com/XiaomiMiMo/MiMo-Code">GitHub</a>
 </p>
 
 ---


### PR DESCRIPTION
## What

The badge-row **Blog** link in `README.md` and `README_npm.md` points to:

`https://mimo.xiaomi.com/en/blog/mimo-code-long-horizon` → **404**

The live English URL has no `/en/` prefix:

`https://mimo.xiaomi.com/blog/mimo-code-long-horizon` → 200 (verified)

`README.zh.md` already uses the working pattern (`/zh/blog/...`), so only the two English READMEs needed the fix.

## Verification

```
$ curl -s -o /dev/null -w '%{http_code}' https://mimo.xiaomi.com/en/blog/mimo-code-long-horizon
404
$ curl -s -o /dev/null -w '%{http_code}' https://mimo.xiaomi.com/blog/mimo-code-long-horizon
200
```

Small docs correction, submitted directly as a PR per CONTRIBUTING.md.

Signed-off-by: LeonSGP43 <LeonSGP43@users.noreply.github.com>