### PR TITLE
feat(session): persist stable system prefix and reuse it on resume

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -552,7 +552,7 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
   // a prior write). The markers that grow the cached prefix are pinned to the
   // *tail* of the request. We place up to three stable breakpoints (Anthropic
   // allows max 4):
-  // 1. Last system message — the immutable prompt prefix.
+  // 1. First system message — the immutable, session-snapshotted prompt prefix.
   // 2+3. The last TWO messages — a "rolling double buffer". Each turn marks
   //      messages[-2] and messages[-1]; next turn the old [-1] is now [-2] and
   //      still carries its marker, so the lookback gets a cache READ hit, while
@@ -577,7 +577,7 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
   const targets: ModelMessage[] = []
 
   const systemMsgs = msgs.filter((msg) => msg.role === "system")
-  if (systemMsgs.length > 0) targets.push(systemMsgs[systemMsgs.length - 1])
+  if (systemMsgs.length > 0) targets.push(systemMsgs[0])
 
   const nonSystem = msgs.filter((msg) => msg.role !== "system")
   for (const msg of nonSystem.slice(-2)) targets.push(msg)

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -36,6 +36,7 @@ import { MCP_TOOL_SEARCH_ID } from "@/tool/mcp-tool-search"
 import { deriveLiveness } from "@/actor/schema"
 import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { Flag } from "@/flag/flag"
+import * as SessionSystemSnapshot from "./system-snapshot"
 
 const log = Log.create({ service: "llm" })
 export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
