### PR TITLE
fix(agent): prevent subagents from spawning nested subagents

### DIFF
--- a/packages/opencode/src/agent/prompt/general.txt
+++ b/packages/opencode/src/agent/prompt/general.txt
@@ -10,7 +10,7 @@ Work autonomously:
 - For investigation or review tasks, return concrete evidence with file and line references. Do not modify files unless the delegated task includes implementation or fixes.
 - Use read and write capabilities freely when they are required by the task. Do not stop at recommendations when the assignment asks for a working change.
 - Keep external side effects within the authority granted by the parent task. Do not publish, push, message people, or perform destructive operations unless explicitly authorized.
-- You may delegate genuinely independent, bounded subtasks when that improves throughput, but do not hand your entire assignment to another agent.
+- Do not spawn or delegate to other subagents. You are already a subagent; complete the assignment yourself using the tools available in this turn. Nested subagent delegation is prohibited.
 
 The parent agent, not you, communicates with the end user. Do not ask the end user questions or send user-facing progress updates. If essential information is missing, investigate first; if still blocked, explain the exact blocker in your final response to the parent.
 

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -18,6 +18,7 @@ import { ActorRegistry } from "@/actor/registry"
 import { ActorWaiter } from "@/actor/waiter"
 import { spawnRef } from "@/actor/spawn-ref"
 import { TaskRegistry } from "@/task/registry"
+import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { TaskID } from "@/task/schema"
 import { SessionCheckpoint } from "@/session/checkpoint"
 import { inboxServiceRef } from "@/inbox/inbox-ref"
@@ -691,7 +692,24 @@ export const ActorTool = Tool.define(
 
         // op.action ==="run" or "spawn" — schema guarantees
         // description / prompt / subagent_type are present and non-empty.
+        //
+        // Final defence line for the no-nested-delegation invariant that
+        // ToolRegistry.available already enforces by masking `actor` out of every
+        // subagent's schema: refuse a spawn whose caller is itself a subagent, so
+        // a stale prompt-cached schema or a hand-rolled call site cannot recurse.
+        // bypassAgentCheck marks a dispatch that did NOT originate from a model
+        // deciding to delegate — handleSubtask (where ctx.agent is the CHILD being
+        // spawned, not the caller) and explicit user @agent mentions — so those
+        // legitimately pass through.
         if (!ctx.extra?.bypassAgentCheck) {
+          const caller = yield* agent.get(ctx.agent)
+          if (caller?.mode === "subagent" && !SYSTEM_SPAWNED_AGENT_TYPES.has(caller.name)) {
+            return yield* Effect.fail(
+              new RecoverableError(
+                `Subagents cannot spawn other subagents. You are running as "${caller.name}"; complete this task yourself with the tools available to you.`,
+              ),
+            )
+          }
           yield* ctx.ask({
             permission: "actor",
             patterns: [op.subagent_type],

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -57,6 +57,7 @@ import { Instruction } from "../session/instruction"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { Bus } from "../bus"
 import { Agent } from "../agent/agent"
+import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { Skill } from "../skill"
 import { Permission } from "@/permission"
 import { ActorRegistry } from "@/actor/registry"
@@ -395,6 +396,23 @@ export const layer = Layer.effect(
       // rather than an allowlist: every other agent — primaries without an
       // allowlist (build/plan/compose) and subagents — must not see `session`.
       filtered = filtered.filter((tool) => tool.id !== "session" || input.agent.name === "orchestrator")
+
+      // No subagent may spawn further subagents. `actor` is the only tool that
+      // spawns/runs child agents, so mask it out for every `mode: "subagent"`
+      // agent — native (general/explore) AND user-config-defined, which default
+      // to `"*": "allow"` and would otherwise recurse. Gate on mode rather than
+      // agent name so a custom subagent cannot opt itself back in.
+      //
+      // SYSTEM_SPAWNED_AGENT_TYPES are exempt: they are spawned by the runtime,
+      // never by a model, so they pose no recursive-delegation risk. The
+      // exemption is also load-bearing for checkpoint-writer, a fork agent whose
+      // LLM-visible tool schema must stay byte-identical to its (primary) parent's
+      // captured ForkContext.tools or the prefix cache breaks — see ForkContext
+      // JSDoc in actor/spawn.ts. Its real tool authority is the actor.tools
+      // whitelist set in tryStartCheckpointWriter, which already omits `actor`.
+      if (input.agent.mode === "subagent" && !SYSTEM_SPAWNED_AGENT_TYPES.has(input.agent.name)) {
+        filtered = filtered.filter((tool) => tool.id !== ActorTool.id)
+      }
 
       return { filtered, useGPTTools }
     })

--- a/packages/opencode/test/tool/actor-subagent-gating.test.ts
+++ b/packages/opencode/test/tool/actor-subagent-gating.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { ToolRegistry } from "../../src/tool"
+import { Agent } from "../../src/agent/agent"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { testEffect } from "../lib/effect"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+
+const it = testEffect(
+  Layer.mergeAll(ToolRegistry.defaultLayer, Agent.defaultLayer, CrossSpawnSpawner.defaultLayer),
+)
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const ids = (agent: Agent.Info) =>
+  Effect.gen(function* () {
+    const tools = yield* (yield* ToolRegistry.Service).tools({
+      providerID: ProviderID.opencode,
+      modelID: ModelID.make("opencode/claude-sonnet-4-6"),
+      agent,
+    })
+    return tools.map((t) => t.id)
+  })
+
+const get = (name: string) =>
+  Effect.gen(function* () {
+    const agent = yield* (yield* Agent.Service).get(name)
+    if (!agent) throw new Error(`no ${name} agent`)
+    return agent
+  })
+
+// `actor` is the only tool that spawns child agents, so no `mode: "subagent"`
+// agent may see it — otherwise a subagent recursively delegates its own work.
+// The gate is on mode, not name, so a user-config subagent (which defaults to
+// `"*": "allow"`) cannot opt itself back in.
+describe("ToolRegistry.tools: actor tool subagent gating", () => {
+  it.live("primaries still see the actor tool", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        expect(yield* ids(yield* get("build"))).toContain("actor")
+      }),
+    ),
+  )
+
+  it.live("native subagents do not see the actor tool", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        expect(yield* ids(yield* get("general"))).not.toContain("actor")
+        expect(yield* ids(yield* get("explore"))).not.toContain("actor")
+      }),
+    ),
+  )
+
+  it.live("user-config subagents do not see the actor tool", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const helper = yield* get("helper")
+          expect(helper.mode).toBe("subagent")
+          expect(helper.toolAllowlist).toBeUndefined()
+          const tools = yield* ids(helper)
+          expect(tools).not.toContain("actor")
+          // still full-capability otherwise — the gate removes only `actor`
+          expect(tools).toContain("edit")
+          expect(tools).toContain("bash")
+        }),
+      { config: { agent: { helper: { description: "Helper", mode: "subagent" } } } },
+    ),
+  )
+
+  // checkpoint-writer is a fork agent: its LLM-visible tool schema must stay
+  // byte-identical to the primary parent's captured ForkContext.tools or the
+  // prefix cache breaks. Its real authority is the actor.tools whitelist in
+  // tryStartCheckpointWriter, which already omits `actor`.
+  it.live("checkpoint-writer keeps actor in its schema (fork prefix-cache parity)", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const writer = yield* get("checkpoint-writer")
+        expect(writer.mode).toBe("subagent")
+        expect(yield* ids(writer)).toEqual(yield* ids(yield* get("build")))
+      }),
+    ),
+  )
+})


