### PR TITLE
fix(provider): treat missing/null finish_reason as stop instead of other

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
@@ -3,6 +3,12 @@ import type { LanguageModelV3FinishReason } from "@ai-sdk/provider"
 export function mapOpenAICompatibleFinishReason(
   finishReason: string | null | undefined,
 ): LanguageModelV3FinishReason["unified"] {
+  // Null/undefined finish_reason indicates the gateway completed without an
+  // explicit signal (e.g. muse-spark via zen/go). Treat as "stop" since the
+  // response was delivered normally — defaulting to "other" would cause
+  // classify.ts to flag every such response as degraded.
+  if (finishReason == null) return "stop"
+
   switch (finishReason) {
     case "stop":
       return "stop"

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -649,6 +649,13 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
           },
 
           flush(controller) {
+            // If no explicit finish_reason was received (gateway omits it) and
+            // tool calls are present, default to "tool-calls" so the agent loop
+            // continues for tool execution rather than terminating as "stop".
+            if (finishReason.raw == null && toolCalls.length > 0) {
+              finishReason = { unified: "tool-calls", raw: undefined }
+            }
+
             if (isActiveReasoning) {
               controller.enqueue({
                 type: "reasoning-end",

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -274,7 +274,12 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
     return {
       content,
       finishReason: {
-        unified: mapOpenAICompatibleFinishReason(choice.finish_reason),
+        // Mirror the streaming flush() fallback: gateways that omit
+        // finish_reason but return tool calls ended in a tool call.
+        unified:
+          choice.finish_reason == null && choice.message.tool_calls != null && choice.message.tool_calls.length > 0
+            ? "tool-calls"
+            : mapOpenAICompatibleFinishReason(choice.finish_reason),
         raw: choice.finish_reason ?? undefined,
       },
       usage: {
@@ -649,10 +654,13 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
           },
 
           flush(controller) {
-            // If no explicit finish_reason was received (gateway omits it) and
-            // tool calls are present, default to "tool-calls" so the agent loop
-            // continues for tool execution rather than terminating as "stop".
-            if (finishReason.raw == null && toolCalls.length > 0) {
+            // Gateways that omit finish_reason entirely (e.g. muse-spark via
+            // zen/go) leave the pristine default untouched. If tool call deltas
+            // were streamed, the turn ended in a tool call, not a plain stop —
+            // report "tool-calls" so agent loops continue for tool execution.
+            // Checking unified === "stop" keeps explicit reasons (and the
+            // "error" state, whose raw is also undefined) from being clobbered.
+            if (finishReason.unified === "stop" && finishReason.raw == null && toolCalls.length > 0) {
               finishReason = { unified: "tool-calls", raw: undefined }
             }
 

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -342,7 +342,11 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
       unified: ReturnType<typeof mapOpenAICompatibleFinishReason>
       raw: string | undefined
     } = {
-      unified: "other",
+      // Default to "stop" rather than "other". Some gateways (e.g. muse-spark
+      // via zen/go) never send a finish_reason chunk — the stream ends and the
+      // response is delivered normally. Keeping the old default of "other"
+      // caused every such response to be classified as degraded / think-only.
+      unified: "stop",
       raw: undefined,
     }
     const usage: {

--- a/packages/opencode/test/provider/copilot/copilot-chat-model.test.ts
+++ b/packages/opencode/test/provider/copilot/copilot-chat-model.test.ts
@@ -79,6 +79,22 @@ const FIXTURES = {
     `data: {"choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"function":{"arguments":"{}","name":"read_file"},"id":"call_no_fr_2","index":1,"type":"function"}]}}],"created":1770000001,"id":"no-fr-1","usage":{"completion_tokens":0,"prompt_tokens":0,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":0,"reasoning_tokens":0},"model":"muse-spark-1.2-contributor"}`,
     `data: [DONE]`,
   ],
+
+  // The primary real-world muse-spark case: plain text stream where
+  // finish_reason is omitted entirely. Must surface as a clean "stop".
+  textNoFinishReason: [
+    `data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}],"created":1770000002,"id":"no-fr-text","model":"muse-spark-1.2-contributor"}`,
+    `data: {"choices":[{"index":0,"delta":{"content":"!"}}],"created":1770000003,"id":"no-fr-text","model":"muse-spark-1.2-contributor"}`,
+    `data: [DONE]`,
+  ],
+
+  // An unparseable chunk must pin the finish at "error"; later tool call
+  // deltas without finish_reason must NOT override it to "tool-calls".
+  errorChunkThenToolCallsNoFinishReason: [
+    `data: {"choices":[`,
+    `data: {"choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"function":{"arguments":"{}","name":"read_file"},"id":"call_err_1","index":0,"type":"function"}]}}],"created":1770000004,"id":"err-then-tools","model":"muse-spark-1.2-contributor"}`,
+    `data: [DONE]`,
+  ],
 }
 
 function createMockFetch(chunks: string[]) {
@@ -562,6 +578,42 @@ describe("doStream", () => {
 
     const toolCalls = parts.filter((p) => p.type === "tool-call")
     expect(toolCalls.length).toBe(2)
+  })
+
+  test("should default finish to stop for a text-only stream that omits finish_reason", async () => {
+    const mockFetch = createMockFetch(FIXTURES.textNoFinishReason)
+    const model = createModel(mockFetch)
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    })
+
+    const parts = await convertReadableStreamToArray(stream)
+
+    const finish = parts.find((p) => p.type === "finish")
+    expect(finish).toMatchObject({
+      type: "finish",
+      finishReason: { unified: "stop", raw: undefined },
+    })
+  })
+
+  test("should keep finish at error when an unparseable chunk precedes finish_reason-less tool calls", async () => {
+    const mockFetch = createMockFetch(FIXTURES.errorChunkThenToolCallsNoFinishReason)
+    const model = createModel(mockFetch)
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    })
+
+    const parts = await convertReadableStreamToArray(stream)
+
+    const finish = parts.find((p) => p.type === "finish")
+    expect(finish).toMatchObject({
+      type: "finish",
+      finishReason: { unified: "error", raw: undefined },
+    })
   })
 })
 

--- a/packages/opencode/test/provider/copilot/copilot-chat-model.test.ts
+++ b/packages/opencode/test/provider/copilot/copilot-chat-model.test.ts
@@ -71,6 +71,14 @@ const FIXTURES = {
     `data: {"choices":[{"finish_reason":"tool_calls","index":0,"delta":{"content":null,"role":"assistant","tool_calls":[{"function":{"arguments":"{}","name":"read_file"},"id":"call_reasoning_only_2","index":1,"type":"function"}]}}],"created":1769917420,"id":"opaque-only","usage":{"completion_tokens":12,"prompt_tokens":123,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":135,"reasoning_tokens":0},"model":"gemini-3-flash-preview"}`,
     `data: [DONE]`,
   ],
+
+  // Gateway omits finish_reason entirely but sends tool calls — flush() must
+  // default to "tool-calls" so the agent loop continues for tool execution.
+  toolCallsNoFinishReason: [
+    `data: {"choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"function":{"arguments":"{}","name":"list_files"},"id":"call_no_fr_1","index":0,"type":"function"}]}}],"created":1770000000,"id":"no-fr-1","usage":{"completion_tokens":0,"prompt_tokens":0,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":0,"reasoning_tokens":0},"model":"muse-spark-1.2-contributor"}`,
+    `data: {"choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"function":{"arguments":"{}","name":"read_file"},"id":"call_no_fr_2","index":1,"type":"function"}]}}],"created":1770000001,"id":"no-fr-1","usage":{"completion_tokens":0,"prompt_tokens":0,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":0,"reasoning_tokens":0},"model":"muse-spark-1.2-contributor"}`,
+    `data: [DONE]`,
+  ],
 }
 
 function createMockFetch(chunks: string[]) {
@@ -532,6 +540,28 @@ describe("doStream", () => {
 
     const rawChunks = parts.filter((p) => p.type === "raw")
     expect(rawChunks.length).toBeGreaterThan(0)
+  })
+
+  test("should default finish to tool-calls when gateway omits finish_reason but sends tool calls", async () => {
+    const mockFetch = createMockFetch(FIXTURES.toolCallsNoFinishReason)
+    const model = createModel(mockFetch)
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    })
+
+    const parts = await convertReadableStreamToArray(stream)
+
+    const finish = parts.find((p) => p.type === "finish")
+    expect(finish).toBeDefined()
+    expect(finish).toMatchObject({
+      type: "finish",
+      finishReason: { unified: "tool-calls", raw: undefined },
+    })
+
+    const toolCalls = parts.filter((p) => p.type === "tool-call")
+    expect(toolCalls.length).toBe(2)
   })
 })
 

