### PR TITLE
feat(session): support append-only interrupted turn recovery

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -234,6 +234,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       session_recovery: {
         [sessionID: string]: SessionRecoveryResponse
       }
+      session_recovery_active: {
+        [sessionID: string]: string | undefined
+      }
       session_goal: {
         [sessionID: string]: SessionGoal
       }
@@ -299,6 +302,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       session: [],
       session_status: {},
       session_recovery: {},
+      session_recovery_active: {},
       session_goal: {},
       session_diff: {},
       session_cwd: {},
@@ -505,6 +509,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
               delete s.question[sid]
               delete s.session_status[sid]
               delete s.session_recovery[sid]
+              delete s.session_recovery_active[sid]
               delete s.session_goal[sid]
               delete s.session_diff[sid]
               delete s.session_cwd[sid]
@@ -539,7 +544,10 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
         case "session.status": {
           setStore("session_status", event.properties.sessionID, nextSessionStatus(event.properties.status))
-          if (event.properties.status.type === "idle") refreshRecovery(event.properties.sessionID)
+          if (event.properties.status.type === "idle") {
+            setStore("session_recovery_active", event.properties.sessionID, undefined)
+            refreshRecovery(event.properties.sessionID)
+          }
           break
         }
 

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -326,7 +326,12 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       void sdk.client.session
         .recovery({ sessionID }, { throwOnError: true })
         .then((response) => setStore("session_recovery", sessionID, response.data ?? []))