### PR DESCRIPTION
## Problem

`actor` is the only tool that spawns child agents, and every `mode: "subagent"` agent could see it — including user-config-defined subagents, which default to `"*": "allow"`. A subagent could therefore hand its entire assignment to another subagent and recurse.

## Fix

Enforced at three layers:

1. **Schema** — `ToolRegistry.available` masks `actor` out of every subagent's tool list. The gate keys on `mode`, not agent name, so a custom subagent cannot opt itself back in.
2. **Runtime** — `ActorTool` refuses a spawn whose caller is itself a subagent, so a stale prompt-cached schema or a hand-rolled call site cannot recurse. `bypassAgentCheck` dispatches (`handleSubtask`, where `ctx.agent` is the child being spawned rather than the caller, and explicit user `@agent` mentions) still pass through.
3. **Prompt** — the general subagent prompt now states the prohibition instead of inviting bounded delegation.

## Exemption

`SYSTEM_SPAWNED_AGENT_TYPES` (`checkpoint-writer`, `dream`, `distill`) are exempt: they are spawned by the runtime, never by a model, so there is no recursive-delegation risk.

The exemption is load-bearing for `checkpoint-writer` — it is a fork agent whose LLM-visible tool schema must stay byte-identical to its primary parent's captured `ForkContext.tools` or the prefix cache breaks (see `ForkContext` JSDoc in `actor/spawn.ts`). Its real tool authority is the `actor.tools` whitelist set in `tryStartCheckpointWriter`, which already omits `actor`.

## Tests

New `test/tool/actor-subagent-gating.test.ts` covers: primaries keep `actor`; native subagents (`general`, `explore`) lose it; a user-config subagent loses it while keeping `edit`/`bash`; `checkpoint-writer`'s schema stays identical to `build`'s.

```
bun test test/tool/actor-subagent-gating.test.ts
4 pass / 0 fail
```