### PR TITLE
fix: surface permission and undo configuration errors

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -6,6 +6,7 @@ import { useRoute } from "@tui/context/route"
 import * as Clipboard from "@tui/util/clipboard"
 import type { PromptInfo } from "@tui/component/prompt/history"
 import { strip } from "@tui/component/prompt/part"
+import { useToast } from "@tui/ui/toast"
 
 export function DialogMessage(props: {
   messageID: string
@@ -14,6 +15,7 @@ export function DialogMessage(props: {
 }) {
   const sync = useSync()
   const sdk = useSDK()
+  const toast = useToast()
   const message = createMemo(() => {
     const buckets = sync.data.message[props.sessionID]
     if (!buckets) return undefined
@@ -37,10 +39,17 @@ export function DialogMessage(props: {
             const msg = message()
             if (!msg) return
 
-            void sdk.client.session.revert({
-              sessionID: props.sessionID,
-              messageID: msg.id,
-            })
+            void sdk.client.session
+              .revert({
+                sessionID: props.sessionID,
+                messageID: msg.id,
+              })
+              .catch((error) => {
+                toast.show({
+                  message: error instanceof Error ? error.message : "Failed to revert changes",
+                  variant: "error",
+                })
+              })
 
             if (props.setPrompt) {
               const parts = sync.data.part[msg.id]

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -744,6 +744,12 @@ export function Session() {
           .then(() => {
             toBottom()
           })
+          .catch((error) => {
+            toast.show({
+              message: error instanceof Error ? error.message : "Failed to undo changes",
+              variant: "error",
+            })
+          })
         const parts = sync.data.part[message.id]
         prompt?.set(
           parts.reduce(
@@ -781,10 +787,17 @@ export function Session() {
           prompt?.set({ input: "", parts: [] })
           return
         }
-        void sdk.client.session.revert({
-          sessionID: route.sessionID,
-          messageID: message.id,
-        })
+        void sdk.client.session
+          .revert({
+            sessionID: route.sessionID,
+            messageID: message.id,
+          })
+          .catch((error) => {
+            toast.show({
+              message: error instanceof Error ? error.message : "Failed to redo changes",
+              variant: "error",
+            })
+          })
       },
     },
     {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -70,6 +70,22 @@ function normalizeLoadedConfig(data: unknown, source: string) {
   return copy
 }
 
+export function parsePermissionEnv(value: string): ConfigPermission.Info {
+  const raw = value.trim()
+  const input = ["allow", "ask", "deny"].includes(raw) ? JSON.stringify(raw) : raw
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(input)
+  } catch {
+    throw new Error("MIMOCODE_PERMISSION must be valid JSON or one of: allow, ask, deny")
+  }
+
+  const result = ConfigPermission.Info.safeParse(parsed)
+  if (!result.success) throw new Error("MIMOCODE_PERMISSION must be a permission action or permission object")
+  return result.data
+}
+
 async function resolveLoadedPlugins<T extends { plugin?: ConfigPlugin.Spec[] }>(config: T, filepath: string) {
   if (!config.plugin) return config
   for (let i = 0; i < config.plugin.length; i++) {
@@ -967,7 +983,7 @@ export const layer = Layer.effect(
         }
 
         if (Flag.MIMOCODE_PERMISSION) {
-          result.permission = mergeDeep(result.permission ?? {}, JSON.parse(Flag.MIMOCODE_PERMISSION))
+          result.permission = mergeDeep(result.permission ?? {}, parsePermissionEnv(Flag.MIMOCODE_PERMISSION))
         }
 
         if (result.tools) {

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -377,6 +377,8 @@ export const layer: Layer.Layer<
         const revert = Effect.fnUntraced(function* (patches: Patch[]) {
           return yield* locked(
             Effect.gen(function* () {
+              if (state.vcs !== "git")
+                throw new Error("Undo is unavailable because this directory is not a Git repository")
               const ops: { hash: string; file: string; rel: string }[] = []
               const seen = new Set<string>()
               for (const item of patches) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe, mock, afterEach, beforeEach } from "bun:test"
 import { Effect, Layer, Option } from "effect"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { Config, ConfigManaged } from "../../src/config"
+import { parsePermissionEnv } from "../../src/config/config"
 import { ConfigParse } from "../../src/config/parse"
 import { EffectFlock } from "@mimo-ai/shared/util/effect-flock"
 
@@ -61,6 +62,13 @@ const listDirs = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.directories()).pipe(Effect.scoped, Effect.provide(layer)))
 const ready = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.waitForDependencies()).pipe(Effect.scoped, Effect.provide(layer)))
+
+test("parses bare permission actions from the environment", () => {
+  expect(parsePermissionEnv("allow")).toEqual({ "*": "allow" })
+  expect(parsePermissionEnv('"deny"')).toEqual({ "*": "deny" })
+  expect(parsePermissionEnv('{"bash":"ask"}')).toEqual({ bash: "ask" })
+  expect(() => parsePermissionEnv("not-json")).toThrow("MIMOCODE_PERMISSION must be valid JSON")
+})
 
 // Get managed config directory from environment (set in preload.ts)
 const managedConfigDir = process.env.MIMOCODE_TEST_MANAGED_CONFIG_DIR!

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -84,6 +84,13 @@ test("revert should remove new files", async () => {
   })
 })
 
+test("revert rejects non-git projects", async () => {
+  await using tmp = await tmpdir({ outsideGit: true })
+  await expect(run(tmp.path, (snapshot) => snapshot.revert([]))).rejects.toThrow(
+    "Undo is unavailable because this directory is not a Git repository",
+  )
+})
+
 test("revert in subdirectory", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({


### PR DESCRIPTION
## Summary

- accept bare `allow`/`ask`/`deny` values for `MIMOCODE_PERMISSION` and report actionable errors for invalid values
- reject snapshot revert in non-Git directories with a clear error
- surface undo/revert failures in the TUI instead of silently ignoring them

Fixes #2170
Fixes #2209

## Verification

- `git diff --check`
- Added focused config and snapshot regression tests
- Full tests/typecheck/lint could not run in this checkout because dependencies are not installed (`@opentui/solid/preload`, `tsgo`, and `oxlint` are unavailable).