### PR TITLE
fix(tool): resolve MCP-prefixed tool aliases

### DIFF
--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -6,7 +6,7 @@ import ts from "typescript"
 import { Effect } from "effect"
 import type { Tool as AiTool } from "ai"
 import { EffectBridge, InstanceState } from "@/effect"
-import { Log, Filesystem } from "@/util"
+import { Log, Filesystem, ToolCompat } from "@/util"
 import { Agent } from "@/agent/agent"
 import type { ModelID, ProviderID } from "../provider/schema"
 import { evalScript, type HostFn } from "../workflow/sandbox"
@@ -529,7 +529,8 @@ export const ToolScriptTool = Tool.define(
             const id = String(name)
             const alias = TOOL_SCRIPT_ALIASES[id as keyof typeof TOOL_SCRIPT_ALIASES]
             const def = byId.get(alias ?? id)
-            const mcpDef = def ? undefined : mcpById.get(id)
+            const mcpID = def ? undefined : ToolCompat.resolveName(id, [...mcpById.keys()])
+            const mcpDef = mcpID ? mcpById.get(mcpID) : undefined
             if (!def && !mcpDef) return Promise.reject(new Error(`unknown tool: ${id}`))
             const toolArgs = id === "exec_command" ? execCommandArgs(args) : args
             calls++

--- a/packages/opencode/src/util/tool-compat.ts
+++ b/packages/opencode/src/util/tool-compat.ts
@@ -3,7 +3,8 @@ import { isRecord } from "./record"
 
 /** Collapse PascalCase, camelCase, snake_case, and kebab-case to one comparable token. */
 export function canonical(name: string): string {
-  return name.replace(/[-_\s]+/g, "").toLowerCase()
+  const mcp = /^mcp__(.+?)__(.+)$/.exec(name)
+  return (mcp ? mcp[1] + "_" + mcp[2] : name).replace(/[-_\s]+/g, "").toLowerCase()
 }
 
 /** Resolve a model-provided identifier to a registered name when casing or separators differ. */

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -744,6 +744,29 @@ describe("exec MCP dispatch", () => {
     expect(result.output).toContain("found: hello")
   })
 
+  test("MCP aliases dispatch to the registered catalog tool", async () => {
+    const seen: string[] = []
+    const mcp = {
+      "feishu-mcp-pro_doc_read": fakeMcpTool(async (args) => {
+        seen.push(args.document_id)
+        return { output: "read: " + args.document_id, metadata: {}, attachments: [] }
+      }),
+    }
+    const result = await runToolScript(
+      `const dashed = await tools["mcp__feishu-mcp-pro__doc_read"]({ document_id: "dash" });
+       const underscored = await tools["mcp__feishu_mcp_pro__doc_read"]({ document_id: "underscore" });
+       return [dashed.output, underscored.output]`,
+      [],
+      undefined,
+      { mcp },
+    )
+
+    expect(result.metadata.status).toBe("completed")
+    expect(result.output).toContain("read: dash")
+    expect(result.output).toContain("read: underscore")
+    expect(seen).toEqual(["dash", "underscore"])
+  }, 15_000)
+
   test("structuredContent crosses into the guest as parsed `structured`", async () => {
     const mcp = {
       srv_data: fakeMcpTool(async () => ({

--- a/packages/opencode/test/util/tool-compat.test.ts
+++ b/packages/opencode/test/util/tool-compat.test.ts
@@ -38,6 +38,13 @@ describe("util.tool-compat", () => {
     test("returns undefined for unknown tools", () => {
       expect(resolveName("grep", tools)).toBeUndefined()
     })
+
+    test("resolves MCP-prefixed names to the registered catalog name", () => {
+      const mcpTools = ["feishu-mcp-pro_doc_read"] as const
+
+      expect(resolveName("mcp__feishu-mcp-pro__doc_read", mcpTools)).toBe("feishu-mcp-pro_doc_read")
+      expect(resolveName("mcp__feishu_mcp_pro__doc_read", mcpTools)).toBe("feishu-mcp-pro_doc_read")
+    })
   })
 
   describe("normalizeInput", () => {

--- a/plans/2026-03-23-mcp-tool-name-aliases.md
+++ b/plans/2026-03-23-mcp-tool-name-aliases.md
@@ -1,0 +1,69 @@
+# MCP Tool Name Aliases Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use compose:subagent (recommended) or compose:execute to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MiMo Code accept canonical MCP tool names and both `mcp__server__tool` spellings without changing the declared catalog names.
+
+**Architecture:** Extend the existing tool-name compatibility resolver so native tool-call repair and the exec sandbox share one alias rule. Keep registered names canonical; resolve aliases only at dispatch time so permissions, catalog output, and metrics retain current identifiers.
+
+**Tech Stack:** TypeScript, Bun test, Effect, AI SDK tools.
+
+## Global Constraints
+
+- Do not add PTC/content parsing in this change.
+- Exact registered tool names always win.
+- Built-in tool IDs continue to win over MCP collisions.
+- The three accepted forms are `feishu-mcp-pro_doc_read`, `mcp__feishu-mcp-pro__doc_read`, and `mcp__feishu_mcp_pro__doc_read`.
+
+---
+
+### Task 1: Resolve MCP aliases in native and exec dispatch
+
+**Files:**
+- Modify: `packages/opencode/src/util/tool-compat.ts`
+- Modify: `packages/opencode/src/tool/tool-script.ts`
+- Test: `packages/opencode/test/util/tool-compat.test.ts`
+- Test: `packages/opencode/test/tool/tool-script.test.ts`
+
+**Interfaces:**
+- Consumes: `ToolCompat.resolveName(name, candidates)` and the exec request-scoped `mcpById` map.
+- Produces: alias-aware resolution to the exact registered MCP tool ID.
+
+- [x] **Step 1: Add failing resolver tests**
+
+Add assertions that both prefixed forms resolve to `feishu-mcp-pro_doc_read`, while exact names and unrelated unknown names retain current behavior.
+
+- [x] **Step 2: Run resolver tests and verify RED**
+
+Run: `bun test test/util/tool-compat.test.ts`
+Expected: the new MCP alias assertions fail because `resolveName` retains the `mcp__` prefix.
+
+- [x] **Step 3: Implement minimal canonicalization**
+
+Normalize a leading `mcp__<server>__<tool>` envelope to `<server>_<tool>` before the existing separator/case collapse. Preserve the existing exact-match and case-match precedence.
+
+- [x] **Step 4: Run resolver tests and verify GREEN**
+
+Run: `bun test test/util/tool-compat.test.ts`
+Expected: all resolver tests pass.
+
+- [x] **Step 5: Add a failing exec integration test**
+
+Register `feishu-mcp-pro_doc_read` in `execMcp.current`, invoke it through each prefixed spelling from sandbox code, and assert both calls execute the same MCP tool.
+
+- [x] **Step 6: Run exec test and verify RED**
+
+Run: `bun test test/tool/tool-script.test.ts --test-name-pattern 'MCP aliases'`
+Expected: exec reports `unknown tool` for the prefixed spelling.
+
+- [x] **Step 7: Resolve aliases at exec MCP lookup**
+
+When a name is not a built-in, pass it through `ToolCompat.resolveName` against `mcpById.keys()`, then execute the resolved map entry. Keep trace labels based on the requested ID and keep builtin collision precedence unchanged.
+
+- [x] **Step 8: Run focused and package verification**
+
+Run: `bun test test/util/tool-compat.test.ts test/tool/tool-script.test.ts`
+Expected: all tests pass.
+
+Run: `bun typecheck`
+Expected: exit code 0.


### PR DESCRIPTION
### Issue / context (if applicable)

Models can emit MCP tool identifiers in mcp__server__tool form, while the registered catalog uses server_tool names. The exec sandbox previously rejected those aliases as unknown tools.

### Type of change

Bug fix

### What does this PR do?

- Normalize MCP-prefixed identifiers through the shared tool compatibility resolver.
- Resolve aliases against registered MCP catalog names before exec dispatch.
- Preserve built-in tool precedence and add resolver plus integration regression coverage.

### How did you verify your code works?

- bun test test/util/tool-compat.test.ts test/tool/tool-script.test.ts (75 passed, 0 failed)
- bun typecheck

### Screenshots / recordings

Not applicable; this is a non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR