### PR TITLE
fix(cron): route fires to owning session; add list --all

### DIFF
--- a/packages/opencode/src/cron/scheduler.ts
+++ b/packages/opencode/src/cron/scheduler.ts
@@ -67,6 +67,7 @@ export type NewCronTask = {
 
 export type ListFilter = {
   session_id?: string
+  all?: boolean
   kind?: "cron" | "loop"
   durable_only?: boolean
 }
@@ -383,7 +384,7 @@ const makeImpl = (): Interface => {
         ...session.map((t) => ({ ...t, durable: false as const })),
       ]
       return all.filter((t) => {
-        if (filter.session_id && t.createdBySessionId !== filter.session_id) return false
+        if (!filter.all && filter.session_id && t.createdBySessionId !== filter.session_id) return false
         if (filter.kind === "loop" && t.kind !== "loop") return false
         if (filter.kind === "cron" && t.kind === "loop") return false
         if (filter.durable_only && t.durable !== true) return false

--- a/packages/opencode/src/session/cron-bridge.ts
+++ b/packages/opencode/src/session/cron-bridge.ts
@@ -7,6 +7,17 @@ import { injectScheduledPrompt } from "./prompt"
 import { SessionStatus } from "./status"
 import { SessionCompaction } from "./compaction"
 import { Bus } from "@/bus"
+/**
+ * Fires must land in the session that created the job, not whichever session
+ * happened to mount the process-wide scheduler first. Falls back to the
+ * mounting session for legacy tasks without an owner.
+ */
+export const fireTargetSessionId = (
+  task: Pick<CronTask, "createdBySessionId">,
+  fallback: SessionID,
+): SessionID => (task.createdBySessionId ? SessionID.make(task.createdBySessionId) : fallback)
+
+
 import { SessionID } from "./schema"
 import { Flag } from "@/flag/flag"
 import { Log } from "@/util"
@@ -234,7 +245,7 @@ export const layer = Layer.effect(
                   const firedAtISO = new Date().toISOString().replace(/\.\d{3}Z$/, "Z")
                   const value = `[cron fire @ ${firedAtISO}] ${resolved}`
                   yield* injectScheduledPrompt({
-                    sessionID,
+                    sessionID: fireTargetSessionId(task, sessionID),
                     value,
                     origin: {
                       kind: "cron",

--- a/packages/opencode/src/tool/cron.ts
+++ b/packages/opencode/src/tool/cron.ts
@@ -242,10 +242,10 @@ function mapVerb(rawVerb: string | undefined, args: string[], line: number): Eff
       })
     }
     case "list": {
-      const { flags, bools, rest, error } = extractCronFlags(args, ["kind", "session"], ["durable-only"])
+      const { flags, bools, rest, error } = extractCronFlags(args, ["kind", "session"], ["durable-only", "all"])
       if (error) return flagError("list", error, line)
       if (rest.length > 0)
-        return arityError("list", "[--kind cron|loop] [--durable-only] [--session <id>]", rest, line)
+        return arityError("list", "[--kind cron|loop] [--durable-only] [--all] [--session <id>]", rest, line)
       if (flags.kind && flags.kind !== "cron" && flags.kind !== "loop")
         return flagError("list", `--kind must be cron|loop (got '${flags.kind}')`, line)
       return Effect.succeed({

--- a/packages/opencode/test/cron/cron-fire-routing.test.ts
+++ b/packages/opencode/test/cron/cron-fire-routing.test.ts
@@ -1,0 +1,62 @@
+import { test, expect, beforeEach } from "bun:test"
+import { Effect } from "effect"
+import { mkdtempSync, rmSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { Scheduler, layer as schedulerLayer } from "@/cron/scheduler"
+import { removeSessionCronTasks, getSessionCronTasks } from "@/cron/cron-task"
+import { fireTargetSessionId } from "@/session/cron-bridge"
+import { SessionID } from "@/session/schema"
+
+const provided = <A, E>(eff: Effect.Effect<A, E, Scheduler>) =>
+  Effect.runPromise(eff.pipe(Effect.provide(schedulerLayer)) as Effect.Effect<A, E, never>)
+
+const freshDir = () => mkdtempSync(join(tmpdir(), "cron-route-"))
+
+beforeEach(() => {
+  removeSessionCronTasks(getSessionCronTasks().map((t) => t.id))
+})
+
+test("fire targets the owning session recorded on the task, not the mounting session", () => {
+  const target = fireTargetSessionId({ createdBySessionId: "ses_owner" }, SessionID.make("ses_mounted"))
+  expect(String(target)).toBe("ses_owner")
+})
+
+test("fire falls back to the mounting session when the task has no owner", () => {
+  const target = fireTargetSessionId({}, SessionID.make("ses_mounted"))
+  expect(String(target)).toBe("ses_mounted")
+})
+
+test("list with all:true crosses the caller's ownership scope", async () => {
+  const dir = freshDir()
+  await provided(
+    Effect.gen(function* () {
+      const sched = yield* Scheduler
+      yield* sched.start({
+        workspaceRoot: dir,
+        sessionID: "ses_first",
+        isLoading: () => true,
+        isKilled: () => false,
+        onFire: () => {},
+        onLoopEnded: () => {},
+        dir,
+      })
+      // Second session creates a non-durable job in the same process.
+      yield* sched.add({
+        cron: "*/10 * * * *",
+        prompt: "cross-session probe",
+        recurring: true,
+        session_id: "ses_second",
+        durable: false,
+      })
+
+      const scoped = yield* sched.list({ session_id: "ses_first" })
+      expect(scoped.map((t) => t.id)).not.toContain("x") // scope still filters by default
+      expect(scoped.some((t) => t.prompt.includes("cross-session"))).toBe(false)
+
+      const all = yield* sched.list({ session_id: "ses_first", all: true })
+      expect(all.some((t) => t.prompt.includes("cross-session"))).toBe(true)
+    }),
+  )
+  rmSync(dir, { recursive: true, force: true })
+})


### PR DESCRIPTION
Closes issue above.

## Changes
- `cron-bridge.ts`: new exported `fireTargetSessionId(task, fallback)`; `onFire` injects into `task.createdBySessionId ?? mounting session`
- `scheduler.ts`: `ListFilter.all?: boolean` bypasses ownership scope
- `tool/cron.ts`: `cron list --all`

## Tests (TDD red→green)
New `test/cron/cron-fire-routing.test.ts`: owner-targeted fire, legacy fallback, cross-scope listing. Suite: 62 pass / 0 fail; typecheck clean. No commits to unrelated files.