### PR TITLE
fix(gpt): update reasoning format instruction to accept both We need and Need

### DIFF
--- a/packages/opencode/src/session/prompt/gpt.txt
+++ b/packages/opencode/src/session/prompt/gpt.txt
@@ -223,5 +223,5 @@ These primitives serve different purposes. Use them only when they are present i
 
 ## Reasoning format
 
-Begin every thinking block with the exact string "We need".
-This applies to all turns, including reasoning that follows a tool result.
+Begin every thinking block with the exact string "We need" or "Need".
+This applies to all turns, including reasoning that before a tool call.


### PR DESCRIPTION
Update the reasoning format instruction in GPT prompt to accept both 'We need' and 'Need' as valid opening strings, and clarify the instruction applies to reasoning before tool calls.