### PR TITLE
fix(provider): align large-model output and compaction reserves

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -258,7 +258,8 @@ const InfoSchema = Schema.Struct({
         description: "Maximum number of tokens from recent turns to preserve verbatim after compaction",
       }),
       reserved: Schema.optional(NonNegativeInt).annotate({
-        description: "Token buffer for compaction. Leaves enough window to avoid overflow during compaction.",
+        description:
+          "Token buffer for compaction. Leaves enough window to avoid overflow during compaction (default: up to 33000, capped by the model's maximum output).",
       }),
       max_context: Schema.optional(Schema.Union([TokenQuantity, Schema.Record(Schema.String, TokenQuantity)])).annotate(
         {

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -4,7 +4,7 @@ import { ProviderTransform } from "@/provider"
 import { Log, Token, Wildcard } from "@/util"
 import type { MessageV2 } from "./message-v2"
 
-const COMPACTION_BUFFER = 20_000
+const COMPACTION_BUFFER = 33_000
 
 // Cap the output reservation so models with large output windows (e.g. 32K, 64K)
 // don't strangle the usable input window. 20K covers >99.99% of compaction

--- a/packages/opencode/test/session/overflow.test.ts
+++ b/packages/opencode/test/session/overflow.test.ts
@@ -36,7 +36,7 @@ function createModel(opts: {
       input: { text: true, image: false, audio: false, video: false },
       output: { text: true, image: false, audio: false, video: false },
     },
-    api: { npm: opts.npm ?? "@ai-sdk/anthropic" },
+    api: { id: opts.id ?? "test-model", npm: opts.npm ?? "@ai-sdk/anthropic" },
     options: {},
   } as Provider.Model
 }
@@ -576,15 +576,15 @@ describe("usable", () => {
     // 200K context with 32K output — without the cap, usable would be 200K - 32K = 168K.
     // With OUTPUT_CAP=20K, usable should be 200K - 20K - reserved.
     const model = createModel({ context: 200_000, output: 32_000 })
-    const cfg = mockCfg() // reserved defaults to min(20K, 32K) = 20K
-    expect(usable({ cfg, model })).toBe(160_000) // 200K - 20K (output cap) - 20K (reserved)
+    const cfg = mockCfg() // reserved defaults to min(33K, 32K) = 32K
+    expect(usable({ cfg, model })).toBe(148_000) // 200K - 20K (output cap) - 32K (reserved)
   })
 
   test("does not cap when model.limit.output is below 20K", () => {
     // 100K context with 8K output — output cap (20K) does not bite.
     // usable should be 100K - 8K - reserved.
     const model = createModel({ context: 100_000, output: 8_000 })
-    const cfg = mockCfg() // reserved defaults to min(20K, 8K) = 8K
+    const cfg = mockCfg() // reserved defaults to min(33K, 8K) = 8K
     expect(usable({ cfg, model })).toBe(84_000) // 100K - 8K (raw output, below cap) - 8K (reserved)
   })
 
@@ -603,11 +603,11 @@ describe("compaction.max_context", () => {
 
   test("no budget configured leaves the model window untouched", () => {
     const model = large()
-    expect(usable({ cfg: mockCfg(), model })).toBe(902_000)
+    expect(usable({ cfg: mockCfg(), model })).toBe(889_000)
     expect(contextWindow({ cfg: mockCfg(), model })).toEqual({
       hard: 922_000,
       effective: 922_000,
-      usable: 902_000,
+      usable: 889_000,
       source: "model",
     })
   })
@@ -618,19 +618,19 @@ describe("compaction.max_context", () => {
     expect(contextWindow({ cfg, model })).toEqual({
       hard: 922_000,
       effective: 300_000,
-      usable: 280_000,
+      usable: 267_000,
       source: "config",
     })
-    const tokens = { input: 280_000, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } as any
+    const tokens = { input: 267_000, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } as any
     expect(isOverflow({ cfg, tokens, model })).toBe(true)
-    const under = { input: 279_999, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } as any
+    const under = { input: 266_999, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } as any
     expect(isOverflow({ cfg, tokens: under, model })).toBe(false)
   })
 
   test("accepts a plain token count and a percentage", () => {
     const model = large()
-    expect(usable({ cfg: mockCfg({ max_context: 500_000 }), model })).toBe(480_000)
-    expect(usable({ cfg: mockCfg({ max_context: "50%" }), model })).toBe(441_000)
+    expect(usable({ cfg: mockCfg({ max_context: 500_000 }), model })).toBe(467_000)
+    expect(usable({ cfg: mockCfg({ max_context: "50%" }), model })).toBe(428_000)
   })
 
   test("never raises the window above the provider cap", () => {
@@ -646,19 +646,19 @@ describe("compaction.max_context", () => {
 
   test("matches per-model keys with wildcards, longest pattern wins", () => {
     const cfg = mockCfg({ max_context: { "test/gpt-5*": "300K", "test/gpt-5.6": "200K" } })
-    expect(usable({ cfg, model: large() })).toBe(180_000)
-    expect(usable({ cfg, model: createModel({ context: 1_050_000, input: 922_000, id: "gpt-5.4" }) })).toBe(280_000)
+    expect(usable({ cfg, model: large() })).toBe(167_000)
+    expect(usable({ cfg, model: createModel({ context: 1_050_000, input: 922_000, id: "gpt-5.4" }) })).toBe(267_000)
   })
 
   test("ignores keys that match no model", () => {
     const cfg = mockCfg({ max_context: { "openai/gpt-4o": "100K" } })
-    expect(usable({ cfg, model: large() })).toBe(902_000)
+    expect(usable({ cfg, model: large() })).toBe(889_000)
   })
 
   test("ignores a budget that leaves no room for the reserves", () => {
     const model = large()
-    expect(usable({ cfg: mockCfg({ max_context: 20_000 }), model })).toBe(902_000)
-    expect(usable({ cfg: mockCfg({ max_context: "not-a-budget" }), model })).toBe(902_000)
+    expect(usable({ cfg: mockCfg({ max_context: 20_000 }), model })).toBe(889_000)
+    expect(usable({ cfg: mockCfg({ max_context: "not-a-budget" }), model })).toBe(889_000)
   })
 
   test("keeps overflow handling disabled when the model reports no window", () => {
@@ -701,11 +701,11 @@ describe("util.token.parseQuantity", () => {
 describe("compaction.max_context reset sentinel", () => {
   test("0 restores the model window without a warning path", () => {
     const model = createModel({ context: 1_050_000, input: 922_000, id: "gpt-5.6" })
-    expect(usable({ cfg: mockCfg({ max_context: { "test/gpt-5.6": 0 } as any }), model })).toBe(902_000)
+    expect(usable({ cfg: mockCfg({ max_context: { "test/gpt-5.6": 0 } as any }), model })).toBe(889_000)
     expect(contextWindow({ cfg: mockCfg({ max_context: 0 }), model }).source).toBe("model")
     // The picker writes a number, but a hand-edited config may carry the string form.
-    expect(usable({ cfg: mockCfg({ max_context: { "test/gpt-5.6": "0" } }), model })).toBe(902_000)
-    expect(usable({ cfg: mockCfg({ max_context: "" }), model })).toBe(902_000)
+    expect(usable({ cfg: mockCfg({ max_context: { "test/gpt-5.6": "0" } }), model })).toBe(889_000)
+    expect(usable({ cfg: mockCfg({ max_context: "" }), model })).toBe(889_000)
   })
 })
 

--- a/packages/opencode/test/session/prune.test.ts
+++ b/packages/opencode/test/session/prune.test.ts
@@ -54,7 +54,7 @@ function createModel(opts: {
       input: { text: true, image: false, audio: false, video: false },
       output: { text: true, image: false, audio: false, video: false },
     },
-    api: { npm: opts.npm ?? "@ai-sdk/anthropic" },
+    api: { id: "test-model", npm: opts.npm ?? "@ai-sdk/anthropic" },
     options: {},
   } as Provider.Model
 }
@@ -287,7 +287,10 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
     config?: Partial<Config.Info>,
   ): Promise<A> {
     return Effect.runPromise(
-      provideTmpdirInstance(() => body, { config }).pipe(Effect.scoped, Effect.provide(harness.env)),
+      provideTmpdirInstance(() => body, { config: { compaction: { reserved: 20_000 }, ...config } }).pipe(
+        Effect.scoped,
+        Effect.provide(harness.env),
+      ),
     )
   }
 
@@ -438,7 +441,9 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
   // successor in the ladder, only for a failure whose class says a retry could
   // succeed, and only once the token count has grown by a full ladder step.
   //
-  // Arithmetic all four cases depend on, stated once. createModel({ context:
+  // Arithmetic all four cases depend on, stated once. The harness pins the
+  // compaction reserve at 20K so these recovery-gate tests remain about writer
+  // retries rather than changes to the product default. createModel({ context:
   // 100_000, output: 32_000 }) with no `limit.input` gives usable = 100_000 -
   // (min(20_000, 32_000) compaction reserve + min(32_000, 20_000) output
   // reserve) = 60_000, so maxAllowed = 60_000 - CHECKPOINT_RESERVED(13_000) =


### PR DESCRIPTION
## Summary
- use 128K output defaults for MiMo, Claude, and GPT-class large models when provider metadata omits an output limit
- increase the default compaction reserve from 20K to 33K while capping it by the model output limit
- update configuration documentation and provider/session test expectations

## Test plan
- `bun test test/session/overflow.test.ts test/session/prune.test.ts` — 67 passed, 0 failed
- `bun typecheck` in `packages/opencode` — passed
- push hook `bun turbo typecheck` — 12/12 tasks passed
- provider test attempt without the repository's required `--timeout 30000` — 338 passed, 2 hit Bun's 5-second default timeout; not rerun per request to push directly
