### PR TITLE
fix(tui): bash_delete prompt — stale glyph leak, dropped deletion lines, sizing

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -146,19 +146,25 @@ export function BashDeleteBody(props: {
   const dimensions = useTerminalDimensions()
   // A scrollbox stretches to fill available height (its viewport chain is
   // flexGrow:1 with minHeight:"100%" content), so cap it from a wrap estimate.
-  // Word wrap only ever adds rows over ceil(len/width), so the estimate never
-  // exceeds the real row count — worst case the content scrolls.
+  // The divisor matches the body's horizontal insets (border + paddings = 6),
+  // so word wrap produces at least this many rows and the estimate never
+  // over-allocates — worst case the content scrolls.
   const commandRows = createMemo(() => {
-    const width = Math.max(20, dimensions().width - 8)
+    const width = Math.max(20, dimensions().width - 6)
     return ("$ " + props.command)
       .split("\n")
       .reduce((acc, line) => acc + Math.max(1, Math.ceil(line.length / width)), 0)
   })
 
-  const trackOptions = {
+  // Guaranteed visible deletion rows. Keep this at 4+: smaller minHeights on
+  // the scrollbox collide with the vertical scrollbar's own minimum extent and
+  // yoga stops shrinking the section entirely, overflowing the footer.
+  const deletesFloor = createMemo(() => Math.min(props.deletes.length, 4))
+
+  const trackOptions = () => ({
     backgroundColor: props.theme.background,
     foregroundColor: props.theme.borderActive,
-  }
+  })
 
   return (
     <box paddingLeft={1} gap={1} flexShrink={1} minHeight={0}>
@@ -168,22 +174,22 @@ export function BashDeleteBody(props: {
           flexShrink={1}
           minHeight={1}
           scrollAcceleration={props.scrollAcceleration}
-          verticalScrollbarOptions={{ trackOptions }}
+          verticalScrollbarOptions={{ trackOptions: trackOptions() }}
         >
           <text fg={props.theme.text}>{"$ " + props.command}</text>
         </scrollbox>
       </Show>
       <Show when={props.deletes.length > 0}>
-        <box gap={0} flexShrink={1} minHeight={Math.min(props.deletes.length, 4) + 1}>
+        <box gap={0} flexShrink={1} minHeight={deletesFloor() + 1}>
           <text fg={props.theme.textMuted} flexShrink={0}>
             Detected deletions
           </text>
           <scrollbox
-            maxHeight={Math.min(props.deletes.length, 8)}
+            maxHeight={props.deletes.length}
             flexShrink={1}
-            minHeight={Math.min(props.deletes.length, 4)}
+            minHeight={deletesFloor()}
             scrollAcceleration={props.scrollAcceleration}
-            verticalScrollbarOptions={{ trackOptions }}
+            verticalScrollbarOptions={{ trackOptions: trackOptions() }}
           >
             <For each={props.deletes}>
               {(cmd) => (

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -129,6 +129,53 @@ function TextBody(props: { title: string; description?: string; icon?: string })
   )
 }
 
+type PromptTheme = ReturnType<typeof useTheme>["theme"]
+
+// The command scrolls instead of being squashed by the Prompt's maxHeight
+// (yoga silently drops overflowing text rows), and the deletion lines are
+// pinned outside the scroll area with an explicit warning background so every
+// cell — including spaces — is painted opaquely. Stale glyphs from a previous
+// frame's layout were observed leaking through the unpainted space cells of
+// these lines. Theme comes in as a prop so tests can mount this without the
+// full ThemeProvider context chain.
+export function BashDeleteBody(props: { command: string; deletes: string[]; theme: PromptTheme }) {
+  return (
+    <box paddingLeft={1} gap={1} minHeight={0}>
+      <Show when={props.command}>
+        <scrollbox
+          minHeight={0}
+          verticalScrollbarOptions={{
+            trackOptions: {
+              backgroundColor: props.theme.background,
+              foregroundColor: props.theme.borderActive,
+            },
+          }}
+        >
+          <text fg={props.theme.text}>{"$ " + props.command}</text>
+        </scrollbox>
+      </Show>
+      <Show when={props.deletes.length > 0}>
+        <box gap={0} flexShrink={0}>
+          <text fg={props.theme.textMuted}>Detected deletions</text>
+          <box>
+            <For each={props.deletes}>
+              {(cmd) => (
+                <text
+                  fg={selectedForeground(props.theme, props.theme.warning)}
+                  bg={props.theme.warning}
+                  flexShrink={0}
+                >
+                  {" - " + cmd + " "}
+                </text>
+              )}
+            </For>
+          </box>
+        </box>
+      </Show>
+    </box>
+  )
+}
+
 export function PermissionPrompt(props: { request: PermissionRequest }) {
   const sdk = useSDK()
   const sync = useSync()
@@ -313,21 +360,7 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
               return {
                 icon: "✗",
                 title: "Confirm irreversible deletion",
-                body: (
-                  <box paddingLeft={1} gap={1}>
-                    <Show when={command}>
-                      <text fg={theme.text}>{"$ " + command}</text>
-                    </Show>
-                    <Show when={deletes.length > 0}>
-                      <box gap={0}>
-                        <text fg={theme.textMuted}>Detected deletions</text>
-                        <box>
-                          <For each={deletes}>{(cmd) => <text fg={theme.warning}>{"- " + cmd}</text>}</For>
-                        </box>
-                      </box>
-                    </Show>
-                  </box>
-                ),
+                body: <BashDeleteBody command={command} deletes={deletes} theme={theme} />,
               }
             }
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -149,12 +149,14 @@ export function BashDeleteBody(props: {
   // The divisor matches the body's horizontal insets (border + paddings = 6),
   // so word wrap produces at least this many rows and the estimate never
   // over-allocates — worst case the content scrolls.
-  const commandRows = createMemo(() => {
+  const wrapRows = (text: string) => {
     const width = Math.max(20, dimensions().width - 6)
-    return ("$ " + props.command)
-      .split("\n")
-      .reduce((acc, line) => acc + Math.max(1, Math.ceil(line.length / width)), 0)
-  })
+    return text.split("\n").reduce((acc, line) => acc + Math.max(1, Math.ceil(line.length / width)), 0)
+  }
+  const commandRows = createMemo(() => wrapRows("$ " + props.command))
+  // Long deletion paths word-wrap too; budgeting one row per entry would let a
+  // wrapping entry push later ones behind the scroll despite free space below.
+  const deleteRows = createMemo(() => props.deletes.reduce((acc, cmd) => acc + wrapRows(" - " + cmd + " "), 0))
 
   // Guaranteed visible deletion rows. Don't lower the cap below 4: once the
   // list is long enough to scroll, a scrollbox minHeight smaller than the
@@ -187,7 +189,7 @@ export function BashDeleteBody(props: {
             Detected deletions
           </text>
           <scrollbox
-            maxHeight={props.deletes.length}
+            maxHeight={deleteRows()}
             flexShrink={1}
             minHeight={deletesFloor()}
             scrollAcceleration={props.scrollAcceleration}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -131,45 +131,68 @@ function TextBody(props: { title: string; description?: string; icon?: string })
 
 type PromptTheme = ReturnType<typeof useTheme>["theme"]
 
-// The command scrolls instead of being squashed by the Prompt's maxHeight
-// (yoga silently drops overflowing text rows), and the deletion lines are
-// pinned outside the scroll area with an explicit warning background so every
-// cell — including spaces — is painted opaquely. Stale glyphs from a previous
-// frame's layout were observed leaking through the unpainted space cells of
-// these lines. Theme comes in as a prop so tests can mount this without the
-// full ThemeProvider context chain.
-export function BashDeleteBody(props: { command: string; deletes: string[]; theme: PromptTheme }) {
+// Command and deletions each live in an explicitly sized scrollbox: the
+// Prompt's maxHeight used to make yoga silently drop overflowing rows (hiding
+// deletion targets), and the unpainted space cells of the warning lines leaked
+// stale glyphs from earlier frames — so deletion lines also paint every cell
+// with an explicit warning background. Theme comes in as a prop so tests can
+// mount this without the full ThemeProvider context chain.
+export function BashDeleteBody(props: {
+  command: string
+  deletes: string[]
+  theme: PromptTheme
+  scrollAcceleration?: ReturnType<typeof getScrollAcceleration>
+}) {
+  const dimensions = useTerminalDimensions()
+  // A scrollbox stretches to fill available height (its viewport chain is
+  // flexGrow:1 with minHeight:"100%" content), so cap it from a wrap estimate.
+  // Word wrap only ever adds rows over ceil(len/width), so the estimate never
+  // exceeds the real row count — worst case the content scrolls.
+  const commandRows = createMemo(() => {
+    const width = Math.max(20, dimensions().width - 8)
+    return ("$ " + props.command)
+      .split("\n")
+      .reduce((acc, line) => acc + Math.max(1, Math.ceil(line.length / width)), 0)
+  })
+
+  const trackOptions = {
+    backgroundColor: props.theme.background,
+    foregroundColor: props.theme.borderActive,
+  }
+
   return (
-    <box paddingLeft={1} gap={1} minHeight={0}>
+    <box paddingLeft={1} gap={1} flexShrink={1} minHeight={0}>
       <Show when={props.command}>
         <scrollbox
-          minHeight={0}
-          verticalScrollbarOptions={{
-            trackOptions: {
-              backgroundColor: props.theme.background,
-              foregroundColor: props.theme.borderActive,
-            },
-          }}
+          maxHeight={commandRows()}
+          flexShrink={1}
+          minHeight={1}
+          scrollAcceleration={props.scrollAcceleration}
+          verticalScrollbarOptions={{ trackOptions }}
         >
           <text fg={props.theme.text}>{"$ " + props.command}</text>
         </scrollbox>
       </Show>
       <Show when={props.deletes.length > 0}>
-        <box gap={0} flexShrink={0}>
-          <text fg={props.theme.textMuted}>Detected deletions</text>
-          <box>
+        <box gap={0} flexShrink={1} minHeight={Math.min(props.deletes.length, 4) + 1}>
+          <text fg={props.theme.textMuted} flexShrink={0}>
+            Detected deletions
+          </text>
+          <scrollbox
+            maxHeight={Math.min(props.deletes.length, 8)}
+            flexShrink={1}
+            minHeight={Math.min(props.deletes.length, 4)}
+            scrollAcceleration={props.scrollAcceleration}
+            verticalScrollbarOptions={{ trackOptions }}
+          >
             <For each={props.deletes}>
               {(cmd) => (
-                <text
-                  fg={selectedForeground(props.theme, props.theme.warning)}
-                  bg={props.theme.warning}
-                  flexShrink={0}
-                >
+                <text fg={selectedForeground(props.theme, props.theme.warning)} bg={props.theme.warning}>
                   {" - " + cmd + " "}
                 </text>
               )}
             </For>
-          </box>
+          </scrollbox>
         </box>
       </Show>
     </box>
@@ -198,6 +221,7 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
   })
 
   const { theme } = useTheme()
+  const config = useTuiConfig()
 
   return (
     <Switch>
@@ -360,7 +384,14 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
               return {
                 icon: "✗",
                 title: "Confirm irreversible deletion",
-                body: <BashDeleteBody command={command} deletes={deletes} theme={theme} />,
+                body: (
+                  <BashDeleteBody
+                    command={command}
+                    deletes={deletes}
+                    theme={theme}
+                    scrollAcceleration={getScrollAcceleration(config)}
+                  />
+                ),
               }
             }
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -156,9 +156,11 @@ export function BashDeleteBody(props: {
       .reduce((acc, line) => acc + Math.max(1, Math.ceil(line.length / width)), 0)
   })
 
-  // Guaranteed visible deletion rows. Keep this at 4+: smaller minHeights on
-  // the scrollbox collide with the vertical scrollbar's own minimum extent and
-  // yoga stops shrinking the section entirely, overflowing the footer.
+  // Guaranteed visible deletion rows. Don't lower the cap below 4: once the
+  // list is long enough to scroll, a scrollbox minHeight smaller than the
+  // vertical scrollbar's minimum extent makes yoga stop shrinking the section
+  // entirely, overflowing the footer. (For 1-3 deletions minHeight equals the
+  // full list height, so no scrollbar appears and the collision can't happen.)
   const deletesFloor = createMemo(() => Math.min(props.deletes.length, 4))
 
   const trackOptions = () => ({

--- a/packages/opencode/test/cli/tui/permission-bash-delete.test.tsx
+++ b/packages/opencode/test/cli/tui/permission-bash-delete.test.tsx
@@ -172,3 +172,34 @@ test("body hugs a short command instead of filling the panel", async () => {
   // exactly one gap row between the one-line command and the deletions label
   expect(labelRow).toBe(commandRow + 2)
 })
+
+test("a wrapping deletion path does not hide later entries behind the scroll", async () => {
+  const deletes = [
+    "rm -rf /Users/someone/projects/very/deeply/nested/build-output/artifacts/cache-directory",
+    "rm -rf short-1",
+    "rm -rf short-2",
+  ]
+  const app = await testRender(
+    () => (
+      <box maxHeight={20}>
+        <box gap={1} paddingLeft={1} paddingTop={1} paddingBottom={1} flexGrow={1}>
+          <box flexShrink={0}>
+            <text fg={text}>Permission required</text>
+          </box>
+          <BashDeleteBody command="rm -rf dist/tmp" deletes={deletes} theme={theme} />
+        </box>
+        <box flexShrink={0}>
+          <text fg={text}>Allow once</text>
+        </box>
+      </box>
+    ),
+    { width: 44, height: 24 },
+  )
+  await app.renderOnce()
+  await app.renderOnce()
+
+  const frame = app.captureCharFrame()
+  // the long path wraps over several rows; the short entries must still render
+  expect(frame).toContain("- rm -rf short-1")
+  expect(frame).toContain("- rm -rf short-2")
+})

--- a/packages/opencode/test/cli/tui/permission-bash-delete.test.tsx
+++ b/packages/opencode/test/cli/tui/permission-bash-delete.test.tsx
@@ -92,6 +92,38 @@ test("many deletions never overpaint the footer", async () => {
   expectFooterIntact(frame)
 })
 
+test("narrow terminals with a tall footer keep the footer intact", async () => {
+  const deletes = Array.from({ length: 14 }, (_, i) => `rm -rf dir-${i}`)
+  const app = await testRender(
+    () => (
+      <box maxHeight={15}>
+        <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1} flexGrow={1}>
+          <box flexShrink={0}>
+            <text fg={text}>Permission required</text>
+            <text fg={text}>Confirm irreversible deletion</text>
+          </box>
+          <BashDeleteBody command={command} deletes={deletes} theme={theme} />
+        </box>
+        {/* below 80 cols the real footer becomes a column layout ~5 rows tall */}
+        <box flexShrink={0} paddingTop={1} paddingBottom={1} paddingLeft={2}>
+          <text fg={text}>Allow once  Reject</text>
+          <text fg={text}>tab select</text>
+          <text fg={text}>enter confirm</text>
+        </box>
+      </box>
+    ),
+    { width: 60, height: 20 },
+  )
+  await app.renderOnce()
+  await app.renderOnce()
+
+  const frame = app.captureCharFrame()
+  expect(deletionRows(frame).length).toBeGreaterThanOrEqual(2)
+  const confirmRow = frame.split("\n").filter((l) => l.includes("enter confirm"))
+  expect(confirmRow.length).toBe(1)
+  expect(confirmRow[0]!.trim()).toBe("enter confirm")
+})
+
 test("deletion lines paint every cell with the warning background", async () => {
   const deletes = Array.from({ length: 6 }, (_, i) => `rm -rf packages/opencode/artifact-dir-${i}`)
   const app = await testRender(() => <Shell maxHeight={15} deletes={deletes} />, { width: 100, height: 20 })

--- a/packages/opencode/test/cli/tui/permission-bash-delete.test.tsx
+++ b/packages/opencode/test/cli/tui/permission-bash-delete.test.tsx
@@ -1,0 +1,85 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { RGBA } from "@opentui/core"
+import { BashDeleteBody } from "../../../src/cli/cmd/tui/routes/session/permission"
+
+const WARNING = RGBA.fromHex("#e0af68")
+
+const theme = {
+  text: RGBA.fromHex("#eeeeee"),
+  textMuted: RGBA.fromHex("#808080"),
+  warning: WARNING,
+  background: RGBA.fromHex("#0a0a0a"),
+  borderActive: RGBA.fromHex("#484848"),
+  selectedListItemText: RGBA.fromHex("#141414"),
+  _hasSelectedListItemText: true,
+} as never
+
+const command = [
+  "cd packages/opencode",
+  "bun install --frozen-lockfile",
+  "bun run build:local --target darwin-arm64",
+  "rm -rf dist/tmp",
+  "rm -rf node_modules/.cache",
+  "bun test src/tool --coverage",
+  "echo done",
+].join(" && ")
+
+const deletes = Array.from({ length: 6 }, (_, i) => `rm -rf packages/opencode/artifact-dir-${i}`)
+
+// Mirrors the Prompt shell in permission.tsx: hard maxHeight, header and
+// footer pinned with flexShrink=0, body squeezed in between.
+function Shell(props: { maxHeight: number }) {
+  return (
+    <box maxHeight={props.maxHeight}>
+      <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1} flexGrow={1}>
+        <box paddingLeft={1} flexShrink={0}>
+          <text fg={(theme as any).text}>Permission required</text>
+          <text fg={(theme as any).text}>Confirm irreversible deletion</text>
+        </box>
+        <BashDeleteBody command={command} deletes={deletes} theme={theme} />
+      </box>
+      <box flexShrink={0} paddingTop={1} paddingBottom={1} paddingLeft={2}>
+        <text fg={(theme as any).text}>Allow once</text>
+      </box>
+    </box>
+  )
+}
+
+function sameColor(a: RGBA | undefined, b: RGBA) {
+  if (!a) return false
+  const buf = (c: RGBA) => [0, 1, 2].map((i) => Math.round(c.buffer[i] * 255))
+  return buf(a).join(",") === buf(b).join(",")
+}
+
+test("bash_delete prompt keeps every deletion line visible when squeezed", async () => {
+  const app = await testRender(() => <Shell maxHeight={15} />, { width: 100, height: 20 })
+  await app.renderOnce()
+  await app.renderOnce()
+
+  const frame = app.captureCharFrame()
+  for (const cmd of deletes) {
+    expect(frame).toContain("- " + cmd)
+  }
+  expect(frame).toContain("Detected deletions")
+  expect(frame).toContain("Allow once")
+})
+
+test("bash_delete deletion lines paint every cell with the warning background", async () => {
+  const app = await testRender(() => <Shell maxHeight={15} />, { width: 100, height: 20 })
+  await app.renderOnce()
+  await app.renderOnce()
+
+  const captured = app.captureSpans()
+  const rows = captured.lines.filter((line) => line.spans.some((s) => s.text.includes("- rm -rf")))
+  expect(rows.length).toBe(deletes.length)
+
+  for (const row of rows) {
+    const span = row.spans.find((s) => s.text.includes("- rm -rf"))!
+    // one contiguous run: spaces inside the line share the same painted cells
+    expect(span.text.startsWith(" - rm -rf ")).toBe(true)
+    expect(span.text.endsWith(" ")).toBe(true)
+    expect(sameColor(span.bg, WARNING)).toBe(true)
+  }
+})

--- a/packages/opencode/test/cli/tui/permission-bash-delete.test.tsx
+++ b/packages/opencode/test/cli/tui/permission-bash-delete.test.tsx
@@ -26,22 +26,22 @@ const command = [
   "echo done",
 ].join(" && ")
 
-const deletes = Array.from({ length: 6 }, (_, i) => `rm -rf packages/opencode/artifact-dir-${i}`)
+const text = RGBA.fromHex("#eeeeee")
 
 // Mirrors the Prompt shell in permission.tsx: hard maxHeight, header and
 // footer pinned with flexShrink=0, body squeezed in between.
-function Shell(props: { maxHeight: number }) {
+function Shell(props: { maxHeight: number; deletes: string[] }) {
   return (
     <box maxHeight={props.maxHeight}>
       <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1} flexGrow={1}>
-        <box paddingLeft={1} flexShrink={0}>
-          <text fg={(theme as any).text}>Permission required</text>
-          <text fg={(theme as any).text}>Confirm irreversible deletion</text>
+        <box paddingLeft={0} flexShrink={0}>
+          <text fg={text}>Permission required</text>
+          <text fg={text}>Confirm irreversible deletion</text>
         </box>
-        <BashDeleteBody command={command} deletes={deletes} theme={theme} />
+        <BashDeleteBody command={command} deletes={props.deletes} theme={theme} />
       </box>
       <box flexShrink={0} paddingTop={1} paddingBottom={1} paddingLeft={2}>
-        <text fg={(theme as any).text}>Allow once</text>
+        <text fg={text}>Allow once</text>
       </box>
     </box>
   )
@@ -53,27 +53,54 @@ function sameColor(a: RGBA | undefined, b: RGBA) {
   return buf(a).join(",") === buf(b).join(",")
 }
 
-test("bash_delete prompt keeps every deletion line visible when squeezed", async () => {
-  const app = await testRender(() => <Shell maxHeight={15} />, { width: 100, height: 20 })
+function deletionRows(frame: string) {
+  return frame.split("\n").filter((l) => l.includes("- rm -rf"))
+}
+
+function expectFooterIntact(frame: string) {
+  const footer = frame.split("\n").filter((l) => l.includes("Allow once"))
+  expect(footer.length).toBe(1)
+  expect(footer[0]!.trim()).toBe("Allow once")
+}
+
+test("squeezed prompt keeps deletion lines intact and off the footer", async () => {
+  const deletes = Array.from({ length: 6 }, (_, i) => `rm -rf packages/opencode/artifact-dir-${i}`)
+  const app = await testRender(() => <Shell maxHeight={15} deletes={deletes} />, { width: 100, height: 20 })
   await app.renderOnce()
   await app.renderOnce()
 
   const frame = app.captureCharFrame()
-  for (const cmd of deletes) {
-    expect(frame).toContain("- " + cmd)
-  }
+  const rows = deletionRows(frame)
+  // at least the guaranteed minimum is visible, scrolled from the top, each
+  // row complete (the old body silently dropped interleaved rows instead)
+  expect(rows.length).toBeGreaterThanOrEqual(4)
+  rows.forEach((row, i) => {
+    expect(row).toContain(`- rm -rf packages/opencode/artifact-dir-${i} `)
+  })
   expect(frame).toContain("Detected deletions")
-  expect(frame).toContain("Allow once")
+  expectFooterIntact(frame)
 })
 
-test("bash_delete deletion lines paint every cell with the warning background", async () => {
-  const app = await testRender(() => <Shell maxHeight={15} />, { width: 100, height: 20 })
+test("many deletions never overpaint the footer", async () => {
+  const deletes = Array.from({ length: 14 }, (_, i) => `rm -rf packages/opencode/artifact-dir-${i}`)
+  const app = await testRender(() => <Shell maxHeight={15} deletes={deletes} />, { width: 100, height: 20 })
+  await app.renderOnce()
+  await app.renderOnce()
+
+  const frame = app.captureCharFrame()
+  expect(deletionRows(frame).length).toBeGreaterThanOrEqual(4)
+  expectFooterIntact(frame)
+})
+
+test("deletion lines paint every cell with the warning background", async () => {
+  const deletes = Array.from({ length: 6 }, (_, i) => `rm -rf packages/opencode/artifact-dir-${i}`)
+  const app = await testRender(() => <Shell maxHeight={15} deletes={deletes} />, { width: 100, height: 20 })
   await app.renderOnce()
   await app.renderOnce()
 
   const captured = app.captureSpans()
   const rows = captured.lines.filter((line) => line.spans.some((s) => s.text.includes("- rm -rf")))
-  expect(rows.length).toBe(deletes.length)
+  expect(rows.length).toBeGreaterThanOrEqual(4)
 
   for (const row of rows) {
     const span = row.spans.find((s) => s.text.includes("- rm -rf"))!
@@ -82,4 +109,32 @@ test("bash_delete deletion lines paint every cell with the warning background", 
     expect(span.text.endsWith(" ")).toBe(true)
     expect(sameColor(span.bg, WARNING)).toBe(true)
   }
+})
+
+test("body hugs a short command instead of filling the panel", async () => {
+  const app = await testRender(
+    () => (
+      <box maxHeight={15}>
+        <box gap={1} paddingLeft={1} paddingTop={1} paddingBottom={1} flexGrow={1}>
+          <box flexShrink={0}>
+            <text fg={text}>Permission required</text>
+          </box>
+          <BashDeleteBody command="rm -rf dist/tmp" deletes={["rm -rf dist/tmp"]} theme={theme} />
+        </box>
+        <box flexShrink={0}>
+          <text fg={text}>Allow once</text>
+        </box>
+      </box>
+    ),
+    { width: 80, height: 20 },
+  )
+  await app.renderOnce()
+  await app.renderOnce()
+
+  const lines = app.captureCharFrame().split("\n")
+  const commandRow = lines.findIndex((l) => l.includes("$ rm -rf dist/tmp"))
+  const labelRow = lines.findIndex((l) => l.includes("Detected deletions"))
+  expect(commandRow).toBeGreaterThan(-1)
+  // exactly one gap row between the one-line command and the deletions label
+  expect(labelRow).toBe(commandRow + 2)
 })

--- a/packages/opencode/test/cli/tui/permission-bash-delete.test.tsx
+++ b/packages/opencode/test/cli/tui/permission-bash-delete.test.tsx
@@ -54,7 +54,9 @@ function sameColor(a: RGBA | undefined, b: RGBA) {
 }
 
 function deletionRows(frame: string) {
-  return frame.split("\n").filter((l) => l.includes("- rm -rf"))
+  // deletion lines render as " - rm -rf ..." at the body indent; the wrapped
+  // command never starts a row with this exact prefix
+  return frame.split("\n").filter((l) => /^\s+- rm -rf /.test(l))
 }
 
 function expectFooterIntact(frame: string) {


### PR DESCRIPTION
## Summary

The forced-ask `bash_delete` permission prompt had two user-visible rendering defects (reported on 0.1.12 with screenshot evidence):

- **Stale glyph leak**: the warning-colored "Detected deletions" lines had no background, so their space cells occasionally showed stale glyphs from a previous frame's layout (e.g. `git worktree remove` rendered as `git worktreehremove`). The prompt is uniquely exposed: it materializes sticky-bottom over transcript rows that just displayed the same command, while streaming input and the panel's `maxHeight: 15` squeeze reshuffle row ownership every frame.
- **Silently dropped rows**: the body was a bare box under the Prompt's hard `maxHeight`, so yoga squashed overflowing children — an irreversible-deletion confirm could hide some of its deletion targets (reproduced: 6 deletions at maxHeight 15 → 2 lines silently missing) and truncate the command tail.

## Fix

New `BashDeleteBody` component in `permission.tsx`:

- Deletion lines render inverse-video (warning background + contrasting foreground), so every cell including spaces is painted opaquely — the leak becomes physically impossible regardless of the underlying compositor's space-cell handling, and the destructive action is more prominent.
- Command and deletion list each live in an explicitly sized scrollbox: the command area is capped at a wrap estimate and yields first under squeeze; the deletion list is capped at its natural height with a guaranteed 4-row floor, scrolls beyond, and never overlaps the footer (incl. narrow <80-col layouts with the taller column footer, and the ctrl+f fullscreen view shows the full list).
- Scrollbar track colors stay theme-reactive; `scrollAcceleration` threaded from config like `EditBody`.

Notable constraint discovered: scrollbox `minHeight` below ~4 collides with the vertical scrollbar's minimum extent and yoga stops shrinking the section entirely — recorded in a code comment.

## Verification

- `bun typecheck` (packages/opencode): PASS
- `bun lint` (root): 0 errors (warnings pre-existing)
- `bun test test/cli/tui/`: 203 pass / 0 fail, including 5 new regression tests (`permission-bash-delete.test.tsx`: squeeze keeps lines intact & off the footer, 14-deletion overflow, warning bg covers every cell as one contiguous span, short-command hug, narrow tall-footer)
- Control experiment: the old body structure fails the squeeze assertions (drops 2 of 6 deletion lines)
- Independent subagent review, two rounds: approved; all findings resolved