### PR TITLE
fix(session): gate dynamic system prompt content behind flag

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -184,6 +184,12 @@ export const Flag = {
   // enable try-best loop detection, automatic turn pausing, and handoff UI.
   MIMOCODE_ENABLE_TRY_BEST_HANDOFF: truthy("MIMOCODE_ENABLE_TRY_BEST_HANDOFF"),
 
+  // Defaults to false. Opt in to append runtime-derived environment and
+  // instruction-file content to the model's system prompt.
+  get MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT() {
+    return truthy("MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT")
+  },
+
   // Defaults to false. The edit tool does pure exact-string matching with
   // explicit error signals. Set MIMOCODE_ENABLE_FUZZY_EDIT=true to opt into the
   // legacy multi-stage fuzzy fallback chain (line-trimmed / block-anchor /

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -312,12 +312,14 @@ export const layer = Layer.effect(
         const captureSession = yield* sessions.get(input.sessionID).pipe(Effect.catch(() => Effect.succeed(undefined)))
         if (!captureSession) return empty
         const [env, instructions] = yield* Effect.all([
-          sys.environment(model, captureSession.time.created),
+          Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+            ? sys.environment(model, captureSession.time.created)
+            : Effect.succeed([]),
           instruction.system().pipe(Effect.orDie),
         ])
         // (checkpoint-writer never requests json_schema output, so STRUCTURED_OUTPUT_SYSTEM_PROMPT
         // is not included; parent's runLoop adds it conditionally based on user.format)
-        const additions = [...env, ...instructions.content]
+        const additions = Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT ? [...env, ...instructions.content] : []
         const prefix = yield* buildLLMRequestPrefix({
           sessionID: input.sessionID,
           agent: ag,
@@ -4007,7 +4009,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
 
             const [env, instructions] = yield* Effect.all([
-              sys.environment(model, session.time.created),
+              Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+                ? sys.environment(model, session.time.created)
+                : Effect.succeed([]),
               instruction.system().pipe(Effect.orDie),
             ])
             // Surface which instruction files (CLAUDE.md, AGENTS.md, ...) were loaded.
@@ -4021,8 +4025,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }
             }
             const additions = [
-              ...env,
-              ...instructions.content,
+              ...(Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT ? [...env, ...instructions.content] : []),
               ...(format.type === "json_schema" ? [STRUCTURED_OUTPUT_SYSTEM_PROMPT] : []),
             ]
             // Note: `buildLLMRequestPrefix` also returns a `tools` field, but we

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -24,6 +24,7 @@ import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { isSkillSearchDisabled, type SkillSearchModel } from "@/skill/search"
+import { Flag } from "@/flag/flag"
 
 function renderGitResult(result: Git.Result, fallback = "(none)") {
   if (result.exitCode !== 0) return fallback
@@ -69,6 +70,7 @@ export const layer = Layer.effect(
 
     return Service.of({
       environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model, now: number) {
+        if (!Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT) return []
         const project = Instance.project
         if (provider(model)[0] === PROMPT_ANTHROPIC) {
           const key = `${Instance.directory}\0${now}\0${model.providerID}\0${model.api.id}`

--- a/packages/opencode/test/flag/dynamic-system-prompt-flag.test.ts
+++ b/packages/opencode/test/flag/dynamic-system-prompt-flag.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+
+function read(value?: string) {
+  const env = { ...process.env }
+  if (value === undefined) delete env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+  else env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT = value
+  const result = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "-e",
+      'import { Flag } from "./src/flag/flag.ts"; process.stdout.write(String(Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT))',
+    ],
+    cwd: process.cwd(),
+    env,
+  })
+  expect(result.exitCode).toBe(0)
+  return result.stdout.toString()
+}
+
+describe("MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT", () => {
+  test("is disabled by default and accepts explicit truthy values", () => {
+    expect(read()).toBe("false")
+    expect(read("true")).toBe("true")
+    expect(read("1")).toBe("true")
+  })
+
+  test("false and zero keep dynamic system prompt injection disabled", () => {
+    expect(read("false")).toBe("false")
+    expect(read("0")).toBe("false")
+  })
+})

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1,4 +1,5 @@
 import { Worktree } from "../../src/worktree"
+import { Instance } from "../../src/project/instance"
 import { NodeFileSystem } from "@effect/platform-node"
 import { FetchHttpClient } from "effect/unstable/http"
 import { afterEach, expect } from "bun:test"
@@ -101,6 +102,22 @@ function withSh<A, E, R>(fx: () => Effect.Effect<A, E, R>) {
         if (prev === undefined) delete process.env.SHELL
         else process.env.SHELL = prev
         Shell.preferred.reset()
+      }),
+  )
+}
+
+function withoutDynamicSystemPrompt<A, E, R>(fx: () => Effect.Effect<A, E, R>) {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+      delete process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+      return previous
+    }),
+    () => fx(),
+    (previous) =>
+      Effect.sync(() => {
+        if (previous === undefined) delete process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+        else process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT = previous
       }),
   )
 }