-        .catch(() => setStore("session_recovery", sessionID, []))
+        .catch((error) =>
+          Log.Default.warn("tui recovery refresh failed", {
+            sessionID,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        )
     }
 
     // A bootstrap that nobody awaits still must not fail silently when the
@@ -566,9 +571,6 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }
 
         case "message.updated": {
-          if ((event.properties.info.agentID ?? "main") === "main") {
-            refreshRecovery(event.properties.info.sessionID)
-          }
           // Bucket every message by agentID. Pre-rewire the TUI dropped non-main
           // messages here; now subagent slices are first-class buckets and the
           // session view renders whichever bucket matches route.agentID.

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -17,6 +17,7 @@ import type {
   SessionStatus,
   ProviderListResponse,
   ProviderAuthMethod,
+  SessionRecoveryResponse,
   VcsInfo,
 } from "@mimo-ai/sdk/v2"
 import { createStore, produce, reconcile } from "solid-js/store"
@@ -230,6 +231,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       session_status: {
         [sessionID: string]: SessionStatus
       }
+      session_recovery: {
+        [sessionID: string]: SessionRecoveryResponse
+      }
       session_goal: {
         [sessionID: string]: SessionGoal
       }
@@ -294,6 +298,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       provider_default: {},
       session: [],
       session_status: {},
+      session_recovery: {},
       session_goal: {},
       session_diff: {},
       session_cwd: {},
@@ -317,6 +322,12 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const project = useProject()
     const sdk = useSDK()
     const toast = useToastOptional()
+    const refreshRecovery = (sessionID: string) => {
+      void sdk.client.session
+        .recovery({ sessionID }, { throwOnError: true })
+        .then((response) => setStore("session_recovery", sessionID, response.data ?? []))
+        .catch(() => setStore("session_recovery", sessionID, []))
+    }
 
     // A bootstrap that nobody awaits still must not fail silently when the
     // server's directory whitelist is the reason. `bootstrap` rethrows the
@@ -488,6 +499,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
               delete s.permission[sid]
               delete s.question[sid]
               delete s.session_status[sid]
+              delete s.session_recovery[sid]
               delete s.session_goal[sid]
               delete s.session_diff[sid]
               delete s.session_cwd[sid]
@@ -522,6 +534,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
         case "session.status": {
           setStore("session_status", event.properties.sessionID, nextSessionStatus(event.properties.status))
+          if (event.properties.status.type === "idle") refreshRecovery(event.properties.sessionID)
           break
         }
 
@@ -553,6 +566,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }
 
         case "message.updated": {
+          if ((event.properties.info.agentID ?? "main") === "main") {
+            refreshRecovery(event.properties.info.sessionID)
+          }
           // Bucket every message by agentID. Pre-rewire the TUI dropped non-main
           // messages here; now subagent slices are first-class buckets and the
           // session view renders whichever bucket matches route.agentID.
@@ -957,6 +973,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           return { id: (await sdk.client.session.create({})).data?.id, created: true }
         },
         status(sessionID: string) {
+          const current = store.session_status[sessionID]
+          if (current) return current.type === "idle" ? "idle" : "working"
           const session = result.session.get(sessionID)
           if (!session) return "idle"
           if (session.time.compacting) return "compacting"
@@ -968,7 +986,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         },
         async sync(sessionID: string) {
           if (fullSyncedSessions.has(sessionID)) return
-          const [session, messages, todo, diff, actors, task, children] = await Promise.all([
+          const [session, messages, recovery, todo, diff, actors, task, children] = await Promise.all([
             sdk.client.session.get({ sessionID }, { throwOnError: true }),
             // ⚠️`limit` is ONE budget shared across every agent bucket, not a
             // per-bucket limit. A session whose real `main` history is crowded out
@@ -979,6 +997,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             // is needed to fix it, since this endpoint already returns up to 1000
             // when `limit` is omitted.
             sdk.client.session.messages({ sessionID, limit: 100, agent_id: "*" }),
+            sdk.client.session
+              .recovery({ sessionID }, { throwOnError: true })
+              .catch(() => ({ data: [] as SessionRecoveryResponse })),
             sdk.client.session.todo({ sessionID }),
             sdk.client.session.diff({ sessionID }),
             sdk.client.session.actors({ sessionID }),
@@ -1003,6 +1024,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
                 if (!childMatch.found) draft.session.splice(childMatch.index, 0, child)
               }
               draft.todo[sessionID] = todo.data ?? []
+              draft.session_recovery[sessionID] = recovery.data ?? []
               draft.task[sessionID] = task.data ?? []
               const flat = (messages.data ?? []).map((x) => x.info)
               // Server returns messages id-ordered and message.updated keeps that order; the footer's post-/rebuild pending-detection deliberately does NOT depend on it (it keys off checkpoint coveredUpTo, model.ts), so reordering here won't resurface the stale-context bug.

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -261,6 +261,7 @@ export const dict: Record<string, string> = {
   "tui.command.session.list.title": "Switch session",
   "tui.command.session.new.title": "New session",
   "tui.command.session.recover.title": "Continue interrupted turn",
+  "tui.session.recovering": "recovering",
   "tui.command.workflow.list.title": "Workflows",
   "tui.command.model.list.title": "Switch model",
   "tui.command.model.cycle_recent.title": "Model cycle",

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -260,6 +260,7 @@ export const dict: Record<string, string> = {
   // App-level commands
   "tui.command.session.list.title": "Switch session",
   "tui.command.session.new.title": "New session",
+  "tui.command.session.recover.title": "Continue interrupted turn",
   "tui.command.workflow.list.title": "Workflows",
   "tui.command.model.list.title": "Switch model",
   "tui.command.model.cycle_recent.title": "Model cycle",
@@ -396,6 +397,9 @@ export const dict: Record<string, string> = {
   "tui.toast.try_best.paused_other": "Try-best loop detected; session {{session}} was paused.",
   "tui.toast.try_best.handoff_failed": "Failed to start the selected harness handoff.",
   "tui.toast.try_best.continue_failed": "Failed to continue session",
+  "tui.toast.session.recover.started": "Continuing interrupted turn",
+  "tui.toast.session.recover.none": "No interrupted turn can be continued",
+  "tui.toast.session.recover.failed": "Failed to continue interrupted turn",
   "tui.dialog.try_best.title": "Try-best loop detected — turn paused",
   "tui.dialog.try_best.reason.edit_repeat": "Near-identical edits repeated {{count}} times.",
   "tui.dialog.try_best.reason.edit_repeat_path": "Near-identical edits repeated {{count}} times in {{path}}.",

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -400,6 +400,7 @@ export const dict: Record<string, string> = {
   "tui.toast.session.recover.started": "Continuing interrupted turn",
   "tui.toast.session.recover.none": "No interrupted turn can be continued",
   "tui.toast.session.recover.failed": "Failed to continue interrupted turn",
+  "tui.toast.session.recover.busy": "The session is still running; try again when it is idle",
   "tui.dialog.try_best.title": "Try-best loop detected — turn paused",
   "tui.dialog.try_best.reason.edit_repeat": "Near-identical edits repeated {{count}} times.",
   "tui.dialog.try_best.reason.edit_repeat_path": "Near-identical edits repeated {{count}} times in {{path}}.",

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -336,6 +336,7 @@ export const dict = {
   // App-level commands
   "tui.command.session.list.title": "Cambiar sesión",
   "tui.command.session.new.title": "Nueva sesión",
+  "tui.command.session.recover.title": "Continuar turno interrumpido",
   "tui.command.workflow.list.title": "Flujos de trabajo",
   "tui.command.model.list.title": "Cambiar modelo",
   "tui.command.model.cycle_recent.title": "Ciclo de modelos",
@@ -441,6 +442,9 @@ export const dict = {
   "tui.toast.try_best.paused_other": "Se detectó un bucle try-best; la sesión {{session}} se ha pausado.",
   "tui.toast.try_best.handoff_failed": "No se pudo iniciar la transferencia al entorno seleccionado.",
   "tui.toast.try_best.continue_failed": "No se pudo continuar la sesión",
+  "tui.toast.session.recover.started": "Continuando el turno interrumpido",
+  "tui.toast.session.recover.none": "No hay ningún turno interrumpido que continuar",
+  "tui.toast.session.recover.failed": "No se pudo continuar el turno interrumpido",
   "tui.dialog.try_best.title": "Bucle try-best detectado — turno pausado",
   "tui.dialog.try_best.reason.edit_repeat": "Se repitieron ediciones casi idénticas {{count}} veces.",
   "tui.dialog.try_best.reason.edit_repeat_path":

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -445,6 +445,7 @@ export const dict = {
   "tui.toast.session.recover.started": "Continuando el turno interrumpido",
   "tui.toast.session.recover.none": "No hay ningún turno interrumpido que continuar",
   "tui.toast.session.recover.failed": "No se pudo continuar el turno interrumpido",
+  "tui.toast.session.recover.busy": "La sesión sigue ejecutándose; inténtalo cuando esté inactiva",
   "tui.dialog.try_best.title": "Bucle try-best detectado — turno pausado",
   "tui.dialog.try_best.reason.edit_repeat": "Se repitieron ediciones casi idénticas {{count}} veces.",
   "tui.dialog.try_best.reason.edit_repeat_path":

--- a/packages/opencode/src/cli/cmd/tui/i18n/es.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/es.ts
@@ -337,6 +337,7 @@ export const dict = {
   "tui.command.session.list.title": "Cambiar sesión",
   "tui.command.session.new.title": "Nueva sesión",
   "tui.command.session.recover.title": "Continuar turno interrumpido",
+  "tui.session.recovering": "recuperando",
   "tui.command.workflow.list.title": "Flujos de trabajo",
   "tui.command.model.list.title": "Cambiar modelo",
   "tui.command.model.cycle_recent.title": "Ciclo de modelos",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -325,6 +325,7 @@ export const dict = {
   "tui.command.session.list.title": "Changer de session",
   "tui.command.session.new.title": "Nouvelle session",
   "tui.command.session.recover.title": "Reprendre le tour interrompu",
+  "tui.session.recovering": "récupération en cours",
   "tui.command.workflow.list.title": "Workflows",
   "tui.command.model.list.title": "Changer de modèle",
   "tui.command.model.cycle_recent.title": "Modèles récents",

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -324,6 +324,7 @@ export const dict = {
   // App-level commands
   "tui.command.session.list.title": "Changer de session",
   "tui.command.session.new.title": "Nouvelle session",
+  "tui.command.session.recover.title": "Reprendre le tour interrompu",
   "tui.command.workflow.list.title": "Workflows",
   "tui.command.model.list.title": "Changer de modèle",
   "tui.command.model.cycle_recent.title": "Modèles récents",
@@ -430,6 +431,9 @@ export const dict = {
   "tui.toast.try_best.paused_other": "Boucle try-best détectée ; la session {{session}} a été suspendue.",
   "tui.toast.try_best.handoff_failed": "Impossible de démarrer le transfert vers le harnais sélectionné.",
   "tui.toast.try_best.continue_failed": "Impossible de poursuivre la session",
+  "tui.toast.session.recover.started": "Reprise du tour interrompu",
+  "tui.toast.session.recover.none": "Aucun tour interrompu à reprendre",
+  "tui.toast.session.recover.failed": "Impossible de reprendre le tour interrompu",
   "tui.dialog.try_best.title": "Boucle try-best détectée — tour suspendu",
   "tui.dialog.try_best.reason.edit_repeat": "Des modifications presque identiques ont été répétées {{count}} fois.",
   "tui.dialog.try_best.reason.edit_repeat_path":

--- a/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/fr.ts
@@ -434,6 +434,7 @@ export const dict = {
   "tui.toast.session.recover.started": "Reprise du tour interrompu",
   "tui.toast.session.recover.none": "Aucun tour interrompu à reprendre",
   "tui.toast.session.recover.failed": "Impossible de reprendre le tour interrompu",
+  "tui.toast.session.recover.busy": "La session est encore active ; réessayez lorsqu'elle sera inactive",
   "tui.dialog.try_best.title": "Boucle try-best détectée — tour suspendu",
   "tui.dialog.try_best.reason.edit_repeat": "Des modifications presque identiques ont été répétées {{count}} fois.",
   "tui.dialog.try_best.reason.edit_repeat_path":

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -268,6 +268,7 @@ export const dict = {
   "tui.command.session.list.title": "セッションを切り替え",
   "tui.command.session.new.title": "新規セッション",
   "tui.command.session.recover.title": "中断したターンを再開",
+  "tui.session.recovering": "復旧中",
   "tui.command.workflow.list.title": "ワークフロー",
   "tui.command.model.list.title": "モデルを切り替え",
   "tui.command.model.cycle_recent.title": "モデルを循環",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -267,6 +267,7 @@ export const dict = {
   // App-level commands
   "tui.command.session.list.title": "セッションを切り替え",
   "tui.command.session.new.title": "新規セッション",
+  "tui.command.session.recover.title": "中断したターンを再開",
   "tui.command.workflow.list.title": "ワークフロー",
   "tui.command.model.list.title": "モデルを切り替え",
   "tui.command.model.cycle_recent.title": "モデルを循環",
@@ -372,6 +373,9 @@ export const dict = {
   "tui.toast.try_best.paused_other": "Try-best ループを検出したため、セッション {{session}} を一時停止しました。",
   "tui.toast.try_best.handoff_failed": "選択したハーネスへの引き継ぎを開始できませんでした。",
   "tui.toast.try_best.continue_failed": "セッションを続行できませんでした",
+  "tui.toast.session.recover.started": "中断したターンを再開しています",
+  "tui.toast.session.recover.none": "再開できる中断ターンはありません",
+  "tui.toast.session.recover.failed": "中断したターンを再開できませんでした",
   "tui.dialog.try_best.title": "Try-best ループを検出 — ターンを一時停止しました",
   "tui.dialog.try_best.reason.edit_repeat": "ほぼ同じ編集が {{count}} 回繰り返されました。",
   "tui.dialog.try_best.reason.edit_repeat_path": "{{path}} でほぼ同じ編集が {{count}} 回繰り返されました。",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ja.ts
@@ -376,6 +376,7 @@ export const dict = {
   "tui.toast.session.recover.started": "中断したターンを再開しています",
   "tui.toast.session.recover.none": "再開できる中断ターンはありません",
   "tui.toast.session.recover.failed": "中断したターンを再開できませんでした",
+  "tui.toast.session.recover.busy": "セッションがまだ実行中です。アイドル状態になってから再試行してください",
   "tui.dialog.try_best.title": "Try-best ループを検出 — ターンを一時停止しました",
   "tui.dialog.try_best.reason.edit_repeat": "ほぼ同じ編集が {{count}} 回繰り返されました。",
   "tui.dialog.try_best.reason.edit_repeat_path": "{{path}} でほぼ同じ編集が {{count}} 回繰り返されました。",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -340,6 +340,7 @@ export const dict = {
   "tui.command.session.list.title": "Сменить сессию",
   "tui.command.session.new.title": "Новая сессия",
   "tui.command.session.recover.title": "Продолжить прерванный ход",
+  "tui.session.recovering": "восстановление",
   "tui.command.workflow.list.title": "Рабочие процессы",
   "tui.command.model.list.title": "Сменить модель",
   "tui.command.model.cycle_recent.title": "Цикл моделей",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -449,6 +449,7 @@ export const dict = {
   "tui.toast.session.recover.started": "Продолжаем прерванный ход",
   "tui.toast.session.recover.none": "Нет прерванного хода для продолжения",
   "tui.toast.session.recover.failed": "Не удалось продолжить прерванный ход",
+  "tui.toast.session.recover.busy": "Сеанс ещё выполняется; повторите попытку после перехода в режим ожидания",
   "tui.dialog.try_best.title": "Обнаружен цикл try-best — ход приостановлен",
   "tui.dialog.try_best.reason.edit_repeat": "Почти одинаковые правки повторились {{count}} раз.",
   "tui.dialog.try_best.reason.edit_repeat_path": "Почти одинаковые правки повторились {{count}} раз в {{path}}.",

--- a/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/ru.ts
@@ -339,6 +339,7 @@ export const dict = {
   // App-level commands
   "tui.command.session.list.title": "Сменить сессию",
   "tui.command.session.new.title": "Новая сессия",
+  "tui.command.session.recover.title": "Продолжить прерванный ход",
   "tui.command.workflow.list.title": "Рабочие процессы",
   "tui.command.model.list.title": "Сменить модель",
   "tui.command.model.cycle_recent.title": "Цикл моделей",
@@ -445,6 +446,9 @@ export const dict = {
   "tui.toast.try_best.paused_other": "Обнаружен цикл try-best; сеанс {{session}} приостановлен.",
   "tui.toast.try_best.handoff_failed": "Не удалось запустить передачу выбранному исполнителю.",
   "tui.toast.try_best.continue_failed": "Не удалось продолжить сеанс",
+  "tui.toast.session.recover.started": "Продолжаем прерванный ход",
+  "tui.toast.session.recover.none": "Нет прерванного хода для продолжения",
+  "tui.toast.session.recover.failed": "Не удалось продолжить прерванный ход",
   "tui.dialog.try_best.title": "Обнаружен цикл try-best — ход приостановлен",
   "tui.dialog.try_best.reason.edit_repeat": "Почти одинаковые правки повторились {{count}} раз.",
   "tui.dialog.try_best.reason.edit_repeat_path": "Почти одинаковые правки повторились {{count}} раз в {{path}}.",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -422,6 +422,7 @@ export const dict = {
   "tui.toast.session.recover.started": "正在继续中断回合",
   "tui.toast.session.recover.none": "没有可继续的中断回合",
   "tui.toast.session.recover.failed": "继续中断回合失败",
+  "tui.toast.session.recover.busy": "会话仍在运行，请等待空闲后再试",
   "tui.dialog.try_best.title": "检测到 Try-best 循环 — 当前轮次已暂停",
   "tui.dialog.try_best.reason.edit_repeat": "近似相同的编辑重复了 {{count}} 次。",
   "tui.dialog.try_best.reason.edit_repeat_path": "在 {{path}} 中，近似相同的编辑重复了 {{count}} 次。",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -282,6 +282,7 @@ export const dict = {
   // App-level commands
   "tui.command.session.list.title": "切换会话",
   "tui.command.session.new.title": "新建会话",
+  "tui.command.session.recover.title": "继续中断回合",
   "tui.command.workflow.list.title": "工作流",
   "tui.command.model.list.title": "切换模型",
   "tui.command.model.cycle_recent.title": "循环切换模型",
@@ -418,6 +419,9 @@ export const dict = {
   "tui.toast.try_best.paused_other": "检测到 Try-best 循环；会话 {{session}} 已暂停。",
   "tui.toast.try_best.handoff_failed": "启动所选 harness 的交接失败。",
   "tui.toast.try_best.continue_failed": "继续会话失败",
+  "tui.toast.session.recover.started": "正在继续中断回合",
+  "tui.toast.session.recover.none": "没有可继续的中断回合",
+  "tui.toast.session.recover.failed": "继续中断回合失败",
   "tui.dialog.try_best.title": "检测到 Try-best 循环 — 当前轮次已暂停",
   "tui.dialog.try_best.reason.edit_repeat": "近似相同的编辑重复了 {{count}} 次。",
   "tui.dialog.try_best.reason.edit_repeat_path": "在 {{path}} 中，近似相同的编辑重复了 {{count}} 次。",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zh.ts
@@ -283,6 +283,7 @@ export const dict = {
   "tui.command.session.list.title": "切换会话",
   "tui.command.session.new.title": "新建会话",
   "tui.command.session.recover.title": "继续中断回合",
+  "tui.session.recovering": "恢复中",
   "tui.command.workflow.list.title": "工作流",
   "tui.command.model.list.title": "切换模型",
   "tui.command.model.cycle_recent.title": "循环切换模型",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -422,6 +422,7 @@ export const dict = {
   "tui.toast.session.recover.started": "正在繼續中斷回合",
   "tui.toast.session.recover.none": "沒有可繼續的中斷回合",
   "tui.toast.session.recover.failed": "繼續中斷回合失敗",
+  "tui.toast.session.recover.busy": "工作階段仍在執行，請等候閒置後再試",
   "tui.dialog.try_best.title": "偵測到 Try-best 迴圈 — 目前輪次已暫停",
   "tui.dialog.try_best.reason.edit_repeat": "近似相同的編輯重複了 {{count}} 次。",
   "tui.dialog.try_best.reason.edit_repeat_path": "在 {{path}} 中，近似相同的編輯重複了 {{count}} 次。",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -282,6 +282,7 @@ export const dict = {
   // App-level commands
   "tui.command.session.list.title": "切換工作階段",
   "tui.command.session.new.title": "新增工作階段",
+  "tui.command.session.recover.title": "繼續中斷回合",
   "tui.command.workflow.list.title": "工作流程",
   "tui.command.model.list.title": "切換模型",
   "tui.command.model.cycle_recent.title": "循環切換模型",
@@ -418,6 +419,9 @@ export const dict = {
   "tui.toast.try_best.paused_other": "偵測到 Try-best 迴圈；工作階段 {{session}} 已暫停。",
   "tui.toast.try_best.handoff_failed": "啟動所選 harness 的交接失敗。",
   "tui.toast.try_best.continue_failed": "繼續工作階段失敗",
+  "tui.toast.session.recover.started": "正在繼續中斷回合",
+  "tui.toast.session.recover.none": "沒有可繼續的中斷回合",
+  "tui.toast.session.recover.failed": "繼續中斷回合失敗",
   "tui.dialog.try_best.title": "偵測到 Try-best 迴圈 — 目前輪次已暫停",
   "tui.dialog.try_best.reason.edit_repeat": "近似相同的編輯重複了 {{count}} 次。",
   "tui.dialog.try_best.reason.edit_repeat_path": "在 {{path}} 中，近似相同的編輯重複了 {{count}} 次。",

--- a/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/zht.ts
@@ -283,6 +283,7 @@ export const dict = {
   "tui.command.session.list.title": "切換工作階段",
   "tui.command.session.new.title": "新增工作階段",
   "tui.command.session.recover.title": "繼續中斷回合",
+  "tui.session.recovering": "恢復中",
   "tui.command.workflow.list.title": "工作流程",
   "tui.command.model.list.title": "切換模型",
   "tui.command.model.cycle_recent.title": "循環切換模型",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -525,6 +525,7 @@ export function Session() {
       { sessionID: route.sessionID, assistantMessageID: candidate.assistantMessageID },
       { throwOnError: true },
     )
+    sync.set("session_recovery_active", route.sessionID, candidate.assistantMessageID)
     toast.show({ message: t("tui.toast.session.recover.started"), variant: "info" })
   }
 
@@ -1497,6 +1498,7 @@ export function Session() {
                           recoveryCandidate()?.assistantMessageID === message.id &&
                           sync.session.status(route.sessionID) === "idle"
                         }
+                        recovering={sync.data.session_recovery_active[route.sessionID] === message.id}
                         onRecover={recover}
                       />
                     </Match>
@@ -1795,6 +1797,7 @@ function AssistantMessage(props: {
   parts: Part[]
   last: boolean
   recoverable: boolean
+  recovering: boolean
   onRecover: (assistantMessageID: string) => Promise<void>
 }) {
   const ctx = use()
@@ -1828,6 +1831,7 @@ function AssistantMessage(props: {
   // while a last message is streaming (finish undefined) or for the final/aborted
   // message, which preserves non-orchestrator behavior.
   const showFooter = createMemo(() => {
+    if (props.recovering) return true
     if (props.message.error?.name === "MessageAbortedError") return true
     if (final()) return true
     return props.last && props.message.finish !== "tool-calls"
@@ -1934,6 +1938,9 @@ function AssistantMessage(props: {
               </Show>
               <Show when={props.message.error?.name === "MessageAbortedError"}>
                 <span style={{ fg: theme.textMuted }}> · interrupted</span>
+              </Show>
+              <Show when={props.recovering}>
+                <span style={{ fg: theme.warning }}> · {t("tui.session.recovering")}</span>
               </Show>
             </text>
             <Show when={props.recoverable}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -197,6 +197,11 @@ export function Session() {
     return messages().findLast((x) => x.role === "assistant")
   })
 
+  const canRecover = createMemo(() => {
+    const message = lastAssistant()
+    return message?.role === "assistant" && message.time.completed === undefined
+  })
+
   const dimensions = useTerminalDimensions()
   const [sidebar, setSidebar] = kv.signal<SidebarPreference>("sidebar", "auto")
   const [conceal, setConceal] = createSignal(true)
@@ -492,6 +497,40 @@ export function Session() {
   const command = useCommandDialog()
   const t = useLanguage().t
   command.register(() => [
+    {
+      title: t("tui.command.session.recover.title"),
+      value: "session.recover",
+      suggested: canRecover(),
+      category: "session",
+      slash: {
+        name: "recover",
+      },
+      onSelect: async (dialog) => {
+        try {
+          const candidates = await sdk.client.session.recovery(
+            { sessionID: route.sessionID },
+            { throwOnError: true },
+          )
+          const candidate = candidates.data?.at(-1)
+          if (!candidate) {
+            toast.show({ message: t("tui.toast.session.recover.none"), variant: "info" })
+            dialog.clear()
+            return
+          }
+          await sdk.client.session.resume(
+            { sessionID: route.sessionID, assistantMessageID: candidate.assistantMessageID },
+            { throwOnError: true },
+          )
+          toast.show({ message: t("tui.toast.session.recover.started"), variant: "info" })
+        } catch (error) {
+          toast.show({
+            message: error instanceof Error ? error.message : t("tui.toast.session.recover.failed"),
+            variant: "error",
+          })
+        }
+        dialog.clear()
+      },
+    },
     {
       title: t(session()?.share?.url ? "tui.command.session.share.copy_link" : "tui.command.session.share.title"),
       value: "session.share",
@@ -1861,6 +1900,9 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               </Show>
               <Show when={props.message.error?.name === "MessageAbortedError"}>
                 <span style={{ fg: theme.textMuted }}> · interrupted</span>
+              </Show>
+              <Show when={props.message.error?.name === "MessageAbortedError" && props.last}>
+                <span style={{ fg: theme.warning }}> · /recover</span>
               </Show>
             </text>
             <Show when={props.message.time.completed}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -197,9 +197,16 @@ export function Session() {
     return messages().findLast((x) => x.role === "assistant")
   })
 
-  const canRecover = createMemo(() => {
+  const recoveryCandidate = createMemo(() => {
     const message = lastAssistant()
-    return message?.role === "assistant" && message.time.completed === undefined
+    if (!message || currentAgentID() !== "main") return undefined
+    return sync.data.session_recovery[route.sessionID]?.find(
+      (candidate) => candidate.assistantMessageID === message.id,
+    )
+  })
+
+  const canRecover = createMemo(() => {
+    return Boolean(recoveryCandidate()) && sync.session.status(route.sessionID) === "idle"
   })
 
   const dimensions = useTerminalDimensions()
@@ -496,6 +503,23 @@ export function Session() {
 
   const command = useCommandDialog()
   const t = useLanguage().t
+  const recover = async () => {
+    const candidates = await sdk.client.session.recovery(
+      { sessionID: route.sessionID },
+      { throwOnError: true },
+    )
+    const candidate = candidates.data?.at(-1)
+    if (!candidate) {
+      toast.show({ message: t("tui.toast.session.recover.none"), variant: "info" })
+      return
+    }
+    await sdk.client.session.resume(
+      { sessionID: route.sessionID, assistantMessageID: candidate.assistantMessageID },
+      { throwOnError: true },
+    )
+    toast.show({ message: t("tui.toast.session.recover.started"), variant: "info" })
+  }
+
   command.register(() => [
     {
       title: t("tui.command.session.recover.title"),
@@ -507,21 +531,7 @@ export function Session() {
       },
       onSelect: async (dialog) => {
         try {
-          const candidates = await sdk.client.session.recovery(
-            { sessionID: route.sessionID },
-            { throwOnError: true },
-          )
-          const candidate = candidates.data?.at(-1)
-          if (!candidate) {
-            toast.show({ message: t("tui.toast.session.recover.none"), variant: "info" })
-            dialog.clear()
-            return
-          }
-          await sdk.client.session.resume(
-            { sessionID: route.sessionID, assistantMessageID: candidate.assistantMessageID },
-            { throwOnError: true },
-          )
-          toast.show({ message: t("tui.toast.session.recover.started"), variant: "info" })
+          await recover()
         } catch (error) {
           toast.show({
             message: error instanceof Error ? error.message : t("tui.toast.session.recover.failed"),
@@ -1471,6 +1481,11 @@ export function Session() {
                         last={lastAssistant()?.id === message.id}
                         message={message as AssistantMessage}
                         parts={sync.data.part[message.id] ?? []}
+                        recoverable={
+                          recoveryCandidate()?.assistantMessageID === message.id &&
+                          sync.session.status(route.sessionID) === "idle"
+                        }
+                        onRecover={recover}
                       />
                     </Match>
                   </Switch>
@@ -1763,7 +1778,13 @@ function UserMessage(props: {
   )
 }
 
-function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; last: boolean }) {
+function AssistantMessage(props: {
+  message: AssistantMessage
+  parts: Part[]
+  last: boolean
+  recoverable: boolean
+  onRecover: () => Promise<void>
+}) {
   const ctx = use()
   const local = useLocal()
   const { theme } = useTheme()
@@ -1772,6 +1793,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const renderer = useRenderer()
   const t = useLanguage().t
   const [copyHover, setCopyHover] = createSignal(false)
+  const [recoverHover, setRecoverHover] = createSignal(false)
   const messages = createMemo(() => sync.data.message[props.message.sessionID]?.[props.message.agentID ?? "main"] ?? [])
   const model = createMemo(() =>
     isFreeApiModel({ providerID: props.message.providerID, modelID: props.message.modelID })
@@ -1901,10 +1923,23 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               <Show when={props.message.error?.name === "MessageAbortedError"}>
                 <span style={{ fg: theme.textMuted }}> · interrupted</span>
               </Show>
-              <Show when={props.message.error?.name === "MessageAbortedError" && props.last}>
-                <span style={{ fg: theme.warning }}> · /recover</span>
-              </Show>
             </text>
+            <Show when={props.recoverable}>
+              <box
+                onMouseOver={() => setRecoverHover(true)}
+                onMouseOut={() => setRecoverHover(false)}
+                onMouseUp={() => {
+                  void props.onRecover().catch((error) => {
+                    toast.show({
+                      message: error instanceof Error ? error.message : t("tui.toast.session.recover.failed"),
+                      variant: "error",
+                    })
+                  })
+                }}
+              >
+                <text fg={recoverHover() ? theme.warning : theme.textMuted}>↻ /recover</text>
+              </box>
+            </Show>
             <Show when={props.message.time.completed}>
               <box
                 onMouseOver={() => setCopyHover(true)}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -206,7 +206,8 @@ export function Session() {
   })
 
   const canRecover = createMemo(() => {
-    return Boolean(recoveryCandidate()) && sync.session.status(route.sessionID) === "idle"
+    const status = sync.data.session_status[route.sessionID]
+    return Boolean(recoveryCandidate()) && status?.type !== "busy" && status?.type !== "retry"
   })
 
   const dimensions = useTerminalDimensions()
@@ -503,16 +504,19 @@ export function Session() {
 
   const command = useCommandDialog()
   const t = useLanguage().t
-  const recover = async (assistantMessageID: string) => {
-    if (!canRecover() || recoveryCandidate()?.assistantMessageID !== assistantMessageID) {
-      toast.show({ message: t("tui.toast.session.recover.none"), variant: "info" })
-      return
-    }
+  const recoveryErrorMessage = (error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error)
+    return /busy|409/i.test(message) ? t("tui.toast.session.recover.busy") : message
+  }
+
+  const recover = async (assistantMessageID?: string) => {
     const candidates = await sdk.client.session.recovery(
       { sessionID: route.sessionID },
       { throwOnError: true },
     )
-    const candidate = candidates.data?.find((item) => item.assistantMessageID === assistantMessageID)
+    const candidate = assistantMessageID
+      ? candidates.data?.find((item) => item.assistantMessageID === assistantMessageID)
+      : candidates.data?.at(-1)
     if (!candidate) {
       toast.show({ message: t("tui.toast.session.recover.none"), variant: "info" })
       return
@@ -536,14 +540,13 @@ export function Session() {
       onSelect: async (dialog) => {
         try {
           const candidate = recoveryCandidate()
-          if (!candidate) {
-            toast.show({ message: t("tui.toast.session.recover.none"), variant: "info" })
-          } else {
-            await recover(candidate.assistantMessageID)
-          }
+          const status = sync.data.session_status[route.sessionID]
+          if (status?.type === "busy" || status?.type === "retry") {
+            toast.show({ message: t("tui.toast.session.recover.busy"), variant: "info" })
+          } else await recover(candidate?.assistantMessageID)
         } catch (error) {
           toast.show({
-            message: error instanceof Error ? error.message : t("tui.toast.session.recover.failed"),
+            message: recoveryErrorMessage(error),
             variant: "error",
           })
         }
@@ -1940,7 +1943,12 @@ function AssistantMessage(props: {
                 onMouseUp={() => {
                   void props.onRecover(props.message.id).catch((error) => {
                     toast.show({
-                      message: error instanceof Error ? error.message : t("tui.toast.session.recover.failed"),
+                      message:
+                        error instanceof Error && /busy|409/i.test(error.message)
+                          ? t("tui.toast.session.recover.busy")
+                          : error instanceof Error
+                            ? error.message
+                            : t("tui.toast.session.recover.failed"),
                       variant: "error",
                     })
                   })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -503,12 +503,16 @@ export function Session() {
 
   const command = useCommandDialog()
   const t = useLanguage().t
-  const recover = async () => {
+  const recover = async (assistantMessageID: string) => {
+    if (!canRecover() || recoveryCandidate()?.assistantMessageID !== assistantMessageID) {
+      toast.show({ message: t("tui.toast.session.recover.none"), variant: "info" })
+      return
+    }
     const candidates = await sdk.client.session.recovery(
       { sessionID: route.sessionID },
       { throwOnError: true },
     )
-    const candidate = candidates.data?.at(-1)
+    const candidate = candidates.data?.find((item) => item.assistantMessageID === assistantMessageID)
     if (!candidate) {
       toast.show({ message: t("tui.toast.session.recover.none"), variant: "info" })
       return
@@ -531,7 +535,12 @@ export function Session() {
       },
       onSelect: async (dialog) => {
         try {
-          await recover()
+          const candidate = recoveryCandidate()
+          if (!candidate) {
+            toast.show({ message: t("tui.toast.session.recover.none"), variant: "info" })
+          } else {
+            await recover(candidate.assistantMessageID)
+          }
         } catch (error) {
           toast.show({
             message: error instanceof Error ? error.message : t("tui.toast.session.recover.failed"),
@@ -1783,7 +1792,7 @@ function AssistantMessage(props: {
   parts: Part[]
   last: boolean
   recoverable: boolean
-  onRecover: () => Promise<void>
+  onRecover: (assistantMessageID: string) => Promise<void>
 }) {
   const ctx = use()
   const local = useLocal()
@@ -1929,7 +1938,7 @@ function AssistantMessage(props: {
                 onMouseOver={() => setRecoverHover(true)}
                 onMouseOut={() => setRecoverHover(false)}
                 onMouseUp={() => {
-                  void props.onRecover().catch((error) => {
+                  void props.onRecover(props.message.id).catch((error) => {
                     toast.show({
                       message: error instanceof Error ? error.message : t("tui.toast.session.recover.failed"),
                       variant: "error",

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -1013,7 +1013,6 @@ export const SessionRoutes = lazy(() =>
                   assistantMessageID: MessageID.zod,
                   parentMessageID: MessageID.zod,
                   created: z.number(),
-                  hasPendingTool: z.boolean(),
                 }).array()),
               },
             },

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -1064,7 +1064,7 @@ export const SessionRoutes = lazy(() =>
           "SessionRoutes.resume.validate",
           c,
           SessionPrompt.Service.use((svc) =>
-            svc.recovery({ sessionID: params.sessionID }).pipe(
+            svc.recovery({ sessionID: params.sessionID, agentID: query.agentID }).pipe(
               Effect.flatMap((candidates) =>
                 candidates.some((candidate) => candidate.assistantMessageID === params.assistantMessageID)
                   ? Effect.void
@@ -1088,10 +1088,11 @@ export const SessionRoutes = lazy(() =>
           })),
         ).catch((error) => {
           log.error("session resume failed", { sessionID: params.sessionID, error })
-          void Bus.publish(Session.Event.Error, {
-            sessionID: params.sessionID,
-            error: new NamedError.Unknown({ message: error instanceof Error ? error.message : String(error) }).toObject(),
-          })
+          const failure =
+            error instanceof Session.BusyError
+              ? new MessageV2.APIError({ message: error.message, statusCode: 409, isRetryable: true }).toObject()
+              : new NamedError.Unknown({ message: error instanceof Error ? error.message : String(error) }).toObject()
+          void Bus.publish(Session.Event.Error, { sessionID: params.sessionID, error: failure })
         })
         return c.body(null, 202)
       },

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -33,6 +33,7 @@ import { Bus } from "@/bus"
 import { NamedError } from "@mimo-ai/shared/util/error"
 import { jsonRequest, runRequest } from "./trace"
 import { RateLimitMiddleware } from "../../rate-limit"
+import { NotFoundError } from "@/storage"
 
 const log = Log.create({ service: "server" })
 
@@ -1021,11 +1022,13 @@ export const SessionRoutes = lazy(() =>
         },
       }),
       validator("param", z.object({ sessionID: SessionID.zod })),
+      validator("query", z.object({ agentID: z.string().optional() })),
       async (c) =>
         jsonRequest("SessionRoutes.recovery", c, function* () {
           const sessionID = c.req.valid("param").sessionID
+          const query = c.req.valid("query")
           const svc = yield* SessionPrompt.Service
-          return yield* svc.recovery({ sessionID })
+          return yield* svc.recovery({ sessionID, agentID: query.agentID })
         }),
     )
     .post(
@@ -1043,8 +1046,15 @@ export const SessionRoutes = lazy(() =>
         sessionID: SessionID.zod,
         assistantMessageID: MessageID.zod,
       })),
+      validator("query", z.object({
+        directory: z.string().optional(),
+        workspace: z.string().optional(),
+        agentID: z.string().optional(),
+        task_id: z.string().optional(),
+      })),
       async (c) => {
         const params = c.req.valid("param")
+        const query = c.req.valid("query")
         await runRequest(
           "SessionRoutes.resume.assertNotBusy",
           c,
@@ -1058,7 +1068,11 @@ export const SessionRoutes = lazy(() =>
               Effect.flatMap((candidates) =>
                 candidates.some((candidate) => candidate.assistantMessageID === params.assistantMessageID)
                   ? Effect.void
-                  : Effect.die(new Error("No resumable interrupted turn found for assistant message " + params.assistantMessageID)),
+                  : Effect.fail(
+                      new NotFoundError({
+                        message: "No resumable interrupted turn found for assistant message " + params.assistantMessageID,
+                      }),
+                    ),
               ),
             ),
           ),
@@ -1069,9 +1083,15 @@ export const SessionRoutes = lazy(() =>
           SessionPrompt.Service.use((svc) => svc.resume({
             sessionID: params.sessionID,
             assistantMessageID: params.assistantMessageID,
+            agentID: query.agentID,
+            task_id: query.task_id,
           })),
         ).catch((error) => {
           log.error("session resume failed", { sessionID: params.sessionID, error })
+          void Bus.publish(Session.Event.Error, {
+            sessionID: params.sessionID,
+            error: new NamedError.Unknown({ message: error instanceof Error ? error.message : String(error) }).toObject(),
+          })
         })
         return c.body(null, 202)
       },

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -997,6 +997,85 @@ export const SessionRoutes = lazy(() =>
         })
       },
     )
+    .get(
+      "/:sessionID/recovery",
+      describeRoute({
+        summary: "List interrupted turn recovery candidates",
+        description: "Return the latest incomplete assistant turn that can be resumed without creating a user message.",
+        operationId: "session.recovery",
+        responses: {
+          200: {
+            description: "Recovery candidates",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({
+                  assistantMessageID: MessageID.zod,
+                  parentMessageID: MessageID.zod,
+                  created: z.number(),
+                  hasPendingTool: z.boolean(),
+                }).array()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ sessionID: SessionID.zod })),
+      async (c) =>
+        jsonRequest("SessionRoutes.recovery", c, function* () {
+          const sessionID = c.req.valid("param").sessionID
+          const svc = yield* SessionPrompt.Service
+          return yield* svc.recovery({ sessionID })
+        }),
+    )
+    .post(
+      "/:sessionID/turn/:assistantMessageID/resume",
+      describeRoute({
+        summary: "Resume an interrupted turn",
+        description: "Resume an incomplete assistant turn without creating another user message.",
+        operationId: "session.resume",
+        responses: {
+          202: { description: "Resume accepted" },
+          ...errors(400, 404, 409),
+        },
+      }),
+      validator("param", z.object({
+        sessionID: SessionID.zod,
+        assistantMessageID: MessageID.zod,
+      })),
+      async (c) => {
+        const params = c.req.valid("param")
+        await runRequest(
+          "SessionRoutes.resume.assertNotBusy",
+          c,
+          SessionRunState.Service.use((svc) => svc.assertNotBusy(params.sessionID)),
+        )
+        await runRequest(
+          "SessionRoutes.resume.validate",
+          c,
+          SessionPrompt.Service.use((svc) =>
+            svc.recovery({ sessionID: params.sessionID }).pipe(
+              Effect.flatMap((candidates) =>
+                candidates.some((candidate) => candidate.assistantMessageID === params.assistantMessageID)
+                  ? Effect.void
+                  : Effect.die(new Error("No resumable interrupted turn found for assistant message " + params.assistantMessageID)),
+              ),
+            ),
+          ),
+        )
+        void runRequest(
+          "SessionRoutes.resume",
+          c,
+          SessionPrompt.Service.use((svc) => svc.resume({
+            sessionID: params.sessionID,
+            assistantMessageID: params.assistantMessageID,
+          })),
+        ).catch((error) => {
+          log.error("session resume failed", { sessionID: params.sessionID, error })
+        })
+        return c.body(null, 202)
+      },
+    )
     .post(
       "/:sessionID/message",
       describeRoute({

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -281,6 +281,16 @@ export type StreamRequest = StreamInput & {
 
 export type Event = Result["fullStream"] extends AsyncIterable<infer T> ? T : never
 
+/** Convert per-turn context into the final model-visible user segment. */
+export function turnContextMessages(user: MessageV2.User): ModelMessage[] {
+  const context = user.system?.trim()
+  if (!context) return []
+  return [{
+    role: "user",
+    content: `<system-reminder>\n${context}\n</system-reminder>`,
+  }]
+}
+
 export interface Interface {
   readonly stream: (input: StreamInput) => Stream.Stream<Event, unknown>
   readonly buildSystemArray: (input: {
@@ -326,8 +336,6 @@ const live: Layer.Layer<
             : SystemPrompt.agent(input.agent, input.model, input.user.harness)),
           // any custom prompt passed into this call
           ...input.system,
-          // any custom prompt from last user message
-          ...(input.user.system ? [input.user.system] : []),
         ]
           .filter((x) => x)
           .join("\n"),
@@ -499,10 +507,11 @@ const live: Layer.Layer<
       const requestMessages = input.dropAssistantPrefill
         ? ProviderTransform.dropTrailingAssistantPrefill(input.messages)
         : input.messages
+      const requestMessagesWithContext = [...requestMessages, ...turnContextMessages(input.user)]
       const messages = isOpenaiOauth
-        ? requestMessages
+        ? requestMessagesWithContext
         : isWorkflow
-          ? requestMessages
+          ? requestMessagesWithContext
           : [
               ...system.map(
                 (x): ModelMessage => ({
@@ -510,7 +519,7 @@ const live: Layer.Layer<
                   content: x,
                 }),
               ),
-              ...requestMessages,
+              ...requestMessagesWithContext,
             ]
 
       const params = yield* plugin.trigger(
@@ -707,7 +716,7 @@ const live: Layer.Layer<
             modelID: input.model.id,
             trajectory: [
               ...system.map((content) => ({ role: "system", content })),
-              ...requestMessages,
+              ...requestMessagesWithContext,
             ],
             systemPrompt: system,
           },

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -500,11 +500,10 @@ const live: Layer.Layer<
         mergeDeep(input.agent.options),
         mergeDeep(variant),
       )
-      if (isOpenaiOauth) {
-        options.instructions = system.join("\n")
-      }
-
       const isWorkflow = language instanceof GitLabWorkflowLanguageModel
+      const providerSystem =
+        (isOpenaiOauth || isWorkflow) && input.user.system?.trim() ? [...system, input.user.system] : system
+      if (isOpenaiOauth) options.instructions = providerSystem.join("\n")
       // Reactive prefill-rejection backstop. The PRIMARY mechanism is the
       // proactive guard in ProviderTransform.message()
       // (ensureTrailingUserMessage): we never send a request ending in an
@@ -520,11 +519,11 @@ const live: Layer.Layer<
         : input.messages
       const requestMessagesWithContext = appendTurnContext(requestMessages, input.user, input.mergeTurnContextIntoLastUser)
       const messages = isOpenaiOauth
-        ? requestMessagesWithContext
+        ? requestMessages
         : isWorkflow
-          ? requestMessagesWithContext
+          ? requestMessages
           : [
-              ...system.map(
+              ...providerSystem.map(
                 (x): ModelMessage => ({
                   role: "system",
                   content: x,
@@ -726,8 +725,8 @@ const live: Layer.Layer<
             providerID: input.model.providerID,
             modelID: input.model.id,
             trajectory: [
-              ...system.map((content) => ({ role: "system", content })),
-              ...requestMessagesWithContext,
+              ...providerSystem.map((content) => ({ role: "system", content })),
+              ...(isOpenaiOauth || isWorkflow ? requestMessages : requestMessagesWithContext),
             ],
             systemPrompt: system,
           },

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -267,6 +267,7 @@ export type StreamInput = {
   retries?: number
   toolChoice?: "auto" | "required" | "none"
   agentID?: string
+  mergeTurnContextIntoLastUser?: boolean
 }
 
 export type StreamRequest = StreamInput & {
@@ -289,6 +290,16 @@ export function turnContextMessages(user: MessageV2.User): ModelMessage[] {
     role: "user",
     content: `<system-reminder>\n${context}\n</system-reminder>`,
   }]
+}
+
+export function appendTurnContext(messages: ModelMessage[], user: MessageV2.User, mergeWithLastUser = false) {
+  const context = turnContextMessages(user)
+  if (!context.length) return messages
+  const last = messages.at(-1)
+  if (!mergeWithLastUser || !last || last.role !== "user" || typeof last.content !== "string") {
+    return [...messages, ...context]
+  }
+  return [...messages.slice(0, -1), { ...last, content: last.content + "\n\n" + context[0].content }]
 }
 
 export interface Interface {
@@ -507,7 +518,7 @@ const live: Layer.Layer<
       const requestMessages = input.dropAssistantPrefill
         ? ProviderTransform.dropTrailingAssistantPrefill(input.messages)
         : input.messages
-      const requestMessagesWithContext = [...requestMessages, ...turnContextMessages(input.user)]
+      const requestMessagesWithContext = appendTurnContext(requestMessages, input.user, input.mergeTurnContextIntoLastUser)
       const messages = isOpenaiOauth
         ? requestMessagesWithContext
         : isWorkflow

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -242,6 +242,8 @@ const elog = EffectLogger.create({ service: "session.prompt" })
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts>
+  readonly recovery: (input: { sessionID: SessionID }) => Effect.Effect<RecoveryCandidate[]>
+  readonly resume: (input: ResumeTurnInput) => Effect.Effect<MessageV2.WithParts>
   readonly loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
   readonly command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts>
@@ -249,6 +251,20 @@ export interface Interface {
   readonly sweepOrphanAssistants: (sessionID: SessionID, immediate?: boolean) => Effect.Effect<void>
   readonly sweepOrphanToolParts: (sessionID: SessionID) => Effect.Effect<void>
   readonly predict: (input: { sessionID: SessionID }) => Effect.Effect<string>
+}
+
+export interface RecoveryCandidate {
+  assistantMessageID: MessageID
+  parentMessageID: MessageID
+  created: number
+  hasPendingTool: boolean
+}
+
+export interface ResumeTurnInput {
+  sessionID: SessionID
+  assistantMessageID: MessageID
+  agentID?: string
+  task_id?: string
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionPrompt") {}
@@ -2744,6 +2760,26 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       throw new Error("Impossible")
     })
 
+    const recovery = Effect.fn("SessionPrompt.recovery")(function* (input: { sessionID: SessionID }) {
+      const msgs = yield* sessions.messages({ sessionID: input.sessionID, agentID: "main" })
+      const candidates: RecoveryCandidate[] = []
+      for (const [index, msg] of msgs.entries()) {
+        if (msg.info.role !== "assistant" || msg.info.time.completed !== undefined) continue
+        const assistant = msg.info
+        if (!msgs.some((parent) => parent.info.role === "user" && parent.info.id === assistant.parentID)) continue
+        if (msgs.slice(index + 1).some((later) => later.info.role === "user" || later.info.role === "assistant")) continue
+        candidates.push({
+          assistantMessageID: assistant.id,
+          parentMessageID: assistant.parentID,
+          created: assistant.time.created,
+          hasPendingTool: msg.parts.some(
+            (part) => part.type === "tool" && (part.state.status === "pending" || part.state.status === "running"),
+          ),
+        })
+      }
+      return candidates.slice(-1)
+    })
+
     const runLoop: (
       sessionID: SessionID,
       agentID?: string,
@@ -4786,9 +4822,27 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       return result
     })
 
+    const resume = Effect.fn("SessionPrompt.resume")(function* (input: ResumeTurnInput) {
+      yield* state.assertNotBusy(input.sessionID)
+      const candidates = yield* recovery({ sessionID: input.sessionID })
+      const candidate = candidates.find((item) => item.assistantMessageID === input.assistantMessageID)
+      if (candidate === undefined) {
+        throw new Error("No resumable interrupted turn found for assistant message " + input.assistantMessageID)
+      }
+      const agentID = input.agentID ?? "main"
+      return yield* state.ensureRunning(
+        input.sessionID,
+        agentID,
+        lastAssistant(input.sessionID, agentID),
+        runLoop(input.sessionID, agentID, input.task_id),
+      )
+    })
+
     const impl = Service.of({
       cancel,
       prompt,
+      recovery,
+      resume,
       loop,
       shell,
       command,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -258,7 +258,6 @@ export interface RecoveryCandidate {
   assistantMessageID: MessageID
   parentMessageID: MessageID
   created: number
-  hasPendingTool: boolean
 }
 
 export interface ResumeTurnInput {
@@ -2774,9 +2773,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           assistantMessageID: assistant.id,
           parentMessageID: assistant.parentID,
           created: assistant.time.created,
-          hasPendingTool: msg.parts.some(
-            (part) => part.type === "tool" && (part.state.status === "pending" || part.state.status === "running"),
-          ),
         })
       }
       return candidates

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2762,10 +2762,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     })
 
     const recovery = Effect.fn("SessionPrompt.recovery")(function* (input: { sessionID: SessionID; agentID?: string }) {
+      if ((yield* status.get(input.sessionID)).type !== "idle") return []
       const msgs = yield* sessions.messages({ sessionID: input.sessionID, agentID: input.agentID ?? "main" })
       const candidates: RecoveryCandidate[] = []
       for (const [index, msg] of msgs.entries()) {
-        if (msg.info.role !== "assistant" || msg.info.time.completed !== undefined) continue
+        if (msg.info.role !== "assistant" || "completed" in msg.info.time) continue
         const assistant = msg.info
         if (!msgs.some((parent) => parent.info.role === "user" && parent.info.id === assistant.parentID)) continue
         if (msgs.slice(index + 1).some((later) => later.info.role === "user" || later.info.role === "assistant")) continue
@@ -2778,7 +2779,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           ),
         })
       }
-      return candidates.slice(-1)
+      return candidates
     })
 
     const abandonRecoveredAssistant = Effect.fn("SessionPrompt.abandonRecoveredAssistant")(function* (input: {
@@ -2788,7 +2789,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     }) {
       const messages = yield* sessions.messages({ sessionID: input.sessionID, agentID: input.agentID ?? "main" })
       const message = messages.find((item) => item.info.id === input.assistantMessageID)
-      if (!message || message.info.role !== "assistant" || message.info.time.completed !== undefined) return
+      if (!message || message.info.role !== "assistant" || "completed" in message.info.time) return
       yield* sessions.updateMessage({
         ...message.info,
         time: { ...message.info.time, completed: Date.now() },
@@ -3997,7 +3998,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   system: additions,
                   prebuiltSystem,
                   messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
-                  mergeTurnContextIntoLastUser: isLastStep,
+                  mergeTurnContextIntoLastUser: true,
                   tools,
                   activeTools,
                   model,
@@ -4165,7 +4166,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               system: additions,
               prebuiltSystem,
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
-              mergeTurnContextIntoLastUser: isLastStep,
+              mergeTurnContextIntoLastUser: true,
               tools,
               activeTools,
               model,
@@ -4859,7 +4860,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         runLoop(input.sessionID, agentID, input.task_id).pipe(
           Effect.ensuring(
             abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID }).pipe(
-              Effect.catchCause(() => Effect.void),
+              Effect.catchCause((cause) =>
+                elog.warn("recovered-assistant-abandon-failed", {
+                  sessionID: input.sessionID,
+                  messageID: input.assistantMessageID,
+                  cause,
+                }),
+              ),
             ),
           ),
         ),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -33,6 +33,7 @@ import { contextPressureLevel, usable, isOverflow as overflowCheck } from "./ove
 import { Config } from "@/config"
 import { isMemoryWriteEnabled } from "@/memory/write-gate"
 import { Global } from "@/global"
+import { NotFoundError } from "@/storage"
 import { Bus } from "../bus"
 import { ProviderTransform } from "../provider"
 import { SystemPrompt } from "./system"
@@ -242,8 +243,8 @@ const elog = EffectLogger.create({ service: "session.prompt" })
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts>
-  readonly recovery: (input: { sessionID: SessionID }) => Effect.Effect<RecoveryCandidate[]>
-  readonly resume: (input: ResumeTurnInput) => Effect.Effect<MessageV2.WithParts>
+  readonly recovery: (input: { sessionID: SessionID; agentID?: string }) => Effect.Effect<RecoveryCandidate[]>
+  readonly resume: (input: ResumeTurnInput) => Effect.Effect<MessageV2.WithParts, InstanceType<typeof NotFoundError>>
   readonly loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
   readonly command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts>
@@ -2760,8 +2761,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       throw new Error("Impossible")
     })
 
-    const recovery = Effect.fn("SessionPrompt.recovery")(function* (input: { sessionID: SessionID }) {
-      const msgs = yield* sessions.messages({ sessionID: input.sessionID, agentID: "main" })
+    const recovery = Effect.fn("SessionPrompt.recovery")(function* (input: { sessionID: SessionID; agentID?: string }) {
+      const msgs = yield* sessions.messages({ sessionID: input.sessionID, agentID: input.agentID ?? "main" })
       const candidates: RecoveryCandidate[] = []
       for (const [index, msg] of msgs.entries()) {
         if (msg.info.role !== "assistant" || msg.info.time.completed !== undefined) continue
@@ -2778,6 +2779,21 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         })
       }
       return candidates.slice(-1)
+    })
+
+    const abandonRecoveredAssistant = Effect.fn("SessionPrompt.abandonRecoveredAssistant")(function* (input: {
+      sessionID: SessionID
+      assistantMessageID: MessageID
+      agentID?: string
+    }) {
+      const messages = yield* sessions.messages({ sessionID: input.sessionID, agentID: input.agentID ?? "main" })
+      const message = messages.find((item) => item.info.id === input.assistantMessageID)
+      if (!message || message.info.role !== "assistant" || message.info.time.completed !== undefined) return
+      yield* sessions.updateMessage({
+        ...message.info,
+        time: { ...message.info.time, completed: Date.now() },
+        error: new MessageV2.AbortedError({ message: "Abandoned: resumed as a new assistant turn" }).toObject(),
+      })
     })
 
     const runLoop: (
@@ -3981,6 +3997,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   system: additions,
                   prebuiltSystem,
                   messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
+                  mergeTurnContextIntoLastUser: isLastStep,
                   tools,
                   activeTools,
                   model,
@@ -4148,6 +4165,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               system: additions,
               prebuiltSystem,
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
+              mergeTurnContextIntoLastUser: isLastStep,
               tools,
               activeTools,
               model,
@@ -4824,17 +4842,27 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
     const resume = Effect.fn("SessionPrompt.resume")(function* (input: ResumeTurnInput) {
       yield* state.assertNotBusy(input.sessionID)
-      const candidates = yield* recovery({ sessionID: input.sessionID })
+      const candidates = yield* recovery({ sessionID: input.sessionID, agentID: input.agentID })
       const candidate = candidates.find((item) => item.assistantMessageID === input.assistantMessageID)
       if (candidate === undefined) {
-        throw new Error("No resumable interrupted turn found for assistant message " + input.assistantMessageID)
+        return yield* Effect.fail(
+          new NotFoundError({
+            message: "No resumable interrupted turn found for assistant message " + input.assistantMessageID,
+          }),
+        )
       }
       const agentID = input.agentID ?? "main"
       return yield* state.ensureRunning(
         input.sessionID,
         agentID,
         lastAssistant(input.sessionID, agentID),
-        runLoop(input.sessionID, agentID, input.task_id),
+        runLoop(input.sessionID, agentID, input.task_id).pipe(
+          Effect.ensuring(
+            abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID }).pipe(
+              Effect.catchCause(() => Effect.void),
+            ),
+          ),
+        ),
       )
     })
 

--- a/packages/opencode/test/cron/end-to-end.test.ts
+++ b/packages/opencode/test/cron/end-to-end.test.ts
@@ -76,6 +76,8 @@ const stubPrompt = Layer.succeed(
         const out: MessageV2.WithParts = { info, parts: [text] }
         return out
       }),
+    recovery: () => Effect.succeed([]),
+    resume: () => Effect.die("resume not expected in cron end-to-end test"),
     loop: () => Effect.die("loop not expected in end-to-end test"),
     shell: () => Effect.die("shell not expected in end-to-end test"),
     command: () => Effect.die("command not expected in end-to-end test"),

--- a/packages/opencode/test/server/session-recovery.test.ts
+++ b/packages/opencode/test/server/session-recovery.test.ts
@@ -48,8 +48,15 @@ describe("session turn recovery routes", () => {
         })
         const app = Server.Default().app
         const errors: unknown[] = []
+        let resolveError!: () => void
+        const errorSeen = new Promise<void>((resolve) => {
+          resolveError = resolve
+        })
         const unsubscribe = Bus.subscribe(Session.Event.Error, (event) => {
-          if (event.properties.sessionID === session.id) errors.push(event.properties.error)
+          if (event.properties.sessionID === session.id) {
+            errors.push(event.properties.error)
+            resolveError()
+          }
         })
         const query = `?directory=${encodeURIComponent(tmp.path)}`
         const listed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/recovery${query}`)))
@@ -58,7 +65,9 @@ describe("session turn recovery routes", () => {
           Promise.resolve(app.request(`/session/${session.id}/turn/${MessageID.ascending()}/resume${query}`, { method: "POST" })),
         )
         const resumed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/turn/${assistant.id}/resume${query}`, { method: "POST" })))
-        yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 1000)))
+        yield* Effect.promise(() =>
+          Promise.race([errorSeen, new Promise((resolve) => setTimeout(resolve, 10_000))]),
+        )
         unsubscribe()
         const after = yield* sessions.messages({ sessionID: session.id, agentID: "main" })
         const abandoned = after.find((item) => item.info.id === assistant.id)?.info

--- a/packages/opencode/test/server/session-recovery.test.ts
+++ b/packages/opencode/test/server/session-recovery.test.ts
@@ -62,7 +62,8 @@ describe("session turn recovery routes", () => {
         unsubscribe()
         const after = yield* sessions.messages({ sessionID: session.id, agentID: "main" })
         const abandoned = after.find((item) => item.info.id === assistant.id)?.info
-        return { listed: listed.status, candidates, resumed: resumed.status, missing: missing.status, userID: user.id, errors, abandoned }
+        const abandonedAssistant = abandoned?.role === "assistant" ? abandoned : undefined
+        return { listed: listed.status, candidates, resumed: resumed.status, missing: missing.status, userID: user.id, errors, abandoned: abandonedAssistant }
       })),
     })
 

--- a/packages/opencode/test/server/session-recovery.test.ts
+++ b/packages/opencode/test/server/session-recovery.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { MessageID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Log } from "../../src/util"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("session turn recovery routes", () => {
+  test("lists the latest incomplete assistant and accepts resume without a new prompt", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const result = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => AppRuntime.runPromise(Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({ title: "recovery route" })
+        const user = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() },
+        })
+        const assistant = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: user.id,
+          sessionID: session.id,
+          mode: "build",
+          agent: "build",
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: ModelID.make("test-model"),
+          providerID: ProviderID.make("test"),
+          time: { created: Date.now() },
+        })
+        const app = Server.Default().app
+        const query = `?directory=${encodeURIComponent(tmp.path)}`
+        const listed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/recovery${query}`)))
+        const candidates = yield* Effect.promise(() => listed.json() as Promise<Array<{ assistantMessageID: string; parentMessageID: string; created: number; hasPendingTool: boolean }>>)
+        const resumed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/turn/${assistant.id}/resume${query}`, { method: "POST" })))
+        return { listed: listed.status, candidates, resumed: resumed.status, userID: user.id }
+      })),
+    })
+
+    expect(result.listed).toBe(200)
+    expect(result.candidates).toEqual([{ assistantMessageID: expect.any(String), parentMessageID: result.userID, created: expect.any(Number), hasPendingTool: false }])
+    expect(result.resumed).toBe(202)
+  })
+})

--- a/packages/opencode/test/server/session-recovery.test.ts
+++ b/packages/opencode/test/server/session-recovery.test.ts
@@ -49,13 +49,17 @@ describe("session turn recovery routes", () => {
         const query = `?directory=${encodeURIComponent(tmp.path)}`
         const listed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/recovery${query}`)))
         const candidates = yield* Effect.promise(() => listed.json() as Promise<Array<{ assistantMessageID: string; parentMessageID: string; created: number; hasPendingTool: boolean }>>)
+        const missing = yield* Effect.promise(() =>
+          Promise.resolve(app.request(`/session/${session.id}/turn/${MessageID.ascending()}/resume${query}`, { method: "POST" })),
+        )
         const resumed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/turn/${assistant.id}/resume${query}`, { method: "POST" })))
-        return { listed: listed.status, candidates, resumed: resumed.status, userID: user.id }
+        return { listed: listed.status, candidates, resumed: resumed.status, missing: missing.status, userID: user.id }
       })),
     })
 
     expect(result.listed).toBe(200)
     expect(result.candidates).toEqual([{ assistantMessageID: expect.any(String), parentMessageID: result.userID, created: expect.any(Number), hasPendingTool: false }])
     expect(result.resumed).toBe(202)
+    expect(result.missing).toBe(404)
   })
 })

--- a/packages/opencode/test/server/session-recovery.test.ts
+++ b/packages/opencode/test/server/session-recovery.test.ts
@@ -7,6 +7,7 @@ import { Session } from "../../src/session"
 import { MessageID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Log } from "../../src/util"
+import { Bus } from "../../src/bus"
 import { tmpdir } from "../fixture/fixture"
 
 void Log.init({ print: false })
@@ -46,6 +47,10 @@ describe("session turn recovery routes", () => {
           time: { created: Date.now() },
         })
         const app = Server.Default().app
+        const errors: unknown[] = []
+        const unsubscribe = Bus.subscribe(Session.Event.Error, (event) => {
+          if (event.properties.sessionID === session.id) errors.push(event.properties.error)
+        })
         const query = `?directory=${encodeURIComponent(tmp.path)}`
         const listed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/recovery${query}`)))
         const candidates = yield* Effect.promise(() => listed.json() as Promise<Array<{ assistantMessageID: string; parentMessageID: string; created: number; hasPendingTool: boolean }>>)
@@ -53,7 +58,11 @@ describe("session turn recovery routes", () => {
           Promise.resolve(app.request(`/session/${session.id}/turn/${MessageID.ascending()}/resume${query}`, { method: "POST" })),
         )
         const resumed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/turn/${assistant.id}/resume${query}`, { method: "POST" })))
-        return { listed: listed.status, candidates, resumed: resumed.status, missing: missing.status, userID: user.id }
+        yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 1000)))
+        unsubscribe()
+        const after = yield* sessions.messages({ sessionID: session.id, agentID: "main" })
+        const abandoned = after.find((item) => item.info.id === assistant.id)?.info
+        return { listed: listed.status, candidates, resumed: resumed.status, missing: missing.status, userID: user.id, errors, abandoned }
       })),
     })
 
@@ -61,5 +70,8 @@ describe("session turn recovery routes", () => {
     expect(result.candidates).toEqual([{ assistantMessageID: expect.any(String), parentMessageID: result.userID, created: expect.any(Number), hasPendingTool: false }])
     expect(result.resumed).toBe(202)
     expect(result.missing).toBe(404)
+    expect(result.errors.length).toBeGreaterThan(0)
+    expect(result.abandoned?.time.completed).toEqual(expect.any(Number))
+    expect(result.abandoned?.error?.data.message).toContain("Abandoned")
   })
 })

--- a/packages/opencode/test/server/session-recovery.test.ts
+++ b/packages/opencode/test/server/session-recovery.test.ts
@@ -60,7 +60,7 @@ describe("session turn recovery routes", () => {
         })
         const query = `?directory=${encodeURIComponent(tmp.path)}`
         const listed = yield* Effect.promise(() => Promise.resolve(app.request(`/session/${session.id}/recovery${query}`)))
-        const candidates = yield* Effect.promise(() => listed.json() as Promise<Array<{ assistantMessageID: string; parentMessageID: string; created: number; hasPendingTool: boolean }>>)
+        const candidates = yield* Effect.promise(() => listed.json() as Promise<Array<{ assistantMessageID: string; parentMessageID: string; created: number }>>)
         const missing = yield* Effect.promise(() =>
           Promise.resolve(app.request(`/session/${session.id}/turn/${MessageID.ascending()}/resume${query}`, { method: "POST" })),
         )
@@ -77,7 +77,7 @@ describe("session turn recovery routes", () => {
     })
 
     expect(result.listed).toBe(200)
-    expect(result.candidates).toEqual([{ assistantMessageID: expect.any(String), parentMessageID: result.userID, created: expect.any(Number), hasPendingTool: false }])
+    expect(result.candidates).toEqual([{ assistantMessageID: expect.any(String), parentMessageID: result.userID, created: expect.any(Number) }])
     expect(result.resumed).toBe(202)
     expect(result.missing).toBe(404)
     expect(result.errors.length).toBeGreaterThan(0)

--- a/packages/opencode/test/session/cron-bridge.integration.test.ts
+++ b/packages/opencode/test/session/cron-bridge.integration.test.ts
@@ -62,6 +62,8 @@ const makeCaptureLayer = (captured: { value: CapturedPrompt[] }) =>
           const out: MessageV2.WithParts = { info, parts: [text] }
           return out
         }),
+      recovery: () => Effect.succeed([]),
+      resume: () => Effect.die("resume not expected in cron-bridge test"),
       loop: () => Effect.die("loop not expected in cron-bridge test"),
       shell: () => Effect.die("shell not expected in cron-bridge test"),
       command: () => Effect.die("command not expected in cron-bridge test"),

--- a/packages/opencode/test/session/keepalive.integration.test.ts
+++ b/packages/opencode/test/session/keepalive.integration.test.ts
@@ -68,6 +68,8 @@ const stubPrompt = Layer.succeed(
         const out: MessageV2.WithParts = { info, parts: [text] }
         return out
       }),
+    recovery: () => Effect.succeed([]),
+    resume: () => Effect.die("resume not expected in keepalive test"),
     loop: () => Effect.die("loop not expected in keepalive test"),
     shell: () => Effect.die("shell not expected in keepalive test"),
     command: () => Effect.die("command not expected in keepalive test"),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1002,6 +1002,38 @@ it.live("serializes concurrent first-query pinning", () =>
   ),
 )
 
+it.live("resume continues an incomplete assistant without creating or rewriting a user message", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      const seeded = yield* seed(chat.id)
+      const before = yield* sessions.messages({ sessionID: chat.id })
+      yield* llm.text("world")
+
+      const candidate = yield* prompt.recovery({ sessionID: chat.id })
+      expect(candidate).toEqual([{ assistantMessageID: seeded.assistant.id, parentMessageID: seeded.user.id, created: expect.any(Number) }])
+      const result = yield* prompt.resume({
+        sessionID: chat.id,
+        assistantMessageID: seeded.assistant.id,
+      })
+
+      const after = yield* sessions.messages({ sessionID: chat.id })
+      expect(after.filter((message) => message.info.role === "user")).toHaveLength(1)
+      expect(after.length).toBe(before.length + 1)
+      expect(after.find((message) => message.info.id === seeded.assistant.id)?.info).toMatchObject(seeded.assistant)
+      expect(result.info.role).toBe("assistant")
+      expect(result.info.id).not.toBe(seeded.assistant.id)
+      expect(result.parts.some((part) => part.type === "text" && part.text === "world")).toBe(true)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("loop does not inject dynamic system prompt additions", () =>
   withoutDynamicSystemPrompt(() =>
     provideTmpdirServer(

--- a/packages/opencode/test/session/turn-context-tail.test.ts
+++ b/packages/opencode/test/session/turn-context-tail.test.ts
@@ -92,7 +92,7 @@ describe("Anthropic cache tail", () => {
 
 describe("system prefix stability across turns", () => {
   // Two consecutive turns whose ONLY difference is the client-supplied per-turn
-  // context — exactly what MiMo Desktop's minute-precision clock produces. The
+  // context — exactly what a minute-precision client clock produces. The
   // system prefix must not move, or the provider's prefix cache is invalidated
   // for the entire conversation sitting behind it.
   it.live("a changed per-turn context leaves the system prefix byte-identical", () =>

--- a/packages/opencode/test/session/turn-context-tail.test.ts
+++ b/packages/opencode/test/session/turn-context-tail.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Session as SessionNs } from "../../src/session"
+import { LLM, turnContextMessages } from "../../src/session/llm"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { ProviderTransform } from "../../src/provider"
+import { ToolRegistry } from "../../src/tool"
+import { Log } from "../../src/util"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { ProviderTest } from "../fake/provider"
+import type { Agent } from "../../src/agent/agent"
+
+void Log.init({ print: false })
+
+const it = testEffect(
+  Layer.mergeAll(
+    SessionNs.defaultLayer,
+    LLM.defaultLayer,
+    ToolRegistry.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+  ),
+)
+
+function makeUser(system?: string): MessageV2.User {
+  return {
+    id: MessageID.ascending(),
+    sessionID: SessionID.make("ses_turncontext"),
+    role: "user",
+    time: { created: 0 },
+    agent: "build",
+    model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test") },
+    system,
+  } as unknown as MessageV2.User
+}
+
+const agent = {
+  name: "build",
+  mode: "primary",
+  options: {},
+  permission: [{ permission: "*", pattern: "*", action: "allow" }],
+} satisfies Agent.Info
+
+describe("turnContextMessages", () => {
+  it.effect("absent, empty and whitespace-only per-turn context add nothing", () =>
+    Effect.sync(() => {
+      expect(turnContextMessages(makeUser())).toEqual([])
+      expect(turnContextMessages(makeUser(""))).toEqual([])
+      expect(turnContextMessages(makeUser("   \n  "))).toEqual([])
+    }),
+  )
+
+  it.effect("per-turn context becomes a trailing user message wrapped in system-reminder", () =>
+    Effect.sync(() => {
+      const messages = turnContextMessages(makeUser("## Current date and time\nlocal time 17:58."))
+      expect(messages).toHaveLength(1)
+      expect(messages[0].role).toBe("user")
+      expect(messages[0].content).toBe(
+        "<system-reminder>\n## Current date and time\nlocal time 17:58.\n</system-reminder>",
+      )
+    }),
+  )
+})
+
+describe("Anthropic cache tail", () => {
+  it.effect("marks only the historical tail and appended context segment", () =>
+    Effect.sync(() => {
+    const model = ProviderTest.model({
+      providerID: ProviderID.make("anthropic"),
+      id: ModelID.make("claude-sonnet-4"),
+      api: { id: "claude-sonnet-4", url: "https://example.com", npm: "@ai-sdk/anthropic" },
+    })
+    const result = ProviderTransform.message([
+      { role: "system", content: "stable system" },
+      { role: "user", content: "old question" },
+      { role: "assistant", content: "old answer" },
+      ...turnContextMessages(makeUser("## Current date and time\nlocal time 17:58.")),
+    ] as any[], model, {}) as any[]
+    const marked = result.filter((message) => message.providerOptions?.anthropic?.cacheControl)
+    expect(marked).toHaveLength(3)
+    expect(marked.map((message) => message.content)).toEqual([
+      "stable system",
+      "old answer",
+      "<system-reminder>\n## Current date and time\nlocal time 17:58.\n</system-reminder>",
+    ])
+    }),
+  )
+})
+
+describe("system prefix stability across turns", () => {
+  // Two consecutive turns whose ONLY difference is the client-supplied per-turn
+  // context — exactly what MiMo Desktop's minute-precision clock produces. The
+  // system prefix must not move, or the provider's prefix cache is invalidated
+  // for the entire conversation sitting behind it.
+  it.live("a changed per-turn context leaves the system prefix byte-identical", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const sessions = yield* SessionNs.Service
+          const llm = yield* LLM.Service
+          const session = yield* sessions.create({})
+          const model = ProviderTest.model({
+            id: ModelID.make("gpt-5.2"),
+            providerID: ProviderID.make("openai"),
+          })
+
+          const build = (clock: string) =>
+            llm.buildSystemArray({
+              agent,
+              model,
+              system: ["# Environment\nstable across turns"],
+              user: makeUser(`## Current date and time\nlocal time ${clock}.`),
+              sessionID: session.id,
+            })
+
+          const first = yield* build("17:57")
+          const second = yield* build("17:58")
+
+          expect(second).toEqual(first)
+          expect(first.join("\n")).not.toContain("17:57")
+          expect(first.join("\n")).toContain("stable across turns")
+        }),
+      { git: true },
+    ),
+  )
+})

--- a/packages/opencode/test/session/turn-context-tail.test.ts
+++ b/packages/opencode/test/session/turn-context-tail.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { Session as SessionNs } from "../../src/session"
-import { LLM, turnContextMessages } from "../../src/session/llm"
+import { appendTurnContext, LLM, turnContextMessages } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, SessionID } from "../../src/session/schema"
 import { ProviderID, ModelID } from "../../src/provider/schema"
@@ -61,6 +61,16 @@ describe("turnContextMessages", () => {
       expect(messages[0].content).toBe(
         "<system-reminder>\n## Current date and time\nlocal time 17:58.\n</system-reminder>",
       )
+    }),
+  )
+
+  it.effect("last-step context merges into the control user message", () =>
+    Effect.sync(() => {
+      const result = appendTurnContext([{ role: "user", content: "MAX_STEPS" }], makeUser("clock"), true)
+      expect(result).toEqual([{
+        role: "user",
+        content: "MAX_STEPS\n\n<system-reminder>\nclock\n</system-reminder>",
+      }])
     }),
   )
 })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -168,6 +168,10 @@ import type {
   SessionPromptAsyncResponses,
   SessionPromptErrors,
   SessionPromptResponses,
+  SessionRecoveryErrors,
+  SessionRecoveryResponses,
+  SessionResumeErrors,
+  SessionResumeResponses,
   SessionRevertErrors,
   SessionRevertResponses,
   SessionShareErrors,
@@ -2526,6 +2530,72 @@ export class Session2 extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<SessionMessageResponses, SessionMessageErrors, ThrowOnError>({
       url: "/session/{sessionID}/message/{messageID}",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * List interrupted turn recovery candidates
+   *
+   * Return the latest incomplete assistant turn that can be resumed without creating a user message.
+   */
+  public recovery<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionRecoveryResponses, SessionRecoveryErrors, ThrowOnError>({
+      url: "/session/{sessionID}/recovery",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Resume an interrupted turn
+   *
+   * Resume an incomplete assistant turn without creating another user message.
+   */
+  public resume<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      assistantMessageID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "assistantMessageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionResumeResponses, SessionResumeErrors, ThrowOnError>({
+      url: "/session/{sessionID}/turn/{assistantMessageID}/resume",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2545,6 +2545,7 @@ export class Session2 extends HeyApiClient {
       sessionID: string
       directory?: string
       workspace?: string
+      agentID?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2556,6 +2557,7 @@ export class Session2 extends HeyApiClient {
             { in: "path", key: "sessionID" },
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+            { in: "query", key: "agentID" },
           ],
         },
       ],
@@ -2578,6 +2580,8 @@ export class Session2 extends HeyApiClient {
       assistantMessageID: string
       directory?: string
       workspace?: string
+      agentID?: string
+      task_id?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2590,6 +2594,8 @@ export class Session2 extends HeyApiClient {
             { in: "path", key: "assistantMessageID" },
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+            { in: "query", key: "agentID" },
+            { in: "query", key: "task_id" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5027,6 +5027,82 @@ export type PartUpdateResponses = {
 
 export type PartUpdateResponse = PartUpdateResponses[keyof PartUpdateResponses]
 
+export type SessionRecoveryData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/recovery"
+}
+
+export type SessionRecoveryErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionRecoveryError = SessionRecoveryErrors[keyof SessionRecoveryErrors]
+
+export type SessionRecoveryResponses = {
+  /**
+   * Recovery candidates
+   */
+  200: Array<{
+    assistantMessageID: string
+    parentMessageID: string
+    created: number
+    hasPendingTool: boolean
+  }>
+}
+
+export type SessionRecoveryResponse = SessionRecoveryResponses[keyof SessionRecoveryResponses]
+
+export type SessionResumeData = {
+  body?: never
+  path: {
+    sessionID: string
+    assistantMessageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn/{assistantMessageID}/resume"
+}
+
+export type SessionResumeErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Conflict — session resource is busy
+   */
+  409: ConflictError
+}
+
+export type SessionResumeError = SessionResumeErrors[keyof SessionResumeErrors]
+
+export type SessionResumeResponses = {
+  /**
+   * Resume accepted
+   */
+  202: unknown
+}
+
 export type SessionPromptAsyncData = {
   body?: {
     messageID?: string

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5035,6 +5035,7 @@ export type SessionRecoveryData = {
   query?: {
     directory?: string
     workspace?: string
+    agentID?: string
   }
   url: "/session/{sessionID}/recovery"
 }
@@ -5075,6 +5076,8 @@ export type SessionResumeData = {
   query?: {
     directory?: string
     workspace?: string
+    agentID?: string
+    task_id?: string
   }
   url: "/session/{sessionID}/turn/{assistantMessageID}/resume"
 }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5061,7 +5061,6 @@ export type SessionRecoveryResponses = {
     assistantMessageID: string
     parentMessageID: string
     created: number
-    hasPendingTool: boolean
   }>
 }
 


### PR DESCRIPTION
### Issue / context (if applicable)

An interrupted coding turn can leave an incomplete assistant message after the process exits unexpectedly. The next invocation needs a durable way to identify and continue that turn without changing the user-visible prompt history.

### Type of change

New feature

### What does this PR do?

- Detect the latest resumable incomplete assistant turn with its parent user message and only expose candidates while the session is idle.
- Return typed 404 responses for stale recovery candidates and publish asynchronous resume failures with preserved error classification.
- Forward agent and task correlation parameters through the resume route.
- Mark the interrupted assistant as abandoned after a resumed assistant turn completes, with failure logging.
- Keep last-step control text and per-turn context in one user message to avoid consecutive user turns across all steps.
- Preserve the provider-specific system/instructions channel for OAuth and workflow models while keeping the stable system prefix unchanged for other providers.
- Sync recovery candidates into the TUI and show the recover action only when the candidate matches the latest assistant and the session is not busy.
- Show explicit recovering state while the append-only resumed assistant is running.
- Provide both a clickable TUI recover action and the /recover command with busy/error handling.
- Add generated SDK methods, all locale strings, and focused recovery, cache-tail, context, and orphan-repair tests.

### How did you verify your code works?

- [x] bun test ./test/server/session-recovery.test.ts ./test/session/turn-context-tail.test.ts (6 passed, 0 failed)
- [x] TUI sync/status/directory tests (13 passed, 0 failed)
- [x] bun test ./test/cli/tui (205 passed; 1 pre-existing sidebar fixture failure)
- [x] bun run typecheck in packages/opencode
- [x] bun turbo typecheck pre-push hook (12 tasks passed)
- [x] TUI E2E with mimo/mimo-v2.5: force-stop during a pending sleep tool, confirm a recovery candidate, reopen the exact session, run /recover, finish with RECOVERY_FINAL_OK, retain one user message, and leave no recovery candidate.

### Review notes

- The route validates the candidate before accepting the request and the service validates again when starting the runner. Both checks are intentional: the first gives synchronous 404 behavior, while the second closes the validation-to-start race.
- The old assistant remains append-only history during recovery. The TUI now labels it as recovering, and the service marks it abandoned after the resumed turn settles; no in-place transcript rewrite is used.

### Screenshots / recordings

Not applicable; this is a terminal-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