@@ -317,47 +318,56 @@ const live: Layer.Layer<
       sessionID: string
       agentID?: string
     }) {
-      const system: string[] = []
-      system.push(
-        [
-          ...SystemPrompt.agent(input.agent, input.model),
-          // any custom prompt passed into this call
-          ...input.system,
-          // any custom prompt from last user message
-          ...(input.user.system ? [input.user.system] : []),
-        ]
-          .filter((x) => x)
-          .join("\n"),
-      )
-
-      // v5: memory-instructions section. Teaches the agent how/where/when to
-      // maintain `MEMORY.md` and (when checkpointing is on) `checkpoint.md`.
-      // Project ID is resolved from the ALS-bound Instance with a safe fallback
-      // to `ProjectID.global` (mirrors the pattern in session/checkpoint.ts so the
-      // path the prompt advertises matches the path the writer actually writes).
-      // Injected only for actors whose context the checkpoint flow serves —
-      // main + peer. Subagents (explore/general/compose) use per-actor compaction
-      // and have no checkpoint duty; system-spawned actors (checkpoint-writer et al.)
-      // are the writers themselves. Shares the exact `servesCheckpoint` judgement
-      // with SessionPrune.fireCheckpoints so the "who owns a checkpoint" and "who is
-      // taught about it" sets can never drift apart. Disabling checkpoints also
-      // disables this memory-system prompt block.
       const servesCheckpoint = yield* actorReg.servesCheckpoint(SessionID.make(input.sessionID), input.agentID)
-      if (servesCheckpoint && !Flag.MIMOCODE_DISABLE_CHECKPOINT) {
-        const projectID =
-          (yield* Effect.try({
-            try: () => Instance.current?.project?.id as ProjectID | undefined,
-            catch: () => undefined,
-          }).pipe(Effect.orElseSucceed(() => undefined))) ?? ProjectID.global
-        // Bootstrap the memory.md → MEMORY.md migration at session start so a
-        // legacy lowercase file is renamed before the agent's first direct
-        // Edit/Write (which would otherwise miss it on a case-sensitive FS, or
-        // create an uppercase sibling and orphan the legacy content). The two
-        // checkpoint-flow call sites cover the writer/rebuild paths; this covers
-        // the "agent edits MEMORY.md before any checkpoint" path. Idempotent.
-        yield* Effect.promise(() => migrateProjectMemory(projectID)).pipe(Effect.ignore)
-        system.push(buildMemoryInstructions(SessionID.make(input.sessionID), projectID, yield* memory.root()))
+      const identity: SessionSystemSnapshot.SessionSystemSnapshotIdentity = {
+        protocol: SessionSystemSnapshot.SESSION_SYSTEM_SNAPSHOT_PROTOCOL,
+        sessionID: SessionID.make(input.sessionID),
+        providerID: input.model.providerID,
+        modelID: input.model.id,
+        agent: input.agent.name,
+        agentID: input.agentID ?? "main",
+        edition: process.env["MIMO_EDITION"] ?? "unscoped",
+        checkpoint: servesCheckpoint && !Flag.MIMOCODE_DISABLE_CHECKPOINT,
       }
+      const existing = yield* Effect.promise(() => SessionSystemSnapshot.read(identity))
+      const stable = existing ?? (yield* Effect.gen(function* () {
+        const system = [SystemPrompt.agent(input.agent, input.model).filter((x) => x).join("\n")]
+
+        // Memory instructions contain session-scoped paths. They are stable for
+        // this compatibility domain and therefore belong in the persisted first
+        // system block rather than in the per-turn suffix.
+        if (identity.checkpoint) {
+          const projectID =
+            (yield* Effect.try({
+              try: () => Instance.current?.project?.id as ProjectID | undefined,
+              catch: () => undefined,
+            }).pipe(Effect.orElseSucceed(() => undefined))) ?? ProjectID.global
+          yield* Effect.promise(() => migrateProjectMemory(projectID)).pipe(Effect.ignore)
+          system.push(buildMemoryInstructions(identity.sessionID, projectID, yield* memory.root()))
+        }
+
+        // The hook input exposes only session/model identity, so treat it as a
+        // session-stable transform. Its first complete output is frozen with the
+        // base instead of being re-run when a session is reopened.
+        yield* plugin.trigger(
+          "experimental.chat.system.transform",
+          { sessionID: input.sessionID, model: input.model },
+          { system },
+        )
+        const candidate = system.filter((x) => x).join("\n\n")
+        return yield* Effect.promise(() => SessionSystemSnapshot.publish(identity, candidate))
+      }))
+
+      const dynamic: string[] = []
+      const turn = [
+        // custom prompt passed into this call (environment/instructions/format)
+        ...input.system,
+        // custom prompt from the current user message (goal/plugins/attachments)
+        ...(input.user.system ? [input.user.system] : []),
+      ]
+        .filter((x) => x)
+        .join("\n")
+      if (turn) dynamic.push(turn)
 
       // Orchestrator fleet roster: inject a compact one-line-per-session
       // list of the orchestrator's ROUTABLE child sessions. Only for the orchestrator
@@ -401,26 +411,13 @@ const live: Layer.Layer<
           ({ actor, title, live }) =>
             `  ${actor.sessionID} | ${title} | ${actor.agent} | ${live === "success" ? "idle" : live}`,
         )
-        if (lines.length > 0) system.push(`${ROSTER_HEADER}\n${lines.join("\n")}`)
+        if (lines.length > 0) dynamic.push(`${ROSTER_HEADER}\n${lines.join("\n")}`)
       }
 
