### PR TITLE
fix(session): stabilize MCP tool ordering

### DIFF
--- a/docs/compose/plans/2026-08-15-sort-appended-mcp-tools.md
+++ b/docs/compose/plans/2026-08-15-sort-appended-mcp-tools.md
@@ -1,0 +1,98 @@
+# Sort Appended MCP Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use compose:subagent (recommended) or compose:execute to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve the established local-tool order while appending MCP tools in deterministic ascending tool-name order.
+
+**Architecture:** Keep tool ordering policy at the `SessionPrompt.resolveTools` request-assembly boundary. The local registry continues to populate the tools record first; only the MCP entries are sorted before the existing append loop, so other MCP service consumers and local-tool ordering remain unchanged.
+
+**Tech Stack:** TypeScript, Effect, Bun test, AI SDK tools
+
+## Global Constraints
+
+- Preserve the existing registration order of all non-MCP tools.
+- Append every directly exposed MCP tool after all non-MCP tools.
+- Sort appended MCP tools by their final sanitized tool name using `localeCompare`.
+- Do not change MCP tool filtering, permissions, execution, or MCP Tool Search behavior.
+- Run tests and type checking from `packages/opencode`, never from the repository root.
+
+---
+
+### Task 1: Deterministic MCP Tool Ordering
+
+**Files:**
+- Modify: `packages/opencode/src/session/prompt.ts:1480`
+- Test: `packages/opencode/test/session/prompt-effect.test.ts:324-345,1214-1245`
+
+**Interfaces:**
+- Consumes: `MCP.Service.tools(context): Effect<Record<string, AITool>>` and the existing insertion-ordered local `tools` record.
+- Produces: the same `Record<string, AITool>` request tool map, with local tools first and MCP entries ordered by ascending final key.
+
+- [ ] **Step 1: Make the MCP fixture expose reverse-ordered names**
+
+In the `mcpIt` fixture in `packages/opencode/test/session/prompt-effect.test.ts`, place `mcp_success` before `mcp_result`. Keep both tool definitions otherwise unchanged. This ensures the test can distinguish source enumeration order from normalized request order.
+
+- [ ] **Step 2: Assert local tools precede the sorted MCP suffix**
+
+Extend `exposes MCP tools directly for non-GPT models by default` after reading `tools`:
+
+```ts
+const names = tools.map(wireToolName).filter((name): name is string => name !== undefined)
+const firstMcp = names.findIndex((name) => name.startsWith("mcp_"))
+expect(firstMcp).toBeGreaterThan(0)
+expect(names.slice(firstMcp)).toEqual(["mcp_result", "mcp_success"])
+```
+
+Retain the existing assertions that `mcp_tool_search` is absent and both direct tools execute correctly.
+
+- [ ] **Step 3: Run the focused test and verify it fails**
+
+Run from `packages/opencode`:
+
+```bash
+bun test test/session/prompt-effect.test.ts -t "exposes MCP tools directly for non-GPT models by default"
+```
+
+Expected: FAIL because the MCP suffix is currently `["mcp_success", "mcp_result"]`.
+
+- [ ] **Step 4: Sort MCP entries at the append boundary**
+
+Replace the MCP entry construction in `SessionPrompt.resolveTools` with:
+
+```ts
+const mcpTools = Object.entries(yield* mcp.tools(input.mcpContext)).toSorted(([a], [b]) => a.localeCompare(b))
+```
+
+Do not sort the complete `tools` record or change the subsequent MCP append loop.
+
+- [ ] **Step 5: Run focused verification**
+
+Run from `packages/opencode`:
+
+```bash
+bun test test/session/prompt-effect.test.ts -t "exposes MCP tools directly for non-GPT models by default"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run broader session tests and type checking**
+
+Run from `packages/opencode`:
+
+```bash
+bun test test/session/prompt-effect.test.ts
+bun typecheck
+```
+
+Expected: both commands exit successfully with no test failures or type errors.
+
+- [ ] **Step 7: Review the final diff**
+
+Run:
+
+```bash
+git diff --check
+git diff -- packages/opencode/src/session/prompt.ts packages/opencode/test/session/prompt-effect.test.ts
+```
+
+Expected: no whitespace errors; the diff contains only the reverse-ordered fixture, the ordering assertions, and the MCP-only sort.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1477,7 +1477,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       }
 
       const localToolNames = new Set(Object.keys(tools))
-      const mcpTools = Object.entries(yield* mcp.tools(input.mcpContext))
+      const mcpTools = Object.entries(yield* mcp.tools(input.mcpContext)).toSorted(([a], [b]) => a.localeCompare(b))
       const agentToolAllowlist = input.agent.toolAllowlist ? new Set(input.agent.toolAllowlist) : undefined
       const disabledMcpTools = Permission.disabled(
         mcpTools.map(([key]) => key),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -324,17 +324,6 @@ const mcpSuccessResult: CallToolResult = {
 const mcpIt = testEffect(
   makeHttp(
     mcpLayer(() => ({
-      mcp_result: dynamicTool({
-        description: "Return a standard MCP tool execution error",
-        inputSchema: jsonSchema({
-          type: "object",
-          properties: {
-            private_error_code: { type: "string", description: "Secret nested MCP error selector" },
-          },
-          additionalProperties: false,
-        }),
-        execute: async () => mcpErrorResult,
-      }),
       mcp_success: dynamicTool({
         description: "Return a standard structured MCP success result",
         inputSchema: jsonSchema({
@@ -345,6 +334,17 @@ const mcpIt = testEffect(
           additionalProperties: false,
         }),
         execute: async () => mcpSuccessResult,
+      }),
+      mcp_result: dynamicTool({
+        description: "Return a standard MCP tool execution error",
+        inputSchema: jsonSchema({
+          type: "object",
+          properties: {
+            private_error_code: { type: "string", description: "Secret nested MCP error selector" },
+          },
+          additionalProperties: false,
+        }),
+        execute: async () => mcpErrorResult,
       }),
     })),
   ),
@@ -1211,39 +1211,46 @@ mcpIt.live("degrades the MCP catalog to names at high context pressure", () =>
   ),
 )
 
-mcpIt.live("exposes MCP tools directly for non-GPT models by default", () =>
-  provideTmpdirServer(
-    Effect.fnUntraced(function* ({ llm }) {
-      const prompt = yield* SessionPrompt.Service
-      const sessions = yield* Session.Service
-      const session = yield* sessions.create({ title: "Direct non-GPT MCP tools" })
+mcpIt.live(
+  "exposes MCP tools directly for non-GPT models by default",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({ title: "Direct non-GPT MCP tools" })
 
-      yield* prompt.prompt({
-        sessionID: session.id,
-        agent: "build",
-        model: ref,
-        noReply: true,
-        parts: [{ type: "text", text: "inspect available MCP tools" }],
-      })
-      yield* llm.tool("mcp_success", {})
-      yield* llm.text("done")
-      yield* prompt.loop({ sessionID: session.id })
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          model: ref,
+          noReply: true,
+          parts: [{ type: "text", text: "inspect available MCP tools" }],
+        })
+        yield* llm.tool("mcp_success", {})
+        yield* llm.text("done")
+        yield* prompt.loop({ sessionID: session.id })
 
-      const tools = (yield* llm.inputs)[0].tools as Array<Record<string, unknown>>
-      expect(tools.map(wireToolName)).not.toContain("mcp_tool_search")
-      expect(tools.map(wireToolName)).toContain("mcp_result")
-      expect(tools.map(wireToolName)).toContain("mcp_success")
-      expect(
-        (yield* MessageV2.filterCompactedEffect(session.id))
-          .flatMap((message) => message.parts)
-          .some(
-            (part) =>
-              part.type === "tool" && part.tool === "mcp_success" && part.state.status === "completed",
-          ),
-      ).toBe(true)
-    }),
-    { git: true, config: providerCfg },
-  ),
+        const tools = (yield* llm.inputs)[0].tools as Array<Record<string, unknown>>
+        const names = tools.map(wireToolName).filter((name): name is string => name !== undefined)
+        const firstMcp = names.findIndex((name) => name.startsWith("mcp_"))
+        expect(firstMcp).toBeGreaterThan(0)
+        expect(names.slice(firstMcp)).toEqual(["mcp_result", "mcp_success"])
+        expect(tools.map(wireToolName)).not.toContain("mcp_tool_search")
+        expect(tools.map(wireToolName)).toContain("mcp_result")
+        expect(tools.map(wireToolName)).toContain("mcp_success")
+        expect(
+          (yield* MessageV2.filterCompactedEffect(session.id))
+            .flatMap((message) => message.parts)
+            .some(
+              (part) =>
+                part.type === "tool" && part.tool === "mcp_success" && part.state.status === "completed",
+            ),
+        ).toBe(true)
+      }),
+      { git: true, config: providerCfg },
+    ),
+  30_000,
 )
 
 mcpIt.live("rejects direct MCP calls disabled for the request", () =>


### PR DESCRIPTION
## Summary
- preserve the existing order of built-in and custom tools
- sort MCP tools by final tool name before appending them to the request tool map
- cover deterministic MCP suffix ordering with a reverse-ordered fixture

## Verification
- `bun test test/session/prompt-effect.test.ts -t \"exposes MCP tools directly for non-GPT models by default\"` (pass)
- `bun typecheck` (pass)
- `git diff --check` (pass)
- full `prompt-effect.test.ts` run was interrupted before completion