### PR TITLE
fix(provider): use 128K output defaults for large models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1393,7 +1393,16 @@ const layer: Layer.Layer<
                   return DEFAULT_CONTEXT_WINDOW
                 })(),
                 input: model.limit?.input ?? existingModel?.limit?.input,
-                output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
+                output:
+                  model.limit?.output ??
+                  existingModel?.limit?.output ??
+                  (ProviderTransform.usesLargeModelDefaults({
+                    id: modelID,
+                    providerID,
+                    api: { id: apiID },
+                  })
+                    ? ProviderTransform.LARGE_MODEL_OUTPUT_TOKEN_MAX
+                    : 0),
               },
               headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
               family: model.family ?? existingModel?.family ?? "",

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -25,7 +25,14 @@ function mimeToModality(mime: string): Modality | undefined {
 }
 
 export const OUTPUT_TOKEN_MAX = Flag.MIMOCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
-const MIMO_OUTPUT_TOKEN_MAX = 128_000
+export const LARGE_MODEL_OUTPUT_TOKEN_MAX = 128_000
+
+export function usesLargeModelDefaults(model: { id: string; providerID: string; api: { id: string } }) {
+  if (["mimo", "xiaomi"].includes(model.providerID.toLowerCase())) return true
+  return [model.id, model.api.id].some((id) =>
+    ["claude", "gpt", "mimo"].some((name) => id.toLowerCase().includes(name)),
+  )
+}
 
 // Maps npm package to the key the AI SDK expects for providerOptions
 function sdkKey(npm: string): string | undefined {
@@ -1841,9 +1848,7 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
 }
 
 export function maxOutputTokens(model: Provider.Model): number {
-  if (model.providerID === "mimo" || model.providerID === "xiaomi" || model.id.toLowerCase().includes("mimo")) {
-    return MIMO_OUTPUT_TOKEN_MAX
-  }
+  if (usesLargeModelDefaults(model)) return LARGE_MODEL_OUTPUT_TOKEN_MAX
   return Math.min(model.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
 }
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2124,7 +2124,7 @@ test("closest checks multiple query terms in order", async () => {
   })
 })
 
-test("model limit defaults to DEFAULT_CONTEXT_WINDOW (1M) when not specified (F41)", async () => {
+test("model limits use family defaults when not specified (F41)", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -2142,6 +2142,18 @@ test("model limit defaults to DEFAULT_CONTEXT_WINDOW (1M) when not specified (F4
                   tool_call: true,
                   // no limit specified
                 },
+                "claude-default": {
+                  name: "Claude",
+                  tool_call: true,
+                },
+                "gpt-default": {
+                  name: "GPT",
+                  tool_call: true,
+                },
+                "mimo-default": {
+                  name: "MiMo",
+                  tool_call: true,
+                },
               },
               options: { apiKey: "test" },
             },
@@ -2157,6 +2169,12 @@ test("model limit defaults to DEFAULT_CONTEXT_WINDOW (1M) when not specified (F4
       const model = providers[ProviderID.make("no-limit")].models["model"]
       expect(model.limit.context).toBe(1_000_000)
       expect(model.limit.output).toBe(0)
+      for (const id of ["claude-default", "gpt-default", "mimo-default"]) {
+        expect(providers[ProviderID.make("no-limit")].models[id].limit).toEqual({
+          context: 1_000_000,
+          output: 128_000,
+        })
+      }
     },
   })
 })
@@ -2942,4 +2960,3 @@ test("plugin config enabled and disabled providers are honored", async () => {
     },
   })
 })
-

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -169,6 +169,24 @@ describe("ProviderTransform.maxOutputTokens", () => {
     ).toBe(128_000)
   })
 
+  test("uses 128K for claude models", () => {
+    expect(
+      ProviderTransform.maxOutputTokens({
+        ...baseModel,
+        id: ModelID.make("claude-sonnet-4-6"),
+      }),
+    ).toBe(128_000)
+  })
+
+  test("uses 128K for gpt models", () => {
+    expect(
+      ProviderTransform.maxOutputTokens({
+        ...baseModel,
+        api: { ...baseModel.api, id: "gpt-5.6" },
+      }),
+    ).toBe(128_000)
+  })
+
   test("keeps the default cap for non-mimo models", () => {
     expect(ProviderTransform.maxOutputTokens({ ...baseModel, limit: { context: 1_000_000, output: 64_000 } })).toBe(
       32_000,


### PR DESCRIPTION
## Summary

- default Claude, GPT, MiMo, and Xiaomi model families to a 128K output limit when no explicit limit exists
- reuse the same family detection for runtime output-token capping
- preserve configured limits and existing defaults for other model families

## Verification

- bun test test/provider/provider.test.ts test/provider/transform.test.ts (340 pass)
- bun typecheck (packages/opencode)
- push hook: bun turbo typecheck (12/12 tasks successful)