### PR TITLE
feat(exec): expose all request-authorized MCP tools to exec without search gating

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1252,6 +1252,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const tools: Record<string, AITool> = {}
       const activeTools = new Set<string>()
       const loadedMcpTools = new Set<string>()
+      const execMcpTools: Record<string, AITool> = {}
       const mcpSearchEntries: McpToolSearchEntry[] = []
       const mcpCatalog = { current: createMcpToolSearchCatalog([]) }
       // exec's request-scoped MCP view. Holder object (same pattern as
@@ -1510,7 +1511,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           })
         }
         if (searchable && !useMcpToolSearch && input.model.capabilities.toolcall) activeTools.add(key)
-        item.execute = (args, opts) =>
+        const executeMcp = (
+          args: Parameters<typeof execute>[0],
+          opts: Parameters<typeof execute>[1],
+          requireLoaded: boolean,
+        ) =>
           run.promise(
             Effect.gen(function* () {
               const startTs = Date.now()
@@ -1526,7 +1531,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   new RecoverableError(`The MCP tool "${key}" is unavailable for this request.`),
                 )
               }
-              if (useMcpToolSearch && !loadedMcpTools.has(key)) {
+              if (requireLoaded && useMcpToolSearch && !loadedMcpTools.has(key)) {
                 return yield* Effect.fail(
                   new RecoverableError(
                     `The MCP tool "${key}" is not loaded for this request. Call ${MCP_TOOL_SEARCH_ID} first, then retry on the next step.`,
@@ -1644,7 +1649,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return output
             }),
           )
+        item.execute = (args, opts) => executeMcp(args, opts, true)
         tools[key] = item
+        if (searchable && input.model.capabilities.toolcall) {
+          execMcpTools[key] = {
+            ...item,
+            execute: (args, opts) => executeMcp(args, opts, false),
+          }
+        }
       }
       mcpCatalog.current = createMcpToolSearchCatalog(
         mcpSearchEntries.toSorted((a, b) => a.name.localeCompare(b.name)),
@@ -1710,15 +1722,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       }
       loadedMcpTools.forEach((name) => activeTools.add(name))
 
-      // Fill exec's request-scoped MCP view (holder declared at the top of
-      // this pass, delivered via ctx.extra.execMcp): exactly the MCP tools
-      // active for this request. Under mcp_tool_search gating that means only
-      // search-loaded tools — exec must not bypass the discovery gate.
-      for (const [key] of mcpTools) {
-        if (!tools[key] || !activeTools.has(key)) continue
-        if (key === MCP_TOOL_SEARCH_ID) continue
-        execMcp.current[key] = tools[key]
-      }
+      // MCP Tool Search keeps full schemas out of the outer model tool list;
+      // it is a context-budget optimization, not an authorization boundary.
+      // exec therefore receives every request-authorized MCP tool so Codex can
+      // call a catalogued tool in the same step without a redundant search
+      // round-trip. These wrappers still run the ordinary permission, plugin,
+      // metrics, normalization, and truncation pipeline above.
+      execMcp.current = execMcpTools
 
       return {
         tools,

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1022,6 +1022,47 @@ mcpIt.live("MCP structuredContent is persisted and reaches the model alongside t
   ),
 )
 
+mcpIt.live("exec can call a catalogued MCP tool without loading its outer schema", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "Exec MCP",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        model: mcpRef,
+        noReply: true,
+        parts: [{ type: "text", text: "inspect the window through exec" }],
+      })
+      yield* llm.tool("exec", {
+        code: "const result = await tools.mcp_success({}); return result.structured",
+      })
+      yield* llm.text("done")
+
+      yield* prompt.loop({ sessionID: session.id })
+
+      const tool = (yield* MessageV2.filterCompactedEffect(session.id))
+        .flatMap((message) => message.parts)
+        .find(
+          (part): part is CompletedToolPart =>
+            part.type === "tool" && part.tool === "exec" && part.state.status === "completed",
+        )
+      expect(tool?.state.output).toContain('"changed": true')
+      expect(tool?.state.output).toContain('"windowID": 42')
+
+      const tools = (yield* llm.inputs)[0].tools as Array<Record<string, unknown>>
+      expect(tools.map(wireToolName)).toContain("mcp_tool_search")
+      expect(tools.map(wireToolName)).not.toContain("mcp_success")
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 mcpIt.live("rejects an MCP call that was not loaded by search", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {


### PR DESCRIPTION
## Summary
- MCP Tool Search keeps full schemas out of the outer model tool list as a context-budget optimization — it is not an authorization boundary. exec now receives every request-authorized MCP tool (via a `requireLoaded=false` execute wrapper) so Codex can call a catalogued MCP tool in the same step without a redundant `mcp_tool_search` round-trip.
- Direct (outer) MCP tool calls keep the search gate: calling an unloaded MCP tool directly still fails with the "call mcp_tool_search first" recoverable error.
- The exec-side wrappers reuse the same execute pipeline — permission ask, plugin before/after hooks, metrics, result normalization, and truncation all apply unchanged.

## Test plan
- New live test: `exec can call a catalogued MCP tool without loading its outer schema` — asserts exec reaches the MCP tool's structured output while the outer tool list still only exposes `mcp_tool_search` (not the raw MCP tool).
- Existing gate test `rejects an MCP call that was not loaded by search` still passes — the outer path remains gated.
- `bun typecheck` and `bun test test/session/prompt-effect.test.ts` (54 pass / 0 fail) from `packages/opencode`.