-      // Plugins still see the multi-part array (base prompt as [0], memory as a
-      // trailing element) so hooks that index or append parts keep working.
-      yield* plugin.trigger(
-        "experimental.chat.system.transform",
-        { sessionID: input.sessionID, model: input.model },
-        { system },
-      )
-
-      // Collapse to a single system message. The historical 2-part split existed
-      // only to keep a byte-stable cache prefix separate from the memory block's
-      // per-session paths — but within a session those paths are fixed, so the
-      // whole thing is stable and one block caches just as well. One message also
-      // keeps the fork-prefix parity invariant trivial (nothing to misalign) and
-      // spares subagents/providers a stray extra system turn. Join with a blank
-      // line (\n\n) so adjacent markdown sections (base prompt, "# Memory system")
-      // don't run together into one heading.
-      return system.length <= 1 ? system : [system.filter((x) => x).join("\n\n")]
+      // Keep the persisted bytes as the first provider block. Turn-scoped data
+      // follows in a separate block so it can change without invalidating or
+      // mutating the session prefix snapshot.
+      return [stable, dynamic.join("\n\n")].filter((x) => x)
     })
 
     const run = Effect.fn("LLM.run")(function* (input: StreamRequest) {
@@ -479,7 +476,7 @@ const live: Layer.Layer<
         mergeDeep(variant),
       )
       if (isOpenaiOauth) {
-        options.instructions = system.join("\n")
+        options.instructions = system.join("\n\n")
       }
 
       const isWorkflow = language instanceof GitLabWorkflowLanguageModel
@@ -591,7 +588,7 @@ const live: Layer.Layer<
           approvalHandler?: (approvalTools: { name: string; args: string }[]) => Promise<{ approved: boolean }>
         }
         workflowModel.sessionID = input.sessionID
-        workflowModel.systemPrompt = system.join("\n")
+        workflowModel.systemPrompt = system.join("\n\n")
         workflowModel.toolExecutor = async (toolName, argsJson, _requestID) => {
           const registered = Object.keys(tools)
           const resolvedName = ToolCompat.resolveName(toolName, registered) ?? toolName

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -24,6 +24,7 @@ import { Snapshot } from "@/snapshot"
 import { ProjectID } from "../project/schema"
 import { WorkspaceID } from "../control-plane/schema"
 import { SessionID, MessageID, PartID } from "./schema"
+import * as SessionSystemSnapshot from "./system-snapshot"
 
 import type { Provider } from "@/provider"
 import { Permission } from "@/permission"
@@ -581,6 +582,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
           // can no longer have background children that need to inherit from it.
           forwardRef.clearParentGrants(sessionID)
         })
+        yield* Effect.promise(() => SessionSystemSnapshot.remove(sessionID)).pipe(Effect.ignore)
       } catch (e) {
         log.error(e)
       }

