### PR TITLE
fix: accept bare permission configuration values

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -70,6 +70,22 @@ function normalizeLoadedConfig(data: unknown, source: string) {
   return copy
 }
 
+export function parsePermissionEnv(value: string): ConfigPermission.Info {
+  const raw = value.trim()
+  const input = ["allow", "ask", "deny"].includes(raw) ? JSON.stringify(raw) : raw
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(input)
+  } catch {
+    throw new Error("MIMOCODE_PERMISSION must be valid JSON or one of: allow, ask, deny")
+  }
+
+  const result = ConfigPermission.Info.safeParse(parsed)
+  if (!result.success) throw new Error("MIMOCODE_PERMISSION must be a permission action or permission object")
+  return result.data
+}
+
 async function resolveLoadedPlugins<T extends { plugin?: ConfigPlugin.Spec[] }>(config: T, filepath: string) {
   if (!config.plugin) return config
   for (let i = 0; i < config.plugin.length; i++) {
@@ -967,7 +983,7 @@ export const layer = Layer.effect(
         }
 
         if (Flag.MIMOCODE_PERMISSION) {
-          result.permission = mergeDeep(result.permission ?? {}, JSON.parse(Flag.MIMOCODE_PERMISSION))
+          result.permission = mergeDeep(result.permission ?? {}, parsePermissionEnv(Flag.MIMOCODE_PERMISSION))
         }
 
         if (result.tools) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe, mock, afterEach, beforeEach } from "bun:test"
 import { Effect, Layer, Option } from "effect"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { Config, ConfigManaged } from "../../src/config"
+import { parsePermissionEnv } from "../../src/config/config"
 import { ConfigParse } from "../../src/config/parse"
 import { EffectFlock } from "@mimo-ai/shared/util/effect-flock"
 
@@ -61,6 +62,13 @@ const listDirs = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.directories()).pipe(Effect.scoped, Effect.provide(layer)))
 const ready = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.waitForDependencies()).pipe(Effect.scoped, Effect.provide(layer)))
+
+test("parses bare permission actions from the environment", () => {
+  expect(parsePermissionEnv("allow")).toEqual({ "*": "allow" })
+  expect(parsePermissionEnv('"deny"')).toEqual({ "*": "deny" })
+  expect(parsePermissionEnv('{"bash":"ask"}')).toEqual({ bash: "ask" })
+  expect(() => parsePermissionEnv("not-json")).toThrow("MIMOCODE_PERMISSION must be valid JSON")
+})
 
 // Get managed config directory from environment (set in preload.ts)
 const managedConfigDir = process.env.MIMOCODE_TEST_MANAGED_CONFIG_DIR!


### PR DESCRIPTION
## Summary
- Accept bare `allow`, `ask`, and `deny` values for `MIMOCODE_PERMISSION`.
- Return actionable errors for invalid JSON and permission shapes.

## Verification
- `git diff --check`
- Added focused config regression coverage.
- Full test/typecheck/lint runs are blocked locally because repository dependencies are not installed.

Fixes #2170