### PR TITLE
fix(skill): pdf-official CJK font protocol — verified TTF ladder, CID fallback, never Helvetica

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/SKILL.md
@@ -119,10 +119,16 @@ Route by the flags:
    reportlab** because Helvetica/Times/Courier don't ship those glyphs. Use
    `<sub>` / `<super>` XML in `Paragraph`, or move the pen manually on canvas.
    See [`compose.md`](compose.md) §5.
-4. **XFA forms are not AcroForms.** If `probe_fields.py` returns `[]` on a
+4. **CJK text renders as black boxes when the font never registered.**
+   reportlab does not consult the OS font system; a bad font name/path (思源黑体,
+   PingFang, Noto on machines that lack it) plus a swallowed exception means a
+   silent Helvetica fallback — and Helvetica has no CJK glyphs. Resolve fonts
+   with the ladder in [`compose.md`](compose.md) §4 (`resolve_cjk_font()`);
+   the terminal fallback is the built-in CID font, never Helvetica.
+5. **XFA forms are not AcroForms.** If `probe_fields.py` returns `[]` on a
    PDF that clearly has widgets in Adobe Reader, it's XFA — flatten it in
    Acrobat first.
-5. **`writer.encrypt(pw)` in pypdf uses RC4 by default**. For real AES-256,
+6. **`writer.encrypt(pw)` in pypdf uses RC4 by default**. For real AES-256,
    pass `algorithm="AES-256"`, or use `qpdf --encrypt … 256 --`.
 
 ## What's next

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/compose.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/compose.md
@@ -160,8 +160,8 @@ way a CJK PDF comes out unreadable, so:
 
 - **Never** reference a CJK font you have not verified on this machine.
   "Source Han Sans / 思源黑体 / Noto Sans CJK" are usually NOT installed;
-  macOS `PingFang.ttc` is not readable from the font dirs; Hiragino uses CFF
-  outlines reportlab's `TTFont` cannot parse.
+  macOS `PingFang.ttc` and `Hiragino Sans GB` are CFF-flavored OpenType —
+  reportlab's `TTFont` only parses TrueType (`glyf`) outlines and raises on CFF.
 - The terminal fallback for CJK is the built-in CID font — **never Helvetica**.
 
 Resolve the font with this ladder (first hit wins) and use the returned name
@@ -178,7 +178,7 @@ CJK_TTF_CANDIDATES = {
         "/System/Library/Fonts/STHeiti Light.ttc",        # sans; 简/繁/日
         "/System/Library/Fonts/STHeiti Medium.ttc",       # heavier weight
         "/System/Library/Fonts/Supplemental/Songti.ttc",  # serif; full 简, partial 繁
-        "/Library/Fonts/Arial Unicode.ttf",               # widest coverage incl. 한국어
+        "/Library/Fonts/Arial Unicode.ttf",               # widest coverage; macOS 11+ usually not preinstalled (comes with Office)
     ],
     "Windows": [
         r"C:\Windows\Fonts\msyh.ttc",    # 微软雅黑 sans
@@ -186,7 +186,9 @@ CJK_TTF_CANDIDATES = {
         r"C:\Windows\Fonts\simsun.ttc",  # 宋体 serif
     ],
     "Linux": [
-        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",       # Debian/Ubuntu
+        "/usr/share/fonts/google-noto-cjk/NotoSansCJK-Regular.ttc",     # Fedora/RHEL
+        "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",            # Arch
         "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc",
     ],
 }

--- a/packages/opencode/src/skill/builtin/.bundle/pdf-official/compose.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pdf-official/compose.md
@@ -149,23 +149,76 @@ pdfmetrics.registerFont(TTFont("Inter-Bold", "Inter-Bold.ttf"))
 c.setFont("Inter-Bold", 18)
 ```
 
-CJK: use the built-in CID fonts — no external files needed.
+### CJK (Chinese / Japanese / Korean) — mandatory protocol
+
+reportlab does not consult the OS font system: every non-builtin font must be
+registered from a real file on disk (or be a built-in CID font). A font name
+that never registered — or a `try/except` that swallows the registration
+failure — silently falls back to Helvetica, which has **no CJK glyphs**: the
+entire document renders as black boxes (tofu). This is the single most common
+way a CJK PDF comes out unreadable, so:
+
+- **Never** reference a CJK font you have not verified on this machine.
+  "Source Han Sans / 思源黑体 / Noto Sans CJK" are usually NOT installed;
+  macOS `PingFang.ttc` is not readable from the font dirs; Hiragino uses CFF
+  outlines reportlab's `TTFont` cannot parse.
+- The terminal fallback for CJK is the built-in CID font — **never Helvetica**.
+
+Resolve the font with this ladder (first hit wins) and use the returned name
+everywhere CJK text appears:
 
 ```python