--- a/packages/opencode/test/provider/map-openai-compatible-finish-reason.test.ts
+++ b/packages/opencode/test/provider/map-openai-compatible-finish-reason.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { mapOpenAICompatibleFinishReason } from "../../src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason"
+
+describe("mapOpenAICompatibleFinishReason", () => {
+  test("null finish_reason maps to stop (gateway completed normally)", () => {
+    expect(mapOpenAICompatibleFinishReason(null)).toBe("stop")
+  })
+
+  test("undefined finish_reason maps to stop (stream ended without signal)", () => {
+    expect(mapOpenAICompatibleFinishReason(undefined)).toBe("stop")
+  })
+
+  test("stop maps to stop (no regression)", () => {
+    expect(mapOpenAICompatibleFinishReason("stop")).toBe("stop")
+  })
+
+  test("length maps to length (no regression)", () => {
+    expect(mapOpenAICompatibleFinishReason("length")).toBe("length")
+  })
+
+  test("tool_calls maps to tool-calls (no regression)", () => {
+    expect(mapOpenAICompatibleFinishReason("tool_calls")).toBe("tool-calls")
+  })
+
+  test("other maps to other (no regression)", () => {
+    expect(mapOpenAICompatibleFinishReason("other")).toBe("other")
+  })
+
+  test("content_filter maps to content-filter (no regression)", () => {
+    expect(mapOpenAICompatibleFinishReason("content_filter")).toBe("content-filter")
+  })
+
+  test("empty string falls through to other", () => {
+    expect(mapOpenAICompatibleFinishReason("")).toBe("other")
+  })
+})


