### PR TITLE
fix(skill): dedupe skills catalog in model messages and cache global discovery

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -22,6 +22,7 @@ import {
   toolAttachmentFilename,
   toolAttachmentPlaceholder,
 } from "./tool-attachment"
+import { isSkillCatalogReminder } from "./skill-catalog"
 
 /** Error shape thrown by Bun's fetch() when gzip/br decompression fails mid-stream */
 interface FetchDecompressionError extends Error {
@@ -646,6 +647,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 ) {
   const result: UIMessage[] = []
   const toolNames = new Set<string>()
+  let skillCatalogSeen = false
 
   const toModelOutput = (options: { toolCallId: string; input: unknown; output: unknown }) => {
     const output = options.output
@@ -705,7 +707,16 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         parts: [],
       }
       result.push(userMessage)
-      for (const part of msg.parts) {
+      const parts = msg.parts.toSorted((a, b) => {
+        const aCatalog = a.type === "text" && isSkillCatalogReminder(a.text)
+        const bCatalog = b.type === "text" && isSkillCatalogReminder(b.text)
+        return Number(aCatalog) - Number(bCatalog)
+      })
+      for (const part of parts) {
+        if (part.type === "text" && isSkillCatalogReminder(part.text)) {
+          if (skillCatalogSeen || part.ignored) continue
+          skillCatalogSeen = true
+        }
         if (part.type === "text" && !part.ignored)
           userMessage.parts.push({
             type: "text",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -120,11 +120,10 @@ import {
   type McpToolSearchMetadata,
 } from "@/tool/mcp-tool-search"
 import { isMcpToolSearchEnabled } from "@/tool/gpt"
+import { isSkillCatalogReminder, SKILL_CATALOG_REMINDER_MARKER } from "./skill-catalog"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
-
-const SKILL_CATALOG_REMINDER_MARKER = "Skills available in this session:"
 
 // Recall-reminder hints, rendered in each tool's configured invocation style so
 // shell-mode sessions never see a JSON-shaped example (which primes models to
@@ -930,7 +929,7 @@ export const layer = Layer.effect(
         : undefined
       const existingCatalogs = input.messages.flatMap((message) =>
         message.parts.flatMap((part) =>
-          part.type === "text" && part.synthetic && !part.ignored && part.text.includes(SKILL_CATALOG_REMINDER_MARKER)
+          part.type === "text" && part.synthetic && !part.ignored && isSkillCatalogReminder(part.text)
             ? [{ message, part }]
             : [],
         ),

--- a/packages/opencode/src/session/skill-catalog.ts
+++ b/packages/opencode/src/session/skill-catalog.ts
@@ -1,0 +1,5 @@
+export const SKILL_CATALOG_REMINDER_MARKER = "Skills available in this session:"
+
+export function isSkillCatalogReminder(text: string) {
+  return text.includes(SKILL_CATALOG_REMINDER_MARKER)
+}

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -2,7 +2,7 @@ import os from "os"
 import path from "path"
 import { pathToFileURL } from "url"
 import z from "zod"
-import { Effect, Layer, Context } from "effect"
+import { Duration, Effect, Layer, Context } from "effect"
 import { NamedError } from "@mimo-ai/shared/util/error"
 import type { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
@@ -167,18 +167,14 @@ const scan = Effect.fnUntraced(function* (
     }),
   )
 
-  for (const match of matches) {
+  for (const match of matches.toSorted()) {
     state.matches.add(match)
     state.dirs.add(path.dirname(match))
   }
 })
 
-const discoverSkills = Effect.fnUntraced(function* (
-  config: Config.Interface,
-  discovery: Discovery.Interface,
+const discoverStableSkills = Effect.fnUntraced(function* (
   fsys: AppFileSystem.Interface,
-  directory: string,
-  worktree: string,
 ) {
   const state: ScanState = { matches: new Set(), dirs: new Set() }
   const bundledRoots: string[] = []
@@ -231,6 +227,34 @@ const discoverSkills = Effect.fnUntraced(function* (
       if (!(yield* fsys.isDir(root))) continue
       yield* scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "global" })
     }
+  }
+
+  return {
+    matches: Array.from(state.matches),
+    dirs: Array.from(state.dirs),
+    bundledRoots,
+  }
+})
+
+const discoverSkills = Effect.fnUntraced(function* (
+  config: Config.Interface,
+  discovery: Discovery.Interface,
+  fsys: AppFileSystem.Interface,
+  stable: DiscoveryState,
+  directory: string,
+  worktree: string,
+) {
+  const state: ScanState = { matches: new Set(stable.matches), dirs: new Set(stable.dirs) }
+  const bundledRoots = [...stable.bundledRoots]
+
+  if (!Flag.MIMOCODE_DISABLE_EXTERNAL_SKILLS) {
+    const externalDirs = EXTERNAL_DIRS.filter((dir) => {
+      if (dir === ".claude" && Flag.MIMOCODE_DISABLE_CLAUDE_CODE_SKILLS) return false
+      if (dir === ".agents" && Flag.MIMOCODE_DISABLE_AGENTS_SKILLS) return false
+      if (dir === ".codex" && Flag.MIMOCODE_DISABLE_CODEX_SKILLS) return false
+      if (dir === ".opencode" && Flag.MIMOCODE_DISABLE_OPENCODE_SKILLS) return false
+      return true
+    })
 
     const upDirs = yield* fsys
       .up({ targets: externalDirs, start: directory, stop: worktree })
@@ -274,7 +298,7 @@ const discoverSkills = Effect.fnUntraced(function* (
 
 const loadSkills = Effect.fnUntraced(function* (state: State, discovered: DiscoveryState, bus: Bus.Interface) {
   yield* Effect.forEach(discovered.matches, (match) => add(state, match, discovered.bundledRoots, bus), {
-    concurrency: "unbounded",
+    concurrency: 1,
     discard: true,
   })
 
@@ -290,9 +314,13 @@ export const layer = Layer.effect(
     const config = yield* Config.Service
     const bus = yield* Bus.Service
     const fsys = yield* AppFileSystem.Service
+    const [stable, invalidateStable] = yield* Effect.cachedInvalidateWithTTL(
+      discoverStableSkills(fsys),
+      Duration.infinity,
+    )
     const discovered = yield* InstanceState.make(
       Effect.fn("Skill.discovery")(function* (ctx) {
-        return yield* discoverSkills(config, discovery, fsys, ctx.directory, ctx.worktree)
+        return yield* discoverSkills(config, discovery, fsys, yield* stable, ctx.directory, ctx.worktree)
       }),
     )
     const state = yield* InstanceState.make(
@@ -335,6 +363,7 @@ export const layer = Layer.effect(
     })
 
     const reload = Effect.fn("Skill.reload")(function* () {
+      yield* invalidateStable
       yield* InstanceState.invalidate(discovered)
       yield* InstanceState.invalidate(state)
     })
@@ -356,7 +385,7 @@ export function fmt(list: Info[], opts: { verbose: boolean }) {
     return [
       "<available_skills>",
       ...list
-        .sort((a, b) => a.name.localeCompare(b.name))
+        .toSorted((a, b) => a.name.localeCompare(b.name))
         .flatMap((skill) => [
           "  <skill>",
           `    <name>${skill.name}</name>`,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -324,25 +324,6 @@ export const layer = Layer.effect(
       return (yield* all()).map((tool) => tool.id)
     })
 
-    const describeSkill = Effect.fn("ToolRegistry.describeSkill")(function* (agent: Agent.Info) {
-      const list = yield* skill.modelInvocable(agent)
-      if (list.length === 0) return "No skills are currently available."
-      return [
-        "Load a specialized skill that provides domain-specific instructions and workflows.",
-        "",
-        "When you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.",
-        "",
-        "The skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.",
-        "",
-        'Tool output includes a `<skill_content name="...">` block with the loaded content.',
-        "",
-        "The following skills provide specialized sets of instructions for particular tasks",
-        "Invoke this tool to load a skill when a task matches one of the available skills listed below:",
-        "",
-        Skill.fmt(list, { verbose: false }),
-      ].join("\n")
-    })
-
     const describeWorkflow = Effect.fn("ToolRegistry.describeWorkflow")(function* () {
       return renderWorkflowCatalog()
     })
@@ -451,7 +432,6 @@ export const layer = Layer.effect(
             description: [
               description,
               tool.id === ActorTool.id ? yield* describeTask(input.agent) : undefined,
-              tool.id === SkillTool.id ? yield* describeSkill(input.agent) : undefined,
               tool.id === WorkflowTool.id ? yield* describeWorkflow() : undefined,
               tool.id === ToolScriptTool.id ? yield* describeToolScript(availableTools.filtered) : undefined,
             ]

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -131,6 +131,56 @@ function basePart(messageID: string, id: string) {
 }
 
 describe("session.message-v2.toModelMessage", () => {
+  test("keeps one skills catalog and orders it after the other user content", async () => {
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo("m-skills-first"),
+        parts: [
+          {
+            ...basePart("m-skills-first", "p-catalog-first"),
+            type: "text",
+            text: "<system-reminder>\nSkills available in this session:\nFIRST\n</system-reminder>",
+            synthetic: true,
+          },
+          { ...basePart("m-skills-first", "p-user"), type: "text", text: "hello" },
+          {
+            ...basePart("m-skills-first", "p-other-reminder"),
+            type: "text",
+            text: "<system-reminder>other</system-reminder>",
+            synthetic: true,
+          },
+        ],
+      },
+      {
+        info: userInfo("m-skills-duplicate"),
+        parts: [
+          {
+            ...basePart("m-skills-duplicate", "p-catalog-duplicate"),
+            type: "text",
+            text: "<system-reminder>\nSkills available in this session:\nSECOND\n</system-reminder>",
+            synthetic: true,
+          },
+          { ...basePart("m-skills-duplicate", "p-next-user"), type: "text", text: "continue" },
+        ],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "hello" },
+          { type: "text", text: "<system-reminder>other</system-reminder>" },
+          {
+            type: "text",
+            text: "<system-reminder>\nSkills available in this session:\nFIRST\n</system-reminder>",
+          },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "continue" }] },
+    ])
+  })
+
   test("preserves structured provider-executed outputs", async () => {
     const userID = "m-provider-user"
     const assistantID = "m-provider-assistant"

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -31,6 +31,19 @@ This skill is loaded from the global home directory.
   )
 }
 
+async function createSkill(root: string, source: ".claude" | ".agents", name: string, description: string) {
+  await Bun.write(
+    path.join(root, source, "skills", name, "SKILL.md"),
+    `---
+name: ${name}
+description: ${description}
+---
+
+# ${name}
+`,
+  )
+}
+
 const withHome = <A, E, R>(home: string, self: Effect.Effect<A, E, R>) =>
   Effect.acquireUseRelease(
     Effect.sync(() => {
@@ -219,6 +232,74 @@ description: A skill in the .claude/skills directory.
         }),
       )
     }),
+  )
+
+  it.live("keeps one global snapshot across project instances until reload", () =>
+    Effect.gen(function* () {
+      const home = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir({ git: true })),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const firstProject = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir({ git: true })),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const secondProject = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir({ git: true })),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+
+      yield* withHome(
+        home.path,
+        Effect.gen(function* () {
+          yield* Effect.promise(() => createSkill(home.path, ".claude", "first-global", "First snapshot"))
+          const skill = yield* Skill.Service
+          expect((yield* skill.all().pipe(provideInstance(firstProject.path))).map((item) => item.name)).toEqual([
+            "first-global",
+          ])
+
+          yield* Effect.promise(() => createSkill(home.path, ".agents", "second-global", "Added later"))
+          expect((yield* skill.all().pipe(provideInstance(secondProject.path))).map((item) => item.name)).toEqual([
+            "first-global",
+          ])
+
+          yield* skill.reload().pipe(provideInstance(secondProject.path))
+          expect((yield* skill.all().pipe(provideInstance(secondProject.path))).map((item) => item.name).toSorted()).toEqual([
+            "first-global",
+            "second-global",
+          ])
+        }),
+      )
+    }),
+    30_000,
+  )
+
+  it.live("uses deterministic source order when global skills share a name", () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir({ git: true })),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+
+      yield* withHome(
+        tmp.path,
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all([
+              createSkill(tmp.path, ".claude", "duplicate-global", "Claude copy"),
+              createSkill(tmp.path, ".agents", "duplicate-global", "Agents copy"),
+            ]),
+          )
+          const skill = yield* Skill.Service
+          const item = (yield* skill.all().pipe(provideInstance(tmp.path))).find(
+            (item) => item.name === "duplicate-global",
+          )
+          expect(item?.description).toBe("Agents copy")
+          expect(item?.location).toContain(path.join(".agents", "skills", "duplicate-global", "SKILL.md"))
+        }),
+      )
+    }),
+    30_000,
   )
 
   it.live("returns empty array when no skills exist", () =>

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -181,10 +181,11 @@ description: Anyone may start this one.
           // call that can never succeed.
           expect(requests).toEqual([])
 
-          // The tool description must not advertise it either, and a mistyped
-          // name must not leak it back through the not-found hint.
+          // The tool schema is static and never embeds either the reachable or
+          // model-gated catalog. A mistyped name must not leak the gated skill.
           expect(tool.description).not.toContain("gated-skill")
-          expect(tool.description).toContain("open-skill")
+          expect(tool.description).not.toContain("open-skill")
+          expect(tool.description).toContain("listed in the system prompt")
           const miss = yield* Effect.exit(tool.execute({ name: "gated-skil" }, ctx))
           const missMsg = miss._tag === "Failure" ? Cause.pretty(miss.cause) : ""
           expect(missMsg).toContain("not found")


### PR DESCRIPTION
## Summary

- **Dedupe the skills catalog in model messages**: only the first `Skills available in this session:` reminder is kept per message and it is ordered after the user's own content (`packages/opencode/src/session/message-v2.ts`, new `src/session/skill-catalog.ts` helper).
- **Cache stable global skill discovery**: the global skill snapshot (home-dir scans) is cached with an infinite TTL and shared across project instances until `skill.reload()`; matches are processed in deterministic sorted order and loaded serially (`src/skill/index.ts`).
- **Static skill tool description**: the `skill` tool schema no longer embeds the per-agent model-gated catalog; it points at the system prompt instead (`src/tool/registry.ts`).

## Tests

- Added: catalog dedupe/ordering in `test/session/message-v2.test.ts`; global-snapshot caching + deterministic source order in `test/skill/skill.test.ts`; updated static-description assertions in `test/tool/skill.test.ts`.
- `bun typecheck` and the affected suites pass (the two `it.live` git-spawning tests are flaky under parallel load and pass in isolation — pre-existing harness flakiness).