### PR TITLE
feat(tool-script): add exec_command parameter schema with yield_time_ms and workdir

### DIFF
--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -28,6 +28,34 @@ const MAX_LOG_BYTES = 64 * 1024
 const MAX_CODE_BYTES = 128 * 1024
 const MAX_FILE_BYTES = 10 * 1024 * 1024
 const TRACE_TAIL_ENTRIES = 20
+const EXEC_COMMAND_DEFAULT_YIELD_TIME_MS = 10_000
+
+const ExecCommandParameters = z.object({
+  cmd: z.string().describe("Shell command to execute."),
+  yield_time_ms: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe(`Wait budget in milliseconds before the command is terminated. Defaults to ${EXEC_COMMAND_DEFAULT_YIELD_TIME_MS} ms.`),
+  workdir: z
+    .string()
+    .optional()
+    .describe("Working directory for the command. Defaults to the current session directory."),
+})
+
+const EXEC_COMMAND_DESCRIPTION =
+  "Runs a shell command through the permission-gated bash executor. `cmd` is required; `yield_time_ms` is optional and defaults to 10000 ms."
+
+function execCommandArgs(args: unknown) {
+  const input = ExecCommandParameters.parse(args)
+  return {
+    command: input.cmd,
+    timeout: input.yield_time_ms ?? EXEC_COMMAND_DEFAULT_YIELD_TIME_MS,
+    workdir: input.workdir,
+    description: input.cmd.length > 80 ? `${input.cmd.slice(0, 77)}...` : input.cmd,
+  }
+}
 
 /** JSON Schema (zod v4 toJSONSchema output) → compact TS type text. Best-effort:
  * anything unrecognized renders as `unknown`, which is safe for declarations. */
