### PR TITLE
feat(exec): add Codex-compatible code mode runtime

### DIFF
--- a/packages/opencode/src/session/llm-request-prefix.ts
+++ b/packages/opencode/src/session/llm-request-prefix.ts
@@ -5,6 +5,7 @@ import { MessageV2 } from "./message-v2"
 import type { SessionID } from "./schema"
 import type { Agent } from "../agent/agent"
 import type { Provider } from "../provider"
+import { openai } from "@ai-sdk/openai"
 import { LLM } from "./llm"
 import { ToolRegistry } from "../tool"
 import { ProviderTransform } from "../provider"
@@ -70,11 +71,19 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
   })
   const tools: Record<string, AITool> = {}
   for (const item of toolDefs) {
-    const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
-    tools[item.id] = tool({
-      description: item.description,
-      inputSchema: jsonSchema(schema),
-    })
+    tools[item.id] =
+      item.freeform &&
+      (input.model.api.npm === "@ai-sdk/openai" ||
+        (input.model.api.npm === "@ai-sdk/azure" && input.model.options["useCompletionUrls"] !== true))
+        ? openai.tools.customTool({
+            name: item.id,
+            description: item.description,
+            format: item.freeform.format,
+          })
+        : tool({
+            description: item.description,
+            inputSchema: jsonSchema(ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))),
+          })
   }
 
   return { system, tools, inheritedMessages }

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -263,6 +263,7 @@ export type StreamInput = {
   small?: boolean
   tools: Record<string, Tool>
   activeTools?: string[]
+  execToolNames?: string[]
   retries?: number
   toolChoice?: "auto" | "required" | "none"
   agentID?: string
@@ -739,6 +740,24 @@ const live: Layer.Layer<
               ...failed.toolCall,
               toolName: repaired.toolName,
               input: repaired.input,
+            }
+          }
+          if (activeTools.includes("exec") && input.execToolNames?.length) {
+            const nested = ToolCompat.repairNestedToolCallAsExec({
+              toolName: failed.toolCall.toolName,
+              input: failed.toolCall.input,
+              nestedToolNames: input.execToolNames,
+              execSchema: await failed.inputSchema({ toolName: "exec" }),
+            })
+            if (nested) {
+              l.info("repairing nested tool call through exec", {
+                tool: failed.toolCall.toolName,
+              })
+              return {
+                ...failed.toolCall,
+                toolName: nested.toolName,
+                input: nested.input,
+              }
             }
           }
           return {

--- a/packages/opencode/src/session/max-mode.ts
+++ b/packages/opencode/src/session/max-mode.ts
@@ -59,6 +59,8 @@ export type MaxStepInput = {
   tools: Record<string, AITool>
   /** Model-visible subset of the execute-bearing tool registry. */
   activeTools?: string[]
+  /** Request-scoped tool names callable through exec's nested namespace. */
+  execToolNames?: string[]
   agentID?: string
   /**
    * Tool-choice from the per-step args. Accepted (so the same processArgs object
@@ -137,6 +139,7 @@ export const runCandidate = (
       messages: input.messages,
       tools: schemaOnly,
       activeTools: input.activeTools,
+      execToolNames: input.execToolNames,
       agentID: input.agentID,
     })
 
@@ -357,6 +360,7 @@ export const runMaxStep = (input: MaxStepInput): Effect.Effect<SessionProcessor.
         messages: input.messages,
         tools: input.tools,
         activeTools: input.activeTools,
+        execToolNames: input.execToolNames,
         model: input.model,
         agentID: input.agentID,
       })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -25,6 +25,7 @@ import {
 } from "ai"
 import { InstallationVersion } from "@/installation/version"
 import type { JSONObject, JSONSchema7 } from "@ai-sdk/provider"
+import { openai } from "@ai-sdk/openai"
 import { SessionPrune } from "./prune"
 import { SessionCheckpoint } from "./checkpoint"
 import { SessionCompaction } from "./compaction"
@@ -119,7 +120,8 @@ import {
   type McpToolSearchMetadata,
 } from "@/tool/mcp-tool-search"
 import { isMcpToolSearchEnabled, usesGPTToolset } from "@/tool/gpt"
-import { GPT_TOOL_SCRIPT_ONLY } from "@/tool/tool-script-ref"
+import { NOT_CALLABLE_IN_EXEC, TOOL_SCRIPT_ALIASES } from "@/tool/tool-script-ref"
+import { renderMcpToolScriptDeclarations } from "@/tool/tool-script"
 import { isSkillCatalogReminder, SKILL_CATALOG_REMINDER_MARKER } from "./skill-catalog"
 
 // @ts-ignore
@@ -1238,6 +1240,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const activeTools = new Set<string>()
       const loadedMcpTools = new Set<string>()
       const execMcpTools: Record<string, AITool> = {}
+      const execNestedToolNames = new Set<string>()
       const mcpSearchEntries: McpToolSearchEntry[] = []
       const mcpCatalog = { current: createMcpToolSearchCatalog([]) }
       // exec's request-scoped MCP view. Holder object (same pattern as
@@ -1270,7 +1273,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const execAllowedByWhitelist =
         usesGPTToolset(input.model.id) &&
         !!whitelist &&
-        [...whitelist].some((toolID) => GPT_TOOL_SCRIPT_ONLY.has(toolID))
+        [...whitelist].some(
+          (toolID) => !NOT_CALLABLE_IN_EXEC.has(toolID) || toolID in TOOL_SCRIPT_ALIASES,
+        )
       // Whether a permission ask must be non-interactive (fail clean, never hang):
       // true for system-spawned actors (checkpoint-writer/dream/distill) AND any
       // background actor such as compose workflow subagents (spawned as "general"
@@ -1369,12 +1374,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         providerID: input.model.providerID,
         agent: input.agent,
       })) {
-        const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
-        tools[item.id] = tool({
-          description: item.description,
-          inputSchema: jsonSchema(schema),
-          execute(args, options) {
-            return run.promise(
+        if (item.id === "exec") item.nestedToolNames?.forEach((name) => execNestedToolNames.add(name))
+        const execute = (args: unknown, options: ToolExecutionOptions) => {
+          return run.promise(
               Effect.gen(function* () {
                 const startTs = Date.now()
                 const callID = options?.toolCallId ?? "?"
@@ -1468,8 +1470,27 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 return output
               }),
             )
-          },
-        })
+        }
+        const supportsFreeform =
+          input.model.api.npm === "@ai-sdk/openai" ||
+          (input.model.api.npm === "@ai-sdk/azure" && input.model.options["useCompletionUrls"] !== true)
+        tools[item.id] =
+          item.freeform && supportsFreeform
+            ? openai.tools.customTool({
+                name: item.id,
+                description: item.description,
+                format: item.freeform.format,
+                execute: (source, options) => execute(item.freeform!.parse(source), options),
+                toModelOutput: ({ output }) => ({
+                  type: "text",
+                  value: (output as Tool.ExecuteResult).output,
+                }),
+              })
+            : tool({
+                description: item.description,
+                inputSchema: jsonSchema(ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))),
+                execute,
+              })
         if (item.id !== MCP_TOOL_SEARCH_ID) activeTools.add(item.id)
       }
 
@@ -1714,7 +1735,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       ) {
         activeTools.add(MCP_TOOL_SEARCH_ID)
       }
-      loadedMcpTools.forEach((name) => activeTools.add(name))
+      if (!usesGPTToolset(input.model.id)) loadedMcpTools.forEach((name) => activeTools.add(name))
 
       // MCP Tool Search keeps full schemas out of the outer model tool list;
       // it is a context-budget optimization, not an authorization boundary.
@@ -1723,10 +1744,21 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       // round-trip. These wrappers still run the ordinary permission, plugin,
       // metrics, normalization, and truncation pipeline above.
       execMcp.current = execMcpTools
+      Object.keys(execMcpTools).forEach((name) => execNestedToolNames.add(name))
+      const mcpDeclarations = yield* Effect.promise(() => renderMcpToolScriptDeclarations(execMcpTools))
+      const execTool = tools["exec"]
+      if (mcpDeclarations && execTool?.type === "provider") {
+        const description = typeof execTool.args.description === "string" ? execTool.args.description : ""
+        execTool.args = { ...execTool.args, description: `${description}\n\n${mcpDeclarations}` }
+      }
+      if (mcpDeclarations && execTool && execTool.type !== "provider") {
+        execTool.description = `${execTool.description ?? ""}\n\n${mcpDeclarations}`
+      }
 
       return {
         tools,
         activeTools: [...activeTools].filter((name) => tools[name]),
+        execToolNames: [...execNestedToolNames],
       }
     })
 
@@ -3759,6 +3791,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             })
             const tools = resolvedTools.tools
             const activeTools = resolvedTools.activeTools
+            const execToolNames = resolvedTools.execToolNames
 
             if (lastUser.format?.type === "json_schema") {
               tools["StructuredOutput"] = createStructuredOutputTool({
@@ -4074,6 +4107,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
               tools,
               activeTools,
+              execToolNames,
               model,
               toolChoice: isLastStep ? ("none" as const) : format.type === "json_schema" ? ("required" as const) : undefined,
               agentID: lastUser.agentID,

--- a/packages/opencode/src/session/prompt/gpt.txt
+++ b/packages/opencode/src/session/prompt/gpt.txt
@@ -218,3 +218,8 @@ These primitives serve different purposes. Use them only when they are present i
 - Use `tools.memory(...)` for durable recalled context and `tools.history(...)` when the exact original wording or literal value matters. Memory can be stale or paraphrased, so verify it against the workspace or current external state before relying on it for a consequential action.
 - Do not manually create checkpoint, summary, or memory artifacts unless the runtime instructions or the user's request call for them. The session lifecycle owns its internal records.
 - A final response is not a substitute for unfinished tool work. Finish all required in-scope actions first, then report the outcome, verification performed, and any genuine residual limitation concisely.
+
+## Reasoning format
+
+Begin every thinking block with the exact string "We need".
+This applies to all turns, including reasoning that follows a tool result.

--- a/packages/opencode/src/tool/code-mode-cell.ts
+++ b/packages/opencode/src/tool/code-mode-cell.ts
@@ -1,0 +1,253 @@
+import { randomUUID } from "node:crypto"
+import type { SessionID } from "@/session/schema"
+import type * as Tool from "./tool"
+
+const DEFAULT_YIELD_TIME_MS = 10_000
+const DEFAULT_MAX_OUTPUT_TOKENS = 10_000
+const CELL_RETENTION_MS = 30 * 60 * 1000
+
+export type CodeModeOutputBuffer = ReturnType<typeof createCodeModeOutputBuffer>
+
+export function createCodeModeOutputBuffer() {
+  let content = Buffer.alloc(0)
+  let yieldVersion = 0
+  const listeners = new Set<() => void>()
+  return {
+    append(value: string) {
+      if (!value) return
+      content = Buffer.concat([content, Buffer.from(value)])
+    },
+    slice(from: number) {
+      return content.subarray(from).toString()
+    },
+    get byteLength() {
+      return content.byteLength
+    },
+    get yieldVersion() {
+      return yieldVersion
+    },
+    yield() {
+      yieldVersion++
+      listeners.forEach((listener) => listener())
+      listeners.clear()
+    },
+    onYield(version: number, listener: () => void) {
+      if (yieldVersion > version) {
+        queueMicrotask(listener)
+        return () => {}
+      }
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  }
+}
+
+type Cell = {
+  sessionID: SessionID
+  promise: Promise<Tool.ExecuteResult>
+  controller: AbortController
+  cleanup: ReturnType<typeof setTimeout>
+  output: CodeModeOutputBuffer
+  deliveredOutputBytes: number
+  yieldVersion: number
+}
+
+const cells = new Map<string, Cell>()
+
+function scheduleCleanup(cellID: string, controller: AbortController) {
+  const timer = setTimeout(() => {
+    controller.abort()
+    cells.delete(cellID)
+  }, CELL_RETENTION_MS)
+  timer.unref?.()
+  return timer
+}
+
+function limited(output: string, maxTokens = DEFAULT_MAX_OUTPUT_TOKENS) {
+  const maxChars = maxTokens * 4
+  if (output.length <= maxChars) return output
+  return `${output.slice(0, maxChars)}\n\n... output truncated to ${maxTokens} tokens ...`
+}
+
+function response(input: {
+  status: "completed" | "failed" | "running" | "terminated"
+  output: string
+  startedAt: number
+  maxTokens?: number
+  result?: Tool.ExecuteResult
+  cellID?: string
+}): Tool.ExecuteResult {
+  const label =
+    input.status === "running"
+      ? `Script running with cell ID ${input.cellID}`
+      : input.status === "terminated"
+        ? "Script terminated"
+        : input.status === "completed"
+          ? "Script completed"
+          : "Script failed"
+  return {
+    title: label,
+    metadata: {
+      ...(input.result?.metadata ?? {}),
+      status:
+        input.status === "running" || input.status === "terminated"
+          ? input.status
+          : (input.result?.metadata.status ?? input.status),
+    },
+    output: `${label}\nWall time ${((Date.now() - input.startedAt) / 1000).toFixed(1)} seconds\nOutput:\n${limited(input.output, input.maxTokens)}`,
+    attachments: input.result?.attachments,
+  }
+}
+
+async function settled(
+  promise: Promise<Tool.ExecuteResult>,
+  yieldTimeMs: number,
+  output?: CodeModeOutputBuffer,
+  yieldVersion = 0,
+) {
+  let cancelYield = () => {}
+  const yielded = new Promise<{ done: false }>((resolve) => {
+    cancelYield = output?.onYield(yieldVersion, () => resolve({ done: false })) ?? (() => {})
+  })
+  const outcome = await Promise.race([
+    promise.then(
+      (value) => ({ done: true as const, value }),
+      (error) => ({ done: true as const, error: error instanceof Error ? error : new Error(String(error)) }),
+    ),
+    new Promise<{ done: false }>((resolve) => setTimeout(() => resolve({ done: false }), yieldTimeMs)),
+    yielded,
+  ])
+  cancelYield()
+  return outcome
+}
+
+function drain(output: CodeModeOutputBuffer, deliveredOutputBytes: number) {
+  return {
+    output: output.slice(deliveredOutputBytes),
+    deliveredOutputBytes: output.byteLength,
+  }
+}
+
+function completedOutput(live: string, result: Tool.ExecuteResult) {
+  return [live, result.output].filter(Boolean).join("\n")
+}
+
+export async function startCell(input: {
+  sessionID: SessionID
+  promise: Promise<Tool.ExecuteResult>
+  controller: AbortController
+  output: CodeModeOutputBuffer
+  yieldTimeMs?: number
+  maxTokens?: number
+}) {
+  for (const value of [input.yieldTimeMs, input.maxTokens]) {
+    if (value !== undefined && (!Number.isSafeInteger(value) || value < 0)) {
+      throw new Error("exec timing and token limits must be non-negative safe integers")
+    }
+  }
+  const startedAt = Date.now()
+  const outcome = await settled(input.promise, input.yieldTimeMs ?? DEFAULT_YIELD_TIME_MS, input.output)
+  const current = drain(input.output, 0)
+  if (outcome.done && "value" in outcome) {
+    return response({
+      status: outcome.value.metadata.status === "completed" ? "completed" : "failed",
+      output: completedOutput(current.output, outcome.value),
+      startedAt,
+      maxTokens: input.maxTokens,
+      result: outcome.value,
+    })
+  }
+  if (outcome.done) {
+    return response({
+      status: "failed",
+      output: [current.output, `Script error:\n${outcome.error.message}`].filter(Boolean).join("\n"),
+      startedAt,
+      maxTokens: input.maxTokens,
+    })
+  }
+
+  const cellID = randomUUID()
+  cells.set(cellID, {
+    sessionID: input.sessionID,
+    promise: input.promise,
+    controller: input.controller,
+    cleanup: scheduleCleanup(cellID, input.controller),
+    output: input.output,
+    deliveredOutputBytes: current.deliveredOutputBytes,
+    yieldVersion: input.output.yieldVersion,
+  })
+  return response({
+    status: "running",
+    output: current.output,
+    startedAt,
+    maxTokens: input.maxTokens,
+    cellID,
+  })
+}
+
+export async function waitCell(input: {
+  sessionID: SessionID
+  cellID: string
+  yieldTimeMs?: number
+  maxTokens?: number
+  terminate?: boolean
+}) {
+  for (const value of [input.yieldTimeMs, input.maxTokens]) {
+    if (value !== undefined && (!Number.isSafeInteger(value) || value < 0)) {
+      throw new Error("wait timing and token limits must be non-negative safe integers")
+    }
+  }
+  const startedAt = Date.now()
+  const cell = cells.get(input.cellID)
+  if (!cell || cell.sessionID !== input.sessionID) throw new Error(`unknown exec cell: ${input.cellID}`)
+  if (input.terminate) cell.controller.abort()
+  const outcome = await settled(
+    cell.promise,
+    input.yieldTimeMs ?? DEFAULT_YIELD_TIME_MS,
+    cell.output,
+    cell.yieldVersion,
+  )
+  const current = drain(cell.output, cell.deliveredOutputBytes)
+  cell.deliveredOutputBytes = current.deliveredOutputBytes
+  cell.yieldVersion = cell.output.yieldVersion
+  if (input.terminate) {
+    clearTimeout(cell.cleanup)
+    cells.delete(input.cellID)
+    return response({
+      status: "terminated",
+      output: current.output,
+      startedAt,
+      maxTokens: input.maxTokens,
+      result: outcome.done && "value" in outcome ? outcome.value : undefined,
+    })
+  }
+  if (!outcome.done) {
+    clearTimeout(cell.cleanup)
+    cell.cleanup = scheduleCleanup(input.cellID, cell.controller)
+    return response({
+      status: "running",
+      output: current.output,
+      startedAt,
+      maxTokens: input.maxTokens,
+      cellID: input.cellID,
+    })
+  }
+
+  clearTimeout(cell.cleanup)
+  cells.delete(input.cellID)
+  if ("value" in outcome) {
+    return response({
+      status: outcome.value.metadata.status === "completed" ? "completed" : "failed",
+      output: completedOutput(current.output, outcome.value),
+      startedAt,
+      maxTokens: input.maxTokens,
+      result: outcome.value,
+    })
+  }
+  return response({
+    status: "failed",
+    output: [current.output, `Script error:\n${outcome.error.message}`].filter(Boolean).join("\n"),
+    startedAt,
+    maxTokens: input.maxTokens,
+  })
+}

--- a/packages/opencode/src/tool/code-mode-wait.ts
+++ b/packages/opencode/src/tool/code-mode-wait.ts
@@ -1,0 +1,41 @@
+import z from "zod"
+import { Effect } from "effect"
+import * as Tool from "./tool"
+import { waitCell } from "./code-mode-cell"
+
+const Parameters = z.object({
+  cell_id: z.string().describe("Identifier of the running exec cell."),
+  yield_time_ms: z.number().optional().describe("Wait before yielding more output. Defaults to 10000 ms."),
+  max_tokens: z.number().optional().describe("Output token budget for this wait call. Defaults to 10000 tokens."),
+  terminate: z.boolean().optional().describe("True stops the running exec cell; false or omitted waits for output."),
+})
+
+export const CODE_MODE_WAIT_DESCRIPTION = `Waits on a yielded \`exec\` cell and returns new output or completion.
+- Use \`wait\` only after \`exec\` returns \`Script running with cell ID ...\`.
+- \`cell_id\` identifies the running \`exec\` cell to resume.
+- \`yield_time_ms\` controls how long to wait for more output before yielding again. Defaults to 10000 ms.
+- \`max_tokens\` limits how much new output this wait call returns. Defaults to 10000 tokens.
+- \`terminate: true\` stops the running cell; false or omitted waits for output.
+- \`wait\` returns only the new output since the last yield, or the final completion or termination result for that cell.
+- If the cell is still running, \`wait\` may yield again with the same \`cell_id\`.
+- If the cell has already finished, \`wait\` returns the remaining output and closes the cell.`
+
+export const CodeModeWaitTool = Tool.define(
+  "wait",
+  Effect.succeed({
+    description: CODE_MODE_WAIT_DESCRIPTION,
+    parameters: Parameters,
+    execute: (params: z.infer<typeof Parameters>, ctx: Tool.Context) =>
+      Effect.tryPromise({
+        try: () =>
+          waitCell({
+            sessionID: ctx.sessionID,
+            cellID: params.cell_id,
+            yieldTimeMs: params.yield_time_ms,
+            maxTokens: params.max_tokens,
+            terminate: params.terminate,
+          }),
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }).pipe(Effect.orDie),
+  }),
+)

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -74,7 +74,8 @@ import * as BashInteractive from "./bash-interactive"
 import { resolveInvocationStyle } from "./invocation-style"
 import { BuiltinWorkflow } from "@/workflow/builtin"
 import { ToolScriptTool, renderToolScriptDeclarations } from "./tool-script"
-import { GPT_TOOL_SCRIPT_ONLY, toolScriptRegistry } from "./tool-script-ref"
+import { CodeModeWaitTool } from "./code-mode-wait"
+import { NOT_CALLABLE_IN_EXEC, TOOL_SCRIPT_ALIASES, toolScriptRegistry } from "./tool-script-ref"
 import { usesGPTToolset } from "./gpt"
 
 const log = Log.create({ service: "tool.registry" })
@@ -167,6 +168,7 @@ export const layer = Layer.effect(
     const sessiontool = yield* SessionTool
     const workflowtool = yield* WorkflowTool
     const toolscript = yield* ToolScriptTool
+    const codemodewait = yield* CodeModeWaitTool
     const agent = yield* Agent.Service
 
     const state = yield* InstanceState.make<State>(
@@ -266,6 +268,7 @@ export const layer = Layer.effect(
           session: Tool.init(sessiontool),
           workflow: Tool.init(workflowtool),
           toolscript: Tool.init(toolscript),
+          codemodewait: Tool.init(codemodewait),
         })
 
         return {
@@ -296,6 +299,7 @@ export const layer = Layer.effect(
             tool.history,
             tool.task,
             tool.toolscript,
+            tool.codemodewait,
             ...(Flag.MIMOCODE_EXPERIMENTAL_CRON ? [tool.cron] : []),
             ...(Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR ? [tool.session] : []),
             ...(Flag.MIMOCODE_EXPERIMENTAL_WORKFLOW_TOOL ? [tool.workflow] : []),
@@ -357,7 +361,8 @@ export const layer = Layer.effect(
     }) {
       const useGPTTools = usesGPTToolset(input.modelID)
       let filtered = (yield* all()).filter((tool) => {
-        if (tool.id === ToolScriptTool.id) return useGPTTools || Flag.MIMOCODE_ENABLE_EXEC_TOOL
+        if (tool.id === ToolScriptTool.id || tool.id === CodeModeWaitTool.id)
+          return useGPTTools || Flag.MIMOCODE_ENABLE_EXEC_TOOL
         if (tool.id === CodeSearchTool.id || tool.id === WebSearchTool.id) {
           if (tool.id === WebSearchTool.id) {
             return (
@@ -428,7 +433,7 @@ export const layer = Layer.effect(
     const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
       const availableTools = yield* available(input)
       const visibleTools = availableTools.useGPTTools
-        ? availableTools.filtered.filter((tool) => !GPT_TOOL_SCRIPT_ONLY.has(tool.id))
+        ? availableTools.filtered.filter((tool) => NOT_CALLABLE_IN_EXEC.has(tool.id))
         : availableTools.filtered
 
       const cfg = yield* config.get()
@@ -456,13 +461,25 @@ export const layer = Layer.effect(
               description,
               tool.id === ActorTool.id ? yield* describeTask(input.agent) : undefined,
               tool.id === WorkflowTool.id ? yield* describeWorkflow() : undefined,
-              tool.id === ToolScriptTool.id ? yield* describeToolScript(availableTools.filtered) : undefined,
+              tool.id === ToolScriptTool.id ? `\n${yield* describeToolScript(availableTools.filtered)}` : undefined,
             ]
               .filter(Boolean)
               .join("\n"),
             parameters: useShell ? effective.parameters : output.parameters,
             execute: effective.execute,
             formatValidationError: effective.formatValidationError,
+            freeform: effective.freeform,
+            nestedToolNames:
+              tool.id === ToolScriptTool.id
+                ? [
+                    ...availableTools.filtered
+                      .filter((item) => !NOT_CALLABLE_IN_EXEC.has(item.id))
+                      .map((item) => item.id),
+                    ...Object.entries(TOOL_SCRIPT_ALIASES).flatMap(([alias, target]) =>
+                      availableTools.filtered.some((item) => item.id === target) ? [alias] : [],
+                    ),
+                  ]
+                : undefined,
           }
         }),
         { concurrency: "unbounded" },

--- a/packages/opencode/src/tool/tool-script-ref.ts
+++ b/packages/opencode/src/tool/tool-script-ref.ts
@@ -16,28 +16,11 @@ export const toolScriptRegistry: {
     | undefined
 } = { current: undefined }
 
-export const GPT_TOOL_SCRIPT_ONLY = new Set([
-  "bash",
-  "apply_patch",
-  "view_image",
-  "actor",
-  "task",
-  "question",
-  "webfetch",
-  "skill_search",
-  "skill",
-  "change_directory",
-  "plan_exit",
-  "memory",
-  "history",
-  "cron",
-])
-
-// Recursive orchestration and internal sentinel tools stay outside scripts.
-// Other control-flow tools are intentionally callable through `tools.<id>` so
-// the GPT/Codex toolset can expose a single outer `exec` surface.
-export const TOOL_SCRIPT_EXCLUDED = new Set([
+// Tools that must not be callable from inside `exec`, regardless of whether
+// they exist in the surrounding registry.
+export const NOT_CALLABLE_IN_EXEC = new Set([
   "exec",
+  "wait",
   "mcp_tool_search",
   "invalid",
   "session",

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -4,16 +4,16 @@ import fs from "fs"
 import path from "path"
 import ts from "typescript"
 import { Effect } from "effect"
-import type { Tool as AiTool } from "ai"
+import { asSchema, type Tool as AiTool } from "ai"
 import { EffectBridge, InstanceState } from "@/effect"
 import { Log, Filesystem } from "@/util"
 import { Agent } from "@/agent/agent"
 import type { ModelID, ProviderID } from "../provider/schema"
 import { evalScript, type HostFn } from "../workflow/sandbox"
-import { toolScriptRegistry, TOOL_SCRIPT_ALIASES, TOOL_SCRIPT_EXCLUDED } from "./tool-script-ref"
+import { toolScriptRegistry, TOOL_SCRIPT_ALIASES, NOT_CALLABLE_IN_EXEC } from "./tool-script-ref"
 import DESCRIPTION from "./tool-script.txt"
 import * as Tool from "./tool"
-import * as Truncate from "./truncate"
+import { createCodeModeOutputBuffer, startCell } from "./code-mode-cell"
 
 const log = Log.create({ service: "tool.exec" })
 
@@ -28,15 +28,43 @@ const MAX_LOG_BYTES = 64 * 1024
 const MAX_CODE_BYTES = 128 * 1024
 const MAX_FILE_BYTES = 10 * 1024 * 1024
 const TRACE_TAIL_ENTRIES = 20
+const SESSION_STORE_RETENTION_MS = 30 * 60 * 1000
+
+type SessionStore = {
+  values: Map<string, unknown>
+  cleanup: ReturnType<typeof setTimeout>
+}
+
+const sessionStores = new Map<string, SessionStore>()
+
+function sessionStore(sessionID: string) {
+  const existing = sessionStores.get(sessionID)
+  if (existing) clearTimeout(existing.cleanup)
+  const store: SessionStore = {
+    values: existing?.values ?? new Map<string, unknown>(),
+    cleanup: setTimeout(() => sessionStores.delete(sessionID), SESSION_STORE_RETENTION_MS),
+  }
+  store.cleanup.unref?.()
+  sessionStores.set(sessionID, store)
+  return store.values
+}
+
+const Parameters = z.object({
+  code: z.string(),
+  yield_time_ms: z.number().int().nonnegative().safe().optional(),
+  max_output_tokens: z.number().int().nonnegative().safe().optional(),
+  max_tool_calls: z.number().int().min(1).max(MAX_TOOL_CALLS_CEILING).optional(),
+  timeout: z.number().int().min(1).max(ACTIVE_DEADLINE_MS_CEILING).optional(),
+})
 
 /** JSON Schema (zod v4 toJSONSchema output) → compact TS type text. Best-effort:
  * anything unrecognized renders as `unknown`, which is safe for declarations. */
-function schemaToTs(schema: any): string {
+function schemaToTs(schema: any, depth = 0): string {
   if (!schema || typeof schema !== "object") return "unknown"
   if (schema.const !== undefined) return JSON.stringify(schema.const)
   if (schema.enum) return schema.enum.map((v: unknown) => JSON.stringify(v)).join(" | ")
   const variants = schema.anyOf ?? schema.oneOf
-  if (variants) return variants.map(schemaToTs).join(" | ")
+  if (variants) return variants.map((variant: unknown) => schemaToTs(variant, depth)).join(" | ")
   switch (schema.type) {
     case "string":
       return "string"
@@ -48,61 +76,243 @@ function schemaToTs(schema: any): string {
     case "null":
       return "null"
     case "array":
-      return `Array<${schemaToTs(schema.items)}>`
+      return `Array<${schemaToTs(schema.items, depth)}>`
     case "object": {
       if (!schema.properties) {
         if (schema.additionalProperties && typeof schema.additionalProperties === "object")
-          return `Record<string, ${schemaToTs(schema.additionalProperties)}>`
+          return `Record<string, ${schemaToTs(schema.additionalProperties, depth)}>`
         return "Record<string, unknown>"
       }
+      if (Object.keys(schema.properties).length === 0) return "{}"
       const required = new Set<string>(schema.required ?? [])
-      const fields = Object.entries(schema.properties).map(
-        ([key, value]) => `${key}${required.has(key) ? "" : "?"}: ${schemaToTs(value)}`,
-      )
-      return `{ ${fields.join("; ")} }`
+      const indent = "  ".repeat(depth + 1)
+      const fields = Object.entries(schema.properties).flatMap(([key, value]) => {
+        const description =
+          value && typeof value === "object" && "description" in value && typeof value.description === "string"
+            ? value.description
+            : undefined
+        return [
+          ...(description
+            ? description.split("\n").map((line: string) => `${indent}// ${line}`)
+            : []),
+          `${indent}${key}${required.has(key) ? "" : "?"}: ${schemaToTs(value, depth + 1)};`,
+        ]
+      })
+      return `{\n${fields.join("\n")}\n${"  ".repeat(depth)}}`
     }
     default:
       return "unknown"
   }
 }
 
-/** Render the `tools` API declaration block appended to the tool description. */
+export const MCP_TYPESCRIPT_PREAMBLE = `type Role = "user" | "assistant";
+type MetaObject = Record<string, unknown>;
+type Annotations = {
+  audience?: Role[];
+  priority?: number;
+  lastModified?: string;
+};
+type Icon = {
+  src: string;
+  mimeType?: string;
+  sizes?: string[];
+  theme?: "light" | "dark";
+};
+type TextResourceContents = {
+  uri: string;
+  mimeType?: string;
+  _meta?: MetaObject;
+  text: string;
+};
+type BlobResourceContents = {
+  uri: string;
+  mimeType?: string;
+  _meta?: MetaObject;
+  blob: string;
+};
+type TextContent = {
+  type: "text";
+  text: string;
+  annotations?: Annotations;
+  _meta?: MetaObject;
+};
+type ImageContent = {
+  type: "image";
+  data: string;
+  mimeType: string;
+  annotations?: Annotations;
+  _meta?: MetaObject;
+};
+type AudioContent = {
+  type: "audio";
+  data: string;
+  mimeType: string;
+  annotations?: Annotations;
+  _meta?: MetaObject;
+};
+type ResourceLink = {
+  icons?: Icon[];
+  name: string;
+  title?: string;
+  uri: string;
+  description?: string;
+  mimeType?: string;
+  annotations?: Annotations;
+  size?: number;
+  _meta?: MetaObject;
+  type: "resource_link";
+};
+type EmbeddedResource = {
+  type: "resource";
+  resource: TextResourceContents | BlobResourceContents;
+  annotations?: Annotations;
+  _meta?: MetaObject;
+};
+type ContentBlock =
+  | TextContent
+  | ImageContent
+  | AudioContent
+  | ResourceLink
+  | EmbeddedResource;
+type CallToolResult<TStructured = { [key: string]: unknown }> = {
+  _meta?: MetaObject;
+  content: ContentBlock[];
+  isError?: boolean;
+  structuredContent?: TStructured;
+  [key: string]: unknown;
+};`
+
+function mcpStructuredContentSchema(schema: any) {
+  if (!schema || typeof schema !== "object" || !schema.properties) return undefined
+  const content = schema.properties.content
+  const isError = schema.properties.isError
+  const meta = schema.properties._meta
+  if (content?.type !== "array" || content.items?.type !== "object") return undefined
+  if (isError?.type !== "boolean" || meta?.type !== "object") return undefined
+  return schema.properties.structuredContent ?? true
+}
+
+export async function renderMcpToolScriptDeclarations(tools: Record<string, AiTool>) {
+  const sections = (
+    await Promise.all(
+      Object.entries(tools).map(async ([rawName, tool]) => {
+        if (!tool.outputSchema) return undefined
+        const outputSchema = await Promise.resolve(asSchema(tool.outputSchema).jsonSchema)
+        const structured = mcpStructuredContentSchema(outputSchema)
+        if (!structured) return undefined
+        const inputSchema = await Promise.resolve(asSchema(tool.inputSchema).jsonSchema)
+        const name = normalizeCodeModeIdentifier(rawName)
+        const heading = name === rawName ? `### \`${name}\`` : `### \`${name}\` (\`${rawName}\`)`
+        const structuredType = structured === true ? "unknown" : schemaToTs(structured)
+        const resultType = structuredType === "unknown" ? "CallToolResult" : `CallToolResult<${structuredType}>`
+        return `${heading}\n${tool.description?.trim() ?? ""}\n\nexec tool declaration:\n\`\`\`ts\ndeclare const tools: { ${name}(args: ${schemaToTs(inputSchema)}): Promise<${resultType}>; };\n\`\`\``
+      }),
+    )
+  ).filter((section): section is string => !!section)
+  if (sections.length === 0) return ""
+  return [`Shared MCP Types:\n\`\`\`ts\n${MCP_TYPESCRIPT_PREAMBLE}\n\`\`\``, ...sections].join("\n\n")
+}
+
+export const CODE_MODE_EXEC_GRAMMAR = `
+start: pragma_source | plain_source
+pragma_source: PRAGMA_LINE NEWLINE SOURCE
+plain_source: SOURCE
+
+PRAGMA_LINE: /[ \\t]*\\/\\/ @exec:[^\\r\\n]*/
+NEWLINE: /\\r?\\n/
+SOURCE: /[\\s\\S]+/
+`
+
+const MAX_JS_SAFE_INTEGER = 2 ** 53 - 1
+
+export function parseExecSource(input: string) {
+  if (!input.trim()) {
+    throw new Error(
+      'exec expects raw JavaScript or TypeScript source text (non-empty). Provide source only, optionally with first-line `// @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}`.',
+    )
+  }
+
+  const newline = input.indexOf("\n")
+  const firstLine = newline === -1 ? input : input.slice(0, newline)
+  const trimmed = firstLine.trimStart()
+  if (!trimmed.startsWith("// @exec:")) {
+    if (input.split(/\r?\n/).slice(1).some((line) => line.trimStart().startsWith("// @exec:"))) {
+      throw new Error("exec pragma must be the first line of the tool input")
+    }
+    return { code: input, yield_time_ms: undefined, max_output_tokens: undefined }
+  }
+  const code = newline === -1 ? "" : input.slice(newline + 1)
+  if (!code.trim()) throw new Error("exec pragma must be followed by JavaScript source on subsequent lines")
+  const directive = trimmed.slice("// @exec:".length).trim()
+  if (!directive) {
+    throw new Error(
+      "exec pragma must be a JSON object with supported fields `yield_time_ms` and `max_output_tokens`",
+    )
+  }
+
+  const value = (() => {
+    try {
+      return JSON.parse(directive) as unknown
+    } catch (error) {
+      throw new Error(
+        `exec pragma must be valid JSON with supported fields \`yield_time_ms\` and \`max_output_tokens\`: ${error}`,
+      )
+    }
+  })()
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      "exec pragma must be a JSON object with supported fields `yield_time_ms` and `max_output_tokens`",
+    )
+  }
+  const pragma = value as Record<string, unknown>
+  const unsupported = Object.keys(pragma).find((key) => !["yield_time_ms", "max_output_tokens"].includes(key))
+  if (unsupported) {
+    throw new Error(
+      `exec pragma only supports \`yield_time_ms\` and \`max_output_tokens\`; got \`${unsupported}\``,
+    )
+  }
+  for (const key of ["yield_time_ms", "max_output_tokens"] as const) {
+    const field = pragma[key]
+    if (field === undefined) continue
+    if (typeof field !== "number" || !Number.isSafeInteger(field) || field < 0 || field > MAX_JS_SAFE_INTEGER) {
+      throw new Error(`exec pragma field \`${key}\` must be a non-negative safe integer`)
+    }
+  }
+  return {
+    code,
+    yield_time_ms: pragma["yield_time_ms"] as number | undefined,
+    max_output_tokens: pragma.max_output_tokens as number | undefined,
+  }
+}
+
+function normalizeCodeModeIdentifier(name: string) {
+  const normalized = [...name]
+    .map((char, index) => (/[$_A-Za-z]/.test(char) || (index > 0 && /[0-9]/.test(char)) ? char : "_"))
+    .join("")
+  return normalized || "_"
+}
+
+/** Render the Codex code-mode declarations appended to the tool description. */
 export function renderToolScriptDeclarations(defs: Tool.Def[]): string {
   const aliases = new Set(Object.keys(TOOL_SCRIPT_ALIASES))
-  const lines = defs
-    .filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id) && !aliases.has(def.id))
+  const sections = defs
+    .filter((def) => !NOT_CALLABLE_IN_EXEC.has(def.id) && !aliases.has(def.id))
     .map((def) => {
-      const summary = def.description.split("\n").find((l) => l.trim()) ?? ""
-      const input = schemaToTs(z.toJSONSchema(def.parameters))
-      return `  /** ${summary.trim().slice(0, 200)} */\n  ${def.id}(input: ${input}): Promise<ToolResult>`
+      const input = def.id === "apply_patch" ? "string" : schemaToTs(z.toJSONSchema(def.parameters))
+      const inputName = def.id === "apply_patch" ? "input" : "args"
+      const name = normalizeCodeModeIdentifier(def.id)
+      const heading = name === def.id ? `### \`${name}\`` : `### \`${name}\` (\`${def.id}\`)`
+      return `${heading}\n${def.description.trim()}\n\nexec tool declaration:\n\`\`\`ts\ndeclare const tools: { ${name}(${inputName}: ${input}): Promise<unknown>; };\n\`\`\``
     })
-  const aliasLines = Object.entries(TOOL_SCRIPT_ALIASES).flatMap(([alias, target]) => {
+  const aliasSections = Object.entries(TOOL_SCRIPT_ALIASES).flatMap(([alias, target]) => {
     const def = defs.find((item) => item.id === target)
     if (!def) return []
-    const summary = def.description.split("\n").find((line) => line.trim()) ?? ""
     const input = schemaToTs(z.toJSONSchema(def.parameters))
-    return [`  /** Alias for ${target}. ${summary.trim().slice(0, 180)} */\n  ${alias}(input: ${input}): Promise<ToolResult>`]
+    return [
+      `### \`${alias}\`\nAlias for ${target}. ${def.description.trim()}\n\nexec tool declaration:\n\`\`\`ts\ndeclare const tools: { ${alias}(args: ${input}): Promise<unknown>; };\n\`\`\``,
+    ]
   })
-  return [
-    "```ts",
-    "type ToolResult = { title: string; output: string; metadata: Record<string, unknown>; structured?: unknown }",
-    "declare const tools: {",
-    ...lines,
-    ...aliasLines,
-    "  /** Request-authorized MCP tools are callable by exact catalog name, normally mcp__<server>__<tool>. */",
-    "  [mcpToolName: string]: (input: Record<string, unknown>) => Promise<ToolResult>",
-    "}",
-    "/** Every tool callable in this execution. Filter by name to discover MCP tools without mcp_tool_search. */",
-    "declare const ALL_TOOLS: ReadonlyArray<{ name: string; description: string }>",
-    "// Raw file IO for machine-to-machine data (pipelines across executions).",
-    "declare const files: {",
-    "  /** Raw file contents — no line numbers, no truncation. null if missing. Paths: worktree or OS tmp. */",
-    "  readText(path: string): Promise<string | null>",
-    "  /** Write raw text; parent dirs auto-created. OS tmp dir ONLY — project writes go through tools.apply_patch. */",
-    "  writeText(path: string, content: string): Promise<void>",
-    "}",
-    "```",
-  ].join("\n")
+  return [...sections, ...aliasSections].join("\n\n")
 }
 
 /** Guest-side prelude: `tools` proxy → __callTool RPC, console → __log capture.
@@ -116,6 +326,45 @@ const tools = new Proxy({}, {
       throw e instanceof Error ? e : new Error(String(e));
     }),
 });
+const __attachments = [];
+const text = (value) => __text(__fmt(value));
+const __dataAttachment = (value, kind) => {
+  let url;
+  let mime;
+  if (typeof value === "string") url = value;
+  else if (value && typeof value === "object" && typeof value.data === "string" && typeof value.mimeType === "string") {
+    mime = value.mimeType;
+    url = "data:" + mime + ";base64," + value.data;
+  } else if (value && typeof value === "object") {
+    url = kind === "image" ? value.image_url : value.audio_url;
+  }
+  if (typeof url !== "string" || !url.startsWith("data:")) throw new Error(kind + " expects a base64-encoded data URL");
+  mime = mime || /^data:([^;,]+)/.exec(url)?.[1] || (kind === "image" ? "image/png" : "audio/mpeg");
+  __attachments.push({ type: "file", mime, url });
+};
+const image = (value) => __dataAttachment(value, "image");
+const audio = (value) => __dataAttachment(value, "audio");
+const generatedImage = (result) => {
+  __dataAttachment(result && result.image_url, "image");
+  if (result && result.output_hint) text(result.output_hint);
+};
+const exit = () => { throw { __codeModeExit: true }; };
+const store = (key, value) => __store(String(key), value);
+const load = (key) => __load(String(key));
+const notify = (value) => __notify(__fmt(value));
+let __timerID = 0;
+const __timers = new Map();
+const setTimeout = (callback, delayMs = 0) => {
+  const id = ++__timerID;
+  __timers.set(id, true);
+  __sleep(Math.max(0, Number(delayMs) || 0)).then(() => {
+    if (!__timers.delete(id)) return;
+    callback();
+  });
+  return id;
+};
+const clearTimeout = (id) => { __timers.delete(id); };
+const yield_control = () => __yieldControl();
 // Explicit JSON-safe serializer. JSON.stringify (and the sandbox marshal
 // fallback) silently degrades non-JSON values — circular refs became
 // "[object Object]", NaN became null with no signal, Error lost its message.
@@ -156,8 +405,8 @@ function __serialize(root, lenient) {
       return undefined;
     }
     if (v instanceof Error) {
-      if (!lenient) warn("Error at " + at() + " serialized as {name, message, stack}");
-      return { name: v.name, message: v.message, stack: v.stack };
+      if (!lenient) warn("Error at " + at() + " serialized as {name, message}");
+      return { name: v.name, message: v.message };
     }
     if (v instanceof Promise) {
       if (lenient) return "[Promise]";
@@ -301,36 +550,12 @@ function makeSemaphore(max: number) {
 export const ToolScriptTool = Tool.define(
   "exec",
   Effect.gen(function* () {
-    const truncate = yield* Truncate.Service
     const agents = yield* Agent.Service
-    return {
-      description: DESCRIPTION,
-      parameters: z.object({
-        code: z
-          .string()
-          .describe(
-            "Raw JavaScript or TypeScript source for the body of an async function, not JSON or a Markdown code block. Call tools via the global `tools` object; inspect `ALL_TOOLS` when needed; `return` the final aggregated value.",
-          ),
-        max_tool_calls: z
-          .number()
-          .int()
-          .min(1)
-          .max(MAX_TOOL_CALLS_CEILING)
-          .optional()
-          .describe(
-            `Tool call budget for this execution (default ${MAX_TOOL_CALLS_DEFAULT}, max ${MAX_TOOL_CALLS_CEILING}). Raise it only when the work genuinely needs more calls.`,
-          ),
-        timeout: z
-          .number()
-          .int()
-          .min(1)
-          .max(ACTIVE_DEADLINE_MS_CEILING)
-          .optional()
-          .describe(
-            `Compute-time budget in milliseconds (default ${ACTIVE_DEADLINE_MS_DEFAULT}, max ${ACTIVE_DEADLINE_MS_CEILING}). Counts only active script compute — time parked on tool calls is not charged.`,
-          ),
-      }),
-      execute: (params: { code: string; max_tool_calls?: number; timeout?: number }, ctx: Tool.Context) =>
+    const executeScript = (
+      params: z.infer<typeof Parameters>,
+      ctx: Tool.Context,
+      output: ReturnType<typeof createCodeModeOutputBuffer>,
+    ) =>
         Effect.gen(function* () {
           const maxToolCalls = params.max_tool_calls ?? MAX_TOOL_CALLS_DEFAULT
           const activeDeadlineMs = params.timeout ?? ACTIVE_DEADLINE_MS_DEFAULT
@@ -379,7 +604,15 @@ export const ToolScriptTool = Tool.define(
                 ? { providerID: model.providerID, modelID: model.id, agent: agentInfo }
                 : undefined,
             )
-          ).filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id) && (!whitelist || whitelist.has(def.id)))
+          ).filter(
+            (def) =>
+              !NOT_CALLABLE_IN_EXEC.has(def.id) &&
+              (!whitelist ||
+                whitelist.has(def.id) ||
+                Object.entries(TOOL_SCRIPT_ALIASES).some(
+                  ([alias, target]) => target === def.id && whitelist.has(alias),
+                )),
+          )
           const byId = new Map(defs.map((def) => [def.id, def]))
           // Request-authorized MCP tools (delivered via ctx.extra.execMcp and
           // filled by SessionPrompt's resolveTools for THIS request). Tool Search
@@ -388,17 +621,33 @@ export const ToolScriptTool = Tool.define(
           // A module-level ref would be overwritten by concurrent sessions.
           // Builtin ids win on collision — an MCP server must not shadow `read`.
           const mcpTools = (ctx.extra?.execMcp as { current?: Record<string, AiTool> } | undefined)?.current ?? {}
+          const reservedNames = new Set([
+            ...Object.keys(TOOL_SCRIPT_ALIASES),
+            ...[...byId.keys()],
+            ...[...byId.keys()].map(normalizeCodeModeIdentifier),
+          ])
           const mcpById = new Map(
-            Object.entries(mcpTools).filter(([id]) => !byId.has(id) && (!whitelist || whitelist.has(id))),
+            Object.entries(mcpTools).filter(
+              ([id]) =>
+                !reservedNames.has(id) &&
+                !reservedNames.has(normalizeCodeModeIdentifier(id)) &&
+                (!whitelist || whitelist.has(id)),
+            ),
           )
           const allTools = [
-            ...[...byId.values()].map((def) => ({ name: def.id, description: def.description })),
+            ...[...byId.values()].map((def) => ({
+              name: normalizeCodeModeIdentifier(def.id),
+              description: def.description,
+            })),
             ...Object.entries(TOOL_SCRIPT_ALIASES).flatMap(([name, target]) => {
               const def = byId.get(target)
               if (!def) return []
               return [{ name, description: `Alias for ${target}. ${def.description}` }]
             }),
-            ...[...mcpById.entries()].map(([name, tool]) => ({ name, description: tool.description ?? "" })),
+            ...[...mcpById.entries()].map(([name, tool]) => ({
+              name: normalizeCodeModeIdentifier(name),
+              description: tool.description ?? "",
+            })),
           ]
           // Non-git projects report worktree === "/" (see Instance.containsPath) —
           // "/" as a jail root would allow EVERYTHING. Fall back to the project
@@ -454,7 +703,6 @@ export const ToolScriptTool = Tool.define(
           }
           const transpiled = result.outputText
 
-          const logs: string[] = []
           let logBytes = 0
           let calls = 0
           const withSlot = makeSemaphore(MAX_CONCURRENT)
@@ -478,8 +726,11 @@ export const ToolScriptTool = Tool.define(
           const callTool: HostFn = (name: unknown, args: unknown) => {
             const id = String(name)
             const alias = TOOL_SCRIPT_ALIASES[id as keyof typeof TOOL_SCRIPT_ALIASES]
-            const def = byId.get(alias ?? id)
-            const mcpDef = def ? undefined : mcpById.get(id)
+            const def = byId.get(alias ?? id) ?? [...byId.values()].find((item) => normalizeCodeModeIdentifier(item.id) === id)
+            const mcpDef = def
+              ? undefined
+              : (mcpById.get(id) ??
+                [...mcpById.entries()].find(([name]) => normalizeCodeModeIdentifier(name) === id)?.[1])
             if (!def && !mcpDef) return Promise.reject(new Error(`unknown tool: ${id}`))
             calls++
             if (calls > maxToolCalls)
@@ -499,8 +750,8 @@ export const ToolScriptTool = Tool.define(
             // truncation. Here we only adapt the wrapped result shape for the
             // guest: structuredContent (when the server sent it) crosses as a
             // parsed value under `structured` so scripts can filter/aggregate
-            // without re-parsing text; media attachments cannot cross the
-            // sandbox string boundary and are dropped with a note.
+            // without re-parsing text; media attachments from the nested call
+            // are not represented in this adapter and are dropped with a note.
             const executeMcp = (tool: AiTool) =>
               Effect.tryPromise({
                 try: () =>
@@ -516,24 +767,32 @@ export const ToolScriptTool = Tool.define(
                 Effect.map((result) => {
                   const r = result as {
                     output?: unknown
-                    metadata?: { mcp?: { structuredContent?: unknown } }
+                    metadata?: { mcp?: { isError?: boolean; structuredContent?: unknown; _meta?: Record<string, unknown> } }
                     attachments?: unknown[]
                   }
                   const structured = r?.metadata?.mcp?.structuredContent
                   const dropped = Array.isArray(r?.attachments) && r.attachments.length
-                    ? `\n[note: ${r.attachments.length} non-text attachment(s) dropped — binary content cannot cross the exec sandbox]`
+                    ? `\n[note: ${r.attachments.length} non-text attachment(s) dropped before the nested result entered the exec isolate]`
                     : ""
                   return {
                     title: id,
                     output: String(r?.output ?? "") + dropped,
                     metadata: (r?.metadata ?? {}) as Record<string, unknown>,
+                    content: [{ type: "text", text: String(r?.output ?? "") }],
+                    isError: r?.metadata?.mcp?.isError,
+                    _meta: r?.metadata?.mcp?._meta,
                     ...(structured !== undefined && { structured }),
+                    ...(structured !== undefined && { structuredContent: structured }),
                   }
                 }),
               )
             return withSlot(() =>
               bridge
-                .promise(def ? def.execute(args, subCtx) : executeMcp(mcpDef!))
+                .promise(
+                  def
+                    ? def.execute(def.id === "apply_patch" && typeof args === "string" ? { patch_text: args } : args, subCtx)
+                    : executeMcp(mcpDef!),
+                )
                 .then(
                   (result) => {
                     trace.push({ name: id, status: "success", durationMs: Date.now() - start })
@@ -560,7 +819,11 @@ export const ToolScriptTool = Tool.define(
             const text = String(message)
             if (logBytes >= MAX_LOG_BYTES) return undefined
             logBytes += Buffer.byteLength(text, "utf8")
-            logs.push(logBytes >= MAX_LOG_BYTES ? text.slice(0, 200) + " …(log budget exhausted)" : text)
+            output.append(`${logBytes >= MAX_LOG_BYTES ? text.slice(0, 200) + " …(log budget exhausted)" : text}\n`)
+            return undefined
+          }
+          const textHook: HostFn = (value: unknown) => {
+            output.append(`${String(value)}\n`)
             return undefined
           }
 
@@ -595,6 +858,28 @@ export const ToolScriptTool = Tool.define(
             await Filesystem.write(abs, text)
             return undefined
           }
+          const pendingStoreWrites = new Map<string, unknown>()
+          const storeValue: HostFn = (key: unknown, value: unknown) => {
+            pendingStoreWrites.set(String(key), value)
+            return undefined
+          }
+          const loadValue: HostFn = (key: unknown) => {
+            const name = String(key)
+            if (pendingStoreWrites.has(name)) return pendingStoreWrites.get(name)
+            return sessionStore(ctx.sessionID).get(name)
+          }
+          const notifyValue: HostFn = (value: unknown) => {
+            bridge
+              .promise(ctx.metadata({ metadata: { running: true, notification: String(value) } }))
+              .catch(() => {})
+            return undefined
+          }
+          const sleep: HostFn = (delay: unknown) =>
+            new Promise((resolve) => setTimeout(resolve, Math.max(0, Number(delay) || 0)))
+          const yieldControl: HostFn = () => {
+            output.yield()
+            return undefined
+          }
 
           const outcome = yield* Effect.tryPromise({
             try: () =>
@@ -608,14 +893,22 @@ export const ToolScriptTool = Tool.define(
                   GUEST_PRELUDE +
                   "\n" +
                   transpiled +
-                  `\nconst __ret = await globalThis.__main();
+                  `\nlet __ret;
+try { __ret = await globalThis.__main(); }
+catch (e) { if (!e || e.__codeModeExit !== true) throw e; }
 const __out = __serialize(__ret, false);
-return { __undef: __out.value === undefined, json: __out.value === undefined ? "" : JSON.stringify(__out.value), warnings: __out.warnings };`,
+return { __undef: __out.value === undefined, json: __out.value === undefined ? "" : JSON.stringify(__out.value), warnings: __out.warnings, attachments: __attachments };`,
                 {
                 __callTool: callTool,
                 __log: logHook,
+                __text: textHook,
                 __readText: readText,
                 __writeText: writeText,
+                __store: storeValue,
+                __load: loadValue,
+                __notify: notifyValue,
+                __sleep: sleep,
+                __yieldControl: yieldControl,
               }, {
                 deterministic: false,
                 deadlineMs: WALL_DEADLINE_MS,
@@ -628,7 +921,6 @@ return { __undef: __out.value === undefined, json: __out.value === undefined ? "
           const traceLines = trace.map(
             (t) => `- ${t.name} → ${t.status}${t.error ? ` (${t.error.slice(0, 200)})` : ""} [${t.durationMs}ms]`,
           )
-          const logBlock = logs.length ? `<logs>\n${logs.join("\n")}\n</logs>\n` : ""
           const traceBlock = trace.length ? `<trace count="${trace.length}">\n${traceLines.join("\n")}\n</trace>\n` : ""
 
           if (outcome._tag === "Failure") {
@@ -650,17 +942,22 @@ return { __undef: __out.value === undefined, json: __out.value === undefined ? "
             return {
               title: status,
               metadata: { status, toolCalls: trace.length, counts: tally(), recent: recentTail() },
-              output: `<exec status="${status}">\n<error_message>\n${explained}\n</error_message>\n${logBlock}${traceBlock}</exec>`,
+              output: `<exec status="${status}">\n<error_message>\n${explained}\n</error_message>\n${traceBlock}</exec>`,
             }
           }
 
-          // XML-wrap the return value verbatim: no JSON.stringify → no \n / \" escaping
-          // pollution. Strings pass through as-is; non-strings arrive as guest-side
-          // strict-serialized JSON (see __serialize) and are re-indented for readability.
-          const envelope = outcome.success as { __undef: boolean; json: string; warnings: string[] }
+          // Keep top-level return for backward compatibility, but emit it directly
+          // rather than inventing a `<return_value>` content channel. `text()` and
+          // console output have already streamed through the cell output buffer.
+          const envelope = outcome.success as {
+            __undef: boolean
+            json: string
+            warnings: string[]
+            attachments: Array<{ type: "file"; mime: string; url: string }>
+          }
           const parsed = envelope.__undef ? undefined : (JSON.parse(envelope.json) as unknown)
           const returnedText =
-            parsed === undefined ? "undefined" : typeof parsed === "string" ? parsed : JSON.stringify(parsed, null, 2)
+            parsed === undefined ? "" : typeof parsed === "string" ? parsed : JSON.stringify(parsed, null, 2)
           const warningsBlock = envelope.warnings.length
             ? `<warnings>\n${envelope.warnings.map((w) => `- ${w}`).join("\n")}\n</warnings>\n`
             : ""
@@ -669,15 +966,53 @@ return { __undef: __out.value === undefined, json: __out.value === undefined ? "
             return {
               title: "result too large",
               metadata: { status: "budget_exceeded", toolCalls: trace.length, counts: tally(), recent: recentTail() },
-              output: `<exec status="budget_exceeded">\n<error_message>\nreturned value is ${returnedBytes} bytes (max ${MAX_RESULT_BYTES}). Aggregate or slice the data before returning.\n</error_message>\n${warningsBlock}${logBlock}${traceBlock}</exec>`,
+              output: `<exec status="budget_exceeded">\n<error_message>\nreturned value is ${returnedBytes} bytes (max ${MAX_RESULT_BYTES}). Aggregate or slice the data before returning.\n</error_message>\n${warningsBlock}${traceBlock}</exec>`,
             }
           }
 
+          if (pendingStoreWrites.size > 0) {
+            const committed = sessionStore(ctx.sessionID)
+            pendingStoreWrites.forEach((value, key) => committed.set(key, value))
+          }
           return {
             title: `${trace.length} tool calls`,
             metadata: { status: "completed", toolCalls: trace.length, counts: tally(), recent: recentTail() },
-            output: `<exec status="completed">\n<return_value>\n${returnedText}\n</return_value>\n${warningsBlock}${logBlock}${traceBlock}</exec>`,
+            output: [returnedText, warningsBlock, traceBlock].filter(Boolean).join("\n"),
+            attachments: envelope.attachments,
           }
+        }).pipe(Effect.orDie)
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      freeform: {
+        format: {
+          type: "grammar" as const,
+          syntax: "lark" as const,
+          definition: CODE_MODE_EXEC_GRAMMAR,
+        },
+        parse: parseExecSource,
+      },
+      execute: (params: z.infer<typeof Parameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const bridge = yield* EffectBridge.make()
+          const controller = new AbortController()
+          if (ctx.abort.aborted) controller.abort()
+          const abort = () => controller.abort()
+          ctx.abort.addEventListener("abort", abort, { once: true })
+          const output = createCodeModeOutputBuffer()
+          const promise = bridge.promise(executeScript(params, { ...ctx, abort: controller.signal }, output))
+          promise.finally(() => ctx.abort.removeEventListener("abort", abort)).catch(() => {})
+          return yield* Effect.promise(() =>
+            startCell({
+              sessionID: ctx.sessionID,
+              promise,
+              controller,
+              output,
+              yieldTimeMs: params.yield_time_ms,
+              maxTokens: params.max_output_tokens,
+            }),
+          )
         }).pipe(Effect.orDie),
     }
   }),

--- a/packages/opencode/src/tool/tool-script.txt
+++ b/packages/opencode/src/tool/tool-script.txt
@@ -1,52 +1,26 @@
-Execute JavaScript to orchestrate the available tools.
+Run JavaScript or TypeScript code to orchestrate/compose tool calls
+- Evaluates the provided JavaScript or TypeScript code in a fresh QuickJS isolate as an async function body.
+- All nested tools are available on the global `tools` object, for example `await tools.exec_command(...)`. Tool names are exposed as normalized JavaScript identifiers, for example `await tools.mcp__ologs__get_profile(...)`.
+- Nested tool methods take either a string or an object as their input argument.
+- Nested built-in tools return `{ title, output, metadata }`; nested MCP tools also expose text `content`, `isError`, and `structuredContent` when available.
+- Provides no Node APIs or direct network access. A jailed `files` helper can read the worktree or OS temp directory and can write only under the OS temp directory.
+- Provides a captured `console` with `log`, `error`, and `warn`; console output is included in the final result.
+- Accepts raw JavaScript or TypeScript source text, not JSON, quoted strings, or markdown code fences.
+- You may optionally start the tool input with a first-line pragma like `// @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}`.
+- `yield_time_ms` asks `exec` to yield early if the script is still running. Defaults to 10000 ms.
+- `max_output_tokens` sets the token budget for the completed `exec` result. Defaults to 10000 tokens.
+- When the script is fully evaluated, the isolate's lifetime ends and unawaited promises are silently discarded.
 
-Write the body of an async function. The global `tools` object exposes every tool available to this execution, and each method returns a promise:
-
-```ts
-const results = await Promise.all(urls.map((url) => tools.webfetch({ url, format: "markdown" })))
-return results.map((result) => result.output)
-```
-
-Use `exec` for every tool declared below, including one small call. JavaScript can also batch multiple independent calls, programmatically transform their results, or keep large intermediate outputs out of the conversation. Run independent calls with `Promise.all` or `Promise.allSettled`, but keep dependent operations sequential.
-
-MCP tools inside `exec` are called through the same global `tools` object as built-in tools. Their names normally use `mcp__<server_name>__<tool_name>`:
-
-```ts
-const result = await tools.mcp__github__get_issue({
-  owner: "openai",
-  repo: "codex",
-  issue_number: 123,
-})
-return result.structured ?? result.output
-```
-
-`mcp_tool_search` is not available inside `exec`. If the exact MCP name is unknown, inspect the read-only `ALL_TOOLS` catalog and dynamically call the matching name:
-
-```ts
-const tool = ALL_TOOLS.find(
-  ({ name }) => name.startsWith("mcp__") && name.includes("docs") && name.includes("search"),
-)
-if (!tool) return "No matching MCP tool"
-const result = await tools[tool.name]({ query: "MCP configuration" })
-return result.structured ?? result.output
-```
-
-The script environment provides JavaScript built-ins plus `tools`, `files`, and `console`. It does not provide Node.js modules, `import`, `require`, `process`, `fetch`, or timers. Use the available tools for external operations.
-
-- Call built-in tools, and other tool IDs that are valid JavaScript identifiers, with `await tools.name(input)`.
-- Call request-authorized MCP tools by their exact catalog name (`await tools.mcp__server__tool(input)` or `await tools[name](input)`); the same permission checks as direct calls apply.
-- `await tools.exec_command(...)` invokes the shell through the `bash` alias; only `await tools.mcp__server__tool(...)` invokes an MCP tool.
-- MCP results carry parsed `structuredContent` in the `structured` field when the server provides it.
-- Use `Promise.all` or `Promise.allSettled` only for independent calls; at most 8 run concurrently.
-- Return a small JSON-serializable aggregate. Circular values, BigInt, and throwing getters fail execution.
-- Use `console.log` only for debugging; logs are included in the result.
-- Tool permissions are enforced for every nested call.
-- State does not persist between executions. For temporary cross-execution data, use `files.writeText` and `files.readText` under the OS temp directory.
-- `bash` is available as both `tools.bash(...)` and its alias `tools.exec_command(...)`; both use the same permission and execution path.
-- Declared conversation-control tools such as `question`, `task`, `actor`, `skill`, `plan_exit`, and `cron` are available through the same `tools` object. Recursive `session` and `workflow` orchestration are excluded.
-
-By default an execution may make 50 tool calls and use 60000 milliseconds of active compute. The `max_tool_calls` and `timeout` inputs can raise those limits to 500 calls and 600000 milliseconds. `timeout` is always measured in milliseconds. Time waiting for nested tools does not count toward active compute.
-
-The result is wrapped in `<exec status="...">` and may contain `<return_value>`, `<warnings>`, `<logs>`, `<trace>`, and `<error_message>` blocks.
-
-The available tools and their exact input types are declared below.
+- Global helpers:
+- `exit()`: Immediately ends the current script successfully (like an early return from the top level).
+- `text(value: string | number | boolean | undefined | null)`: Appends a text item. Non-string values are stringified with `JSON.stringify(...)` when possible.
+- `image(imageUrlOrItem: string | { image_url: string } | { type: "image"; data: string; mimeType: string })`: Appends an image item from a base64-encoded `data:` URL or an in-script image value. Media attachments returned by nested MCP tools are dropped before entering the isolate and cannot be forwarded with this helper.
+- `audio(audioUrlOrItem: string | { audio_url: string } | { type: "audio"; data: string; mimeType: string })`: Appends an audio item from a base64-encoded `data:` URL or an in-script audio value. Media attachments returned by nested MCP tools are dropped before entering the isolate.
+- `generatedImage(result: { image_url: string; output_hint?: string })`: Appends an image-generation result and its optional output hint. HTTP(S) URLs are not supported.
+- `store(key: string, value: any)`: stores a serializable value under a string key for later `exec` calls in the same session. Inactive session stores expire after 30 minutes.
+- `load(key: string)`: returns the stored value for a string key, or `undefined` if it is missing.
+- `notify(value: string | number | boolean | undefined | null)`: publishes an immediate progress notification for this exec call. Not part of the final return text.
+- `setTimeout(callback: () => void, delayMs?: number)`: schedules a callback to run later and returns a timeout id. Pending timeouts do not keep `exec` alive by themselves; await an explicit promise if you need to wait for one.
+- `clearTimeout(timeoutId?: number)`: cancels a timeout created by `setTimeout`.
+- `ALL_TOOLS`: metadata for the enabled nested tools as `{ name, description }` entries.
+- `yield_control()`: asks the current `exec` or `wait` call to yield the output accumulated since the previous yield while the script keeps running. It may be called repeatedly.

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -50,6 +50,15 @@ export interface Def<Parameters extends z.ZodType = z.ZodType, M extends Metadat
   parameters: Parameters
   execute(args: z.infer<Parameters>, ctx: Context): Effect.Effect<ExecuteResult<M>>
   formatValidationError?(error: z.ZodError): string
+  freeform?: {
+    format: {
+      type: "grammar"
+      syntax: "lark"
+      definition: string
+    }
+    parse(input: string): z.infer<Parameters>
+  }
+  nestedToolNames?: string[]
   shell?: {
     description: string
     parse(script: string): Effect.Effect<z.infer<Parameters>[], unknown>

--- a/packages/opencode/src/util/tool-compat.ts
+++ b/packages/opencode/src/util/tool-compat.ts
@@ -191,6 +191,23 @@ export type RepairedToolCall = {
   input: string
 }
 
+export function repairNestedToolCallAsExec(input: {
+  toolName: string
+  input: string
+  nestedToolNames: readonly string[]
+  execSchema: JSONSchema7
+}): RepairedToolCall | undefined {
+  const toolName = resolveName(input.toolName, input.nestedToolNames)
+  if (!toolName) return undefined
+  const args = JSON.stringify(parseToolInput(input.input))
+  if (args === undefined) return undefined
+  const code = `const result = await tools[${JSON.stringify(toolName)}](${args});\ntext(result && typeof result === "object" && "output" in result ? result.output : result);`
+  return {
+    toolName: "exec",
+    input: input.execSchema.type === "string" ? JSON.stringify(code) : JSON.stringify({ code }),
+  }
+}
+
 /** Repair tool name and/or argument keys so AI SDK validation can succeed. */
 export async function repairToolCall(input: RepairToolCallInput): Promise<RepairedToolCall | undefined> {
   const resolvedName = resolveName(input.toolName, input.toolNames)

--- a/packages/opencode/test/provider/strict-schema-wire.test.ts
+++ b/packages/opencode/test/provider/strict-schema-wire.test.ts
@@ -5,6 +5,7 @@ import { createXai } from "@ai-sdk/xai"
 import { dynamicTool, generateObject, generateText, jsonSchema, tool } from "ai"
 import z from "zod"
 import { ProviderTransform } from "../../src/provider"
+import { CODE_MODE_EXEC_GRAMMAR } from "../../src/tool/tool-script"
 
 // WIRE-LEVEL proof that function tools ship with an explicit `strict: false` to
 // the OpenAI Responses API.
@@ -125,6 +126,29 @@ const anthropicMessages = (tools: Record<string, any>) =>
   outbound(tools, anthropicReply, (fetch) => createAnthropic({ apiKey: "test-key", fetch })("claude-sonnet-4"))
 
 describe("function tools reach the OpenAI Responses API with an explicit strict: false", () => {
+  test("exec reaches the wire as the Codex custom tool with the exact Lark grammar", async () => {
+    const body = await openaiResponses(
+      ProviderTransform.tools(
+        {
+          exec: createOpenAI({ apiKey: "unused" }).tools.customTool({
+            name: "exec",
+            description: "Run JavaScript code to orchestrate/compose tool calls",
+            format: { type: "grammar", syntax: "lark", definition: CODE_MODE_EXEC_GRAMMAR },
+          }),
+        },
+        model("@ai-sdk/openai"),
+      ),
+    )
+    expect(body.tools).toEqual([
+      {
+        type: "custom",
+        name: "exec",
+        description: "Run JavaScript code to orchestrate/compose tool calls",
+        format: { type: "grammar", syntax: "lark", definition: CODE_MODE_EXEC_GRAMMAR },
+      },
+    ])
+  })
+
   test("CONTROL: untransformed tools omit `strict` entirely (the defect)", async () => {
     const body = await openaiResponses(toolset())
     expect(body.tools).toHaveLength(2)

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -338,31 +338,52 @@ const mcpSuccessResult: CallToolResult = {
   structuredContent: { changed: true, windowID: 42 },
   _meta: { privateToken: "success-meta-is-client-only" },
 }
+const mcpCallResultOutputSchema = jsonSchema({
+  type: "object",
+  properties: {
+    content: { type: "array", items: { type: "object", properties: {}, additionalProperties: true } },
+    isError: { type: "boolean" },
+    _meta: { type: "object", additionalProperties: true },
+    structuredContent: {
+      type: "object",
+      description: "Structured MCP result visible to exec",
+      additionalProperties: true,
+    },
+  },
+  required: ["content"],
+  additionalProperties: true,
+})
 const mcpIt = testEffect(
   makeHttp(
     mcpLayer(() => ({
-      mcp_success: dynamicTool({
-        description: "Return a standard structured MCP success result",
-        inputSchema: jsonSchema({
-          type: "object",
-          properties: {
-            private_window_id: { type: "number", description: "Secret nested MCP window selector" },
-          },
-          additionalProperties: false,
+      mcp_success: Object.assign(
+        dynamicTool({
+          description: "Return a standard structured MCP success result",
+          inputSchema: jsonSchema({
+            type: "object",
+            properties: {
+              private_window_id: { type: "number", description: "Secret nested MCP window selector" },
+            },
+            additionalProperties: false,
+          }),
+          execute: async () => mcpSuccessResult,
         }),
-        execute: async () => mcpSuccessResult,
-      }),
-      mcp_result: dynamicTool({
-        description: "Return a standard MCP tool execution error",
-        inputSchema: jsonSchema({
-          type: "object",
-          properties: {
-            private_error_code: { type: "string", description: "Secret nested MCP error selector" },
-          },
-          additionalProperties: false,
+        { outputSchema: mcpCallResultOutputSchema },
+      ),
+      mcp_result: Object.assign(
+        dynamicTool({
+          description: "Return a standard MCP tool execution error",
+          inputSchema: jsonSchema({
+            type: "object",
+            properties: {
+              private_error_code: { type: "string", description: "Secret nested MCP error selector" },
+            },
+            additionalProperties: false,
+          }),
+          execute: async () => mcpErrorResult,
         }),
-        execute: async () => mcpErrorResult,
-      }),
+        { outputSchema: mcpCallResultOutputSchema },
+      ),
     })),
   ),
 )
@@ -1010,7 +1031,7 @@ mcpIt.live("MCP structuredContent is persisted and reaches the model alongside t
       expect(catalog).toContain("mcp_success — Return a standard structured MCP success result")
       expect(catalog).not.toContain("private_error_code")
       expect(catalog).not.toContain("Secret nested MCP window selector")
-      expect(loadedTools.map(wireToolName)).toContain("mcp_success")
+      expect(loadedTools.map(wireToolName)).not.toContain("mcp_success")
       expect(loadedTools.map(wireToolName)).not.toContain("mcp_result")
 
       const followup = JSON.stringify(requests[2])
@@ -1058,8 +1079,53 @@ mcpIt.live("exec can call a catalogued MCP tool without loading its outer schema
       const tools = (yield* llm.inputs)[0].tools as Array<Record<string, unknown>>
       expect(tools.map(wireToolName)).toContain("mcp_tool_search")
       expect(tools.map(wireToolName)).not.toContain("mcp_success")
+      const execDescription = wireToolDescription(wireTool(tools, "exec") ?? {}) ?? ""
+      expect(execDescription.match(/Shared MCP Types:/g)).toHaveLength(1)
+      expect(execDescription).toContain("mcp_success")
+      expect(execDescription).toContain("Promise<CallToolResult<")
+      expect(execDescription).toContain("// Secret nested MCP window selector")
     }),
     { git: true, config: providerCfg },
+  ),
+)
+
+mcpIt.live("repairs unavailable top-level webfetch and memory calls through exec", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "Repair nested webfetch",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        model: { providerID: ProviderID.openai, modelID: ModelID.make("gpt-5.2") },
+        noReply: true,
+        parts: [{ type: "text", text: "fetch a URL" }],
+      })
+      yield* llm.tool("webfetch", { url: "http://127.0.0.1/private", format: "text" })
+      yield* llm.tool("memory", { operation: "search", query: "missing-memory-entry" })
+      yield* llm.text("done")
+
+      yield* prompt.loop({ sessionID: session.id })
+
+      const parts = (yield* MessageV2.filterCompactedEffect(session.id)).flatMap((message) => message.parts)
+      const exec = parts.filter(
+        (part): part is CompletedToolPart =>
+          part.type === "tool" && part.tool === "exec" && part.state.status === "completed",
+      )
+      expect(exec).toHaveLength(2)
+      expect(exec.map((part) => part.state.output).join("\n")).not.toContain("Model tried to call unavailable tool")
+      expect(parts.some((part) => part.type === "tool" && part.tool === "invalid")).toBeFalse()
+      const tools = (yield* llm.inputs)[0].tools as Array<Record<string, unknown>>
+      expect(tools.map(wireToolName)).toContain("exec")
+      expect(tools.map(wireToolName)).not.toContain("webfetch")
+      expect(tools.map(wireToolName)).not.toContain("memory")
+    }),
+    { git: true, config: gptProviderCfg },
   ),
 )
 
@@ -1132,7 +1198,7 @@ mcpIt.live("resets loaded MCP tools for a new user request", () =>
       yield* prompt.loop({ sessionID: session.id })
 
       const requests = yield* llm.inputs
-      expect((requests[1].tools as Array<Record<string, unknown>>).map(wireToolName)).toContain("mcp_success")
+      expect((requests[1].tools as Array<Record<string, unknown>>).map(wireToolName)).not.toContain("mcp_success")
       expect((requests[3].tools as Array<Record<string, unknown>>).map(wireToolName)).not.toContain("mcp_success")
       expect((requests[3].tools as Array<Record<string, unknown>>).map(wireToolName)).toContain("mcp_tool_search")
     }),
@@ -1160,10 +1226,10 @@ mcpIt.live("accumulates MCP matches across searches in one user request", () =>
       yield* prompt.loop({ sessionID: session.id })
 
       const requests = yield* llm.inputs
-      expect((requests[1].tools as Array<Record<string, unknown>>).map(wireToolName)).toContain("mcp_result")
+      expect((requests[1].tools as Array<Record<string, unknown>>).map(wireToolName)).not.toContain("mcp_result")
       expect((requests[1].tools as Array<Record<string, unknown>>).map(wireToolName)).not.toContain("mcp_success")
-      expect((requests[2].tools as Array<Record<string, unknown>>).map(wireToolName)).toContain("mcp_result")
-      expect((requests[2].tools as Array<Record<string, unknown>>).map(wireToolName)).toContain("mcp_success")
+      expect((requests[2].tools as Array<Record<string, unknown>>).map(wireToolName)).not.toContain("mcp_result")
+      expect((requests[2].tools as Array<Record<string, unknown>>).map(wireToolName)).not.toContain("mcp_success")
     }),
     { git: true, config: providerCfg },
   ),
@@ -1200,7 +1266,7 @@ mcpIt.live("keeps discovery reachable when permissions allow only an MCP tool", 
       expect(catalog).toContain("mcp_success — Return a standard structured MCP success result")
       expect(catalog).not.toContain("mcp_result")
       expect(catalog).not.toContain("standard MCP tool execution error")
-      expect((requests[1].tools as Array<Record<string, unknown>>).map(wireToolName)).toContain("mcp_success")
+      expect((requests[1].tools as Array<Record<string, unknown>>).map(wireToolName)).not.toContain("mcp_success")
       expect((requests[1].tools as Array<Record<string, unknown>>).map(wireToolName)).not.toContain("mcp_result")
     }),
     { git: true, config: providerCfg },
