### PR TITLE
fix(checkpoint): hide disabled lifecycle prompt copy

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -141,10 +141,7 @@ export const persistentRetrySchedule = Schedule.exponential("500 millis", 2).pip
  * files already present in the rebuild dump, and the Subagent return
  * format contract.
  *
- * When `MIMOCODE_DISABLE_CHECKPOINT` is on, the checkpoint.md / writer /
- * Active-recall sections are omitted so the prompt does not teach a
- * lifecycle that is not running. MEMORY.md, notes.md, and global memory
- * instructions stay.
+ * This block is not appended when `MIMOCODE_DISABLE_CHECKPOINT` is on.
  *
  * `memoryRoot` is the same absolute root returned by Memory.root(), so these
  * paths match the files used by checkpoint restore and memory/task detection.
@@ -343,11 +340,10 @@ const live: Layer.Layer<
       // and have no checkpoint duty; system-spawned actors (checkpoint-writer et al.)
       // are the writers themselves. Shares the exact `servesCheckpoint` judgement
       // with SessionPrune.fireCheckpoints so the "who owns a checkpoint" and "who is
-      // taught about it" sets can never drift apart. MIMOCODE_DISABLE_CHECKPOINT
-      // still injects this block, but strips the checkpoint.md / writer / recall
-      // sections so the prompt does not describe a disabled lifecycle.
+      // taught about it" sets can never drift apart. Disabling checkpoints also
+      // disables this memory-system prompt block.
       const servesCheckpoint = yield* actorReg.servesCheckpoint(SessionID.make(input.sessionID), input.agentID)
-      if (servesCheckpoint) {
+      if (servesCheckpoint && !Flag.MIMOCODE_DISABLE_CHECKPOINT) {
         const projectID =
           (yield* Effect.try({
             try: () => Instance.current?.project?.id as ProjectID | undefined,

--- a/packages/opencode/test/session/llm-system-prompt.test.ts
+++ b/packages/opencode/test/session/llm-system-prompt.test.ts
@@ -479,7 +479,7 @@ describe("session.llm system prompt — memory-instructions guard", () => {
     })
   })
 
-  test("MIMOCODE_DISABLE_CHECKPOINT=true — checkpoint sections omitted, MEMORY.md kept", async () => {
+  test("MIMOCODE_DISABLE_CHECKPOINT=true — memory instructions are not appended", async () => {
     const previous = process.env.MIMOCODE_DISABLE_CHECKPOINT
     process.env.MIMOCODE_DISABLE_CHECKPOINT = "true"
     const server = queueState.server!
@@ -536,12 +536,12 @@ describe("session.llm system prompt — memory-instructions guard", () => {
             .map((m) => m.content)
             .join("\n")
 
-          expect(allSys).toContain("# Memory system")
-          expect(allSys).toContain("MEMORY.md")
-          expect(allSys).toContain("Notes scratchpad")
-          expect(allSys).toContain("Subagent return format")
-          expect(allSys).toContain(path.join(Global.Path.data, "memory", "projects", Instance.current.project.id, "MEMORY.md"))
-
+          expect(allSys).not.toContain("# Memory system")
+          expect(allSys).not.toContain("Notes scratchpad")
+          expect(allSys).not.toContain("Subagent return format")
+          expect(allSys).not.toContain(
+            path.join(Global.Path.data, "memory", "projects", Instance.current.project.id, "MEMORY.md"),
+          )
           expect(allSys).not.toContain("checkpoint.md")
           expect(allSys).not.toContain("Active recall protocol")
           expect(allSys).not.toContain("sole curator")


### PR DESCRIPTION
## Summary

- omit checkpoint-only copy from actor, memory, and task tool schemas when `MIMOCODE_DISABLE_CHECKPOINT` is on
- skip the entire memory-system prompt block in that mode, including MEMORY.md / notes / subagent-return instructions
- keep the model from being taught a checkpoint lifecycle that is not running

## Test plan

- [x] `bun test test/session/llm-system-prompt.test.ts` from `packages/opencode` (6 pass)
- [ ] `bun test test/tool/checkpoint-tool-description.test.ts` from `packages/opencode`
- [ ] `bun typecheck` from `packages/opencode`


Made with [Cursor](https://cursor.com)