@@ -654,6 +671,38 @@ it.live("loop calls LLM and returns assistant message", () =>
       expect(yield* llm.hits).toHaveLength(1)
     }),
     { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loop does not inject dynamic system prompt additions", () =>
+  withoutDynamicSystemPrompt(() =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const marker = "dynamic-instruction-marker"
+        yield* Effect.promise(() => Bun.write(path.join(Instance.directory, "AGENTS.md"), marker))
+        const chat = yield* sessions.create({
+          title: "No cwd",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* prompt.prompt({
+          sessionID: chat.id,
+          agent: "build",
+          model: ref,
+          noReply: true,
+          parts: [{ type: "text", text: "hello" }],
+        })
+        yield* llm.text("world")
+
+        yield* prompt.loop({ sessionID: chat.id })
+
+        const inputs = JSON.stringify(yield* llm.inputs)
+        expect(inputs).not.toContain("Working directory:")
+        expect(inputs).not.toContain(marker)
+      }),
+      { git: true, config: providerCfg },
+    ),
   ),
 )
 

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { $ } from "bun"
 import os from "os"
 import path from "path"
@@ -14,7 +14,36 @@ function load<A>(dir: string, fn: (svc: Agent.Interface) => Effect.Effect<A>) {
   return Effect.runPromise(provideInstance(dir)(Agent.Service.use(fn)).pipe(Effect.provide(Agent.defaultLayer)))
 }
 
+const dynamicSystemPrompt = process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+
+beforeEach(() => {
+  process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT = "true"
+})
+
+afterEach(() => {
+  if (dynamicSystemPrompt === undefined) delete process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+  else process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT = dynamicSystemPrompt
+})
+
 describe("session.system", () => {
+  test("does not render dynamic environment information by default", async () => {
+    delete process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const prompt = await Effect.runPromise(
+          Effect.gen(function* () {
+            return yield* (yield* SystemPrompt.Service).environment(ProviderTest.model(), Date.now())
+          }).pipe(Effect.provide(SystemPrompt.defaultLayer)),
+        )
+
+        expect(prompt).toEqual([])
+      },
+    })
+  })
+
   test("Anthropic template does not contain machine-specific snapshots", () => {
     const prompt = SystemPrompt.provider(
       ProviderTest.model({


### PR DESCRIPTION
## Summary

- Adds a new opt-in flag `MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT` (defaults to `false`) in `packages/opencode/src/flag/flag.ts`.
- When disabled (default), the runtime-derived environment and instruction-file (`CLAUDE.md`, `AGENTS.md`, ...) content is no longer appended to the model's system prompt, restoring the previous default behavior.
- When enabled, the dynamic environment + instruction content is appended as before.
- `SystemPrompt.environment` short-circuits to `[]` when the flag is off.
- Adds tests covering both flag states in `test/session/prompt-effect.test.ts`, `test/session/system.test.ts`, and a new `test/flag/dynamic-system-prompt-flag.test.ts`.

Typecheck (pre-push hook) passes across all 18 packages.