@@ -1231,10 +1297,7 @@ mcpIt.live("searches only MCP tools allowed by the configured agent", () =>
       expect(initialTools.map(wireToolName)).toEqual(["mcp_tool_search"])
       expect(catalog).toContain("mcp_success — Return a standard structured MCP success result")
       expect(catalog).not.toContain("mcp_result")
-      expect((requests[1].tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual([
-        "mcp_tool_search",
-        "mcp_success",
-      ])
+      expect((requests[1].tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(["mcp_tool_search"])
     }),
     { git: true, config: restrictedAgentProviderCfg },
   ),
@@ -1266,8 +1329,8 @@ mcpIt.live(
         expect(tools.map(wireToolName)).not.toContain("mcp_result")
         expect(catalog).toContain("mcp_success — Return a standard structured MCP success result")
         expect(catalog).toContain("mcp_result — Return a standard MCP tool execution error")
-        expect(JSON.stringify(tools)).not.toContain("private_window_id")
-        expect(JSON.stringify(tools)).not.toContain("Secret nested MCP error selector")
+        expect(catalog).not.toContain("private_window_id")
+        expect(catalog).not.toContain("Secret nested MCP error selector")
       }),
       { git: true, config: gptProviderCfg },
     ),

--- a/packages/opencode/test/tool/registry-invocation-style.test.ts
+++ b/packages/opencode/test/tool/registry-invocation-style.test.ts
@@ -8,6 +8,8 @@ import { ProviderID, ModelID } from "../../src/provider/schema"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { testEffect } from "../lib/effect"
 import { provideTmpdirInstance } from "../fixture/fixture"
