### PR TITLE
feat(provider): route Xiaomi PTC through Responses custom exec

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -27,6 +27,7 @@ import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { isRecord } from "@/util/record"
 import { withStatics } from "@/util/schema"
 import { isFreeApiModel, isFreeApiSunset } from "@/util/free-api-sunset"
+import { usesMimoCodexMode } from "../tool/gpt"
 
 import * as ProviderTransform from "./transform"
 import { ModelID, ProviderID } from "./schema"
@@ -323,6 +324,14 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           return sdk.responses(modelID)
         },
         options: { headerTimeout: DEFAULT_OPENAI_HEADER_TIMEOUT },
+      }),
+    xiaomi: () =>
+      Effect.succeed({
+        autoload: false,
+        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
+          return usesMimoCodexMode(modelID) ? sdk.responses(modelID) : sdk.languageModel(modelID)
+        },
+        options: {},
       }),
     xai: () =>
       Effect.succeed({
@@ -1719,7 +1728,14 @@ const layer: Layer.Layer<
           return wrapSSE(bounded, chunkTimeout, chunkAbortCtl)
         }
 
-        const bundledLoader = BUNDLED_PROVIDERS[model.api.npm]
+        const bundledLoader =
+          model.providerID === "xiaomi" && model.api.npm === "@ai-sdk/openai-compatible"
+            ? () =>
+                import("./sdk/copilot").then(
+                  (module) => (options: any) =>
+                    module.createOpenaiCompatible({ ...options, customToolNames: ["exec"] }),
+                )
+            : BUNDLED_PROVIDERS[model.api.npm]
         if (bundledLoader) {
           log.info("using bundled provider", {
             providerID: model.providerID,

--- a/packages/opencode/src/provider/sdk/copilot/copilot-provider.ts
+++ b/packages/opencode/src/provider/sdk/copilot/copilot-provider.ts
@@ -24,6 +24,9 @@ export interface OpenaiCompatibleProviderSettings {
    */
   name?: string
 
+  /** Function tools to expose as Responses free-form custom tools. */
+  customToolNames?: readonly string[]
+
   /**
    * Custom headers to include in the requests.
    */
@@ -77,6 +80,8 @@ export function createOpenaiCompatible(options: OpenaiCompatibleProviderSettings
   const createResponsesModel = (modelId: OpenaiCompatibleModelId) => {
     return new OpenAIResponsesLanguageModel(modelId, {
       provider: `${options.name ?? "openai-compatible"}.responses`,
+      providerOptionsKey: options.name === "github-copilot" ? "copilot" : options.name,
+      customToolNames: options.customToolNames,
       headers: getHeaders,
       url: ({ path }) => `${baseURL}${path}`,
       fetch: options.fetch,

--- a/packages/opencode/src/provider/sdk/copilot/responses/convert-to-openai-responses-input.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/convert-to-openai-responses-input.ts
@@ -1,9 +1,4 @@
-import {
-  type LanguageModelV3Prompt,
-  type LanguageModelV3ToolCallPart,
-  type SharedV3Warning,
-  UnsupportedFunctionalityError,
-} from "@ai-sdk/provider"
+import { type LanguageModelV3Prompt, type SharedV3Warning, UnsupportedFunctionalityError } from "@ai-sdk/provider"
 import { convertToBase64, parseProviderOptions } from "@ai-sdk/provider-utils"
 import { z } from "zod/v4"
 import type { OpenAIResponsesInput, OpenAIResponsesReasoning } from "./openai-responses-api-types"
@@ -18,18 +13,37 @@ function isFileId(data: string, prefixes?: readonly string[]): boolean {
   return prefixes.some((prefix) => data.startsWith(prefix))
 }
 
+function customExecSource(input: unknown): string {
+  if (typeof input !== "string") {
+    if (input && typeof input === "object" && "code" in input && typeof input.code === "string") return input.code
+    throw new Error("Custom exec calls require a string code field")
+  }
+  try {
+    const parsed = JSON.parse(input) as unknown
+    if (typeof parsed === "string") return parsed
+    if (parsed && typeof parsed === "object" && "code" in parsed && typeof parsed.code === "string") {
+      return parsed.code
+    }
+  } catch {
+    // A raw JavaScript body is the native custom-tool representation.
+  }
+  return input
+}
+
 export async function convertToOpenAIResponsesInput({
   prompt,
   systemMessageMode,
   fileIdPrefixes,
   store,
   hasLocalShellTool = false,
+  providerOptionsKey = "copilot",
 }: {
   prompt: LanguageModelV3Prompt
   systemMessageMode: "system" | "developer" | "remove"
   fileIdPrefixes?: readonly string[]
   store: boolean
   hasLocalShellTool?: boolean
+  providerOptionsKey?: string
 }): Promise<{
   input: OpenAIResponsesInput
   warnings: Array<SharedV3Warning>
@@ -37,6 +51,7 @@ export async function convertToOpenAIResponsesInput({
   const input: OpenAIResponsesInput = []
   const warnings: Array<SharedV3Warning> = []
   const processedApprovalIds = new Set<string>()
+  const customToolCallIds = new Set<string>()
 
   for (const { role, content } of prompt) {
     switch (role) {
@@ -119,7 +134,6 @@ export async function convertToOpenAIResponsesInput({
 
       case "assistant": {
         const reasoningMessages: Record<string, OpenAIResponsesReasoning> = {}
-        const toolCallParts: Record<string, LanguageModelV3ToolCallPart> = {}
 
         for (const part of content) {
           switch (part.type) {
@@ -132,8 +146,6 @@ export async function convertToOpenAIResponsesInput({
               break
             }
             case "tool-call": {
-              toolCallParts[part.toolCallId] = part
-
               if (part.providerExecuted) {
                 break
               }
@@ -154,6 +166,18 @@ export async function convertToOpenAIResponsesInput({
                   },
                 })
 
+                break
+              }
+
+              if (part.providerOptions?.openai?.toolCallType === "custom") {
+                customToolCallIds.add(part.toolCallId)
+                input.push({
+                  type: "custom_tool_call",
+                  call_id: part.toolCallId,
+                  name: part.toolName,
+                  input: customExecSource(part.input),
+                  id: (part.providerOptions?.openai?.itemId as string) ?? undefined,
+                })
                 break
               }
 
@@ -184,7 +208,7 @@ export async function convertToOpenAIResponsesInput({
 
             case "reasoning": {
               const providerOptions = await parseProviderOptions({
-                provider: "copilot",
+                provider: providerOptionsKey,
                 providerOptions: part.providerOptions,
                 schema: openaiResponsesReasoningProviderOptionsSchema,
               })
@@ -307,11 +331,19 @@ export async function convertToOpenAIResponsesInput({
               break
           }
 
-          input.push({
-            type: "function_call_output",
-            call_id: part.toolCallId,
-            output: contentValue,
-          })
+          input.push(
+            customToolCallIds.has(part.toolCallId)
+              ? {
+                  type: "custom_tool_call_output",
+                  call_id: part.toolCallId,
+                  output: contentValue,
+                }
+              : {
+                  type: "function_call_output",
+                  call_id: part.toolCallId,
+                  output: contentValue,
+                },
+          )
         }
 
         break

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-config.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-config.ts
@@ -2,6 +2,8 @@ import type { FetchFunction } from "@ai-sdk/provider-utils"
 
 export type OpenAIConfig = {
   provider: string
+  providerOptionsKey?: string
+  customToolNames?: readonly string[]
   url: (options: { modelId: string; path: string }) => string
   headers: () => Record<string, string | undefined>
   fetch?: FetchFunction

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-api-types.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-api-types.ts
@@ -8,6 +8,8 @@ export type OpenAIResponsesInputItem =
   | OpenAIResponsesAssistantMessage
   | OpenAIResponsesFunctionCall
   | OpenAIResponsesFunctionCallOutput
+  | OpenAIResponsesCustomToolCall
+  | OpenAIResponsesCustomToolCallOutput
   | OpenAIResponsesComputerCall
   | OpenAIResponsesLocalShellCall
   | OpenAIResponsesLocalShellCallOutput
@@ -59,6 +61,20 @@ export type OpenAIResponsesFunctionCall = {
 
 export type OpenAIResponsesFunctionCallOutput = {
   type: "function_call_output"
+  call_id: string
+  output: string
+}
+
+export type OpenAIResponsesCustomToolCall = {
+  type: "custom_tool_call"
+  call_id: string
+  name: string
+  input: string
+  id?: string
+}
+
+export type OpenAIResponsesCustomToolCallOutput = {
+  type: "custom_tool_call_output"
   call_id: string
   output: string
 }
@@ -136,6 +152,11 @@ export type OpenAIResponsesFileSearchToolCompoundFilter = {
 }
 
 export type OpenAIResponsesTool =
+  | {
+      type: "custom"
+      name: string
+      description: string | undefined
+    }
   | {
       type: "function"
       name: string

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -106,6 +106,15 @@ const imageGenerationCallItem = z.object({
   result: z.string(),
 })
 
+const customToolCallItem = z.object({
+  type: z.literal("custom_tool_call"),
+  id: z.string(),
+  call_id: z.string(),
+  name: z.string(),
+  input: z.string(),
+  status: z.string().optional(),
+})
+
 /**
  * `top_logprobs` request body argument can be set to an integer between
  * 0 and 20 specifying the number of most likely tokens to return at each
@@ -194,7 +203,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
     }
 
     const openaiOptions = await parseProviderOptions({
-      provider: "copilot",
+      provider: this.config.providerOptionsKey ?? "copilot",
       providerOptions,
       schema: openaiResponsesProviderOptionsSchema,
     })
@@ -205,6 +214,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       fileIdPrefixes: this.config.fileIdPrefixes,
       store: openaiOptions?.store ?? true,
       hasLocalShellTool: hasOpenAITool("openai.local_shell"),
+      providerOptionsKey: this.config.providerOptionsKey ?? "copilot",
     })
 
     warnings.push(...inputWarnings)
@@ -377,6 +387,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       tools,
       toolChoice,
       strictJsonSchema,
+      customToolNames: this.config.customToolNames ? new Set(this.config.customToolNames) : undefined,
     })
 
     return {
@@ -459,6 +470,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
               codeInterpreterCallItem,
               imageGenerationCallItem,
               localShellCallItem,
+              customToolCallItem,
               z.object({
                 type: z.literal("function_call"),
                 call_id: z.string(),
@@ -624,6 +636,24 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             providerMetadata: {
               openai: {
                 itemId: part.id,
+              },
+            },
+          })
+          break
+        }
+
+        case "custom_tool_call": {
+          hasFunctionCall = true
+
+          content.push({
+            type: "tool-call",
+            toolCallId: part.call_id,
+            toolName: part.name,
+            input: JSON.stringify({ code: part.input }),
+            providerMetadata: {
+              openai: {
+                itemId: part.id,
+                toolCallType: "custom",
               },
             },
           })
@@ -826,6 +856,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
           codeInterpreter?: {
             containerId: string
           }
+          custom?: {
+            inputEnded: boolean
+          }
         }
       | undefined
     > = {}
@@ -888,6 +921,23 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   type: "tool-input-start",
                   id: value.item.call_id,
                   toolName: value.item.name,
+                })
+              } else if (value.item.type === "custom_tool_call") {
+                ongoingToolCalls[value.output_index] = {
+                  toolName: value.item.name,
+                  toolCallId: value.item.call_id,
+                  custom: { inputEnded: false },
+                }
+
+                controller.enqueue({
+                  type: "tool-input-start",
+                  id: value.item.call_id,
+                  toolName: value.item.name,
+                })
+                controller.enqueue({
+                  type: "tool-input-delta",
+                  id: value.item.call_id,
+                  delta: '{"code":"',
                 })
               } else if (value.item.type === "web_search_call") {
                 ongoingToolCalls[value.output_index] = {
@@ -996,6 +1046,27 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   providerMetadata: {
                     openai: {
                       itemId: value.item.id,
+                    },
+                  },
+                })
+              } else if (value.item.type === "custom_tool_call") {
+                const toolCall = ongoingToolCalls[value.output_index]
+                if (toolCall?.custom && !toolCall.custom.inputEnded) {
+                  controller.enqueue({ type: "tool-input-delta", id: value.item.call_id, delta: '"}' })
+                  controller.enqueue({ type: "tool-input-end", id: value.item.call_id })
+                }
+                ongoingToolCalls[value.output_index] = undefined
+                hasFunctionCall = true
+
+                controller.enqueue({
+                  type: "tool-call",
+                  toolCallId: value.item.call_id,
+                  toolName: value.item.name,
+                  input: JSON.stringify({ code: value.item.input }),
+                  providerMetadata: {
+                    openai: {
+                      itemId: value.item.id,
+                      toolCallType: "custom",
                     },
                   },
                 })
@@ -1144,6 +1215,24 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   id: toolCall.toolCallId,
                   delta: value.delta,
                 })
+              }
+            } else if (isResponseCustomToolCallInputDeltaChunk(value)) {
+              const toolCall = ongoingToolCalls[value.output_index]
+
+              if (toolCall?.custom) {
+                controller.enqueue({
+                  type: "tool-input-delta",
+                  id: toolCall.toolCallId,
+                  delta: JSON.stringify(value.delta).slice(1, -1),
+                })
+              }
+            } else if (isResponseCustomToolCallInputDoneChunk(value)) {
+              const toolCall = ongoingToolCalls[value.output_index]
+
+              if (toolCall?.custom && !toolCall.custom.inputEnded) {
+                toolCall.custom.inputEnded = true
+                controller.enqueue({ type: "tool-input-delta", id: toolCall.toolCallId, delta: '"}' })
+                controller.enqueue({ type: "tool-input-end", id: toolCall.toolCallId })
               }
             } else if (isResponseImageGenerationCallPartialImageChunk(value)) {
               controller.enqueue({
@@ -1415,6 +1504,7 @@ const responseOutputItemAddedSchema = z.object({
       name: z.string(),
       arguments: z.string(),
     }),
+    customToolCallItem,
     z.object({
       type: z.literal("web_search_call"),
       id: z.string(),
@@ -1478,6 +1568,7 @@ const responseOutputItemDoneSchema = z.object({
       arguments: z.string(),
       status: z.literal("completed"),
     }),
+    customToolCallItem,
     codeInterpreterCallItem,
     imageGenerationCallItem,
     webSearchCallItem,
@@ -1496,6 +1587,20 @@ const responseFunctionCallArgumentsDeltaSchema = z.object({
   item_id: z.string(),
   output_index: z.number(),
   delta: z.string(),
+})
+
+const responseCustomToolCallInputDeltaSchema = z.object({
+  type: z.literal("response.custom_tool_call_input.delta"),
+  item_id: z.string(),
+  output_index: z.number(),
+  delta: z.string(),
+})
+
+const responseCustomToolCallInputDoneSchema = z.object({
+  type: z.literal("response.custom_tool_call_input.done"),
+  item_id: z.string(),
+  output_index: z.number(),
+  input: z.string(),
 })
 
 const responseImageGenerationCallPartialImageSchema = z.object({
@@ -1559,6 +1664,8 @@ const openaiResponsesChunkSchema = z.union([
   responseOutputItemAddedSchema,
   responseOutputItemDoneSchema,
   responseFunctionCallArgumentsDeltaSchema,
+  responseCustomToolCallInputDeltaSchema,
+  responseCustomToolCallInputDoneSchema,
   responseImageGenerationCallPartialImageSchema,
   responseCodeInterpreterCallCodeDeltaSchema,
   responseCodeInterpreterCallCodeDoneSchema,
@@ -1607,6 +1714,18 @@ function isResponseFunctionCallArgumentsDeltaChunk(
   chunk: z.infer<typeof openaiResponsesChunkSchema>,
 ): chunk is z.infer<typeof responseFunctionCallArgumentsDeltaSchema> {
   return chunk.type === "response.function_call_arguments.delta"
+}
+
+function isResponseCustomToolCallInputDeltaChunk(
+  chunk: z.infer<typeof openaiResponsesChunkSchema>,
+): chunk is z.infer<typeof responseCustomToolCallInputDeltaSchema> {
+  return chunk.type === "response.custom_tool_call_input.delta"
+}
+
+function isResponseCustomToolCallInputDoneChunk(
+  chunk: z.infer<typeof openaiResponsesChunkSchema>,
+): chunk is z.infer<typeof responseCustomToolCallInputDoneSchema> {
+  return chunk.type === "response.custom_tool_call_input.done"
 }
 function isResponseImageGenerationCallPartialImageChunk(
   chunk: z.infer<typeof openaiResponsesChunkSchema>,

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-prepare-tools.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-prepare-tools.ts
@@ -10,10 +10,12 @@ export function prepareResponsesTools({
   tools,
   toolChoice,
   strictJsonSchema,
+  customToolNames,
 }: {
   tools: LanguageModelV3CallOptions["tools"]
   toolChoice?: LanguageModelV3CallOptions["toolChoice"]
   strictJsonSchema: boolean
+  customToolNames?: ReadonlySet<string>
 }): {
   tools?: Array<OpenAIResponsesTool>
   toolChoice?:
@@ -24,6 +26,7 @@ export function prepareResponsesTools({
     | { type: "web_search_preview" }
     | { type: "web_search" }
     | { type: "function"; name: string }
+    | { type: "custom"; name: string }
     | { type: "code_interpreter" }
     | { type: "image_generation" }
   toolWarnings: SharedV3Warning[]
@@ -42,6 +45,14 @@ export function prepareResponsesTools({
   for (const tool of tools) {
     switch (tool.type) {
       case "function":
+        if (customToolNames?.has(tool.name)) {
+          openaiTools.push({
+            type: "custom",
+            name: tool.name,
+            description: tool.description,
+          })
+          break
+        }
         openaiTools.push({
           type: "function",
           name: tool.name,
@@ -151,6 +162,13 @@ export function prepareResponsesTools({
     case "required":
       return { tools: openaiTools, toolChoice: type, toolWarnings }
     case "tool":
+      if (customToolNames?.has(toolChoice.toolName)) {
+        return {
+          tools: openaiTools,
+          toolChoice: { type: "custom", name: toolChoice.toolName },
+          toolWarnings,
+        }
+      }
       return {
         tools: openaiTools,
         toolChoice:

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -353,7 +353,7 @@ export const ToolScriptTool = Tool.define(
         code: z
           .string()
           .describe(
-            "Raw JavaScript or TypeScript source for the body of an async function, not JSON or a Markdown code block. Call tools via the global `tools` object; inspect `ALL_TOOLS` when needed; `return` the final aggregated value.",
+            "The `code` field value is raw JavaScript or TypeScript source for the body of an async function, not JSON or a Markdown code block. The outer exec tool arguments must still be a JSON object containing this field. Call tools via the global `tools` object; inspect `ALL_TOOLS` when needed; `return` the final aggregated value.",
           ),
         max_tool_calls: z
           .number()

--- a/packages/opencode/src/tool/tool-script.txt
+++ b/packages/opencode/src/tool/tool-script.txt
@@ -1,5 +1,7 @@
 Execute JavaScript to orchestrate the available tools.
 
+On Responses APIs, `exec` is exposed as a custom tool whose input is this raw source body. On JSON function-tool transports, the compatibility envelope is `{"code":"<source>"}`. Do not add that envelope inside the source itself.
+
 Write the body of an async function. The global `tools` object exposes every tool available to this execution, and each method returns a promise:
 
 ```ts

--- a/packages/opencode/src/util/tool-compat.ts
+++ b/packages/opencode/src/util/tool-compat.ts
@@ -199,6 +199,18 @@ export async function repairToolCall(input: RepairToolCallInput): Promise<Repair
 
   const schema = await Promise.resolve(input.getSchema(resolvedName))
   const parsed = parseToolInput(input.input)
+  const codeSchema = isRecord(schema.properties) ? schema.properties.code : undefined
+  if (
+    resolvedName === "exec" &&
+    typeof parsed === "string" &&
+    isRecord(codeSchema) &&
+    codeSchema.type === "string"
+  ) {
+    return {
+      toolName: resolvedName,
+      input: JSON.stringify({ code: parsed }),
+    }
+  }
   const normalized = normalizeInput(parsed, schema)
   const repairedInput = stringifyToolInput(normalized)
 

--- a/packages/opencode/test/provider/openai-responses-exec-custom.test.ts
+++ b/packages/opencode/test/provider/openai-responses-exec-custom.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, test } from "bun:test"
+import type { JSONSchema7, LanguageModelV3Prompt } from "@ai-sdk/provider"
+import { convertToOpenAIResponsesInput } from "../../src/provider/sdk/copilot/responses/convert-to-openai-responses-input"
+import { prepareResponsesTools } from "../../src/provider/sdk/copilot/responses/openai-responses-prepare-tools"
+import { createOpenaiCompatible } from "../../src/provider/sdk/copilot/copilot-provider"
+import { generateText, jsonSchema, stepCountIs, tool } from "ai"
+
+const execTool = {
+  type: "function",
+  name: "exec",
+  description: "Run a JavaScript tool orchestration body.",
+  inputSchema: {
+    type: "object",
+    properties: { code: { type: "string" } },
+    required: ["code"],
+  } satisfies JSONSchema7,
+}
+
+const userPrompt: LanguageModelV3Prompt = [{ role: "user", content: [{ type: "text", text: "run it" }] }]
+
+function response(output: unknown[]) {
+  return {
+    id: "resp_exec",
+    object: "response",
+    created_at: 1_755_000_000,
+    status: "completed",
+    model: "mimo-ptc",
+    output,
+    usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    incomplete_details: null,
+    service_tier: null,
+  }
+}
+
+function sse(events: unknown[]) {
+  return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") + "data: [DONE]\n\n", {
+    headers: { "content-type": "text/event-stream" },
+  })
+}
+
+describe("Responses exec custom tool", () => {
+  test("advertises exec as a free-form custom tool", () => {
+    const result = prepareResponsesTools({
+      tools: [execTool] as any,
+      strictJsonSchema: false,
+      customToolNames: new Set(["exec"]),
+    })
+
+    expect(result.tools).toEqual([
+      {
+        type: "custom",
+        name: "exec",
+        description: execTool.description,
+      },
+    ])
+  })
+
+  test("keeps exec as a function tool when the provider has no custom-tool capability", () => {
+    const result = prepareResponsesTools({
+      tools: [execTool] as any,
+      strictJsonSchema: false,
+    })
+
+    expect(result.tools?.[0]).toMatchObject({
+      type: "function",
+      name: "exec",
+      parameters: execTool.inputSchema,
+    })
+  })
+
+  test("keeps ordinary tools as JSON function tools", () => {
+    const result = prepareResponsesTools({
+      tools: [{ ...execTool, name: "read" }] as any,
+      strictJsonSchema: false,
+    })
+
+    expect(result.tools?.[0]).toMatchObject({
+      type: "function",
+      name: "read",
+      parameters: execTool.inputSchema,
+    })
+  })
+
+  test("round-trips an exec custom call and its output with the original call type", async () => {
+    const source = 'const r = await tools.exec_command({ cmd: "pwd" }); return r.output'
+    const prompt: LanguageModelV3Prompt = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call_exec_1",
+            toolName: "exec",
+            input: { code: source },
+            providerOptions: {
+              openai: {
+                itemId: "ctc_1",
+                toolCallType: "custom",
+              },
+            },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_exec_1",
+            toolName: "exec",
+            output: { type: "text", value: "ok" },
+          },
+        ],
+      },
+    ]
+
+    const result = await convertToOpenAIResponsesInput({
+      prompt,
+      systemMessageMode: "system",
+      store: false,
+    })
+
+    expect(result.input).toEqual([
+      {
+        type: "custom_tool_call",
+        id: "ctc_1",
+        call_id: "call_exec_1",
+        name: "exec",
+        input: source,
+      },
+      {
+        type: "custom_tool_call_output",
+        call_id: "call_exec_1",
+        output: "ok",
+      },
+    ])
+  })
+
+  test("keeps legacy function-call round trips unchanged", async () => {
+    const prompt: LanguageModelV3Prompt = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call_read_1",
+            toolName: "read",
+            input: { path: "/tmp/a" },
+            providerOptions: { openai: { itemId: "fc_1" } },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_read_1",
+            toolName: "read",
+            output: { type: "text", value: "contents" },
+          },
+        ],
+      },
+    ]
+
+    const result = await convertToOpenAIResponsesInput({
+      prompt,
+      systemMessageMode: "system",
+      store: false,
+    })
+
+    expect(result.input).toEqual([
+      {
+        type: "function_call",
+        id: "fc_1",
+        call_id: "call_read_1",
+        name: "read",
+        arguments: JSON.stringify({ path: "/tmp/a" }),
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_read_1",
+        output: "contents",
+      },
+    ])
+  })
+
+  test("parses a non-streaming custom exec call into the internal code envelope", async () => {
+    const source = 'const r = await tools.exec_command({ cmd: "pwd" }); return r.output'
+    const provider = createOpenaiCompatible({
+      baseURL: "https://example.test/v1",
+      fetch: (async () =>
+        new Response(
+          JSON.stringify(
+            response([
+              {
+                type: "custom_tool_call",
+                id: "ctc_nonstream",
+                call_id: "call_nonstream",
+                name: "exec",
+                input: source,
+              },
+            ]),
+          ),
+          { headers: { "content-type": "application/json" } },
+        )) as any,
+    })
+
+    const result = await provider.responses("mimo-ptc").doGenerate({ prompt: userPrompt })
+
+    expect(result.content).toContainEqual({
+      type: "tool-call",
+      toolCallId: "call_nonstream",
+      toolName: "exec",
+      input: JSON.stringify({ code: source }),
+      providerMetadata: { openai: { itemId: "ctc_nonstream", toolCallType: "custom" } },
+    })
+  })
+
+  test("parses fragmented and adjacent streaming custom exec calls without separators", async () => {
+    const sources = [
+      'const a = await tools.exec_command({ cmd: "pwd" }); return a.output',
+      'const b = await tools.exec_command({ cmd: "git status" }); return b.output',
+    ]
+    const events: unknown[] = [
+      {
+        type: "response.created",
+        response: { id: "resp_stream", created_at: 1_755_000_000, model: "mimo-ptc", service_tier: null },
+      },
+    ]
+    for (const [outputIndex, source] of sources.entries()) {
+      const item = {
+        type: "custom_tool_call",
+        id: `ctc_${outputIndex}`,
+        call_id: `call_${outputIndex}`,
+        name: "exec",
+        input: source,
+      }
+      events.push(
+        { type: "response.output_item.added", output_index: outputIndex, item: { ...item, input: "" } },
+        {
+          type: "response.custom_tool_call_input.delta",
+          item_id: item.id,
+          output_index: outputIndex,
+          delta: source.slice(0, 17),
+        },
+        {
+          type: "response.custom_tool_call_input.delta",
+          item_id: item.id,
+          output_index: outputIndex,
+          delta: source.slice(17),
+        },
+        {
+          type: "response.custom_tool_call_input.done",
+          item_id: item.id,
+          output_index: outputIndex,
+          input: source,
+        },
+        { type: "response.output_item.done", output_index: outputIndex, item: { ...item, status: "completed" } },
+      )
+    }
+    events.push({
+      type: "response.completed",
+      response: {
+        incomplete_details: null,
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        service_tier: null,
+      },
+    })
+
+    const provider = createOpenaiCompatible({
+      baseURL: "https://example.test/v1",
+      fetch: (async () => sse(events)) as any,
+    })
+    const result = await provider.responses("mimo-ptc").doStream({ prompt: userPrompt })
+    const parts: any[] = []
+    const reader = result.stream.getReader()
+    while (true) {
+      const next = await reader.read()
+      if (next.done) break
+      parts.push(next.value)
+    }
+
+    expect(parts.filter((part) => part.type === "tool-call")).toEqual(
+      sources.map((source, index) => ({
+        type: "tool-call",
+        toolCallId: `call_${index}`,
+        toolName: "exec",
+        input: JSON.stringify({ code: source }),
+        providerMetadata: { openai: { itemId: `ctc_${index}`, toolCallType: "custom" } },
+      })),
+    )
+  })
+
+  test("executes and returns a custom-tool output in the next Responses request", async () => {
+    const source = "return 42"
+    const bodies: any[] = []
+    let request = 0
+    const provider = createOpenaiCompatible({
+      name: "xiaomi",
+      customToolNames: ["exec"],
+      baseURL: "https://example.test/v1",
+      fetch: (async (_url: string, init: RequestInit) => {
+        bodies.push(JSON.parse(String(init.body)))
+        request++
+        const output =
+          request === 1
+            ? [
+                {
+                  type: "custom_tool_call",
+                  id: "ctc_loop",
+                  call_id: "call_loop",
+                  name: "exec",
+                  input: source,
+                },
+              ]
+            : [
+                {
+                  type: "message",
+                  id: "msg_done",
+                  role: "assistant",
+                  status: "completed",
+                  content: [{ type: "output_text", text: "done", annotations: [] }],
+                },
+              ]
+        return new Response(JSON.stringify(response(output)), { headers: { "content-type": "application/json" } })
+      }) as any,
+    })
+
+    const result = await generateText({
+      model: provider.responses("mimo-ptc"),
+      prompt: "run it",
+      tools: {
+        exec: tool({
+          description: execTool.description,
+          inputSchema: jsonSchema(execTool.inputSchema),
+          execute: async ({ code }) => `executed:${code}`,
+        }),
+      },
+      providerOptions: { xiaomi: { store: false } },
+      stopWhen: stepCountIs(2),
+    })
+
+    expect(result.text).toBe("done")
+    expect(bodies[0].tools).toEqual([
+      { type: "custom", name: "exec", description: execTool.description },
+    ])
+    expect(bodies[0].store).toBe(false)
+    expect(bodies[1].input).toContainEqual({
+      type: "custom_tool_call",
+      id: "ctc_loop",
+      call_id: "call_loop",
+      name: "exec",
+      input: source,
+    })
+    expect(bodies[1].input).toContainEqual({
+      type: "custom_tool_call_output",
+      call_id: "call_loop",
+      output: "executed:return 42",
+    })
+  })
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1522,6 +1522,84 @@ test("provider with custom npm package", async () => {
   })
 })
 
+test("xiaomi models use the Responses harness for free-form exec PTC", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          enabled_providers: ["xiaomi"],
+          provider: {
+            xiaomi: {
+              npm: "@ai-sdk/openai-compatible",
+              models: {
+                "mimo-ptc-test": {
+                  name: "MiMo PTC Test",
+                  tool_call: true,
+                  limit: { context: 8192, output: 2048 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: "https://example.test/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("XIAOMI_API_KEY", "test-key")
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("xiaomi"), ModelID.make("mimo-ptc-test"))
+      const language = await getLanguage(model)
+      expect(language.provider).toBe("xiaomi.responses")
+    },
+  })
+})
+
+test("xiaomi models outside PTC mode stay on Chat Completions", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          enabled_providers: ["xiaomi"],
+          provider: {
+            xiaomi: {
+              models: {
+                "mimo-v2.5": {
+                  name: "MiMo V2.5",
+                  tool_call: true,
+                  limit: { context: 8192, output: 2048 },
+                },
+              },
+              options: { apiKey: "test-key", baseURL: "https://example.test/v1" },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("XIAOMI_API_KEY", "test-key")
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("xiaomi"), ModelID.make("mimo-v2.5"))
+      const language = await getLanguage(model)
+      expect(language.provider).toBe("xiaomi.chat")
+    },
+  })
+})
+
 // Edge cases for model configuration
 
 test("model alias name defaults to alias key when id differs", async () => {

--- a/packages/opencode/test/util/tool-compat.test.ts
+++ b/packages/opencode/test/util/tool-compat.test.ts
@@ -193,6 +193,41 @@ describe("util.tool-compat", () => {
 
       expect(repaired).toBeUndefined()
     })
+
+    test("wraps raw exec source in the code argument object", async () => {
+      const execSchema = {
+        type: "object",
+        properties: {
+          code: { type: "string" },
+          max_tool_calls: { type: "number" },
+        },
+        required: ["code"],
+      } satisfies JSONSchema7
+      const source = 'const result = await tools.exec_command({ cmd: "pwd" }); return result.output'
+
+      const repaired = await repairToolCall({
+        toolName: "exec",
+        input: source,
+        toolNames: ["exec"],
+        getSchema: () => execSchema,
+      })
+
+      expect(repaired).toEqual({
+        toolName: "exec",
+        input: JSON.stringify({ code: source }),
+      })
+    })
+
+    test("does not wrap raw input for other object tools", async () => {
+      const repaired = await repairToolCall({
+        toolName: "read",
+        input: "/tmp/a.ts",
+        toolNames: ["read"],
+        getSchema: () => readSchema,
+      })
+
+      expect(repaired).toBeUndefined()
+    })
   })
 
   describe("parseToolInput CJK / broken unicode escapes", () => {


### PR DESCRIPTION
## Summary
- Route Xiaomi PTC models through the Responses API and expose `exec` as a free-form custom tool.
- Preserve legacy Chat Completions behavior and function-call compatibility for non-PTC models and providers.
- Normalize raw custom-tool source into the internal `{ code: source }` envelope and document the transport contract.
- Add custom-tool round-trip, streaming, routing, and compatibility regression coverage.

## Test Plan
- [x] `bun test --timeout 30000 test/provider/openai-responses-exec-custom.test.ts test/util/tool-compat.test.ts test/provider/provider.test.ts`
- [x] Repository pre-push typecheck hook (12/12 tasks successful)
