### PR TITLE
feat(agent): make one level of subagent delegation the default

### DIFF
--- a/docs/compose/spec/subagent-no-nesting.md
+++ b/docs/compose/spec/subagent-no-nesting.md
@@ -1,0 +1,66 @@
+---
+feature: subagent-no-nesting
+status: designed
+updated: 2026-06-18
+branch: subagent-no-nesting
+commits: <base-sha>..<head-sha>
+---
+
+# Subagent nesting off by default
+
+## Report
+
+## [S1] Problem
+
+A `general` subagent can spawn further subagents, with no depth limit.
+
+- `agent.ts` gives `general` `Permission.merge(defaults, user)`, and `defaults` carries `"*": "allow"`; it declares no `toolAllowlist`.
+- `Permission.disabled` (permission/index.ts:669) only drops a tool when a matching rule has `pattern === "*"` and `action === "deny"`, so nothing removes `actor` from `general`'s schema.
+- `tool/actor.ts` passes `tools: "INHERIT"` for an agent without a `toolAllowlist`, and `prompt.ts:1276` turns `INHERIT` into "no runtime whitelist".
+- `Actor.spawn` records only `parentActorID`; there is no depth field and no ancestry check anywhere on the spawn path.
+- `prompt/general.txt` actively invites it: "You may delegate genuinely independent, bounded subtasks when that improves throughput".
+
+Verified empirically before the change: `bun dev debug agent general` reports `"actor": true`, `bun dev debug agent explore` reports `"actor": false` (explore only because of its own blanket `"*": "deny"`, not by design).
+
+Consequences: unbounded fan-out of agent trees, cost and concurrency that no single cap governs (`workflow/runtime.ts:34`'s lifecycle cap only bounds `workflow()`'s own `spawnRef` spawns), and a parent that cannot account for work done two levels down.
+
+## [S2] Design
+
+Make one level of delegation the default: a subagent does not see the `actor` tool at all.
+
+**Mechanism.** In `agent.ts`, after the config merge loop and alongside the existing `whitelistedDirs` normalization pass, inject `actor: "deny"` for every agent with `mode === "subagent"`. The rule is merged **before** the agent's accumulated ruleset, so `agent.<name>.permission.actor: "allow"` in user config still wins (`evaluate` uses `findLast`).
+
+```ts
+for (const name in agents) {
+  if (agents[name].mode !== "subagent") continue
+  agents[name].permission = Permission.merge(
+    Permission.fromConfig({ actor: "deny" }),
+    agents[name].permission,
+  )
+}
+```
+
+Because the rule's pattern is `"*"`, `Permission.disabled` removes `actor` from the subagent's LLM-visible tool schema (`llm.ts` `resolveTools`), which also makes `ctx.ask({ permission: "actor" })` unreachable for that agent. Verified rule semantics:
+`disabled(["actor"], merge(defaults, fromConfig({ actor: "deny" })))` → `["actor"]`.
+
+**Scope.** All `mode === "subagent"` agents, native and user-defined, including hidden ones. Hidden internals already lack `actor` through `toolAllowlist` (`title`/`summary`/`compaction` have `[]`; `dream`/`distill` enumerate their tools), so the rule is a no-op for them.
+
+**checkpoint-writer parity.** `checkpoint-writer` is the one hidden subagent with no `toolAllowlist`, because a fork must mirror the parent's tool schema for prefix-cache alignment. Its visibility ruleset is `merge(writer.permission, parentPermission)` (`llm.ts` `resolveTools` via `prompt.ts:3896`), and `parentPermission` is merged last, so the parent primary's `"*": "allow"` out-ranks the injected deny under `findLast`. Parity therefore holds; a test pins this rather than leaving it to inspection.
+
+**Prompt alignment.** `prompt/general.txt` must stop inviting delegation, and must not push the model to look for an absent tool. Replace the delegation bullet with an explicit statement that the assignment is the subagent's own to finish, and that a genuinely out-of-scope piece is reported back to the parent instead of delegated. No other prompt mentions subagent-side delegation; `tool/actor.txt` is only rendered for agents that still hold the tool, so it stays unchanged.
+
+**Behavior after the change.** Peer/orchestrator sessions (`session` tool, already orchestrator-only), `workflow()`'s internal `spawnRef` spawns, and `checkpoint-writer` forks are all untouched — none of them route through the subagent's `actor` tool schema. A subagent loses `actor`'s non-spawn verbs (`status`/`wait`/`cancel`/`send`/`models`) as an accepted cost of full invisibility.
+
+## [S3] Out of Scope
+
+- No depth counter or ancestry check in `Actor.spawn`; the gate is tool visibility only.
+- No change to the `session` tool, orchestrator peers, or the workflow runtime's own spawn cap.
+- Not fixing the pre-existing permission-name split where `registry.ts:340` filters spawnable types with `evaluate("task", ...)` while `actor.ts:696` asks with `permission: "actor"`.
+- No new config key or experimental flag; the existing `agent.<name>.permission.actor` is the opt-back-in.
+
+## Tasks
+
+- [ ] T1: Inject `actor: "deny"` for every `mode === "subagent"` agent in `agent.ts`, merged before the agent's own rules — acceptance: `bun dev debug agent general` reports `"actor": false`, and a config `agent.general.permission.actor: "allow"` restores `true` (covers: S2)
+- [ ] T2: Rewrite the delegation bullet in `prompt/general.txt` so it neither invites delegation nor names an absent tool — acceptance: the file no longer contains "You may delegate", and states that the subagent completes or reports back (covers: S2; depends: T1)
+- [ ] T3: Add regression tests — every `mode === "subagent"` agent has `actor` disabled, a user `actor: "allow"` override re-enables it, and `checkpoint-writer` under a parent primary's `parentPermission` still sees `actor` — acceptance: new tests fail on `main`'s behavior and pass here (covers: S2; depends: T1)
+- [ ] T4: Verify with `bun turbo typecheck`, the agent/actor test files, and a live `bun dev debug agent` for `general` + `explore` — acceptance: recorded commands with PASS/PRE-EXISTING status (covers: S2; depends: T1, T2, T3)

