### PR TITLE
feat(exec): add ALL_TOOLS catalog and transpile scripts with TypeScript

### DIFF
--- a/packages/opencode/src/tool/mcp-tool-search.ts
+++ b/packages/opencode/src/tool/mcp-tool-search.ts
@@ -50,6 +50,7 @@ let cached: SearchIndex | undefined
 const DESCRIPTION = [
   "Search locally available MCP tools and load only the matching capabilities for the current user request.",
   "Use this before attempting an MCP operation. Matching tools become callable on the next step.",
+  "This tool is not available inside exec; exec scripts discover their request-authorized MCP tools through the global ALL_TOOLS catalog and call them through tools.",
 ].join("\n")
 
 function normalizeMetadata(value: string) {

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -2,6 +2,7 @@ import z from "zod"
 import os from "os"
 import fs from "fs"
 import path from "path"
+import ts from "typescript"
 import { Effect } from "effect"
 import type { Tool as AiTool } from "ai"
 import { EffectBridge, InstanceState } from "@/effect"
@@ -88,9 +89,11 @@ export function renderToolScriptDeclarations(defs: Tool.Def[]): string {
     "declare const tools: {",
     ...lines,
     ...aliasLines,
-    "  /** Active MCP tools (if any) are also callable as tools.<name>(input). MCP results carry parsed structuredContent in `structured` when the server provides it. */",
+    "  /** Request-authorized MCP tools are callable by exact catalog name, normally mcp__<server>__<tool>. */",
     "  [mcpToolName: string]: (input: Record<string, unknown>) => Promise<ToolResult>",
     "}",
+    "/** Every tool callable in this execution. Filter by name to discover MCP tools without mcp_tool_search. */",
+    "declare const ALL_TOOLS: ReadonlyArray<{ name: string; description: string }>",
     "// Raw file IO for machine-to-machine data (pipelines across executions).",
     "declare const files: {",
     "  /** Raw file contents — no line numbers, no truncation. null if missing. Paths: worktree or OS tmp. */",
@@ -306,7 +309,7 @@ export const ToolScriptTool = Tool.define(
         code: z
           .string()
           .describe(
-            "TypeScript (or JavaScript) source for the body of an async function. Call tools via the global `tools` object; `return` the final aggregated value.",
+            "Raw JavaScript or TypeScript source for the body of an async function, not JSON or a Markdown code block. Call tools via the global `tools` object; inspect `ALL_TOOLS` when needed; `return` the final aggregated value.",
           ),
         max_tool_calls: z
           .number()
@@ -378,16 +381,25 @@ export const ToolScriptTool = Tool.define(
             )
           ).filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id) && (!whitelist || whitelist.has(def.id)))
           const byId = new Map(defs.map((def) => [def.id, def]))
-          // MCP tools (request-scoped view delivered via ctx.extra.execMcp,
-          // filled by SessionPrompt's resolveTools for THIS request — under
-          // mcp_tool_search gating only search-loaded tools appear, so exec
-          // cannot bypass the discovery gate; a module-level ref would be
-          // overwritten by concurrent sessions). Builtin ids win on collision
-          // — an MCP server must not shadow `read`/`grep`.
+          // Request-authorized MCP tools (delivered via ctx.extra.execMcp and
+          // filled by SessionPrompt's resolveTools for THIS request). Tool Search
+          // only limits the outer model's schema list; exec receives the full
+          // authorized view so it can call tools[exactCatalogName](...) directly.
+          // A module-level ref would be overwritten by concurrent sessions.
+          // Builtin ids win on collision — an MCP server must not shadow `read`.
           const mcpTools = (ctx.extra?.execMcp as { current?: Record<string, AiTool> } | undefined)?.current ?? {}
           const mcpById = new Map(
             Object.entries(mcpTools).filter(([id]) => !byId.has(id) && (!whitelist || whitelist.has(id))),
           )
