### PR TITLE
fix: report undo errors outside Git repositories

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -6,6 +6,7 @@ import { useRoute } from "@tui/context/route"
 import * as Clipboard from "@tui/util/clipboard"
 import type { PromptInfo } from "@tui/component/prompt/history"
 import { strip } from "@tui/component/prompt/part"
+import { useToast } from "@tui/ui/toast"
 
 export function DialogMessage(props: {
   messageID: string
@@ -14,6 +15,7 @@ export function DialogMessage(props: {
 }) {
   const sync = useSync()
   const sdk = useSDK()
+  const toast = useToast()
   const message = createMemo(() => {
     const buckets = sync.data.message[props.sessionID]
     if (!buckets) return undefined
@@ -37,10 +39,17 @@ export function DialogMessage(props: {
             const msg = message()
             if (!msg) return
 
-            void sdk.client.session.revert({
-              sessionID: props.sessionID,
-              messageID: msg.id,
-            })
+            void sdk.client.session
+              .revert({
+                sessionID: props.sessionID,
+                messageID: msg.id,
+              })
+              .catch((error) => {
+                toast.show({
+                  message: error instanceof Error ? error.message : "Failed to revert changes",
+                  variant: "error",
+                })
+              })
 
             if (props.setPrompt) {
               const parts = sync.data.part[msg.id]

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -744,6 +744,12 @@ export function Session() {
           .then(() => {
             toBottom()
           })
+          .catch((error) => {
+            toast.show({
+              message: error instanceof Error ? error.message : "Failed to undo changes",
+              variant: "error",
+            })
+          })
         const parts = sync.data.part[message.id]
         prompt?.set(
           parts.reduce(
@@ -781,10 +787,17 @@ export function Session() {
           prompt?.set({ input: "", parts: [] })
           return
         }
-        void sdk.client.session.revert({
-          sessionID: route.sessionID,
-          messageID: message.id,
-        })
+        void sdk.client.session
+          .revert({
+            sessionID: route.sessionID,
+            messageID: message.id,
+          })
+          .catch((error) => {
+            toast.show({
+              message: error instanceof Error ? error.message : "Failed to redo changes",
+              variant: "error",
+            })
+          })
       },
     },
     {

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -377,6 +377,8 @@ export const layer: Layer.Layer<
         const revert = Effect.fnUntraced(function* (patches: Patch[]) {
           return yield* locked(
             Effect.gen(function* () {
+              if (state.vcs !== "git")
+                throw new Error("Undo is unavailable because this directory is not a Git repository")
               const ops: { hash: string; file: string; rel: string }[] = []
               const seen = new Set<string>()
               for (const item of patches) {

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -84,6 +84,13 @@ test("revert should remove new files", async () => {
   })
 })
 
+test("revert rejects non-git projects", async () => {
+  await using tmp = await tmpdir({ outsideGit: true })
+  await expect(run(tmp.path, (snapshot) => snapshot.revert([]))).rejects.toThrow(
+    "Undo is unavailable because this directory is not a Git repository",
+  )
+})
+
 test("revert in subdirectory", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({


### PR DESCRIPTION
## Summary
- Reject snapshot revert in directories that are not Git repositories.
- Surface revert and redo failures as TUI error toasts.

## Verification
- `git diff --check`
- Added focused snapshot regression coverage.
- Full test/typecheck/lint runs are blocked locally because repository dependencies are not installed.

Fixes #2209