### PR TITLE
fix(codex): remove 372K context cap for GPT models

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -14,21 +14,6 @@ const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
-// Hard prompt capacity of the ChatGPT Codex backend for gpt-* models, lower than what
-// models.dev reports for the raw OpenAI API. OpenAI's Codex model registry declares
-// context_window = max_context_window = 372000 for the gpt-5.6 variants
-// (openai/codex#31860 quotes the served catalog), and a direct Codex request with
-// 350,317 input tokens completes (can1357/oh-my-pi#5705), so 372K is capacity rather
-// than a billing boundary.
-//
-// Not to be confused with 272K: OpenAI prices prompts above 272K input at 2x input /
-// 1.5x output for the whole request, and Codex's bundled metadata was lowered to 272000
-// (openai/codex#33972) to keep default sessions under that line. That is a spending
-// policy, not a capacity limit, so it belongs in `compaction.max_context` — see the
-// Compaction section of the config docs.
-//
-// Applied as a clamp, so models whose real window is already smaller keep it.
-const CODEX_GPT_CONTEXT_CAP = 372_000
 
 interface PkceCodes {
   verifier: string
@@ -390,19 +375,6 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
             input: 0,
             output: 0,
             cache: { read: 0, write: 0 },
-          }
-          // The Codex backend accepts a smaller prompt than the raw OpenAI API for
-          // gpt-* models. Clamp, never raise: models whose real window is already
-          // below the cap (gpt-4o at 128K) must keep it, and limit.context === 0 is
-          // the sentinel that disables overflow handling entirely.
-          // limit.input is what Overflow.usable() reads when present, so it must be
-          // clamped too — but only when the catalog already publishes it. Introducing
-          // one would switch usable() to the input branch and drop the output reserve.
-          // The v1 SDK model type predates limit.input; the runtime object carries it.
-          const limit = model.limit as { context: number; output: number; input?: number }
-          if (modelID.startsWith("gpt-") && limit.context > 0) {
-            limit.context = Math.min(limit.context, CODEX_GPT_CONTEXT_CAP)
-            if (limit.input) limit.input = Math.min(limit.input, CODEX_GPT_CONTEXT_CAP)
           }
         }
 

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -32,7 +32,7 @@ function createTestJwt(payload: object): string {
 
 describe("plugin.codex", () => {
   describe("loader", () => {
-    test("clamps gpt context to the Codex cap without raising smaller windows", async () => {
+    test("zeroes costs for Codex without modifying model limits", async () => {
       const hooks = await CodexAuthPlugin(fakeInput)
       const model = (modelID: string, limit: { context: number; input?: number }) =>
         [modelID, { api: { id: modelID }, cost: {}, limit }] as const
@@ -52,16 +52,16 @@ describe("plugin.codex", () => {
       )
 
       expect(Object.keys(provider.models)).toEqual(["gpt-5.6-sol", "gpt-5.3-codex", "gpt-4o", "gpt-image-1", "o3"])
-      expect(provider.models["gpt-5.6-sol"].limit).toEqual({ context: 372_000, input: 372_000 })
-      // 272K input cap is already below the Codex cap — it must survive untouched,
-      // otherwise we would raise the trigger above what the provider accepts.
-      expect(provider.models["gpt-5.3-codex"].limit).toEqual({ context: 372_000, input: 272_000 })
-      // Real window below the cap: never raised.
+      // Limits are no longer clamped — catalog values pass through unchanged.
+      expect(provider.models["gpt-5.6-sol"].limit).toEqual({ context: 1_050_000, input: 922_000 })
+      expect(provider.models["gpt-5.3-codex"].limit).toEqual({ context: 400_000, input: 272_000 })
       expect(provider.models["gpt-4o"].limit).toEqual({ context: 128_000 })
-      // context 0 is the "overflow handling disabled" sentinel — leave it alone.
       expect(provider.models["gpt-image-1"].limit).toEqual({ context: 0, input: 0 })
-      // Non-gpt models keep catalog limits.
       expect(provider.models.o3.limit).toEqual({ context: 200_000 })
+      // Costs are zeroed for all models.
+      for (const model of Object.values(provider.models)) {
+        expect(model.cost).toEqual({ input: 0, output: 0, cache: { read: 0, write: 0 } })
+      }
     })
 
     test("forwards request cancellation while refreshing an expired token", async () => {

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -634,9 +634,9 @@ the `/context-limit` command in the TUI to set the budget for the current model 
 preset tiers.
 
 A common reason to set this: OpenAI prices GPT-5.6 prompts above 272K input tokens at 2x
-input and 1.5x output **for the whole request**. The models are capped at their Codex
-capacity (372K) rather than that billing line, so if you want to stay inside the cheaper
-tier, set the budget yourself:
+input and 1.5x output **for the whole request**. The models use their full catalog
+context window, which may exceed that billing line, so if you want to stay inside the
+cheaper tier, set the budget yourself:
 
 ```json title="opencode.json"
 {


### PR DESCRIPTION
## Summary

Remove the hardcoded 372K context window clamp applied to all `gpt-*` models when using Codex OAuth. Models now use their full catalog-reported context windows — GPT-5.6 Sol supports up to 1M.

## Reverts

This reverts the context cap introduced in:

- **#1926** (`fix(codex): cap imported GPT context at 300K`) — original 300K cap
- **#1930** (`fix(compaction): per-model early-compaction budget, and fix the Codex context clamp`) — refined to a 372K clamp based on the Codex model registry capacity

Both PRs were merged on 2026-07-27, at a time when Codex subscription users were hard-capped at ~272K/372K by the Codex backend. That restriction has since been lifted.

## Background

On 2026-08-17, Tibo (@thsottiaux, Codex team) confirmed on Twitter that the context window restriction for Codex subscription users has been removed. Users can now configure `model_context_window` and `model_auto_compact_token_limit` in `~/.codex/config.toml` to use larger context windows (up to 1M for GPT-5.6 Sol).

The 372K clamp was originally introduced to prevent sending prompts larger than what the Codex backend would accept. With the backend restriction lifted, the clamp now actively prevents users from using the context window they're paying for.

**Note on billing:** OpenAI prices prompts above 272K input tokens at 2x input / 1.5x output for the whole request. This is a spending policy, not a capacity limit. Users who want to stay in the cheaper tier can configure `compaction.max_context` — this is already documented in the config docs.

## Changes

| File | Change |
|------|--------|
| `packages/opencode/src/plugin/codex.ts` | Remove `CODEX_GPT_CONTEXT_CAP` constant and the clamp logic in the loader |
| `packages/opencode/test/plugin/codex.test.ts` | Update test: limits pass through unchanged, costs still zeroed |
| `packages/web/src/content/docs/config.mdx` | Update docs to reflect models use full catalog context window |

## Verification

- `bun test test/plugin/codex.test.ts` — 15/15 pass
- `bun typecheck` — clean