### PR TITLE
feat(session): persist prompt and harness selection

### DIFF
--- a/packages/opencode/migration/20260821000000_session_prompt/migration.sql
+++ b/packages/opencode/migration/20260821000000_session_prompt/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `session` ADD COLUMN `prompt` text;

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -244,7 +244,12 @@ export const layer: Layer.Layer<
         throw new Error(`Compaction parent must be a user message: ${input.parentID}`)
       }
       const promptConfig = yield* session.resolvePrompt({ sessionID: input.sessionID })
-      const userMessage = { ...parent.info, system: promptConfig.system, harness: promptConfig.harness }
+      const userMessage = {
+        ...parent.info,
+        system: promptConfig.system,
+        systemMode: promptConfig.systemMode,
+        harness: promptConfig.harness,
+      }
       const compactionPart = parent.parts.find((part): part is MessageV2.CompactionPart => part.type === "compaction")
 
       // Truncate history at the previous compaction boundary so a repeat
@@ -433,6 +438,7 @@ export const layer: Layer.Layer<
             format: original.format,
             tools: original.tools,
             system: promptConfig.system,
+            systemMode: promptConfig.systemMode,
             harness: promptConfig.harness,
           })
           for (const part of replay.parts) {

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -246,8 +246,11 @@ export const layer: Layer.Layer<
       const promptConfig = yield* session.resolvePrompt({ sessionID: input.sessionID })
       const userMessage = {
         ...parent.info,
-        system: promptConfig.system,
-        systemMode: promptConfig.systemMode,
+        // The compaction agent owns its summarization prompt. The session's
+        // extra system prompt is already persisted and will be restored on the
+        // replay/next user turn; injecting it here can change the summary task.
+        system: undefined,
+        systemMode: undefined,
         harness: promptConfig.harness,
       }
       const compactionPart = parent.parts.find((part): part is MessageV2.CompactionPart => part.type === "compaction")

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -243,7 +243,8 @@ export const layer: Layer.Layer<
       if (!parent || parent.info.role !== "user") {
         throw new Error(`Compaction parent must be a user message: ${input.parentID}`)
       }
-      const userMessage = parent.info
+      const promptConfig = yield* session.resolvePrompt({ sessionID: input.sessionID })
+      const userMessage = { ...parent.info, system: promptConfig.system, harness: promptConfig.harness }
       const compactionPart = parent.parts.find((part): part is MessageV2.CompactionPart => part.type === "compaction")
 
       // Truncate history at the previous compaction boundary so a repeat
@@ -431,7 +432,8 @@ export const layer: Layer.Layer<
             model: original.model,
             format: original.format,
             tools: original.tools,
-            system: original.system,
+            system: promptConfig.system,
+            harness: promptConfig.harness,
           })
           for (const part of replay.parts) {
             if (part.type === "compaction") continue

--- a/packages/opencode/src/session/llm-request-prefix.ts
+++ b/packages/opencode/src/session/llm-request-prefix.ts
@@ -8,6 +8,7 @@ import type { Provider } from "../provider"
 import { LLM } from "./llm"
 import { ToolRegistry } from "../tool"
 import { ProviderTransform } from "../provider"
+import type { PromptConfig } from "./session"
 
 /**
  * Build the LLM request prefix (system + tools + inheritedMessages) from the
@@ -37,6 +38,7 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
    * order. Caller is responsible for the ordering and content.
    */
   additions: string[]
+  prompt?: PromptConfig
 }) {
   const llm = yield* LLM.Service
   const toolRegistry = yield* ToolRegistry.Service
@@ -50,7 +52,9 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
   const lastUserMsg = input.msgs.findLast((m) => m.info.role === "user")
   if (!lastUserMsg)
     return yield* Effect.die(new Error("buildLLMRequestPrefix: no user message in msgs"))
-  const lastUser = lastUserMsg.info as MessageV2.User
+  const lastUser = input.prompt
+    ? { ...(lastUserMsg.info as MessageV2.User), system: input.prompt.system, harness: input.prompt.harness }
+    : (lastUserMsg.info as MessageV2.User)
 
   // Build system using LLM.buildSystemArray (single source of truth shared with stream())
   const system = yield* llm.buildSystemArray({
@@ -67,6 +71,7 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
     modelID: input.model.id,
     providerID: input.model.providerID,
     agent: input.agent,
+    harness: lastUser.harness,
   })
   const tools: Record<string, AITool> = {}
   for (const item of toolDefs) {

--- a/packages/opencode/src/session/llm-request-prefix.ts
+++ b/packages/opencode/src/session/llm-request-prefix.ts
@@ -53,7 +53,12 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
   if (!lastUserMsg)
     return yield* Effect.die(new Error("buildLLMRequestPrefix: no user message in msgs"))
   const lastUser = input.prompt
-    ? { ...(lastUserMsg.info as MessageV2.User), system: input.prompt.system, harness: input.prompt.harness }
+    ? {
+        ...(lastUserMsg.info as MessageV2.User),
+        system: input.prompt.system,
+        systemMode: input.prompt.systemMode,
+        harness: input.prompt.harness,
+      }
     : (lastUserMsg.info as MessageV2.User)
 
   // Build system using LLM.buildSystemArray (single source of truth shared with stream())

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -321,7 +321,7 @@ const live: Layer.Layer<
       const system: string[] = []
       system.push(
         [
-          ...SystemPrompt.agent(input.agent, input.model),
+          ...SystemPrompt.agent(input.agent, input.model, input.user.harness),
           // any custom prompt passed into this call
           ...input.system,
           // any custom prompt from last user message

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -321,7 +321,9 @@ const live: Layer.Layer<
       const system: string[] = []
       system.push(
         [
-          ...SystemPrompt.agent(input.agent, input.model, input.user.harness),
+          ...(input.user.systemMode === "replace-agent"
+            ? []
+            : SystemPrompt.agent(input.agent, input.model, input.user.harness)),
           // any custom prompt passed into this call
           ...input.system,
           // any custom prompt from last user message

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -431,6 +431,7 @@ export const User = Base.extend({
     variant: z.string().optional(),
   }),
   system: z.string().optional(),
+  harness: z.enum(["codex", "default"]).optional(),
   tools: z.record(z.string(), z.boolean()).optional(),
   provenance: Provenance.optional(),
 }).meta({

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -431,7 +431,8 @@ export const User = Base.extend({
     variant: z.string().optional(),
   }),
   system: z.string().optional(),
-  harness: z.enum(["codex", "default"]).optional(),
+  systemMode: z.enum(["append", "replace-agent"]).optional(),
+  harness: z.enum(["auto", "codex", "default"]).optional(),
   tools: z.record(z.string(), z.boolean()).optional(),
   provenance: Provenance.optional(),
 }).meta({

--- a/packages/opencode/src/session/projectors.ts
+++ b/packages/opencode/src/session/projectors.ts
@@ -55,6 +55,7 @@ export function toPartialRow(info: DeepPartial<Session.Info>) {
     summary_diffs: grab(info, "summary", (v) => grab(v, "diffs")),
     revert: grab(info, "revert"),
     permission: grab(info, "permission"),
+    prompt: grab(info, "prompt"),
     time_created: grab(info, "time", (v) => grab(v, "created")),
     time_updated: grab(info, "time", (v) => grab(v, "updated")),
     time_compacting: grab(info, "time", (v) => grab(v, "compacting")),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4908,7 +4908,7 @@ export const PromptInput = z.object({
     .enum(["auto", "codex", "default"])
     .optional()
     .describe(
-      "Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference; explicit default forces the native tool schema.",
+      "Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
     ),
   variant: z.string().optional(),
   parts: z.array(
@@ -5008,7 +5008,9 @@ export const CommandInput = z.object({
   harness: z
     .enum(["auto", "codex", "default"])
     .optional()
-    .describe("Harness mode selected by the session's first user command. Later values are ignored."),
+    .describe(
+      "Harness mode selected by the session's first user command. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
+    ),
   parts: z
     .array(
       z.discriminatedUnion("type", [

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2231,6 +2231,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           variant,
         },
         system: input.system,
+        systemMode: input.systemMode,
         harness: input.harness,
         format: input.format,
         provenance: input.provenance,
@@ -2532,10 +2533,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const prompt = yield* sessions.resolvePrompt({
         sessionID: input.sessionID,
         ...(parts.some((part) => !("synthetic" in part) || !part.synthetic)
-          ? { fallback: { system: input.system, harness: input.harness } }
+          ? { fallback: { system: input.system, systemMode: input.systemMode, harness: input.harness } }
           : {}),
       })
-      const message: MessageV2.User = { ...info, system: prompt.system, harness: prompt.harness }
+      const message: MessageV2.User = {
+        ...info,
+        system: prompt.system,
+        systemMode: prompt.systemMode,
+        harness: prompt.harness,
+      }
 
       yield* plugin.trigger(
         "chat.message",
@@ -3356,7 +3362,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
-          lastUser = { ...lastUser, system: sessionPrompt.system, harness: sessionPrompt.harness }
+          lastUser = {
+            ...lastUser,
+            system: sessionPrompt.system,
+            systemMode: sessionPrompt.systemMode,
+            harness: sessionPrompt.harness,
+          }
           const usageRecovered =
             !!lastFinished &&
             msgs.some(
@@ -4762,6 +4773,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         agent: userAgent,
         parts,
         variant: input.variant,
+        system: input.system,
+        systemMode: input.systemMode,
+        harness: input.harness,
       })
       yield* bus.publish(Command.Event.Executed, {
         name: input.command,
@@ -4886,11 +4900,15 @@ export const PromptInput = z.object({
     .string()
     .optional()
     .describe("Additional system prompt selected by the session's first user query. Later values are ignored."),
+  systemMode: z
+    .enum(["append", "replace-agent"])
+    .optional()
+    .describe("Whether the selected system prompt appends to or replaces the agent prompt. Later values are ignored."),
   harness: z
-    .enum(["codex", "default"])
+    .enum(["auto", "codex", "default"])
     .optional()
     .describe(
-      "Harness mode selected by the session's first user query. Later values are ignored. Explicit default overrides the process-wide Codex mode flag.",
+      "Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference; explicit default forces the native tool schema.",
     ),
   variant: z.string().optional(),
   parts: z.array(
@@ -4979,6 +4997,18 @@ export const CommandInput = z.object({
   arguments: z.string(),
   command: z.string(),
   variant: z.string().optional(),
+  system: z
+    .string()
+    .optional()
+    .describe("Additional system prompt selected by the session's first user command. Later values are ignored."),
+  systemMode: z
+    .enum(["append", "replace-agent"])
+    .optional()
+    .describe("Whether the selected system prompt appends to or replaces the agent prompt. Later values are ignored."),
+  harness: z
+    .enum(["auto", "codex", "default"])
+    .optional()
+    .describe("Harness mode selected by the session's first user command. Later values are ignored."),
   parts: z
     .array(
       z.discriminatedUnion("type", [

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -311,9 +311,11 @@ export const layer = Layer.effect(
         // parity, so fall through to empty rather than emit a divergent date.
         const captureSession = yield* sessions.get(input.sessionID).pipe(Effect.catch(() => Effect.succeed(undefined)))
         if (!captureSession) return empty
+        const capturePrompt = yield* sessions.resolvePrompt({ sessionID: input.sessionID })
+        const captureMessages = input.msgs as MessageV2.WithParts[]
         const [env, instructions] = yield* Effect.all([
           Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
-            ? sys.environment(model, captureSession.time.created)
+            ? sys.environment(model, captureSession.time.created, capturePrompt.harness)
             : Effect.succeed([]),
           instruction.system().pipe(Effect.orDie),
         ])
@@ -324,8 +326,9 @@ export const layer = Layer.effect(
           sessionID: input.sessionID,
           agent: ag,
           model,
-          msgs: input.msgs as Parameters<typeof buildLLMRequestPrefix>[0]["msgs"],
+          msgs: captureMessages,
           additions,
+          prompt: capturePrompt,
         }).pipe(
           Effect.provideService(LLM.Service, llm),
           Effect.provideService(ToolRegistry.Service, registry),
@@ -1232,6 +1235,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       agentID?: string
       task_id?: string
       mcpContext: MCP.TurnContext
+      harness?: MessageV2.User["harness"]
     }) {
       using _ = log.time("resolveTools")
       const tools: Record<string, AITool> = {}
@@ -1249,6 +1253,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const execMcp: { current: Record<string, AITool> } = { current: {} }
       const useMcpToolSearch = isMcpToolSearchEnabled(
         Flag.MIMOCODE_EXPERIMENTAL_MCP_TOOL_SEARCH,
+        input.harness,
         input.model.id,
         input.model.api.id,
         input.model.family,
@@ -1267,7 +1272,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         return new Set(actor.tools)
       })
       const whitelist = yield* whitelistFor()
-      const useGPTTools = usesGPTToolset(input.model.id)
+      const useGPTTools = usesGPTToolset(input.model.id, input.harness)
       const execAllowedByWhitelist =
         useGPTTools &&
         !!whitelist &&
@@ -1317,6 +1322,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         callID: options.toolCallId,
         extra: {
           model: input.model,
+          harness: input.harness,
           bypassAgentCheck: input.bypassAgentCheck,
           promptOps,
           ...(whitelist ? { toolWhitelist: [...whitelist] } : {}),
@@ -1372,6 +1378,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         modelID: input.model.id,
         providerID: input.model.providerID,
         agent: input.agent,
+        harness: input.harness,
       })) {
         const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
         tools[item.id] = tool({
@@ -2224,6 +2231,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           variant,
         },
         system: input.system,
+        harness: input.harness,
         format: input.format,
         provenance: input.provenance,
       }
@@ -2521,6 +2529,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         return { info, parts: [] }
       }
 
+      const prompt = yield* sessions.resolvePrompt({
+        sessionID: input.sessionID,
+        ...(parts.some((part) => !("synthetic" in part) || !part.synthetic)
+          ? { fallback: { system: input.system, harness: input.harness } }
+          : {}),
+      })
+      const message: MessageV2.User = { ...info, system: prompt.system, harness: prompt.harness }
+
       yield* plugin.trigger(
         "chat.message",
         {
@@ -2530,10 +2546,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           messageID: input.messageID,
           variant: input.variant,
         },
-        { message: info, parts },
+        { message, parts },
       )
 
-      const parsed = MessageV2.Info.safeParse(info)
+      const parsed = MessageV2.Info.safeParse(message)
       if (!parsed.success) {
         log.error("invalid user message before save", {
           sessionID: input.sessionID,
@@ -2557,10 +2573,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         })
       })
 
-      yield* sessions.updateMessage(info)
+      yield* sessions.updateMessage(message)
       for (const part of parts) yield* sessions.updatePart(part)
 
-      return { info, parts }
+      return { info: message, parts }
     }, Effect.scoped)
 
     const sweepOrphanAssistants = Effect.fn("SessionPrompt.sweepOrphanAssistants")(function* (
@@ -2733,6 +2749,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         const slog = elog.with({ sessionID })
         let structured: unknown | undefined
         let step = 0
+        const sessionPrompt = yield* sessions.resolvePrompt({ sessionID })
         const session = yield* sessions.get(sessionID)
         let lastFinishedForPrune: MessageV2.Assistant | undefined
         let lastModelForPrune: Provider.Model | undefined
@@ -3339,6 +3356,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
+          lastUser = { ...lastUser, system: sessionPrompt.system, harness: sessionPrompt.harness }
           const usageRecovered =
             !!lastFinished &&
             msgs.some(
@@ -3765,6 +3783,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               agentID: lastUser.agentID,
               task_id,
               mcpContext,
+              harness: lastUser.harness,
             })
             const tools = resolvedTools.tools
             const activeTools = resolvedTools.activeTools
@@ -4025,7 +4044,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             const [env, instructions] = yield* Effect.all([
               Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
-                ? sys.environment(model, session.time.created)
+                ? sys.environment(model, session.time.created, sessionPrompt.harness)
                 : Effect.succeed([]),
               instruction.system().pipe(Effect.orDie),
             ])
@@ -4061,6 +4080,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 model,
                 msgs,
                 additions,
+                prompt: sessionPrompt,
               }).pipe(
                 Effect.provideService(LLM.Service, llm),
                 Effect.provideService(ToolRegistry.Service, registry),
@@ -4862,7 +4882,16 @@ export const PromptInput = z.object({
     .optional()
     .describe("@deprecated tools and permissions have been merged, you can set permissions on the session itself now"),
   format: MessageV2.Format.optional(),
-  system: z.string().optional(),
+  system: z
+    .string()
+    .optional()
+    .describe("Additional system prompt selected by the session's first user query. Later values are ignored."),
+  harness: z
+    .enum(["codex", "default"])
+    .optional()
+    .describe(
+      "Harness mode selected by the session's first user query. Later values are ignored. Explicit default overrides the process-wide Codex mode flag.",
+    ),
   variant: z.string().optional(),
   parts: z.array(
     z.discriminatedUnion("type", [

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -34,6 +34,7 @@ export const SessionTable = sqliteTable(
     summary_diffs: text({ mode: "json" }).$type<Snapshot.FileDiff[]>(),
     revert: text({ mode: "json" }).$type<{ messageID: MessageID; partID?: PartID; snapshot?: string; diff?: string }>(),
     permission: text({ mode: "json" }).$type<Permission.Ruleset>(),
+    prompt: text({ mode: "json" }).$type<{ system?: string; harness: "codex" | "default" }>(),
     ...Timestamps,
     time_compacting: integer(),
     time_archived: integer(),

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -34,7 +34,11 @@ export const SessionTable = sqliteTable(
     summary_diffs: text({ mode: "json" }).$type<Snapshot.FileDiff[]>(),
     revert: text({ mode: "json" }).$type<{ messageID: MessageID; partID?: PartID; snapshot?: string; diff?: string }>(),
     permission: text({ mode: "json" }).$type<Permission.Ruleset>(),
-    prompt: text({ mode: "json" }).$type<{ system?: string; harness: "codex" | "default" }>(),
+    prompt: text({ mode: "json" }).$type<{
+      system?: string
+      systemMode?: "append" | "replace-agent"
+      harness: "auto" | "codex" | "default"
+    }>(),
     ...Timestamps,
     time_compacting: integer(),
     time_archived: integer(),

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -30,12 +30,21 @@ import { Permission } from "@/permission"
 import { forwardRef } from "@/permission/permission-forward-ref"
 import { Global } from "@/global"
 import { ActorRegistry } from "@/actor/registry"
-import { Effect, Layer, Option, Context } from "effect"
+import { Effect, Layer, Option, Context, Semaphore } from "effect"
 
 const log = Log.create({ service: "session" })
 
 const parentTitlePrefix = "New session - "
 const childTitlePrefix = "Child session - "
+const promptLocks = new Map<SessionID, Semaphore.Semaphore>()
+
+function promptLock(sessionID: SessionID) {
+  const current = promptLocks.get(sessionID)
+  if (current) return current
+  const next = Semaphore.makeUnsafe(1)
+  promptLocks.set(sessionID, next)
+  return next
+}
 
 function createDefaultTitle(isChild = false) {
   return (isChild ? childTitlePrefix : parentTitlePrefix) + new Date().toISOString()
@@ -76,6 +85,7 @@ export function fromRow(row: SessionRow): Info {
     share,
     revert,
     permission: row.permission ?? undefined,
+    prompt: row.prompt ?? undefined,
     time: {
       created: row.time_created,
       updated: row.time_updated,
@@ -104,6 +114,7 @@ export function toRow(info: Info) {
     summary_diffs: info.summary?.diffs,
     revert: info.revert ?? null,
     permission: info.permission,
+    prompt: info.prompt ?? null,
     time_created: info.time.created,
     time_updated: info.time.updated,
     time_compacting: info.time.compacting,
@@ -120,6 +131,12 @@ function getForkedTitle(title: string): string {
   }
   return `${title} (fork #1)`
 }
+
+export const PromptConfig = z.object({
+  system: z.string().optional(),
+  harness: z.enum(["codex", "default"]),
+})
+export type PromptConfig = z.output<typeof PromptConfig>
 
 export const Info = z
   .object({
@@ -153,6 +170,7 @@ export const Info = z
       archived: z.number().optional(),
     }),
     permission: Permission.Ruleset.zod.optional(),
+    prompt: PromptConfig.optional(),
     revert: z
       .object({
         messageID: MessageID.zod,
@@ -385,6 +403,10 @@ export interface Interface {
   readonly setTitle: (input: { sessionID: SessionID; title: string }) => Effect.Effect<void>
   readonly setArchived: (input: { sessionID: SessionID; time?: number }) => Effect.Effect<void>
   readonly setPermission: (input: { sessionID: SessionID; permission: Permission.Ruleset }) => Effect.Effect<void>
+  readonly resolvePrompt: (input: {
+    sessionID: SessionID
+    fallback?: Partial<PromptConfig>
+  }) => Effect.Effect<PromptConfig>
   readonly setRevert: (input: {
     sessionID: SessionID
     revert: Info["revert"]
@@ -461,6 +483,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
       workspaceID?: WorkspaceID
       directory: string
       permission?: Permission.Ruleset
+      prompt?: PromptConfig
     }) {
       const ctx = yield* InstanceState.context
       const result: Info = {
@@ -475,6 +498,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
         contextWatermark: input.contextWatermark,
         title: input.title ?? createDefaultTitle(!!input.parentID),
         permission: input.permission,
+        prompt: input.prompt,
         time: {
           created: Date.now(),
           updated: Date.now(),
@@ -580,6 +604,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
           // process. Cleared here — the removal point — since a deleted session
           // can no longer have background children that need to inherit from it.
           forwardRef.clearParentGrants(sessionID)
+          promptLocks.delete(sessionID)
         })
       } catch (e) {
         log.error(e)
@@ -649,6 +674,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
         directory,
         title: input?.title,
         permission: input?.permission,
+        prompt: input?.parentID ? (yield* get(input.parentID)).prompt : undefined,
         workspaceID: workspace,
       })
     })
@@ -661,6 +687,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
         directory,
         workspaceID: original.workspaceID,
         title,
+        prompt: original.prompt,
       })
       const msgs = yield* messages({ sessionID: input.sessionID, agentID: "*" })
       const idMap = new Map<string, MessageID>()
@@ -710,6 +737,40 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
       permission: Permission.Ruleset
     }) {
       yield* patch(input.sessionID, { permission: input.permission, time: { updated: Date.now() } })
+    })
+
+    const resolvePrompt = Effect.fn("Session.resolvePrompt")(function (input: {
+      sessionID: SessionID
+      fallback?: Partial<PromptConfig>
+    }) {
+      return promptLock(input.sessionID).withPermits(1)(
+        Effect.gen(function* () {
+          const session = yield* get(input.sessionID)
+          if (session.prompt) return session.prompt
+          const firstUser = (yield* messages({ sessionID: input.sessionID })).find(
+            (message) =>
+              message.info.role === "user" &&
+              message.parts.some((part) => !("synthetic" in part) || !part.synthetic),
+          )
+          if (firstUser?.info.role === "user") {
+            const prompt: PromptConfig = {
+              system: firstUser.info.system,
+              harness: firstUser.info.harness ?? (Flag.MIMOCODE_CODEX_MODE ? "codex" : "default"),
+            }
+            if (input.fallback) yield* patch(input.sessionID, { prompt })
+            return prompt
+          }
+          if (input.fallback) {
+            const prompt: PromptConfig = {
+              system: input.fallback.system,
+              harness: input.fallback.harness ?? (Flag.MIMOCODE_CODEX_MODE ? "codex" : "default"),
+            }
+            yield* patch(input.sessionID, { prompt })
+            return prompt
+          }
+          return { harness: Flag.MIMOCODE_CODEX_MODE ? "codex" : "default" } satisfies PromptConfig
+        }),
+      )
     })
 
     const setRevert = Effect.fn("Session.setRevert")(function* (input: {
@@ -826,6 +887,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
       setTitle,
       setArchived,
       setPermission,
+      resolvePrompt,
       setRevert,
       clearRevert,
       setSummary,

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -85,7 +85,7 @@ export function fromRow(row: SessionRow): Info {
     share,
     revert,
     permission: row.permission ?? undefined,
-    prompt: row.prompt ?? undefined,
+    prompt: row.prompt ? PromptConfig.parse(row.prompt) : undefined,
     time: {
       created: row.time_created,
       updated: row.time_updated,
@@ -134,7 +134,8 @@ function getForkedTitle(title: string): string {
 
 export const PromptConfig = z.object({
   system: z.string().optional(),
-  harness: z.enum(["codex", "default"]),
+  systemMode: z.enum(["append", "replace-agent"]).default("append"),
+  harness: z.enum(["auto", "codex", "default"]),
 })
 export type PromptConfig = z.output<typeof PromptConfig>
 
@@ -755,7 +756,8 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
           if (firstUser?.info.role === "user") {
             const prompt: PromptConfig = {
               system: firstUser.info.system,
-              harness: firstUser.info.harness ?? (Flag.MIMOCODE_CODEX_MODE ? "codex" : "default"),
+              systemMode: firstUser.info.systemMode ?? "append",
+              harness: firstUser.info.harness ?? "auto",
             }
             if (input.fallback) yield* patch(input.sessionID, { prompt })
             return prompt
@@ -763,12 +765,16 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
           if (input.fallback) {
             const prompt: PromptConfig = {
               system: input.fallback.system,
-              harness: input.fallback.harness ?? (Flag.MIMOCODE_CODEX_MODE ? "codex" : "default"),
+              systemMode: input.fallback.systemMode ?? "append",
+              harness: input.fallback.harness ?? "auto",
             }
             yield* patch(input.sessionID, { prompt })
             return prompt
           }
-          return { harness: Flag.MIMOCODE_CODEX_MODE ? "codex" : "default" } satisfies PromptConfig
+          return {
+            systemMode: "append",
+            harness: "auto",
+          } satisfies PromptConfig
         }),
       )
     })

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -23,7 +23,7 @@ import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { Flag } from "@/flag/flag"
-import { type HarnessMode, usesMimoCodexMode } from "@/tool/gpt"
+import { type HarnessMode, isGPTModel, usesMimoCodexMode } from "@/tool/gpt"
 
 function renderGitResult(result: Git.Result, fallback = "(none)") {
   if (result.exitCode !== 0) return fallback
@@ -35,9 +35,9 @@ const anthropicEnvironment = new Map<string, string>()
 export function provider(model: Provider.Model, harness?: HarnessMode) {
   if (harness === "codex" || ((harness === undefined || harness === "auto") && Flag.MIMOCODE_CODEX_MODE)) return [PROMPT_GPT]
   const prompt = (id: string) => {
-    if (harness !== "default" && usesMimoCodexMode(id)) return PROMPT_GPT
+    if (isGPTModel(id)) return PROMPT_GPT
+    if (usesMimoCodexMode(id)) return harness === "default" ? PROMPT_DEFAULT : PROMPT_GPT
     if (id.includes("gpt-4") || id.includes("o1") || id.includes("o3")) return PROMPT_BEAST
-    if (id.includes("gpt")) return PROMPT_GPT
     if (id.includes("gemini-")) return PROMPT_GEMINI
     if (id.includes("claude")) return PROMPT_ANTHROPIC
     if (id.toLowerCase().includes("trinity")) return PROMPT_TRINITY

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -33,9 +33,9 @@ function renderGitResult(result: Git.Result, fallback = "(none)") {
 const anthropicEnvironment = new Map<string, string>()
 
 export function provider(model: Provider.Model, harness?: HarnessMode) {
-  if (harness === "codex" || (harness === undefined && Flag.MIMOCODE_CODEX_MODE)) return [PROMPT_GPT]
+  if (harness === "codex" || ((harness === undefined || harness === "auto") && Flag.MIMOCODE_CODEX_MODE)) return [PROMPT_GPT]
   const prompt = (id: string) => {
-    if (usesMimoCodexMode(id)) return PROMPT_GPT
+    if (harness !== "default" && usesMimoCodexMode(id)) return PROMPT_GPT
     if (id.includes("gpt-4") || id.includes("o1") || id.includes("o3")) return PROMPT_BEAST
     if (id.includes("gpt")) return PROMPT_GPT
     if (id.includes("gemini-")) return PROMPT_GEMINI

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -23,7 +23,7 @@ import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { Flag } from "@/flag/flag"
-import { usesMimoCodexMode } from "@/tool/gpt"
+import { type HarnessMode, usesMimoCodexMode } from "@/tool/gpt"
 
 function renderGitResult(result: Git.Result, fallback = "(none)") {
   if (result.exitCode !== 0) return fallback
@@ -32,8 +32,8 @@ function renderGitResult(result: Git.Result, fallback = "(none)") {
 
 const anthropicEnvironment = new Map<string, string>()
 
-export function provider(model: Provider.Model) {
-  if (Flag.MIMOCODE_CODEX_MODE) return [PROMPT_GPT]
+export function provider(model: Provider.Model, harness?: HarnessMode) {
+  if (harness === "codex" || (harness === undefined && Flag.MIMOCODE_CODEX_MODE)) return [PROMPT_GPT]
   const prompt = (id: string) => {
     if (usesMimoCodexMode(id)) return PROMPT_GPT
     if (id.includes("gpt-4") || id.includes("o1") || id.includes("o3")) return PROMPT_BEAST
@@ -49,12 +49,12 @@ export function provider(model: Provider.Model) {
   return [prompt(model.id) ?? prompt(model.api.id) ?? PROMPT_DEFAULT]
 }
 
-export function agent(agent: Agent.Info, model: Provider.Model) {
-  return agent.prompt ? [agent.prompt] : provider(model)
+export function agent(agent: Agent.Info, model: Provider.Model, harness?: HarnessMode) {
+  return agent.prompt ? [agent.prompt] : provider(model, harness)
 }
 
 export interface Interface {
-  readonly environment: (model: Provider.Model, now: number) => Effect.Effect<string[]>
+  readonly environment: (model: Provider.Model, now: number, harness?: HarnessMode) => Effect.Effect<string[]>
   readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
   readonly available: (agent?: Agent.Info) => Effect.Effect<Skill.Info[]>
   readonly all: () => Effect.Effect<Skill.Info[]>
@@ -70,10 +70,14 @@ export const layer = Layer.effect(
     const git = yield* Git.Service
 
     return Service.of({
-      environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model, now: number) {
+      environment: Effect.fn("SystemPrompt.environment")(function* (
+        model: Provider.Model,
+        now: number,
+        harness?: HarnessMode,
+      ) {
         if (!Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT) return []
         const project = Instance.project
-        if (provider(model)[0] === PROMPT_ANTHROPIC) {
+        if (provider(model, harness)[0] === PROMPT_ANTHROPIC) {
           const key = `${Instance.directory}\0${now}\0${model.providerID}\0${model.api.id}`
           const cached = anthropicEnvironment.get(key)
           if (cached)

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -1,10 +1,11 @@
 import { Flag } from "@/flag/flag"
 
-export type HarnessMode = "codex" | "default"
+export type HarnessMode = "auto" | "codex" | "default"
 
-function usesCodexHarness(harness?: HarnessMode) {
-  if (harness) return harness === "codex"
-  return Flag.MIMOCODE_CODEX_MODE
+function codexHarnessOverride(harness?: HarnessMode): boolean | undefined {
+  if (harness === "codex") return true
+  if (harness === "default") return false
+  return undefined
 }
 
 export function isGPTModel(...values: Array<string | undefined>) {
@@ -18,7 +19,8 @@ export function isMcpToolSearchEnabled(
   harness: HarnessMode | undefined,
   ...modelIDs: Array<string | undefined>
 ) {
-  return usesCodexHarness(harness) || enabled || isGPTModel(...modelIDs) || usesMimoCodexMode(...modelIDs)
+  return enabled || (codexHarnessOverride(harness)
+    ?? (Flag.MIMOCODE_CODEX_MODE || isGPTModel(...modelIDs) || usesMimoCodexMode(...modelIDs)))
 }
 
 export function usesMimoCodexMode(...values: Array<string | undefined>) {
@@ -28,8 +30,8 @@ export function usesMimoCodexMode(...values: Array<string | undefined>) {
 }
 
 export function usesGPTToolset(modelID: string, harness?: HarnessMode) {
-  return (
-    usesCodexHarness(harness) ||
+  return codexHarnessOverride(harness) ?? (
+    Flag.MIMOCODE_CODEX_MODE ||
     (modelID.includes("gpt-") && !modelID.includes("oss") && !modelID.includes("gpt-4")) ||
     usesMimoCodexMode(modelID)
   )

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -1,13 +1,24 @@
 import { Flag } from "@/flag/flag"
 
+export type HarnessMode = "codex" | "default"
+
+function usesCodexHarness(harness?: HarnessMode) {
+  if (harness) return harness === "codex"
+  return Flag.MIMOCODE_CODEX_MODE
+}
+
 export function isGPTModel(...values: Array<string | undefined>) {
   const ids = values.flatMap((value) => (value ? [value.toLowerCase()] : []))
   if (ids.some((id) => id.includes("gpt-oss"))) return false
   return ids.some((id) => id.includes("gpt"))
 }
 
-export function isMcpToolSearchEnabled(enabled: boolean, ...modelIDs: Array<string | undefined>) {
-  return Flag.MIMOCODE_CODEX_MODE || enabled || isGPTModel(...modelIDs) || usesMimoCodexMode(...modelIDs)
+export function isMcpToolSearchEnabled(
+  enabled: boolean,
+  harness: HarnessMode | undefined,
+  ...modelIDs: Array<string | undefined>
+) {
+  return usesCodexHarness(harness) || enabled || isGPTModel(...modelIDs) || usesMimoCodexMode(...modelIDs)
 }
 
 export function usesMimoCodexMode(...values: Array<string | undefined>) {
@@ -16,9 +27,9 @@ export function usesMimoCodexMode(...values: Array<string | undefined>) {
   return ids.some((id) => /(?:^|[/_-])mimo(?:$|[/_.-])/.test(id))
 }
 
-export function usesGPTToolset(modelID: string) {
+export function usesGPTToolset(modelID: string, harness?: HarnessMode) {
   return (
-    Flag.MIMOCODE_CODEX_MODE ||
+    usesCodexHarness(harness) ||
     (modelID.includes("gpt-") && !modelID.includes("oss") && !modelID.includes("gpt-4")) ||
     usesMimoCodexMode(modelID)
   )

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -19,8 +19,8 @@ export function isMcpToolSearchEnabled(
   harness: HarnessMode | undefined,
   ...modelIDs: Array<string | undefined>
 ) {
-  return enabled || (codexHarnessOverride(harness)
-    ?? (Flag.MIMOCODE_CODEX_MODE || isGPTModel(...modelIDs) || usesMimoCodexMode(...modelIDs)))
+  if (isGPTModel(...modelIDs)) return true
+  return enabled || (codexHarnessOverride(harness) ?? (Flag.MIMOCODE_CODEX_MODE || usesMimoCodexMode(...modelIDs)))
 }
 
 export function usesMimoCodexMode(...values: Array<string | undefined>) {
@@ -30,9 +30,6 @@ export function usesMimoCodexMode(...values: Array<string | undefined>) {
 }
 
 export function usesGPTToolset(modelID: string, harness?: HarnessMode) {
-  return codexHarnessOverride(harness) ?? (
-    Flag.MIMOCODE_CODEX_MODE ||
-    (modelID.includes("gpt-") && !modelID.includes("oss") && !modelID.includes("gpt-4")) ||
-    usesMimoCodexMode(modelID)
-  )
+  if (isGPTModel(modelID)) return true
+  return codexHarnessOverride(harness) ?? (Flag.MIMOCODE_CODEX_MODE || usesMimoCodexMode(modelID))
 }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -75,7 +75,7 @@ import { resolveInvocationStyle } from "./invocation-style"
 import { BuiltinWorkflow } from "@/workflow/builtin"
 import { ToolScriptTool, renderToolScriptDeclarations } from "./tool-script"
 import { GPT_TOP_LEVEL_TOOLS, TOOL_SCRIPT_EXCLUDED, toolScriptRegistry } from "./tool-script-ref"
-import { usesGPTToolset } from "./gpt"
+import { type HarnessMode, usesGPTToolset } from "./gpt"
 
 const log = Log.create({ service: "tool.registry" })
 
@@ -120,11 +120,17 @@ export interface Interface {
   readonly ids: () => Effect.Effect<string[]>
   readonly all: () => Effect.Effect<Tool.Def[]>
   readonly named: () => Effect.Effect<{ actor: ActorDef; read: ReadDef }>
-  readonly tools: (model: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info }) => Effect.Effect<Tool.Def[]>
+  readonly tools: (model: {
+    providerID: ProviderID
+    modelID: ModelID
+    agent: Agent.Info
+    harness?: HarnessMode
+  }) => Effect.Effect<Tool.Def[]>
   readonly registered: (model: {
     providerID: ProviderID
     modelID: ModelID
     agent: Agent.Info
+    harness?: HarnessMode
   }) => Effect.Effect<Tool.Def[]>
   readonly reload: () => Effect.Effect<void>
 }
@@ -359,8 +365,9 @@ export const layer = Layer.effect(
       providerID: ProviderID
       modelID: ModelID
       agent: Agent.Info
+      harness?: HarnessMode
     }) {
-      const useGPTTools = usesGPTToolset(input.modelID)
+      const useGPTTools = usesGPTToolset(input.modelID, input.harness)
       let filtered = (yield* all()).filter((tool) => {
         if (tool.id === ToolScriptTool.id) return useGPTTools || Flag.MIMOCODE_ENABLE_EXEC_TOOL
         if (tool.id === CodeSearchTool.id || tool.id === WebSearchTool.id) {
@@ -439,7 +446,7 @@ export const layer = Layer.effect(
       input ? available(input).pipe(Effect.map((result) => result.filtered)) : all()
 
     const definitions = Effect.fn("ToolRegistry.definitions")(function* (
-      input: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info },
+      input: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info; harness?: HarnessMode },
       includeHidden: boolean,
     ) {
       const availableTools = yield* available(input)

--- a/packages/opencode/src/tool/tool-script-ref.ts
+++ b/packages/opencode/src/tool/tool-script-ref.ts
@@ -9,10 +9,16 @@ import type { Effect } from "effect"
 import type { Agent } from "../agent/agent"
 import type { ModelID, ProviderID } from "../provider/schema"
 import type * as Tool from "./tool"
+import type { HarnessMode } from "./gpt"
 
 export const toolScriptRegistry: {
   current:
-    | ((input?: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info }) => Effect.Effect<Tool.Def[]>)
+    | ((input?: {
+        providerID: ProviderID
+        modelID: ModelID
+        agent: Agent.Info
+        harness?: HarnessMode
+      }) => Effect.Effect<Tool.Def[]>)
     | undefined
 } = { current: undefined }
 

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -11,6 +11,7 @@ import { Agent } from "@/agent/agent"
 import type { ModelID, ProviderID } from "../provider/schema"
 import { evalScript, type HostFn } from "../workflow/sandbox"
 import { toolScriptRegistry, TOOL_SCRIPT_ALIASES, TOOL_SCRIPT_EXCLUDED } from "./tool-script-ref"
+import type { HarnessMode } from "./gpt"
 import DESCRIPTION from "./tool-script.txt"
 import * as Tool from "./tool"
 import * as Truncate from "./truncate"
@@ -403,13 +404,14 @@ export const ToolScriptTool = Tool.define(
           if (!getDefs) throw new Error("exec tool registry unavailable")
           const agentInfo = yield* agents.get(ctx.agent)
           const model = ctx.extra?.model as { id: ModelID; providerID: ProviderID } | undefined
+          const harness = ctx.extra?.harness as HarnessMode | undefined
           const whitelist = Array.isArray(ctx.extra?.toolWhitelist)
             ? new Set(ctx.extra.toolWhitelist.filter((id): id is string => typeof id === "string"))
             : undefined
           const defs = (
             yield* getDefs(
               model
-                ? { providerID: model.providerID, modelID: model.id, agent: agentInfo }
+                ? { providerID: model.providerID, modelID: model.id, agent: agentInfo, harness }
                 : undefined,
             )
           ).filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id) && (!whitelist || whitelist.has(def.id)))

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -1062,6 +1062,19 @@ itTool.live("compose's tool list swaps GPT-specific file tools", () =>
       expect(claudeIDs).toContain("read")
       expect(claudeIDs).not.toContain("apply_patch")
       expect(claudeIDs).not.toContain("view_image")
+
+      const claudeCodexIDs = (
+        yield* registry.tools({
+          modelID: ModelID.make("claude-opus-4-7"),
+          providerID: ProviderID.make("anthropic"),
+          agent: compose!,
+          harness: "codex",
+        })
+      ).map((tool) => tool.id)
+      expect(claudeCodexIDs).toContain("exec")
+      expect(claudeCodexIDs).not.toContain("edit")
+      expect(claudeCodexIDs).not.toContain("write")
+      expect(claudeCodexIDs).not.toContain("read")
     }),
   ),
 )

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -860,6 +860,103 @@ it.live("does not pin an empty parent while creating a child", () =>
   ),
 )
 
+it.live("persists auto as its own harness mode", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const explicit = yield* sessions.create({ title: "Explicit auto" })
+      const omitted = yield* sessions.create({ title: "Omitted harness" })
+
+      yield* prompt.prompt({
+        sessionID: explicit.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        harness: "auto",
+        parts: [{ type: "text", text: "first explicit auto query" }],
+      })
+      yield* prompt.prompt({
+        sessionID: explicit.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        harness: "codex",
+        parts: [{ type: "text", text: "later override" }],
+      })
+      yield* prompt.prompt({
+        sessionID: omitted.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "first omitted query" }],
+      })
+
+      expect((yield* sessions.get(explicit.id)).prompt?.harness).toBe("auto")
+      expect((yield* sessions.get(omitted.id)).prompt?.harness).toBe("auto")
+      const users = (yield* sessions.messages({ sessionID: explicit.id }))
+        .map((message) => message.info)
+        .filter((message): message is MessageV2.User => message.role === "user")
+      expect(users.map((message) => message.harness)).toEqual(["auto", "auto"])
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("restores the pinned prompt after compaction without sending it to the summarizer", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const compaction = yield* SessionCompaction.Service
+      const chat = yield* sessions.create({ title: "Compaction prompt" })
+      const marker = "SESSION_SYSTEM_MUST_SKIP_COMPACTION"
+
+      const first = yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        system: marker,
+        systemMode: "replace-agent",
+        harness: "codex",
+        parts: [{ type: "text", text: "first query" }],
+      })
+
+      yield* llm.text("summary")
+      expect(
+        yield* compaction.process({
+          parentID: first.info.id,
+          messages: yield* sessions.messages({ sessionID: chat.id }),
+          sessionID: chat.id,
+          auto: false,
+        }),
+      ).toBe("continue")
+      expect(JSON.stringify((yield* llm.inputs)[0])).not.toContain(marker)
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "after compaction" }],
+      })
+      yield* llm.text("continued")
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const request = (yield* llm.inputs)[1]
+      expect(JSON.stringify(request)).toContain(marker)
+      expect((request.tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(["exec"])
+      expect((yield* sessions.get(chat.id)).prompt).toEqual({
+        system: marker,
+        systemMode: "replace-agent",
+        harness: "codex",
+      })
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("serializes concurrent first-query pinning", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* () {
@@ -1419,6 +1516,36 @@ mcpIt.live(
         expect(tools.map(wireToolName)).toEqual(["exec"])
         expect(JSON.stringify(tools)).not.toContain("private_window_id")
         expect(JSON.stringify(tools)).not.toContain("Secret nested MCP error selector")
+      }),
+      { git: true, config: gptProviderCfg },
+    ),
+  30_000,
+)
+
+mcpIt.live(
+  "keeps the Codex prompt and tool schema for GPT models with the default harness",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({ title: "GPT Codex tools" })
+
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          model: { providerID: ProviderID.openai, modelID: ModelID.make("gpt-5.2") },
+          harness: "default",
+          noReply: true,
+          parts: [{ type: "text", text: "inspect the Codex tools" }],
+        })
+        yield* llm.text("done")
+        yield* prompt.loop({ sessionID: session.id })
+
+        const request = (yield* llm.inputs)[0]
+        expect((request.tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(["exec"])
+        expect(JSON.stringify(request)).toContain("You are Codex")
+        expect(JSON.stringify(request)).toContain("tools.apply_patch")
       }),
       { git: true, config: gptProviderCfg },
     ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -677,6 +677,7 @@ it.live("locks system and harness to the first user query", () =>
         model: ref,
         noReply: true,
         system: "first system prompt",
+        systemMode: "replace-agent",
         harness: "codex",
         parts: [{ type: "text", text: "first query" }],
       })
@@ -702,7 +703,7 @@ it.live("locks system and harness to the first user query", () =>
 
       const input = (yield* llm.inputs)[0]
       const request = JSON.stringify(input)
-      expect(request).toContain("You are Codex")
+      expect(request).not.toContain("You are Codex")
       expect(request).toContain("first system prompt")
       expect((input.tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(["exec"])
 
@@ -712,6 +713,7 @@ it.live("locks system and harness to the first user query", () =>
         model: ref,
         noReply: true,
         system: "second system prompt",
+        systemMode: "append",
         harness: "default",
         parts: [{ type: "text", text: "second query" }],
       })
@@ -721,12 +723,15 @@ it.live("locks system and harness to the first user query", () =>
         .filter((message): message is MessageV2.User => message.role === "user")
       expect(users.map((message) => message.harness)).toEqual(["codex", undefined, "codex"])
       expect(users.map((message) => message.system)).toEqual(["first system prompt", undefined, "first system prompt"])
+      expect(users.map((message) => message.systemMode)).toEqual(["replace-agent", undefined, "replace-agent"])
       expect((yield* sessions.get(chat.id)).prompt).toEqual({
         system: "first system prompt",
+        systemMode: "replace-agent",
         harness: "codex",
       })
       expect((yield* sessions.create({ parentID: chat.id })).prompt).toEqual({
         system: "first system prompt",
+        systemMode: "replace-agent",
         harness: "codex",
       })
 
@@ -766,6 +771,7 @@ it.live("locks system and harness to the first user query", () =>
       })
       expect(yield* sessions.resolvePrompt({ sessionID: legacy.id })).toEqual({
         system: "legacy first system",
+        systemMode: "append",
         harness: "default",
       })
       expect((yield* sessions.get(legacy.id)).prompt).toBeUndefined()
@@ -776,6 +782,7 @@ it.live("locks system and harness to the first user query", () =>
         }),
       ).toEqual({
         system: "legacy first system",
+        systemMode: "append",
         harness: "default",
       })
     }),
@@ -846,8 +853,8 @@ it.live("does not pin an empty parent while creating a child", () =>
         parts: [{ type: "text", text: "child first query" }],
       })
 
-      expect((yield* sessions.get(parent.id)).prompt).toEqual({ system: "parent system", harness: "default" })
-      expect((yield* sessions.get(child.id)).prompt).toEqual({ system: "child system", harness: "codex" })
+      expect((yield* sessions.get(parent.id)).prompt).toEqual({ system: "parent system", systemMode: "append", harness: "default" })
+      expect((yield* sessions.get(child.id)).prompt).toEqual({ system: "child system", systemMode: "append", harness: "codex" })
     }),
     { git: true, config: providerCfg },
   ),
@@ -891,6 +898,7 @@ it.live("serializes concurrent first-query pinning", () =>
       expect(pinned).toBeDefined()
       expect(users).toHaveLength(2)
       expect(users.every((message) => message.system === pinned?.system)).toBe(true)
+      expect(users.every((message) => message.systemMode === pinned?.systemMode)).toBe(true)
       expect(users.every((message) => message.harness === pinned?.harness)).toBe(true)
     }),
     { git: true, config: providerCfg },

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -664,6 +664,239 @@ it.live("loop calls LLM and returns assistant message", () =>
   ),
 )
 
+it.live("locks system and harness to the first user query", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        system: "first system prompt",
+        harness: "codex",
+        parts: [{ type: "text", text: "first query" }],
+      })
+
+      const synthetic = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        sessionID: chat.id,
+        role: "user",
+        time: { created: Date.now() },
+        agent: "build",
+        model: ref,
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: synthetic.id,
+        sessionID: chat.id,
+        type: "text",
+        text: "synthetic recovery",
+        synthetic: true,
+      })
+      yield* llm.text("recovered")
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const input = (yield* llm.inputs)[0]
+      const request = JSON.stringify(input)
+      expect(request).toContain("You are Codex")
+      expect(request).toContain("first system prompt")
+      expect((input.tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(["exec"])
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        system: "second system prompt",
+        harness: "default",
+        parts: [{ type: "text", text: "second query" }],
+      })
+
+      const users = (yield* sessions.messages({ sessionID: chat.id }))
+        .map((message) => message.info)
+        .filter((message): message is MessageV2.User => message.role === "user")
+      expect(users.map((message) => message.harness)).toEqual(["codex", undefined, "codex"])
+      expect(users.map((message) => message.system)).toEqual(["first system prompt", undefined, "first system prompt"])
+      expect((yield* sessions.get(chat.id)).prompt).toEqual({
+        system: "first system prompt",
+        harness: "codex",
+      })
+      expect((yield* sessions.create({ parentID: chat.id })).prompt).toEqual({
+        system: "first system prompt",
+        harness: "codex",
+      })
+
+      const legacy = yield* sessions.create({ title: "Legacy" })
+      const legacyFirst = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        sessionID: legacy.id,
+        role: "user",
+        time: { created: Date.now() },
+        agent: "build",
+        model: ref,
+        system: "legacy first system",
+        harness: "default",
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: legacyFirst.id,
+        sessionID: legacy.id,
+        type: "text",
+        text: "legacy real query",
+      })
+      const legacySynthetic = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        sessionID: legacy.id,
+        role: "user",
+        time: { created: Date.now() },
+        agent: "build",
+        model: ref,
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: legacySynthetic.id,
+        sessionID: legacy.id,
+        type: "text",
+        text: "legacy synthetic recovery",
+        synthetic: true,
+      })
+      expect(yield* sessions.resolvePrompt({ sessionID: legacy.id })).toEqual({
+        system: "legacy first system",
+        harness: "default",
+      })
+      expect((yield* sessions.get(legacy.id)).prompt).toBeUndefined()
+      expect(
+        yield* sessions.resolvePrompt({
+          sessionID: legacy.id,
+          fallback: { system: "wrong fallback", harness: "codex" },
+        }),
+      ).toEqual({
+        system: "legacy first system",
+        harness: "default",
+      })
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("does not pin an empty parent while creating a child", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const parent = yield* sessions.create({ title: "Empty parent" })
+      const child = yield* sessions.create({ parentID: parent.id, title: "Early child" })
+      const fork = yield* sessions.fork({ sessionID: parent.id })
+
+      expect((yield* sessions.get(parent.id)).prompt).toBeUndefined()
+      expect(child.prompt).toBeUndefined()
+      expect(fork.prompt).toBeUndefined()
+
+      const empty = yield* prompt.prompt({
+        sessionID: parent.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        system: "empty system",
+        harness: "codex",
+        parts: [{ type: "text", text: "   " }],
+      })
+      expect(empty.parts).toEqual([])
+      expect((yield* sessions.get(parent.id)).prompt).toBeUndefined()
+
+      yield* prompt.prompt({
+        sessionID: parent.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        system: "synthetic system",
+        harness: "codex",
+        parts: [{ type: "text", text: "synthetic cron", synthetic: true }],
+      })
+      expect((yield* sessions.get(parent.id)).prompt).toBeUndefined()
+
+      yield* prompt.shell({
+        sessionID: parent.id,
+        agent: "build",
+        model: ref,
+        command: "echo before-query",
+      })
+      expect((yield* sessions.get(parent.id)).prompt).toBeUndefined()
+
+      yield* prompt.prompt({
+        sessionID: parent.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        system: "parent system",
+        harness: "default",
+        parts: [{ type: "text", text: "parent first query" }],
+      })
+      yield* prompt.prompt({
+        sessionID: child.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        system: "child system",
+        harness: "codex",
+        parts: [{ type: "text", text: "child first query" }],
+      })
+
+      expect((yield* sessions.get(parent.id)).prompt).toEqual({ system: "parent system", harness: "default" })
+      expect((yield* sessions.get(child.id)).prompt).toEqual({ system: "child system", harness: "codex" })
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("serializes concurrent first-query pinning", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({ title: "Concurrent pin" })
+
+      yield* Effect.all(
+        [
+          prompt.prompt({
+            sessionID: session.id,
+            agent: "build",
+            model: ref,
+            noReply: true,
+            system: "system a",
+            harness: "codex",
+            parts: [{ type: "text", text: "query a" }],
+          }),
+          prompt.prompt({
+            sessionID: session.id,
+            agent: "build",
+            model: ref,
+            noReply: true,
+            system: "system b",
+            harness: "default",
+            parts: [{ type: "text", text: "query b" }],
+          }),
+        ],
+        { concurrency: "unbounded" },
+      )
+
+      const pinned = (yield* sessions.get(session.id)).prompt
+      const users = (yield* sessions.messages({ sessionID: session.id }))
+        .map((message) => message.info)
+        .filter((message): message is MessageV2.User => message.role === "user")
+      expect(pinned).toBeDefined()
+      expect(users).toHaveLength(2)
+      expect(users.every((message) => message.system === pinned?.system)).toBe(true)
+      expect(users.every((message) => message.harness === pinned?.harness)).toBe(true)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("loop does not inject dynamic system prompt additions", () =>
   withoutDynamicSystemPrompt(() =>
     provideTmpdirServer(

--- a/packages/opencode/test/session/prompt-skill-command-multi.test.ts
+++ b/packages/opencode/test/session/prompt-skill-command-multi.test.ts
@@ -39,6 +39,53 @@ const injected = (parts: MessageV2.WithParts["parts"]) =>
 // a single owner, so invoking one skill cannot suppress the others.
 describe("skill command with additional mentions", () => {
   it.live(
+    "pins system prompt and harness when the first user query is a command",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ dir, llm }) {
+          yield* writeSkill(dir, "skill-profile", "PROFILE_SKILL_MARKER")
+          yield* llm.text("ok")
+
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const session = yield* sessions.create({ title: "profile command" })
+
+          yield* prompt.command({
+            sessionID: session.id,
+            command: "skill-profile",
+            arguments: "run",
+            model: `${ref.providerID}/${ref.modelID}`,
+            system: "COMMAND_SYSTEM_MARKER",
+            systemMode: "replace-agent",
+            harness: "codex",
+          })
+
+          expect((yield* sessions.get(session.id)).prompt).toEqual({
+            system: "COMMAND_SYSTEM_MARKER",
+            systemMode: "replace-agent",
+            harness: "codex",
+          })
+          const user = (yield* sessions.messages({ sessionID: session.id }))
+            .find((message) => message.info.role === "user")
+          expect(user?.info).toMatchObject({
+            role: "user",
+            system: "COMMAND_SYSTEM_MARKER",
+            systemMode: "replace-agent",
+            harness: "codex",
+          })
+          const request = (yield* llm.inputs)[0]
+          expect(JSON.stringify(request)).toContain("COMMAND_SYSTEM_MARKER")
+          expect((request.tools as Array<Record<string, unknown>>).map((tool) =>
+            typeof tool.function === "object" && tool.function && "name" in tool.function
+              ? String(tool.function.name)
+              : "",
+          )).toEqual(["exec"])
+        }),
+        { git: true, config: providerCfg },
+      ),
+  )
+
+  it.live(
     "injects every mentioned skill when the message is a skill command",
     () =>
       provideTmpdirServer(

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -63,6 +63,15 @@ describe("session.system", () => {
     expect(prompt).not.toContain("gitStatus:")
   })
 
+  test("explicit default harness overrides MiMo Codex prompt inference", () => {
+    const model = ProviderTest.model({
+      id: ModelID.make("mimo-v2.6"),
+      api: { id: "mimo-v2.6" } as never,
+    })
+    expect(SystemPrompt.provider(model, "codex")[0]).not.toBe(SystemPrompt.provider(model, "default")[0])
+    expect(SystemPrompt.provider(model, "codex")[0]).toContain("Codex")
+  })
+
   test("renders machine and repository environment only for Claude models", async () => {
     await using tmp = await tmpdir({ git: true })
     await $`git branch -M prompt-test`.cwd(tmp.path).quiet()

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -135,12 +135,21 @@ describe("session.system", () => {
                 }),
                 now,
               ),
+              system.environment(
+                ProviderTest.model({
+                  id: ModelID.make("custom-model"),
+                  api: { id: "claude-sonnet-4-6" } as never,
+                }),
+                now,
+                "codex",
+              ),
             ])
           }).pipe(Effect.provide(SystemPrompt.defaultLayer)),
         )
 
         expect(prompts[0].join("\n")).not.toContain("gitStatus:")
         expect(prompts[1].join("\n")).toContain("gitStatus:")
+        expect(prompts[2].join("\n")).not.toContain("gitStatus:")
       },
     })
   })
@@ -214,6 +223,18 @@ describe("session.system", () => {
     )[0]
 
     expect(prompt).toBe(gpt)
+  })
+
+  test("allows the resolved session mode to override the process harness mode", () => {
+    const model = ProviderTest.model({
+      id: ModelID.make("claude-sonnet-4-6"),
+      providerID: ProviderID.make("anthropic"),
+    })
+    const gpt = SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("gpt-5.4") }))[0]
+
+    expect(SystemPrompt.provider(model, "codex")[0]).toBe(gpt)
+    process.env.MIMOCODE_CODEX_MODE = "true"
+    expect(SystemPrompt.provider(model, "default")[0]).not.toBe(gpt)
   })
 
   test("uses the same prompted subagent system across models", () => {

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -63,13 +63,15 @@ describe("session.system", () => {
     expect(prompt).not.toContain("gitStatus:")
   })
 
-  test("explicit default harness overrides MiMo Codex prompt inference", () => {
-    const model = ProviderTest.model({
-      id: ModelID.make("mimo-v2.6"),
-      api: { id: "mimo-v2.6" } as never,
-    })
-    expect(SystemPrompt.provider(model, "codex")[0]).not.toBe(SystemPrompt.provider(model, "default")[0])
-    expect(SystemPrompt.provider(model, "codex")[0]).toContain("Codex")
+  test("GPT ignores harness while explicit default overrides MiMo Codex inference", () => {
+    const gpt = ProviderTest.model({ id: ModelID.make("gpt-5.2"), api: { id: "gpt-5.2" } as never })
+    expect(SystemPrompt.provider(gpt, "default")[0]).toContain("You are Codex")
+    expect(SystemPrompt.provider(gpt, "default")[0]).toContain("tools.apply_patch")
+
+    const mimo = ProviderTest.model({ id: ModelID.make("mimo-v2.6"), api: { id: "mimo-v2.6" } as never })
+    expect(SystemPrompt.provider(mimo, "codex")[0]).toContain("You are Codex")
+    expect(SystemPrompt.provider(mimo, "default")[0]).not.toContain("You are Codex")
+    expect(SystemPrompt.provider(mimo, "default")[0]).not.toContain("tools.apply_patch")
   })
 
   test("renders machine and repository environment only for Claude models", async () => {

--- a/packages/opencode/test/tool/gpt.test.ts
+++ b/packages/opencode/test/tool/gpt.test.ts
@@ -47,6 +47,8 @@ describe("isMcpToolSearchEnabled", () => {
     expect(isMcpToolSearchEnabled(false, "codex", "claude-opus-4-6")).toBe(true)
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(isMcpToolSearchEnabled(false, "default", "claude-opus-4-6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "default", "mimo-v2.6", "gpt-5.2")).toBe(false)
+    expect(isMcpToolSearchEnabled(true, "default", "mimo-v2.6")).toBe(true)
   })
 })
 
@@ -67,5 +69,7 @@ describe("usesGPTToolset", () => {
     expect(usesGPTToolset("claude-opus-4-6", "codex")).toBe(true)
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(usesGPTToolset("claude-opus-4-6", "default")).toBe(false)
+    expect(usesGPTToolset("mimo-v2.6", "default")).toBe(false)
+    expect(usesGPTToolset("gpt-5.2", "default")).toBe(false)
   })
 })

--- a/packages/opencode/test/tool/gpt.test.ts
+++ b/packages/opencode/test/tool/gpt.test.ts
@@ -45,9 +45,13 @@ describe("isMcpToolSearchEnabled", () => {
 
   test("allows the resolved session mode to override the process mode", () => {
     expect(isMcpToolSearchEnabled(false, "codex", "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, "auto", "gpt-5.2")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, "auto", "claude-opus-4-6")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
+    expect(isMcpToolSearchEnabled(false, "auto", "claude-opus-4-6")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "default", "claude-opus-4-6")).toBe(false)
-    expect(isMcpToolSearchEnabled(false, "default", "mimo-v2.6", "gpt-5.2")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "default", "mimo-v2.6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "default", "gpt-5.2")).toBe(true)
     expect(isMcpToolSearchEnabled(true, "default", "mimo-v2.6")).toBe(true)
   })
 })
@@ -67,9 +71,13 @@ describe("usesGPTToolset", () => {
 
   test("allows the resolved session mode to override the process mode", () => {
     expect(usesGPTToolset("claude-opus-4-6", "codex")).toBe(true)
+    expect(usesGPTToolset("gpt-5.2", "auto")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6", "auto")).toBe(true)
+    expect(usesGPTToolset("claude-opus-4-6", "auto")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
+    expect(usesGPTToolset("claude-opus-4-6", "auto")).toBe(true)
     expect(usesGPTToolset("claude-opus-4-6", "default")).toBe(false)
     expect(usesGPTToolset("mimo-v2.6", "default")).toBe(false)
-    expect(usesGPTToolset("gpt-5.2", "default")).toBe(false)
+    expect(usesGPTToolset("gpt-5.2", "default")).toBe(true)
   })
 })

--- a/packages/opencode/test/tool/gpt.test.ts
+++ b/packages/opencode/test/tool/gpt.test.ts
@@ -29,18 +29,24 @@ describe("isGPTModel", () => {
 
 describe("isMcpToolSearchEnabled", () => {
   test("defaults to GPT models and allows explicit non-GPT opt-in", () => {
-    expect(isMcpToolSearchEnabled(false, "claude-opus-4-6")).toBe(false)
-    expect(isMcpToolSearchEnabled(false, "mimo-v2.5")).toBe(false)
-    expect(isMcpToolSearchEnabled(false, "mimo-v2.5-pro")).toBe(false)
-    expect(isMcpToolSearchEnabled(false, "mimo-v2.6")).toBe(true)
-    expect(isMcpToolSearchEnabled(false, "gpt-5.2")).toBe(true)
-    expect(isMcpToolSearchEnabled(false, "gpt-oss-120b")).toBe(false)
-    expect(isMcpToolSearchEnabled(true, "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "claude-opus-4-6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.5")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.5-pro")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "gpt-5.2")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "gpt-oss-120b")).toBe(false)
+    expect(isMcpToolSearchEnabled(true, undefined, "claude-opus-4-6")).toBe(true)
   })
 
   test("is enabled for non-GPT models in Codex mode", () => {
     process.env.MIMOCODE_CODEX_MODE = "true"
-    expect(isMcpToolSearchEnabled(false, "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "claude-opus-4-6")).toBe(true)
+  })
+
+  test("allows the resolved session mode to override the process mode", () => {
+    expect(isMcpToolSearchEnabled(false, "codex", "claude-opus-4-6")).toBe(true)
+    process.env.MIMOCODE_CODEX_MODE = "true"
+    expect(isMcpToolSearchEnabled(false, "default", "claude-opus-4-6")).toBe(false)
   })
 })
 
@@ -55,5 +61,11 @@ describe("usesGPTToolset", () => {
     expect(usesGPTToolset("claude-opus-4-6")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(usesGPTToolset("claude-opus-4-6")).toBe(true)
+  })
+
+  test("allows the resolved session mode to override the process mode", () => {
+    expect(usesGPTToolset("claude-opus-4-6", "codex")).toBe(true)
+    process.env.MIMOCODE_CODEX_MODE = "true"
+    expect(usesGPTToolset("claude-opus-4-6", "default")).toBe(false)
   })
 })

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -62,6 +62,8 @@ export type UserMessage = {
     modelID: string
   }
   system?: string
+  systemMode?: "append" | "replace-agent"
+  harness?: "auto" | "codex" | "default"
   tools?: {
     [key: string]: boolean
   }
@@ -545,6 +547,11 @@ export type Session = {
     created: number
     updated: number
     compacting?: number
+  }
+  prompt?: {
+    system?: string
+    systemMode?: "append" | "replace-agent"
+    harness: "auto" | "codex" | "default"
   }
   revert?: {
     messageID: string
@@ -2586,6 +2593,8 @@ export type SessionPromptData = {
     agent?: string
     noReply?: boolean
     system?: string
+    systemMode?: "append" | "replace-agent"
+    harness?: "auto" | "codex" | "default"
     tools?: {
       [key: string]: boolean
     }
@@ -2681,6 +2690,8 @@ export type SessionPromptAsyncData = {
     agent?: string
     noReply?: boolean
     system?: string
+    systemMode?: "append" | "replace-agent"
+    harness?: "auto" | "codex" | "default"
     tools?: {
       [key: string]: boolean
     }
@@ -2727,6 +2738,10 @@ export type SessionCommandData = {
     model?: string
     arguments: string
     command: string
+    variant?: string
+    system?: string
+    systemMode?: "append" | "replace-agent"
+    harness?: "auto" | "codex" | "default"
   }
   path: {
     /**

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2412,7 +2412,8 @@ export class Session2 extends HeyApiClient {
       }
       format?: OutputFormat
       system?: string
-      harness?: "codex" | "default"
+      systemMode?: "append" | "replace-agent"
+      harness?: "auto" | "codex" | "default"
       variant?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
@@ -2438,6 +2439,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "tools" },
             { in: "body", key: "format" },
             { in: "body", key: "system" },
+            { in: "body", key: "systemMode" },
             { in: "body", key: "harness" },
             { in: "body", key: "variant" },
             { in: "body", key: "parts" },
@@ -2556,7 +2558,8 @@ export class Session2 extends HeyApiClient {
       }
       format?: OutputFormat
       system?: string
-      harness?: "codex" | "default"
+      systemMode?: "append" | "replace-agent"
+      harness?: "auto" | "codex" | "default"
       variant?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
@@ -2582,6 +2585,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "tools" },
             { in: "body", key: "format" },
             { in: "body", key: "system" },
+            { in: "body", key: "systemMode" },
             { in: "body", key: "harness" },
             { in: "body", key: "variant" },
             { in: "body", key: "parts" },
@@ -2617,6 +2621,9 @@ export class Session2 extends HeyApiClient {
       arguments?: string
       command?: string
       variant?: string
+      system?: string
+      systemMode?: "append" | "replace-agent"
+      harness?: "auto" | "codex" | "default"
       parts?: Array<{
         id?: string
         type: "file"
@@ -2642,6 +2649,9 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "arguments" },
             { in: "body", key: "command" },
             { in: "body", key: "variant" },
+            { in: "body", key: "system" },
+            { in: "body", key: "systemMode" },
+            { in: "body", key: "harness" },
             { in: "body", key: "parts" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2412,6 +2412,7 @@ export class Session2 extends HeyApiClient {
       }
       format?: OutputFormat
       system?: string
+      harness?: "codex" | "default"
       variant?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
@@ -2437,6 +2438,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "tools" },
             { in: "body", key: "format" },
             { in: "body", key: "system" },
+            { in: "body", key: "harness" },
             { in: "body", key: "variant" },
             { in: "body", key: "parts" },
           ],
@@ -2554,6 +2556,7 @@ export class Session2 extends HeyApiClient {
       }
       format?: OutputFormat
       system?: string
+      harness?: "codex" | "default"
       variant?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
@@ -2579,6 +2582,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "tools" },
             { in: "body", key: "format" },
             { in: "body", key: "system" },
+            { in: "body", key: "harness" },
             { in: "body", key: "variant" },
             { in: "body", key: "parts" },
           ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -997,6 +997,7 @@ export type UserMessage = {
     variant?: string
   }
   system?: string
+  harness?: "codex" | "default"
   tools?: {
     [key: string]: boolean
   }
@@ -1402,6 +1403,10 @@ export type Session = {
     archived?: number
   }
   permission?: PermissionRuleset
+  prompt?: {
+    system?: string
+    harness: "codex" | "default"
+  }
   revert?: {
     messageID: string
     partID?: string
@@ -1531,6 +1536,10 @@ export type SyncEventSessionUpdated = {
         archived: number | null
       }
       permission: PermissionRuleset | null
+      prompt: {
+        system?: string
+        harness: "codex" | "default"
+      } | null
       revert: {
         messageID: string
         partID?: string
@@ -2218,7 +2227,7 @@ export type Config = {
      */
     preserve_recent_tokens?: number
     /**
-     * Token buffer for compaction. Leaves enough window to avoid overflow during compaction.
+     * Token buffer for compaction. Leaves enough window to avoid overflow during compaction (default: up to 33000, capped by the model's maximum output).
      */
     reserved?: number
     /**
@@ -2656,6 +2665,10 @@ export type GlobalSession = {
     archived?: number
   }
   permission?: PermissionRuleset
+  prompt?: {
+    system?: string
+    harness: "codex" | "default"
+  }
   revert?: {
     messageID: string
     partID?: string
@@ -4811,7 +4824,14 @@ export type SessionPromptData = {
       [key: string]: boolean
     }
     format?: OutputFormat
+    /**
+     * Additional system prompt selected by the session's first user query. Later values are ignored.
+     */
     system?: string
+    /**
+     * Harness mode selected by the session's first user query. Later values are ignored. Explicit default overrides the process-wide Codex mode flag.
+     */
+    harness?: "codex" | "default"
     variant?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
@@ -5026,7 +5046,14 @@ export type SessionPromptAsyncData = {
       [key: string]: boolean
     }
     format?: OutputFormat
+    /**
+     * Additional system prompt selected by the session's first user query. Later values are ignored.
+     */
     system?: string
+    /**
+     * Harness mode selected by the session's first user query. Later values are ignored. Explicit default overrides the process-wide Codex mode flag.
+     */
+    harness?: "codex" | "default"
     variant?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4837,7 +4837,7 @@ export type SessionPromptData = {
      */
     systemMode?: "append" | "replace-agent"
     /**
-     * Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference; explicit default forces the native tool schema.
+     * Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.
      */
     harness?: "auto" | "codex" | "default"
     variant?: string
@@ -5063,7 +5063,7 @@ export type SessionPromptAsyncData = {
      */
     systemMode?: "append" | "replace-agent"
     /**
-     * Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference; explicit default forces the native tool schema.
+     * Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.
      */
     harness?: "auto" | "codex" | "default"
     variant?: string
@@ -5118,7 +5118,7 @@ export type SessionCommandData = {
      */
     systemMode?: "append" | "replace-agent"
     /**
-     * Harness mode selected by the session's first user command. Later values are ignored.
+     * Harness mode selected by the session's first user command. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.
      */
     harness?: "auto" | "codex" | "default"
     parts?: Array<{

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -997,7 +997,8 @@ export type UserMessage = {
     variant?: string
   }
   system?: string
-  harness?: "codex" | "default"
+  systemMode?: "append" | "replace-agent"
+  harness?: "auto" | "codex" | "default"
   tools?: {
     [key: string]: boolean
   }
@@ -1405,7 +1406,8 @@ export type Session = {
   permission?: PermissionRuleset
   prompt?: {
     system?: string
-    harness: "codex" | "default"
+    systemMode?: "append" | "replace-agent"
+    harness: "auto" | "codex" | "default"
   }
   revert?: {
     messageID: string
@@ -1538,7 +1540,8 @@ export type SyncEventSessionUpdated = {
       permission: PermissionRuleset | null
       prompt: {
         system?: string
-        harness: "codex" | "default"
+        systemMode?: "append" | "replace-agent"
+        harness: "auto" | "codex" | "default"
       } | null
       revert: {
         messageID: string
@@ -2667,7 +2670,8 @@ export type GlobalSession = {
   permission?: PermissionRuleset
   prompt?: {
     system?: string
-    harness: "codex" | "default"
+    systemMode?: "append" | "replace-agent"
+    harness: "auto" | "codex" | "default"
   }
   revert?: {
     messageID: string
@@ -4829,9 +4833,13 @@ export type SessionPromptData = {
      */
     system?: string
     /**
-     * Harness mode selected by the session's first user query. Later values are ignored. Explicit default overrides the process-wide Codex mode flag.
+     * Whether the selected system prompt appends to or replaces the agent prompt. Later values are ignored.
      */
-    harness?: "codex" | "default"
+    systemMode?: "append" | "replace-agent"
+    /**
+     * Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference; explicit default forces the native tool schema.
+     */
+    harness?: "auto" | "codex" | "default"
     variant?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
@@ -5051,9 +5059,13 @@ export type SessionPromptAsyncData = {
      */
     system?: string
     /**
-     * Harness mode selected by the session's first user query. Later values are ignored. Explicit default overrides the process-wide Codex mode flag.
+     * Whether the selected system prompt appends to or replaces the agent prompt. Later values are ignored.
      */
-    harness?: "codex" | "default"
+    systemMode?: "append" | "replace-agent"
+    /**
+     * Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference; explicit default forces the native tool schema.
+     */
+    harness?: "auto" | "codex" | "default"
     variant?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
@@ -5097,6 +5109,18 @@ export type SessionCommandData = {
     arguments: string
     command: string
     variant?: string
+    /**
+     * Additional system prompt selected by the session's first user command. Later values are ignored.
+     */
+    system?: string
+    /**
+     * Whether the selected system prompt appends to or replaces the agent prompt. Later values are ignored.
+     */
+    systemMode?: "append" | "replace-agent"
+    /**
+     * Harness mode selected by the session's first user command. Later values are ignored.
+     */
+    harness?: "auto" | "codex" | "default"
     parts?: Array<{
       id?: string
       type: "file"


### PR DESCRIPTION
## Summary
- persist the first real user query system prompt and harness mode at the session level
- preserve the resolved selection across loops, compaction, forks, child sessions, and tool resolution
- add the database migration, generated SDK surface, and regression coverage

## Test Plan
- [x] `bun typecheck` in `packages/opencode`
- [x] 26 affected tests across session, system prompt, GPT tool selection, and agent registry