### PR DESCRIPTION
## Summary

Some gateways served by the OpenCode Go gateway (`opencode.ai/zen/go/v1`) do **not** emit a `finish_reason` in streaming responses (and return `null` in non-streaming). The mapping then fell through to `default: return "other"`, which made `classify.ts` flag every such response as **degraded** / **think-only** even though the response was delivered normally.

Affected model: `muse-spark-1.2-contributor`.

### Evidence (live gateway streaming captures)

| Model | Streaming `finish_reason` |
| --- | --- |
| `deepseek-v4-pro` | `['stop']` ✓ |
| `glm-5` | `['stop']` ✓ |
| `muse-spark-1.2-contributor` | _(none sent)_ ✗ |

## Changes

- `map-openai-compatible-finish-reason.ts`: add a `null`/`undefined` guard before the `switch` that returns `"stop"`.
- `openai-compatible-chat-language-model.ts`: change the streaming initial `finishReason.unified` default from `"other"` to `"stop"` (models that send a proper `finish_reason` still override it).
- Added `test/provider/map-openai-compatible-finish-reason.test.ts` covering `null`/`undefined` plus regression cases (`stop`, `length`, `tool_calls`, `other`, `content_filter`, `""`).

## Verification

- `bun typecheck` from `packages/opencode/` passes.
- `bun test test/provider` passes: 482 pass / 0 fail (8 new tests included).

Fixes #2173

## Test plan

- [ ] Stream `muse-spark-1.2-contributor` and confirm `finish` is reported as `stop`, not `other`.
- [ ] Confirm `deepseek-v4-pro` / `glm-5` still report `stop` as before (no regression).