--- a/docs/compose/spec/subagent-no-nesting.md
+++ b/docs/compose/spec/subagent-no-nesting.md
@@ -22,14 +22,14 @@ Programmatic spawn paths are untouched by design, because none of them reads the
 - `bun lint` (oxlint, repo root) — 0 errors, 4092 warnings PRE-EXISTING
 - `bun test test/agent/ test/tool/actor.test.ts test/tool/actor-recover.test.ts test/actor/` — 233 pass / 9 fail; the identical 9 failures reproduce on clean `main` → PRE-EXISTING (this machine's global config sets `edit: "ask"`, which un-denies edit-family tools for read-only agents). `main` additionally flaked `runLoop emits a per-step turn heartbeat`.
 - `bun test test/session/prompt-effect.test.ts test/session/recall-reminder.test.ts test/tool/actor.test.ts` — 74 pass, 0 fail
-- New tests (5) all PASS: subagent-wide `actor` deny with primaries as the negative control, config opt-back-in, `checkpoint-writer` fork parity, `general` prompt wording, recall hint omission.
+- New tests (5) all PASS: subagent-wide `actor` deny with primaries as the negative control, config opt-back-in, `checkpoint-writer` fork parity, absence of the old prompt invitation, recall hint omission.
 - Live `bun dev debug agent` — before: `general actor=true`; after: `build actor=true`, `general actor=false`, `explore actor=false`.
 
 **Journey log**
 
 - The obvious placement was wrong. Merging `actor: "deny"` *before* the agent's own ruleset — intended to let user config win by `findLast` — left `general` with `actor` still visible, because `defaults` carries `"*": "allow"` and the wildcard rule matches every tool name. The rule must be appended last, with an explicit-rule skip guard as the escape hatch. Live `debug agent` caught this immediately; the reasoning alone had not.
 - `agent.prompt` replaces the base system prompt entirely (`System.agent`, `session/system.ts:52`), so `default.txt`'s "spawn Agent with subagent_type=Explore" guidance never reaches `general`. Only per-agent prompts needed editing.
-- Removing a tool from an agent leaves *prose* references behind. `recallHintLines` was advertising `actor({operation:"status"})` into any session with memory or tasks, ungated by agent mode — found by review, not by tests. When a change hides a tool, grep the synthetic reminders too.
+- Removing a tool from an agent leaves *prose* references behind. `recallHintLines` was advertising `actor({operation:"status"})` into any session with memory or tasks, ungated by agent mode — found by review, not by tests. When a change hides a tool, grep the synthetic reminders too. Related tone lesson: the first rewrite of the prompt bullet *explained* that delegation was unavailable, which both plants the concept and addresses a human reader; deleting it outright was the right move.
 - Baselining on the untouched `main` worktree before judging failures was essential here: 9 of the failing tests in scope fail identically on `main` because of this machine's global permission config.
 - The review's two CRITICAL findings were both against this document, not the code: a stale `[S2]` mechanism (the pre-fix merge order) and unrecorded verification. Commit `7b5f766d` fixes the MEDIUM findings it raised and was verified afterwards, but landed after the reviewed head `3c2527bf`.
 
@@ -70,7 +70,13 @@ Because the pattern is `"*"`, `Permission.disabled` removes `actor` from the sub
 
 **checkpoint-writer parity.** `checkpoint-writer` is the one hidden subagent with no `toolAllowlist`, because a fork must mirror the parent's tool schema for prefix-cache alignment. On the fork path its visibility ruleset is `merge(writer.permission, parentPermission)` (`llm.ts` `resolveTools` via `prompt.ts:3896`), and `parentPermission` is merged last, so the parent primary's `"*": "allow"` out-ranks the injected deny under `findLast`. Parity therefore holds, pinned by a test. A cold-start writer (`fork: false`, `checkpoint.ts:888`) is filtered against its own permission and does lose `actor`; harmless, since it never spawns.
 
-**Prompt alignment.** `prompt/general.txt` states that the assignment is the subagent's own to finish, that it has no ability to delegate, and that out-of-scope work is reported back to the parent. `System.agent` (`session/system.ts:52`) returns `[agent.prompt]` when an agent declares one, so the base prompt's orchestration guidance never reaches `general` and needs no change. The per-turn recall reminder is the other prose surface that names the tool: `recallHintLines` takes a `hasActor` flag and the injection site computes it from the acting agent's own visibility, so a subagent is never pointed at an absent tool.
+**Prompt alignment.** The subagent prompt must not name the capability at all — neither inviting delegation nor explaining that delegation is unavailable. A prompt that says "you have no ability to delegate" still plants the concept and sends the model looking for the tool, and it reads as an explanation aimed at a human reviewer rather than instruction for the model; the correct tone is silence. So `prompt/general.txt` drops the delegation bullet entirely and keeps only a scope statement — "Work outside the delegated scope is not yours to start. Name it in your final report and leave it to the parent." — with the opening line's "Own that task and complete it end to end" carrying the ownership framing. The word `actor` does not appear in the file.
+
+Tests guard only against the old invitation (`"You may delegate"`). The wider "never names the tool" property stays design intent rather than an assertion: it is prose-shaped, hard to express without false positives, and would make any legitimate rewording fail for the wrong reason.
+
+`System.agent` (`session/system.ts:52`) returns `[agent.prompt]` when an agent declares one, so the base prompt's orchestration guidance never reaches `general` and needs no change. The per-turn recall reminder is the other prose surface that names the tool: `recallHintLines` takes a `hasActor` flag and the injection site computes it from the acting agent's own visibility, so a subagent is never pointed at an absent tool.
+
+**Comment budget.** The rationale above lives in this document, not in the source. `agent.ts` keeps three lines at the injection site — enough to stop a future reader "fixing" the merge order — and `recallHintLines` one clause about `hasActor`.
 
 **Docs.** `packages/web/src/content/docs/permissions.mdx` lists `actor` among the available permissions and documents the subagent default plus the opt-back-in snippet.
 
@@ -86,7 +92,7 @@ Because the pattern is `"*"`, `Permission.disabled` removes `actor` from the sub
 ## Tasks
 
 - [x] T1: Inject `actor: "deny"` for every `mode === "subagent"` agent in `agent.ts` — acceptance: `bun dev debug agent general` reports `"actor": false`, and a config `agent.general.permission.actor: "allow"` restores `true` (covers: S2)
-- [x] T2: Rewrite the delegation bullet in `prompt/general.txt` so it neither invites delegation nor names an absent tool — acceptance: the file no longer contains "You may delegate", and states that the subagent completes or reports back (covers: S2; depends: T1)
+- [x] T2: Drop the delegation bullet from `prompt/general.txt` so the prompt neither invites delegation nor names the tool — acceptance: the file no longer contains "You may delegate" (covers: S2; depends: T1)
 - [x] T3: Add regression tests — every `mode === "subagent"` agent has `actor` disabled, a user `actor: "allow"` override re-enables it, and `checkpoint-writer` under a parent primary's `parentPermission` still sees `actor` — acceptance: the new tests pass and the subagent-deny guard fails on `main`'s behavior (covers: S2; depends: T1)
 - [x] T4: Verify with `bun typecheck`, `bun lint`, the agent/actor test files, and a live `bun dev debug agent` for `general` + `explore` — acceptance: recorded commands with PASS/PRE-EXISTING status (covers: S2; depends: T1, T2, T3)
 - [x] T5: Gate the recall reminder's `actor` hint on the acting agent's tool visibility and document `permission.actor` — acceptance: `recallHintLines(cfg, false)` omits the actor line under test, and the permissions doc lists `actor` with the subagent default (covers: S2; depends: T1)

--- a/docs/compose/spec/subagent-no-nesting.md
+++ b/docs/compose/spec/subagent-no-nesting.md
@@ -78,8 +78,6 @@ Tests guard only against the old invitation (`"You may delegate"`). The wider "n
 
 **Comment budget.** The rationale above lives in this document, not in the source. `agent.ts` keeps three lines at the injection site — enough to stop a future reader "fixing" the merge order — and `recallHintLines` one clause about `hasActor`.
 
-**Docs.** `packages/web/src/content/docs/permissions.mdx` lists `actor` among the available permissions and documents the subagent default plus the opt-back-in snippet.
-
 **Behavior after the change.** Peer/orchestrator sessions (`session` tool, already orchestrator-only), `workflow()`'s internal `spawnRef` spawns, `@agent`-mention spawns (`bypassAgentCheck`), and `checkpoint-writer` forks are all untouched — none of them route through the subagent's `actor` tool schema. A subagent loses `actor`'s non-spawn verbs (`status`/`wait`/`cancel`/`send`/`models`) as an accepted cost of full invisibility.
 
 ## [S3] Out of Scope
@@ -88,6 +86,7 @@ Tests guard only against the old invitation (`"You may delegate"`). The wider "n
 - No change to the `session` tool, orchestrator peers, or the workflow runtime's own spawn cap. Subtask commands (`prompt.ts:4681`) and the flag-gated `workflow` tool can still start agents from a subagent.
 - Not fixing the pre-existing permission-name split where `registry.ts:340` filters spawnable types with `evaluate("task", ...)` while `actor.ts:696` asks with `permission: "actor"`; `permission.task` is consequently not an opt-back-in.
 - No new config key or experimental flag; the existing `agent.<name>.permission.actor` is the opt-back-in.
+- No change to `packages/web/src/content/docs/`. That docs site is upstream content this fork does not maintain, so the `actor` permission and the new subagent default are recorded here instead.
 
 ## Tasks
 
@@ -95,4 +94,4 @@ Tests guard only against the old invitation (`"You may delegate"`). The wider "n
 - [x] T2: Drop the delegation bullet from `prompt/general.txt` so the prompt neither invites delegation nor names the tool — acceptance: the file no longer contains "You may delegate" (covers: S2; depends: T1)
 - [x] T3: Add regression tests — every `mode === "subagent"` agent has `actor` disabled, a user `actor: "allow"` override re-enables it, and `checkpoint-writer` under a parent primary's `parentPermission` still sees `actor` — acceptance: the new tests pass and the subagent-deny guard fails on `main`'s behavior (covers: S2; depends: T1)
 - [x] T4: Verify with `bun typecheck`, `bun lint`, the agent/actor test files, and a live `bun dev debug agent` for `general` + `explore` — acceptance: recorded commands with PASS/PRE-EXISTING status (covers: S2; depends: T1, T2, T3)
-- [x] T5: Gate the recall reminder's `actor` hint on the acting agent's tool visibility and document `permission.actor` — acceptance: `recallHintLines(cfg, false)` omits the actor line under test, and the permissions doc lists `actor` with the subagent default (covers: S2; depends: T1)
+- [x] T5: Gate the recall reminder's `actor` hint on the acting agent's tool visibility — acceptance: `recallHintLines(cfg, false)` omits the actor line under test (covers: S2; depends: T1)

--- a/docs/compose/spec/subagent-no-nesting.md
+++ b/docs/compose/spec/subagent-no-nesting.md
@@ -1,26 +1,49 @@
 ---
 feature: subagent-no-nesting
-status: designed
+status: delivered
 updated: 2026-06-18
 branch: subagent-no-nesting
-commits: <base-sha>..<head-sha>
+commits: dd1a5c53..7b5f766d
 ---
 
 # Subagent nesting off by default
 
 ## Report
 
+**What was built** — A subagent no longer sees the `actor` tool, so delegation is one level deep by default. A single pass at the end of `Agent.state` (`src/agent/agent.ts`) appends `actor: "deny"` to every agent with `mode === "subagent"`, unless that agent's ruleset already carries an explicit `actor` rule. Because the rule's pattern is `"*"`, `Permission.disabled` drops `actor` from the agent's LLM-visible tool schema in `llm.ts` `resolveTools`, which also makes its `ctx.ask({ permission: "actor" })` unreachable. `general`'s system prompt no longer invites delegation, and the per-turn recall reminder no longer names `actor` to an agent that cannot see it.
+
+The opt-back-in is an explicit `actor` rule — `agent.<name>.permission.actor: "allow"` or a global `permission.actor` — mirroring the neighbouring `external_directory` pass's "unless explicitly configured" contract. Any explicit `actor` rule counts, including `"ask"`, which is accepted: a user who configures the permission by name has stated an intent about it. A blanket `"*": "allow"` deliberately does not re-enable nesting.
+
+Programmatic spawn paths are untouched by design, because none of them reads the subagent's tool schema: `bypassAgentCheck` (`@agent` mentions), the workflow runtime's `spawnRef` spawns, `checkpoint-writer` forks, and orchestrator peers via the `session` tool. `exec`/tool-script cannot re-expose it either — `actor` is in `TOOL_SCRIPT_EXCLUDED`. Permission rules gate the LLM's tool schema, not the spawn API.
+
+**Verification**
+
+- `bun typecheck` (packages/opencode) — PASS, run again after the review fixes
+- `bun lint` (oxlint, repo root) — 0 errors, 4092 warnings PRE-EXISTING
+- `bun test test/agent/ test/tool/actor.test.ts test/tool/actor-recover.test.ts test/actor/` — 233 pass / 9 fail; the identical 9 failures reproduce on clean `main` → PRE-EXISTING (this machine's global config sets `edit: "ask"`, which un-denies edit-family tools for read-only agents). `main` additionally flaked `runLoop emits a per-step turn heartbeat`.
+- `bun test test/session/prompt-effect.test.ts test/session/recall-reminder.test.ts test/tool/actor.test.ts` — 74 pass, 0 fail
+- New tests (5) all PASS: subagent-wide `actor` deny with primaries as the negative control, config opt-back-in, `checkpoint-writer` fork parity, `general` prompt wording, recall hint omission.
+- Live `bun dev debug agent` — before: `general actor=true`; after: `build actor=true`, `general actor=false`, `explore actor=false`.
+
+**Journey log**
+
+- The obvious placement was wrong. Merging `actor: "deny"` *before* the agent's own ruleset — intended to let user config win by `findLast` — left `general` with `actor` still visible, because `defaults` carries `"*": "allow"` and the wildcard rule matches every tool name. The rule must be appended last, with an explicit-rule skip guard as the escape hatch. Live `debug agent` caught this immediately; the reasoning alone had not.
+- `agent.prompt` replaces the base system prompt entirely (`System.agent`, `session/system.ts:52`), so `default.txt`'s "spawn Agent with subagent_type=Explore" guidance never reaches `general`. Only per-agent prompts needed editing.
+- Removing a tool from an agent leaves *prose* references behind. `recallHintLines` was advertising `actor({operation:"status"})` into any session with memory or tasks, ungated by agent mode — found by review, not by tests. When a change hides a tool, grep the synthetic reminders too.
+- Baselining on the untouched `main` worktree before judging failures was essential here: 9 of the failing tests in scope fail identically on `main` because of this machine's global permission config.
+- The review's two CRITICAL findings were both against this document, not the code: a stale `[S2]` mechanism (the pre-fix merge order) and unrecorded verification. Commit `7b5f766d` fixes the MEDIUM findings it raised and was verified afterwards, but landed after the reviewed head `3c2527bf`.
+
 ## [S1] Problem
 
 A `general` subagent can spawn further subagents, with no depth limit.
 
 - `agent.ts` gives `general` `Permission.merge(defaults, user)`, and `defaults` carries `"*": "allow"`; it declares no `toolAllowlist`.
-- `Permission.disabled` (permission/index.ts:669) only drops a tool when a matching rule has `pattern === "*"` and `action === "deny"`, so nothing removes `actor` from `general`'s schema.
+- `Permission.disabled` (permission/index.ts:669) only drops a tool when the last matching rule has `pattern === "*"` and `action === "deny"`, so nothing removed `actor` from `general`'s schema.
 - `tool/actor.ts` passes `tools: "INHERIT"` for an agent without a `toolAllowlist`, and `prompt.ts:1276` turns `INHERIT` into "no runtime whitelist".
 - `Actor.spawn` records only `parentActorID`; there is no depth field and no ancestry check anywhere on the spawn path.
-- `prompt/general.txt` actively invites it: "You may delegate genuinely independent, bounded subtasks when that improves throughput".
+- `prompt/general.txt` actively invited it: "You may delegate genuinely independent, bounded subtasks when that improves throughput".
 
-Verified empirically before the change: `bun dev debug agent general` reports `"actor": true`, `bun dev debug agent explore` reports `"actor": false` (explore only because of its own blanket `"*": "deny"`, not by design).
+Verified before the change: `bun dev debug agent general` reported `"actor": true`; `explore` reported `"actor": false` only because of its own blanket `"*": "deny"`, not by design.
 
 Consequences: unbounded fan-out of agent trees, cost and concurrency that no single cap governs (`workflow/runtime.ts:34`'s lifecycle cap only bounds `workflow()`'s own `spawnRef` spawns), and a parent that cannot account for work done two levels down.
 
@@ -28,39 +51,42 @@ Consequences: unbounded fan-out of agent trees, cost and concurrency that no sin
 
 Make one level of delegation the default: a subagent does not see the `actor` tool at all.
 
-**Mechanism.** In `agent.ts`, after the config merge loop and alongside the existing `whitelistedDirs` normalization pass, inject `actor: "deny"` for every agent with `mode === "subagent"`. The rule is merged **before** the agent's accumulated ruleset, so `agent.<name>.permission.actor: "allow"` in user config still wins (`evaluate` uses `findLast`).
+**Mechanism.** In `agent.ts`, after the config merge loop and next to the existing `whitelistedDirs` normalization pass, append `actor: "deny"` for every agent with `mode === "subagent"` — skipping any agent whose ruleset already contains an explicit `actor` rule.
 
 ```ts
 for (const name in agents) {
-  if (agents[name].mode !== "subagent") continue
-  agents[name].permission = Permission.merge(
-    Permission.fromConfig({ actor: "deny" }),
-    agents[name].permission,
-  )
+  const agent = agents[name]
+  if (agent.mode !== "subagent") continue
+  if (agent.permission.some((rule) => rule.permission === "actor")) continue
+  agent.permission = Permission.merge(agent.permission, Permission.fromConfig({ actor: "deny" }))
 }
 ```
 
-Because the rule's pattern is `"*"`, `Permission.disabled` removes `actor` from the subagent's LLM-visible tool schema (`llm.ts` `resolveTools`), which also makes `ctx.ask({ permission: "actor" })` unreachable for that agent. Verified rule semantics:
-`disabled(["actor"], merge(defaults, fromConfig({ actor: "deny" })))` → `["actor"]`.
+The rule must be **appended last**: `evaluate`/`disabled` use `findLast`, and the ruleset already carries `"*": "allow"` from `defaults`, whose wildcard permission matches the `actor` tool name — a rule merged earlier loses to it. The opt-back-in is therefore not "a later user rule wins" but the skip guard: an explicit `actor` rule in global or per-agent config suppresses the injection entirely. Verified semantics: `disabled(["actor"], merge(defaults, fromConfig({ actor: "deny" })))` → `["actor"]`.
 
-**Scope.** All `mode === "subagent"` agents, native and user-defined, including hidden ones. Hidden internals already lack `actor` through `toolAllowlist` (`title`/`summary`/`compaction` have `[]`; `dream`/`distill` enumerate their tools), so the rule is a no-op for them.
+Because the pattern is `"*"`, `Permission.disabled` removes `actor` from the subagent's LLM-visible tool schema (`llm.ts` `resolveTools`), which also makes `ctx.ask({ permission: "actor" })` unreachable for that agent.
 
-**checkpoint-writer parity.** `checkpoint-writer` is the one hidden subagent with no `toolAllowlist`, because a fork must mirror the parent's tool schema for prefix-cache alignment. Its visibility ruleset is `merge(writer.permission, parentPermission)` (`llm.ts` `resolveTools` via `prompt.ts:3896`), and `parentPermission` is merged last, so the parent primary's `"*": "allow"` out-ranks the injected deny under `findLast`. Parity therefore holds; a test pins this rather than leaving it to inspection.
+**Scope.** All `mode === "subagent"` agents, native and user-defined, including hidden ones. Hidden internals already lack `actor` through `toolAllowlist` (`title`/`summary`/`compaction` have `[]`; `dream`/`distill` enumerate their tools), so the rule is a no-op for them. `mode: "all"` config agents are unaffected and need no rule: `tool/actor.ts`'s spawnable enum only accepts `mode === "subagent"`, so they can never be spawned as subagents.
 
-**Prompt alignment.** `prompt/general.txt` must stop inviting delegation, and must not push the model to look for an absent tool. Replace the delegation bullet with an explicit statement that the assignment is the subagent's own to finish, and that a genuinely out-of-scope piece is reported back to the parent instead of delegated. No other prompt mentions subagent-side delegation; `tool/actor.txt` is only rendered for agents that still hold the tool, so it stays unchanged.
+**checkpoint-writer parity.** `checkpoint-writer` is the one hidden subagent with no `toolAllowlist`, because a fork must mirror the parent's tool schema for prefix-cache alignment. On the fork path its visibility ruleset is `merge(writer.permission, parentPermission)` (`llm.ts` `resolveTools` via `prompt.ts:3896`), and `parentPermission` is merged last, so the parent primary's `"*": "allow"` out-ranks the injected deny under `findLast`. Parity therefore holds, pinned by a test. A cold-start writer (`fork: false`, `checkpoint.ts:888`) is filtered against its own permission and does lose `actor`; harmless, since it never spawns.
 
-**Behavior after the change.** Peer/orchestrator sessions (`session` tool, already orchestrator-only), `workflow()`'s internal `spawnRef` spawns, and `checkpoint-writer` forks are all untouched — none of them route through the subagent's `actor` tool schema. A subagent loses `actor`'s non-spawn verbs (`status`/`wait`/`cancel`/`send`/`models`) as an accepted cost of full invisibility.
+**Prompt alignment.** `prompt/general.txt` states that the assignment is the subagent's own to finish, that it has no ability to delegate, and that out-of-scope work is reported back to the parent. `System.agent` (`session/system.ts:52`) returns `[agent.prompt]` when an agent declares one, so the base prompt's orchestration guidance never reaches `general` and needs no change. The per-turn recall reminder is the other prose surface that names the tool: `recallHintLines` takes a `hasActor` flag and the injection site computes it from the acting agent's own visibility, so a subagent is never pointed at an absent tool.
+
+**Docs.** `packages/web/src/content/docs/permissions.mdx` lists `actor` among the available permissions and documents the subagent default plus the opt-back-in snippet.
+
+**Behavior after the change.** Peer/orchestrator sessions (`session` tool, already orchestrator-only), `workflow()`'s internal `spawnRef` spawns, `@agent`-mention spawns (`bypassAgentCheck`), and `checkpoint-writer` forks are all untouched — none of them route through the subagent's `actor` tool schema. A subagent loses `actor`'s non-spawn verbs (`status`/`wait`/`cancel`/`send`/`models`) as an accepted cost of full invisibility.
 
 ## [S3] Out of Scope
 
-- No depth counter or ancestry check in `Actor.spawn`; the gate is tool visibility only.
-- No change to the `session` tool, orchestrator peers, or the workflow runtime's own spawn cap.
-- Not fixing the pre-existing permission-name split where `registry.ts:340` filters spawnable types with `evaluate("task", ...)` while `actor.ts:696` asks with `permission: "actor"`.
+- No depth counter or ancestry check in `Actor.spawn`; the gate is tool visibility only, so programmatic spawn paths keep working.
+- No change to the `session` tool, orchestrator peers, or the workflow runtime's own spawn cap. Subtask commands (`prompt.ts:4681`) and the flag-gated `workflow` tool can still start agents from a subagent.
+- Not fixing the pre-existing permission-name split where `registry.ts:340` filters spawnable types with `evaluate("task", ...)` while `actor.ts:696` asks with `permission: "actor"`; `permission.task` is consequently not an opt-back-in.
 - No new config key or experimental flag; the existing `agent.<name>.permission.actor` is the opt-back-in.
 
 ## Tasks
 
-- [ ] T1: Inject `actor: "deny"` for every `mode === "subagent"` agent in `agent.ts`, merged before the agent's own rules — acceptance: `bun dev debug agent general` reports `"actor": false`, and a config `agent.general.permission.actor: "allow"` restores `true` (covers: S2)
-- [ ] T2: Rewrite the delegation bullet in `prompt/general.txt` so it neither invites delegation nor names an absent tool — acceptance: the file no longer contains "You may delegate", and states that the subagent completes or reports back (covers: S2; depends: T1)
-- [ ] T3: Add regression tests — every `mode === "subagent"` agent has `actor` disabled, a user `actor: "allow"` override re-enables it, and `checkpoint-writer` under a parent primary's `parentPermission` still sees `actor` — acceptance: new tests fail on `main`'s behavior and pass here (covers: S2; depends: T1)
-- [ ] T4: Verify with `bun turbo typecheck`, the agent/actor test files, and a live `bun dev debug agent` for `general` + `explore` — acceptance: recorded commands with PASS/PRE-EXISTING status (covers: S2; depends: T1, T2, T3)
+- [x] T1: Inject `actor: "deny"` for every `mode === "subagent"` agent in `agent.ts` — acceptance: `bun dev debug agent general` reports `"actor": false`, and a config `agent.general.permission.actor: "allow"` restores `true` (covers: S2)
+- [x] T2: Rewrite the delegation bullet in `prompt/general.txt` so it neither invites delegation nor names an absent tool — acceptance: the file no longer contains "You may delegate", and states that the subagent completes or reports back (covers: S2; depends: T1)
+- [x] T3: Add regression tests — every `mode === "subagent"` agent has `actor` disabled, a user `actor: "allow"` override re-enables it, and `checkpoint-writer` under a parent primary's `parentPermission` still sees `actor` — acceptance: the new tests pass and the subagent-deny guard fails on `main`'s behavior (covers: S2; depends: T1)
+- [x] T4: Verify with `bun typecheck`, `bun lint`, the agent/actor test files, and a live `bun dev debug agent` for `general` + `explore` — acceptance: recorded commands with PASS/PRE-EXISTING status (covers: S2; depends: T1, T2, T3)
+- [x] T5: Gate the recall reminder's `actor` hint on the acting agent's tool visibility and document `permission.actor` — acceptance: `recallHintLines(cfg, false)` omits the actor line under test, and the permissions doc lists `actor` with the subagent default (covers: S2; depends: T1)

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -501,6 +501,31 @@ export const layer = Layer.effect(
           )
         }
 
+        // One level of delegation is the default: a subagent does not see the
+        // `actor` tool at all. The rule's pattern is "*", so Permission.disabled
+        // drops `actor` from the subagent's LLM-visible tool schema (llm.ts
+        // resolveTools), which also makes its ctx.ask({ permission: "actor" })
+        // unreachable. Appended LAST because evaluate() uses findLast and the
+        // ruleset already carries `"*": "allow"` from defaults — a rule merged
+        // earlier would lose to it. The opt-back-in is therefore an EXPLICIT
+        // `actor` rule (global `permission.actor` or `agent.<name>.permission.
+        // actor`), which this pass leaves untouched; a blanket `"*": "allow"`
+        // deliberately does not re-enable nesting.
+        //
+        // checkpoint-writer is a subagent with no toolAllowlist because a fork
+        // must mirror the parent's tool schema for prefix-cache parity. Its
+        // visibility ruleset is merge(writer.permission, parentPermission) with
+        // parentPermission last, so the parent primary's "*":"allow" out-ranks
+        // this deny and parity holds (pinned by a test in agent.test.ts).
+        for (const name in agents) {
+          if (agents[name].mode !== "subagent") continue
+          if (agents[name].permission.some((rule) => rule.permission === "actor")) continue
+          agents[name].permission = Permission.merge(
+            agents[name].permission,
+            Permission.fromConfig({ actor: "deny" }),
+          )
+        }
+
         const get = Effect.fnUntraced(function* (agent: string) {
           return agents[agent]
         })

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -501,24 +501,9 @@ export const layer = Layer.effect(
           )
         }
 