--- a/packages/opencode/src/session/system-snapshot.ts
+++ b/packages/opencode/src/session/system-snapshot.ts
@@ -1,0 +1,110 @@
+import { createHash, randomUUID } from "crypto"
+import fs from "fs/promises"
+import path from "path"
+import { Flock } from "@mimo-ai/shared/util/flock"
+import { Global } from "@/global"
+import type { SessionID } from "./schema"
+
+export const SESSION_SYSTEM_SNAPSHOT_PROTOCOL = 1
+
+export type SessionSystemSnapshotIdentity = {
+  protocol: number
+  sessionID: SessionID
+  providerID: string
+  modelID: string
+  agent: string
+  agentID: string
+  edition: string
+  checkpoint: boolean
+}
+
+type Snapshot = {
+  version: 1
+  identity: SessionSystemSnapshotIdentity
+  system: string
+}
+
+function digest(value: string) {
+  return createHash("sha256").update(value).digest("hex")
+}
+
+function canonical(identity: SessionSystemSnapshotIdentity) {
+  return JSON.stringify({
+    protocol: identity.protocol,
+    sessionID: identity.sessionID,
+    providerID: identity.providerID,
+    modelID: identity.modelID,
+    agent: identity.agent,
+    agentID: identity.agentID,
+    edition: identity.edition,
+    checkpoint: identity.checkpoint,
+  })
+}
+
+function sessionDir(sessionID: SessionID, root = path.join(Global.Path.data, "session-system")) {
+  return path.join(root, digest(sessionID))
+}
+
+export function snapshotPath(
+  identity: SessionSystemSnapshotIdentity,
+  root = path.join(Global.Path.data, "session-system"),
+) {
+  return path.join(sessionDir(identity.sessionID, root), `${digest(canonical(identity))}.json`)
+}
+
+function valid(value: unknown, identity: SessionSystemSnapshotIdentity): value is Snapshot {
+  if (!value || typeof value !== "object") return false
+  const raw = value as Record<string, unknown>
+  if (raw["version"] !== 1 || typeof raw["system"] !== "string") return false
+  return canonical(raw["identity"] as SessionSystemSnapshotIdentity) === canonical(identity)
+}
+
+export async function read(
+  identity: SessionSystemSnapshotIdentity,
+  root = path.join(Global.Path.data, "session-system"),
+) {
+  return fs
+    .readFile(snapshotPath(identity, root), "utf8")
+    .then((text) => JSON.parse(text) as unknown)
+    .then((value) => (valid(value, identity) ? value.system : undefined))
+    .catch(() => undefined)
+}
+
+async function write(identity: SessionSystemSnapshotIdentity, system: string, root: string) {
+  const file = snapshotPath(identity, root)
+  await fs.mkdir(path.dirname(file), { recursive: true, mode: 0o700 })
+  await fs.chmod(path.dirname(file), 0o700).catch(() => undefined)
+  const tmp = `${file}.${process.pid}.${randomUUID()}.tmp`
+  const snapshot: Snapshot = { version: 1, identity, system }
+  await fs.writeFile(tmp, JSON.stringify(snapshot), { mode: 0o600 })
+  await fs.rename(tmp, file).finally(() => fs.rm(tmp, { force: true }))
+  await fs.chmod(file, 0o600).catch(() => undefined)
+}
+
+/**
+ * Publish the first complete stable system for one compatibility domain.
+ * The lock spans the second read and atomic write, so concurrent creators all
+ * receive the same winning bytes and no caller can observe a partial file.
+ */
+export function publish(
+  identity: SessionSystemSnapshotIdentity,
+  system: string,
+  root = path.join(Global.Path.data, "session-system"),
+) {
+  return Flock
+    .withLock(`session-system:${canonical(identity)}`, async () => {
+      const existing = await read(identity, root)
+      if (existing !== undefined) return existing
+      await write(identity, system, root)
+      return system
+    })
+    // A local cache must never become a model-availability dependency. The
+    // current request can safely use the fully assembled candidate even when
+    // the disk is read-only or the lock service is unavailable; a later request
+    // will retry persistence because read() still reports a miss.
+    .catch(() => system)
+}
+
+export function remove(sessionID: SessionID, root = path.join(Global.Path.data, "session-system")) {
+  return fs.rm(sessionDir(sessionID, root), { recursive: true, force: true })
+}

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3108,13 +3108,14 @@ describe("ProviderTransform.message - cache control on gateway", () => {
     expect(result[0].providerOptions).toBeUndefined()
   })
 