+          const allTools = [
+            ...[...byId.values()].map((def) => ({ name: def.id, description: def.description })),
+            ...Object.entries(TOOL_SCRIPT_ALIASES).flatMap(([name, target]) => {
+              const def = byId.get(target)
+              if (!def) return []
+              return [{ name, description: `Alias for ${target}. ${def.description}` }]
+            }),
+            ...[...mcpById.entries()].map(([name, tool]) => ({ name, description: tool.description ?? "" })),
+          ]
           // Non-git projects report worktree === "/" (see Instance.containsPath) —
           // "/" as a jail root would allow EVERYTHING. Fall back to the project
           // directory in that case. Relative guest paths resolve against roots[0].
@@ -403,38 +415,44 @@ export const ToolScriptTool = Tool.define(
           const bridge = yield* EffectBridge.make()
 
           // Wrap before transpiling: the code is the BODY of an async function
-          // (top-level `return`/`await`), which is invalid at module top level —
-          // Bun.Transpiler would reject it. The wrapped form transpiles to a plain
-          // JS async-arrow expression the guest body can invoke.
-          // Bun surfaces syntax errors as BuildMessage (single) or AggregateError
-          // (several), each carrying a position. Report line/column relative to
-          // the CALLER's code (the wrapper adds one line above), plus the source
-          // line text — a bare "Parse error" is undebuggable in a 100-line script.
-          const formatBuildError = (err: unknown): string => {
-            const messages = err instanceof AggregateError ? err.errors : [err]
-            const rendered = messages
-              .map((m: any) => {
-                const pos = m?.position
-                if (!pos || typeof pos.line !== "number") return String(m?.message ?? m)
-                return `line ${pos.line - 1}, column ${pos.column}: ${m.message}\n  ${pos.lineText ?? ""}`
+          // (top-level `return`/`await`), which is invalid at module top level.
+          // The wrapped form transpiles to a plain JS async-arrow expression the
+          // guest body can invoke. Use TypeScript rather than Bun.Transpiler: this
+          // core module also ships in the Node bundle, and some standalone Bun
+          // runtimes expose Transpiler without a constructible implementation.
+          // Report line/column relative to the CALLER's code (the wrapper adds one
+          // line above), plus source text — a bare parse error is undebuggable.
+          const source = `globalThis.__main = async () => {\n${params.code}\n}`
+          const result = ts.transpileModule(source, {
+            reportDiagnostics: true,
+            compilerOptions: {
+              module: ts.ModuleKind.ESNext,
+              target: ts.ScriptTarget.ESNext,
+            },
+          })
+          const hasImport = /^\s*(import|export)\s/m.test(params.code)
+          const formatDiagnostics = (diagnostics: readonly ts.Diagnostic[]): string => {
+            const rendered = diagnostics
+              .map((diagnostic) => {
+                if (!diagnostic.file || diagnostic.start === undefined)
+                  return ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")
+                const pos = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start)
+                return `line ${pos.line}, column ${pos.character + 1}: ${ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")}\n  ${diagnostic.file.text.split("\n")[pos.line] ?? ""}`
               })
               .join("\n")
-            const importHint = /^\s*(import|export)\s/m.test(params.code)
+            const importHint = hasImport
               ? "\nnote: import/export are NOT supported — the code runs as a sandboxed function body. Use the provided `tools` / `files` globals instead of Node modules."
               : ""
-            return `TypeScript transpile failed:\n${rendered}${importHint}`
+            return `TypeScript transpile failed:\n${rendered || "import/export declaration is not supported"}${importHint}`
           }
-          const transpiled = yield* Effect.try({
-            try: () => new Bun.Transpiler({ loader: "ts" }).transformSync(`globalThis.__main = async () => {\n${params.code}\n}`),
-            catch: (err) => err,
-          }).pipe(Effect.catch((err) => Effect.succeed({ error: formatBuildError(err) })))
-          if (typeof transpiled === "object") {
+          if (result.diagnostics?.length || hasImport) {
             return {
               title: "transpile error",
               metadata: { status: "code_error", toolCalls: 0, counts: tally(), recent: recentTail() },
-              output: `<exec status="code_error">\n<error_message>\n${transpiled.error}\n</error_message>\n</exec>`,
+              output: `<exec status="code_error">\n<error_message>\n${formatDiagnostics(result.diagnostics ?? [])}\n</error_message>\n</exec>`,
             }
           }
+          const transpiled = result.outputText
 
           const logs: string[] = []
           let logBytes = 0
@@ -586,7 +604,8 @@ export const ToolScriptTool = Tool.define(
               // and lossy conversions (NaN→null, Map→array, Error→plain object) are
               // reported as warnings. The envelope crosses the boundary as plain JSON.
               evalScript(
-                GUEST_PRELUDE +
+                `const ALL_TOOLS = Object.freeze(${JSON.stringify(allTools)}.map(Object.freeze));\n` +
+                  GUEST_PRELUDE +
                   "\n" +
                   transpiled +
                   `\nconst __ret = await globalThis.__main();

--- a/packages/opencode/src/tool/tool-script.txt
+++ b/packages/opencode/src/tool/tool-script.txt
@@ -9,10 +9,34 @@ return results.map((result) => result.output)
 
 Use `exec` when JavaScript can batch multiple independent tool calls, programmatically transform their results, or keep large intermediate outputs out of the conversation. Run independent calls with `Promise.all` or `Promise.allSettled`, but keep dependent operations sequential. Prefer direct tool calls when a result needs model judgment before the next call or only one small call is needed; do not use `exec` merely to force concurrency.
 
+MCP tools inside `exec` are called through the same global `tools` object as built-in tools. Their names normally use `mcp__<server_name>__<tool_name>`:
+
+```ts
+const result = await tools.mcp__github__get_issue({
+  owner: "openai",
+  repo: "codex",
+  issue_number: 123,
+})
+return result.structured ?? result.output
+```
+
+`mcp_tool_search` is not available inside `exec`. If the exact MCP name is unknown, inspect the read-only `ALL_TOOLS` catalog and dynamically call the matching name:
+
+```ts
+const tool = ALL_TOOLS.find(
+  ({ name }) => name.startsWith("mcp__") && name.includes("docs") && name.includes("search"),
+)
+if (!tool) return "No matching MCP tool"
+const result = await tools[tool.name]({ query: "MCP configuration" })
+return result.structured ?? result.output
+```
+
 The script environment provides JavaScript built-ins plus `tools`, `files`, and `console`. It does not provide Node.js modules, `import`, `require`, `process`, `fetch`, or timers. Use the available tools for external operations.
 
-- Call tools with `await tools.name(input)`.
-- Active MCP tools are also callable as `tools.<mcp_tool_name>(input)` with the same permission checks as direct calls. When the MCP server returns structured data, the result carries it pre-parsed in the `structured` field.
+- Call built-in tools, and other tool IDs that are valid JavaScript identifiers, with `await tools.name(input)`.
+- Call request-authorized MCP tools by their exact catalog name (`await tools.mcp__server__tool(input)` or `await tools[name](input)`); the same permission checks as direct calls apply.
+- `await tools.exec_command(...)` invokes the shell through the `bash` alias; only `await tools.mcp__server__tool(...)` invokes an MCP tool.
+- MCP results carry parsed `structuredContent` in the `structured` field when the server provides it.
 - Use `Promise.all` or `Promise.allSettled` only for independent calls; at most 8 run concurrently.
 - Return a small JSON-serializable aggregate. Circular values, BigInt, and throwing getters fail execution.
 - Use `console.log` only for debugging; logs are included in the result.

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -306,12 +306,17 @@ describe("exec", () => {
   }, 15_000)
 
   test("excluded tools are not dispatchable", async () => {
-    const defs = [fakeDef("task", async () => "should never run")]
+    const defs = [
+      fakeDef("task", async () => "should never run"),
+      fakeDef("mcp_tool_search", async () => "should never run"),
+    ]
     const result = await runToolScript(
-      `try { await tools.task({}) } catch (e) { return e.message }`,
+      `const listed = ALL_TOOLS.some((tool) => tool.name === "mcp_tool_search");
+       try { await tools.mcp_tool_search({ query: "docs" }) } catch (e) { return { listed, error: e.message } }`,
       defs,
     )
-    expect(result.output).toContain("unknown tool: task")
+    expect(result.output).toContain('"listed": false')
+    expect(result.output).toContain("unknown tool: mcp_tool_search")
   })
 
   test("bash and exec_command dispatch through the same tool definition", async () => {
@@ -537,23 +542,53 @@ describe("exec", () => {
     expect(result.output).toContain('"tail": "after"')
     await fs.rm(nulFile, { force: true })
   })
+
+  test("discovers an MCP tool through ALL_TOOLS and dispatches its exact name", async () => {
+    const result = await runToolScript(
+      `const match = ALL_TOOLS.find((tool) => tool.name.includes("browser") && tool.name.includes("navigate"));
+       if (!match) return "not found";
+       const navigation = await tools[match.name]({ url: "https://example.com" });
+       return navigation.output`,
+      [],
+      undefined,
+      {
+        mcp: {
+          mcp__chrome_devtools__browser_navigate: {
+            description: "Navigate a browser page to a URL",
+            inputSchema: z.object({ url: z.string() }),
+            execute: async (args: { url: string }) => ({
+              output: `navigated: ${args.url}`,
+              metadata: { mcp: { isError: false } },
+              attachments: [],
+            }),
+          },
+        },
+      },
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("navigated: https://example.com")
+  })
 })
 
 describe("renderToolScriptDeclarations", () => {
   test("renders TS signatures and skips excluded tools", () => {
     const defs = [
       fakeDef("read", async () => "x"),
+      fakeDef("mcp_tool_search", async () => "x"),
       fakeDef("task", async () => "x"),
       fakeDef("question", async () => "x"),
     ]
     const text = renderToolScriptDeclarations(defs)
     expect(text).toContain("read(input:")
+    expect(text).not.toContain("mcp_tool_search(input:")
+    expect(text).toContain("mcp__<server>__<tool>")
+    expect(text).toContain("declare const ALL_TOOLS")
     expect(text).not.toContain("task(input:")
     expect(text).not.toContain("question(input:")
     expect(text).toContain("declare const tools")
   })
 
-  test("exclusion list covers agent control-flow tools but allows bash", () => {
+  test("exclusion list covers agent control-flow tools and MCP search but allows bash", () => {
     for (const id of ["task", "question", "actor", "skill", "plan_exit", "exec", "mcp_tool_search"]) {
       expect(TOOL_SCRIPT_EXCLUDED.has(id)).toBe(true)
     }


### PR DESCRIPTION
## Summary
- Expose a read-only `ALL_TOOLS` catalog inside `exec` so scripts can discover request-authorized MCP tools by exact catalog name (`mcp__<server>__<tool>`) without calling `mcp_tool_search`.
- Document that MCP tools are invoked through the same `tools` object, and that `mcp_tool_search` is not available in exec.
- Replace `Bun.Transpiler` with `ts.transpileModule` so guest scripts still compile in the Node bundle / standalone Bun runtimes that lack a constructible Transpiler.

## Test plan
- [ ] `cd packages/opencode && bun test test/tool/tool-script.test.ts`
- [ ] Confirm an exec script can `ALL_TOOLS.find(...)` an MCP tool and call `tools[match.name](...)`
- [ ] Confirm `mcp_tool_search` is neither listed in `ALL_TOOLS` nor dispatchable from exec
- [ ] Confirm TypeScript syntax errors still report caller-relative line/column, and `import`/`export` still fail with the sandbox note


Made with [Cursor](https://cursor.com)