### PR TITLE
fix(session): preserve automatic harness inference

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -246,8 +246,11 @@ export const layer: Layer.Layer<
       const promptConfig = yield* session.resolvePrompt({ sessionID: input.sessionID })
       const userMessage = {
         ...parent.info,
-        system: promptConfig.system,
-        systemMode: promptConfig.systemMode,
+        // The compaction agent owns its summarization prompt. The session's
+        // extra system prompt is already persisted and will be restored on the
+        // replay/next user turn; injecting it here can change the summary task.
+        system: undefined,
+        systemMode: undefined,
         harness: promptConfig.harness,
       }
       const compactionPart = parent.parts.find((part): part is MessageV2.CompactionPart => part.type === "compaction")

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4908,7 +4908,7 @@ export const PromptInput = z.object({
     .enum(["auto", "codex", "default"])
     .optional()
     .describe(
-      "Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference; explicit default forces the native tool schema.",
+      "Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
     ),
   variant: z.string().optional(),
   parts: z.array(
@@ -5008,7 +5008,9 @@ export const CommandInput = z.object({
   harness: z
     .enum(["auto", "codex", "default"])
     .optional()
-    .describe("Harness mode selected by the session's first user command. Later values are ignored."),
+    .describe(
+      "Harness mode selected by the session's first user command. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
+    ),
   parts: z
     .array(
       z.discriminatedUnion("type", [

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -23,7 +23,7 @@ import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { Flag } from "@/flag/flag"
-import { type HarnessMode, usesMimoCodexMode } from "@/tool/gpt"
+import { type HarnessMode, isGPTModel, usesMimoCodexMode } from "@/tool/gpt"
 
 function renderGitResult(result: Git.Result, fallback = "(none)") {
   if (result.exitCode !== 0) return fallback
@@ -35,9 +35,9 @@ const anthropicEnvironment = new Map<string, string>()
 export function provider(model: Provider.Model, harness?: HarnessMode) {
   if (harness === "codex" || ((harness === undefined || harness === "auto") && Flag.MIMOCODE_CODEX_MODE)) return [PROMPT_GPT]
   const prompt = (id: string) => {
-    if (harness !== "default" && usesMimoCodexMode(id)) return PROMPT_GPT
+    if (isGPTModel(id)) return PROMPT_GPT
+    if (usesMimoCodexMode(id)) return harness === "default" ? PROMPT_DEFAULT : PROMPT_GPT
     if (id.includes("gpt-4") || id.includes("o1") || id.includes("o3")) return PROMPT_BEAST
-    if (id.includes("gpt")) return PROMPT_GPT
     if (id.includes("gemini-")) return PROMPT_GEMINI
     if (id.includes("claude")) return PROMPT_ANTHROPIC
     if (id.toLowerCase().includes("trinity")) return PROMPT_TRINITY

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -19,8 +19,8 @@ export function isMcpToolSearchEnabled(
   harness: HarnessMode | undefined,
   ...modelIDs: Array<string | undefined>
 ) {
-  return enabled || (codexHarnessOverride(harness)
-    ?? (Flag.MIMOCODE_CODEX_MODE || isGPTModel(...modelIDs) || usesMimoCodexMode(...modelIDs)))
+  if (isGPTModel(...modelIDs)) return true
+  return enabled || (codexHarnessOverride(harness) ?? (Flag.MIMOCODE_CODEX_MODE || usesMimoCodexMode(...modelIDs)))
 }
 
 export function usesMimoCodexMode(...values: Array<string | undefined>) {
@@ -30,9 +30,6 @@ export function usesMimoCodexMode(...values: Array<string | undefined>) {
 }
 
 export function usesGPTToolset(modelID: string, harness?: HarnessMode) {
-  return codexHarnessOverride(harness) ?? (
-    Flag.MIMOCODE_CODEX_MODE ||
-    (modelID.includes("gpt-") && !modelID.includes("oss") && !modelID.includes("gpt-4")) ||
-    usesMimoCodexMode(modelID)
-  )
+  if (isGPTModel(modelID)) return true
+  return codexHarnessOverride(harness) ?? (Flag.MIMOCODE_CODEX_MODE || usesMimoCodexMode(modelID))
 }

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -860,6 +860,103 @@ it.live("does not pin an empty parent while creating a child", () =>
   ),
 )
 
+it.live("persists auto as its own harness mode", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const explicit = yield* sessions.create({ title: "Explicit auto" })
+      const omitted = yield* sessions.create({ title: "Omitted harness" })
+
+      yield* prompt.prompt({
+        sessionID: explicit.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        harness: "auto",
+        parts: [{ type: "text", text: "first explicit auto query" }],
+      })
+      yield* prompt.prompt({
+        sessionID: explicit.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        harness: "codex",
+        parts: [{ type: "text", text: "later override" }],
+      })
+      yield* prompt.prompt({
+        sessionID: omitted.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "first omitted query" }],
+      })
+
+      expect((yield* sessions.get(explicit.id)).prompt?.harness).toBe("auto")
+      expect((yield* sessions.get(omitted.id)).prompt?.harness).toBe("auto")
+      const users = (yield* sessions.messages({ sessionID: explicit.id }))
+        .map((message) => message.info)
+        .filter((message): message is MessageV2.User => message.role === "user")
+      expect(users.map((message) => message.harness)).toEqual(["auto", "auto"])
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("restores the pinned prompt after compaction without sending it to the summarizer", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const compaction = yield* SessionCompaction.Service
+      const chat = yield* sessions.create({ title: "Compaction prompt" })
+      const marker = "SESSION_SYSTEM_MUST_SKIP_COMPACTION"
+
+      const first = yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        system: marker,
+        systemMode: "replace-agent",
+        harness: "codex",
+        parts: [{ type: "text", text: "first query" }],
+      })
+
+      yield* llm.text("summary")
+      expect(
+        yield* compaction.process({
+          parentID: first.info.id,
+          messages: yield* sessions.messages({ sessionID: chat.id }),
+          sessionID: chat.id,
+          auto: false,
+        }),
+      ).toBe("continue")
+      expect(JSON.stringify((yield* llm.inputs)[0])).not.toContain(marker)
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "after compaction" }],
+      })
+      yield* llm.text("continued")
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const request = (yield* llm.inputs)[1]
+      expect(JSON.stringify(request)).toContain(marker)
+      expect((request.tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(["exec"])
+      expect((yield* sessions.get(chat.id)).prompt).toEqual({
+        system: marker,
+        systemMode: "replace-agent",
+        harness: "codex",
+      })
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("serializes concurrent first-query pinning", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* () {
@@ -1419,6 +1516,36 @@ mcpIt.live(
         expect(tools.map(wireToolName)).toEqual(["exec"])
         expect(JSON.stringify(tools)).not.toContain("private_window_id")
         expect(JSON.stringify(tools)).not.toContain("Secret nested MCP error selector")
+      }),
+      { git: true, config: gptProviderCfg },
+    ),
+  30_000,
+)
+
+mcpIt.live(
+  "keeps the Codex prompt and tool schema for GPT models with the default harness",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({ title: "GPT Codex tools" })
+
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          model: { providerID: ProviderID.openai, modelID: ModelID.make("gpt-5.2") },
+          harness: "default",
+          noReply: true,
+          parts: [{ type: "text", text: "inspect the Codex tools" }],
+        })
+        yield* llm.text("done")
+        yield* prompt.loop({ sessionID: session.id })
+
+        const request = (yield* llm.inputs)[0]
+        expect((request.tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(["exec"])
+        expect(JSON.stringify(request)).toContain("You are Codex")
+        expect(JSON.stringify(request)).toContain("tools.apply_patch")
       }),
       { git: true, config: gptProviderCfg },
     ),

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -63,13 +63,15 @@ describe("session.system", () => {
     expect(prompt).not.toContain("gitStatus:")
   })
 
-  test("explicit default harness overrides MiMo Codex prompt inference", () => {
-    const model = ProviderTest.model({
-      id: ModelID.make("mimo-v2.6"),
-      api: { id: "mimo-v2.6" } as never,
-    })
-    expect(SystemPrompt.provider(model, "codex")[0]).not.toBe(SystemPrompt.provider(model, "default")[0])
-    expect(SystemPrompt.provider(model, "codex")[0]).toContain("Codex")
+  test("GPT ignores harness while explicit default overrides MiMo Codex inference", () => {
+    const gpt = ProviderTest.model({ id: ModelID.make("gpt-5.2"), api: { id: "gpt-5.2" } as never })
+    expect(SystemPrompt.provider(gpt, "default")[0]).toContain("You are Codex")
+    expect(SystemPrompt.provider(gpt, "default")[0]).toContain("tools.apply_patch")
+
+    const mimo = ProviderTest.model({ id: ModelID.make("mimo-v2.6"), api: { id: "mimo-v2.6" } as never })
+    expect(SystemPrompt.provider(mimo, "codex")[0]).toContain("You are Codex")
+    expect(SystemPrompt.provider(mimo, "default")[0]).not.toContain("You are Codex")
+    expect(SystemPrompt.provider(mimo, "default")[0]).not.toContain("tools.apply_patch")
   })
 
   test("renders machine and repository environment only for Claude models", async () => {

--- a/packages/opencode/test/tool/gpt.test.ts
+++ b/packages/opencode/test/tool/gpt.test.ts
@@ -45,9 +45,13 @@ describe("isMcpToolSearchEnabled", () => {
 
   test("allows the resolved session mode to override the process mode", () => {
     expect(isMcpToolSearchEnabled(false, "codex", "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, "auto", "gpt-5.2")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, "auto", "claude-opus-4-6")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
+    expect(isMcpToolSearchEnabled(false, "auto", "claude-opus-4-6")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "default", "claude-opus-4-6")).toBe(false)
-    expect(isMcpToolSearchEnabled(false, "default", "mimo-v2.6", "gpt-5.2")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "default", "mimo-v2.6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "default", "gpt-5.2")).toBe(true)
     expect(isMcpToolSearchEnabled(true, "default", "mimo-v2.6")).toBe(true)
   })
 })
@@ -67,9 +71,13 @@ describe("usesGPTToolset", () => {
 
   test("allows the resolved session mode to override the process mode", () => {
     expect(usesGPTToolset("claude-opus-4-6", "codex")).toBe(true)
+    expect(usesGPTToolset("gpt-5.2", "auto")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6", "auto")).toBe(true)
+    expect(usesGPTToolset("claude-opus-4-6", "auto")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
+    expect(usesGPTToolset("claude-opus-4-6", "auto")).toBe(true)
     expect(usesGPTToolset("claude-opus-4-6", "default")).toBe(false)
     expect(usesGPTToolset("mimo-v2.6", "default")).toBe(false)
-    expect(usesGPTToolset("gpt-5.2", "default")).toBe(false)
+    expect(usesGPTToolset("gpt-5.2", "default")).toBe(true)
   })
 })

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -62,6 +62,8 @@ export type UserMessage = {
     modelID: string
   }
   system?: string
+  systemMode?: "append" | "replace-agent"
+  harness?: "auto" | "codex" | "default"
   tools?: {
     [key: string]: boolean
   }
@@ -545,6 +547,11 @@ export type Session = {
     created: number
     updated: number
     compacting?: number
+  }
+  prompt?: {
+    system?: string
+    systemMode?: "append" | "replace-agent"
+    harness: "auto" | "codex" | "default"
   }
   revert?: {
     messageID: string
@@ -2586,6 +2593,8 @@ export type SessionPromptData = {
     agent?: string
     noReply?: boolean
     system?: string
+    systemMode?: "append" | "replace-agent"
+    harness?: "auto" | "codex" | "default"
     tools?: {
       [key: string]: boolean
     }
@@ -2681,6 +2690,8 @@ export type SessionPromptAsyncData = {
     agent?: string
     noReply?: boolean
     system?: string
+    systemMode?: "append" | "replace-agent"
+    harness?: "auto" | "codex" | "default"
     tools?: {
       [key: string]: boolean
     }
@@ -2727,6 +2738,10 @@ export type SessionCommandData = {
     model?: string
     arguments: string
     command: string
+    variant?: string
+    system?: string
+    systemMode?: "append" | "replace-agent"
+    harness?: "auto" | "codex" | "default"
   }
   path: {
     /**

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4837,7 +4837,7 @@ export type SessionPromptData = {
      */
     systemMode?: "append" | "replace-agent"
     /**
-     * Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference; explicit default forces the native tool schema.
+     * Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.
      */
     harness?: "auto" | "codex" | "default"
     variant?: string
@@ -5063,7 +5063,7 @@ export type SessionPromptAsyncData = {
      */
     systemMode?: "append" | "replace-agent"
     /**
-     * Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference; explicit default forces the native tool schema.
+     * Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.
      */
     harness?: "auto" | "codex" | "default"
     variant?: string
@@ -5118,7 +5118,7 @@ export type SessionCommandData = {
      */
     systemMode?: "append" | "replace-agent"
     /**
-     * Harness mode selected by the session's first user command. Later values are ignored.
+     * Harness mode selected by the session's first user command. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.
      */
     harness?: "auto" | "codex" | "default"
     parts?: Array<{


### PR DESCRIPTION
## Summary

- preserve automatic harness inference when prompt and command inputs omit an explicit override
- align system prompt and GPT toolset selection with inferred harness behavior
- update generated SDK types and add regression coverage

## Verification

- [x] `bun turbo typecheck` (12 tasks passed via pre-push hook)