+import { CODE_MODE_EXEC_GRAMMAR } from "../../src/tool/tool-script"
+import z from "zod"
 
 const it = testEffect(
   Layer.mergeAll(ToolRegistry.defaultLayer, Agent.defaultLayer, CrossSpawnSpawner.defaultLayer),
@@ -44,11 +46,36 @@ describe("ToolRegistry.tools: invocation style resolution", () => {
         ]
 
         expect(ids).toContain("exec")
+        expect(ids).toContain("wait")
         nested.forEach((id) => expect(ids).not.toContain(id))
 
-        const description = tools.find((tool) => tool.id === "exec")?.description ?? ""
-        nested.forEach((id) => expect(description).toContain(`${id}(input:`))
-        expect(description).toContain("timeout measured in milliseconds")
+        const exec = tools.find((tool) => tool.id === "exec")
+        const description = exec?.description ?? ""
+        nested
+          .filter((id) => id !== "apply_patch")
+          .forEach((id) => expect(description).toContain(`${id}(args:`))
+        expect(description).toContain("apply_patch(input: string)")
+        expect(exec?.freeform?.format).toEqual({
+          type: "grammar",
+          syntax: "lark",
+          definition: CODE_MODE_EXEC_GRAMMAR,
+        })
+        const wait = tools.find((tool) => tool.id === "wait")
+        expect(z.toJSONSchema(wait!.parameters)).toMatchObject({
+          type: "object",
+          required: ["cell_id"],
+          additionalProperties: false,
+          properties: {
+            cell_id: { type: "string", description: "Identifier of the running exec cell." },
+            yield_time_ms: { type: "number", description: "Wait before yielding more output. Defaults to 10000 ms." },
+            max_tokens: { type: "number", description: "Output token budget for this wait call. Defaults to 10000 tokens." },
+            terminate: {
+              type: "boolean",
+              description: "True stops the running exec cell; false or omitted waits for output.",
+            },
+          },
+        })
+        expect(wait?.description).toContain("only the new output since the last yield")
       }),
     ),
   )

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -7,9 +7,17 @@ import path from "path"
 import { evalScript } from "../../src/workflow/sandbox"
 import { Agent } from "../../src/agent/agent"
 import { Truncate, Tool } from "../../src/tool"
