### PR TITLE
fix(session): roll back the compaction boundary when no summary lands

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -383,6 +383,16 @@ export const layer: Layer.Layer<
         model,
       })
 
+      const rollback = Effect.fn("SessionCompaction.rollback")(function* (message: string) {
+        if (!processor.message.error) {
+          processor.message.error = new MessageV2.InvalidOutputError({ message }).toObject()
+          processor.message.finish = "error"
+          yield* session.updateMessage(processor.message)
+        }
+        yield* session.removeMessage({ sessionID: input.sessionID, messageID: input.parentID })
+        return "stop" as const
+      })
+
       if (result === "overflow") {
         processor.message.error = new MessageV2.ContextOverflowError({
           message: replay
@@ -391,10 +401,15 @@ export const layer: Layer.Layer<
         }).toObject()
         processor.message.finish = "error"
         yield* session.updateMessage(processor.message)
-        return "stop"
+        return yield* rollback("Compaction exceeded the model context limit")
       }
 
-      if (result === "text-repeat") return "stop"
+      if (result === "text-repeat") return yield* rollback("Compaction produced repeated text")
+      if (result === "stop") return yield* rollback("Compaction failed before producing a summary")
+      if (
+        !MessageV2.parts(msg.id).some((part) => part.type === "text" && part.text.trim().length > 0)
+      )
+        return yield* rollback("Compaction produced no usable summary")
 
       if (compactionPart && selected.tail_start_id && compactionPart.tail_start_id !== selected.tail_start_id) {
         yield* session.updatePart({

--- a/packages/opencode/test/session/auto-overflow-writer-first.test.ts
+++ b/packages/opencode/test/session/auto-overflow-writer-first.test.ts
@@ -6,6 +6,7 @@ import { GlobalBus } from "../../src/bus/global"
 import { Database, desc, eq } from "../../src/storage"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
 import { MessageTable, SessionTable } from "../../src/session/session.sql"
 import { checkpointPath } from "../../src/session/checkpoint-paths"
@@ -301,6 +302,57 @@ async function seedFinishedAssistant(sessionID: SessionID, parentID: MessageID, 
 // with no summary at all. Degrading is therefore a real loss, not a cheaper
 // summary.
 describe("Auto context overflow: write a checkpoint before degrading to compaction", () => {
+  test(
+    "checkpoint disabled + empty compaction summary restores the original context",
+    async () => {
+      const previous = process.env.MIMOCODE_DISABLE_CHECKPOINT
+      process.env.MIMOCODE_DISABLE_CHECKPOINT = "true"
+      const llm = startLLM("")
+      try {
+        await using tmp = await tmpdir({
+          git: true,
+          init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
+        })
+
+        await Instance.provide({
+          directory: tmp.path,
+          fn: () =>
+            run(
+              Effect.gen(function* () {
+                const prompt = yield* SessionPrompt.Service
+                const sessions = yield* Session.Service
+                const info = yield* sessions.create({ title: "checkpoint-off-empty-compaction" })
+                const first = yield* Effect.promise(() => seedUserMessage(info.id, "context that must survive"))
+                yield* Effect.promise(() => seedFinishedAssistant(info.id, first.id, 50_000))
+
+                yield* prompt.prompt({
+                  sessionID: info.id,
+                  parts: [{ type: "text", text: "next question that triggers compaction" }],
+                  agent: "build",
+                })
+
+                const after = yield* sessions.messages({ sessionID: info.id, agentID: "main" })
+                expect(after.some((message) => message.parts.some((part) => part.type === "compaction"))).toBe(false)
+                expect(
+                  after.some((message) =>
+                    message.parts.some((part) => part.type === "text" && part.text === "context that must survive"),
+                  ),
+                ).toBe(true)
+                expect(
+                  MessageV2.filterCompacted(after).some((message) => message.info.id === first.id),
+                ).toBe(true)
+              }),
+            ),
+        })
+      } finally {
+        if (previous === undefined) delete process.env.MIMOCODE_DISABLE_CHECKPOINT
+        else process.env.MIMOCODE_DISABLE_CHECKPOINT = previous
+        await llm.stop()
+      }
+    },
+    { timeout: 60_000 },
+  )
+
   test(
     "a completed high-usage turn is rebuilt exactly once",
     async () => {


### PR DESCRIPTION
## Summary

Compaction wrote the boundary message *before* the summary existed and never undid it when the summary failed to materialize. Because `filterCompacted` treats a boundary as authoritative and discards everything before it, a summary-less boundary destroyed the entire history while contributing no replacement context — strictly worse than not compacting at all.

Observed symptom: a request payload containing the literal `Summary of previous conversation:` with **no summary body after it**. The model then had no idea what the original task was and could only emit repeated "no usable answer from the previous turn" notices — a context-degradation spiral.

## What changed

`packages/opencode/src/session/compaction.ts` adds a `rollback` helper and routes **all four** ways a summary can fail to materialize through it:

| path | before | after |
|---|---|---|
| `overflow` | early return, boundary kept | rollback (keeps its specific `ContextOverflowError`) |
| `text-repeat` | early return, boundary kept | rollback |
| `stop` | fell through entirely | rollback (**new branch**) |
| empty summary text | not detected at all | rollback (**new check** — this is the one that reproduces the reported symptom) |

`rollback` calls `session.removeMessage(input.parentID)`, which removes the synthetic boundary message so the pre-compaction history survives. It returns `"stop"`, and the existing caller at `prompt.ts:3504-3527` already does `if (result === "stop") break`, so the turn ends cleanly instead of continuing into a gutted context.

`rollback` guards on `if (!processor.message.error)` so the overflow branch keeps its more specific `ContextOverflowError` rather than being overwritten by the generic `InvalidOutputError`. **Please preserve this guard in any refactor** — losing it degrades a user-facing diagnostic.

## Why removing the boundary message is the right lever

Verified end to end:

- The compaction boundary is a **separate synthetic user message** minted by `SessionCompaction.create` (`compaction.ts:514-549`) carrying a `type: "compaction"` part — not a flag on a real user turn. `type: "compaction"` has exactly **one** production site in `src/`, and the message it attaches to is freshly minted immediately above with no text parts. So `removeMessage(parentID)` cannot delete a genuine user turn.
- `Session.removeMessage` doesn't touch the DB itself; it emits `MessageV2.Event.Removed`.
- That event's projector (`projectors.ts:108-112`) does a real `db.delete(MessageTable)...run()`.
- `PartTable.message_id` has `onDelete: "cascade"` (`session.sql.ts:72-75`) and `PRAGMA foreign_keys = ON` is set (`storage/db.ts:93`), so the `compaction` part is cascade-deleted with the row.

Net effect: `filterCompacted` no longer encounters a boundary, and the history is retained.

## Test

`packages/opencode/test/session/auto-overflow-writer-first.test.ts` adds a first case to the existing describe block: `"checkpoint disabled + empty compaction summary restores the original context"`.

Fault injection: `MIMOCODE_DISABLE_CHECKPOINT=true` (forces the overflow path to fall back to compaction) + `startLLM("")` (empty completion ⇒ empty summary) + a seeded 50k-token assistant turn to trigger overflow. It asserts the inverse of the failure mode: no `compaction` part survives, the seeded text `"context that must survive"` is still present, and `filterCompacted(after)` still contains the original message id.

## Verification

- `bun typecheck` — clean (also re-run across all 12 packages by the pre-push hook: 12/12 successful)
- `bun test test/session/auto-overflow-writer-first.test.ts` — **6 pass / 0 fail**, 26 assertions, 24.96s

## Known limitation

This is **compensating, not atomic**. A crash or process kill between the boundary write and the rollback still leaves an orphaned boundary, with the same symptom as before the fix. Deferring the boundary write until a non-empty summary is in hand would be structurally immune to that window; this PR does not do that. Every *normal* failure mode (empty model output, context overflow, repeated text, early stop) is covered.