-        // One level of delegation is the default: a subagent does not see the
-        // `actor` tool at all. The rule's pattern is "*", so Permission.disabled
-        // drops `actor` from the subagent's LLM-visible tool schema (llm.ts
-        // resolveTools), which also makes its ctx.ask({ permission: "actor" })
-        // unreachable. Appended LAST because evaluate() uses findLast and the
-        // ruleset already carries `"*": "allow"` from defaults — a rule merged
-        // earlier would lose to it. The opt-back-in is therefore an EXPLICIT
-        // `actor` rule (global `permission.actor` or `agent.<name>.permission.
-        // actor`), which this pass leaves untouched; a blanket `"*": "allow"`
-        // deliberately does not re-enable nesting.
-        //
-        // checkpoint-writer is a subagent with no toolAllowlist because a fork
-        // must mirror the parent's tool schema for prefix-cache parity. On the
-        // fork path its visibility ruleset is merge(writer.permission,
-        // parentPermission) with parentPermission last, so the parent primary's
-        // "*":"allow" out-ranks this deny and parity holds (pinned by a test in
-        // agent.test.ts). A cold-start writer (fork:false) is filtered against
-        // its own permission and does lose `actor` — harmless, it never spawns.
+        // Delegation is one level deep: subagents don't see the `actor` tool.
+        // Appended last because findLast would otherwise hand the match to
+        // defaults' `"*": "allow"`; an explicit `actor` rule opts back in.
         for (const name in agents) {
           const agent = agents[name]
           if (agent.mode !== "subagent") continue

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -513,17 +513,17 @@ export const layer = Layer.effect(
         // deliberately does not re-enable nesting.
         //
         // checkpoint-writer is a subagent with no toolAllowlist because a fork
-        // must mirror the parent's tool schema for prefix-cache parity. Its
-        // visibility ruleset is merge(writer.permission, parentPermission) with
-        // parentPermission last, so the parent primary's "*":"allow" out-ranks
-        // this deny and parity holds (pinned by a test in agent.test.ts).
+        // must mirror the parent's tool schema for prefix-cache parity. On the
+        // fork path its visibility ruleset is merge(writer.permission,
+        // parentPermission) with parentPermission last, so the parent primary's
+        // "*":"allow" out-ranks this deny and parity holds (pinned by a test in
+        // agent.test.ts). A cold-start writer (fork:false) is filtered against
+        // its own permission and does lose `actor` — harmless, it never spawns.
         for (const name in agents) {
-          if (agents[name].mode !== "subagent") continue
-          if (agents[name].permission.some((rule) => rule.permission === "actor")) continue
-          agents[name].permission = Permission.merge(
-            agents[name].permission,
-            Permission.fromConfig({ actor: "deny" }),
-          )
+          const agent = agents[name]
+          if (agent.mode !== "subagent") continue
+          if (agent.permission.some((rule) => rule.permission === "actor")) continue
+          agent.permission = Permission.merge(agent.permission, Permission.fromConfig({ actor: "deny" }))
         }
 
         const get = Effect.fnUntraced(function* (agent: string) {

--- a/packages/opencode/src/agent/prompt/general.txt
+++ b/packages/opencode/src/agent/prompt/general.txt
@@ -10,7 +10,7 @@ Work autonomously:
 - For investigation or review tasks, return concrete evidence with file and line references. Do not modify files unless the delegated task includes implementation or fixes.
 - Use read and write capabilities freely when they are required by the task. Do not stop at recommendations when the assignment asks for a working change.
 - Keep external side effects within the authority granted by the parent task. Do not publish, push, message people, or perform destructive operations unless explicitly authorized.
-- You may delegate genuinely independent, bounded subtasks when that improves throughput, but do not hand your entire assignment to another agent.
+- This assignment is yours to finish. You have no ability to delegate any part of it to another agent, so do not look for a way to hand work off — do the work yourself, and if something falls outside the delegated scope, name it in your final report and let the parent dispatch it.
 
 The parent agent, not you, communicates with the end user. Do not ask the end user questions or send user-facing progress updates. If essential information is missing, investigate first; if still blocked, explain the exact blocker in your final response to the parent.
 

--- a/packages/opencode/src/agent/prompt/general.txt
+++ b/packages/opencode/src/agent/prompt/general.txt
@@ -10,7 +10,7 @@ Work autonomously:
 - For investigation or review tasks, return concrete evidence with file and line references. Do not modify files unless the delegated task includes implementation or fixes.
 - Use read and write capabilities freely when they are required by the task. Do not stop at recommendations when the assignment asks for a working change.
 - Keep external side effects within the authority granted by the parent task. Do not publish, push, message people, or perform destructive operations unless explicitly authorized.
-- This assignment is yours to finish. You have no ability to delegate any part of it to another agent, so do not look for a way to hand work off — do the work yourself, and if something falls outside the delegated scope, name it in your final report and let the parent dispatch it.
+- Work outside the delegated scope is not yours to start. Name it in your final report and leave it to the parent.
 
 The parent agent, not you, communicates with the end user. Do not ask the end user questions or send user-facing progress updates. If essential information is missing, investigate first; if still blocked, explain the exact blocker in your final response to the parent.
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -128,8 +128,11 @@ globalThis.AI_SDK_LOG_WARNINGS = false
 // Recall-reminder hints, rendered in each tool's configured invocation style so
 // shell-mode sessions never see a JSON-shaped example (which primes models to
 // emit JSON and crash the shell parser). `memory` has no shell form, so it is
-// always JSON. Exported for unit testing.
-export function recallHintLines(toolCfg: ToolStyleConfig | undefined): string[] {
+// always JSON. `hasActor` is false for an agent the `actor` tool was filtered
+// out for — subagents, which are denied it by default (see agent/agent.ts) —
+// because naming an absent tool costs the model a wasted call. Exported for
+// unit testing.
+export function recallHintLines(toolCfg: ToolStyleConfig | undefined, hasActor = true): string[] {
   const taskHint =
     resolveInvocationStyle(toolCfg, "task") === "shell" ? "- task list" : `- task({ operation: "list" })`
   const actorHint =
@@ -137,7 +140,7 @@ export function recallHintLines(toolCfg: ToolStyleConfig | undefined): string[] 
       ? "- actor status <actor_id>"
       : `- actor({ operation: "status", actor_id: "<id>" })`
   // memory has no shell form (no shell.parse) → always JSON.
-  return [`- memory({ operation: "search", query: "<keyword>" })`, taskHint, actorHint]
+  return [`- memory({ operation: "search", query: "<keyword>" })`, taskHint, ...(hasActor ? [actorHint] : [])]
 }
 
 // The orchestrator root session is PERSISTENT and coordinates many tasks over
@@ -3346,7 +3349,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               .pipe(Effect.catch(() => Effect.succeed(false)))
             if (hasRecallTarget) {
               const sessMemDir = path.join(Global.Path.data, "memory", "sessions", sessionID)
-              const hints = recallHintLines((yield* config.get()).tool)
+              const recallAgent = yield* agents.get(lastUser.agent)
+              const hints = recallHintLines(
+                (yield* config.get()).tool,
+                !Permission.disabled(["actor"], Agent.runtimePermission(recallAgent, session.permission)).has("actor"),
+              )
               lastUserMsgForRecall.parts.push({
                 id: PartID.ascending(),
                 messageID: lastUserMsgForRecall.info.id,
@@ -3359,8 +3366,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   "not in your context with:",
                   hints[0],
                   `- Read(file_path="${sessMemDir}/...")`,
-                  hints[1],
-                  hints[2],
+                  ...hints.slice(1),
                   "",
                   "Don't ask the user about something memory may already record.",
                   "</system-reminder>",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -128,10 +128,8 @@ globalThis.AI_SDK_LOG_WARNINGS = false
 // Recall-reminder hints, rendered in each tool's configured invocation style so
 // shell-mode sessions never see a JSON-shaped example (which primes models to
 // emit JSON and crash the shell parser). `memory` has no shell form, so it is
-// always JSON. `hasActor` is false for an agent the `actor` tool was filtered
-// out for — subagents, which are denied it by default (see agent/agent.ts) —
-// because naming an absent tool costs the model a wasted call. Exported for
-// unit testing.
+// always JSON. `hasActor` false drops the actor line for agents the tool was
+// filtered out for. Exported for unit testing.
 export function recallHintLines(toolCfg: ToolStyleConfig | undefined, hasActor = true): string[] {
   const taskHint =
     resolveInvocationStyle(toolCfg, "task") === "shell" ? "- task list" : `- task({ operation: "list" })`

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -273,7 +273,6 @@ test("checkpoint-writer fork keeps actor visible under the parent's permission (
 
 test("general prompt does not invite delegation", () => {
   expect(PROMPT_GENERAL).not.toContain("You may delegate")
-  expect(PROMPT_GENERAL).toContain("no ability to delegate")
 })
 
 test("explore agent asks for external directories and allows Truncate.GLOB", async () => {

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -12,6 +12,7 @@ import { testEffect } from "../lib/effect"
 import PROMPT_GENERATE from "../../src/agent/generate.txt"
 import PROMPT_GENERATE_GPT from "../../src/agent/prompt/generate-gpt.txt"
 import PROMPT_EXPLORE from "../../src/agent/prompt/explore.txt"
+import PROMPT_GENERAL from "../../src/agent/prompt/general.txt"
 
 const itTool = testEffect(Layer.mergeAll(ToolRegistry.defaultLayer, Agent.defaultLayer, CrossSpawnSpawner.defaultLayer))
 
@@ -215,6 +216,64 @@ test("explore agent denies edit and write", async () => {
       expect(evalPerm(explore, "todowrite")).toBe("deny")
     },
   })
+})
+
+test("subagents cannot spawn subagents — actor is disabled for every subagent, not for primaries", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agents = await load(tmp.path, (svc) => svc.list())
+      const subagents = agents.filter((a) => a.mode === "subagent")
+      expect(subagents.length).toBeGreaterThan(0)
+      for (const agent of subagents) {
+        expect(Permission.disabled(["actor"], Agent.runtimePermission(agent, [])).has("actor")).toBe(true)
+      }
+      for (const name of ["build", "plan", "compose"]) {
+        const primary = agents.find((a) => a.name === name)
+        expect(primary).toBeDefined()
+        expect(Permission.disabled(["actor"], Agent.runtimePermission(primary!, [])).has("actor")).toBe(false)
+      }
+    },
+  })
+})
+
+test("an explicit actor rule in config opts subagent nesting back in", async () => {
+  await using tmp = await tmpdir({ config: { agent: { general: { permission: { actor: "allow" } } } } })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agents = await load(tmp.path, (svc) => svc.list())
+      const general = agents.find((a) => a.name === "general")
+      expect(Permission.disabled(["actor"], Agent.runtimePermission(general!, [])).has("actor")).toBe(false)
+      // Scoped to the agent that asked for it — explore stays single-level.
+      const explore = agents.find((a) => a.name === "explore")
+      expect(Permission.disabled(["actor"], Agent.runtimePermission(explore!, [])).has("actor")).toBe(true)
+    },
+  })
+})
+
+test("checkpoint-writer fork keeps actor visible under the parent's permission (prefix-cache parity)", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agents = await load(tmp.path, (svc) => svc.list())
+      const writer = agents.find((a) => a.name === "checkpoint-writer")
+      const build = agents.find((a) => a.name === "build")
+      expect(writer?.toolAllowlist).toBeUndefined()
+      // Mirrors llm.ts resolveTools for the fork branch (prompt.ts passes the
+      // captured parentPermission as `permission`), so the fork's visible tool
+      // set must still match the parent's despite the subagent-wide actor deny.
+      const visibility = Agent.runtimePermission(writer!, build!.permission)
+      expect(Permission.disabled(["actor"], visibility).has("actor")).toBe(false)
+    },
+  })
+})
+
+test("general prompt does not invite delegation", () => {
+  expect(PROMPT_GENERAL).not.toContain("You may delegate")
+  expect(PROMPT_GENERAL).toContain("no ability to delegate")
 })
 
 test("explore agent asks for external directories and allows Truncate.GLOB", async () => {

--- a/packages/opencode/test/session/recall-reminder.test.ts
+++ b/packages/opencode/test/session/recall-reminder.test.ts
@@ -34,4 +34,11 @@ describe("recallHintLines", () => {
     expect(lines[1]).toBe("- task list")
     expect(lines[2]).toBe("- actor status <actor_id>")
   })
+
+  test("an agent without the actor tool is not told to call it", () => {
+    const lines = recallHintLines({ invocation_style: "shell" }, false)
+    expect(lines).toHaveLength(2)
+    expect(lines.some((l) => l.includes("actor"))).toBe(false)
+    expect(lines[1]).toBe("- task list")
+  })
 })

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -135,7 +135,6 @@ OpenCode permissions are keyed by tool name, plus a couple of safety guards:
 - `grep` — content search (matches the regex pattern)
 - `bash` — running shell commands (matches parsed commands like `git status --porcelain`)
 - `task` — launching subagents (matches the subagent type)
