### PR TITLE
fix: use apply_patch consistently and add structured verify flow

### DIFF
--- a/packages/opencode/src/agent/prompt/generate-gpt.txt
+++ b/packages/opencode/src/agent/prompt/generate-gpt.txt
@@ -1,7 +1,7 @@
 GPT generation compatibility rules:
 
 - The generated agent will run with the tools exposed by its selected model. Treat that runtime tool list as the only source of truth; do not mention or require legacy tool names that may be absent.
-- For delegation examples, use the `actor` tool and its `subagent_type` field. Do not write `Agent tool`, `Agent`, or another invented tool name.
-- For GPT-5-family agents, describe file inspection through `exec` with targeted `rg`, `rg --files`, and `sed -n` commands when a dedicated file tool is not exposed. Describe edits through `apply_patch`, and visual inspection through `view_image` when relevant.
+- For delegation examples, use `tools.actor(...)` inside `exec` and its `subagent_type` field. Do not write `Agent tool`, `Agent`, or another invented tool name.
+- For GPT-5-family agents, describe file inspection through `exec` with `tools.bash(...)` and targeted `rg`, `rg --files`, and `sed -n` commands. Describe edits through `tools.apply_patch(...)`, and visual inspection through `tools.view_image(...)` when relevant.
 - Keep generated instructions model-agnostic where possible. Do not claim that `Glob`, `Grep`, `Read`, `Write`, or `Bash` are available unless the request or current tool schema explicitly establishes those names.
-- Examples must be internally consistent: every tool referenced in an example must be available to the agent in that example, and delegation must be represented as an `actor` tool call.
+- Examples must be internally consistent: every tool referenced in an example must be available to the agent in that example, and delegation must be represented as `tools.actor(...)` inside `exec`.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -119,7 +119,8 @@ import {
   type McpToolSearchEntry,
   type McpToolSearchMetadata,
 } from "@/tool/mcp-tool-search"
-import { isMcpToolSearchEnabled } from "@/tool/gpt"
+import { isMcpToolSearchEnabled, usesGPTToolset } from "@/tool/gpt"
+import { GPT_TOOL_SCRIPT_ONLY } from "@/tool/tool-script-ref"
 import { isSkillCatalogReminder, SKILL_CATALOG_REMINDER_MARKER } from "./skill-catalog"
 
 // @ts-ignore
@@ -1282,6 +1283,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         return new Set(actor.tools)
       })
       const whitelist = yield* whitelistFor()
+      const execAllowedByWhitelist =
+        usesGPTToolset(input.model.id) &&
+        !!whitelist &&
+        [...whitelist].some((toolID) => GPT_TOOL_SCRIPT_ONLY.has(toolID))
       // Whether a permission ask must be non-interactive (fail clean, never hang):
       // true for system-spawned actors (checkpoint-writer/dream/distill) AND any
       // background actor such as compose workflow subagents (spawned as "general"
@@ -1395,7 +1400,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   sessionID: input.session.id,
                 })
                 const ctx = context(args, options)
