### PR TITLE
fix(session): don't tell subagents to call the masked actor tool

### DIFF
--- a/packages/opencode/src/agent/config.ts
+++ b/packages/opencode/src/agent/config.ts
@@ -4,6 +4,15 @@
  */
 export const SYSTEM_SPAWNED_AGENT_TYPES: ReadonlySet<string> = new Set(["checkpoint-writer", "dream", "distill"])
 
+/** Whether an agent sees the `actor` tool: subagents don't, because they must not
+ *  spawn further subagents. Shared by ToolRegistry.available (which masks the tool
+ *  out) and any prompt surface that would otherwise name it — a hint pointing at a
+ *  masked tool costs a wasted call.
+ */
+export function hasActorTool(agent: { name: string; mode: string }) {
+  return agent.mode !== "subagent" || SYSTEM_SPAWNED_AGENT_TYPES.has(agent.name)
+}
+
 export type InvalidOutputPolicy = "primary" | "actor" | "checkpoint"
 
 /** System agents must opt into an invalid-output contract instead of inheriting

--- a/packages/opencode/src/agent/config.ts
+++ b/packages/opencode/src/agent/config.ts
@@ -1,6 +1,7 @@
 import type { Info } from "./agent"
 
-/** Agent types that are spawned by the runtime (prune, scheduler, system code), *  NOT by the model. They get tool whitelist defaults and are skipped by
+/** Agent types that are spawned by the runtime (prune, scheduler, system code),
+ *  NOT by the model. They get tool whitelist defaults and are skipped by
  *  prune/bootstrap/memory/recall scans.
  */
 export const SYSTEM_SPAWNED_AGENT_TYPES: ReadonlySet<string> = new Set(["checkpoint-writer", "dream", "distill"])

--- a/packages/opencode/src/agent/config.ts
+++ b/packages/opencode/src/agent/config.ts
@@ -1,15 +1,22 @@
-/** Agent types that are spawned by the runtime (prune, scheduler, system code),
- *  NOT by the model. They get tool whitelist defaults and are skipped by
+import type { Info } from "./agent"
+
+/** Agent types that are spawned by the runtime (prune, scheduler, system code), *  NOT by the model. They get tool whitelist defaults and are skipped by
  *  prune/bootstrap/memory/recall scans.
  */
 export const SYSTEM_SPAWNED_AGENT_TYPES: ReadonlySet<string> = new Set(["checkpoint-writer", "dream", "distill"])
 
-/** Whether an agent sees the `actor` tool: subagents don't, because they must not
- *  spawn further subagents. Shared by ToolRegistry.available (which masks the tool
- *  out) and any prompt surface that would otherwise name it — a hint pointing at a
- *  masked tool costs a wasted call.
+/** Whether the `actor` tool is in an agent's schema: subagents don't get it,
+ *  because they must not spawn further subagents, and neither does an agent whose
+ *  toolAllowlist omits it (dream/distill). Read by ToolRegistry.available (which
+ *  applies the mask) and by prompt surfaces that would otherwise name the tool, so
+ *  the schema and the prose can't drift apart. Accepts undefined because
+ *  `Agent.Service.get` is typed `Info` but returns `agents[name]`, which is absent
+ *  for a name no longer in config; an unresolvable agent keeps the tool, matching
+ *  prior behavior.
  */