-import { ToolScriptTool, renderToolScriptDeclarations } from "../../src/tool/tool-script"
-import { toolScriptRegistry, TOOL_SCRIPT_EXCLUDED } from "../../src/tool/tool-script-ref"
+import {
+  CODE_MODE_EXEC_GRAMMAR,
+  ToolScriptTool,
+  parseExecSource,
+  renderToolScriptDeclarations,
+  renderMcpToolScriptDeclarations,
+} from "../../src/tool/tool-script"
+import { toolScriptRegistry, NOT_CALLABLE_IN_EXEC } from "../../src/tool/tool-script-ref"
 import { Instance } from "../../src/project/instance"
+import { CodeModeWaitTool } from "../../src/tool/code-mode-wait"
+import { createCodeModeOutputBuffer, startCell, waitCell } from "../../src/tool/code-mode-cell"
 
 describe("sandbox non-deterministic mode", () => {
   test("deterministic:false keeps Date and Math.random", async () => {
@@ -93,8 +101,11 @@ async function runToolScript(
     ask?: () => Effect.Effect<void>
     maxToolCalls?: number
     timeoutMs?: number
+    yieldTimeMs?: number
+    maxOutputTokens?: number
     toolWhitelist?: string[]
     mcp?: Record<string, any>
+    metadata?: (input: { title?: string; metadata: Tool.Metadata }) => Effect.Effect<void>
   },
 ) {
   const prev = toolScriptRegistry.current
@@ -111,6 +122,8 @@ async function runToolScript(
               code,
               ...(opts?.maxToolCalls !== undefined && { max_tool_calls: opts.maxToolCalls }),
               ...(opts?.timeoutMs !== undefined && { timeout: opts.timeoutMs }),
+              ...(opts?.yieldTimeMs !== undefined && { yield_time_ms: opts.yieldTimeMs }),
+              ...(opts?.maxOutputTokens !== undefined && { max_output_tokens: opts.maxOutputTokens }),
             },
             {
               sessionID: "ses_test" as any,
@@ -123,7 +136,7 @@ async function runToolScript(
                 ...(opts?.mcp ? { execMcp: { current: opts.mcp } } : {}),
               },
               messages: [],
-              metadata: () => Effect.void,
+              metadata: opts?.metadata ?? (() => Effect.void),
               ask: opts?.ask ?? (() => Effect.void),
             },
           ),
@@ -136,14 +149,183 @@ async function runToolScript(
 }
 
 describe("exec", () => {
-  test("declares the exec timeout in milliseconds", async () => {
+  test("uses the Codex freeform grammar and pragma schema", async () => {
     const info = await runtime.runPromise(ToolScriptTool)
     const def = await runtime.runPromise(Tool.init(info))
-    const parsed = def.parameters.parse({ code: "return 1", timeout: 120_000 })
 
-    expect(parsed.timeout).toBe(120_000)
-    expect(def.description).toContain("`timeout` is always measured in milliseconds")
-    expect(def.description).toContain("600000 milliseconds")
+    expect(def.freeform?.format).toEqual({
+      type: "grammar",
+      syntax: "lark",
+      definition: CODE_MODE_EXEC_GRAMMAR,
+    })
+    expect(def.description).toContain('// @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}')
+    expect(def.description).toContain("captured `console`")
+    expect(def.description).toContain("jailed `files` helper")
+    expect(def.description).toContain("Not part of the final return text")
+    expect(def.description).toContain("It may be called repeatedly")
+    expect(def.freeform?.parse('// @exec: {"yield_time_ms": 25, "max_output_tokens": 128}\nreturn 1')).toEqual({
+      code: "return 1",
+      yield_time_ms: 25,
+      max_output_tokens: 128,
+    })
+  })
+
+  test("parseExecSource rejects malformed pragmas like Codex", () => {
+    expect(() => parseExecSource("")).toThrow("exec expects raw JavaScript or TypeScript source text")
+    expect(() => parseExecSource('// @exec: {"yield_time_ms": 1}')).toThrow(
+      "exec pragma must be followed by JavaScript source",
+    )
+    expect(() => parseExecSource('// @exec: {"unknown": 1}\nreturn 1')).toThrow(
+      "exec pragma only supports `yield_time_ms` and `max_output_tokens`; got `unknown`",
+    )
+    expect(() => parseExecSource('// @exec: {"yield_time_ms": -1}\nreturn 1')).toThrow(
+      "exec pragma field `yield_time_ms` must be a non-negative safe integer",
+    )
+    expect(() => parseExecSource('\n// @exec: {"yield_time_ms": 1}\nreturn 1')).toThrow(
+      "exec pragma must be the first line",
+    )
+  })
+
+  test("text helper emits output without requiring a return value", async () => {
+    const result = await runToolScript(`text("first"); text({ second: 2 })`, [])
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain('first\n{"second":2}')
+    expect(result.output).not.toContain("<return_value>\nundefined")
+  })
+
+  test("notify publishes metadata without entering the final return text", async () => {
+    const notifications: string[] = []
+    const result = await runToolScript(`notify("building"); return "done"`, [], undefined, {
+      metadata: (input) =>
+        Effect.sync(() => {
+          if (typeof input.metadata.notification === "string") notifications.push(input.metadata.notification)
+        }),
+    })
+    expect(result.output).toContain("done")
+    expect(result.output).not.toContain("building")
+    expect(notifications).toContain("building")
+  })
+
+  test("yielded scripts resume through the Codex wait tool", async () => {
+    const result = await runToolScript(
+      `const result = await tools.slow({}); text(result.output)`,
+      [
+        fakeDef("slow", async () => {
+          await new Promise((resolve) => setTimeout(resolve, 50))
+          return "finished"
+        }),
+      ],
+      undefined,
+      { yieldTimeMs: 0 },
+    )
+    expect(result.output).toContain("Script running with cell ID")
+    const cellID = /Script running with cell ID ([^\s]+)/.exec(result.output)?.[1]
+    expect(cellID).toBeDefined()
+
+    const info = await runtime.runPromise(CodeModeWaitTool)
+    const def = await runtime.runPromise(Tool.init(info))
+    const waited = await Instance.provide({
+      directory: tmp,
+      fn: () =>
+        runtime.runPromise(
+          def.execute(
+            { cell_id: cellID!, yield_time_ms: 1000 },
+            {
+              sessionID: "ses_test" as any,
+              messageID: "msg_wait" as any,
+              agent: "build",
+              abort: new AbortController().signal,
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          ),
+        ),
+    })
+    expect(waited.output).toContain("Script completed")
+    expect(waited.output).toContain("finished")
+  })
+
+  test("wait drains only output added since the previous yield", async () => {
+    const result = await runToolScript(
+      `text("one"); yield_control();
+       await tools.pause({});
+       text("two"); yield_control();
+       await tools.pause({});
+       text("three")`,
+      [
+        fakeDef("pause", async () => {
+          await new Promise((resolve) => setTimeout(resolve, 30))
+          return "ok"
+        }),
+      ],
+    )
+    const cellID = /Script running with cell ID ([^\s]+)/.exec(result.output)?.[1]
+    expect(cellID).toBeDefined()
+    expect(result.output).toContain("one")
+
+    const second = await waitCell({ sessionID: "ses_test" as any, cellID: cellID!, yieldTimeMs: 1000 })
+    expect(second.output).toContain("two")
+    expect(second.output).not.toContain("one")
+
+    const final = await waitCell({ sessionID: "ses_test" as any, cellID: cellID!, yieldTimeMs: 1000 })
+    expect(final.output).toContain("three")
+    expect(final.output).not.toContain("one")
+    expect(final.output).not.toContain("two")
+  })
+
+  test("terminating an already-settled cell preserves its attachments", async () => {
+    const promise = new Promise<Tool.ExecuteResult>((resolve) =>
+      setTimeout(
+        () =>
+          resolve({
+            title: "done",
+            output: "done",
+            metadata: { status: "completed" },
+            attachments: [{ type: "file", mime: "image/png", url: "data:image/png;base64,eA==" }],
+          }),
+        20,
+      ),
+    )
+    const started = await startCell({
+      sessionID: "ses_attachments" as any,
+      promise,
+      controller: new AbortController(),
+      output: createCodeModeOutputBuffer(),
+      yieldTimeMs: 0,
+    })
+    const cellID = /Script running with cell ID ([^\s]+)/.exec(started.output)?.[1]
+    expect(cellID).toBeDefined()
+    await promise
+    const terminated = await waitCell({
+      sessionID: "ses_attachments" as any,
+      cellID: cellID!,
+      yieldTimeMs: 0,
+      terminate: true,
+    })
+    expect(terminated.metadata.status).toBe("terminated")
+    expect(terminated.attachments).toHaveLength(1)
+  })
+
+  test("store writes commit only after successful script completion", async () => {
+    const stored = await runToolScript(`store("committed", { ok: true }); return "stored"`, [])
+    expect(stored.metadata.status).toBe("completed")
+    const loaded = await runToolScript(`return load("committed")`, [])
+    expect(loaded.output).toContain('"ok": true')
+
+    const failed = await runToolScript(`store("failed", "leak"); throw new Error("stop")`, [])
+    expect(failed.metadata.status).toBe("code_error")
+    const afterFailure = await runToolScript(`return load("failed") ?? "missing"`, [])
+    expect(afterFailure.output).toContain("missing")
+    expect(afterFailure.output).not.toContain("leak")
+
+    const cancelled = await runToolScript(`store("cancelled", "leak"); while (true) {}`, [], undefined, {
+      timeoutMs: 50,
+    })
+    expect(cancelled.metadata.status).toBe("timeout")
+    const afterCancel = await runToolScript(`return load("cancelled") ?? "missing"`, [])
+    expect(afterCancel.output).toContain("missing")
+    expect(afterCancel.output).not.toContain("leak")
   })
 
   test("cannot call tools outside the actor runtime whitelist", async () => {
@@ -218,9 +400,8 @@ describe("exec", () => {
     expect(result.output).toContain("[\n  2,\n  4,\n  6\n]")
   })
 
-  test("console.log is captured into Logs block", async () => {
+  test("console.log is captured into live output", async () => {
     const result = await runToolScript(`console.log("hello", { a: 1 }); return 1`, [])
-    expect(result.output).toContain("<logs>")
     expect(result.output).toContain('hello {"a":1}')
   })
 
@@ -351,6 +532,33 @@ describe("exec", () => {
     expect(result.output).toContain("ran:direct")
     expect(result.output).toContain("ran:alias")
     expect(seen.toSorted()).toEqual(["alias", "direct"])
+  })
+
+  test("an exec_command-only runtime whitelist authorizes its bash target", async () => {
+    const result = await runToolScript(
+      `return await tools.exec_command({ value: "allowed" })`,
+      [fakeDef("bash", async (args) => `ran:${args.value}`)],
+      undefined,
+      { toolWhitelist: ["exec_command"] },
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("ran:allowed")
+  })
+
+  test("apply_patch uses the Codex freeform string declaration and dispatch shape", async () => {
+    let seen: unknown
+    const defs = [
+      fakeDef("apply_patch", async (args) => {
+        seen = args
+        return "done"
+      }),
+    ]
+    const result = await runToolScript(`return await tools.apply_patch("*** Begin Patch")`, defs)
+    const description = renderToolScriptDeclarations(defs)
+
+    expect(description).toContain("apply_patch(input: string)")
+    expect(result.metadata.status).toBe("completed")
+    expect(seen).toEqual({ patch_text: "*** Begin Patch" })
   })
 
   test("supports parallel bash calls with millisecond timeouts", async () => {
@@ -512,6 +720,7 @@ describe("exec", () => {
     expect(result.output).toContain("NaN at $.n serialized as null")
     expect(result.output).toContain('"m": [')
     expect(result.output).toContain('"message": "msg"')
+    expect(result.output).not.toContain('"stack"')
     expect(result.output).toContain('"r": "/x/g"')
   })
 
@@ -535,6 +744,7 @@ describe("exec", () => {
     const result = await runToolScript(`return "line1\\nline2 with \\"quotes\\""`, [])
     expect(result.metadata.status).toBe("completed")
     expect(result.output).toContain('line1\nline2 with "quotes"')
+    expect(result.output).not.toContain("<return_value>")
   })
 
   test("syntax error reports line, column, and source line", async () => {
@@ -627,29 +837,61 @@ describe("renderToolScriptDeclarations", () => {
       fakeDef("question", async () => "x"),
     ]
     const text = renderToolScriptDeclarations(defs)
-    expect(text).toContain("read(input:")
-    expect(text).not.toContain("mcp_tool_search(input:")
-    expect(text).toContain("mcp__<server>__<tool>")
-    expect(text).toContain("declare const ALL_TOOLS")
-    expect(text).toContain("task(input:")
-    expect(text).toContain("question(input:")
+    expect(text).toContain("read(args:")
+    expect(text).not.toContain("mcp_tool_search(args:")
+    expect(text).toContain("task(args:")
+    expect(text).toContain("question(args:")
     expect(text).toContain("declare const tools")
   })
 
-  test("exclusion list covers recursive and internal tools but allows Codex nested tools", () => {
-    for (const id of ["exec", "mcp_tool_search", "invalid", "session", "workflow"]) {
-      expect(TOOL_SCRIPT_EXCLUDED.has(id)).toBe(true)
+  test("not-callable set covers recursive and internal tools but allows Codex nested tools", () => {
+    for (const id of ["exec", "wait", "mcp_tool_search", "invalid", "session", "workflow"]) {
+      expect(NOT_CALLABLE_IN_EXEC.has(id)).toBe(true)
     }
     for (const id of ["bash", "task", "question", "actor", "skill", "plan_exit", "cron", "change_directory"]) {
-      expect(TOOL_SCRIPT_EXCLUDED.has(id)).toBe(false)
+      expect(NOT_CALLABLE_IN_EXEC.has(id)).toBe(false)
     }
   })
 
   test("renders exec_command as an alias for bash", () => {
     const text = renderToolScriptDeclarations([fakeDef("bash", async () => "x")])
-    expect(text).toContain("bash(input:")
-    expect(text).toContain("exec_command(input:")
+    expect(text).toContain("bash(args:")
+    expect(text).toContain("exec_command(args:")
     expect(text).toContain("Alias for bash")
+  })
+
+  test("renders schema property descriptions as TypeScript comments", () => {
+    const parameters = z.object({ query: z.string().describe("Search terms supplied by the user") })
+    const def: Tool.Def<typeof parameters> = {
+      id: "search",
+      description: "Search",
+      parameters,
+      execute: () => Effect.succeed({ title: "", output: "", metadata: {} }),
+    }
+    expect(renderToolScriptDeclarations([def])).toContain("// Search terms supplied by the user")
+  })
+
+  test("renders the shared MCP preamble once and preserves structured output types", async () => {
+    const declarations = await renderMcpToolScriptDeclarations({
+      mcp__sample__search: {
+        description: "Search structured records",
+        inputSchema: z.object({ query: z.string().describe("Query sent to the MCP server") }),
+        outputSchema: z.object({
+          content: z.array(z.object({ type: z.string() })),
+          isError: z.boolean(),
+          _meta: z.record(z.string(), z.unknown()),
+          structuredContent: z.object({
+            results: z.array(z.object({ id: z.string() })).describe("Structured search hits"),
+          }),
+        }),
+        execute: async () => ({ content: [], isError: false, _meta: {}, structuredContent: { results: [] } }),
+      },
+    })
+    expect(declarations.match(/Shared MCP Types:/g)).toHaveLength(1)
+    expect(declarations).toContain("type CallToolResult")
+    expect(declarations).toContain("Promise<CallToolResult<")
+    expect(declarations).toContain("// Query sent to the MCP server")
+    expect(declarations).toContain("// Structured search hits")
   })
 
 })
@@ -732,6 +974,22 @@ describe("exec MCP dispatch", () => {
       { mcp },
     )
     expect(result.output).toContain("builtin version")
+  })
+
+  test("reserved aliases cannot be shadowed by MCP tools", async () => {
+    const mcp = {
+      exec_command: fakeMcpTool(async () => ({ output: "mcp version", metadata: {}, attachments: [] })),
+    }
+    const result = await runToolScript(
+      `const listed = ALL_TOOLS.some((tool) => tool.name === "exec_command");
+       try { await tools.exec_command({}) } catch (e) { return { listed, error: e.message } }`,
+      [],
+      undefined,
+      { mcp },
+    )
+    expect(result.output).toContain('"listed": false')
+    expect(result.output).toContain("unknown tool: exec_command")
+    expect(result.output).not.toContain("mcp version")
   })
 
   test("attachments are dropped with a note", async () => {

--- a/packages/opencode/test/util/tool-compat.test.ts
+++ b/packages/opencode/test/util/tool-compat.test.ts
@@ -4,6 +4,7 @@ import {
   canonical,
   normalizeInput,
   parseToolInput,
+  repairNestedToolCallAsExec,
   repairToolCall,
   resolveName,
 } from "../../src/util/tool-compat"
@@ -185,6 +186,69 @@ describe("util.tool-compat", () => {
       })
 
       expect(repaired).toBeUndefined()
+    })
+  })
+
+  describe("repairNestedToolCallAsExec", () => {
+    test("wraps an unavailable top-level webfetch call in freeform exec source", () => {
+      const repaired = repairNestedToolCallAsExec({
+        toolName: "webfetch",
+        input: JSON.stringify({ url: "https://example.com", format: "markdown" }),
+        nestedToolNames: ["webfetch"],
+        execSchema: { type: "string" },
+      })
+
+      expect(repaired?.toolName).toBe("exec")
+      expect(JSON.parse(repaired!.input)).toContain(
+        'tools["webfetch"]({"url":"https://example.com","format":"markdown"})',
+      )
+      expect(JSON.parse(repaired!.input)).toContain("text(")
+    })
+
+    test("wraps source in { code } for providers that expose exec as a function tool", () => {
+      const repaired = repairNestedToolCallAsExec({
+        toolName: "WebFetch",
+        input: JSON.stringify({ url: "https://example.com" }),
+        nestedToolNames: ["webfetch"],
+        execSchema: { type: "object", properties: { code: { type: "string" } } },
+      })
+
+      expect(repaired?.toolName).toBe("exec")
+      expect(JSON.parse(repaired!.input).code).toContain('tools["webfetch"]')
+    })
+
+    test("serializes hostile arguments as data instead of executable source", async () => {
+      const url = 'https://example.com/"; globalThis.injected = true; //'
+      const repaired = repairNestedToolCallAsExec({
+        toolName: "webfetch",
+        input: JSON.stringify({ url }),
+        nestedToolNames: ["webfetch"],
+        execSchema: { type: "string" },
+      })
+      let received: unknown
+      const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+      await new AsyncFunction("tools", "text", JSON.parse(repaired!.input))(
+        {
+          webfetch: async (args: unknown) => {
+            received = args
+            return { output: "ok" }
+          },
+        },
+        () => {},
+      )
+      expect(received).toEqual({ url })
+      expect((globalThis as { injected?: boolean }).injected).toBeUndefined()
+    })
+
+    test("does not rewrite tools that are not nested exec capabilities", () => {
+      expect(
+        repairNestedToolCallAsExec({
+          toolName: "unknown",
+          input: "{}",
+          nestedToolNames: ["webfetch"],
+          execSchema: { type: "string" },
+        }),
+      ).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
## Summary
- expose `exec` as a Codex-compatible freeform custom tool with Lark grammar
- add streamed output helpers, resumable code-mode cells, and the `wait` control tool
- route nested built-in and MCP tools through `exec` with repair and compatibility coverage

## Testing
- `bun turbo typecheck` (12/12 tasks successful)
- pre-push hook passed