### PR TITLE
fix(session): avoid _- in session IDs

### DIFF
--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -82,6 +82,13 @@ export function create(prefix: string, direction: "descending" | "ascending", ti
   }
 
   const mark = direction === "descending" ? "-" : "g"
+  // Session IDs are copied into the resume command. Session lists primarily
+  // order by update time, so keep this user-facing payload hexadecimal instead
+  // of exposing the v2 sort marker.
+  if (prefix === prefixes.session) {
+    return prefix + "_" + timeBytes.toString("hex") + randomBase62(LENGTH - TIME_BYTES * 2)
+  }
+
   return prefix + "_" + mark + timeBytes.toString("hex") + randomBase62(LENGTH - 1 - TIME_BYTES * 2)
 }
 

--- a/packages/opencode/test/id/id.test.ts
+++ b/packages/opencode/test/id/id.test.ts
@@ -29,10 +29,15 @@ describe("Identifier", () => {
   })
 
   test("descending v2 starts with - so it sorts before every v1 id", () => {
-    const next = Identifier.descending("session")
+    const next = Identifier.descending("message")
     expect(next[4]).toBe("-")
-    expect(next < v1("ses", "000000000000")).toBe(true)
-    expect(next < v1("ses", "ffffffffffff")).toBe(true)
+    expect(next < v1("msg", "000000000000")).toBe(true)
+    expect(next < v1("msg", "ffffffffffff")).toBe(true)
+  })
+
+  test("session IDs keep a hexadecimal payload without a sort marker", () => {
+    const next = Identifier.descending("session")
+    expect(next).toMatch(/^ses_[0-9a-f]{16}[0-9A-Za-z]{10}$/)
   })
 
   test("ascending ids stay ordered across the old 48-bit wrap", () => {


### PR DESCRIPTION
## Summary
- Keep the 64-bit timestamp payload for session identifiers.
- Omit the internal sort marker from user-facing session IDs so resume commands never contain ses_-.
- Preserve v2 sort markers for other identifier types and add regression coverage.

## Tests
- bun test test/id/id.test.ts
- bun run typecheck
- Pre-push bun turbo typecheck (12/12 tasks successful)
