### PR TITLE
feat(session): support append-only interrupted turn recovery

### DIFF
--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -997,6 +997,85 @@ export const SessionRoutes = lazy(() =>
         })
       },
     )
+    .get(
+      "/:sessionID/recovery",
+      describeRoute({
+        summary: "List interrupted turn recovery candidates",
+        description: "Return the latest incomplete assistant turn that can be resumed without creating a user message.",
+        operationId: "session.recovery",
+        responses: {
+          200: {
+            description: "Recovery candidates",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({
+                  assistantMessageID: MessageID.zod,
+                  parentMessageID: MessageID.zod,
+                  created: z.number(),
+                  hasPendingTool: z.boolean(),
+                }).array()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ sessionID: SessionID.zod })),
+      async (c) =>
+        jsonRequest("SessionRoutes.recovery", c, function* () {
+          const sessionID = c.req.valid("param").sessionID
+          const svc = yield* SessionPrompt.Service
+          return yield* svc.recovery({ sessionID })
+        }),
+    )
+    .post(
+      "/:sessionID/turn/:assistantMessageID/resume",
+      describeRoute({
+        summary: "Resume an interrupted turn",
+        description: "Resume an incomplete assistant turn without creating another user message.",
+        operationId: "session.resume",
+        responses: {
+          202: { description: "Resume accepted" },
+          ...errors(400, 404, 409),
+        },
+      }),
+      validator("param", z.object({
+        sessionID: SessionID.zod,
+        assistantMessageID: MessageID.zod,
+      })),
+      async (c) => {
+        const params = c.req.valid("param")
+        await runRequest(
+          "SessionRoutes.resume.assertNotBusy",
+          c,
+          SessionRunState.Service.use((svc) => svc.assertNotBusy(params.sessionID)),
+        )
+        await runRequest(
+          "SessionRoutes.resume.validate",
+          c,
+          SessionPrompt.Service.use((svc) =>
+            svc.recovery({ sessionID: params.sessionID }).pipe(
+              Effect.flatMap((candidates) =>
+                candidates.some((candidate) => candidate.assistantMessageID === params.assistantMessageID)
+                  ? Effect.void
+                  : Effect.die(new Error("No resumable interrupted turn found for assistant message " + params.assistantMessageID)),
+              ),
+            ),
+          ),
+        )
+        void runRequest(
+          "SessionRoutes.resume",
+          c,
+          SessionPrompt.Service.use((svc) => svc.resume({
+            sessionID: params.sessionID,
+            assistantMessageID: params.assistantMessageID,
+          })),
+        ).catch((error) => {
+          log.error("session resume failed", { sessionID: params.sessionID, error })
+        })
+        return c.body(null, 202)
+      },
+    )
     .post(
       "/:sessionID/message",
       describeRoute({

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -280,6 +280,16 @@ export type StreamRequest = StreamInput & {
 
 export type Event = Result["fullStream"] extends AsyncIterable<infer T> ? T : never
 
+/** Convert per-turn context into the final model-visible user segment. */
+export function turnContextMessages(user: MessageV2.User): ModelMessage[] {
+  const context = user.system?.trim()
+  if (!context) return []
+  return [{
+    role: "user",
+    content: `<system-reminder>\n${context}\n</system-reminder>`,
+  }]
+}
+
 export interface Interface {
   readonly stream: (input: StreamInput) => Stream.Stream<Event, unknown>
   readonly buildSystemArray: (input: {
@@ -323,8 +333,6 @@ const live: Layer.Layer<
           ...SystemPrompt.agent(input.agent, input.model),
           // any custom prompt passed into this call
           ...input.system,
-          // any custom prompt from last user message
-          ...(input.user.system ? [input.user.system] : []),
         ]
           .filter((x) => x)
           .join("\n"),
@@ -496,10 +504,11 @@ const live: Layer.Layer<
       const requestMessages = input.dropAssistantPrefill
         ? ProviderTransform.dropTrailingAssistantPrefill(input.messages)
         : input.messages
+      const requestMessagesWithContext = [...requestMessages, ...turnContextMessages(input.user)]
       const messages = isOpenaiOauth
-        ? requestMessages
+        ? requestMessagesWithContext
         : isWorkflow
-          ? requestMessages
+          ? requestMessagesWithContext
           : [
               ...system.map(
                 (x): ModelMessage => ({
@@ -507,7 +516,7 @@ const live: Layer.Layer<
                   content: x,
                 }),
               ),
-              ...requestMessages,
+              ...requestMessagesWithContext,
             ]
 
       const params = yield* plugin.trigger(
@@ -704,7 +713,7 @@ const live: Layer.Layer<
             modelID: input.model.id,
             trajectory: [
               ...system.map((content) => ({ role: "system", content })),
-              ...requestMessages,
+              ...requestMessagesWithContext,
             ],
             systemPrompt: system,
           },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -242,6 +242,8 @@ const elog = EffectLogger.create({ service: "session.prompt" })
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts>
+  readonly recovery: (input: { sessionID: SessionID }) => Effect.Effect<RecoveryCandidate[]>
+  readonly resume: (input: ResumeTurnInput) => Effect.Effect<MessageV2.WithParts>
   readonly loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
   readonly command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts>
@@ -249,6 +251,20 @@ export interface Interface {
   readonly sweepOrphanAssistants: (sessionID: SessionID, immediate?: boolean) => Effect.Effect<void>
   readonly sweepOrphanToolParts: (sessionID: SessionID) => Effect.Effect<void>
   readonly predict: (input: { sessionID: SessionID }) => Effect.Effect<string>
+}
+
+export interface RecoveryCandidate {
+  assistantMessageID: MessageID
+  parentMessageID: MessageID
+  created: number
+  hasPendingTool: boolean
+}
+
+export interface ResumeTurnInput {
+  sessionID: SessionID
+  assistantMessageID: MessageID
+  agentID?: string
+  task_id?: string
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionPrompt") {}
@@ -2722,6 +2738,26 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       throw new Error("Impossible")
     })
 
+    const recovery = Effect.fn("SessionPrompt.recovery")(function* (input: { sessionID: SessionID }) {
+      const msgs = yield* sessions.messages({ sessionID: input.sessionID, agentID: "main" })
+      const candidates: RecoveryCandidate[] = []
+      for (const [index, msg] of msgs.entries()) {
+        if (msg.info.role !== "assistant" || msg.info.time.completed !== undefined) continue
+        const assistant = msg.info
+        if (!msgs.some((parent) => parent.info.role === "user" && parent.info.id === assistant.parentID)) continue
+        if (msgs.slice(index + 1).some((later) => later.info.role === "user" || later.info.role === "assistant")) continue
+        candidates.push({
+          assistantMessageID: assistant.id,
+          parentMessageID: assistant.parentID,
+          created: assistant.time.created,
+          hasPendingTool: msg.parts.some(
+            (part) => part.type === "tool" && (part.state.status === "pending" || part.state.status === "running"),
+          ),
+        })
+      }
+      return candidates.slice(-1)
+    })
+
     const runLoop: (
       sessionID: SessionID,
       agentID?: string,
@@ -4752,9 +4788,27 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       return result
     })
 
+    const resume = Effect.fn("SessionPrompt.resume")(function* (input: ResumeTurnInput) {
+      yield* state.assertNotBusy(input.sessionID)
+      const candidates = yield* recovery({ sessionID: input.sessionID })
+      const candidate = candidates.find((item) => item.assistantMessageID === input.assistantMessageID)
+      if (candidate === undefined) {
+        throw new Error("No resumable interrupted turn found for assistant message " + input.assistantMessageID)
+      }
+      const agentID = input.agentID ?? "main"
+      return yield* state.ensureRunning(
+        input.sessionID,
+        agentID,
+        lastAssistant(input.sessionID, agentID),
+        runLoop(input.sessionID, agentID, input.task_id),
+      )
+    })
+
     const impl = Service.of({
       cancel,
       prompt,
+      recovery,
+      resume,
       loop,
       shell,
       command,

--- a/packages/opencode/test/cron/end-to-end.test.ts
+++ b/packages/opencode/test/cron/end-to-end.test.ts
@@ -76,6 +76,8 @@ const stubPrompt = Layer.succeed(
         const out: MessageV2.WithParts = { info, parts: [text] }
         return out
       }),
+    recovery: () => Effect.succeed([]),
+    resume: () => Effect.die("resume not expected in cron end-to-end test"),
     loop: () => Effect.die("loop not expected in end-to-end test"),
     shell: () => Effect.die("shell not expected in end-to-end test"),
     command: () => Effect.die("command not expected in end-to-end test"),

--- a/packages/opencode/test/server/session-recovery.test.ts
+++ b/packages/opencode/test/server/session-recovery.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { MessageID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Log } from "../../src/util"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("session turn recovery routes", () => {
+  test("lists the latest incomplete assistant and accepts resume without a new prompt", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const result = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => AppRuntime.runPromise(Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({ title: "recovery route" })
+        const user = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() },
+        })
+        const assistant = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: user.id,
+          sessionID: session.id,
+          mode: "build",
+          agent: "build",
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: ModelID.make("test-model"),
+          providerID: ProviderID.make("test"),
+          time: { created: Date.now() },
+        })
+        const app = Server.Default().app
+        const query = `?directory=${encodeURIComponent(tmp.path)}`
+        const listed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/recovery${query}`)))
+        const candidates = yield* Effect.promise(() => listed.json() as Promise<Array<{ assistantMessageID: string; parentMessageID: string; created: number; hasPendingTool: boolean }>>)
+        const resumed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/turn/${assistant.id}/resume${query}`, { method: "POST" })))
+        return { listed: listed.status, candidates, resumed: resumed.status, userID: user.id }
+      })),
+    })
+
+    expect(result.listed).toBe(200)
+    expect(result.candidates).toEqual([{ assistantMessageID: expect.any(String), parentMessageID: result.userID, created: expect.any(Number), hasPendingTool: false }])
+    expect(result.resumed).toBe(202)
+  })
+})