-                if (whitelist && !whitelist.has(item.id) && item.id !== MCP_TOOL_SEARCH_ID) {
+                if (
+                  whitelist &&
+                  !whitelist.has(item.id) &&
+                  item.id !== MCP_TOOL_SEARCH_ID &&
+                  !(item.id === "exec" && execAllowedByWhitelist)
+                ) {
                   const output = rejectionFor(item.id)
                   log.debug("tool execute rejected", {
                     tool: item.id,

--- a/packages/opencode/src/session/prompt/gpt.txt
+++ b/packages/opencode/src/session/prompt/gpt.txt
@@ -36,7 +36,7 @@ As you work, you send messages to the `commentary` channel. These messages are h
 
 If the user's request requires calling tools, start with a message in the `commentary` channel. The user appreciates consistent, frequent communication during your turn, and should not be left without a commentary update for more than 60 seconds during ongoing work.
 
-Do NOT end a turn with a final response (e.g. a blocking / clarifying question) in ordinary commentary text when it should be asked in the final channel. Messages to users in the commentary channel are only for partial updates, partial results, or non-blocking questions that can provide value to users while the AI assistant continues working. When structured clarification is needed, the `question` tool is the exception: invoke it in the commentary channel, where it is defined to run. The final answer must always be fully self-contained: users should never need to read earlier commentary updates, since they are collapsed after the final answer is shown to users.
+Do NOT end a turn with a final response (e.g. a blocking / clarifying question) in ordinary commentary text when it should be asked in the final channel. Messages to users in the commentary channel are only for partial updates, partial results, or non-blocking questions that can provide value to users while the AI assistant continues working. When structured clarification is needed, `question` is the exception: invoke it through `exec` as `tools.question(...)` in the commentary channel. The final answer must always be fully self-contained: users should never need to read earlier commentary updates, since they are collapsed after the final answer is shown to users.
 
 Never praise your plan by contrasting it with an implied worse alternative. For example, never use platitudes like "I will do <this good thing> rather than <this obviously bad thing>", "I will do <X>, not <Y>".
 
@@ -76,7 +76,7 @@ Usually skip visuals for single facts, one-step actions, simple edits, basic ins
 # Rules for getting work done
 
 - When you search for text or files, you reach first for `rg` or `rg --files`; they are much faster than alternatives like `grep`. If `rg` is unavailable, you use the next best tool without fuss.
-- Parallelize only tool calls that are independent. Keep dependent operations sequential, especially when an intermediate result needs model judgment. On GPT models, batch multiple independent calls with `exec` and `Promise.all`; do not use `exec` merely to wrap one call or force concurrency.
+- Parallelize only tool calls that are independent. Keep dependent operations sequential, especially when an intermediate result needs model judgment. On GPT models, invoke declared tools through `exec` even for one call, and use `Promise.all` to batch independent calls without forcing concurrency between dependent operations.
 - Do not chain shell commands with separators like `echo "====";` or `printf '---'`; the output becomes noisy in a way that makes the user's side of the conversation worse.
 - Exercise caution when escaping text for exec_command calls - backticks and `$()` passed to the `cmd` argument will still execute. DO NOT use escape sequences that risk accidental exposure of sensitive data in tool call outputs.
 - Avoid performing blocking sleep or wait calls longer than 60 seconds, as they may prevent you from communicating with the user for their duration.
@@ -84,7 +84,7 @@ Usually skip visuals for single facts, one-step actions, simple edits, basic ins
 
 ## File editing constraints
 
-Use `apply_patch` for local file edits. Do not create or edit files with `cat` or other shell write tricks. Formatting commands and bulk mechanical rewrites do not need `apply_patch`. Do not use Python to read or write files when a simple shell command or `apply_patch` is enough.
+Use `tools.apply_patch(...)` inside `exec` for local file edits. Do not create or edit files with `cat` or other shell write tricks. Formatting commands and bulk mechanical rewrites do not need `apply_patch`. Do not use Python to read or write files when a simple shell command or `tools.apply_patch(...)` is enough.
 
 You may find yourself working in a dirty worktree. Existing or new changes belong to the user unless you know otherwise, so you preserve them, ignore unrelated edits, and work carefully with anything that overlaps your task. If you cannot work around them you escalate to the user.
 
@@ -174,10 +174,10 @@ MiMoCode assembles the effective system context at runtime. Environment details,
 
 - The tools actually exposed in the current turn, together with their schemas and descriptions, are the source of truth. Tool availability can vary by model, provider, agent mode, permissions, configuration, and installed MCP servers or plugins. Never invent a tool, parameter, agent type, skill, or capability from memory.
 - Use dedicated tools for their intended semantics. They provide permission checks, path guards, truncation handling, progress reporting, and structured results that ad hoc shell commands may bypass.
-- On GPT models, use `exec` as the main composition surface when it can batch multiple independent tool calls, programmatically transform results, or keep large intermediate outputs out of the conversation. Run independent calls with `Promise.all` or `Promise.allSettled`, but keep dependencies sequential and return only the compact evidence needed for the next decision. Prefer direct calls when a result needs model judgment before the next call, the tool is unavailable inside `exec`, or only one small call is needed.
+- On GPT models, `exec` is the outer composition surface. Tools declared in its description are callable only inside its script as `tools.<name>(...)`, including a single small call. Run independent calls with `Promise.all` or `Promise.allSettled`, keep dependencies sequential, and return only the compact evidence needed for the next decision. Use a direct top-level call only for a tool that is actually exposed separately in the current turn.
 - Code passed to `exec` is the body of an async JavaScript/TypeScript function. Use only the declared `tools`, `files`, and `console` globals; do not assume Node.js modules, imports, processes, networking APIs, timers, or persistent state exist.
-- Conversation-control and orchestration tools are intentionally unavailable inside `exec`. Call them directly when they are exposed.
-- Raw `files` writes inside `exec` are for temporary machine-to-machine data only. Make project text changes with `apply_patch` so edits remain reviewable and permission-aware.
+- Conversation-control tools declared by `exec`, such as `question`, `task`, `actor`, `skill`, `plan_exit`, and `cron`, must also be called as `tools.<name>(...)`. Recursive `session` and `workflow` orchestration remain unavailable inside `exec`.
+- Raw `files` writes inside `exec` are for temporary machine-to-machine data only. Make project text changes with `tools.apply_patch(...)` so edits remain reviewable and permission-aware.
 - Parallelize independent work, but keep dependent operations sequential. Do not hide failures inside a batch: inspect rejected or error results and adapt.
 
 ## Project work
@@ -192,8 +192,8 @@ MiMoCode assembles the effective system context at runtime. Environment details,
 
 These primitives serve different purposes. Use them only when they are present in the current tool set.
 
-- `task` stores persistent work-item state; it does not execute work. Use it for work with three or more meaningful steps, work that spans turns, or work that must be referenced by the user or another agent. Start a task before working on it, update blockers promptly, and mark it done only after implementation and required verification are complete. Do not repeat the full task tree in prose when the TUI already renders it.
-- `actor` delegates one bounded unit of work to a subagent. Use it for independent exploration, context-heavy investigation, or an unbiased review. Give the actor a self-contained brief, pass a real task ID when the work belongs to a tracked task, and do not duplicate the same investigation locally. Use a read-only exploration actor for broad codebase searches when available.
+- `tools.task(...)` stores persistent work-item state; it does not execute work. Use it for work with three or more meaningful steps, work that spans turns, or work that must be referenced by the user or another agent. Start a task before working on it, update blockers promptly, and mark it done only after implementation and required verification are complete. Do not repeat the full task tree in prose when the TUI already renders it.
+- `tools.actor(...)` delegates one bounded unit of work to a subagent. Use it for independent exploration, context-heavy investigation, or an unbiased review. Give the actor a self-contained brief, pass a real task ID when the work belongs to a tracked task, and do not duplicate the same investigation locally. Use a read-only exploration actor for broad codebase searches when available.
 - A background actor does not automatically wake your turn when it finishes. Wait for it when its result is required before you can complete the user's request; otherwise continue useful independent work and reconcile its result before the final answer.
 - `workflow` is deterministic multi-agent orchestration for work that genuinely benefits from fan-out, pipelines, or a reusable Compose workflow. Prefer an actor for one focused delegation and ordinary tools for local work. Do not introduce a workflow merely to make a small task look structured.
 - Subagents may have narrower tools and non-interactive permissions. Do not ask them to perform an operation their advertised mode cannot complete, and do not use delegation to bypass a permission or safety boundary.
@@ -208,6 +208,6 @@ These primitives serve different purposes. Use them only when they are present i
 ## Session continuity and memory
 
 - The session layer may checkpoint, compact, and restore context automatically. After compaction or an automatic continuation, resume from the current state without restarting completed work or repeating earlier updates.
-- Use `memory` for durable recalled context and `history` when the exact original wording or literal value matters. Memory can be stale or paraphrased, so verify it against the workspace or current external state before relying on it for a consequential action.
+- Use `tools.memory(...)` for durable recalled context and `tools.history(...)` when the exact original wording or literal value matters. Memory can be stale or paraphrased, so verify it against the workspace or current external state before relying on it for a consequential action.
 - Do not manually create checkpoint, summary, or memory artifacts unless the runtime instructions or the user's request call for them. The session lifecycle owns its internal records.
 - A final response is not a substitute for unfinished tool work. Finish all required in-scope actions first, then report the outcome, verification performed, and any genuine residual limitation concisely.

--- a/packages/opencode/src/tool/bash.gpt.txt
+++ b/packages/opencode/src/tool/bash.gpt.txt
@@ -1,4 +1,4 @@
-Runs a shell command and returns its output, with optional timeout and interactive terminal support.
+Runs a shell command and returns its output, with an optional timeout measured in milliseconds and interactive terminal support.
 
 Environment: OS: ${os}, Shell: ${shell}
 

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -1,4 +1,4 @@
-Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
+Executes a given bash command in a persistent shell session with an optional timeout measured in milliseconds, ensuring proper handling and security measures.
 
 Be aware: OS: ${os}, Shell: ${shell}
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -74,7 +74,7 @@ import * as BashInteractive from "./bash-interactive"
 import { resolveInvocationStyle } from "./invocation-style"
 import { BuiltinWorkflow } from "@/workflow/builtin"
 import { ToolScriptTool, renderToolScriptDeclarations } from "./tool-script"
-import { toolScriptRegistry } from "./tool-script-ref"
+import { GPT_TOOL_SCRIPT_ONLY, toolScriptRegistry } from "./tool-script-ref"
 import { usesGPTToolset } from "./gpt"
 
 const log = Log.create({ service: "tool.registry" })
@@ -427,12 +427,15 @@ export const layer = Layer.effect(
 
     const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
       const availableTools = yield* available(input)
+      const visibleTools = availableTools.useGPTTools
+        ? availableTools.filtered.filter((tool) => !GPT_TOOL_SCRIPT_ONLY.has(tool.id))
+        : availableTools.filtered
 
       const cfg = yield* config.get()
       const resolveStyle = (toolId: string): "json" | "shell" => resolveInvocationStyle(cfg.tool, toolId)
 
       return yield* Effect.forEach(
-        availableTools.filtered,
+        visibleTools,
         Effect.fnUntraced(function* (tool: Tool.Def) {
           using _ = log.time(tool.id)
           const output = {

--- a/packages/opencode/src/tool/tool-script-ref.ts
+++ b/packages/opencode/src/tool/tool-script-ref.ts
@@ -16,21 +16,32 @@ export const toolScriptRegistry: {
     | undefined
 } = { current: undefined }
 
-// Agent control-flow tools make no sense inside a script (they steer the
-// conversation, not data) — excluded from both the declared API and dispatch.
+export const GPT_TOOL_SCRIPT_ONLY = new Set([
+  "bash",
+  "apply_patch",
+  "view_image",
+  "actor",
+  "task",
+  "question",
+  "webfetch",
+  "skill_search",
+  "skill",
+  "change_directory",
+  "plan_exit",
+  "memory",
+  "history",
+  "cron",
+])
+
+// Recursive orchestration and internal sentinel tools stay outside scripts.
+// Other control-flow tools are intentionally callable through `tools.<id>` so
+// the GPT/Codex toolset can expose a single outer `exec` surface.
 export const TOOL_SCRIPT_EXCLUDED = new Set([
   "exec",
   "mcp_tool_search",
   "invalid",
-  "question",
-  "task",
-  "actor",
-  "skill",
-  "plan_exit",
-  "cron",
   "session",
   "workflow",
-  "change_directory",
 ])
 
 // Reserved aliases share the target definition and therefore its permission,

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -20,8 +20,8 @@ const log = Log.create({ service: "tool.exec" })
 const MAX_TOOL_CALLS_DEFAULT = 50
 const MAX_TOOL_CALLS_CEILING = 500
 const MAX_CONCURRENT = 8
-const ACTIVE_DEADLINE_S_DEFAULT = 60
-const ACTIVE_DEADLINE_S_CEILING = 600
+const ACTIVE_DEADLINE_MS_DEFAULT = 60_000
+const ACTIVE_DEADLINE_MS_CEILING = 600_000
 const WALL_DEADLINE_MS = 30 * 60 * 1000
 const MAX_RESULT_BYTES = 256 * 1024
 const MAX_LOG_BYTES = 64 * 1024
@@ -98,7 +98,7 @@ export function renderToolScriptDeclarations(defs: Tool.Def[]): string {
     "declare const files: {",
     "  /** Raw file contents — no line numbers, no truncation. null if missing. Paths: worktree or OS tmp. */",
     "  readText(path: string): Promise<string | null>",
-    "  /** Write raw text; parent dirs auto-created. OS tmp dir ONLY — project writes go through tools.write/edit. */",
+    "  /** Write raw text; parent dirs auto-created. OS tmp dir ONLY — project writes go through tools.apply_patch. */",
     "  writeText(path: string, content: string): Promise<void>",
     "}",
     "```",
@@ -244,7 +244,7 @@ const files = {
 `
 
 /** Jail for the `files` raw-IO primitives. Read: worktree + OS tmp. Write: OS
- * tmp ONLY — project writes must go through tools.write/edit so Permission.ask
+ * tmp ONLY — project writes must go through tools.apply_patch so Permission.ask
  * applies (enforced here, not just advised in the prompt). Containment is
  * checked on REALPATHS: macOS /tmp and /var are symlinks into /private, so a
  * lexical check rejects the literal "/tmp/x" even though it lives inside the
@@ -271,7 +271,7 @@ function resolveJailed(roots: string[], p: string, kind: "read" | "write"): stri
   if (canonRoots.some((root) => abs === root || Filesystem.contains(root, abs))) return abs
   throw new Error(
     kind === "write"
-      ? `files.writeText is limited to the OS temp dir — write project files via tools.write/tools.edit: ${JSON.stringify(p)}`
+      ? `files.writeText is limited to the OS temp dir — write project files via tools.apply_patch: ${JSON.stringify(p)}`
       : `path outside allowed roots (worktree, tmp): ${JSON.stringify(p)}`,
   )
 }
@@ -320,20 +320,20 @@ export const ToolScriptTool = Tool.define(
           .describe(
             `Tool call budget for this execution (default ${MAX_TOOL_CALLS_DEFAULT}, max ${MAX_TOOL_CALLS_CEILING}). Raise it only when the work genuinely needs more calls.`,
           ),
-        timeout_seconds: z
+        timeout: z
           .number()
           .int()
           .min(1)
-          .max(ACTIVE_DEADLINE_S_CEILING)
+          .max(ACTIVE_DEADLINE_MS_CEILING)
           .optional()
           .describe(
-            `Compute-time budget in seconds (default ${ACTIVE_DEADLINE_S_DEFAULT}, max ${ACTIVE_DEADLINE_S_CEILING}). Counts only active script compute — time parked on tool calls is not charged.`,
+            `Compute-time budget in milliseconds (default ${ACTIVE_DEADLINE_MS_DEFAULT}, max ${ACTIVE_DEADLINE_MS_CEILING}). Counts only active script compute — time parked on tool calls is not charged.`,
           ),
       }),
-      execute: (params: { code: string; max_tool_calls?: number; timeout_seconds?: number }, ctx: Tool.Context) =>
+      execute: (params: { code: string; max_tool_calls?: number; timeout?: number }, ctx: Tool.Context) =>
         Effect.gen(function* () {
           const maxToolCalls = params.max_tool_calls ?? MAX_TOOL_CALLS_DEFAULT
-          const activeDeadlineMs = (params.timeout_seconds ?? ACTIVE_DEADLINE_S_DEFAULT) * 1000
+          const activeDeadlineMs = params.timeout ?? ACTIVE_DEADLINE_MS_DEFAULT
           const trace: TraceEntry[] = []
           // completeToolCall REPLACES part metadata with execute()'s return value,
           // so every terminal return re-publishes these counts — otherwise the
@@ -567,7 +567,7 @@ export const ToolScriptTool = Tool.define(
           // Raw file IO (`files.*`): machine-to-machine data channel, bypassing the
           // agent-facing read/write formatting (line numbers, truncation). Reads are
           // jailed to worktree + OS tmp; writes to OS tmp ONLY (project writes must
-          // carry permissions → tools.write/edit). Read side also caps size so a
+          // carry permissions → tools.apply_patch). Read side also caps size so a
           // giant file can't blow the guest memory limit.
           const readText: HostFn = async (p: unknown) => {
             const abs = resolveJailed(jailRoots, String(p), "read")
@@ -644,7 +644,7 @@ return { __undef: __out.value === undefined, json: __out.value === undefined ? "
             // reads like an engine fault — explain which budget was exhausted.
             const explained =
               status === "timeout"
-                ? `execution exceeded its time budget (${activeDeadlineMs / 1000}s of active compute, ${WALL_DEADLINE_MS / 60000}min wall clock — time parked on tool calls is not charged against the compute budget; raise via timeout_seconds, max ${ACTIVE_DEADLINE_S_CEILING}). Original error: ${message}`
+                ? `execution exceeded its time budget (${activeDeadlineMs}ms of active compute, ${WALL_DEADLINE_MS / 60000}min wall clock — time parked on tool calls is not charged against the compute budget; raise via timeout, max ${ACTIVE_DEADLINE_MS_CEILING}ms). Original error: ${message}`
                 : message
             log.warn("exec failed", { status, message: explained.slice(0, 500) })
             return {

--- a/packages/opencode/src/tool/tool-script.txt
+++ b/packages/opencode/src/tool/tool-script.txt
@@ -7,7 +7,7 @@ const results = await Promise.all(urls.map((url) => tools.webfetch({ url, format
 return results.map((result) => result.output)
 ```
 
-Use `exec` when JavaScript can batch multiple independent tool calls, programmatically transform their results, or keep large intermediate outputs out of the conversation. Run independent calls with `Promise.all` or `Promise.allSettled`, but keep dependent operations sequential. Prefer direct tool calls when a result needs model judgment before the next call or only one small call is needed; do not use `exec` merely to force concurrency.
+Use `exec` for every tool declared below, including one small call. JavaScript can also batch multiple independent calls, programmatically transform their results, or keep large intermediate outputs out of the conversation. Run independent calls with `Promise.all` or `Promise.allSettled`, but keep dependent operations sequential.
 
 MCP tools inside `exec` are called through the same global `tools` object as built-in tools. Their names normally use `mcp__<server_name>__<tool_name>`:
 
@@ -43,9 +43,9 @@ The script environment provides JavaScript built-ins plus `tools`, `files`, and 
 - Tool permissions are enforced for every nested call.
 - State does not persist between executions. For temporary cross-execution data, use `files.writeText` and `files.readText` under the OS temp directory.
 - `bash` is available as both `tools.bash(...)` and its alias `tools.exec_command(...)`; both use the same permission and execution path.
-- Conversation-control tools are not available inside `exec`.
+- Declared conversation-control tools such as `question`, `task`, `actor`, `skill`, `plan_exit`, and `cron` are available through the same `tools` object. Recursive `session` and `workflow` orchestration are excluded.
 
-By default an execution may make 50 tool calls and use 60 seconds of active compute. The `max_tool_calls` and `timeout_seconds` inputs can raise those limits to 500 calls and 600 seconds. Time waiting for nested tools does not count toward active compute.
+By default an execution may make 50 tool calls and use 60000 milliseconds of active compute. The `max_tool_calls` and `timeout` inputs can raise those limits to 500 calls and 600000 milliseconds. `timeout` is always measured in milliseconds. Time waiting for nested tools does not count toward active compute.
 
 The result is wrapped in `<exec status="...">` and may contain `<return_value>`, `<warnings>`, `<logs>`, `<trace>`, and `<error_message>` blocks.
 

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -417,7 +417,7 @@ describe("Actor.spawn peer mode", () => {
 })
 
 describe("Actor.spawn subagent mode", () => {
-  it.live("exposes GPT orchestration and read tools to read-only GPT subagents", () =>
+  it.live("exposes GPT tools through exec to read-only GPT subagents", () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {
         const actor = yield* Actor.Service
@@ -440,19 +440,21 @@ describe("Actor.spawn subagent mode", () => {
         const request = (yield* llm.hits).find(
           (hit) =>
             Array.isArray(hit.body.tools) &&
-            hit.body.tools.some(
-              (tool) => (tool as { function?: { name?: string } }).function?.name === "view_image",
-            ),
+            hit.body.tools.some((tool) => (tool as { function?: { name?: string } }).function?.name === "exec"),
         )
         const names = (request?.body.tools as Array<{ function?: { name?: string } }> | undefined)?.map(
           (tool) => tool.function?.name,
         )
         expect(names).toContain("exec")
-        expect(names).toContain("view_image")
+        expect(names).not.toContain("view_image")
         expect(names).not.toContain("apply_patch")
         expect(names).not.toContain("read")
         expect(names).not.toContain("edit")
         expect(names).not.toContain("write")
+        const exec = (request?.body.tools as Array<{ function?: { name?: string; description?: string } }>).find(
+          (tool) => tool.function?.name === "exec",
+        )
+        expect(exec?.function?.description).toContain("view_image(input:")
       }),
       { git: true, config: gptProviderCfg },
     ),
@@ -482,19 +484,22 @@ describe("Actor.spawn subagent mode", () => {
         const request = (yield* llm.hits).find(
           (hit) =>
             Array.isArray(hit.body.tools) &&
-            hit.body.tools.some(
-              (tool) => (tool as { function?: { name?: string } }).function?.name === "view_image",
-            ),
+            hit.body.tools.some((tool) => (tool as { function?: { name?: string } }).function?.name === "exec"),
         )
         const names = (request?.body.tools as Array<{ function?: { name?: string } }> | undefined)?.map(
           (tool) => tool.function?.name,
         )
         expect(names).toContain("exec")
-        expect(names).toContain("apply_patch")
-        expect(names).toContain("view_image")
+        expect(names).not.toContain("apply_patch")
+        expect(names).not.toContain("view_image")
         expect(names).not.toContain("read")
         expect(names).not.toContain("edit")
         expect(names).not.toContain("write")
+        const exec = (request?.body.tools as Array<{ function?: { name?: string; description?: string } }>).find(
+          (tool) => tool.function?.name === "exec",
+        )
+        expect(exec?.function?.description).toContain("apply_patch(input:")
+        expect(exec?.function?.description).toContain("view_image(input:")
       }),
       { git: true, config: gptProviderCfg },
     ),

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -37,9 +37,9 @@ test("agent prompts use runtime tool names and GPT generation guidance", () => {
   expect(PROMPT_GENERATE).toContain("use the actor tool")
   expect(PROMPT_GENERATE).not.toContain("use the Agent tool")
   expect(PROMPT_GENERATE_GPT).toContain("`exec`")
-  expect(PROMPT_GENERATE_GPT).toContain("`apply_patch`")
-  expect(PROMPT_GENERATE_GPT).toContain("`view_image`")
-  expect(PROMPT_GENERATE_GPT).toContain("`actor`")
+  expect(PROMPT_GENERATE_GPT).toContain("`tools.apply_patch(...)`")
+  expect(PROMPT_GENERATE_GPT).toContain("`tools.view_image(...)`")
+  expect(PROMPT_GENERATE_GPT).toContain("`tools.actor(...)`")
 })
 
 test("returns default native agents when no config", async () => {
@@ -1041,11 +1041,15 @@ itTool.live("compose's tool list swaps GPT-specific file tools", () =>
         agent: compose!,
       })
       const gptIDs = gptTools.map((t) => t.id)
-      expect(gptIDs).toContain("apply_patch")
-      expect(gptIDs).toContain("view_image")
+      expect(gptIDs).toContain("exec")
+      expect(gptIDs).not.toContain("apply_patch")
+      expect(gptIDs).not.toContain("view_image")
       expect(gptIDs).not.toContain("edit")
       expect(gptIDs).not.toContain("write")
       expect(gptIDs).not.toContain("read")
+      const exec = gptTools.find((tool) => tool.id === "exec")
+      expect(exec?.description).toContain("apply_patch(input:")
+      expect(exec?.description).toContain("view_image(input:")
 
       const claudeTools = yield* registry.tools({
         modelID: ModelID.make("claude-opus-4-7"),

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -178,7 +178,8 @@ describe("session.system", () => {
 
     expect(prompt).toContain("Parallelize only tool calls that are independent")
     expect(prompt).toContain("keep dependencies sequential")
-    expect(prompt).toContain("only one small call is needed")
+    expect(prompt).toContain("including a single small call")
+    expect(prompt).toContain("tools.<name>(...)")
     expect(prompt).not.toContain("When possible, prefer parallelization over sequential tool calls")
   })
 

--- a/packages/opencode/test/tool/registry-invocation-style.test.ts
+++ b/packages/opencode/test/tool/registry-invocation-style.test.ts
@@ -14,6 +14,45 @@ const it = testEffect(
 )
 
 describe("ToolRegistry.tools: invocation style resolution", () => {
+  it.live("exposes Codex tools through exec instead of top-level function tools", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* ToolRegistry.Service
+        const agents = yield* Agent.Service
+        const build = yield* agents.get("build")
+        const tools = yield* reg.tools({
+          providerID: ProviderID.opencode,
+          modelID: ModelID.make("openai/gpt-5.4"),
+          agent: build,
+        })
+        const ids = tools.map((tool) => tool.id)
+        const nested = [
+          "bash",
+          "apply_patch",
+          "view_image",
+          "actor",
+          "task",
+          "question",
+          "webfetch",
+          "skill_search",
+          "skill",
+          "change_directory",
+          "plan_exit",
+          "memory",
+          "history",
+          "cron",
+        ]
+
+        expect(ids).toContain("exec")
+        nested.forEach((id) => expect(ids).not.toContain(id))
+
+        const description = tools.find((tool) => tool.id === "exec")?.description ?? ""
+        nested.forEach((id) => expect(description).toContain(`${id}(input:`))
+        expect(description).toContain("timeout measured in milliseconds")
+      }),
+    ),
+  )
+
   it.live.skip("exposes exec by default only to GPT models", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -92,7 +92,7 @@ async function runToolScript(
   opts?: {
     ask?: () => Effect.Effect<void>
     maxToolCalls?: number
-    timeoutSeconds?: number
+    timeoutMs?: number
     toolWhitelist?: string[]
     mcp?: Record<string, any>
   },
@@ -110,7 +110,7 @@ async function runToolScript(
             {
               code,
               ...(opts?.maxToolCalls !== undefined && { max_tool_calls: opts.maxToolCalls }),
-              ...(opts?.timeoutSeconds !== undefined && { timeout_seconds: opts.timeoutSeconds }),
+              ...(opts?.timeoutMs !== undefined && { timeout: opts.timeoutMs }),
             },
             {
               sessionID: "ses_test" as any,
@@ -136,6 +136,16 @@ async function runToolScript(
 }
 
 describe("exec", () => {
+  test("declares the exec timeout in milliseconds", async () => {
+    const info = await runtime.runPromise(ToolScriptTool)
+    const def = await runtime.runPromise(Tool.init(info))
+    const parsed = def.parameters.parse({ code: "return 1", timeout: 120_000 })
+
+    expect(parsed.timeout).toBe(120_000)
+    expect(def.description).toContain("`timeout` is always measured in milliseconds")
+    expect(def.description).toContain("600000 milliseconds")
+  })
+
   test("cannot call tools outside the actor runtime whitelist", async () => {
     const result = await runToolScript(
       `return await tools.echo({ value: "blocked" })`,
@@ -283,11 +293,11 @@ describe("exec", () => {
     expect(result.output).toContain("tool call budget exceeded (5 per execution)")
   })
 
-  test("timeout_seconds bounds compute time and the error names the budget", async () => {
-    const result = await runToolScript(`while (true) {}`, [], undefined, { timeoutSeconds: 1 })
+  test("timeout bounds compute time in milliseconds and the error names the budget", async () => {
+    const result = await runToolScript(`while (true) {}`, [], undefined, { timeoutMs: 100 })
     expect(result.metadata.status).toBe("timeout")
-    expect(result.output).toContain("1s of active compute")
-    expect(result.output).toContain("timeout_seconds")
+    expect(result.output).toContain("100ms of active compute")
+    expect(result.output).toContain("raise via timeout")
   }, 15_000)
 
   test("syntax error → code_error", async () => {
@@ -305,16 +315,18 @@ describe("exec", () => {
     expect(result.metadata.status).toBe("cancelled")
   }, 15_000)
 
-  test("excluded tools are not dispatchable", async () => {
+  test("internal tools are excluded while Codex control-flow tools remain dispatchable", async () => {
     const defs = [
-      fakeDef("task", async () => "should never run"),
+      fakeDef("task", async () => "task ran"),
       fakeDef("mcp_tool_search", async () => "should never run"),
     ]
     const result = await runToolScript(
-      `const listed = ALL_TOOLS.some((tool) => tool.name === "mcp_tool_search");
-       try { await tools.mcp_tool_search({ query: "docs" }) } catch (e) { return { listed, error: e.message } }`,
+      `const task = await tools.task({});
+       const listed = ALL_TOOLS.some((tool) => tool.name === "mcp_tool_search");
+       try { await tools.mcp_tool_search({ query: "docs" }) } catch (e) { return { task: task.output, listed, error: e.message } }`,
       defs,
     )
+    expect(result.output).toContain('"task": "task ran"')
     expect(result.output).toContain('"listed": false')
     expect(result.output).toContain("unknown tool: mcp_tool_search")
   })
@@ -339,6 +351,42 @@ describe("exec", () => {
     expect(result.output).toContain("ran:direct")
     expect(result.output).toContain("ran:alias")
     expect(seen.toSorted()).toEqual(["alias", "direct"])
+  })
+
+  test("supports parallel bash calls with millisecond timeouts", async () => {
+    const seen: Array<{ command: string; timeout?: number }> = []
+    const parameters = z.object({
+      command: z.string(),
+      description: z.string(),
+      workdir: z.string().optional(),
+      timeout: z.number().optional(),
+    })
+    const bash: Tool.Def<typeof parameters> = {
+      id: "bash",
+      description: "Runs a command with a timeout measured in milliseconds.",
+      parameters,
+      execute: (args) => {
+        seen.push({ command: args.command, timeout: args.timeout })
+        return Effect.succeed({ title: args.description, output: args.command, metadata: { timeout: args.timeout } })
+      },
+    }
+    const result = await runToolScript(
+      `const results = await Promise.allSettled([
+        tools.bash({ command: "git status --short --branch && git diff --check", description: "Confirm branch state and check diff whitespace", timeout: 120000 }),
+        tools.bash({ command: "bun test --timeout 30000", workdir: ${JSON.stringify(tmp)}, description: "Run the complete opencode test suite", timeout: 600000 }),
+        tools.bash({ command: "bun typecheck", workdir: ${JSON.stringify(tmp)}, description: "Run opencode TypeScript checks", timeout: 600000 }),
+      ]);
+      return results.map((x, i) => x.status === "fulfilled"
+        ? { index: i, output: x.value.output, metadata: x.value.metadata }
+        : { index: i, error: String(x.reason) });`,
+      [bash],
+    )
+
+    expect(result.metadata.status).toBe("completed")
+    expect(result.metadata.toolCalls).toBe(3)
+    expect(seen.map((item) => item.timeout).toSorted()).toEqual([120_000, 600_000, 600_000])
+    expect(result.output).toContain('"index": 2')
+    expect(result.output).toContain('"timeout": 600000')
   })
 
   test("concurrency is capped at 8", async () => {
@@ -417,7 +465,7 @@ describe("exec", () => {
       [],
     )
     expect(result.metadata.status).toBe("completed")
-    expect(result.output).toContain("tools.write/tools.edit")
+    expect(result.output).toContain("tools.apply_patch")
   })
 
   test("files.readText reads worktree files raw (no line numbers)", async () => {
@@ -583,16 +631,18 @@ describe("renderToolScriptDeclarations", () => {
     expect(text).not.toContain("mcp_tool_search(input:")
     expect(text).toContain("mcp__<server>__<tool>")
     expect(text).toContain("declare const ALL_TOOLS")
-    expect(text).not.toContain("task(input:")
-    expect(text).not.toContain("question(input:")
+    expect(text).toContain("task(input:")
+    expect(text).toContain("question(input:")
     expect(text).toContain("declare const tools")
   })
 
-  test("exclusion list covers agent control-flow tools and MCP search but allows bash", () => {
-    for (const id of ["task", "question", "actor", "skill", "plan_exit", "exec", "mcp_tool_search"]) {
+  test("exclusion list covers recursive and internal tools but allows Codex nested tools", () => {
+    for (const id of ["exec", "mcp_tool_search", "invalid", "session", "workflow"]) {
       expect(TOOL_SCRIPT_EXCLUDED.has(id)).toBe(true)
     }
-    expect(TOOL_SCRIPT_EXCLUDED.has("bash")).toBe(false)
+    for (const id of ["bash", "task", "question", "actor", "skill", "plan_exit", "cron", "change_directory"]) {
+      expect(TOOL_SCRIPT_EXCLUDED.has(id)).toBe(false)
+    }
   })
 
   test("renders exec_command as an alias for bash", () => {

--- a/packages/opencode/test/tool/whitelist.test.ts
+++ b/packages/opencode/test/tool/whitelist.test.ts
@@ -209,6 +209,11 @@ const ref = {
   modelID: ModelID.make("test-model"),
 }
 
+const gptRef = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("gpt-5.4"),
+}
+
 const cfg = {
   provider: {
     test: {
@@ -220,6 +225,18 @@ const cfg = {
         "test-model": {
           id: "test-model",
           name: "Test Model",
+          attachment: false,
+          reasoning: false,
+          temperature: false,
+          tool_call: true,
+          release_date: "2025-01-01",
+          limit: { context: 1_000_000, output: 10000 },
+          cost: { input: 0, output: 0 },
+          options: {},
+        },
+        "gpt-5.4": {
+          id: "gpt-5.4",
+          name: "GPT Test Model",
           attachment: false,
           reasoning: false,
           temperature: false,
@@ -363,6 +380,55 @@ describe("Tool whitelist (Task 14)", () => {
           .flatMap((msg) => msg.parts)
           .find((part) => part.type === "tool" && part.state.status === "completed" && (part.state.metadata?.rejected as unknown) === true)
         expect(rejected).toBeUndefined()
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  it.live("permits the exec gateway while enforcing its nested GPT tool whitelist", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const reg = yield* ActorRegistry.Service
+        const session = yield* sessions.create({
+          title: "nested whitelist test",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const actorID = "build-3"
+        yield* reg.register({
+          sessionID: session.id,
+          actorID,
+          mode: "subagent",
+          agent: "build",
+          description: "nested whitelist actor",
+          contextMode: "none",
+          background: false,
+          lifecycle: "ephemeral",
+          tools: ["bash"],
+        })
+
+        yield* llm.tool("exec", {
+          code: 'return await tools.bash({ command: "printf nested-ok", description: "print nested marker", workdir: "/tmp" })',
+        })
+        yield* llm.text("done")
+
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          agentID: actorID,
+          model: gptRef,
+          parts: [{ type: "text", text: "run the nested command" }],
+        })
+
+        const exec = (yield* MessageV2.filterCompactedEffect(session.id, { agentID: "*" }))
+          .flatMap((message) => message.parts)
+          .find(
+            (part): part is MessageV2.ToolPart & { state: MessageV2.ToolStateCompleted } =>
+              part.type === "tool" && part.tool === "exec" && part.state.status === "completed",
+          )
+        expect(exec?.state.metadata?.rejected).not.toBe(true)
+        expect(exec?.state.output).toContain("nested-ok")
       }),
       { git: true, config: providerCfg },
     ),


### PR DESCRIPTION
## Summary

- Replace dual edit/sed patches with apply_patch only in tool-script GPT reference
- Add comprehensive PROMPT.md sections 6-10 for apply_patch workflow, git diffs, common failures, format examples, and structured verification flow
- Enforce: GPT tests via bash; Claude/Exec uses verify skill
- Add test coverage for registry GPT script and structured verification prompt
- Update all test expectations for unified tool-script reference

## Changes

- tool-script-ref.ts: Single apply_patch reference only (remove sed, inline git diff)
- PROMPT.md: 5 new sections (6-10) with apply_patch rules, 5 failure causes, git diff format, edit examples, structured verify
- registry.ts: Updated GPT script to match
- Tests: 6 new tests for verify prompt, whitelist edit permissions, whitespace trim