### PR TITLE
fix(gpt): use normal prompt for mimo-v2.5 models

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -24,7 +24,7 @@ import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { isSkillSearchDisabled, type SkillSearchModel } from "@/skill/search"
 import { Flag } from "@/flag/flag"
-import { isMimoModel } from "@/tool/gpt"
+import { usesMimoCodexMode } from "@/tool/gpt"
 
 function renderGitResult(result: Git.Result, fallback = "(none)") {
   if (result.exitCode !== 0) return fallback
@@ -36,7 +36,7 @@ const anthropicEnvironment = new Map<string, string>()
 export function provider(model: Provider.Model) {
   if (Flag.MIMOCODE_CODEX_MODE) return [PROMPT_GPT]
   const prompt = (id: string) => {
-    if (isMimoModel(id)) return PROMPT_GPT
+    if (usesMimoCodexMode(id)) return PROMPT_GPT
     if (id.includes("gpt-4") || id.includes("o1") || id.includes("o3")) return PROMPT_BEAST
     if (id.includes("gpt")) return PROMPT_GPT
     if (id.includes("gemini-")) return PROMPT_GEMINI

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -7,17 +7,19 @@ export function isGPTModel(...values: Array<string | undefined>) {
 }
 
 export function isMcpToolSearchEnabled(enabled: boolean, ...modelIDs: Array<string | undefined>) {
-  return Flag.MIMOCODE_CODEX_MODE || enabled || isGPTModel(...modelIDs) || isMimoModel(...modelIDs)
+  return Flag.MIMOCODE_CODEX_MODE || enabled || isGPTModel(...modelIDs) || usesMimoCodexMode(...modelIDs)
 }
 
-export function isMimoModel(...values: Array<string | undefined>) {
-  return values.some((value) => value && /(?:^|[/_-])mimo(?:$|[/_.-])/i.test(value))
+export function usesMimoCodexMode(...values: Array<string | undefined>) {
+  const ids = values.flatMap((value) => (value ? [value.toLowerCase()] : []))
+  if (ids.some((id) => /(?:^|[/])mimo-v2\.5(?:-pro)?$/.test(id))) return false
+  return ids.some((id) => /(?:^|[/_-])mimo(?:$|[/_.-])/.test(id))
 }
 
 export function usesGPTToolset(modelID: string) {
   return (
     Flag.MIMOCODE_CODEX_MODE ||
     (modelID.includes("gpt-") && !modelID.includes("oss") && !modelID.includes("gpt-4")) ||
-    isMimoModel(modelID)
+    usesMimoCodexMode(modelID)
   )
 }

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -182,9 +182,10 @@ describe("session.system", () => {
     expect(prompt).not.toContain("When possible, prefer parallelization over sequential tool calls")
   })
 
-  test("uses the GPT prompt for Codex and MiMo models", () => {
+  test("uses the GPT prompt for Codex models and the normal prompt for MiMo v2.5 models", () => {
     const gpt = SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("gpt-5.4") }))[0]
-    const prompts = ["gpt-5.4-codex", "mimo-v2.5"].map(
+    const normal = SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("model-default") }))[0]
+    const prompts = ["mimo-v2.5", "mimo-v2.5-pro"].map(
       (id) =>
         SystemPrompt.provider(
           ProviderTest.model({
@@ -193,7 +194,9 @@ describe("session.system", () => {
         )[0],
     )
 
-    expect(prompts).toEqual([gpt, gpt])
+    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("gpt-5.4-codex") }))[0]).toBe(gpt)
+    expect(prompts).toEqual([normal, normal])
+    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6") }))[0]).toBe(gpt)
   })
 
   test("Codex mode forces the GPT prompt for non-GPT models", () => {

--- a/packages/opencode/test/tool/gpt.test.ts
+++ b/packages/opencode/test/tool/gpt.test.ts
@@ -30,6 +30,9 @@ describe("isGPTModel", () => {
 describe("isMcpToolSearchEnabled", () => {
   test("defaults to GPT models and allows explicit non-GPT opt-in", () => {
     expect(isMcpToolSearchEnabled(false, "claude-opus-4-6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "mimo-v2.5")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "mimo-v2.5-pro")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "mimo-v2.6")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "gpt-5.2")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "gpt-oss-120b")).toBe(false)
     expect(isMcpToolSearchEnabled(true, "claude-opus-4-6")).toBe(true)
@@ -42,6 +45,12 @@ describe("isMcpToolSearchEnabled", () => {
 })
 
 describe("usesGPTToolset", () => {
+  test("uses the normal toolset for MiMo v2.5 models", () => {
+    expect(usesGPTToolset("mimo-v2.5")).toBe(false)
+    expect(usesGPTToolset("mimo-v2.5-pro")).toBe(false)
+    expect(usesGPTToolset("mimo-v2.6")).toBe(true)
+  })
+
   test("uses the GPT toolset for every model in Codex mode", () => {
     expect(usesGPTToolset("claude-opus-4-6")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"


### PR DESCRIPTION
## Summary
- MiMo v2.5 and v2.5-pro models no longer get the GPT codex prompt / GPT toolset; they fall back to the normal prompt and toolset
- `mimo-v2.6` and later still use the GPT prompt, matching the codex-mode flag behavior
- Rename `isMimoModel` → `usesMimoCodexMode` to reflect the narrowed semantics

## Verification
- `bun test test/session/system.test.ts test/tool/gpt.test.ts` — 20 pass, 0 fail
- `bun typecheck` passes