### PR TITLE
docs(harness): fix product name typo in Token Efficient Mode title (MiM -> MiMo)

### DIFF
--- a/docs/harness/MiMo Token Efficient Mode.md
+++ b/docs/harness/MiMo Token Efficient Mode.md
@@ -1,4 +1,4 @@
-# MiM Token Efficient Mode
+# MiMo Token Efficient Mode
 
 **一句话总结**：使用通用正则过滤pipeline \+ 启发式过滤pipeline过滤Bash Output中冗余token（实验功能，默认关闭）
 


### PR DESCRIPTION
## What

The Chinese (base) version of `docs/harness/MiMo Token Efficient Mode.md` has the H1 title "MiM Token Efficient Mode" — missing the final "o" in the product name. All four translated versions of the same doc (`.en.md`, `.ja.md`, \.fr.md`, `.ru.md`) already spell it "MiMo" correctly, so only the base file is inconsistent.

## Change

```diff
-# MiM Token Efficient Mode
+# MiMo Token Efficient Mode
```

## Verification

- `grep -rn 'MiM ' docs/harness/` before the fix: exactly one hit, the H1 of this file; after the fix: zero hits.
- Checked all other `docs/` files for the same pattern — no other occurrences.