-  test("multi-turn anthropic pins breakpoints to last system + last two messages", () => {
+  test("[TP-R16-02] multi-turn anthropic pins breakpoints to stable first system + last two messages", () => {
     const model = createModel({
       providerID: "anthropic",
       api: { id: "claude-sonnet-4", url: "https://api.anthropic.com", npm: "@ai-sdk/anthropic" },
     })
     const msgs = [
-      { role: "system", content: "You are a helpful assistant" },
+      { role: "system", content: "stable session system" },
+      { role: "system", content: "dynamic turn system" },
       { role: "user", content: "first question" },
       { role: "assistant", content: "first answer" },
       { role: "user", content: "second question" },
@@ -3124,7 +3125,7 @@ describe("ProviderTransform.message - cache control on gateway", () => {
 
     const result = ProviderTransform.message(msgs, model, {}) as any[]
 
-    // The last system message plus the last TWO messages carry a breakpoint
+    // The stable first system message plus the last TWO messages carry a breakpoint
     // (rolling double buffer): the prior turn's tail marker survives as the
     // read point while the new tail marker is the next write.
     const marked = result
@@ -3133,12 +3134,13 @@ describe("ProviderTransform.message - cache control on gateway", () => {
 
     expect(marked).toEqual([
       { index: 0, role: "system", hasCache: true },
-      { index: 4, role: "assistant", hasCache: true },
-      { index: 5, role: "user", hasCache: true },
+      { index: 5, role: "assistant", hasCache: true },
+      { index: 6, role: "user", hasCache: true },
     ])
+    expect(result[1].providerOptions?.anthropic).toBeUndefined()
     // No drifting midpoint marker on earlier turns.
-    expect(result[2].providerOptions?.anthropic).toBeUndefined()
     expect(result[3].providerOptions?.anthropic).toBeUndefined()
+    expect(result[4].providerOptions?.anthropic).toBeUndefined()
   })
 
   test("content-level provider marks the last two messages regardless of role", () => {

--- a/packages/opencode/test/session/llm-system-prompt.test.ts
+++ b/packages/opencode/test/session/llm-system-prompt.test.ts
@@ -185,8 +185,9 @@ describe("session.llm system prompt — memory-instructions guard", () => {
         const capture = await request
         const messages = capture.body.messages as Array<{ role: string; content: string }>
         const sysMsgs = messages.filter((m) => m.role === "system")
-        // buildSystemArray now collapses everything into a single system message.
-        expect(sysMsgs.length).toBe(1)
+        // Stable session system is the first cacheable block; the current-turn
+        // system remains a separate suffix so it can change without rewriting it.
+        expect(sysMsgs.length).toBe(2)
         const allSys = sysMsgs.map((m) => m.content).join("\n")
         expect(allSys).toContain("# Memory system")
       },

--- a/packages/opencode/test/session/system-snapshot-integration.test.ts
+++ b/packages/opencode/test/session/system-snapshot-integration.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { LLM } from "../../src/session/llm"
+import { Session as SessionNs } from "../../src/session"
+import { MessageID } from "../../src/session/schema"
+import { ProviderTest } from "../fake/provider"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import * as SessionSystemSnapshot from "../../src/session/system-snapshot"
+import type { Agent } from "../../src/agent/agent"
+import type { MessageV2 } from "../../src/session/message-v2"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+
+const it = testEffect(Layer.mergeAll(SessionNs.defaultLayer, LLM.defaultLayer, CrossSpawnSpawner.defaultLayer))
+
+function agent(prompt: string): Agent.Info {
+  return {
+    name: "build",
+    mode: "primary",
+    prompt,
+    options: {},
+    permission: [{ permission: "*", pattern: "*", action: "allow" }],
+  }
+}
+
+describe("LLM session system snapshot integration", () => {
+  it.live("[TP-R16-01][TP-R16-02][TP-R16-05] stable block is reused while current-turn system stays live", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* SessionNs.Service
+        const llm = yield* LLM.Service
+        const session = yield* sessions.create({})
+        const model = ProviderTest.model()
+        const user = (system: string): MessageV2.User => ({
+          id: MessageID.ascending(),
+          sessionID: session.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "build",
+          model: { providerID: model.providerID, modelID: model.id },
+          system,
+        })
+
+        const first = yield* llm.buildSystemArray({
+          agent: agent("stable-first"),
+          model,
+          system: ["addition-one"],
+          user: user("turn-one"),
+          sessionID: session.id,
+        })
+        const reopened = yield* llm.buildSystemArray({
+          agent: agent("reassembled-different"),
+          model,
+          system: ["addition-two"],
+          user: user("turn-two"),
+          sessionID: session.id,
+        })
+
+        expect(first.length).toBe(2)
+        expect(first[0]).toContain("stable-first")
+        expect(first[1]).toContain("addition-one\nturn-one")
+        expect(reopened[0]).toBe(first[0])
+        expect(reopened[0]).not.toContain("reassembled-different")
+        expect(reopened[1]).toContain("addition-two\nturn-two")
+        expect(reopened[1]).not.toContain("addition-one")
+
+        const identity: SessionSystemSnapshot.SessionSystemSnapshotIdentity = {
+          protocol: SessionSystemSnapshot.SESSION_SYSTEM_SNAPSHOT_PROTOCOL,
+          sessionID: session.id,
+          providerID: model.providerID,
+          modelID: model.id,
+          agent: "build",
+          agentID: "main",
+          edition: process.env["MIMO_EDITION"] ?? "unscoped",
+          checkpoint: true,
+        }
+        expect(yield* Effect.promise(() => SessionSystemSnapshot.read(identity))).toBe(first[0])
+
+        yield* sessions.remove(session.id)
+        expect(yield* Effect.promise(() => SessionSystemSnapshot.read(identity))).toBeUndefined()
+
+        const parent = yield* sessions.create({ title: "snapshot parent" })
+        const child = yield* sessions.create({ parentID: parent.id, title: "snapshot child" })
+        const snapshotIdentity = (sessionID: typeof parent.id): SessionSystemSnapshot.SessionSystemSnapshotIdentity => ({
+          ...identity,
+          sessionID,
+        })
+        yield* Effect.promise(() => SessionSystemSnapshot.publish(snapshotIdentity(parent.id), "parent"))
+        yield* Effect.promise(() => SessionSystemSnapshot.publish(snapshotIdentity(child.id), "child"))
+        yield* sessions.remove(parent.id)
+        expect(yield* Effect.promise(() => SessionSystemSnapshot.read(snapshotIdentity(parent.id)))).toBeUndefined()
+        expect(yield* Effect.promise(() => SessionSystemSnapshot.read(snapshotIdentity(child.id)))).toBeUndefined()
+      }),
+    ),
+    20_000,
+  )
+})

--- a/packages/opencode/test/session/system-snapshot.test.ts
+++ b/packages/opencode/test/session/system-snapshot.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+import { SessionID } from "../../src/session/schema"
+import {
+  SESSION_SYSTEM_SNAPSHOT_PROTOCOL,
+  publish,
+  read,
+  remove,
+  snapshotPath,
+  type SessionSystemSnapshotIdentity,
+} from "../../src/session/system-snapshot"
+
+function identity(
+  sessionID: SessionID,
+  input: Partial<SessionSystemSnapshotIdentity> = {},
+): SessionSystemSnapshotIdentity {
+  return {
+    protocol: SESSION_SYSTEM_SNAPSHOT_PROTOCOL,
+    sessionID,
+    providerID: "anthropic",
+    modelID: "claude-sonnet-4-6",
+    agent: "build",
+    agentID: "main",
+    edition: "overseas",
+    checkpoint: true,
+    ...input,
+  }
+}
+
+describe("session system snapshot", () => {
+  test("[TP-R16-01] first publish wins and reopened readers reuse the exact bytes", async () => {
+    await using tmp = await tmpdir()
+    const key = identity(SessionID.descending())
+
+    expect(await publish(key, "first\nbytes", tmp.path)).toBe("first\nbytes")
+    expect(await publish(key, "reassembled-but-different", tmp.path)).toBe("first\nbytes")
+    expect(await read(key, tmp.path)).toBe("first\nbytes")
+  })
+
+  test("[TP-R16-03] compatibility domains remain independent", async () => {
+    await using tmp = await tmpdir()
+    const sessionID = SessionID.descending()
+    const base = identity(sessionID)
+    const provider = identity(sessionID, { providerID: "bedrock" })
+    const model = identity(sessionID, { modelID: "claude-opus-4-6" })
+    const agent = identity(sessionID, { agent: "plan" })
+    const actor = identity(sessionID, { agentID: "peer-1" })
+    const edition = identity(sessionID, { edition: "domestic" })
+    const checkpoint = identity(sessionID, { checkpoint: false })
+    const protocol = identity(sessionID, { protocol: SESSION_SYSTEM_SNAPSHOT_PROTOCOL + 1 })
+
+    await Promise.all([
+      publish(base, "base", tmp.path),
+      publish(provider, "provider", tmp.path),
+      publish(model, "model", tmp.path),
+      publish(agent, "agent", tmp.path),
+      publish(actor, "actor", tmp.path),
+      publish(edition, "edition", tmp.path),
+      publish(checkpoint, "checkpoint", tmp.path),
+      publish(protocol, "protocol", tmp.path),
+    ])
+
+    expect(await Promise.all(
+      [base, provider, model, agent, actor, edition, checkpoint, protocol].map((key) => read(key, tmp.path)),
+    )).toEqual(["base", "provider", "model", "agent", "actor", "edition", "checkpoint", "protocol"])
+  })
+
+  test("[TP-R16-04] corrupt files rebuild completely and concurrent creators share one winner", async () => {
+    await using tmp = await tmpdir()
+    const key = identity(SessionID.descending())
+    const file = snapshotPath(key, tmp.path)
+    await fs.mkdir(path.dirname(file), { recursive: true })
+    await fs.writeFile(file, "{broken")
+
+    expect(await publish(key, "repaired", tmp.path)).toBe("repaired")
+    await fs.writeFile(file, JSON.stringify({ version: 1, identity: key, system: 42 }))
+    expect(await publish(key, "repaired-type", tmp.path)).toBe("repaired-type")
+    await fs.writeFile(file, JSON.stringify({
+      version: 1,
+      identity: { ...key, modelID: "wrong-model" },
+      system: "wrong-domain",
+    }))
+    expect(await publish(key, "repaired-identity", tmp.path)).toBe("repaired-identity")
+
+    const concurrent = identity(SessionID.descending())
+    const winners = await Promise.all([
+      publish(concurrent, "one", tmp.path),
+      publish(concurrent, "two", tmp.path),
+      publish(concurrent, "three", tmp.path),
+    ])
+    expect(new Set(winners).size).toBe(1)
+    expect(await read(concurrent, tmp.path)).toBe(winners[0])
+
+    const blockedRoot = path.join(tmp.path, "not-a-directory")
+    await fs.writeFile(blockedRoot, "occupied")
+    expect(await publish(identity(SessionID.descending()), "disk-fallback", blockedRoot)).toBe("disk-fallback")
+  })
+
+  test("[TP-R16-05] files are private and removing a session clears every domain", async () => {
+    await using tmp = await tmpdir()
+    const sessionID = SessionID.descending()
+    const first = identity(sessionID)
+    const second = identity(sessionID, { agent: "plan" })
+    await publish(first, "first", tmp.path)
+    await publish(second, "second", tmp.path)
+
+    if (process.platform !== "win32") {
+      expect((await fs.stat(path.dirname(snapshotPath(first, tmp.path)))).mode & 0o777).toBe(0o700)
+      expect((await fs.stat(snapshotPath(first, tmp.path))).mode & 0o777).toBe(0o600)
+    }
+
+    await remove(sessionID, tmp.path)
+    expect(await read(first, tmp.path)).toBeUndefined()
+    expect(await read(second, tmp.path)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Persist the session-stable system as the first provider block on the first real model request, then reuse those exact bytes for the same compatibility domain after reopen/restart.
- Keep turn-scoped system (attachments, goal/plan, structured output, live roster) in a following dynamic block so it can change without rewriting the frozen prefix.
- Pin Anthropic cache markers to the first (stable) system message. Snapshot files stay local (`0700`/`0600`), and deleting a session removes its snapshots.

## Test plan

- [ ] `packages/opencode/test/session/system-snapshot.test.ts` — first publish wins, compatibility isolation, corrupt/missing rebuild, concurrent unique winner
- [ ] `packages/opencode/test/session/system-snapshot-integration.test.ts` — stable/dynamic split, cache marker, session delete cleanup
- [ ] `packages/opencode/test/provider/transform.test.ts` — cache marker on first system block

Made with [Cursor](https://cursor.com)