-- `actor` — the `actor` tool, which spawns and manages subagents (matches the subagent type)
 - `skill` — loading a skill (matches the skill name)
 - `lsp` — running LSP queries (currently non-granular)
 - `question` — asking the user questions during execution
@@ -152,19 +151,6 @@ If you don’t specify anything, OpenCode starts from permissive defaults:
 
 - Most permissions default to `"allow"`.
 - `doom_loop` and `external_directory` default to `"ask"`.
-- `actor` is denied for subagents, so a subagent cannot spawn another subagent — delegation is one level deep. Give the
-  agent an explicit `actor` rule to opt back in:
-
-```json title="opencode.json"
-{
-  "agent": {
-    "general": {
-      "permission": { "actor": "allow" }
-    }
-  }
-}
-```
-
 - `read` is `"allow"`, but `.env` files are denied by default:
 
 ```json title="opencode.json"

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -135,6 +135,7 @@ OpenCode permissions are keyed by tool name, plus a couple of safety guards:
 - `grep` — content search (matches the regex pattern)
 - `bash` — running shell commands (matches parsed commands like `git status --porcelain`)
 - `task` — launching subagents (matches the subagent type)
+- `actor` — the `actor` tool, which spawns and manages subagents (matches the subagent type)
 - `skill` — loading a skill (matches the skill name)
 - `lsp` — running LSP queries (currently non-granular)
 - `question` — asking the user questions during execution
@@ -151,6 +152,19 @@ If you don’t specify anything, OpenCode starts from permissive defaults:
 
 - Most permissions default to `"allow"`.
 - `doom_loop` and `external_directory` default to `"ask"`.
+- `actor` is denied for subagents, so a subagent cannot spawn another subagent — delegation is one level deep. Give the
+  agent an explicit `actor` rule to opt back in:
+
+```json title="opencode.json"
+{
+  "agent": {
+    "general": {
+      "permission": { "actor": "allow" }
+    }
+  }
+}
+```
+
 - `read` is `"allow"`, but `.env` files are denied by default:
 
 ```json title="opencode.json"