+import os, platform
 from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfbase.cidfonts import UnicodeCIDFont
 
-pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
-c.setFont("STSong-Light", 14)
+CJK_TTF_CANDIDATES = {
+    "Darwin": [
+        "/System/Library/Fonts/STHeiti Light.ttc",        # sans; 简/繁/日
+        "/System/Library/Fonts/STHeiti Medium.ttc",       # heavier weight
+        "/System/Library/Fonts/Supplemental/Songti.ttc",  # serif; full 简, partial 繁
+        "/Library/Fonts/Arial Unicode.ttf",               # widest coverage incl. 한국어
+    ],
+    "Windows": [
+        r"C:\Windows\Fonts\msyh.ttc",    # 微软雅黑 sans
+        r"C:\Windows\Fonts\simhei.ttf",  # 黑体 sans
+        r"C:\Windows\Fonts\simsun.ttc",  # 宋体 serif
+    ],
+    "Linux": [
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc",
+    ],
+}
+
+def resolve_cjk_font():
+    for p in CJK_TTF_CANDIDATES.get(platform.system(), []):
+        if os.path.exists(p):
+            try:
+                pdfmetrics.registerFont(TTFont("CJK", p))
+                return "CJK"              # embedded -> renders on any device
+            except Exception:
+                continue                  # unparseable face: try the next one
+    pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
+    return "STSong-Light"                 # ships with reportlab, never fails
+
+CJK_FONT = resolve_cjk_font()
+c.setFont(CJK_FONT, 14)
 c.drawString(50, 700, "简体中文示例")
 ```
 
-For a **Platypus** document (the multi-page report flow above), the CID font
+A registered TTF/TTC is embedded in the PDF and renders everywhere. The CID
+fallback `STSong-Light` always registers (its data ships with reportlab) but
+is **not embedded** — most modern viewers map it, yet fidelity depends on the
+viewing machine. Prefer the TTF ladder; treat CID as the safety net.
+
+For a **Platypus** document (the multi-page report flow above), the CJK font
 must also be set on the styles, not just the canvas — otherwise `Paragraph` /
-`Table` flowables fall back to Helvetica and CJK becomes black boxes. After
-`registerFont(UnicodeCIDFont("STSong-Light"))`, set `fontName="STSong-Light"`
-on each `ParagraphStyle` carrying CJK text and add `("FONTNAME", (0,0), (-1,-1),
-"STSong-Light")` to the `TableStyle` of any table with CJK cells.
+`Table` flowables fall back to Helvetica and CJK becomes black boxes. Set
+`fontName=CJK_FONT` on each `ParagraphStyle` carrying CJK text and add
+`("FONTNAME", (0, 0), (-1, -1), CJK_FONT)` to the `TableStyle` of any table
+with CJK cells. Headers/footers drawn in the `build` callback (§3) need
+`canv.setFont(CJK_FONT, …)` too if they contain CJK.
 
 ## 5. Subscripts / superscripts / inline markup
 
@@ -300,6 +353,8 @@ scripts/sanity_check.py out.pdf                # open + round-trip clean?
 
 Common regressions caught by the eyeball step:
 
+- Every CJK character is a black box → the CJK font never registered and
+  reportlab fell back to Helvetica → §4 `resolve_cjk_font()`
 - Black rectangles where subscripts should be → §5
 - Truncated table columns → widen `colWidths` or shrink `fontSize`
 - Missing images → paths are relative to `cwd`, not to the output file


### PR DESCRIPTION
## Summary

pdf-official 技能(compose.md §4)未约束 CJK 字体注册路径,导致模型照搬 docx/pptx 字体名
(PingFang/思源黑体)直接传给 reportlab,注册必败 → try/except 吞异常 → 静默回落 Helvetica
(无 CJK 字形)→ 中文全渲染为黑色方块。

## Changes

- `compose.md` §4: 整段替换为强制 CJK 协议
  - per-OS 实测 TTF 阶梯(macOS: STHeiti/Songti/Arial Unicode; Windows: msyh/simhei/simsun; Linux: Noto CJK/wqy)
  - 全缺回落内置 CID STSong-Light,禁回落 Helvetica
  - Platypus 样式 + 页眉页脚回调须同步设 CJK_FONT
  - 列出已知失败字体(PingFang.ttc/Hiragino Sans GB/思源黑体)
- `SKILL.md`: Common gotchas 新增 #4 CJK 黑盒条目

## Verification

macOS 捆绑运行时(reportlab 4.2.5)实测:
- STHeiti Light.ttc 注册+嵌入 OK
- Songti.ttc 注册+嵌入 OK
- CID STSong-Light 注册 OK
- PingFang.ttc / Hiragino Sans GB 确认不可用(已排除)
- 真机验收:canvas + Platypus 简繁日零豆腐