-export function hasActorTool(agent: { name: string; mode: string }) {
+export function hasActorTool(agent: Pick<Info, "name" | "mode" | "toolAllowlist"> | undefined) {
+  if (!agent) return true
+  if (agent.toolAllowlist && !agent.toolAllowlist.includes("actor")) return false
   return agent.mode !== "subagent" || SYSTEM_SPAWNED_AGENT_TYPES.has(agent.name)
 }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -8,7 +8,7 @@ import { Log, Token } from "../util"
 import { SessionRevert } from "./revert"
 import * as Session from "./session"
 import { Agent } from "../agent/agent"
-import { decideAskRouting, resolveInvalidOutputPolicy, SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
+import { decideAskRouting, hasActorTool, resolveInvalidOutputPolicy, SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { renderActorNotification } from "@/inbox/render"
 import { parseReturnHeader } from "@/actor/return-header"
 import { Provider } from "../provider"
@@ -128,8 +128,9 @@ globalThis.AI_SDK_LOG_WARNINGS = false
 // Recall-reminder hints, rendered in each tool's configured invocation style so
 // shell-mode sessions never see a JSON-shaped example (which primes models to
 // emit JSON and crash the shell parser). `memory` has no shell form, so it is
-// always JSON. Exported for unit testing.
-export function recallHintLines(toolCfg: ToolStyleConfig | undefined): string[] {
+// always JSON. `hasActor` false drops the actor line for an agent the tool is
+// masked out for. Exported for unit testing.
+export function recallHintLines(toolCfg: ToolStyleConfig | undefined, hasActor = true): string[] {
   const taskHint =
     resolveInvocationStyle(toolCfg, "task") === "shell" ? "- task list" : `- task({ operation: "list" })`
   const actorHint =
@@ -137,7 +138,7 @@ export function recallHintLines(toolCfg: ToolStyleConfig | undefined): string[] 
       ? "- actor status <actor_id>"
       : `- actor({ operation: "status", actor_id: "<id>" })`
   // memory has no shell form (no shell.parse) → always JSON.
-  return [`- memory({ operation: "search", query: "<keyword>" })`, taskHint, actorHint]
+  return [`- memory({ operation: "search", query: "<keyword>" })`, taskHint, ...(hasActor ? [actorHint] : [])]
 }
 
 // The orchestrator root session is PERSISTENT and coordinates many tasks over
@@ -3346,7 +3347,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               .pipe(Effect.catch(() => Effect.succeed(false)))
             if (hasRecallTarget) {
               const sessMemDir = path.join(Global.Path.data, "memory", "sessions", sessionID)
-              const hints = recallHintLines((yield* config.get()).tool)
+              const hints = recallHintLines(
+                (yield* config.get()).tool,
+                hasActorTool(yield* agents.get(lastUser.agent)),
+              )
               lastUserMsgForRecall.parts.push({
                 id: PartID.ascending(),
                 messageID: lastUserMsgForRecall.info.id,
@@ -3359,8 +3363,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   "not in your context with:",
                   hints[0],
                   `- Read(file_path="${sessMemDir}/...")`,
-                  hints[1],
-                  hints[2],
+                  ...hints.slice(1),
                   "",
                   "Don't ask the user about something memory may already record.",
                   "</system-reminder>",

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -57,7 +57,7 @@ import { Instruction } from "../session/instruction"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { Bus } from "../bus"
 import { Agent } from "../agent/agent"
-import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
+import { hasActorTool } from "@/agent/config"
 import { Skill } from "../skill"
 import { Permission } from "@/permission"
 import { ActorRegistry } from "@/actor/registry"
@@ -410,7 +410,9 @@ export const layer = Layer.effect(
       // captured ForkContext.tools or the prefix cache breaks — see ForkContext
       // JSDoc in actor/spawn.ts. Its real tool authority is the actor.tools
       // whitelist set in tryStartCheckpointWriter, which already omits `actor`.
-      if (input.agent.mode === "subagent" && !SYSTEM_SPAWNED_AGENT_TYPES.has(input.agent.name)) {
+      // The condition lives in hasActorTool so prompt surfaces that name the tool
+      // read the same gate.
+      if (!hasActorTool(input.agent)) {
         filtered = filtered.filter((tool) => tool.id !== ActorTool.id)
       }
 

--- a/packages/opencode/test/session/recall-reminder.test.ts
+++ b/packages/opencode/test/session/recall-reminder.test.ts
@@ -25,9 +25,8 @@ describe("recallHintLines", () => {
     expect(lines).toContain(`- actor({ operation: "status", actor_id: "<id>" })`)
   })
 
-  // Guards the positional contract the reminder block relies on: hints[0]=memory,
-  // hints[1]=task, hints[2]=actor. A future edit that reorders the returned array
-  // would silently swap which hint lands in which reminder slot — this catches it.
+  // hints[0]=memory is the only position the reminder body depends on (it spreads
+  // the rest), so this guards that slot plus the default-argument shape.
   test("returned order is [memory, task, actor]", () => {
     const lines = recallHintLines({ invocation_style: "shell" })
     expect(lines).toHaveLength(3)
@@ -52,5 +51,18 @@ describe("hasActorTool", () => {
     expect(hasActorTool({ name: "checkpoint-writer", mode: "subagent" })).toBe(true)
     expect(hasActorTool({ name: "general", mode: "subagent" })).toBe(false)
     expect(hasActorTool({ name: "explore", mode: "subagent" })).toBe(false)
+  })
+
+  // dream/distill are system-spawned, so the mode gate exempts them, but their
+  // toolAllowlist omits `actor` — the schema is what the reminder must follow.
+  test("an allowlist without actor wins over the system-spawned exemption", () => {
+    expect(hasActorTool({ name: "distill", mode: "subagent", toolAllowlist: ["read", "memory"] })).toBe(false)
+    expect(hasActorTool({ name: "build", mode: "primary", toolAllowlist: ["read"] })).toBe(false)
+  })
+
+  // Agent.Service.get is typed `Info` but returns agents[name], absent for a name
+  // no longer in config. The reminder must degrade, not throw, in a runLoop turn.
+  test("an unresolvable agent keeps the hint instead of throwing", () => {
+    expect(hasActorTool(undefined)).toBe(true)
   })
 })

--- a/packages/opencode/test/session/recall-reminder.test.ts
+++ b/packages/opencode/test/session/recall-reminder.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test"
 import { recallHintLines } from "../../src/session/prompt"
+import { hasActorTool } from "../../src/agent/config"
 
 describe("recallHintLines", () => {
   test("json mode (no tool config): task and actor use JSON form", () => {
@@ -33,5 +34,23 @@ describe("recallHintLines", () => {
     expect(lines[0]).toContain("memory(")
     expect(lines[1]).toBe("- task list")
     expect(lines[2]).toBe("- actor status <actor_id>")
+  })
+
+  test("drops the actor hint when the tool is masked out for the agent", () => {
+    const lines = recallHintLines({ invocation_style: "shell" }, false)
+    expect(lines).toEqual([`- memory({ operation: "search", query: "<keyword>" })`, "- task list"])
+  })
+})
+
+// The reminder names `actor`, so it must read the same gate ToolRegistry.available
+// uses to mask the tool out — otherwise a subagent is told to call a tool it has
+// no schema for.
+describe("hasActorTool", () => {
+  test("primaries and system-spawned agents keep it, other subagents don't", () => {
+    expect(hasActorTool({ name: "build", mode: "primary" })).toBe(true)
+    expect(hasActorTool({ name: "helper", mode: "all" })).toBe(true)
+    expect(hasActorTool({ name: "checkpoint-writer", mode: "subagent" })).toBe(true)
+    expect(hasActorTool({ name: "general", mode: "subagent" })).toBe(false)
+    expect(hasActorTool({ name: "explore", mode: "subagent" })).toBe(false)
   })
 })

--- a/packages/opencode/test/tool/actor-subagent-gating.test.ts
+++ b/packages/opencode/test/tool/actor-subagent-gating.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { ToolRegistry } from "../../src/tool"
 import { Agent } from "../../src/agent/agent"
+import { hasActorTool } from "../../src/agent/config"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { testEffect } from "../lib/effect"
@@ -83,6 +84,25 @@ describe("ToolRegistry.tools: actor tool subagent gating", () => {
         expect(writer.mode).toBe("subagent")
         expect(yield* ids(writer)).toEqual(yield* ids(yield* get("build")))
       }),
+    ),
+  )
+
+  // Prompt surfaces name `actor` based on hasActorTool rather than resolving the
+  // schema, so the predicate must agree with the mask for every registered agent
+  // — otherwise a reminder points at a tool the model has no schema for.
+  it.live("hasActorTool agrees with the mask for every agent", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const agents = yield* (yield* Agent.Service).list()
+          for (const agent of agents) {
+            expect({ agent: agent.name, actor: (yield* ids(agent)).includes("actor") }).toEqual({
+              agent: agent.name,
+              actor: hasActorTool(agent),
+            })
+          }
+        }),
+      { config: { agent: { helper: { description: "Helper", mode: "subagent" } } } },
     ),
   )
 })


### PR DESCRIPTION
## Problem

Follow-up to #2139, which masks `actor` out of every subagent's tool schema. The per-turn recall reminder still names it: `recallHintLines` (`src/session/prompt.ts:132`) and its injection site (~`:3350`) are ungated by agent, so any session with memory or tasks appends

```
- actor({ operation: "status", actor_id: "<id>" })
```

to the last user message — on subagent turns too, where the tool is no longer in the schema. The model spends a call discovering that, then recovers through the invalid-tool path. `skill-search-reminder.ts` gates its analogous hint; this one didn't.

## Fix

Extract the gate #2139 put in `ToolRegistry.available` as `hasActorTool` in `agent/config.ts` (next to `SYSTEM_SPAWNED_AGENT_TYPES` and the other pure gates) and read it at both sites, so the reminder and the tool schema cannot drift apart. `recallHintLines` takes a `hasActor` flag and drops the line; the reminder body spreads the remaining hints instead of indexing `hints[2]`.

The predicate answers "is `actor` in this agent's schema", which is the mode gate **plus** `toolAllowlist`: `dream`/`distill` are exempt from the mode gate as system-spawned agents, but their allowlist omits `actor`, so they must not be told about it either. It also accepts `undefined`, because `Agent.Service.get` is typed `Effect<Info>` while returning `agents[name]` — absent for an agent no longer in config, and a bare deref would throw inside the runLoop.

Registry behavior for primaries and for the agents #2139 exempted is unchanged — same condition, now named.

## Test plan

- `bun typecheck` (packages/opencode) — PASS
- `bun lint` — 0 errors
- `bun test test/session/recall-reminder.test.ts test/tool/actor-subagent-gating.test.ts` — 12 pass / 0 fail
- `bun test test/agent/` — 6 failures, identical on an unmodified `main` checkout (PRE-EXISTING: a local global config sets `edit: "ask"`, which un-denies edit-family tools for read-only agents)
- `bun test test/session/prompt-effect.test.ts test/tool/actor.test.ts` — 69 pass / 2 skip / 0 fail
- New tests: the actor hint is dropped when the tool is masked; the predicate's mode/allowlist/undefined cases; and a parity test that walks every registered agent asserting `hasActorTool(agent) === schema.includes("actor")`. That parity test is what caught the `dream`/`distill` allowlist hole in the first cut — it locks the two call sites together, which is the point of the extraction. #2139's own gating test passes unchanged.

## Known residuals (not in this PR)

- `session/system.ts:158-162` — the `<vision-capability>` block tells a non-vision agent to "dispatch a vision-capable subagent via the actor tool". `environment()` takes no agent, so gating it means a signature change plus touching system content that #2119 just stabilized for prefix caching.
- `checkpoint-writer` keeps `actor` in its schema for fork prefix-cache parity, so the reminder still names it, while its runtime authority is the `actor.tools` whitelist in `tryStartCheckpointWriter`, which omits `actor`. Pre-existing on `main`; the reminder block has no system-spawned-agent guard at all (contrast `prompt.ts:4388`).