### PR TITLE
feat(session): support request-scoped execution profiles

### DIFF
--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -19,6 +19,7 @@ import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import { MessageV2 } from "@/session/message-v2"
+import type { VisibilityPolicy } from "@/skill/policy"
 import { SessionRetry } from "@/session/retry"
 import { Inbox } from "@/inbox"
 import { renderActorNotification } from "@/inbox/render"
@@ -244,6 +245,11 @@ export interface SpawnInput {
    * object is surfaced on AgentOutcome.structured.
    */
   format?: MessageV2.OutputFormat
+  executionProfile?: "claude" | "gpt"
+  system?: string
+  replaceAgentPrompt?: boolean
+  codexMode?: boolean
+  skillPolicy?: VisibilityPolicy
   /**
    * Fired SYNCHRONOUSLY with the freshly-allocated actorID inside the spawn
    * Effect — right after the actor is registered, BEFORE its work fiber detaches
@@ -336,6 +342,11 @@ export const layer = Layer.effect(
       source: "spawn" | "hook"
       provenance?: MessageV2.Provenance
       format?: MessageV2.OutputFormat
+      executionProfile?: "claude" | "gpt"
+      system?: string
+      replaceAgentPrompt?: boolean
+      codexMode?: boolean
+      skillPolicy?: VisibilityPolicy
     }) {
       const result = yield* sessionPrompt.prompt({
         sessionID: input.sessionID,
@@ -347,6 +358,11 @@ export const layer = Layer.effect(
         task_id: input.task_id,
         parts: [{ type: "text", text: input.task }],
         ...(input.format ? { format: input.format } : {}),
+        executionProfile: input.executionProfile,
+        system: input.system,
+        replaceAgentPrompt: input.replaceAgentPrompt,
+        codexMode: input.codexMode,
+        skillPolicy: input.skillPolicy,
       })
       // structured output (json_schema) takes precedence over finalText: when the
       // child produced a validated object it IS the authoritative result and the
@@ -391,6 +407,11 @@ export const layer = Layer.effect(
       // gate; specialized/system agents and peers create no user tasks.
       gateEligible?: boolean
       format?: MessageV2.OutputFormat
+      executionProfile?: "claude" | "gpt"
+      system?: string
+      replaceAgentPrompt?: boolean
+      codexMode?: boolean
+      skillPolicy?: VisibilityPolicy
       // When set, the child's work fiber runs under this InstanceContext (via
       // InstanceRef) instead of inheriting the spawner's. Used by peers placed
       // in their own git worktree so their tools resolve paths/write-boundary
@@ -812,6 +833,11 @@ export const layer = Layer.effect(
         lifecycle: input.lifecycle ?? "persistent",
         task_id: input.task_id,
         format: input.format,
+        executionProfile: input.executionProfile,
+        system: input.system,
+        replaceAgentPrompt: input.replaceAgentPrompt,
+        codexMode: input.codexMode,
+        skillPolicy: input.skillPolicy,
         ...(instanceRef ? { instanceRef } : {}),
       })
       if (!input.background) yield* Fiber.join(fiber).pipe(Effect.ignore)
@@ -869,6 +895,11 @@ export const layer = Layer.effect(
         task_id: input.task_id,
         gateEligible,
         format: input.format,
+        executionProfile: input.executionProfile,
+        system: input.system,
+        replaceAgentPrompt: input.replaceAgentPrompt,
+        codexMode: input.codexMode,
+        skillPolicy: input.skillPolicy,
       })
       if (input.onReady) yield* Effect.ignore(input.onReady({ actorID, sessionID: input.sessionID }))
       if (!input.background) yield* Fiber.join(fiber).pipe(Effect.ignore)

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -278,6 +278,18 @@ export type StreamRequest = StreamInput & {
   dropAssistantPrefill?: boolean
 }
 
+export function executionProfileSystemSections(
+  agentPrompt: string[],
+  additions: string[],
+  user: Pick<MessageV2.User, "replaceAgentPrompt" | "system">,
+) {
+  return [
+    ...(user.replaceAgentPrompt ? [] : agentPrompt),
+    ...additions,
+    ...(user.system ? [user.system] : []),
+  ]
+}
+
 export type Event = Result["fullStream"] extends AsyncIterable<infer T> ? T : never
 
 export interface Interface {
@@ -319,13 +331,11 @@ const live: Layer.Layer<
     }) {
       const system: string[] = []
       system.push(
-        [
-          ...SystemPrompt.agent(input.agent, input.model),
-          // any custom prompt passed into this call
-          ...input.system,
-          // any custom prompt from last user message
-          ...(input.user.system ? [input.user.system] : []),
-        ]
+        executionProfileSystemSections(
+          SystemPrompt.agent(input.agent, input.model),
+          input.system,
+          input.user,
+        )
           .filter((x) => x)
           .join("\n"),
       )

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -431,6 +431,14 @@ export const User = Base.extend({
     variant: z.string().optional(),
   }),
   system: z.string().optional(),
+  executionProfile: z.enum(["claude", "gpt"]).optional(),
+  replaceAgentPrompt: z.boolean().optional(),
+  codexMode: z.boolean().optional(),
+  skillPolicy: z.object({
+    includeMimocodeBundled: z.literal(true),
+    allowedDesktopSkillNames: z.array(z.string()),
+    explicitlySelectedSkillNames: z.array(z.string()),
+  }).optional(),
   tools: z.record(z.string(), z.boolean()).optional(),
   provenance: Provenance.optional(),
 }).meta({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -57,6 +57,7 @@ import {
   TEXT_NGRAM_RECOVERY_REPLAN,
 } from "../session/prompt/text-ngram-detection"
 import { builtinSkillRoot, matchDocumentSkills } from "@/skill/builtin/extract"
+import { VisibilityPolicy } from "@/skill/policy"
 import { ToolRegistry } from "../tool"
 import { MCP } from "../mcp"
 import { normalizeToolResult } from "../mcp/tool-result"
@@ -919,12 +920,13 @@ export const layer = Layer.effect(
     }) {
       const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
       if (!userMessage) return input.messages
+      const skillPolicy = userMessage.info.role === "user" ? userMessage.info.skillPolicy : undefined
 
       const runtimeAgent = {
         ...input.agent,
         permission: Agent.runtimePermission(input.agent, input.session.permission),
       }
-      const skills = yield* sys.skills(runtimeAgent)
+      const skills = yield* sys.skills(runtimeAgent, skillPolicy)
       const catalogText = skills
         ? ["<system-reminder>", SKILL_CATALOG_REMINDER_MARKER, skills, "</system-reminder>"].join("\n")
         : undefined
@@ -1005,7 +1007,7 @@ ${entries}
 
       // Sole injection point for skill bodies — free-text mentions ("/foo ... /bar") and slash-command
       // invocations alike. Only harness-generated synthetic parts count as already loaded.
-      const allSkills = yield* sys.available(runtimeAgent)
+      const allSkills = yield* sys.available(runtimeAgent, skillPolicy)
       if (allSkills.length > 0) {
         const loaded = new Set(
           userMessage.parts.flatMap((part) => {
@@ -1232,6 +1234,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       agentID?: string
       task_id?: string
       mcpContext: MCP.TurnContext
+      codexMode?: boolean
+      skillPolicy?: VisibilityPolicy
     }) {
       using _ = log.time("resolveTools")
       const tools: Record<string, AITool> = {}
@@ -1249,6 +1253,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const execMcp: { current: Record<string, AITool> } = { current: {} }
       const useMcpToolSearch = isMcpToolSearchEnabled(
         Flag.MIMOCODE_EXPERIMENTAL_MCP_TOOL_SEARCH,
+        input.codexMode,
         input.model.id,
         input.model.api.id,
         input.model.family,
@@ -1267,7 +1272,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         return new Set(actor.tools)
       })
       const whitelist = yield* whitelistFor()
-      const useGPTTools = usesGPTToolset(input.model.id)
+      const useGPTTools = usesGPTToolset(input.model.id, input.codexMode)
       const execAllowedByWhitelist =
         useGPTTools &&
         !!whitelist &&
@@ -1322,6 +1327,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           ...(whitelist ? { toolWhitelist: [...whitelist] } : {}),
           mcpToolSearch: mcpCatalog.current,
           execMcp,
+          skillPolicy: input.skillPolicy,
         },
         agent: input.agent.name,
         actorID: input.agentID,
@@ -1372,6 +1378,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         modelID: input.model.id,
         providerID: input.model.providerID,
         agent: input.agent,
+        codexMode: input.codexMode,
       })) {
         const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
         tools[item.id] = tool({
@@ -2224,6 +2231,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           variant,
         },
         system: input.system,
+        executionProfile: input.executionProfile,
+        replaceAgentPrompt: input.replaceAgentPrompt,
+        codexMode: input.codexMode,
+        skillPolicy: input.skillPolicy,
         format: input.format,
         provenance: input.provenance,
       }
@@ -3765,6 +3776,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               agentID: lastUser.agentID,
               task_id,
               mcpContext,
+              codexMode: lastUser.codexMode,
+              skillPolicy: lastUser.skillPolicy,
             })
             const tools = resolvedTools.tools
             const activeTools = resolvedTools.activeTools
@@ -4742,6 +4755,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         agent: userAgent,
         parts,
         variant: input.variant,
+        system: input.system,
+        executionProfile: input.executionProfile,
+        replaceAgentPrompt: input.replaceAgentPrompt,
+        codexMode: input.codexMode,
+        skillPolicy: input.skillPolicy,
       })
       yield* bus.publish(Command.Event.Executed, {
         name: input.command,
@@ -4863,6 +4881,10 @@ export const PromptInput = z.object({
     .describe("@deprecated tools and permissions have been merged, you can set permissions on the session itself now"),
   format: MessageV2.Format.optional(),
   system: z.string().optional(),
+  executionProfile: z.enum(["claude", "gpt"]).optional(),
+  replaceAgentPrompt: z.boolean().optional(),
+  codexMode: z.boolean().optional(),
+  skillPolicy: VisibilityPolicy.optional(),
   variant: z.string().optional(),
   parts: z.array(
     z.discriminatedUnion("type", [
@@ -4950,6 +4972,11 @@ export const CommandInput = z.object({
   arguments: z.string(),
   command: z.string(),
   variant: z.string().optional(),
+  system: z.string().optional(),
+  executionProfile: z.enum(["claude", "gpt"]).optional(),
+  replaceAgentPrompt: z.boolean().optional(),
+  codexMode: z.boolean().optional(),
+  skillPolicy: VisibilityPolicy.optional(),
   parts: z
     .array(
       z.discriminatedUnion("type", [

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -24,6 +24,7 @@ import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { Flag } from "@/flag/flag"
 import { usesMimoCodexMode } from "@/tool/gpt"
+import { applyVisibilityPolicy, type VisibilityPolicy } from "@/skill/policy"
 
 function renderGitResult(result: Git.Result, fallback = "(none)") {
   if (result.exitCode !== 0) return fallback
@@ -55,8 +56,8 @@ export function agent(agent: Agent.Info, model: Provider.Model) {
 
 export interface Interface {
   readonly environment: (model: Provider.Model, now: number) => Effect.Effect<string[]>
-  readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
-  readonly available: (agent?: Agent.Info) => Effect.Effect<Skill.Info[]>
+  readonly skills: (agent: Agent.Info, policy?: VisibilityPolicy) => Effect.Effect<string | undefined>
+  readonly available: (agent?: Agent.Info, policy?: VisibilityPolicy) => Effect.Effect<Skill.Info[]>
   readonly all: () => Effect.Effect<Skill.Info[]>
 }
 
@@ -169,10 +170,12 @@ export const layer = Layer.effect(
         return base
       }),
 
-      skills: Effect.fn("SystemPrompt.skills")(function* (agent: Agent.Info) {
+      skills: Effect.fn("SystemPrompt.skills")(function* (agent: Agent.Info, policy?: VisibilityPolicy) {
         if (Permission.disabled(["skill"], agent.permission).has("skill")) return
 
-        const list = yield* skill.modelInvocable(agent)
+        const list = policy
+          ? applyVisibilityPolicy(yield* skill.available(agent), policy)
+          : yield* skill.modelInvocable(agent)
 
         return [
           "Skills available in this session:",
@@ -185,8 +188,8 @@ export const layer = Layer.effect(
       // The user surface: authorization-filtered but NOT model-reachability
       // filtered, because it backs the mention scan that loads a skill the user
       // invoked explicitly. Do not switch this to modelInvocable.
-      available: Effect.fn("SystemPrompt.available")(function* (agent?: Agent.Info) {
-        return yield* skill.available(agent)
+      available: Effect.fn("SystemPrompt.available")(function* (agent?: Agent.Info, policy?: VisibilityPolicy) {
+        return applyVisibilityPolicy(yield* skill.available(agent), policy)
       }),
 
       all: Effect.fn("SystemPrompt.all")(function* () {

--- a/packages/opencode/src/skill/policy.ts
+++ b/packages/opencode/src/skill/policy.ts
@@ -1,0 +1,21 @@
+import z from "zod"
+import type { Info } from "."
+
+export const VisibilityPolicy = z.object({
+  includeMimocodeBundled: z.literal(true),
+  allowedDesktopSkillNames: z.array(z.string()),
+  explicitlySelectedSkillNames: z.array(z.string()),
+})
+export type VisibilityPolicy = z.infer<typeof VisibilityPolicy>
+
+export function applyVisibilityPolicy(skills: Info[], policy?: VisibilityPolicy) {
+  if (!policy) return skills
+  const desktop = new Set(policy.allowedDesktopSkillNames)
+  const explicit = new Set(policy.explicitlySelectedSkillNames)
+  return skills.filter((skill) => {
+    if (explicit.has(skill.name)) return true
+    if (skill.disable_model_invocation) return false
+    if (policy.includeMimocodeBundled && skill.bundled) return true
+    return desktop.has(skill.name)
+  })
+}

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -790,6 +790,8 @@ export const ActorTool = Tool.define(
         // the agent loop, and sending inbox notifications on terminal — replacing
         // the legacy session.create + manual fork path that lived here pre-Task-29.
         const actor = yield* requireActor()
+        const parentUser = ctx.messages.findLast((message) => message.info.role === "user")
+        const execution = parentUser?.info.role === "user" ? parentUser.info : undefined
         const spawnResult = yield* actor.spawn({
           mode: "subagent",
           sessionID: ctx.sessionID,
@@ -801,6 +803,11 @@ export const ActorTool = Tool.define(
           model,
           background,
           task_id: effectiveTaskId,
+          executionProfile: execution?.executionProfile,
+          system: execution?.system,
+          replaceAgentPrompt: execution?.replaceAgentPrompt,
+          codexMode: execution?.codexMode,
+          skillPolicy: execution?.skillPolicy,
           onReady: ({ actorID, sessionID }) =>
             ctx.metadata({
               title: op.description,

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -6,8 +6,8 @@ export function isGPTModel(...values: Array<string | undefined>) {
   return ids.some((id) => id.includes("gpt"))
 }
 
-export function isMcpToolSearchEnabled(enabled: boolean, ...modelIDs: Array<string | undefined>) {
-  return Flag.MIMOCODE_CODEX_MODE || enabled || isGPTModel(...modelIDs) || usesMimoCodexMode(...modelIDs)
+export function isMcpToolSearchEnabled(enabled: boolean, codexMode: boolean | undefined, ...modelIDs: Array<string | undefined>) {
+  return Flag.MIMOCODE_CODEX_MODE || codexMode === true || (codexMode !== false && (enabled || isGPTModel(...modelIDs) || usesMimoCodexMode(...modelIDs)))
 }
 
 export function usesMimoCodexMode(...values: Array<string | undefined>) {
@@ -16,10 +16,11 @@ export function usesMimoCodexMode(...values: Array<string | undefined>) {
   return ids.some((id) => /(?:^|[/_-])mimo(?:$|[/_.-])/.test(id))
 }
 
-export function usesGPTToolset(modelID: string) {
+export function usesGPTToolset(modelID: string, codexMode?: boolean) {
   return (
     Flag.MIMOCODE_CODEX_MODE ||
-    (modelID.includes("gpt-") && !modelID.includes("oss") && !modelID.includes("gpt-4")) ||
-    usesMimoCodexMode(modelID)
+    codexMode === true ||
+    (codexMode !== false && ((modelID.includes("gpt-") && !modelID.includes("oss") && !modelID.includes("gpt-4")) ||
+    usesMimoCodexMode(modelID)))
   )
 }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -120,11 +120,12 @@ export interface Interface {
   readonly ids: () => Effect.Effect<string[]>
   readonly all: () => Effect.Effect<Tool.Def[]>
   readonly named: () => Effect.Effect<{ actor: ActorDef; read: ReadDef }>
-  readonly tools: (model: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info }) => Effect.Effect<Tool.Def[]>
+  readonly tools: (model: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info; codexMode?: boolean }) => Effect.Effect<Tool.Def[]>
   readonly registered: (model: {
     providerID: ProviderID
     modelID: ModelID
     agent: Agent.Info
+    codexMode?: boolean
   }) => Effect.Effect<Tool.Def[]>
   readonly reload: () => Effect.Effect<void>
 }
@@ -359,8 +360,9 @@ export const layer = Layer.effect(
       providerID: ProviderID
       modelID: ModelID
       agent: Agent.Info
+      codexMode?: boolean
     }) {
-      const useGPTTools = usesGPTToolset(input.modelID)
+      const useGPTTools = usesGPTToolset(input.modelID, input.codexMode)
       let filtered = (yield* all()).filter((tool) => {
         if (tool.id === ToolScriptTool.id) return useGPTTools || Flag.MIMOCODE_ENABLE_EXEC_TOOL
         if (tool.id === CodeSearchTool.id || tool.id === WebSearchTool.id) {
@@ -432,7 +434,7 @@ export const layer = Layer.effect(
       input ? available(input).pipe(Effect.map((result) => result.filtered)) : all()
 
     const definitions = Effect.fn("ToolRegistry.definitions")(function* (
-      input: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info },
+      input: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info; codexMode?: boolean },
       includeHidden: boolean,
     ) {
       const availableTools = yield* available(input)

--- a/packages/opencode/src/tool/skill-search.ts
+++ b/packages/opencode/src/tool/skill-search.ts
@@ -7,6 +7,7 @@ import { Skill } from "../skill"
 import { searchSkills } from "../skill/search"
 import * as Tool from "./tool"
 import { renderSkillContent } from "./skill-content"
+import { applyVisibilityPolicy, type VisibilityPolicy } from "../skill/policy"
 
 const Parameters = z.object({
   query: z
@@ -33,7 +34,10 @@ export const SkillSearchTool = Tool.define(
       execute: (params: z.infer<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
           const agent = yield* agents.get(ctx.agent)
-          const available = yield* skill.modelInvocable(agent)
+          const policy = ctx.extra?.skillPolicy as VisibilityPolicy | undefined
+          const available = yield* (policy
+            ? skill.available(agent).pipe(Effect.map((items) => applyVisibilityPolicy(items, policy)))
+            : skill.modelInvocable(agent))
           const results = searchSkills(params.query, available)
           if (results.length === 0) {
             return {

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -7,6 +7,7 @@ import { BuiltinWorkflow } from "../workflow/builtin"
 import * as Tool from "./tool"
 import { renderSkillContent } from "./skill-content"
 import DESCRIPTION from "./skill.txt"
+import { applyVisibilityPolicy, type VisibilityPolicy } from "../skill/policy"
 
 const Parameters = z.object({
   name: z.string().describe("The name of the skill from available_skills"),
@@ -38,16 +39,29 @@ export const SkillTool = Tool.define(
             }
             // Same set the tool description advertises, so a near miss cannot
             // reveal a skill the model is not allowed to see.
-            const available = (yield* skill.modelInvocable(yield* agents.get(ctx.agent)))
+            const policy = ctx.extra?.skillPolicy as VisibilityPolicy | undefined
+            const agent = yield* agents.get(ctx.agent)
+            const available = (yield* (policy
+              ? skill.available(agent).pipe(Effect.map((items) => applyVisibilityPolicy(items, policy)))
+              : skill.modelInvocable(agent)))
               .map((item) => item.name)
               .join(", ")
             throw new Error(`Skill "${params.name}" not found. Available skills: ${available || "none"}`)
           }
 
+          const policy = ctx.extra?.skillPolicy as VisibilityPolicy | undefined
+          const agent = yield* agents.get(ctx.agent)
+          const allowed = (yield* (policy
+            ? skill.available(agent).pipe(Effect.map((items) => applyVisibilityPolicy(items, policy)))
+            : skill.modelInvocable(agent)
+          )).some((item) => item.name === info.name)
+          if (!allowed) throw new Error(`Skill "${info.name}" is not available in this execution profile.`)
+
           // Model reachability gate. The user can still load this skill by
           // typing /name; redirect there instead of dead-ending, so the model
           // reports the option rather than retrying and giving up.
-          if (info.disable_model_invocation) {
+          const explicit = policy?.explicitlySelectedSkillNames.includes(info.name)
+          if (info.disable_model_invocation && !explicit) {
             throw new Error(
               `Skill "${info.name}" sets disable-model-invocation, so it cannot be loaded with the skill tool. ` +
                 `Only the user can start it by typing /${info.name}. Do not retry this tool — tell the user to run ` +

--- a/packages/opencode/test/session/execution-profile-input.test.ts
+++ b/packages/opencode/test/session/execution-profile-input.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { CommandInput, PromptInput } from "../../src/session/prompt"
+import { executionProfileSystemSections } from "../../src/session/llm"
+
+const policy = {
+  includeMimocodeBundled: true as const,
+  allowedDesktopSkillNames: ["research"],
+  explicitlySelectedSkillNames: ["creative"],
+}
+
+describe("request-scoped execution profile input", () => {
+  test("prompt accepts the profile, prompt replacement, Codex mode, and skill policy together", () => {
+    const result = PromptInput.safeParse({
+      sessionID: "ses_test",
+      model: { providerID: "xiaomi", modelID: "mimo-v2.5-pro" },
+      parts: [{ type: "text", text: "hello" }],
+      system: "profile prompt",
+      executionProfile: "gpt",
+      replaceAgentPrompt: true,
+      codexMode: true,
+      skillPolicy: policy,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test("slash command accepts the same request-scoped profile contract", () => {
+    const result = CommandInput.safeParse({
+      sessionID: "ses_test",
+      command: "review",
+      arguments: "now",
+      system: "profile prompt",
+      executionProfile: "claude",
+      replaceAgentPrompt: true,
+      codexMode: false,
+      skillPolicy: policy,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test("rejects unknown profiles and unstructured skill policies", () => {
+    expect(PromptInput.safeParse({
+      sessionID: "ses_test",
+      parts: [{ type: "text", text: "hello" }],
+      executionProfile: "unknown",
+      skillPolicy: { allowedDesktopSkillNames: "research" },
+    }).success).toBe(false)
+  })
+
+  test("profile prompt replaces the agent personality but keeps dynamic additions", () => {
+    expect(executionProfileSystemSections(
+      ["desktop base"],
+      ["runtime guard"],
+      { replaceAgentPrompt: true, system: "gpt profile" },
+    )).toEqual(["runtime guard", "gpt profile"])
+    expect(executionProfileSystemSections(
+      ["desktop base"],
+      ["runtime guard"],
+      { replaceAgentPrompt: false, system: "turn system" },
+    )).toEqual(["desktop base", "runtime guard", "turn system"])
+  })
+})

--- a/packages/opencode/test/skill/visibility-policy.test.ts
+++ b/packages/opencode/test/skill/visibility-policy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { applyVisibilityPolicy } from "../../src/skill/policy"
+import type { Skill } from "../../src/skill"
+
+const item = (name: string, input: Partial<Skill.Info> = {}): Skill.Info => ({
+  name,
+  description: name,
+  location: `/skills/${name}/SKILL.md`,
+  content: name,
+  ...input,
+})
+
+describe("request-scoped skill visibility", () => {
+  test("keeps bundled defaults and allowed desktop skills", () => {
+    const result = applyVisibilityPolicy([
+      item("builtin", { bundled: true }),
+      item("desktop"),
+      item("hidden"),
+    ], {
+      includeMimocodeBundled: true,
+      allowedDesktopSkillNames: ["desktop"],
+      explicitlySelectedSkillNames: [],
+    })
+    expect(result.map((skill) => skill.name)).toEqual(["builtin", "desktop"])
+  })
+
+  test("explicit selection restores a filtered or model-disabled skill", () => {
+    const result = applyVisibilityPolicy([
+      item("creative", { disable_model_invocation: true }),
+      item("other"),
+    ], {
+      includeMimocodeBundled: true,
+      allowedDesktopSkillNames: [],
+      explicitlySelectedSkillNames: ["creative"],
+    })
+    expect(result.map((skill) => skill.name)).toEqual(["creative"])
+  })
+})

--- a/packages/opencode/test/tool/gpt.test.ts
+++ b/packages/opencode/test/tool/gpt.test.ts
@@ -29,18 +29,20 @@ describe("isGPTModel", () => {
 
 describe("isMcpToolSearchEnabled", () => {
   test("defaults to GPT models and allows explicit non-GPT opt-in", () => {
-    expect(isMcpToolSearchEnabled(false, "claude-opus-4-6")).toBe(false)
-    expect(isMcpToolSearchEnabled(false, "mimo-v2.5")).toBe(false)
-    expect(isMcpToolSearchEnabled(false, "mimo-v2.5-pro")).toBe(false)
-    expect(isMcpToolSearchEnabled(false, "mimo-v2.6")).toBe(true)
-    expect(isMcpToolSearchEnabled(false, "gpt-5.2")).toBe(true)
-    expect(isMcpToolSearchEnabled(false, "gpt-oss-120b")).toBe(false)
-    expect(isMcpToolSearchEnabled(true, "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "claude-opus-4-6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.5")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.5-pro")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "gpt-5.2")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "gpt-oss-120b")).toBe(false)
+    expect(isMcpToolSearchEnabled(true, undefined, "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, true, "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(true, false, "claude-opus-4-6")).toBe(false)
   })
 
   test("is enabled for non-GPT models in Codex mode", () => {
     process.env.MIMOCODE_CODEX_MODE = "true"
-    expect(isMcpToolSearchEnabled(false, "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "claude-opus-4-6")).toBe(true)
   })
 })
 
@@ -55,5 +57,10 @@ describe("usesGPTToolset", () => {
     expect(usesGPTToolset("claude-opus-4-6")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(usesGPTToolset("claude-opus-4-6")).toBe(true)
+  })
+
+  test("request-scoped mode overrides model inference", () => {
+    expect(usesGPTToolset("claude-opus-4-6", true)).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6", false)).toBe(false)
   })
 })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2412,6 +2412,14 @@ export class Session2 extends HeyApiClient {
       }
       format?: OutputFormat
       system?: string
+      executionProfile?: "claude" | "gpt"
+      replaceAgentPrompt?: boolean
+      codexMode?: boolean
+      skillPolicy?: {
+        includeMimocodeBundled: true
+        allowedDesktopSkillNames: Array<string>
+        explicitlySelectedSkillNames: Array<string>
+      }
       variant?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
@@ -2437,6 +2445,10 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "tools" },
             { in: "body", key: "format" },
             { in: "body", key: "system" },
+            { in: "body", key: "executionProfile" },
+            { in: "body", key: "replaceAgentPrompt" },
+            { in: "body", key: "codexMode" },
+            { in: "body", key: "skillPolicy" },
             { in: "body", key: "variant" },
             { in: "body", key: "parts" },
           ],
@@ -2554,6 +2566,14 @@ export class Session2 extends HeyApiClient {
       }
       format?: OutputFormat
       system?: string
+      executionProfile?: "claude" | "gpt"
+      replaceAgentPrompt?: boolean
+      codexMode?: boolean
+      skillPolicy?: {
+        includeMimocodeBundled: true
+        allowedDesktopSkillNames: Array<string>
+        explicitlySelectedSkillNames: Array<string>
+      }
       variant?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
@@ -2579,6 +2599,10 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "tools" },
             { in: "body", key: "format" },
             { in: "body", key: "system" },
+            { in: "body", key: "executionProfile" },
+            { in: "body", key: "replaceAgentPrompt" },
+            { in: "body", key: "codexMode" },
+            { in: "body", key: "skillPolicy" },
             { in: "body", key: "variant" },
             { in: "body", key: "parts" },
           ],
@@ -2613,6 +2637,15 @@ export class Session2 extends HeyApiClient {
       arguments?: string
       command?: string
       variant?: string
+      system?: string
+      executionProfile?: "claude" | "gpt"
+      replaceAgentPrompt?: boolean
+      codexMode?: boolean
+      skillPolicy?: {
+        includeMimocodeBundled: true
+        allowedDesktopSkillNames: Array<string>
+        explicitlySelectedSkillNames: Array<string>
+      }
       parts?: Array<{
         id?: string
         type: "file"
@@ -2638,6 +2671,11 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "arguments" },
             { in: "body", key: "command" },
             { in: "body", key: "variant" },
+            { in: "body", key: "system" },
+            { in: "body", key: "executionProfile" },
+            { in: "body", key: "replaceAgentPrompt" },
+            { in: "body", key: "codexMode" },
+            { in: "body", key: "skillPolicy" },
             { in: "body", key: "parts" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -997,6 +997,14 @@ export type UserMessage = {
     variant?: string
   }
   system?: string
+  executionProfile?: "claude" | "gpt"
+  replaceAgentPrompt?: boolean
+  codexMode?: boolean
+  skillPolicy?: {
+    includeMimocodeBundled: true
+    allowedDesktopSkillNames: Array<string>
+    explicitlySelectedSkillNames: Array<string>
+  }
   tools?: {
     [key: string]: boolean
   }
@@ -2218,7 +2226,7 @@ export type Config = {
      */
     preserve_recent_tokens?: number
     /**
-     * Token buffer for compaction. Leaves enough window to avoid overflow during compaction.
+     * Token buffer for compaction. Leaves enough window to avoid overflow during compaction (default: up to 33000, capped by the model's maximum output).
      */
     reserved?: number
     /**
@@ -4812,6 +4820,14 @@ export type SessionPromptData = {
     }
     format?: OutputFormat
     system?: string
+    executionProfile?: "claude" | "gpt"
+    replaceAgentPrompt?: boolean
+    codexMode?: boolean
+    skillPolicy?: {
+      includeMimocodeBundled: true
+      allowedDesktopSkillNames: Array<string>
+      explicitlySelectedSkillNames: Array<string>
+    }
     variant?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
@@ -5027,6 +5043,14 @@ export type SessionPromptAsyncData = {
     }
     format?: OutputFormat
     system?: string
+    executionProfile?: "claude" | "gpt"
+    replaceAgentPrompt?: boolean
+    codexMode?: boolean
+    skillPolicy?: {
+      includeMimocodeBundled: true
+      allowedDesktopSkillNames: Array<string>
+      explicitlySelectedSkillNames: Array<string>
+    }
     variant?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
@@ -5070,6 +5094,15 @@ export type SessionCommandData = {
     arguments: string
     command: string
     variant?: string
+    system?: string
+    executionProfile?: "claude" | "gpt"
+    replaceAgentPrompt?: boolean
+    codexMode?: boolean
+    skillPolicy?: {
+      includeMimocodeBundled: true
+      allowedDesktopSkillNames: Array<string>
+      explicitlySelectedSkillNames: Array<string>
+    }
     parts?: Array<{
       id?: string
       type: "file"


### PR DESCRIPTION
## Summary

- add request-scoped execution profile fields to prompt and slash-command inputs
- support per-request agent-prompt replacement, Codex tool mode, and Skill visibility policy without process-global state
- apply one Skill policy consistently to the catalog, mention loading, `skill`, and `skill_search`
- inherit the execution profile into spawned actors and regenerate the v2 SDK

## Tests

- `bun typecheck` in `packages/opencode`
- `bun test test/session/execution-profile-input.test.ts test/tool/gpt.test.ts test/skill/visibility-policy.test.ts`
- `bun test test/actor/spawn.test.ts test/tool/actor.test.ts`
- pre-push `bun turbo typecheck` (12/12 packages passed)