--- a/packages/opencode/test/session/cron-bridge.integration.test.ts
+++ b/packages/opencode/test/session/cron-bridge.integration.test.ts
@@ -62,6 +62,8 @@ const makeCaptureLayer = (captured: { value: CapturedPrompt[] }) =>
           const out: MessageV2.WithParts = { info, parts: [text] }
           return out
         }),
+      recovery: () => Effect.succeed([]),
+      resume: () => Effect.die("resume not expected in cron-bridge test"),
       loop: () => Effect.die("loop not expected in cron-bridge test"),
       shell: () => Effect.die("shell not expected in cron-bridge test"),
       command: () => Effect.die("command not expected in cron-bridge test"),

--- a/packages/opencode/test/session/keepalive.integration.test.ts
+++ b/packages/opencode/test/session/keepalive.integration.test.ts
@@ -68,6 +68,8 @@ const stubPrompt = Layer.succeed(
         const out: MessageV2.WithParts = { info, parts: [text] }
         return out
       }),
+    recovery: () => Effect.succeed([]),
+    resume: () => Effect.die("resume not expected in keepalive test"),
     loop: () => Effect.die("loop not expected in keepalive test"),
     shell: () => Effect.die("shell not expected in keepalive test"),
     command: () => Effect.die("command not expected in keepalive test"),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -674,6 +674,38 @@ it.live("loop calls LLM and returns assistant message", () =>
   ),
 )
 
