### PR TITLE
fix(provider): scale output budget with reasoning effort

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1847,8 +1847,14 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
   return { [key]: options }
 }
 
-export function maxOutputTokens(model: Provider.Model): number {
-  if (usesLargeModelDefaults(model)) return LARGE_MODEL_OUTPUT_TOKEN_MAX
+export function maxOutputTokens(model: Provider.Model, opts?: { reasoningEffort?: string }): number {
+  // Deep reasoning efforts spend tens of thousands of tokens thinking before
+  // the answer; a flat small cap truncates mid-reasoning and leaves nothing
+  // for output, producing think-only turns whose retries hit the identical
+  // shortfall. Effort-demanding requests earn the wide budget, bounded by
+  // the model's own output limit.
+  const deep = opts?.reasoningEffort === "high" || opts?.reasoningEffort === "xhigh" || opts?.reasoningEffort === "max"
+  if (deep || usesLargeModelDefaults(model)) return Math.min(model.limit.output, LARGE_MODEL_OUTPUT_TOKEN_MAX)
   return Math.min(model.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
 }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1854,7 +1854,8 @@ export function maxOutputTokens(model: Provider.Model, opts?: { reasoningEffort?
   // shortfall. Effort-demanding requests earn the wide budget, bounded by
   // the model's own output limit.
   const deep = opts?.reasoningEffort === "high" || opts?.reasoningEffort === "xhigh" || opts?.reasoningEffort === "max"
-  if (deep || usesLargeModelDefaults(model)) return Math.min(model.limit.output, LARGE_MODEL_OUTPUT_TOKEN_MAX)
+  if (usesLargeModelDefaults(model)) return LARGE_MODEL_OUTPUT_TOKEN_MAX
+  if (deep) return Math.min(model.limit.output, LARGE_MODEL_OUTPUT_TOKEN_MAX)
   return Math.min(model.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
 }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1855,7 +1855,7 @@ export function maxOutputTokens(model: Provider.Model, opts?: { reasoningEffort?
   // the model's own output limit.
   const deep = opts?.reasoningEffort === "high" || opts?.reasoningEffort === "xhigh" || opts?.reasoningEffort === "max"
   if (usesLargeModelDefaults(model)) return LARGE_MODEL_OUTPUT_TOKEN_MAX
-  if (deep) return Math.min(model.limit.output, LARGE_MODEL_OUTPUT_TOKEN_MAX)
+  if (deep) return Math.min(model.limit.output || LARGE_MODEL_OUTPUT_TOKEN_MAX, LARGE_MODEL_OUTPUT_TOKEN_MAX)
   return Math.min(model.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
 }
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -526,7 +526,7 @@ const live: Layer.Layer<
             : undefined,
           topP: input.agent.topP ?? ProviderTransform.topP(input.model),
           topK: ProviderTransform.topK(input.model),
-          maxOutputTokens: ProviderTransform.maxOutputTokens(input.model),
+          maxOutputTokens: ProviderTransform.maxOutputTokens(input.model, { reasoningEffort: options?.reasoningEffort }),
           options,
         },
       )

--- a/packages/opencode/test/cli/cmd/tui/autocomplete-suspend.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/autocomplete-suspend.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test"
+
+/**
+ * Tests for the command keybinds suspend/resume mechanism.
+ *
+ * The `suspendCount` in dialog-command.tsx is a counter that blocks ALL
+ * command keybinds (including Ctrl+X leader combos) when > 0.
+ *
+ * Two sources can increment it: the ghost text effect (createEffect with
+ * onCleanup) and autocomplete show/hide. The counter must always return
+ * to 0 when both sources are done.
+ *
+ * Regresses the bug where autocomplete had no onCleanup -- when the
+ * Prompt component unmounts while autocomplete was visible, hide() was
+ * never called, leaving suspendCount stuck > 0.
+ */
+describe("command keybinds suspend count", () => {
+  function makeCounter() {
+    let count = 0
+    const keybinds = (enabled: boolean) => {
+      count += enabled ? -1 : 1
+    }
+    const suspended = () => count > 0
+    return { count, keybinds, suspended, get countVal() { return count } }
+  }
+
+  test("single suspend/resume cycle", () => {
+    const { keybinds, suspended } = makeCounter()
+    expect(suspended()).toBe(false)
+
+    // suspend (e.g. autocomplete show)
+    keybinds(false)
+    expect(suspended()).toBe(true)
+
+    // resume (e.g. autocomplete hide)
+    keybinds(true)
+    expect(suspended()).toBe(false)
+  })
+
+  test("double suspend/resume balances correctly (ghost + autocomplete)", () => {
+    const { keybinds, suspended } = makeCounter()
+    expect(suspended()).toBe(false)
+
+    // ghost text appears: suspend
+    keybinds(false)
+    expect(suspended()).toBe(true)
+
+    // autocomplete shows: suspend
+    keybinds(false)
+    expect(suspended()).toBe(true)
+
+    // ghost text clears: resume
+    keybinds(true)
+    expect(suspended()).toBe(true)
+
+    // autocomplete hides: resume
+    keybinds(true)
+    expect(suspended()).toBe(false)
+  })
+
+  test("autocomplete show without hide leaves counter stuck", () => {
+    const { keybinds, suspended } = makeCounter()
+    expect(suspended()).toBe(false)
+
+    // autocomplete shows
+    keybinds(false)
+    expect(suspended()).toBe(true)
+
+    // component unmounts, but NO hide() is called (the bug)
+    // << no cleanup >>
+
+    // counter is stuck
+    expect(suspended()).toBe(true)
+
+    // This is the bug: without onCleanup, no more hide() calls happen
+    // and keybinds stay blocked until something else clears ghost text
+  })
+
+  test("autocomplete onCleanup resumes on unmount", () => {
+    const { keybinds, suspended } = makeCounter()
+    expect(suspended()).toBe(false)
+
+    // autocomplete shows
+    keybinds(false)
+    expect(suspended()).toBe(true)
+
+    // onCleanup fires on unmount
+    keybinds(true)
+    expect(suspended()).toBe(false)
+  })
+
+  test("idempotent show prevents double increment", () => {
+    const { keybinds, suspended } = makeCounter()
+
+    // show() should only increment once
+    let visible = false
+    function show() {
+      if (!visible) keybinds(false)
+      visible = true
+    }
+    function hide() {
+      if (visible) keybinds(true)
+      visible = false
+    }
+
+    show()
+    expect(suspended()).toBe(true)
+
+    // show() again while already visible
+    show()
+    expect(suspended()).toBe(true) // still 1, not 2
+
+    // hide once
+    hide()
+    expect(suspended()).toBe(false)
+  })
+})

--- a/packages/opencode/test/provider/max-output-tokens.test.ts
+++ b/packages/opencode/test/provider/max-output-tokens.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import { maxOutputTokens } from "../../src/provider/transform"
+
+// Structural stand-in: maxOutputTokens/usesLargeModelDefaults read only
+// id/providerID/api.id/limit.output.
+type BudgetModel = {
+  id: string
+  providerID: string
+  api: { id: string }
+  limit: { context: number; output: number }
+}
+
+function model(overrides: Partial<BudgetModel> = {}): BudgetModel {
+  return {
+    id: "ox-alpha-free",
+    providerID: "go-orb",
+    api: { id: "ox-alpha-free" },
+    limit: { context: 1_000_000, output: 131_072 },
+    ...overrides,
+  }
+}
+
+describe("maxOutputTokens", () => {
+  test("mimo-family keeps the wide budget", () => {
+    expect(maxOutputTokens(model({ id: "mimo-v2.5", providerID: "xiaomi" }) as never)).toBe(128_000)
+  })
+
+  test("default effort stays at the flat cap", () => {
+    const m = model()
+    expect(maxOutputTokens(m as never)).toBe(Math.min(m.limit.output, 32_000))
+    expect(maxOutputTokens(m as never, { reasoningEffort: "low" })).toBe(Math.min(m.limit.output, 32_000))
+    expect(maxOutputTokens(m as never, { reasoningEffort: "medium" })).toBe(Math.min(m.limit.output, 32_000))
+  })
+
+  test("deep reasoning efforts raise the ceiling to the wide budget", () => {
+    for (const effort of ["high", "xhigh", "max"]) {
+      expect(maxOutputTokens(model() as never, { reasoningEffort: effort })).toBe(
+        Math.min(model().limit.output, 128_000),
+      )
+    }
+  })
+
+  test("model output limit still bounds deep-effort budgets", () => {
+    const small = model({ limit: { context: 100_000, output: 16_384 } })
+    expect(maxOutputTokens(small as never, { reasoningEffort: "max" })).toBe(16_384)
+  })
+})

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -386,7 +386,11 @@ describe("session.llm.stream", () => {
         expect(body.stream).toBe(true)
 
         const maxTokens = (body.max_tokens as number | undefined) ?? (body.max_output_tokens as number | undefined)
-        const expectedMaxTokens = ProviderTransform.maxOutputTokens(resolved)
+        // The request budget is effort-aware; derive the effort from the same
+        // merged options the provider saw (reflected on the request body).
+        const requestedEffort =
+          (body.reasoningEffort as string | undefined) ?? (body.reasoning_effort as string | undefined)
+        const expectedMaxTokens = ProviderTransform.maxOutputTokens(resolved, { reasoningEffort: requestedEffort })
         expect(maxTokens).toBe(expectedMaxTokens)
 
         const reasoning = (body.reasoningEffort as string | undefined) ?? (body.reasoning_effort as string | undefined)


### PR DESCRIPTION
## Root cause (Ox Alpha '✗ Error think-only')

`maxOutputTokens` capped non-large models at **32k output tokens shared between reasoning and answer**. At `reasoningEffort: max` the thinking alone can exhaust that cap → turn ends mid-reasoning with no answer → classifies as `think-only` → every nudge retry re-truncates identically → retry limit hard-errors. Retries cannot fix a deterministic budget shortfall.

## Fix

Deep efforts (`high`/`xhigh`/`max`) now earn `LARGE_MODEL_OUTPUT_TOKEN_MAX` (128k), still bounded by `model.limit.output`. `session/llm.ts` threads the resolved `reasoningEffort` from provider options into the request budget.

Routing-independent: applies to every provider path, unlike finish-reason remapping (#2174).

## Tests

New `test/provider/max-output-tokens.test.ts` (red→green verified): mimo regression, flat cap for low/medium/default, wide budget for high/xhigh/max, model limit still bounds. Typecheck clean.