@@ -82,8 +110,10 @@ export function renderToolScriptDeclarations(defs: Tool.Def[]): string {
   const aliasLines = Object.entries(TOOL_SCRIPT_ALIASES).flatMap(([alias, target]) => {
     const def = defs.find((item) => item.id === target)
     if (!def) return []
-    const summary = def.description.split("\n").find((line) => line.trim()) ?? ""
-    const input = schemaToTs(z.toJSONSchema(def.parameters))
+    const summary = alias === "exec_command"
+      ? EXEC_COMMAND_DESCRIPTION
+      : def.description.split("\n").find((line) => line.trim()) ?? ""
+    const input = schemaToTs(z.toJSONSchema(alias === "exec_command" ? ExecCommandParameters : def.parameters))
     return [`  /** Alias for ${target}. ${summary.trim().slice(0, 180)} */\n  ${alias}(input: ${input}): Promise<ToolResult>`]
   })
   return [
@@ -401,7 +431,10 @@ export const ToolScriptTool = Tool.define(
             ...Object.entries(TOOL_SCRIPT_ALIASES).flatMap(([name, target]) => {
               const def = byId.get(target)
               if (!def) return []
-              return [{ name, description: `Alias for ${target}. ${def.description}` }]
+              return [{
+                name,
+                description: name === "exec_command" ? EXEC_COMMAND_DESCRIPTION : `Alias for ${target}. ${def.description}`,
+              }]
             }),
             ...[...mcpById.entries()].map(([name, tool]) => ({ name, description: tool.description ?? "" })),
           ]
@@ -486,6 +519,7 @@ export const ToolScriptTool = Tool.define(
             const def = byId.get(alias ?? id)
             const mcpDef = def ? undefined : mcpById.get(id)
             if (!def && !mcpDef) return Promise.reject(new Error(`unknown tool: ${id}`))
+            const toolArgs = id === "exec_command" ? execCommandArgs(args) : args
             calls++
             if (calls > maxToolCalls)
               return Promise.reject(new Error(`tool call budget exceeded (${maxToolCalls} per execution)`))
@@ -510,7 +544,7 @@ export const ToolScriptTool = Tool.define(
               Effect.tryPromise({
                 try: () =>
                   Promise.resolve(
-                    tool.execute!(args ?? {}, {
+                    tool.execute!(toolArgs ?? {}, {
                       toolCallId: subCtx.callID,
                       messages: [],
                       abortSignal: ctx.abort,
@@ -538,7 +572,7 @@ export const ToolScriptTool = Tool.define(
               )
             return withSlot(() =>
               bridge
-                .promise(def ? def.execute(args, subCtx) : executeMcp(mcpDef!))
+                .promise(def ? def.execute(toolArgs, subCtx) : executeMcp(mcpDef!))
                 .then(
                   (result) => {
                     trace.push({ name: id, status: "success", durationMs: Date.now() - start })

--- a/packages/opencode/src/tool/tool-script.txt
+++ b/packages/opencode/src/tool/tool-script.txt
@@ -21,7 +21,7 @@ const result = await tools[name]({
 return result.structured ?? result.output
 ```
 
-`mcp_tool_search` is not available inside `exec`. If the exact MCP name is unknown, inspect the read-only `ALL_TOOLS` catalog and dynamically call the matching name:
+If the exact MCP name is unknown, inspect the read-only `ALL_TOOLS` catalog and dynamically call the matching name:
 
 ```ts
 const tool = ALL_TOOLS.find(
@@ -36,7 +36,7 @@ The script environment provides JavaScript built-ins plus `tools`, `files`, and 
 
 - Call built-in tools, and other tool IDs that are valid JavaScript identifiers, with `await tools.name(input)`.
 - Search `ALL_TOOLS` names and descriptions for the capability you need, then call the exact catalog name with `await tools[name](input)`; the same permission checks as direct calls apply. Do not infer availability or MCP status from a name prefix.
-- Use `await tools.exec_command(...)` for shell commands. The runtime maps it to the `bash` tool, preserving its input validation, permissions, execution, timeout, and truncation behavior.
+- Use `await tools.exec_command({ cmd, yield_time_ms?, workdir? })` for shell commands. `yield_time_ms` defaults to 10000 ms. The runtime maps it to the `bash` tool, preserving its permissions, execution, timeout, and truncation behavior; commands still running when the wait budget expires are terminated.
 - MCP results carry parsed `structuredContent` in the `structured` field when the server provides it.
 - Use `Promise.all` or `Promise.allSettled` only for independent calls; at most 8 run concurrently.
 - Return a small JSON-serializable aggregate. Circular values, BigInt, and throwing getters fail execution.

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -332,25 +332,57 @@ describe("exec", () => {
   })
 
   test("exec_command maps to bash while direct bash remains backward compatible", async () => {
-    const seen: string[] = []
-    const defs = [
-      fakeDef("bash", async (args) => {
-        seen.push(args.value)
-        return `ran:${args.value}`
-      }),
-    ]
+    const seen: Array<{ command: string; timeout: number; description: string }> = []
+    const parameters = z.object({
+      command: z.string(),
+      timeout: z.number(),
+      workdir: z.string().optional(),
+      description: z.string(),
+    })
+    const bash: Tool.Def<typeof parameters> = {
+      id: "bash",
+      description: "fake bash",
+      parameters,
+      execute: (args) => {
+        seen.push({ command: args.command, timeout: args.timeout, description: args.description })
+        return Effect.succeed({ title: args.description, output: `ran:${args.command}`, metadata: {} })
+      },
+    }
     const result = await runToolScript(
       `return await Promise.all([
-        tools.bash({ value: "direct" }),
-        tools.exec_command({ value: "alias" }),
+        tools.bash({ command: "direct", timeout: 25000, description: "direct bash" }),
+        tools.exec_command({ cmd: "alias", yield_time_ms: 15000 }),
       ])`,
-      defs,
+      [bash],
     )
     expect(result.metadata.status).toBe("completed")
     expect(result.metadata.toolCalls).toBe(2)
     expect(result.output).toContain("ran:direct")
     expect(result.output).toContain("ran:alias")
-    expect(seen.toSorted()).toEqual(["alias", "direct"])
+    expect(seen).toEqual(expect.arrayContaining([
+      { command: "direct", timeout: 25000, description: "direct bash" },
+      { command: "alias", timeout: 15000, description: "alias" },
+    ]))
+  })
+
+  test("exec_command defaults yield_time_ms to 10000 ms", async () => {
+    const parameters = z.object({
+      command: z.string(),
+      timeout: z.number(),
+      workdir: z.string().optional(),
+      description: z.string(),
+    })
+    const bash: Tool.Def<typeof parameters> = {
+      id: "bash",
+      description: "fake bash",
+      parameters,
+      execute: (args) =>
+        Effect.succeed({ title: args.description, output: String(args.timeout), metadata: {} }),
+    }
+    const result = await runToolScript(`return await tools.exec_command({ cmd: "echo ok" })`, [bash])
+
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain('"output": "10000"')
   })
 
   test("lists exec_command instead of bash in the code-mode catalog", async () => {
@@ -658,6 +690,13 @@ describe("renderToolScriptDeclarations", () => {
     const text = renderToolScriptDeclarations([fakeDef("bash", async () => "x")])
     expect(text).toContain("exec_command(input:")
     expect(text).toContain("Alias for bash")
+    expect(text).toContain("cmd: string")
+    expect(text).toContain("yield_time_ms?: number")
+    expect(text).not.toContain("command: string")
+    expect(text).not.toContain("timeout?: number")
+    expect(text).not.toContain("interactive?: boolean")
+    const declaration = text.split("\n").find((line) => line.includes("exec_command(input:"))
+    expect(declaration).not.toContain("description:")
     expect(text).not.toContain("\n  bash(input:")
   })
 


### PR DESCRIPTION
## Summary

Define a typed `ExecCommandParameters` schema (`cmd`, `yield_time_ms`, `workdir`) so `exec_command` no longer leaks bash's internal parameter names to code-mode callers. The args are translated via `execCommandArgs` before dispatch.

## Changes

- Add `ExecCommandParameters` zod schema with `cmd`, `yield_time_ms`, and `workdir` fields
- Add `execCommandArgs()` helper that maps `{ cmd, yield_time_ms, workdir }` → `{ command, timeout, workdir, description }`
- Update generated type declarations to expose the new typed interface
- Update tool catalog description for `exec_command` to document the new parameters
- Update script guidance to reflect the new `{ cmd, yield_time_ms?, workdir? }` interface
- Add tests for parameter mapping and default `yield_time_ms` of 10000 ms

## Test plan

- [x] `exec_command` maps to bash while direct bash remains backward compatible
- [x] `exec_command` defaults `yield_time_ms` to 10000 ms
- [x] Generated declarations use the new parameter schema
- [x] Typecheck passes