+it.live("resume continues an incomplete assistant without creating or rewriting a user message", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      const seeded = yield* seed(chat.id)
+      const before = yield* sessions.messages({ sessionID: chat.id })
+      yield* llm.text("world")
+
+      const candidate = yield* prompt.recovery!({ sessionID: chat.id })
+      expect(candidate).toEqual([expect.objectContaining({ assistantMessageID: seeded.assistant.id })])
+      const result = yield* prompt.resume!({
+        sessionID: chat.id,
+        assistantMessageID: seeded.assistant.id,
+      })
+
+      const after = yield* sessions.messages({ sessionID: chat.id })
+      expect(after.filter((message) => message.info.role === "user")).toHaveLength(1)
+      expect(after.length).toBe(before.length + 1)
+      expect(after.find((message) => message.info.id === seeded.assistant.id)?.info).toMatchObject(seeded.assistant)
+      expect(result.info.role).toBe("assistant")
+      expect(result.info.id).not.toBe(seeded.assistant.id)
+      expect(result.parts.some((part) => part.type === "text" && part.text === "world")).toBe(true)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("loop does not inject dynamic system prompt additions", () =>
   withoutDynamicSystemPrompt(() =>
     provideTmpdirServer(

--- a/packages/opencode/test/session/turn-context-tail.test.ts
+++ b/packages/opencode/test/session/turn-context-tail.test.ts
@@ -92,7 +92,7 @@ describe("Anthropic cache tail", () => {
 
 describe("system prefix stability across turns", () => {
   // Two consecutive turns whose ONLY difference is the client-supplied per-turn
-  // context — exactly what MiMo Desktop's minute-precision clock produces. The
+  // context — exactly what a minute-precision client clock produces. The
   // system prefix must not move, or the provider's prefix cache is invalidated
   // for the entire conversation sitting behind it.
   it.live("a changed per-turn context leaves the system prefix byte-identical", () =>

--- a/packages/opencode/test/session/turn-context-tail.test.ts
+++ b/packages/opencode/test/session/turn-context-tail.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Session as SessionNs } from "../../src/session"
+import { LLM, turnContextMessages } from "../../src/session/llm"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { ProviderTransform } from "../../src/provider"
+import { ToolRegistry } from "../../src/tool"
+import { Log } from "../../src/util"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { ProviderTest } from "../fake/provider"
+import type { Agent } from "../../src/agent/agent"
+
+void Log.init({ print: false })
+
+const it = testEffect(
+  Layer.mergeAll(
+    SessionNs.defaultLayer,
+    LLM.defaultLayer,
+    ToolRegistry.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+  ),
+)
+
+function makeUser(system?: string): MessageV2.User {
+  return {
+    id: MessageID.ascending(),
+    sessionID: SessionID.make("ses_turncontext"),
+    role: "user",
+    time: { created: 0 },
+    agent: "build",
+    model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test") },
+    system,
+  } as unknown as MessageV2.User
+}
+
+const agent = {
+  name: "build",
+  mode: "primary",
+  options: {},
+  permission: [{ permission: "*", pattern: "*", action: "allow" }],
+} satisfies Agent.Info
+
+describe("turnContextMessages", () => {
+  it.effect("absent, empty and whitespace-only per-turn context add nothing", () =>
+    Effect.sync(() => {
+      expect(turnContextMessages(makeUser())).toEqual([])
+      expect(turnContextMessages(makeUser(""))).toEqual([])
+      expect(turnContextMessages(makeUser("   \n  "))).toEqual([])
+    }),
+  )
+
+  it.effect("per-turn context becomes a trailing user message wrapped in system-reminder", () =>
+    Effect.sync(() => {
+      const messages = turnContextMessages(makeUser("## Current date and time\nlocal time 17:58."))
+      expect(messages).toHaveLength(1)
+      expect(messages[0].role).toBe("user")
+      expect(messages[0].content).toBe(
+        "<system-reminder>\n## Current date and time\nlocal time 17:58.\n</system-reminder>",
+      )
+    }),
+  )
+})
+
+describe("Anthropic cache tail", () => {
+  it.effect("marks only the historical tail and appended context segment", () =>
+    Effect.sync(() => {
+    const model = ProviderTest.model({
+      providerID: ProviderID.make("anthropic"),
+      id: ModelID.make("claude-sonnet-4"),
+      api: { id: "claude-sonnet-4", url: "https://example.com", npm: "@ai-sdk/anthropic" },
+    })
+    const result = ProviderTransform.message([
+      { role: "system", content: "stable system" },
+      { role: "user", content: "old question" },
+      { role: "assistant", content: "old answer" },
+      ...turnContextMessages(makeUser("## Current date and time\nlocal time 17:58.")),
+    ] as any[], model, {}) as any[]
+    const marked = result.filter((message) => message.providerOptions?.anthropic?.cacheControl)
+    expect(marked).toHaveLength(3)
+    expect(marked.map((message) => message.content)).toEqual([
+      "stable system",
+      "old answer",
+      "<system-reminder>\n## Current date and time\nlocal time 17:58.\n</system-reminder>",
+    ])
+    }),
+  )
+})
+
+describe("system prefix stability across turns", () => {
+  // Two consecutive turns whose ONLY difference is the client-supplied per-turn
+  // context — exactly what MiMo Desktop's minute-precision clock produces. The
+  // system prefix must not move, or the provider's prefix cache is invalidated
+  // for the entire conversation sitting behind it.
+  it.live("a changed per-turn context leaves the system prefix byte-identical", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const sessions = yield* SessionNs.Service
+          const llm = yield* LLM.Service
+          const session = yield* sessions.create({})
+          const model = ProviderTest.model({
+            id: ModelID.make("gpt-5.2"),
+            providerID: ProviderID.make("openai"),
+          })
+
+          const build = (clock: string) =>
+            llm.buildSystemArray({
+              agent,
+              model,
+              system: ["# Environment\nstable across turns"],
+              user: makeUser(`## Current date and time\nlocal time ${clock}.`),
+              sessionID: session.id,
+            })
+
+          const first = yield* build("17:57")
+          const second = yield* build("17:58")
+
+          expect(second).toEqual(first)
+          expect(first.join("\n")).not.toContain("17:57")
+          expect(first.join("\n")).toContain("stable across turns")
+        }),
+      { git: true },
+    ),
+  )
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -168,6 +168,10 @@ import type {
   SessionPromptAsyncResponses,
   SessionPromptErrors,
   SessionPromptResponses,
+  SessionRecoveryErrors,
+  SessionRecoveryResponses,
+  SessionResumeErrors,
+  SessionResumeResponses,
   SessionRevertErrors,
   SessionRevertResponses,
   SessionShareErrors,
@@ -2522,6 +2526,72 @@ export class Session2 extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<SessionMessageResponses, SessionMessageErrors, ThrowOnError>({
       url: "/session/{sessionID}/message/{messageID}",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * List interrupted turn recovery candidates
+   *
+   * Return the latest incomplete assistant turn that can be resumed without creating a user message.
+   */
+  public recovery<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionRecoveryResponses, SessionRecoveryErrors, ThrowOnError>({
+      url: "/session/{sessionID}/recovery",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Resume an interrupted turn
+   *
+   * Resume an incomplete assistant turn without creating another user message.
+   */
+  public resume<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      assistantMessageID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "assistantMessageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionResumeResponses, SessionResumeErrors, ThrowOnError>({
+      url: "/session/{sessionID}/turn/{assistantMessageID}/resume",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2218,7 +2218,7 @@ export type Config = {
      */
     preserve_recent_tokens?: number
     /**
-     * Token buffer for compaction. Leaves enough window to avoid overflow during compaction.
+     * Token buffer for compaction. Leaves enough window to avoid overflow during compaction (default: up to 33000, capped by the model's maximum output).
      */
     reserved?: number
     /**
@@ -4998,6 +4998,82 @@ export type PartUpdateResponses = {
 }
 
 export type PartUpdateResponse = PartUpdateResponses[keyof PartUpdateResponses]
+
+export type SessionRecoveryData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/recovery"
+}
+
+export type SessionRecoveryErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionRecoveryError = SessionRecoveryErrors[keyof SessionRecoveryErrors]
+
+export type SessionRecoveryResponses = {
+  /**
+   * Recovery candidates
+   */
+  200: Array<{
+    assistantMessageID: string
+    parentMessageID: string
+    created: number
+    hasPendingTool: boolean
+  }>
+}
+
+export type SessionRecoveryResponse = SessionRecoveryResponses[keyof SessionRecoveryResponses]
+
+export type SessionResumeData = {
+  body?: never
+  path: {
+    sessionID: string
+    assistantMessageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn/{assistantMessageID}/resume"
+}
+
+export type SessionResumeErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Conflict — session resource is busy
+   */
+  409: ConflictError
+}
+
+export type SessionResumeError = SessionResumeErrors[keyof SessionResumeErrors]
+
+export type SessionResumeResponses = {
+  /**
+   * Resume accepted
+   */
+  202: unknown
+}
 
 export type SessionPromptAsyncData = {
   body?: {


### PR DESCRIPTION
### Issue / context (if applicable)

An interrupted coding turn can leave an incomplete assistant message after the process exits unexpectedly. The next invocation needs a durable way to identify and continue that turn without changing the user-visible prompt history.

### Type of change

New feature

### What does this PR do?

- Detect the latest resumable incomplete assistant turn with its parent user message.
- Add recovery and resume endpoints with busy-state and candidate validation.
- Resume the existing turn append-only, without creating another user message.
- Keep per-turn context in the trailing user segment so the existing provider cache prefix remains stable.
- Add generated SDK methods and focused recovery, cache-tail, context, and orphan-repair tests.

### How did you verify your code works?

- [x] bun test ./test/server/session-recovery.test.ts ./test/session/turn-context-tail.test.ts (5 passed, 0 failed)
- [x] bun run typecheck in packages/opencode
- [x] bun turbo typecheck pre-push hook (12 tasks passed)
- [x] End-to-end with mimo/mimo-v2.5 through the configured MiMo Router provider: interrupted during a pending tool, resumed with HTTP 202, retained exactly one user message, completed the assistant turn, and returned no remaining recovery candidate.

### Screenshots / recordings

Not applicable; this is a non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