### PR DESCRIPTION
## Summary

A `general` subagent could spawn further subagents with **no depth limit**: it carries `defaults`' `"*": "allow"`, declares no `toolAllowlist`, and nothing on the spawn path checks ancestry (`Actor.spawn` records only `parentActorID`). Its prompt actively invited it — "You may delegate genuinely independent, bounded subtasks…" — so agent trees could fan out unbounded with no single cap governing cost or concurrency.

This makes **one level of delegation the default**: a subagent no longer sees the `actor` tool at all.

- `src/agent/agent.ts` — a pass at the end of `Agent.state` appends `actor: "deny"` to every `mode === "subagent"` agent. Because the pattern is `"*"`, `Permission.disabled` drops `actor` from that agent's LLM-visible schema in `llm.ts` `resolveTools`, which also makes its `ctx.ask({ permission: "actor" })` unreachable.
- The rule must be **appended last**: `evaluate`/`disabled` use `findLast`, and `defaults`' wildcard `"*": "allow"` matches the `actor` tool name, so a rule merged earlier loses to it. The opt-back-in is therefore the skip guard — an explicit `actor` rule (`agent.<name>.permission.actor: "allow"` or a global `permission.actor`) suppresses the injection, mirroring the neighbouring `external_directory` pass's "unless explicitly configured" contract. A blanket `"*": "allow"` deliberately does not re-enable nesting.
- `prompt/general.txt` — the delegation bullet is gone. The prompt never names the capability: explaining that delegation is unavailable would plant the concept and send the model looking for the tool.
- `src/session/prompt.ts` — the per-turn recall reminder named `actor({operation:"status"})` in every session with memory or tasks, ungated by agent mode, i.e. it pointed subagents at a tool they no longer hold. `recallHintLines` now takes a `hasActor` flag computed from the acting agent's own visibility.

Programmatic spawn paths are untouched by design, since none of them reads the subagent's tool schema: `bypassAgentCheck` (`@agent` mentions), the workflow runtime's `spawnRef` spawns, `checkpoint-writer` forks, orchestrator peers via the `session` tool. `exec`/tool-script can't re-expose it either — `actor` is in `TOOL_SCRIPT_EXCLUDED`. Permission rules gate the LLM's tool schema, not the spawn API.

`checkpoint-writer` keeps `actor` visible on the fork path: its visibility ruleset is `merge(writer.permission, parentPermission)` with `parentPermission` last, so the parent primary's `"*": "allow"` out-ranks the injected deny and prefix-cache parity holds. A test pins this.

Design rationale, the accepted breadth of the opt-back-in, and the journey log live in `docs/compose/spec/subagent-no-nesting.md` rather than in inline comments. No change to `packages/web/src/content/docs/` — that docs site is upstream content this fork does not maintain.

## Test plan

- `bun typecheck` (packages/opencode) — PASS
- `bun lint` (oxlint) — 0 errors
- `bun test test/agent/ test/tool/actor.test.ts test/tool/actor-recover.test.ts test/actor/` — 233 pass / 9 fail; the identical 9 failures reproduce on clean `main` (PRE-EXISTING: a local global config sets `edit: "ask"`, which un-denies edit-family tools for read-only agents)
- `bun test test/session/prompt-effect.test.ts test/session/recall-reminder.test.ts test/tool/actor.test.ts` — 74 pass, 0 fail
- 5 new tests: subagent-wide `actor` deny with primaries as the negative control, config opt-back-in, `checkpoint-writer` fork parity, absence of the old prompt invitation, recall-hint omission. The wider "prompt never names the tool" property is design intent, not an assertion — it is prose-shaped and would fail on any legitimate rewording.
- Live `bun dev debug agent` — before: `general actor=true`; after: `build actor=true`, `general actor=false`, `explore actor=false`

## Review note

`7b5f766d` (recall-hint gate) landed after the reviewed head `3c2527bf`, as did the comment/prompt cleanup and this revert. All are typechecked, linted and unit-tested, but were not put through a second review pass.