### PR TITLE
refactor(session): centralize provider retry coordination

### DIFF
--- a/docs/architecture/retry-coordinator.md
+++ b/docs/architecture/retry-coordinator.md
@@ -37,7 +37,7 @@ Persistent network retry 只适用于 transport connection failure，不适用�
 
 ## 配置
 
-全局配置提供默认预算，provider.<id>.retry 对同名字段做覆盖。maxRetries 是初始 attempt 之外的重试次数，schema 硬上限为 100；deadlineMs 必须是正整数。需要取消 wall-clock deadline 时必须显式设置 noDeadline: true；该选项不会取消 bounded budget 的 maxRetries 限制。
+全局配置提供默认预算，provider.<id>.retry 对同名字段做覆盖。maxRetries 是初始 attempt 之外的重试次数，schema 硬上限为 100；deadlineMs 必须是正整数，且不能与 noDeadline 同时出现。需要取消 wall-clock deadline 时必须显式设置 noDeadline: true；该选项不会取消 bounded budget 的 maxRetries 限制。
 
 配置示例：
 
@@ -67,7 +67,7 @@ Persistent network retry 仍受 AbortSignal、进程退出和 provider chunkTime
 
 ## 可观测性
 
-每次实际 retry 发布 session.retry.attempt，包含 phase、scope、kind、attempt、phaseAttempt、maxAttempts、nextDelayMs 和 reason。attempt 是当前 session 跨 request/stream 的连续序号，phaseAttempt 是当前 phase 内的局部序号；maxAttempts 为 0 表示 persistent retry。terminal UI notice 使用独立的 session status notice，不伪装成 retry attempt。Persistent network retry 不重复创建 transcript message；UI 只更新当前状态。成功、终止、取消都必须清理 retry 状态并回到 idle。
+每次实际 retry 发布 session.retry.attempt，包含 phase、scope、kind、attempt、phaseAttempt、maxAttempts、nextDelayMs 和 reason。attempt 是当前 session 跨 request/stream 的连续序号，phaseAttempt 是当前 phase 内的局部序号；attempt counter 独立于 busy/notice 状态，只在 session 回到 idle 时清零。maxAttempts 为 0 表示 persistent retry。terminal UI notice 使用独立的 session status notice，不伪装成 retry attempt。Persistent network retry 不重复创建 transcript message；UI 只更新当前状态。成功、终止、取消都必须清理 retry 状态并回到 idle。
 
 ## 兼容性
 

--- a/docs/architecture/retry-coordinator.md
+++ b/docs/architecture/retry-coordinator.md
@@ -1,0 +1,74 @@
+# Retry Coordinator Design
+
+本文是 MiMoCode provider retry 的单一设计来源。实现位于 packages/opencode/src/session/retry.ts，配置 schema 位于 packages/opencode/src/config/config.ts 与 packages/opencode/src/config/provider.ts。
+
+## 目标
+
+Retry 必须区分两个问题：错误是否可能恢复，以及当前 scope 是否应该继续等待。事实归一化、终态判断、预算选择和 UI 通知必须分离。
+
+- 用户取消、鉴权、额度、上下文溢出和确定性请求错误立即停止。
+- 网络连接失败可以长时间等待网络恢复，适合 long-running harness。
+- 已建立的 stream 使用有限预算，避免重复推理和重复计费。
+- 已执行 tool side effect 后禁止自动重放整个 model step。
+- 所有 retry scope 使用同一个分类器、退避算法、Retry-After 解析器和事件模型。
+- 次数、deadline、退避和 persistent network 模式可以配置，provider 可以覆盖全局默认值。
+
+## 分层模型
+
+原始 provider / transport error -> cause summary -> RetryDecision(kind, phase, scope) -> budget -> exponential backoff -> RetryAttempt event。
+
+| Scope         | 语义                                    | 默认策略                        |
+| ------------- | --------------------------------------- | ------------------------------- |
+| request       | 尚未产生 provider output 的请求建立失败 | 1 次，250ms 起步，30s deadline  |
+| live-step     | 已建立 stream、但未完成的普通 turn      | 按错误 kind 选择预算            |
+| max-candidate | max-mode 内存 candidate                 | 3 次，500ms 起步，3min deadline |
+| max-judge     | max-mode 内存 judge                     | 3 次，500ms 起步，3min deadline |
+
+| Kind       | 默认策略                                                                      |
+| ---------- | ----------------------------------------------------------------------------- |
+| network    | persistent，5s 起步，最大间隔 60s；默认无次数上限，受用户取消和 deadline 控制 |
+| stream     | 5 次，2s 起步，10min deadline                                                 |
+| server     | 8 次，2s 起步，15min deadline                                                 |
+| rate_limit | 5 次，优先 Retry-After，最大 delay 5min                                       |
+| unknown    | 1 次，2s 起步，30s deadline                                                   |
+| terminal   | 0 次                                                                          |
+
+Persistent network retry 只适用于 transport connection failure，不适用于 quota、auth、context overflow 或已经跨过 tool side-effect boundary 的 live step。每次等待只更新同一个 retry 状态，不能向 transcript 无限追加 Reconnecting 文本。
+
+## 配置
+
+全局配置提供默认预算，provider.<id>.retry 对同名字段做覆盖。maxRetries 是初始 attempt 之外的重试次数；deadlineMs 为 0 表示不设置 wall-clock deadline。
+
+配置示例：
+
+    {
+      "retry": {
+        "request": { "maxRetries": 1, "deadlineMs": 30000, "initialDelayMs": 250 },
+        "stream": { "maxRetries": 5, "deadlineMs": 600000, "initialDelayMs": 2000 },
+        "maxCandidate": { "maxRetries": 3, "deadlineMs": 180000, "initialDelayMs": 500 },
+        "maxJudge": { "maxRetries": 3, "deadlineMs": 180000, "initialDelayMs": 500 },
+        "network": { "mode": "persistent", "deadlineMs": 0, "initialDelayMs": 5000, "maxDelayMs": 60000 },
+        "server": { "maxRetries": 8, "deadlineMs": 900000 },
+        "rateLimit": { "maxRetries": 5, "maxDelayMs": 300000 },
+        "unknown": { "maxRetries": 1, "deadlineMs": 30000 },
+        "jitterRatio": 0.2
+      }
+    }
+
+Persistent network retry 仍受 AbortSignal、进程退出和 provider chunkTimeout 约束。
+
+## 退避
+
+无服务端 retry hint 时使用 min(maxDelay, initialDelay \* 2^(attempt - 1))，再乘以 full jitter。Retry-After header 优先于指数退避；自然语言 retry hint 使用严格格式解析并设置独立上限，防止错误文本把 session 挂起数天。
+
+## 副作用边界
+
+普通 live-step 在收到 tool-call 后将 replaySafe 设为 false。之后即使 stream error 属于 network/server，也只能保存当前工具状态并终止本次 step，不能重放整个请求。max candidate/judge 不执行工具，可以独立重建内存 accumulator。
+
+## 可观测性
+
+每次实际 retry 发布 session.retry.attempt，包含 phase、scope、kind、attempt、maxAttempts、nextDelayMs 和 reason。maxAttempts 为 0 表示 persistent retry。Persistent network retry 不重复创建 transcript message；UI 只更新当前状态。成功、终止、取消都必须清理 retry 状态并回到 idle。
+
+## 兼容性
+
+语义 retry（structured output、invalid output、text tool call、length recovery）不是 transport retry，不进入本 coordinator；它们有自己的 prompt-level bounded loop。LoadAPIKeyError 仍由 MessageV2.fromError() 识别，外部消费者只检查归一化后的 provider auth error 或 401/403 APIError。

--- a/docs/architecture/retry-coordinator.md
+++ b/docs/architecture/retry-coordinator.md
@@ -19,14 +19,14 @@ Retry 必须区分两个问题：错误是否可能恢复，以及当前 scope �
 
 | Scope         | 语义                                    | 默认策略                        |
 | ------------- | --------------------------------------- | ------------------------------- |
-| request       | 尚未产生 provider output 的请求建立失败 | 1 次，250ms 起步，30s deadline  |
+| request       | 尚未产生 provider output 的请求建立失败 | 4 次，200ms 起步，30s deadline  |
 | live-step     | 已建立 stream、但未完成的普通 turn      | 按错误 kind 选择预算            |
 | max-candidate | max-mode 内存 candidate                 | 3 次，500ms 起步，3min deadline |
 | max-judge     | max-mode 内存 judge                     | 3 次，500ms 起步，3min deadline |
 
 | Kind       | 默认策略                                                                      |
 | ---------- | ----------------------------------------------------------------------------- |
-| network    | persistent，5s 起步，最大间隔 60s；默认无次数上限，受用户取消和 deadline 控制 |
+| network    | persistent，5s 起步，最大间隔 60s，无 jitter；默认无次数上限，受用户取消和 deadline 控制 |
 | stream     | 5 次，2s 起步，10min deadline                                                 |
 | server     | 8 次，2s 起步，15min deadline                                                 |
 | rate_limit | 5 次，优先 Retry-After，最大 delay 5min                                       |
@@ -37,29 +37,29 @@ Persistent network retry 只适用于 transport connection failure，不适用�
 
 ## 配置
 
-全局配置提供默认预算，provider.<id>.retry 对同名字段做覆盖。maxRetries 是初始 attempt 之外的重试次数；deadlineMs 为 0 表示不设置 wall-clock deadline。
+全局配置提供默认预算，provider.<id>.retry 对同名字段做覆盖。maxRetries 是初始 attempt 之外的重试次数，schema 硬上限为 100；deadlineMs 为 0 表示不设置 wall-clock deadline。
 
 配置示例：
 
     {
       "retry": {
-        "request": { "maxRetries": 1, "deadlineMs": 30000, "initialDelayMs": 250 },
+        "request": { "maxRetries": 4, "deadlineMs": 30000, "initialDelayMs": 200 },
         "stream": { "maxRetries": 5, "deadlineMs": 600000, "initialDelayMs": 2000 },
         "maxCandidate": { "maxRetries": 3, "deadlineMs": 180000, "initialDelayMs": 500 },
         "maxJudge": { "maxRetries": 3, "deadlineMs": 180000, "initialDelayMs": 500 },
-        "network": { "mode": "persistent", "deadlineMs": 0, "initialDelayMs": 5000, "maxDelayMs": 60000 },
+        "network": { "mode": "persistent", "deadlineMs": 0, "initialDelayMs": 5000, "maxDelayMs": 60000, "jitterRatio": 0 },
         "server": { "maxRetries": 8, "deadlineMs": 900000 },
         "rateLimit": { "maxRetries": 5, "maxDelayMs": 300000 },
         "unknown": { "maxRetries": 8, "deadlineMs": 900000 },
-        "jitterRatio": 0.2
+        "jitterRatio": 0.1
       }
     }
 
-Persistent network retry 仍受 AbortSignal、进程退出和 provider chunkTimeout 约束。
+Persistent network retry 仍受 AbortSignal、进程退出和 provider chunkTimeout 约束。默认 provider chunkTimeout 为 5 分钟；provider 可以用 chunkTimeout 覆盖该单次 stream idle timeout。
 
 ## 退避
 
-无服务端 retry hint 时使用 min(maxDelay, initialDelay \* 2^(attempt - 1))，再乘以 full jitter。Retry-After header 优先于指数退避；自然语言 retry hint 使用严格格式解析并设置独立上限，防止错误文本把 session 挂起数天。
+无服务端 retry hint 时使用 min(maxDelay, initialDelay \* 2^(attempt - 1))，再乘以 budget jitter。request/stream/server 等普通 budget 默认使用 10% jitter，network budget 默认不使用 jitter。Retry-After header 优先于指数退避；自然语言 retry hint 使用严格格式解析并设置独立上限，防止错误文本把 session 挂起数天。
 
 ## 副作用边界
 

--- a/docs/architecture/retry-coordinator.md
+++ b/docs/architecture/retry-coordinator.md
@@ -30,7 +30,7 @@ Retry 必须区分两个问题：错误是否可能恢复，以及当前 scope �
 | stream     | 5 次，2s 起步，10min deadline                                                 |
 | server     | 8 次，2s 起步，15min deadline                                                 |
 | rate_limit | 5 次，优先 Retry-After，最大 delay 5min                                       |
-| unknown    | 1 次，2s 起步，30s deadline                                                   |
+| unknown    | 8 次，2s 起步，15min deadline                                                 |
 | terminal   | 0 次                                                                          |
 
 Persistent network retry 只适用于 transport connection failure，不适用于 quota、auth、context overflow 或已经跨过 tool side-effect boundary 的 live step。每次等待只更新同一个 retry 状态，不能向 transcript 无限追加 Reconnecting 文本。
@@ -50,7 +50,7 @@ Persistent network retry 只适用于 transport connection failure，不适用�
         "network": { "mode": "persistent", "deadlineMs": 0, "initialDelayMs": 5000, "maxDelayMs": 60000 },
         "server": { "maxRetries": 8, "deadlineMs": 900000 },
         "rateLimit": { "maxRetries": 5, "maxDelayMs": 300000 },
-        "unknown": { "maxRetries": 1, "deadlineMs": 30000 },
+        "unknown": { "maxRetries": 8, "deadlineMs": 900000 },
         "jitterRatio": 0.2
       }
     }

--- a/docs/architecture/retry-coordinator.md
+++ b/docs/architecture/retry-coordinator.md
@@ -37,7 +37,7 @@ Persistent network retry 只适用于 transport connection failure，不适用�
 
 ## 配置
 
-全局配置提供默认预算，provider.<id>.retry 对同名字段做覆盖。maxRetries 是初始 attempt 之外的重试次数，schema 硬上限为 100；deadlineMs 为 0 表示不设置 wall-clock deadline。
+全局配置提供默认预算，provider.<id>.retry 对同名字段做覆盖。maxRetries 是初始 attempt 之外的重试次数，schema 硬上限为 100；deadlineMs 必须是正整数。需要取消 wall-clock deadline 时必须显式设置 noDeadline: true；该选项不会取消 bounded budget 的 maxRetries 限制。
 
 配置示例：
 
@@ -47,7 +47,7 @@ Persistent network retry 只适用于 transport connection failure，不适用�
         "stream": { "maxRetries": 5, "deadlineMs": 600000, "initialDelayMs": 2000 },
         "maxCandidate": { "maxRetries": 3, "deadlineMs": 180000, "initialDelayMs": 500 },
         "maxJudge": { "maxRetries": 3, "deadlineMs": 180000, "initialDelayMs": 500 },
-        "network": { "mode": "persistent", "deadlineMs": 0, "initialDelayMs": 5000, "maxDelayMs": 60000, "jitterRatio": 0 },
+        "network": { "mode": "persistent", "noDeadline": true, "initialDelayMs": 5000, "maxDelayMs": 60000, "jitterRatio": 0 },
         "server": { "maxRetries": 8, "deadlineMs": 900000 },
         "rateLimit": { "maxRetries": 5, "maxDelayMs": 300000 },
         "unknown": { "maxRetries": 8, "deadlineMs": 900000 },
@@ -67,7 +67,7 @@ Persistent network retry 仍受 AbortSignal、进程退出和 provider chunkTime
 
 ## 可观测性
 
-每次实际 retry 发布 session.retry.attempt，包含 phase、scope、kind、attempt、maxAttempts、nextDelayMs 和 reason。maxAttempts 为 0 表示 persistent retry。terminal UI notice 使用独立的 session status notice，不伪装成 retry attempt。Persistent network retry 不重复创建 transcript message；UI 只更新当前状态。成功、终止、取消都必须清理 retry 状态并回到 idle。
+每次实际 retry 发布 session.retry.attempt，包含 phase、scope、kind、attempt、phaseAttempt、maxAttempts、nextDelayMs 和 reason。attempt 是当前 session 跨 request/stream 的连续序号，phaseAttempt 是当前 phase 内的局部序号；maxAttempts 为 0 表示 persistent retry。terminal UI notice 使用独立的 session status notice，不伪装成 retry attempt。Persistent network retry 不重复创建 transcript message；UI 只更新当前状态。成功、终止、取消都必须清理 retry 状态并回到 idle。
 
 ## 兼容性
 

--- a/docs/architecture/retry-coordinator.md
+++ b/docs/architecture/retry-coordinator.md
@@ -55,7 +55,7 @@ Persistent network retry 只适用于 transport connection failure，不适用�
       }
     }
 
-Persistent network retry 仍受 AbortSignal、进程退出和 provider chunkTimeout 约束。默认 provider chunkTimeout 为 5 分钟；provider 可以用 chunkTimeout 覆盖该单次 stream idle timeout。
+Persistent network retry 仍受 AbortSignal、进程退出和 provider chunkTimeout 约束。默认 provider chunkTimeout 为 8 分钟；provider 可以用 chunkTimeout 覆盖该单次 stream idle timeout。
 
 ## 退避
 

--- a/docs/architecture/retry-coordinator.md
+++ b/docs/architecture/retry-coordinator.md
@@ -26,7 +26,7 @@ Retry 必须区分两个问题：错误是否可能恢复，以及当前 scope �
 
 | Kind       | 默认策略                                                                      |
 | ---------- | ----------------------------------------------------------------------------- |
-| network    | persistent，5s 起步，最大间隔 60s，无 jitter；默认无次数上限，受用户取消和 deadline 控制 |
+| network    | live stream persistent，5s 起步，最大间隔 60s，无 jitter；request 阶段使用 request budget |
 | stream     | 5 次，2s 起步，10min deadline                                                 |
 | server     | 8 次，2s 起步，15min deadline                                                 |
 | rate_limit | 5 次，优先 Retry-After，最大 delay 5min                                       |
@@ -67,7 +67,7 @@ Persistent network retry 仍受 AbortSignal、进程退出和 provider chunkTime
 
 ## 可观测性
 
-每次实际 retry 发布 session.retry.attempt，包含 phase、scope、kind、attempt、maxAttempts、nextDelayMs 和 reason。maxAttempts 为 0 表示 persistent retry。Persistent network retry 不重复创建 transcript message；UI 只更新当前状态。成功、终止、取消都必须清理 retry 状态并回到 idle。
+每次实际 retry 发布 session.retry.attempt，包含 phase、scope、kind、attempt、maxAttempts、nextDelayMs 和 reason。maxAttempts 为 0 表示 persistent retry。terminal UI notice 使用独立的 session status notice，不伪装成 retry attempt。Persistent network retry 不重复创建 transcript message；UI 只更新当前状态。成功、终止、取消都必须清理 retry 状态并回到 idle。
 
 ## 兼容性
 

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -45,7 +45,6 @@ import { MessageV2 } from "@/session/message-v2"
 import { Config } from "@/config"
 import { ConfigMCP } from "@/config/mcp"
 import { z } from "zod"
-import { LoadAPIKeyError } from "ai"
 import type { AssistantMessage, Event, OpencodeClient, SessionMessageResponse, ToolPart } from "@mimo-ai/sdk/v2"
 import { applyPatch } from "diff"
 import { InstallationVersion } from "@/installation/version"
@@ -571,7 +570,7 @@ export class Agent implements ACPAgent {
       const error = MessageV2.fromError(e, {
         providerID: ProviderID.make(this.config.defaultModel?.providerID ?? "unknown"),
       })
-      if (LoadAPIKeyError.isInstance(error)) {
+      if (MessageV2.isAuthError(error)) {
         throw RequestError.authRequired()
       }
       throw e
@@ -642,7 +641,7 @@ export class Agent implements ACPAgent {
       const error = MessageV2.fromError(e, {
         providerID: ProviderID.make(this.config.defaultModel?.providerID ?? "unknown"),
       })
-      if (LoadAPIKeyError.isInstance(error)) {
+      if (MessageV2.isAuthError(error)) {
         throw RequestError.authRequired()
       }
       throw e
@@ -687,7 +686,7 @@ export class Agent implements ACPAgent {
       const error = MessageV2.fromError(e, {
         providerID: ProviderID.make(this.config.defaultModel?.providerID ?? "unknown"),
       })
-      if (LoadAPIKeyError.isInstance(error)) {
+      if (MessageV2.isAuthError(error)) {
         throw RequestError.authRequired()
       }
       throw e
@@ -753,7 +752,7 @@ export class Agent implements ACPAgent {
       const error = MessageV2.fromError(e, {
         providerID: ProviderID.make(this.config.defaultModel?.providerID ?? "unknown"),
       })
-      if (LoadAPIKeyError.isInstance(error)) {
+      if (MessageV2.isAuthError(error)) {
         throw RequestError.authRequired()
       }
       throw e
@@ -784,7 +783,7 @@ export class Agent implements ACPAgent {
       const error = MessageV2.fromError(e, {
         providerID: ProviderID.make(this.config.defaultModel?.providerID ?? "unknown"),
       })
-      if (LoadAPIKeyError.isInstance(error)) {
+      if (MessageV2.isAuthError(error)) {
         throw RequestError.authRequired()
       }
       throw e

--- a/packages/opencode/src/actor/group.ts
+++ b/packages/opencode/src/actor/group.ts
@@ -71,6 +71,7 @@ export function joinGroup(
   input: { members: Member[]; timeout_ms?: number },
 ): Effect.Effect<JoinResult> {
   return Effect.gen(function* () {
+    const context = yield* Effect.context()
     const timeoutMs = input.timeout_ms ?? DEFAULT_TIMEOUT_MS
 
     // Dedup members by sessionID:actorID — a caller may list the same child
@@ -177,7 +178,7 @@ export function joinGroup(
                 "complete",
               )
               Deferred.doneUnsafe(resolved, Effect.succeed(agg))
-            }).pipe(Effect.catchCause((cause) => Effect.logError(`group join snapshot failed: ${cause}`))),
+            }).pipe(Effect.catchCause((cause) => Effect.logError(`group join snapshot failed: ${cause}`)), Effect.provide(context)),
           )
         }),
       () =>

--- a/packages/opencode/src/actor/waiter.ts
+++ b/packages/opencode/src/actor/waiter.ts
@@ -55,6 +55,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | ActorRegistry.Serv
     const reg = yield* ActorRegistry.Service
     const bus = yield* Bus.Service
     const sessions = yield* Session.Service
+    const context = yield* Effect.context()
 
     // Pull the most recent assistant text + structured object from the actor's
     // slice. Used as result body when the actor reaches idle/success on
@@ -129,6 +130,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | ActorRegistry.Serv
               Effect.catchCause((cause) =>
                 Effect.logError(`waiter rehydrate failed: ${cause}`),
               ),
+              Effect.provide(context),
             ),
           )
         }),

--- a/packages/opencode/src/cli/cmd/run-completion.ts
+++ b/packages/opencode/src/cli/cmd/run-completion.ts
@@ -1,6 +1,6 @@
 // packages/opencode/src/cli/cmd/run-completion.ts
 
-export type StatusInfo = { type: "idle" | "busy" | "retry"; [k: string]: unknown }
+export type StatusInfo = { type: "idle" | "busy" | "retry" | "notice"; [k: string]: unknown }
 
 /** Returns current status of the tracked session, or undefined if absent (= idle). */
 export type StatusQuery = () => Promise<StatusInfo | undefined>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -345,8 +345,9 @@ export function Session() {
 
   event.on("session.status", (evt) => {
     if (evt.properties.sessionID !== route.sessionID) return
-    if (evt.properties.status.type !== "retry") return
-    if (evt.properties.status.message !== SessionRetry.GO_UPSELL_MESSAGE) return
+    const status = evt.properties.status
+    if (status.type === "idle" || status.type === "busy") return
+    if (status.message !== SessionRetry.GO_UPSELL_MESSAGE) return
     if (dialog.stack.length > 0) return
 
     const seen = kv.get(GO_UPSELL_LAST_SEEN_AT)

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -41,6 +41,7 @@ import { ConfigPaths } from "./paths"
 import { ConfigPermission } from "./permission"
 import { ConfigPlugin } from "./plugin"
 import { ConfigProvider } from "./provider"
+import { ConfigRetry } from "./retry"
 import { ConfigServer } from "./server"
 import { ConfigLLMServer } from "./llm-server"
 import { ConfigSkills } from "./skills"
@@ -202,6 +203,9 @@ const InfoSchema = Schema.Struct({
   ).annotate({ description: "Agent configuration, see https://mimo.xiaomi.com/mimocode/agents" }),
   provider: Schema.optional(Schema.Record(Schema.String, ConfigProvider.Info)).annotate({
     description: "Custom provider configurations and model overrides",
+  }),
+  retry: Schema.optional(ConfigRetry.Info).annotate({
+    description: "Retry budgets for provider requests, streams, and long-running network recovery",
   }),
   mcp: Schema.optional(
     Schema.Record(

--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -1,6 +1,7 @@
 import { Schema } from "effect"
 import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
+import { ConfigRetry } from "./retry"
 
 const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
 
@@ -133,6 +134,9 @@ export class Info extends Schema.Class<Info>("ProviderConfig")({
       [Schema.Record(Schema.String, Schema.Any)],
     ),
   ),
+  retry: Schema.optional(ConfigRetry.Info).annotate({
+    description: "Provider-specific overrides for retry budgets",
+  }),
   models: Schema.optional(Schema.Record(Schema.String, Model)),
   only_configured_models: Schema.optional(Schema.Boolean).annotate({
     description:

--- a/packages/opencode/src/config/retry.ts
+++ b/packages/opencode/src/config/retry.ts
@@ -6,9 +6,15 @@ const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterTh
 const Ratio = Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)).check(Schema.isLessThanOrEqualTo(1))
 
 export const Budget = Schema.Struct({
-  mode: Schema.optional(Schema.Literals(["bounded", "persistent"])),
-  maxRetries: Schema.optional(MaxRetries),
-  deadlineMs: Schema.optional(NonNegativeInt),
+  mode: Schema.optional(Schema.Literals(["bounded", "persistent"])).annotate({
+    description: "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
+  }),
+  maxRetries: Schema.optional(MaxRetries).annotate({
+    description: "Retries after the initial attempt; 0 disables retries and the maximum is 100",
+  }),
+  deadlineMs: Schema.optional(NonNegativeInt).annotate({
+    description: "Wall-clock retry deadline in milliseconds; 0 means no deadline",
+  }),
   initialDelayMs: Schema.optional(PositiveInt),
   maxDelayMs: Schema.optional(PositiveInt),
   jitterRatio: Schema.optional(Ratio),

--- a/packages/opencode/src/config/retry.ts
+++ b/packages/opencode/src/config/retry.ts
@@ -1,15 +1,17 @@
 import { Schema } from "effect"
 
 const NonNegativeInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThanOrEqualTo(0))
+const MaxRetries = NonNegativeInt.check(Schema.isLessThanOrEqualTo(100))
 const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
 const Ratio = Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)).check(Schema.isLessThanOrEqualTo(1))
 
 export const Budget = Schema.Struct({
   mode: Schema.optional(Schema.Literals(["bounded", "persistent"])),
-  maxRetries: Schema.optional(NonNegativeInt),
+  maxRetries: Schema.optional(MaxRetries),
   deadlineMs: Schema.optional(NonNegativeInt),
   initialDelayMs: Schema.optional(PositiveInt),
   maxDelayMs: Schema.optional(PositiveInt),
+  jitterRatio: Schema.optional(Ratio),
 })
 
 export const Info = Schema.Struct({

--- a/packages/opencode/src/config/retry.ts
+++ b/packages/opencode/src/config/retry.ts
@@ -1,0 +1,30 @@
+import { Schema } from "effect"
+
+const NonNegativeInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThanOrEqualTo(0))
+const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
+const Ratio = Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)).check(Schema.isLessThanOrEqualTo(1))
+
+export const Budget = Schema.Struct({
+  mode: Schema.optional(Schema.Literals(["bounded", "persistent"])),
+  maxRetries: Schema.optional(NonNegativeInt),
+  deadlineMs: Schema.optional(NonNegativeInt),
+  initialDelayMs: Schema.optional(PositiveInt),
+  maxDelayMs: Schema.optional(PositiveInt),
+})
+
+export const Info = Schema.Struct({
+  request: Schema.optional(Budget),
+  stream: Schema.optional(Budget),
+  maxCandidate: Schema.optional(Budget),
+  maxJudge: Schema.optional(Budget),
+  network: Schema.optional(Budget),
+  server: Schema.optional(Budget),
+  rateLimit: Schema.optional(Budget),
+  unknown: Schema.optional(Budget),
+  jitterRatio: Schema.optional(Ratio),
+})
+
+export type Budget = Schema.Schema.Type<typeof Budget>
+export type Info = Schema.Schema.Type<typeof Info>
+
+export * as ConfigRetry from "./retry"

--- a/packages/opencode/src/config/retry.ts
+++ b/packages/opencode/src/config/retry.ts
@@ -4,6 +4,12 @@ const NonNegativeInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreate
 const MaxRetries = NonNegativeInt.check(Schema.isLessThanOrEqualTo(100))
 const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
 const Ratio = Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)).check(Schema.isLessThanOrEqualTo(1))
+const DeadlineOptions = Schema.makeFilter<{ deadlineMs?: number; noDeadline?: boolean }>((input) =>
+  input.deadlineMs === undefined || input.noDeadline !== true || {
+    path: ["noDeadline"],
+    message: "deadlineMs and noDeadline cannot be configured together",
+  },
+)
 
 export const Budget = Schema.Struct({
   mode: Schema.optional(Schema.Literals(["bounded", "persistent"])).annotate({
@@ -21,7 +27,7 @@ export const Budget = Schema.Struct({
   initialDelayMs: Schema.optional(PositiveInt),
   maxDelayMs: Schema.optional(PositiveInt),
   jitterRatio: Schema.optional(Ratio),
-})
+}).check(DeadlineOptions)
 
 export const Info = Schema.Struct({
   request: Schema.optional(Budget),

--- a/packages/opencode/src/config/retry.ts
+++ b/packages/opencode/src/config/retry.ts
@@ -12,8 +12,11 @@ export const Budget = Schema.Struct({
   maxRetries: Schema.optional(MaxRetries).annotate({
     description: "Retries after the initial attempt; 0 disables retries and the maximum is 100",
   }),
-  deadlineMs: Schema.optional(NonNegativeInt).annotate({
-    description: "Wall-clock retry deadline in milliseconds; 0 means no deadline",
+  deadlineMs: Schema.optional(PositiveInt).annotate({
+    description: "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+  }),
+  noDeadline: Schema.optional(Schema.Boolean).annotate({
+    description: "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
   }),
   initialDelayMs: Schema.optional(PositiveInt),
   maxDelayMs: Schema.optional(PositiveInt),

--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -4,7 +4,7 @@ export interface Runner<A, E = never> {
   readonly state: State<A, E>
   readonly busy: boolean
   readonly ensureRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
-  readonly start: (work: Effect.Effect<A, E>) => Effect.Effect<void, E>
+  readonly start: (work: Effect.Effect<A, E>) => Effect.Effect<void>
   readonly startShell: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
   readonly cancel: Effect.Effect<void>
 }
@@ -164,19 +164,24 @@ export const make = <A, E = never>(
       }),
     ).pipe(Effect.flatten)
 
-  const start = (work: Effect.Effect<A, E>) =>
+  const start = (work: Effect.Effect<A, E>): Effect.Effect<void> =>
     SynchronizedRef.modifyEffect(
       ref,
       Effect.fnUntraced(function* (st) {
         if (st._tag !== "Idle") {
-          if (opts?.busy) opts.busy()
-          throw new Error("Runner is busy")
+          let error: unknown = new Error("Runner is busy")
+          try {
+            if (opts?.busy) opts.busy()
+          } catch (caught) {
+            error = caught
+          }
+          return [Effect.fail(error as E), st] as unknown as readonly [Effect.Effect<void, never>, State<A, E>]
         }
         const done = yield* Deferred.make<A, E | Cancelled>()
         const run = yield* startRun(work, done)
         return [Effect.void, { _tag: "Running", run } as const] as const
       }),
-    ).pipe(Effect.flatten)
+    ).pipe(Effect.flatten) as Effect.Effect<void>
 
   const cancel = SynchronizedRef.modify(ref, (st) => {
     switch (st._tag) {

--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -1,11 +1,11 @@
 import { Cause, Deferred, Effect, Exit, Fiber, Schema, Scope, SynchronizedRef } from "effect"
 
-export interface Runner<A, E = never> {
+export interface Runner<A, E = never, B = never> {
   readonly state: State<A, E>
   readonly busy: boolean
   readonly ensureRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
-  readonly start: (work: Effect.Effect<A, E>) => Effect.Effect<void>
-  readonly startShell: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
+  readonly start: (work: Effect.Effect<A, E>) => Effect.Effect<void, B>
+  readonly startShell: (work: Effect.Effect<A, E>) => Effect.Effect<A, E | B>
   readonly cancel: Effect.Effect<void>
 }
 
@@ -34,17 +34,17 @@ export type State<A, E> =
   | { readonly _tag: "Shell"; readonly shell: ShellHandle<A, E> }
   | { readonly _tag: "ShellThenRun"; readonly shell: ShellHandle<A, E>; readonly run: PendingHandle<A, E> }
 
-export const make = <A, E = never>(
+export const make = <A, E = never, B = never>(
   scope: Scope.Scope,
   opts?: {
     onIdle?: Effect.Effect<void>
     onBusy?: Effect.Effect<void>
     onInterrupt?: Effect.Effect<A, E>
-    busy?: () => never
+    busy?: () => B
     label?: string
     onReentryWarn?: (info: { label: string; existingRunId: number }) => Effect.Effect<void>
   },
-): Runner<A, E> => {
+): Runner<A, E, B> => {
   const ref = SynchronizedRef.makeUnsafe<State<A, E>>({ _tag: "Idle" })
   const idle = opts?.onIdle ?? Effect.void
   const busy = opts?.onBusy ?? Effect.void
@@ -87,6 +87,9 @@ export const make = <A, E = never>(
       )
       return { id, done, fiber } satisfies RunHandle<A, E>
     })
+
+  const busyFailure = <C>(): Effect.Effect<C, B> =>
+    opts?.busy ? Effect.fail(opts.busy()) : Effect.die(new Error("Runner is busy"))
 
   const finishShell = (id: number) =>
     SynchronizedRef.modifyEffect(
@@ -140,13 +143,7 @@ export const make = <A, E = never>(
       ref,
       Effect.fnUntraced(function* (st) {
         if (st._tag !== "Idle") {
-          return [
-            Effect.sync(() => {
-              if (opts?.busy) opts.busy()
-              throw new Error("Runner is busy")
-            }),
-            st,
-          ] as const
+          return [busyFailure<A>(), st] as readonly [Effect.Effect<A, E | B>, State<A, E>]
         }
         yield* busy
         const id = next()
@@ -160,28 +157,22 @@ export const make = <A, E = never>(
             return yield* Effect.failCause(exit.cause)
           }),
           { _tag: "Shell", shell },
-        ] as const
+        ] as readonly [Effect.Effect<A, E | B>, State<A, E>]
       }),
     ).pipe(Effect.flatten)
 
-  const start = (work: Effect.Effect<A, E>): Effect.Effect<void> =>
+  const start = (work: Effect.Effect<A, E>): Effect.Effect<void, B> =>
     SynchronizedRef.modifyEffect(
       ref,
       Effect.fnUntraced(function* (st) {
         if (st._tag !== "Idle") {
-          let error: unknown = new Error("Runner is busy")
-          try {
-            if (opts?.busy) opts.busy()
-          } catch (caught) {
-            error = caught
-          }
-          return [Effect.fail(error as E), st] as unknown as readonly [Effect.Effect<void, never>, State<A, E>]
+          return [busyFailure<void>(), st] as const
         }
         const done = yield* Deferred.make<A, E | Cancelled>()
         const run = yield* startRun(work, done)
         return [Effect.void, { _tag: "Running", run } as const] as const
       }),
-    ).pipe(Effect.flatten) as Effect.Effect<void>
+    ).pipe(Effect.flatten)
 
   const cancel = SynchronizedRef.modify(ref, (st) => {
     switch (st._tag) {
@@ -191,7 +182,6 @@ export const make = <A, E = never>(
         return [
           Effect.gen(function* () {
             yield* Fiber.interrupt(st.run.fiber)
-            yield* Deferred.await(st.run.done).pipe(Effect.exit, Effect.asVoid)
             yield* idleIfCurrent()
           }),
           { _tag: "Idle" } as const,

--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -4,6 +4,7 @@ export interface Runner<A, E = never> {
   readonly state: State<A, E>
   readonly busy: boolean
   readonly ensureRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
+  readonly start: (work: Effect.Effect<A, E>) => Effect.Effect<void, E>
   readonly startShell: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
   readonly cancel: Effect.Effect<void>
 }
@@ -163,6 +164,20 @@ export const make = <A, E = never>(
       }),
     ).pipe(Effect.flatten)
 
+  const start = (work: Effect.Effect<A, E>) =>
+    SynchronizedRef.modifyEffect(
+      ref,
+      Effect.fnUntraced(function* (st) {
+        if (st._tag !== "Idle") {
+          if (opts?.busy) opts.busy()
+          throw new Error("Runner is busy")
+        }
+        const done = yield* Deferred.make<A, E | Cancelled>()
+        const run = yield* startRun(work, done)
+        return [Effect.void, { _tag: "Running", run } as const] as const
+      }),
+    ).pipe(Effect.flatten)
+
   const cancel = SynchronizedRef.modify(ref, (st) => {
     switch (st._tag) {
       case "Idle":
@@ -204,6 +219,7 @@ export const make = <A, E = never>(
       return state()._tag !== "Idle"
     },
     ensureRunning,
+    start,
     startShell,
     cancel,
   }

--- a/packages/opencode/src/mcp/sampling.ts
+++ b/packages/opencode/src/mcp/sampling.ts
@@ -89,7 +89,7 @@ const log = Log.create({ service: "mcp.sampling" })
  * is now the whole of it. This value used to be justified against the silence bound
  * as well — "3x below it, so a peer sees at least two beats before a stall is
  * declared" — and that ratio is void: the silence bound is now the provider's
- * `chunkTimeout` (8 minutes by default), against which 15 s is ~32x rather than 3x.
+ * `chunkTimeout` (5 minutes by default), against which 15 s is 20x rather than 3x.
  * The surviving reason is the one that never depended on the stall bound: a beat
  * every 15 s sits well inside the MCP SDK's 60 s DEFAULT_REQUEST_TIMEOUT_MSEC, so
  * several land within one peer timeout window instead of one landing near its edge,
@@ -108,16 +108,16 @@ export const DEFAULT_LIVENESS_INTERVAL = 15_000
  * 3x the liveness interval. The repo already had this exact concept — "no output
  * for this long means the stream is dead" — as `chunkTimeout`, wired in
  * `provider.ts:wrapSSE`, configurable per provider in `mimocode.json`, default
- * `DEFAULT_CHUNK_TIMEOUT` = 8 minutes. Carrying a second, tighter, differently
+ * `DEFAULT_CHUNK_TIMEOUT` = 5 minutes. Carrying a second, tighter, differently
  * named silence bound in the same repo for the same question was the defect; 45 s
- * against 480 s is not a divergence to justify but a 10x disagreement about the
+ * against 300 s is still a tighter disagreement about the same
  * same fact.
  *
  * AND THE REPO'S NUMBER IS THE ARGUED ONE. `DEFAULT_CHUNK_TIMEOUT`'s comment
  * records a real observation — "mimo-v2.5-pro on MiMo Router whose cold-path TTFT
  * after context rebuild can dip to ~5 minutes silent" — which is the only
  * statement anywhere here about how long LEGITIMATE provider silence lasts. Our
- * 45 s was 10x tighter than a value tuned to tolerate a real 5-minute silent cold
+ * 45 s was still tighter than a value tuned to tolerate a real 5-minute silent cold
  * path, so it would have declared a stall on calls the main path is explicitly
  * built to survive. The false-positive risk the old constant's comment listed as
  * hypothetical was in fact already measured, elsewhere, against us.

--- a/packages/opencode/src/mcp/sampling.ts
+++ b/packages/opencode/src/mcp/sampling.ts
@@ -89,7 +89,7 @@ const log = Log.create({ service: "mcp.sampling" })
  * is now the whole of it. This value used to be justified against the silence bound
  * as well — "3x below it, so a peer sees at least two beats before a stall is
  * declared" — and that ratio is void: the silence bound is now the provider's
- * `chunkTimeout` (5 minutes by default), against which 15 s is 20x rather than 3x.
+ * `chunkTimeout` (8 minutes by default), against which 15 s is ~32x rather than 3x.
  * The surviving reason is the one that never depended on the stall bound: a beat
  * every 15 s sits well inside the MCP SDK's 60 s DEFAULT_REQUEST_TIMEOUT_MSEC, so
  * several land within one peer timeout window instead of one landing near its edge,
@@ -108,16 +108,16 @@ export const DEFAULT_LIVENESS_INTERVAL = 15_000
  * 3x the liveness interval. The repo already had this exact concept — "no output
  * for this long means the stream is dead" — as `chunkTimeout`, wired in
  * `provider.ts:wrapSSE`, configurable per provider in `mimocode.json`, default
- * `DEFAULT_CHUNK_TIMEOUT` = 5 minutes. Carrying a second, tighter, differently
+ * `DEFAULT_CHUNK_TIMEOUT` = 8 minutes. Carrying a second, tighter, differently
  * named silence bound in the same repo for the same question was the defect; 45 s
- * against 300 s is still a tighter disagreement about the same
+ * against 480 s is not a divergence to justify but a 10x disagreement about the
  * same fact.
  *
  * AND THE REPO'S NUMBER IS THE ARGUED ONE. `DEFAULT_CHUNK_TIMEOUT`'s comment
  * records a real observation — "mimo-v2.5-pro on MiMo Router whose cold-path TTFT
  * after context rebuild can dip to ~5 minutes silent" — which is the only
  * statement anywhere here about how long LEGITIMATE provider silence lasts. Our
- * 45 s was still tighter than a value tuned to tolerate a real 5-minute silent cold
+ * 45 s was 10x tighter than a value tuned to tolerate a real 5-minute silent cold
  * path, so it would have declared a stall on calls the main path is explicitly
  * built to survive. The false-positive risk the old constant's comment listed as
  * hypothetical was in fact already measured, elsewhere, against us.

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -18,6 +18,7 @@ import { PermissionID } from "./schema"
 import { forwardRef } from "./permission-forward-ref"
 import { inboxServiceRef } from "@/inbox/inbox-ref"
 import { TuiEvent } from "@/cli/cmd/tui/event"
+import { EffectBridge } from "@/effect"
 
 // A forwarded ask (orchestrator peer) that no one ever approves resolves DENY
 // after this bound rather than hanging — preserving the hang-safety the old
@@ -226,6 +227,7 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const bus = yield* Bus.Service
+    const bridge = yield* EffectBridge.make()
     const state = yield* InstanceState.make<State>(
       Effect.fn("Permission.state")(function* (ctx) {
         const row = Database.use((db) =>
@@ -401,7 +403,7 @@ export const layer = Layer.effect(
             childSessionID: info.sessionID,
             parentSessionID,
             resolve: (decision) =>
-              Effect.runFork(
+              bridge.fork(
                 decision === "allow"
                   ? Deferred.succeed(deferred, void 0)
                   : Deferred.fail(deferred, new RejectedError()),

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -250,7 +250,7 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   const responseBody = JSON.stringify(body)
   if (body.type !== "error") return
 
-  switch (body?.error?.code ?? body?.error?.type) {
+  switch (body?.error?.code || body?.error?.type) {
     case "overloaded_error":
     case "server_is_overloaded":
     case "server_error":

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -318,7 +318,7 @@ export function parseAPICallError(input: { providerID: ProviderID; error: APICal
     }
   }
 
-  const metadata = input.error.url ? { url: input.error.url } : undefined
+  const metadata = { providerID: input.providerID, ...(input.error.url ? { url: input.error.url } : {}) }
   return {
     type: "api_error",
     message: m,

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -250,7 +250,8 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   const responseBody = JSON.stringify(body)
   if (body.type !== "error") return
 
-  switch (body?.error?.code) {
+  switch (body?.error?.code ?? body?.error?.type) {
+    case "overloaded_error":
     case "server_is_overloaded":
     case "server_error":
     case "stream_read_error":

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -148,8 +148,8 @@ const MODEL_NOT_FOUND_RETRY_ADAPTERS = new Set([
   "@llmgateway/ai-sdk-provider",
 ])
 
-export function allowsModelNotFoundRetry(model: { api: { npm: string } }): boolean {
-  return MODEL_NOT_FOUND_RETRY_ADAPTERS.has(model.api.npm)
+export function allowsModelNotFoundRetry(model: { api?: { npm?: string } }): boolean {
+  return typeof model.api?.npm === "string" && MODEL_NOT_FOUND_RETRY_ADAPTERS.has(model.api.npm)
 }
 
 // Providers not reliably handled in this function:

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -132,11 +132,24 @@ const OVERFLOW_PATTERNS = [
   /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
 ]
 
-function isOpenAiErrorRetryable(e: APICallError) {
+function isApiErrorRetryable(e: APICallError, allow404Retry = false) {
   const status = e.statusCode
   if (!status) return e.isRetryable
-  // openai sometimes returns 404 for models that are actually available
-  return status === 404 || e.isRetryable
+  return (status === 404 && allow404Retry) || e.isRetryable
+}
+
+const MODEL_NOT_FOUND_RETRY_ADAPTERS = new Set([
+  "@ai-sdk/openai",
+  "@ai-sdk/openai-compatible",
+  "@ai-sdk/azure",
+  "@ai-sdk/groq",
+  "@ai-sdk/togetherai",
+  "@openrouter/ai-sdk-provider",
+  "@llmgateway/ai-sdk-provider",
+])
+
+export function allowsModelNotFoundRetry(model: { api: { npm: string } }): boolean {
+  return MODEL_NOT_FOUND_RETRY_ADAPTERS.has(model.api.npm)
 }
 
 // Providers not reliably handled in this function:
@@ -307,7 +320,7 @@ export type ParsedAPICallError =
       metadata?: Record<string, string>
     }
 
-export function parseAPICallError(input: { providerID: ProviderID; error: APICallError }): ParsedAPICallError {
+export function parseAPICallError(input: { providerID: ProviderID; error: APICallError; allow404Retry?: boolean }): ParsedAPICallError {
   const m = message(input.providerID, input.error)
   const body = json(input.error.responseBody)
   if (isOverflow(m) || input.error.statusCode === 413 || body?.error?.code === "context_length_exceeded") {
@@ -318,12 +331,16 @@ export function parseAPICallError(input: { providerID: ProviderID; error: APICal
     }
   }
 
-  const metadata = { providerID: input.providerID, ...(input.error.url ? { url: input.error.url } : {}) }
+  const metadata = {
+    providerID: input.providerID,
+    allow404Retry: input.allow404Retry ? "true" : "false",
+    ...(input.error.url ? { url: input.error.url } : {}),
+  }
   return {
     type: "api_error",
     message: m,
     statusCode: input.error.statusCode,
-    isRetryable: input.providerID.startsWith("openai") ? isOpenAiErrorRetryable(input.error) : input.error.isRetryable,
+    isRetryable: isApiErrorRetryable(input.error, input.allow404Retry),
     responseHeaders: input.error.responseHeaders,
     responseBody: input.error.responseBody,
     metadata,

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -3,6 +3,111 @@ import { STATUS_CODES } from "http"
 import { iife } from "@/util/iife"
 import type { ProviderID } from "./schema"
 
+const RETRYABLE_NETWORK_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTDOWN",
+  "EHOSTUNREACH",
+  "EPIPE",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "EAI_AGAIN",
+  "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_RES_CONTENT_LENGTH_MISMATCH",
+  "UND_ERR_ABORTED",
+  "UND_ERR_SOCKET",
+])
+
+const RETRYABLE_NETWORK_MESSAGES = [
+  /^fetch failed$/i,
+  /^SSE read timed out$/i,
+  /connection (?:aborted|closed|refused|reset)(?: by server)?$/i,
+  /network (?:connection|error)/i,
+  /response body (?:terminated|closed)/i,
+  /socket hang up/i,
+]
+
+export type CauseSummary = {
+  depth: number
+  name?: string
+  message?: string
+  code?: string
+  statusCode?: number
+  source: "cause" | "aggregate" | "root"
+}
+
+function codeOf(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined
+  const code = (error as { code?: unknown }).code
+  return typeof code === "string" ? code : undefined
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false
+  const code = codeOf(error)
+  if (code === "UND_ERR_ABORTED") return false
+  return (error as { name?: unknown }).name === "AbortError" || code === "ABORT_ERR"
+}
+
+export function summarizeCause(input: unknown): CauseSummary[] {
+  const seen = new Set<object>()
+  const queue: Array<{ value: unknown; depth: number; source: CauseSummary["source"] }> = [
+    { value: input, depth: 0, source: "root" },
+  ]
+  const result: CauseSummary[] = []
+  while (queue.length > 0 && result.length < 16) {
+    const node = queue.shift()!
+    if (typeof node.value !== "object" || node.value === null || seen.has(node.value)) continue
+    seen.add(node.value)
+    const object = node.value as {
+      name?: unknown
+      message?: unknown
+      code?: unknown
+      status?: unknown
+      statusCode?: unknown
+      cause?: unknown
+      errors?: unknown
+    }
+    const status = object.statusCode ?? object.status
+    const statusCode = typeof status === "string" ? Number.parseInt(status, 10) : status
+    result.push({
+      depth: node.depth,
+      name: typeof object.name === "string" ? object.name : undefined,
+      message: typeof object.message === "string" ? object.message : undefined,
+      code: typeof object.code === "string" ? object.code : undefined,
+      statusCode: typeof statusCode === "number" && !Number.isNaN(statusCode) ? statusCode : undefined,
+      source: node.source,
+    })
+    if (object.cause !== undefined && node.depth < 8)
+      queue.push({ value: object.cause, depth: node.depth + 1, source: "cause" })
+    if (Array.isArray(object.errors) && node.depth < 8) {
+      for (const error of object.errors) queue.push({ value: error, depth: node.depth + 1, source: "aggregate" })
+    }
+  }
+  return result
+}
+export function networkErrorCode(input: unknown): string | undefined {
+  return summarizeCause(input)
+    .map((cause) => cause.code)
+    .find((code): code is string => code !== undefined && RETRYABLE_NETWORK_CODES.has(code))
+}
+
+export function isRetryableNetworkError(input: unknown): boolean {
+  const chain = summarizeCause(input)
+  if (chain.some((cause) => (cause.name === "AbortError" && cause.code !== "UND_ERR_ABORTED") || cause.code === "ABORT_ERR")) return false
+
+  return chain.some((cause) => {
+    const code = cause.code
+    if (code && RETRYABLE_NETWORK_CODES.has(code)) return true
+    const message = cause.message
+    return message !== undefined && RETRYABLE_NETWORK_MESSAGES.some((pattern) => pattern.test(message))
+  })
+}
+
 // Adapted from overflow detection patterns in:
 // https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/utils/overflow.ts
 const OVERFLOW_PATTERNS = [
@@ -148,6 +253,7 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   switch (body?.error?.code) {
     case "server_is_overloaded":
     case "server_error":
+    case "stream_read_error":
       return {
         type: "api_error",
         message: typeof body?.error?.message === "string" ? body.error.message : "OpenAI server error",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -41,8 +41,10 @@ const BUILTIN_TIERS = new Set(["ultra", "standard", "lite"])
 const warnedContextDefaults = new Set<string>()
 
 export const DEFAULT_OPENAI_HEADER_TIMEOUT = 300_000
-export const DEFAULT_CHUNK_TIMEOUT = 300_000 // 5 minutes — bounds single-attempt SSE stall.
-// Matches the default stream idle budget used by the provider retry runtime. Override
+export const DEFAULT_CHUNK_TIMEOUT = 480_000 // 8 minutes — bounds single-attempt SSE stall.
+// Tuned for mimo-v2.5-pro on MiMo Router whose cold-path TTFT after context
+// rebuild can dip to ~5 minutes silent. Reasoning models with multi-minute
+// thinking still emit partial chunks / heartbeats within this window. Override
 // per-provider via mimocode.json's `chunkTimeout` config for tighter or looser
 // bounds.
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -41,10 +41,8 @@ const BUILTIN_TIERS = new Set(["ultra", "standard", "lite"])
 const warnedContextDefaults = new Set<string>()
 
 export const DEFAULT_OPENAI_HEADER_TIMEOUT = 300_000
-export const DEFAULT_CHUNK_TIMEOUT = 480_000 // 8 minutes — bounds single-attempt SSE stall.
-// Tuned for mimo-v2.5-pro on MiMo Router whose cold-path TTFT after context
-// rebuild can dip to ~5 minutes silent. Reasoning models with multi-minute
-// thinking still emit partial chunks / heartbeats within this window. Override
+export const DEFAULT_CHUNK_TIMEOUT = 300_000 // 5 minutes — bounds single-attempt SSE stall.
+// Matches the default stream idle budget used by the provider retry runtime. Override
 // per-provider via mimocode.json's `chunkTimeout` config for tighter or looser
 // bounds.
 

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -1057,7 +1057,7 @@ export const SessionRoutes = lazy(() =>
         await runRequest(
           "SessionRoutes.resume.assertNotBusy",
           c,
-          SessionRunState.Service.use((svc) => svc.assertNotBusy(params.sessionID)),
+          SessionRunState.Service.use((svc) => svc.assertNotBusy(params.sessionID, query.agentID)),
         )
         await runRequest(
           "SessionRoutes.resume.validate",
@@ -1079,7 +1079,7 @@ export const SessionRoutes = lazy(() =>
         void runRequest(
           "SessionRoutes.resume",
           c,
-          SessionPrompt.Service.use((svc) => svc.resume({
+          SessionPrompt.Service.use((svc) => svc.resumeBackground({
             sessionID: params.sessionID,
             assistantMessageID: params.assistantMessageID,
             agentID: query.agentID,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -913,7 +913,7 @@ const live: Layer.Layer<
                 const wait = SessionRetry.retryDelay(
                   nextAttempt,
                   decision,
-                  retryConfig.jitterRatio,
+                  budget.jitterRatio,
                   budget.initialDelayMs,
                   budget.maxDelayMs,
                 )

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -98,7 +98,7 @@ type Result = Awaited<ReturnType<typeof streamText>>
  *   is HTTP-byte-level: keep-alive comments still count as activity, so
  *   the error only fires when the underlying TCP stream is genuinely dead.
  *
- * Auth errors (401/403), client errors (400, 404, 422), and user-
+ * Authentication failures, client errors (400, 404, 422), and user-
  * initiated aborts are NOT retryable.
  *
  * @deprecated Use `isRetryableTransientError` from `./retry` directly.
@@ -888,18 +888,14 @@ const live: Layer.Layer<
             source: Stream.Stream<Event, unknown, never>,
             retryCount: number,
             startedAt?: number,
+            prefillRepaired = false,
           ): Stream.Stream<Event, unknown, never> =>
             source.pipe(
               Stream.catchCause((primaryCause) => {
                 const primaryError = Cause.squash(primaryCause)
                 if (ProviderTransform.isAssistantPrefillRejection(primaryError)) {
-                  return attempt(true, false).pipe(
-                    Stream.catchCause((retryCause) =>
-                      ProviderTransform.isAssistantPrefillRejection(Cause.squash(retryCause))
-                        ? Stream.failCause(primaryCause)
-                        : Stream.failCause(retryCause),
-                    ),
-                  )
+                  if (prefillRepaired) return Stream.failCause(primaryCause)
+                  return retryRequest(attempt(true, true), retryCount, startedAt, true)
                 }
                 const normalized = MessageV2.fromError(primaryError, { providerID: input.model.providerID })
                 const decision = SessionRetry.decide(normalized, "request")

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import { Provider } from "@/provider"
 import { Log } from "@/util"
-import { Context, Duration, Effect, Layer, Record, Schedule, Ref, Cause } from "effect"
+import { Context, Duration, Effect, Layer, Record, Cause } from "effect"
 import * as Stream from "effect/Stream"
 import { streamText, wrapLanguageModel, type ModelMessage, type Tool, tool, jsonSchema } from "ai"
 import { mergeDeep, pipe } from "remeda"
@@ -10,7 +10,7 @@ import { ProviderTransform } from "@/provider"
 import { Config } from "@/config"
 import { Instance } from "@/project/instance"
 import { Agent } from "@/agent/agent"
-import type { MessageV2 } from "./message-v2"
+import { MessageV2 } from "./message-v2"
 import { Plugin } from "@/plugin"
 import { SystemPrompt } from "./system"
 import { Permission } from "@/permission"
@@ -32,6 +32,7 @@ import * as OtelTracer from "@effect/opentelemetry/Tracer"
 import { ActorRegistry } from "@/actor/registry"
 import { Memory } from "@/memory"
 import { isRetryableTransientError } from "./retry"
+import * as SessionRetry from "./retry"
 import { MCP_TOOL_SEARCH_ID } from "@/tool/mcp-tool-search"
 import { TOOL_SCRIPT_EXCLUDED } from "@/tool/tool-script-ref"
 import { deriveLiveness } from "@/actor/schema"
@@ -75,7 +76,7 @@ export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
 export const ROSTER_HEADER =
   "Your fleet — your routable child sessions right now. This list is internal working context, " +
   "not output: never repeat it, or these session ids and titles, back to the user — report the " +
-  "routing DECISION instead (\"routing this to the docs child\"). Format is id | title | agent | status:"
+  'routing DECISION instead ("routing this to the docs child"). Format is id | title | agent | status:'
 
 // How many FINISHED-but-resumable child sessions the fleet roster carries,
 // most-recently-active first. The roster is re-injected on EVERY request,
@@ -87,7 +88,7 @@ export const ROSTER_IDLE_LIMIT = 5
 type Result = Awaited<ReturnType<typeof streamText>>
 
 /**
- * Match transient errors that the PERSISTENT_RETRY layer should retry.
+ * Match transient errors that max-mode local retries should retry.
  *
  * - HTTP 429 / 5xx / 529 — capacity / overload responses
  * - ECONNRESET / EPIPE / ETIMEDOUT — network errors typically caused by
@@ -106,26 +107,6 @@ type Result = Awaited<ReturnType<typeof streamText>>
 export function isTransientCapacityError(error: unknown): boolean {
   return isRetryableTransientError(error)
 }
-
-/**
- * Persistent-retry schedule with exponential backoff.
- *
- * Exponential backoff 500ms × 2 (i.e. 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256s),
- * each individual delay capped at 5 minutes, total attempts capped at 10.
- *
- * Worst-case total = 11 attempts × chunkTimeout + cumulative backoff
- *                  ≈ 11 × 8min + 9min ≈ 97 min (with DEFAULT_CHUNK_TIMEOUT = 8min).
- *
- * Intentionally NOT capped via Schedule.upTo() — retry persistence under
- * brief upstream outages is the design goal. Bounding per-attempt latency
- * via chunkTimeout is the primary lever for hang-time control.
- */
-export const persistentRetrySchedule = Schedule.exponential("500 millis", 2).pipe(
-  Schedule.modifyDelay((_, delay) =>
-    Effect.succeed(Duration.isLessThanOrEqualTo(delay, Duration.minutes(5)) ? delay : Duration.minutes(5)),
-  ),
-  Schedule.both(Schedule.recurs(10)),
-)
 
 /**
  * Memory-system instructions appended to the main agent's system prompt.
@@ -259,12 +240,11 @@ export type StreamInput = {
   agent: Agent.Info
   permission?: Permission.Ruleset
   system: string[]
-  prebuiltSystem?: string[]      // when set, skip buildSystemArray and use this verbatim
+  prebuiltSystem?: string[] // when set, skip buildSystemArray and use this verbatim
   messages: ModelMessage[]
   small?: boolean
   tools: Record<string, Tool>
   activeTools?: string[]
-  retries?: number
   toolChoice?: "auto" | "required" | "none"
   agentID?: string
   mergeTurnContextIntoLastUser?: boolean
@@ -287,8 +267,8 @@ export function turnContextMessages(user: MessageV2.User): ModelMessage[] {
   const context = user.system?.trim()
   if (!context) return []
   return [{
-    role: "user",
-    content: `<system-reminder>\n${context}\n</system-reminder>`,
+      role: "user",
+      content: `<system-reminder>\n${context}\n</system-reminder>`,
   }]
 }
 
@@ -319,7 +299,13 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/LL
 const live: Layer.Layer<
   Service,
   never,
-  Auth.Service | Config.Service | Provider.Service | Plugin.Service | Permission.Service | ActorRegistry.Service | Memory.Service
+  | Auth.Service
+  | Config.Service
+  | Provider.Service
+  | Plugin.Service
+  | Permission.Service
+  | ActorRegistry.Service
+  | Memory.Service
 > = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -392,10 +378,7 @@ const live: Layer.Layer<
         // listPeerChildren joins through the Session row's parent_id, because a
         // peer child registers its actor row under its OWN session id — a
         // session_id-keyed lookup (listByParent) never matches a peer.
-        const children = yield* actorReg.listPeerChildren(
-          SessionID.make(input.sessionID),
-          input.agentID ?? "main",
-        )
+        const children = yield* actorReg.listPeerChildren(SessionID.make(input.sessionID), input.agentID ?? "main")
         const now = Date.now()
         const routable = children
           .filter(({ actor }) => !SYSTEM_SPAWNED_AGENT_TYPES.has(actor.agent))
@@ -788,16 +771,9 @@ const live: Layer.Layer<
           ...headers,
           "User-Agent": `mimocode/${InstallationVersion}`,
         },
-        // AI SDK's internal retry loop is SILENT — it emits no events and does
-        // not update session status, so the TUI shows only a dead spinner while
-        // it runs. Its backoff is also UNCAPPED (delay *= 2 each attempt, capped
-        // only by a retry-after header), so the prior default of 10 meant up to
-        // ~34 min (2+4+…+1024s) of invisible retrying before the error surfaced.
-        // We keep this layer short (absorb a couple of quick blips) and let the
-        // VISIBLE processor-level SessionRetry.policy own long-haul resilience —
-        // it publishes `type: "retry"` so the `[retrying attempt #N]` banner
-        // shows, and its per-attempt delay is capped at 30s.
-        maxRetries: input.retries ?? 2,
+        // Keep one SDK-level retry for a failure before response headers. The
+        // processor owns the persistent stream retry budget below this layer.
+        maxRetries: 0,
         messages,
         model: wrapLanguageModel({
           model: language,
@@ -835,7 +811,7 @@ const live: Layer.Layer<
       // Build the scoped stream for one attempt. `dropAssistantPrefill` forces
       // run() to hard-prune the trailing assistant prefill before send — used only
       // by the reactive one-shot retry below.
-      const attempt = (dropAssistantPrefill: boolean) =>
+      const attempt = (dropAssistantPrefill: boolean, allowRequestRetry: boolean) =>
         Stream.scoped(
           Stream.unwrap(
             Effect.gen(function* () {
@@ -843,45 +819,7 @@ const live: Layer.Layer<
                 Effect.sync(() => new AbortController()),
                 (ctrl) => Effect.sync(() => ctrl.abort()),
               )
-              const attemptRef = yield* Ref.make(0)
-
-              const publishRetryEvent = (error: unknown, nextAttempt: number) =>
-                Effect.gen(function* () {
-                  log.debug("retry attempt", {
-                    sessionID: input.sessionID,
-                    messageID: input.user.id,
-                    attempt: nextAttempt,
-                    reason: error instanceof Error ? error.message : String(error),
-                  })
-                  if (nextAttempt > 10) return
-                  const delayMs = Math.min(500 * 2 ** (nextAttempt - 1), 300_000)
-                  yield* Effect.promise(() =>
-                    Bus.publish(Session.Event.RetryAttempt, {
-                      sessionID: SessionID.make(input.sessionID),
-                      messageID: input.user.id,
-                      attempt: nextAttempt,
-                      maxAttempts: 10,
-                      reason: error instanceof Error ? error.message : String(error),
-                      nextDelayMs: delayMs,
-                    })
-                  )
-                })
-
-              const streamWithTelemetry = run({ ...input, abort: ctrl.signal, dropAssistantPrefill }).pipe(
-                Effect.tapError((error) => {
-                  if (!isTransientCapacityError(error)) return Effect.void
-                  return Ref.updateAndGet(attemptRef, (n) => n + 1).pipe(
-                    Effect.flatMap((nextAttempt) => publishRetryEvent(error, nextAttempt))
-                  )
-                })
-              )
-
-              const result = yield* streamWithTelemetry.pipe(
-                Effect.retry({
-                  while: isTransientCapacityError,
-                  schedule: persistentRetrySchedule,
-                }),
-              )
+              const result = yield* run({ ...input, abort: ctrl.signal, dropAssistantPrefill })
 
               // Structurally identical to the pre-guard stream: a bare scoped
               // stream over the provider's fullStream. No per-event combinator, no
@@ -889,8 +827,29 @@ const live: Layer.Layer<
               // AbortController scope teardown are exactly as before. The reactive
               // prefill retry is layered lazily below and only pays a cost when an
               // actual error surfaces.
-              return Stream.fromAsyncIterable(result.fullStream, (e) =>
+              const rawStream = Stream.fromAsyncIterable(result.fullStream, (e) =>
                 e instanceof Error ? e : new Error(String(e)),
+              )
+              let hasProviderOutput = false
+              return rawStream.pipe(
+                Stream.mapEffect((event) =>
+                  Effect.gen(function* () {
+                    if (
+                      event.type === "error" &&
+                      !hasProviderOutput &&
+                      allowRequestRetry &&
+                      !ProviderTransform.isAssistantPrefillRejection(event.error)
+                    ) {
+                      const normalized = MessageV2.fromError(event.error, {
+                        providerID: input.model.providerID,
+                        aborted: ctrl.signal.aborted,
+                      })
+                      if (SessionRetry.decide(normalized, "request").retryable) return yield* Effect.fail(event.error)
+                    }
+                    if (event.type !== "start" && event.type !== "error") hasProviderOutput = true
+                    return event
+                  }),
+                ),
               )
             }),
           ),
@@ -903,7 +862,7 @@ const live: Layer.Layer<
       // per-event Effect fiber, unlike `Stream.mapEffect`), and the failing branch
       // is only ever constructed for the specific error event. On a clean stream
       // this is a transparent passthrough.
-      const promotePrefillRejection = (stream: Stream.Stream<Event, Error, never>) =>
+      const promotePrefillRejection = (stream: Stream.Stream<Event, unknown, never>) =>
         stream.pipe(
           Stream.flatMap((event) =>
             event.type === "error" && ProviderTransform.isAssistantPrefillRejection(event.error)
@@ -922,19 +881,69 @@ const live: Layer.Layer<
       // hard-pruned. Guarded to a single reprune so a persistent failure surfaces
       // the retry's OWN error, falling back to the original prefill cause only when
       // the resend is again prefill-rejected.
-      return promotePrefillRejection(attempt(false)).pipe(
-        Stream.catchCause((primaryCause) => {
-          if (!ProviderTransform.isAssistantPrefillRejection(Cause.squash(primaryCause)))
-            return Stream.failCause(primaryCause)
-          // Pruned resend passes events through untouched: any residual error flows
-          // to the processor and surfaces normally (no promotion, no loop).
-          return attempt(true).pipe(
-            Stream.catchCause((retryCause) =>
-              ProviderTransform.isAssistantPrefillRejection(Cause.squash(retryCause))
-                ? Stream.failCause(primaryCause)
-                : Stream.failCause(retryCause),
-            ),
-          )
+      return Stream.unwrap(
+        Effect.gen(function* () {
+          const retryConfig = SessionRetry.resolve(yield* config.get(), input.model.providerID)
+          const retryRequest = (
+            source: Stream.Stream<Event, unknown, never>,
+            retryCount: number,
+            startedAt?: number,
+          ): Stream.Stream<Event, unknown, never> =>
+            source.pipe(
+              Stream.catchCause((primaryCause) => {
+                const primaryError = Cause.squash(primaryCause)
+                if (ProviderTransform.isAssistantPrefillRejection(primaryError)) {
+                  return attempt(true, false).pipe(
+                    Stream.catchCause((retryCause) =>
+                      ProviderTransform.isAssistantPrefillRejection(Cause.squash(retryCause))
+                        ? Stream.failCause(primaryCause)
+                        : Stream.failCause(retryCause),
+                    ),
+                  )
+                }
+                const normalized = MessageV2.fromError(primaryError, { providerID: input.model.providerID })
+                const decision = SessionRetry.decide(normalized, "request")
+                if (!decision.retryable) return Stream.failCause(primaryCause)
+                const budget = SessionRetry.budgetFor(retryConfig, decision)
+                const nextAttempt = retryCount + 1
+                if (budget.mode === "bounded" && (budget.maxRetries ?? 0) < nextAttempt)
+                  return Stream.failCause(primaryCause)
+                const deadlineStart = startedAt ?? Date.now()
+                const elapsed = Date.now() - deadlineStart
+                const wait = SessionRetry.retryDelay(
+                  nextAttempt,
+                  decision,
+                  retryConfig.jitterRatio,
+                  budget.initialDelayMs,
+                  budget.maxDelayMs,
+                )
+                if (
+                  budget.maxElapsedMs > 0 &&
+                  (elapsed >= budget.maxElapsedMs || wait >= budget.maxElapsedMs - elapsed)
+                )
+                  return Stream.failCause(primaryCause)
+                return Stream.unwrap(
+                  Effect.gen(function* () {
+                    yield* Effect.promise(() =>
+                      Bus.publish(Session.Event.RetryAttempt, {
+                        sessionID: SessionID.make(input.sessionID),
+                        messageID: input.user.id,
+                        attempt: nextAttempt,
+                        maxAttempts: budget.maxRetries ?? 0,
+                        phase: "request",
+                        kind: decision.kind,
+                        scope: "request",
+                        reason: decision.message,
+                        nextDelayMs: wait,
+                      }),
+                    )
+                    yield* Effect.sleep(Duration.millis(wait))
+                    return retryRequest(attempt(false, true), nextAttempt, deadlineStart)
+                  }),
+                )
+              }),
+            )
+          return retryRequest(promotePrefillRejection(attempt(false, true)), 0)
         }),
       )
     }
@@ -957,10 +966,7 @@ export const defaultLayer = Layer.suspend(() =>
 )
 
 function resolveTools(input: Pick<StreamInput, "tools" | "activeTools" | "agent" | "permission" | "user">) {
-  const disabled = Permission.disabled(
-    Object.keys(input.tools),
-    Agent.runtimePermission(input.agent, input.permission),
-  )
+  const disabled = Permission.disabled(Object.keys(input.tools), Agent.runtimePermission(input.agent, input.permission))
   const allowExecGateway =
     input.activeTools?.includes("exec") === true &&
     Object.keys(input.tools).some(

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -925,9 +925,10 @@ const live: Layer.Layer<
                   return Stream.failCause(primaryCause)
                 return Stream.unwrap(
                   Effect.gen(function* () {
-                    yield* status.set(SessionID.make(input.sessionID), {
+                    const globalAttempt = yield* status.setRetry(SessionID.make(input.sessionID), {
                       type: "retry",
                       attempt: nextAttempt,
+                      phaseAttempt: nextAttempt,
                       message: decision.message,
                       next: Date.now() + wait,
                       phase: "request",
@@ -937,7 +938,8 @@ const live: Layer.Layer<
                       Bus.publish(Session.Event.RetryAttempt, {
                         sessionID: SessionID.make(input.sessionID),
                         messageID: input.user.id,
-                        attempt: nextAttempt,
+                        attempt: globalAttempt,
+                        phaseAttempt: nextAttempt,
                         maxAttempts: budget.maxRetries ?? 0,
                         phase: "request",
                         kind: decision.kind,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { Provider } from "@/provider"
+import { Provider, ProviderError } from "@/provider"
 import { Log } from "@/util"
 import { Context, Duration, Effect, Layer, Record, Cause } from "effect"
 import * as Stream from "effect/Stream"
@@ -847,6 +847,7 @@ const live: Layer.Layer<
                       const normalized = MessageV2.fromError(event.error, {
                         providerID: input.model.providerID,
                         aborted: ctrl.signal.aborted,
+                        allow404Retry: ProviderError.allowsModelNotFoundRetry(input.model),
                       })
                       if (SessionRetry.decide(normalized, "request").retryable) return yield* Effect.fail(event.error)
                     }
@@ -901,7 +902,7 @@ const live: Layer.Layer<
                   if (prefillRepaired) return Stream.failCause(primaryCause)
                   return retryRequest(attempt(true, true), retryCount, startedAt, true)
                 }
-                const normalized = MessageV2.fromError(primaryError, { providerID: input.model.providerID })
+                const normalized = MessageV2.fromError(primaryError, { providerID: input.model.providerID, allow404Retry: ProviderError.allowsModelNotFoundRetry(input.model) })
                 const decision = SessionRetry.decide(normalized, "request")
                 if (!decision.retryable) return Stream.failCause(primaryCause)
                 const budget = SessionRetry.budgetFor(retryConfig, decision)
@@ -929,6 +930,8 @@ const live: Layer.Layer<
                       attempt: nextAttempt,
                       message: decision.message,
                       next: Date.now() + wait,
+                      phase: "request",
+                      scope: "request",
                     })
                     yield* Effect.promise(() =>
                       Bus.publish(Session.Event.RetryAttempt, {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -20,6 +20,7 @@ import { Wildcard, ToolCompat } from "@/util"
 import { asSchema } from "@ai-sdk/provider-utils"
 import { SessionID } from "@/session/schema"
 import * as Session from "@/session/session"
+import { SessionStatus } from "@/session/status"
 import { migrateProjectMemory } from "./checkpoint-paths"
 import { ProjectID } from "@/project/schema"
 import { Auth } from "@/auth"
@@ -307,6 +308,7 @@ const live: Layer.Layer<
   | Permission.Service
   | ActorRegistry.Service
   | Memory.Service
+  | SessionStatus.Service
 > = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -317,6 +319,7 @@ const live: Layer.Layer<
     const perm = yield* Permission.Service
     const actorReg = yield* ActorRegistry.Service
     const memory = yield* Memory.Service
+    const status = yield* SessionStatus.Service
 
     const buildSystemArray = Effect.fn("LLM.buildSystemArray")(function* (input: {
       agent: Agent.Info
@@ -921,6 +924,12 @@ const live: Layer.Layer<
                   return Stream.failCause(primaryCause)
                 return Stream.unwrap(
                   Effect.gen(function* () {
+                    yield* status.set(SessionID.make(input.sessionID), {
+                      type: "retry",
+                      attempt: nextAttempt,
+                      message: decision.message,
+                      next: Date.now() + wait,
+                    })
                     yield* Effect.promise(() =>
                       Bus.publish(Session.Event.RetryAttempt, {
                         sessionID: SessionID.make(input.sessionID),

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -245,6 +245,7 @@ export type StreamInput = {
   small?: boolean
   tools: Record<string, Tool>
   activeTools?: string[]
+  retries?: number
   toolChoice?: "auto" | "required" | "none"
   agentID?: string
   mergeTurnContextIntoLastUser?: boolean
@@ -773,7 +774,7 @@ const live: Layer.Layer<
         },
         // Keep one SDK-level retry for a failure before response headers. The
         // processor owns the persistent stream retry budget below this layer.
-        maxRetries: 0,
+        maxRetries: input.retries ?? 0,
         messages,
         model: wrapLanguageModel({
           model: language,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -973,6 +973,7 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(Plugin.defaultLayer),
     Layer.provide(ActorRegistry.defaultLayer),
     Layer.provide(Memory.defaultLayer),
+    Layer.provide(SessionStatus.defaultLayer),
   ),
 )
 

--- a/packages/opencode/src/session/max-mode.ts
+++ b/packages/opencode/src/session/max-mode.ts
@@ -75,14 +75,14 @@ export type MaxStepInput = {
   retryConfig?: SessionRetry.RetryConfigSource
 }
 
-function retryPolicy(input: MaxStepInput, scope: "max-candidate" | "max-judge") {
+function retryPolicy(input: MaxStepInput, scope: "max-candidate" | "max-judge", aborted: () => boolean) {
   const retryConfig = SessionRetry.resolve(input.retryConfig, input.model.providerID)
   return SessionRetry.policy({
     phase: "stream",
     scope,
     budget: (decision) => SessionRetry.budgetFor(retryConfig, decision),
     jitterRatio: retryConfig.jitterRatio,
-    parse: (error) => MessageV2.fromError(error, { providerID: input.model.providerID }),
+    parse: (error) => MessageV2.fromError(error, { providerID: input.model.providerID, aborted: aborted() }),
     set: (info) =>
       input.onRetry
         ? input.onRetry({ ...info, nextDelayMs: Math.max(0, info.next - Date.now()) })
@@ -120,8 +120,9 @@ export function toSchemaOnlyTools(tools: Record<string, AITool>): Record<string,
  */
 // Exported for integration tests (drives the real candidate path with a mock
 // llm.stream). Not part of the public surface — call sites use runMaxStep.
-export const runCandidate = (input: MaxStepInput, index: number): Effect.Effect<Candidate | null | "text-repeat"> =>
-  Effect.gen(function* () {
+export const runCandidate = (input: MaxStepInput, index: number): Effect.Effect<Candidate | null | "text-repeat"> => {
+  let aborted = false
+  return Effect.gen(function* () {
     const monitor = createTextNgramMonitor()
     // Fresh accumulator per attempt: the retry below re-runs this whole block,
     // so partial reasoning/text/toolCalls from a failed attempt must not carry
@@ -202,7 +203,7 @@ export const runCandidate = (input: MaxStepInput, index: number): Effect.Effect<
       (cause) => !Cause.hasInterruptsOnly(cause),
       (cause) => Effect.fail(Cause.squash(cause)),
     ),
-    Effect.retry(retryPolicy(input, "max-candidate")),
+    Effect.retry(retryPolicy(input, "max-candidate", () => aborted)),
     Effect.catchIf(isTextNgramRepeat, () => Effect.succeed("text-repeat" as const)),
     Effect.catch((e) =>
       Effect.sync(() => {
@@ -210,7 +211,9 @@ export const runCandidate = (input: MaxStepInput, index: number): Effect.Effect<
         return null
       }),
     ),
+    Effect.onInterrupt(() => Effect.sync(() => { aborted = true })),
   )
+}
 
 /** Render a candidate compactly for the judge. `label` is its judge-facing index. */
 function renderCandidate(c: Candidate, label: number): string {
@@ -254,8 +257,9 @@ export function parseJudgeIndex(out: string, count: number): number {
  * token usage. Falls back to index 0 on any parse/out-of-range issue.
  */
 /** Exported for integration tests; call sites go through runMaxStep. */
-export const judge = (input: MaxStepInput, candidates: Candidate[]): Effect.Effect<{ pick: number; usage?: any }> =>
-  Effect.gen(function* () {
+export const judge = (input: MaxStepInput, candidates: Candidate[]): Effect.Effect<{ pick: number; usage?: any }> => {
+  let aborted = false
+  return Effect.gen(function* () {
     if (candidates.length === 1) return { pick: 0, usage: undefined }
 
     const rendered = candidates.map((c, i) => renderCandidate(c, i)).join("\n\n")
@@ -309,14 +313,16 @@ export const judge = (input: MaxStepInput, candidates: Candidate[]): Effect.Effe
     // `out`/`usage` locally and emits nothing externally until it returns, so
     // re-streaming after a mid-stream reset is safe. Without this, a single
     // ECONNRESET during judging silently collapses the whole step to pick 0.
-    Effect.retry(retryPolicy(input, "max-judge")),
+    Effect.retry(retryPolicy(input, "max-judge", () => aborted)),
     Effect.catch((e) => {
       log.warn("judge failed, defaulting to candidate 0", {
         error: e instanceof Error ? e.message : String(e),
       })
       return Effect.succeed({ pick: 0, usage: undefined })
     }),
+    Effect.onInterrupt(() => Effect.sync(() => { aborted = true })),
   )
+}
 
 /**
  * Run one max-mode step: N parallel propose-only candidates → judge picks the

--- a/packages/opencode/src/session/max-mode.ts
+++ b/packages/opencode/src/session/max-mode.ts
@@ -4,6 +4,7 @@ import type { ModelMessage, Tool as AITool } from "ai"
 import { LLM } from "./llm"
 import { SessionProcessor } from "./processor"
 import * as Session from "./session"
+import { ProviderError } from "@/provider"
 import type { Provider } from "@/provider"
 import type { Agent } from "@/agent/agent"
 import { MessageV2 } from "./message-v2"
@@ -82,7 +83,7 @@ function retryPolicy(input: MaxStepInput, scope: "max-candidate" | "max-judge", 
     scope,
     budget: (decision) => SessionRetry.budgetFor(retryConfig, decision),
     jitterRatio: retryConfig.jitterRatio,
-    parse: (error) => MessageV2.fromError(error, { providerID: input.model.providerID, aborted: aborted() }),
+    parse: (error) => MessageV2.fromError(error, { providerID: input.model.providerID, aborted: aborted(), allow404Retry: ProviderError.allowsModelNotFoundRetry(input.model) }),
     set: (info) =>
       input.onRetry
         ? input.onRetry({ ...info, nextDelayMs: Math.max(0, info.next - Date.now()) })

--- a/packages/opencode/src/session/max-mode.ts
+++ b/packages/opencode/src/session/max-mode.ts
@@ -6,12 +6,9 @@ import { SessionProcessor } from "./processor"
 import * as Session from "./session"
 import type { Provider } from "@/provider"
 import type { Agent } from "@/agent/agent"
-import type { MessageV2 } from "./message-v2"
-import {
-  createTextNgramMonitor,
-  isTextNgramRepeat,
-  textNgramRepeat,
-} from "./prompt/text-ngram-detection"
+import { MessageV2 } from "./message-v2"
+import * as SessionRetry from "./retry"
+import { createTextNgramMonitor, isTextNgramRepeat, textNgramRepeat } from "./prompt/text-ngram-detection"
 import type { Permission } from "@/permission"
 import { Log } from "@/util"
 
@@ -74,6 +71,23 @@ export type MaxStepInput = {
    * or undefined to clear back to a plain busy state.
    */
   setStatus?: (message: string | undefined) => Effect.Effect<void>
+  onRetry?: (info: { attempt: number; maxAttempts: number; phase: SessionRetry.RetryPhase; scope: SessionRetry.RetryScope; kind: SessionRetry.RetryKind; message: string; nextDelayMs: number }) => Effect.Effect<void>
+  retryConfig?: SessionRetry.RetryConfigSource
+}
+
+function retryPolicy(input: MaxStepInput, scope: "max-candidate" | "max-judge") {
+  const retryConfig = SessionRetry.resolve(input.retryConfig, input.model.providerID)
+  return SessionRetry.policy({
+    phase: "stream",
+    scope,
+    budget: (decision) => SessionRetry.budgetFor(retryConfig, decision),
+    jitterRatio: retryConfig.jitterRatio,
+    parse: (error) => MessageV2.fromError(error, { providerID: input.model.providerID }),
+    set: (info) =>
+      input.onRetry
+        ? input.onRetry({ ...info, nextDelayMs: Math.max(0, info.next - Date.now()) })
+        : Effect.void,
+  })
 }
 
 /**
@@ -96,8 +110,7 @@ export function toSchemaOnlyTools(tools: Record<string, AITool>): Record<string,
  * proposed tool calls without executing anything. Returns null on failure so a
  * single bad draw doesn't sink the whole step.
  *
- * Transient network failures (ECONNRESET / EPIPE / SSE timeout / 5xx) are
- * retried with the same persistent schedule the normal stream path uses. This
+ * Transient network failures are retried with a bounded local schedule. This
  * is safe — and deliberately broader than the normal path — because a
  * candidate emits NOTHING externally until it completes: each attempt rebuilds
  * a fresh accumulator, so re-streaming after a mid-stream reset cannot
@@ -107,10 +120,7 @@ export function toSchemaOnlyTools(tools: Record<string, AITool>): Record<string,
  */
 // Exported for integration tests (drives the real candidate path with a mock
 // llm.stream). Not part of the public surface — call sites use runMaxStep.
-export const runCandidate = (
-  input: MaxStepInput,
-  index: number,
-): Effect.Effect<Candidate | null | "text-repeat"> =>
+export const runCandidate = (input: MaxStepInput, index: number): Effect.Effect<Candidate | null | "text-repeat"> =>
   Effect.gen(function* () {
     const monitor = createTextNgramMonitor()
     // Fresh accumulator per attempt: the retry below re-runs this whole block,
@@ -192,10 +202,7 @@ export const runCandidate = (
       (cause) => !Cause.hasInterruptsOnly(cause),
       (cause) => Effect.fail(Cause.squash(cause)),
     ),
-    Effect.retry({
-      while: LLM.isTransientCapacityError,
-      schedule: LLM.persistentRetrySchedule,
-    }),
+    Effect.retry(retryPolicy(input, "max-candidate")),
     Effect.catchIf(isTextNgramRepeat, () => Effect.succeed("text-repeat" as const)),
     Effect.catch((e) =>
       Effect.sync(() => {
@@ -210,9 +217,7 @@ function renderCandidate(c: Candidate, label: number): string {
   const tools =
     c.toolCalls.length === 0
       ? "(no tool calls — final answer / text only)"
-      : c.toolCalls
-          .map((t) => `  - ${t.toolName}(${JSON.stringify(t.input)})`)
-          .join("\n")
+      : c.toolCalls.map((t) => `  - ${t.toolName}(${JSON.stringify(t.input)})`).join("\n")
   const reasoning = c.reasoning.trim() ? c.reasoning.trim() : "(no reasoning emitted)"
   const text = c.text.trim() ? c.text.trim() : "(no text emitted)"
   return [
@@ -304,10 +309,7 @@ export const judge = (input: MaxStepInput, candidates: Candidate[]): Effect.Effe
     // `out`/`usage` locally and emits nothing externally until it returns, so
     // re-streaming after a mid-stream reset is safe. Without this, a single
     // ECONNRESET during judging silently collapses the whole step to pick 0.
-    Effect.retry({
-      while: LLM.isTransientCapacityError,
-      schedule: LLM.persistentRetrySchedule,
-    }),
+    Effect.retry(retryPolicy(input, "max-judge")),
     Effect.catch((e) => {
       log.warn("judge failed, defaulting to candidate 0", {
         error: e instanceof Error ? e.message : String(e),
@@ -327,8 +329,7 @@ export const judge = (input: MaxStepInput, candidates: Candidate[]): Effect.Effe
 export const runMaxStep = (input: MaxStepInput): Effect.Effect<SessionProcessor.Result> =>
   Effect.gen(function* () {
     const n = Math.max(1, input.candidates ?? DEFAULT_CANDIDATES)
-    const setStatus = (message: string | undefined) =>
-      input.setStatus ? input.setStatus(message) : Effect.void
+    const setStatus = (message: string | undefined) => (input.setStatus ? input.setStatus(message) : Effect.void)
 
     // Total wall-clock of the whole ensemble phase (N parallel candidates +
     // judge), measured from just before the candidates start until just before
@@ -365,7 +366,12 @@ export const runMaxStep = (input: MaxStepInput): Effect.Effect<SessionProcessor.
     yield* setStatus(`judging ${survivors.length} candidates`)
     const { pick, usage: judgeUsage } = yield* judge(input, survivors)
     const winner = survivors[pick]
-    log.info("max step", { candidates: n, survivors: survivors.length, winner: pick, toolCalls: winner.toolCalls.length })
+    log.info("max step", {
+      candidates: n,
+      survivors: survivors.length,
+      winner: pick,
+      toolCalls: winner.toolCalls.length,
+    })
 
     // The winner's own usage is what actually enters history, so it (and only
     // it) must drive the message's `tokens` — that field feeds the context

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -74,8 +74,16 @@ export const APIError = NamedError.create(
 )
 export type APIError = z.infer<typeof APIError.Schema>
 
+function isAuthenticationFailure(error: APIError): boolean {
+  if (error.data.statusCode === 401) return true
+  if (error.data.statusCode !== 403) return false
+  const body = error.data.responseBody?.toLowerCase() ?? ""
+  const message = error.data.message.toLowerCase()
+  return /(?:invalid|expired|missing|malformed).*(?:api[ _-]?key|token|credential)|(?:api[ _-]?key|token|credential).*(?:invalid|expired|missing|malformed)|authentication|unauthorized/.test(`${message} ${body}`)
+}
+
 export function isAuthError(error: unknown): boolean {
-  return AuthError.isInstance(error) || (APIError.isInstance(error) && (error.data.statusCode === 401 || error.data.statusCode === 403))
+  return AuthError.isInstance(error) || (APIError.isInstance(error) && isAuthenticationFailure(error))
 }
 export const ContextOverflowError = NamedError.create(
   "ContextOverflowError",
@@ -1228,7 +1236,7 @@ export function fromError(
           responseHeaders: parsed.responseHeaders,
           responseBody: parsed.responseBody,
           metadata: (() => {
-            const metadata = { ...parsed.metadata, ...(causeMetadata(e) ?? {}) }
+            const metadata = { ...parsed.metadata, ...causeMetadata(e) }
             return Object.keys(metadata).length > 0 ? metadata : undefined
           })(),
         },

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1146,8 +1146,8 @@ function fromParsedStreamError(
 }
 
 export function fromError(
-  e: unknown,
-  ctx: { providerID: ProviderID; aborted?: boolean },
+ e: unknown,
+  ctx: { providerID: ProviderID; aborted?: boolean; allow404Retry?: boolean },
 ): NonNullable<Assistant["error"]> {
   switch (true) {
     case e instanceof DOMException && e.name === "AbortError":
@@ -1218,6 +1218,7 @@ export function fromError(
       const parsed = ProviderError.parseAPICallError({
         providerID: ctx.providerID,
         error: e,
+        allow404Retry: ctx.allow404Retry,
       })
       if (parsed.type === "context_overflow") {
         return new ContextOverflowError(

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -79,7 +79,8 @@ function isAuthenticationFailure(error: APIError): boolean {
   if (error.data.statusCode !== 403) return false
   const body = error.data.responseBody?.toLowerCase() ?? ""
   const message = error.data.message.toLowerCase()
-  return /(?:invalid|expired|missing|malformed).*(?:api[ _-]?key|token|credential)|(?:api[ _-]?key|token|credential).*(?:invalid|expired|missing|malformed)|authentication|unauthorized/.test(`${message} ${body}`)
+  const text = `${message} ${body}`
+  return /(?:invalid|expired|missing|malformed)\s*(?:api[ _-]?key|token|credential)|(?:api[ _-]?key|token|credential)\s*(?:invalid|expired|missing|malformed)|\b(?:authentication|authorization)\s+(?:failed|required|invalid|missing)|\binvalid credentials?\b|\baccess denied\b/.test(text)
 }
 
 export function isAuthError(error: unknown): boolean {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -2,7 +2,14 @@ import { BusEvent } from "@/bus/bus-event"
 import { SessionID, MessageID, PartID } from "./schema"
 import z from "zod"
 import { NamedError } from "@mimo-ai/shared/util/error"
-import { APICallError, convertToModelMessages, LoadAPIKeyError, RetryError, type ModelMessage, type UIMessage } from "ai"
+import {
+  APICallError,
+  convertToModelMessages,
+  LoadAPIKeyError,
+  RetryError,
+  type ModelMessage,
+  type UIMessage,
+} from "ai"
 import { LSP } from "../lsp"
 import { Snapshot } from "@/snapshot"
 import { SyncEvent } from "../sync"
@@ -11,7 +18,6 @@ import { MessageTable, PartTable, SessionTable } from "./session.sql"
 import { ProviderError } from "@/provider"
 import { errorMessage } from "@/util/error"
 import { isMedia } from "@/util/media"
-import type { SystemError } from "bun"
 import type { Provider } from "@/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect } from "effect"
@@ -29,6 +35,11 @@ interface FetchDecompressionError extends Error {
   code: "ZlibError"
   errno: number
   path: string
+}
+
+function causeMetadata(error: unknown): Record<string, string> | undefined {
+  const causeChain = ProviderError.summarizeCause(error)
+  return causeChain.length > 1 ? { causeChain: JSON.stringify(causeChain) } : undefined
 }
 
 export const SYNTHETIC_ATTACHMENT_PROMPT = "Attached file(s) from tool result:"
@@ -62,6 +73,10 @@ export const APIError = NamedError.create(
   }),
 )
 export type APIError = z.infer<typeof APIError.Schema>
+
+export function isAuthError(error: unknown): boolean {
+  return AuthError.isInstance(error) || (APIError.isInstance(error) && (error.data.statusCode === 401 || error.data.statusCode === 403))
+}
 export const ContextOverflowError = NamedError.create(
   "ContextOverflowError",
   z.object({ message: z.string(), responseBody: z.string().optional() }),
@@ -973,10 +988,7 @@ export function page(input: { sessionID: SessionID; limit: number; before?: stri
   // Slice contract: agentID `undefined` (default) ⇒ main slice only;
   // `"*"` ⇒ every slice (full-stream opt-out for export/stats/share/etc.);
   // any other string ⇒ that subagent's actorID slice.
-  const agentClause =
-    input.agentID === "*"
-      ? undefined
-      : eq(MessageTable.agent_id, input.agentID ?? "main")
+  const agentClause = input.agentID === "*" ? undefined : eq(MessageTable.agent_id, input.agentID ?? "main")
   const where = and(
     eq(MessageTable.session_id, input.sessionID),
     ...(before ? [older(before)] : []),
@@ -1102,6 +1114,28 @@ export const filterCompactedEffect = Effect.fnUntraced(function* (
   return [...parentFiltered, ...ownMessages]
 })
 
+function fromParsedStreamError(
+  parsed: ProviderError.ParsedStreamError,
+  cause: unknown,
+): NonNullable<Assistant["error"]> {
+  const metadata = causeMetadata(cause)
+  if (parsed.type === "context_overflow") {
+    return new ContextOverflowError(
+      { message: parsed.message, responseBody: parsed.responseBody },
+      { cause },
+    ).toObject()
+  }
+  return new APIError(
+    {
+      message: parsed.message,
+      isRetryable: parsed.isRetryable,
+      responseBody: parsed.responseBody,
+      ...(metadata ? { metadata } : {}),
+    },
+    { cause },
+  ).toObject()
+}
+
 export function fromError(
   e: unknown,
   ctx: { providerID: ProviderID; aborted?: boolean },
@@ -1109,6 +1143,8 @@ export function fromError(
   switch (true) {
     case e instanceof DOMException && e.name === "AbortError":
       return new AbortedError({ message: e.message }, { cause: e }).toObject()
+    case ProviderError.isAbortError(e):
+      return new AbortedError({ message: errorMessage(e) }, { cause: e }).toObject()
     // The AI SDK wraps the real failure in AI_RetryError after exhausting its
     // own maxRetries. Unwrap to the underlying error (.lastError) so the
     // APICallError branch below can extract statusCode/isRetryable/responseBody.
@@ -1117,12 +1153,10 @@ export function fromError(
     // can't classify, so the visible retry status never fires and the turn
     // hangs with a dead spinner.
     case RetryError.isInstance(e): {
-      const inner = e.lastError ?? e.errors[e.errors.length - 1]
+      const errors = Array.isArray(e.errors) ? e.errors : []
+      const inner = e.lastError ?? errors[errors.length - 1]
       if (inner !== undefined && inner !== e) return fromError(inner, ctx)
-      return new APIError(
-        { message: e.message, isRetryable: true },
-        { cause: e },
-      ).toObject()
+      return new NamedError.Unknown({ message: e.message }, { cause: e }).toObject()
     }
     case OutputLengthError.isInstance(e):
       return e
@@ -1134,31 +1168,27 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
-    case (e as SystemError)?.code === "ECONNRESET":
+    case e instanceof Error && ProviderError.isRetryableNetworkError(e): {
+      const code = ProviderError.networkErrorCode(e)
+      const message =
+        code === "ECONNRESET"
+          ? "Connection reset by server"
+          : code === "ETIMEDOUT"
+            ? "Request timed out"
+            : errorMessage(e) || "Transient network error"
       return new APIError(
         {
-          message: "Connection reset by server",
+          message,
           isRetryable: true,
           metadata: {
-            code: (e as SystemError).code ?? "",
-            syscall: (e as SystemError).syscall ?? "",
-            message: (e as SystemError).message ?? "",
+            ...(code ? { code } : {}),
+            message: e.message,
+            ...causeMetadata(e),
           },
         },
         { cause: e },
       ).toObject()
-    case (e as SystemError)?.code === "ETIMEDOUT":
-      return new APIError(
-        {
-          message: (e as SystemError).message || "Request timed out",
-          isRetryable: true,
-          metadata: {
-            code: "ETIMEDOUT",
-            message: (e as SystemError).message ?? "",
-          },
-        },
-        { cause: e },
-      ).toObject()
+    }
     case e instanceof Error && (e as FetchDecompressionError).code === "ZlibError":
       if (ctx.aborted) {
         return new AbortedError({ message: e.message }, { cause: e }).toObject()
@@ -1170,6 +1200,7 @@ export function fromError(
           metadata: {
             code: (e as FetchDecompressionError).code,
             message: e.message,
+            ...causeMetadata(e),
           },
         },
         { cause: e },
@@ -1196,7 +1227,10 @@ export function fromError(
           isRetryable: parsed.isRetryable,
           responseHeaders: parsed.responseHeaders,
           responseBody: parsed.responseBody,
-          metadata: parsed.metadata,
+          metadata: (() => {
+            const metadata = { ...parsed.metadata, ...(causeMetadata(e) ?? {}) }
+            return Object.keys(metadata).length > 0 ? metadata : undefined
+          })(),
         },
         { cause: e },
       ).toObject()
@@ -1204,38 +1238,17 @@ export function fromError(
     // is a programming defect, not a transient API failure. Surface it as a
     // named error so it is diagnosable instead of collapsing to UnknownError.
     case e instanceof TypeError:
-      return new NamedError.Unknown(
-        { message: `TypeError: ${errorMessage(e)}` },
-        { cause: e },
-      ).toObject()
-    case e instanceof Error:
-      return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
-    default:
-      try {
-        const parsed = ProviderError.parseStreamError(e)
-        if (parsed) {
-          if (parsed.type === "context_overflow") {
-            return new ContextOverflowError(
-              {
-                message: parsed.message,
-                responseBody: parsed.responseBody,
-              },
-              { cause: e },
-            ).toObject()
-          }
-          return new APIError(
-            {
-              message: parsed.message,
-              isRetryable: parsed.isRetryable,
-              responseBody: parsed.responseBody,
-            },
-            {
-              cause: e,
-            },
-          ).toObject()
-        }
-      } catch {}
-      return new NamedError.Unknown({ message: JSON.stringify(e) }, { cause: e }).toObject()
+    case e instanceof Error: {
+      const parsed = ProviderError.parseStreamError(e)
+      if (parsed) return fromParsedStreamError(parsed, e)
+      const message = e instanceof TypeError ? `TypeError: ${errorMessage(e)}` : errorMessage(e)
+      return new NamedError.Unknown({ message }, { cause: e }).toObject()
+    }
+    default: {
+      const parsed = ProviderError.parseStreamError(e)
+      if (parsed) return fromParsedStreamError(parsed, e)
+      return new NamedError.Unknown({ message: JSON.stringify(e) ?? String(e) }, { cause: e }).toObject()
+    }
   }
 }
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -80,7 +80,7 @@ function isAuthenticationFailure(error: APIError): boolean {
   const body = error.data.responseBody?.toLowerCase() ?? ""
   const message = error.data.message.toLowerCase()
   const text = `${message} ${body}`
-  return /(?:invalid|expired|missing|malformed)\s*(?:api[ _-]?key|token|credential)|(?:api[ _-]?key|token|credential)\s*(?:invalid|expired|missing|malformed)|\b(?:authentication|authorization)\s+(?:failed|required|invalid|missing)|\binvalid credentials?\b|\baccess denied\b/.test(text)
+  return /(?:invalid|expired|missing|malformed)\s*(?:api[ _-]?key|token|credential)|(?:api[ _-]?key|token|credential)\s*(?:invalid|expired|missing|malformed)|\b(?:authentication|authorization)\s+(?:failed|required|invalid|missing)|\binvalid credentials?\b|\baccess denied\b/.test(text) || message.trim() === "unauthorized" || body.trim() === "unauthorized"
 }
 
 export function isAuthError(error: unknown): boolean {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -182,6 +182,7 @@ interface ProcessorContext extends Input {
   textNgramMonitor: TextNgramMonitor | undefined
   textNgramRepeat: boolean
   textPartPersisted: boolean
+  retrySafe: boolean
 }
 
 type StreamEvent = Event
@@ -239,6 +240,7 @@ export const layer: Layer.Layer<
         textNgramMonitor: undefined,
         textNgramRepeat: false,
         textPartPersisted: false,
+        retrySafe: true,
       }
       let aborted = false
       // Only the main agent owns session-level status. Subagents (explore,
@@ -490,6 +492,9 @@ export const layer: Layer.Layer<
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.toolName}`)
             }
+            // A tool call may already have caused an external side effect before
+            // the provider stream fails. Replaying the whole model step is unsafe.
+            ctx.retrySafe = false
             yield* updateToolCall(value.toolCallId, (match) => ({
               ...match,
               tool: value.toolName,
@@ -619,8 +624,7 @@ export const layer: Layer.Layer<
               .publish(Metrics.ModelCall, {
                 sessionID: ctx.sessionID,
                 finish_reason: value.finishReason,
-                ttft_ms:
-                  ctx.firstTokenAt && ctx.stepStartedAt ? ctx.firstTokenAt - ctx.stepStartedAt : undefined,
+                ttft_ms: ctx.firstTokenAt && ctx.stepStartedAt ? ctx.firstTokenAt - ctx.stepStartedAt : undefined,
                 latency_ms: ctx.stepStartedAt ? Date.now() - ctx.stepStartedAt : 0,
                 cached_read_tokens: usage.tokens.cache.read,
                 model_id: ctx.model.id,
@@ -799,7 +803,9 @@ export const layer: Layer.Layer<
       const process = Effect.fn("SessionProcessor.process")(function* (streamInput: LLM.StreamInput) {
         slog.info("process")
         ctx.needsOverflowHandling = false
-        ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        const cfg = yield* config.get()
+        ctx.shouldBreak = cfg.experimental?.continue_loop_on_deny !== true
+        const retryConfig = SessionRetry.resolve(cfg, streamInput.model.providerID)
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
@@ -807,6 +813,7 @@ export const layer: Layer.Layer<
             ctx.reasoningMap = {}
             ctx.stepPartIds = []
             ctx.toolcalls = {}
+            ctx.retrySafe = true
             ctx.textNgramRepeat = false
             ctx.textNgramMonitor = createTextNgramMonitor()
             const stream = llm.stream(streamInput)
@@ -831,6 +838,7 @@ export const layer: Layer.Layer<
             ),
             Effect.tapError(() =>
               Effect.gen(function* () {
+                if (!ctx.retrySafe) return
                 for (const partId of ctx.stepPartIds) {
                   yield* session.removePart({
                     sessionID: ctx.sessionID,
@@ -844,17 +852,39 @@ export const layer: Layer.Layer<
             Effect.retry(
               SessionRetry.policy({
                 parse,
-                silentRetry: (error) =>
-                  SessionRetry.isGptModel(input.model) && SessionRetry.isGptServerOverloadedError(error),
+                phase: "stream",
+                budget: (decision) => SessionRetry.budgetFor(retryConfig, decision),
+                jitterRatio: retryConfig.jitterRatio,
+                replaySafe: () => ctx.retrySafe,
+                silentRetry: (error) => isMain && SessionRetry.isGptServerOverloadedError(error),
+                onTerminal: (decision) =>
+                  isMain && decision.uiMessage
+                    ? status.set(ctx.sessionID, { type: "retry", attempt: 0, message: decision.uiMessage, next: Date.now() })
+                    : Effect.void,
                 set: (info) =>
-                  isMain
-                    ? status.set(ctx.sessionID, {
+                  Effect.gen(function* () {
+                    if (isMain) {
+                      yield* status.set(ctx.sessionID, {
                         type: "retry",
                         attempt: info.attempt,
                         message: info.message,
                         next: info.next,
                       })
-                    : Effect.void,
+                    }
+                    yield* bus
+                      .publish(Session.Event.RetryAttempt, {
+                        sessionID: ctx.sessionID,
+                        messageID: ctx.assistantMessage.id,
+                        attempt: info.attempt,
+                        maxAttempts: info.maxAttempts,
+                        phase: info.phase,
+                        kind: info.kind,
+                        scope: info.scope,
+                        reason: info.message,
+                        nextDelayMs: Math.max(0, info.next - Date.now()),
+                      })
+                      .pipe(Effect.ignore)
+                  }),
               }),
             ),
             Effect.catch(halt),
@@ -1018,7 +1048,10 @@ export const layer: Layer.Layer<
             // a supplementary ModelCall metric, but NOT to message.tokens (set
             // by the finish-step above from the winner only) so context
             // estimators stay honest.
-            if (input.overhead && (input.overhead.cost > 0 || input.overhead.tokensIn > 0 || input.overhead.tokensOut > 0)) {
+            if (
+              input.overhead &&
+              (input.overhead.cost > 0 || input.overhead.tokensIn > 0 || input.overhead.tokensOut > 0)
+            ) {
               ctx.assistantMessage.cost += input.overhead.cost
               yield* session.updateMessage(ctx.assistantMessage)
               if (ctx.agentMetrics) {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -865,10 +865,12 @@ export const layer: Layer.Layer<
                     : Effect.void,
                 set: (info) =>
                   Effect.gen(function* () {
+                    let attempt = info.attempt
                     if (isMain) {
-                      yield* status.set(ctx.sessionID, {
+                      attempt = yield* status.setRetry(ctx.sessionID, {
                         type: "retry",
                         attempt: info.attempt,
+                        phaseAttempt: info.attempt,
                         message: info.message,
                         next: info.next,
                         phase: info.phase,
@@ -879,7 +881,8 @@ export const layer: Layer.Layer<
                       .publish(Session.Event.RetryAttempt, {
                         sessionID: ctx.sessionID,
                         messageID: ctx.assistantMessage.id,
-                        attempt: info.attempt,
+                        attempt,
+                        phaseAttempt: info.attempt,
                         maxAttempts: info.maxAttempts,
                         phase: info.phase,
                         kind: info.kind,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -859,7 +859,7 @@ export const layer: Layer.Layer<
                 silentRetry: (error) => isMain && SessionRetry.isGptServerOverloadedError(error),
                 onTerminal: (decision) =>
                   isMain && decision.uiMessage
-                    ? status.set(ctx.sessionID, { type: "retry", attempt: 0, message: decision.uiMessage, next: Date.now() })
+                    ? status.set(ctx.sessionID, { type: "notice", message: decision.uiMessage })
                     : Effect.void,
                 set: (info) =>
                   Effect.gen(function* () {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -17,6 +17,7 @@ import type { SessionID } from "./schema"
 import { SessionRetry } from "./retry"
 import { SessionStatus } from "./status"
 import { SessionSummary } from "./summary"
+import { ProviderError } from "@/provider"
 import type { Provider } from "@/provider"
 import { Question } from "@/question"
 import { errorMessage } from "@/util/error"
@@ -255,6 +256,7 @@ export const layer: Layer.Layer<
         MessageV2.fromError(e, {
           providerID: input.model.providerID,
           aborted,
+          allow404Retry: ProviderError.allowsModelNotFoundRetry(input.model),
         })
 
       const tryBestConfig = (yield* config.get()).experimental?.try_best
@@ -869,6 +871,8 @@ export const layer: Layer.Layer<
                         attempt: info.attempt,
                         message: info.message,
                         next: info.next,
+                        phase: info.phase,
+                        scope: info.scope,
                       })
                     }
                     yield* bus

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -806,6 +806,7 @@ export const layer = Layer.effect(
           tools: {},
           model: mdl,
           sessionID: input.session.id,
+          retries: 2,
           messages: [{ role: "user", content: "Generate a title for this conversation:\n" }, ...msgs],
         })
         .pipe(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -805,7 +805,6 @@ export const layer = Layer.effect(
           tools: {},
           model: mdl,
           sessionID: input.session.id,
-          retries: 2,
           messages: [{ role: "user", content: "Generate a title for this conversation:\n" }, ...msgs],
         })
         .pipe(
@@ -4172,7 +4171,8 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
                 Effect.provideService(ToolRegistry.Service, registry),
               )
             lastSystemPrompt = prebuiltSystem
-            const maxModeCfg = (yield* config.get()).experimental?.maxMode
+            const cfg = yield* config.get()
+            const maxModeCfg = cfg.experimental?.maxMode
             const useMaxMode =
               agent.name === MaxMode.MAX_MODE_AGENT && maxModeCfg !== undefined && format.type !== "json_schema"
 
@@ -4242,9 +4242,22 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
                   handle,
                   llm,
                   candidates: maxModeCfg?.candidates,
-                  setStatus: (message) =>
-                    status.set(sessionID, message ? { type: "busy", message } : { type: "busy" }),
-                })
+                  retryConfig: cfg,
+                 setStatus: (message) =>
+                   status.set(sessionID, message ? { type: "busy", message } : { type: "busy" }),
+                  onRetry: (info) =>
+                    bus.publish(Session.Event.RetryAttempt, {
+                      sessionID,
+                      messageID: handle.message.id,
+                      attempt: info.attempt,
+                      maxAttempts: info.maxAttempts,
+                      phase: info.phase,
+                      kind: info.kind,
+                      scope: info.scope,
+                      reason: info.message,
+                      nextDelayMs: info.nextDelayMs,
+                    }),
+               })
               : handle.process(processArgs)
 
             const result = yield* stepEffect.pipe(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4252,6 +4252,7 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
                       sessionID,
                       messageID: handle.message.id,
                       attempt: info.attempt,
+                      phaseAttempt: info.attempt,
                       maxAttempts: info.maxAttempts,
                       phase: info.phase,
                       kind: info.kind,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -246,10 +246,10 @@ export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts>
   readonly recovery: (input: { sessionID: SessionID; agentID?: string; allowBusy?: boolean }) => Effect.Effect<RecoveryCandidate[]>
-  readonly resume: (input: ResumeTurnInput) => Effect.Effect<MessageV2.WithParts, InstanceType<typeof NotFoundError>>
-  readonly resumeBackground: (input: ResumeTurnInput) => Effect.Effect<void, InstanceType<typeof NotFoundError>>
+  readonly resume: (input: ResumeTurnInput) => Effect.Effect<MessageV2.WithParts, InstanceType<typeof NotFoundError> | Session.BusyError>
+  readonly resumeBackground: (input: ResumeTurnInput) => Effect.Effect<void, InstanceType<typeof NotFoundError> | Session.BusyError>
   readonly loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts>
-  readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
+  readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts, Session.BusyError>
   readonly command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts>
   readonly resolvePromptParts: (template: string) => Effect.Effect<PromptInput["parts"]>
   readonly sweepOrphanAssistants: (sessionID: SessionID, immediate?: boolean) => Effect.Effect<void>
@@ -4566,7 +4566,7 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
       )
     })
 
-    const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.shell")(
+    const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts, Session.BusyError> = Effect.fn("SessionPrompt.shell")(
       function* (input: ShellInput) {
         return yield* state.startShell(input.sessionID, lastAssistant(input.sessionID), shellImpl(input))
       },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -245,8 +245,9 @@ const elog = EffectLogger.create({ service: "session.prompt" })
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts>
-  readonly recovery: (input: { sessionID: SessionID; agentID?: string }) => Effect.Effect<RecoveryCandidate[]>
+  readonly recovery: (input: { sessionID: SessionID; agentID?: string; allowBusy?: boolean }) => Effect.Effect<RecoveryCandidate[]>
   readonly resume: (input: ResumeTurnInput) => Effect.Effect<MessageV2.WithParts, InstanceType<typeof NotFoundError>>
+  readonly resumeBackground: (input: ResumeTurnInput) => Effect.Effect<void, InstanceType<typeof NotFoundError>>
   readonly loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
   readonly command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts>
@@ -2761,8 +2762,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       throw new Error("Impossible")
     })
 
-    const recovery = Effect.fn("SessionPrompt.recovery")(function* (input: { sessionID: SessionID; agentID?: string }) {
-      if ((yield* status.get(input.sessionID)).type !== "idle") return []
+    const recovery = Effect.fn("SessionPrompt.recovery")(function* (input: { sessionID: SessionID; agentID?: string; allowBusy?: boolean }) {
+      if (!input.allowBusy && (yield* status.get(input.sessionID)).type !== "idle") return []
       const msgs = yield* sessions.messages({ sessionID: input.sessionID, agentID: input.agentID ?? "main" })
       const candidates: RecoveryCandidate[] = []
       for (const [index, msg] of msgs.entries()) {
@@ -4876,7 +4877,7 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
     })
 
     const resume = Effect.fn("SessionPrompt.resume")(function* (input: ResumeTurnInput) {
-      yield* state.assertNotBusy(input.sessionID)
+      yield* state.assertNotBusy(input.sessionID, input.agentID)
       const candidates = yield* recovery({ sessionID: input.sessionID, agentID: input.agentID })
       const candidate = candidates.find((item) => item.assistantMessageID === input.assistantMessageID)
       if (candidate === undefined) {
@@ -4907,11 +4908,44 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
       )
     })
 
+    const resumeBackground = Effect.fn("SessionPrompt.resumeBackground")(function* (input: ResumeTurnInput) {
+      const candidates = yield* recovery({ sessionID: input.sessionID, agentID: input.agentID, allowBusy: true })
+      const candidate = candidates.find((item) => item.assistantMessageID === input.assistantMessageID)
+      if (candidate === undefined) {
+        return yield* Effect.fail(
+          new NotFoundError({
+            message: "No resumable interrupted turn found for assistant message " + input.assistantMessageID,
+          }),
+        )
+      }
+      const agentID = input.agentID ?? "main"
+      yield* state.start(
+        input.sessionID,
+        agentID,
+        lastAssistant(input.sessionID, agentID),
+        runLoop(input.sessionID, agentID, input.task_id).pipe(
+          Effect.ensuring(
+            abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID }).pipe(
+              Effect.catchCause((cause) =>
+                elog.warn("recovered-assistant-abandon-failed", {
+                  sessionID: input.sessionID,
+                  messageID: input.assistantMessageID,
+                  cause,
+                }),
+              ),
+            ),
+          ),
+        ),
+      )
+      return
+    })
+
     const impl = Service.of({
       cancel,
       prompt,
       recovery,
       resume,
+      resumeBackground,
       loop,
       shell,
       command,

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -335,7 +335,7 @@ export function decide(
   if (signals.code === "SubscriptionUsageLimitError" || responseBody?.includes("SubscriptionUsageLimitError"))
     return terminal()
   if (status === 402 || status === 501 || status === 505) return terminal()
-  if (status === 404 && (!MessageV2.APIError.isInstance(error) || !error.data.metadata?.providerID?.startsWith("openai"))) return terminal()
+  if (status === 404 && (!MessageV2.APIError.isInstance(error) || error.data.metadata?.allow404Retry !== "true")) return terminal()
   if (signals.code === "stream_read_error" || signals.type === "upstream_error")
     return retry("stream", "stream", signals.message || "Upstream stream read failed")
   if (ProviderError.isRetryableNetworkError(error)) return retry("network")

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -1,220 +1,383 @@
 import type { NamedError } from "@mimo-ai/shared/util/error"
 import { Cause, Clock, Duration, Effect, Schedule } from "effect"
 import { MessageV2 } from "./message-v2"
-import { iife } from "@/util/iife"
+import { ProviderError } from "@/provider"
+import type { Budget as RetryBudgetConfig, Info as RetryConfig } from "@/config/retry"
 
 export type Err = ReturnType<NamedError["toObject"]>
 
-// This exported message is shared with the TUI upsell detector. Matching on a
-// literal error string kind of sucks, but it is the simplest for now.
 export const GO_UPSELL_MESSAGE = "Free usage exceeded, subscribe to Go https://opencode.ai/go"
+export const RETRY_INITIAL_DELAY = 2000
+export const RETRY_BACKOFF_FACTOR = 2
+export const RETRY_MAX_DELAY_NO_HEADERS = 30_000
+export const RETRY_MAX_DELAY_MESSAGE = 5 * 60_000
+export const RETRY_MAX_DELAY = 2_147_483_647
+export const GPT_OVERLOAD_RETRIES = 3
+export const REQUEST_MAX_RETRIES = 1
+export const REQUEST_INITIAL_DELAY_MS = 250
+export const STREAM_MAX_RETRIES = 5
+export const REQUEST_RETRY_DEADLINE_MS = 30_000
+export const STREAM_RETRY_DEADLINE_MS = 10 * 60_000
+export const RETRY_JITTER_RATIO = 0.2
+export const NETWORK_INITIAL_DELAY_MS = 5000
+export const NETWORK_MAX_DELAY_MS = 60_000
+export const SERVER_MAX_RETRIES = 8
+export const SERVER_RETRY_DEADLINE_MS = 15 * 60_000
+export const RATE_LIMIT_MAX_RETRIES = 5
+export const UNKNOWN_MAX_RETRIES = 1
 
-// Shared with the TUI: does this retry status message indicate a rate-limit /
-// queue ("too many requests" / HTTP 429) condition? retryable() normalizes
-// every 429 variant into a message containing one of these substrings.
+export type RetryBudget = {
+  mode: "bounded" | "persistent"
+  maxRetries?: number
+  maxElapsedMs: number
+  initialDelayMs: number
+  maxDelayMs: number
+}
+
+export type RetryConfigSource = {
+  retry?: RetryConfig
+  provider?: Record<string, { retry?: RetryConfig } | undefined>
+}
+
+export type ResolvedRetryConfig = {
+  request: RetryBudget
+  stream: RetryBudget
+  maxCandidate: RetryBudget
+  maxJudge: RetryBudget
+  network: RetryBudget
+  server: RetryBudget
+  rateLimit: RetryBudget
+  unknown: RetryBudget
+  jitterRatio: number
+}
+
+const DEFAULT_RETRY_CONFIG: ResolvedRetryConfig = {
+  request: {
+    mode: "bounded",
+    maxRetries: REQUEST_MAX_RETRIES,
+    maxElapsedMs: REQUEST_RETRY_DEADLINE_MS,
+    initialDelayMs: REQUEST_INITIAL_DELAY_MS,
+    maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+  },
+  stream: {
+    mode: "bounded",
+    maxRetries: STREAM_MAX_RETRIES,
+    maxElapsedMs: STREAM_RETRY_DEADLINE_MS,
+    initialDelayMs: RETRY_INITIAL_DELAY,
+    maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+  },
+  maxCandidate: {
+    mode: "bounded",
+    maxRetries: 3,
+    maxElapsedMs: 3 * 60_000,
+    initialDelayMs: 500,
+    maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+  },
+  maxJudge: {
+    mode: "bounded",
+    maxRetries: 3,
+    maxElapsedMs: 3 * 60_000,
+    initialDelayMs: 500,
+    maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+  },
+  network: {
+    mode: "persistent",
+    maxElapsedMs: 0,
+    initialDelayMs: NETWORK_INITIAL_DELAY_MS,
+    maxDelayMs: NETWORK_MAX_DELAY_MS,
+  },
+  server: {
+    mode: "bounded",
+    maxRetries: SERVER_MAX_RETRIES,
+    maxElapsedMs: SERVER_RETRY_DEADLINE_MS,
+    initialDelayMs: RETRY_INITIAL_DELAY,
+    maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+  },
+  rateLimit: {
+    mode: "bounded",
+    maxRetries: RATE_LIMIT_MAX_RETRIES,
+    maxElapsedMs: SERVER_RETRY_DEADLINE_MS,
+    initialDelayMs: RETRY_INITIAL_DELAY,
+    maxDelayMs: RETRY_MAX_DELAY_MESSAGE,
+  },
+  unknown: {
+    mode: "bounded",
+    maxRetries: UNKNOWN_MAX_RETRIES,
+    maxElapsedMs: REQUEST_RETRY_DEADLINE_MS,
+    initialDelayMs: RETRY_INITIAL_DELAY,
+    maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+  },
+  jitterRatio: RETRY_JITTER_RATIO,
+}
+
+function mergeBudget(base: RetryBudget, ...overrides: (RetryBudgetConfig | undefined)[]): RetryBudget {
+  const merged = overrides.reduce<RetryBudgetConfig>((result, override) => ({ ...result, ...override }), {})
+  const { deadlineMs, ...rest } = merged
+  const result = { ...base, ...rest, ...(deadlineMs !== undefined ? { maxElapsedMs: deadlineMs } : {}) }
+  return result.mode === "persistent" ? { ...result, maxRetries: undefined } : result
+}
+
+export function resolve(config: RetryConfigSource | undefined, providerID?: string): ResolvedRetryConfig {
+  const global = config?.retry
+  const provider = providerID ? config?.provider?.[providerID]?.retry : undefined
+  return {
+    request: mergeBudget(DEFAULT_RETRY_CONFIG.request, global?.request, provider?.request),
+    stream: mergeBudget(DEFAULT_RETRY_CONFIG.stream, global?.stream, provider?.stream),
+    maxCandidate: mergeBudget(DEFAULT_RETRY_CONFIG.maxCandidate, global?.maxCandidate, provider?.maxCandidate),
+    maxJudge: mergeBudget(DEFAULT_RETRY_CONFIG.maxJudge, global?.maxJudge, provider?.maxJudge),
+    network: mergeBudget(DEFAULT_RETRY_CONFIG.network, global?.network, provider?.network),
+    server: mergeBudget(DEFAULT_RETRY_CONFIG.server, global?.server, provider?.server),
+    rateLimit: mergeBudget(DEFAULT_RETRY_CONFIG.rateLimit, global?.rateLimit, provider?.rateLimit),
+    unknown: mergeBudget(DEFAULT_RETRY_CONFIG.unknown, global?.unknown, provider?.unknown),
+    jitterRatio: provider?.jitterRatio ?? global?.jitterRatio ?? DEFAULT_RETRY_CONFIG.jitterRatio,
+  }
+}
+
+export function budgetFor(config: ResolvedRetryConfig, decision: RetryDecision): RetryBudget {
+  if (decision.kind === "network") return config.network
+  if (decision.phase === "request") return config.request
+  if (decision.scope === "max-candidate") return config.maxCandidate
+  if (decision.scope === "max-judge") return config.maxJudge
+  if (decision.kind === "server") return config.server
+  if (decision.kind === "rate_limit") return config.rateLimit
+  if (decision.kind === "unknown") return config.unknown
+  return config.stream
+}
+
+export type RetryPhase = "request" | "stream"
+export type RetryScope = "request" | "live-step" | "max-candidate" | "max-judge"
+export type RetryKind = "network" | "rate_limit" | "server" | "stream" | "unknown" | "terminal"
+export type RetryDecision = {
+  retryable: boolean
+  phase: RetryPhase
+  scope: RetryScope
+  kind: RetryKind
+  message: string
+  uiMessage?: string
+  statusCode?: number
+  retryAfterMs?: number
+}
+
+const RETRYABLE_HTTP_STATUS = new Set([408, 425, 429])
+const SSE_TIMEOUT_MESSAGE = "SSE read timed out"
+
 export function isRateLimitMessage(message: string): boolean {
   const lower = message.toLowerCase()
   return (
     lower.includes("too many requests") ||
     lower.includes("too_many_requests") ||
     lower.includes("rate limit") ||
-    // Providers also spell it with an underscore in structured bodies/types
-    // (e.g. "rate_limit_error", "rate_limited"). Prior fix only matched the
-    // spaced form, so these slipped through into the raw TUI error. See T18.
     lower.includes("rate_limit") ||
+    lower.includes("rate limited") ||
     lower.includes("rate increased too quickly")
   )
 }
 
-export const RETRY_INITIAL_DELAY = 2000
-export const RETRY_BACKOFF_FACTOR = 2
-export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
-export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
-export const GPT_OVERLOAD_RETRIES = 3
-
-const NETWORK_ERROR_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT"])
-const SSE_TIMEOUT_MESSAGE = "SSE read timed out"
-const RETRYABLE_HTTP_STATUS = new Set([429, 500, 502, 503, 504, 529])
-
-/**
- * Single source of truth for "is this transient and retryable?".
- *
- * Used by:
- * - `retryable()` below (processor-level Effect.retry policy via SessionRetry.policy)
- * - `isTransientCapacityError()` in llm.ts (LLM-internal retry around streamText)
- *
- * Both call sites previously had divergent logic — this hung sessions on
- * SSE timeouts that one path retried but the other dropped. See Spec ③.
- */
-export function isRetryableTransientError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-
-  const status =
-    (error as { status?: number | string }).status ??
-    (error as { statusCode?: number | string }).statusCode ??
-    (error as { response?: { status?: number | string } }).response?.status
-  // Some providers surface the HTTP status as a numeric string (e.g. "429")
-  // rather than a number — coerce before matching so the 429 path is not missed.
-  const statusNum = typeof status === "string" ? Number.parseInt(status, 10) : status
-  if (typeof statusNum === "number" && !Number.isNaN(statusNum) && RETRYABLE_HTTP_STATUS.has(statusNum)) return true
-
-  const code = (error as { code?: string }).code
-  if (typeof code === "string" && NETWORK_ERROR_CODES.has(code)) return true
-
-  if (error.message === SSE_TIMEOUT_MESSAGE) return true
-
-  return false
+function cap(ms: number) {
+  return Math.min(Math.max(0, ms), RETRY_MAX_DELAY)
 }
 
-function cap(ms: number) {
-  return Math.min(ms, RETRY_MAX_DELAY)
+function parseBody(input: unknown): Record<string, any> | undefined {
+  if (typeof input !== "string") return undefined
+  try {
+    const parsed = JSON.parse(input)
+    return parsed && typeof parsed === "object" ? parsed : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function statusOf(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined
+  const value =
+    (error as { statusCode?: number | string }).statusCode ??
+    (error as { status?: number | string }).status ??
+    (error as { data?: { statusCode?: number | string } }).data?.statusCode ??
+    (error as { response?: { status?: number | string } }).response?.status
+  const status = typeof value === "string" ? Number.parseInt(value, 10) : value
+  return typeof status === "number" && !Number.isNaN(status) ? status : undefined
+}
+
+function messageOf(error: unknown): string {
+  if (typeof error === "object" && error !== null) {
+    const message = (error as { message?: unknown }).message
+    if (typeof message === "string") return message
+    const dataMessage = (error as { data?: { message?: unknown } }).data?.message
+    if (typeof dataMessage === "string") return dataMessage
+  }
+  const summary = ProviderError.summarizeCause(error)[0]
+  return summary?.message || summary?.name || "Provider request failed"
+}
+
+function responseBodyOf(error: unknown): string | undefined {
+  if (MessageV2.APIError.isInstance(error)) return error.data.responseBody
+  if (typeof error === "object" && error !== null) {
+    const body = (error as { responseBody?: unknown }).responseBody
+    const dataMessage = (error as { data?: { message?: unknown } }).data?.message
+    if (typeof dataMessage === "string") return dataMessage
+    return typeof body === "string" ? body : undefined
+  }
+  return undefined
+}
+
+function retryAfterValue(value: string): number | undefined {
+  const normalized = value.trim()
+  if (/^\d+(?:\.\d+)?$/.test(normalized)) return cap(Math.ceil(Number.parseFloat(normalized) * 1000))
+  const date = Date.parse(normalized) - Date.now()
+  return !Number.isNaN(date) && date > 0 ? cap(Math.ceil(date)) : undefined
+}
+
+function retryAfterFromHeaders(error: MessageV2.APIError): number | undefined {
+  const headers = error.data.responseHeaders
+  if (!headers) return undefined
+  const retryAfterMs = headers["retry-after-ms"]
+  if (retryAfterMs) {
+    const parsed = Number.parseFloat(retryAfterMs)
+    if (!Number.isNaN(parsed)) return cap(Math.ceil(parsed))
+  }
+  const retryAfter = headers["retry-after"]
+  return retryAfter ? retryAfterValue(retryAfter) : undefined
+}
+
+function retryAfterFromMessage(message: string): number | undefined {
+  const match = message.match(
+    /(?:try again|retry(?:ing)?)(?: in| after)\s+(\d+(?:\.\d+)?)\s*(ms|milliseconds?|s|seconds?|m|minutes?|h|hours?)/i,
+  )
+  if (!match) return undefined
+  const value = Number.parseFloat(match[1])
+  const unit = match[2].toLowerCase()
+  const multiplier = unit.startsWith("ms") ? 1 : unit.startsWith("s") ? 1000 : unit.startsWith("m") ? 60_000 : 3_600_000
+  return Math.min(cap(Math.ceil(value * multiplier)), RETRY_MAX_DELAY_MESSAGE)
+}
+
+function bodySignals(body: Record<string, any> | undefined) {
+  const code = String(body?.error?.code ?? body?.code ?? "")
+  const type = String(body?.error?.type ?? body?.type ?? "")
+  const message = String(body?.error?.message ?? body?.message ?? "")
+  return { code, type, message }
+}
+
+export function decide(
+  error: unknown,
+  phase: RetryPhase = "stream",
+  scope: RetryScope = phase === "request" ? "request" : "live-step",
+): RetryDecision {
+  if (error === null || typeof error !== "object")
+    return { retryable: false, phase, scope, kind: "terminal", message: String(error) }
+  if (MessageV2.ContextOverflowError.isInstance(error)) {
+    return { retryable: false, phase, scope, kind: "terminal", message: "Context window exceeded" }
+  }
+  if (MessageV2.AbortedError.isInstance(error)) {
+    return { retryable: false, phase, scope, kind: "terminal", message: error.data.message }
+  }
+  if (MessageV2.AuthError.isInstance(error)) {
+    return { retryable: false, phase, scope, kind: "terminal", message: error.data.message }
+  }
+  if (
+    !(error instanceof Error) &&
+    !MessageV2.APIError.isInstance(error) &&
+    !(typeof (error as { data?: { message?: unknown } }).data?.message === "string")
+  ) {
+    return { retryable: false, phase, scope, kind: "terminal", message: messageOf(error) }
+  }
+  if (
+    ProviderError.summarizeCause(error).some(
+      (cause) => (cause.name === "AbortError" && cause.code !== "UND_ERR_ABORTED") || cause.code === "ABORT_ERR",
+    )
+  ) {
+    return { retryable: false, phase, scope, kind: "terminal", message: messageOf(error) }
+  }
+
+  const status = statusOf(error)
+  const responseBody = responseBodyOf(error)
+  const signals = bodySignals(parseBody(responseBody))
+  const message = messageOf(error)
+  const retryAfterMs = MessageV2.APIError.isInstance(error)
+    ? (retryAfterFromHeaders(error) ?? retryAfterFromMessage(message))
+    : retryAfterFromMessage(message)
+  const retry = (kind: RetryKind, retryPhase = phase, retryMessage = message): RetryDecision => ({
+    retryable: true,
+    phase: retryPhase,
+    scope,
+    kind,
+    message: retryMessage || "Transient provider failure",
+    statusCode: status,
+    retryAfterMs,
+  })
+  const terminal = (terminalMessage = message, uiMessage?: string): RetryDecision => ({
+    retryable: false,
+    phase,
+    scope,
+    kind: "terminal",
+    message: terminalMessage || "Provider request failed",
+    ...(uiMessage ? { uiMessage } : {}),
+    statusCode: status,
+  })
+
+  if (signals.code === "FreeUsageLimitError" || responseBody?.includes("FreeUsageLimitError"))
+    return terminal("Usage limit reached", GO_UPSELL_MESSAGE)
+  if (signals.code === "SubscriptionUsageLimitError" || responseBody?.includes("SubscriptionUsageLimitError"))
+    return terminal()
+  if (signals.code === "stream_read_error" || signals.type === "upstream_error")
+    return retry("stream", "stream", signals.message || "Upstream stream read failed")
+  if (ProviderError.isRetryableNetworkError(error)) return retry("network")
+  if (message === SSE_TIMEOUT_MESSAGE) return retry("stream", "stream", message)
+  if (
+    signals.type === "too_many_requests" ||
+    signals.type.includes("rate_limit") ||
+    signals.code.includes("rate_limit") ||
+    signals.code === "429" ||
+    isRateLimitMessage(signals.message)
+  )
+    return retry("rate_limit", phase, "Too Many Requests")
+  if (isRateLimitMessage(message)) return retry("rate_limit", phase, message)
+  if (signals.code.includes("exhausted") || signals.code.includes("unavailable"))
+    return retry("server", phase, "Provider is overloaded")
+  if (status !== undefined && (RETRYABLE_HTTP_STATUS.has(status) || (status >= 500 && status <= 599)))
+    return retry(status === 429 ? "rate_limit" : "server")
+  if (MessageV2.APIError.isInstance(error)) {
+    if (status === 400 || status === 401 || status === 403 || status === 422) return terminal()
+    if (error.data.isRetryable) return retry("unknown")
+  }
+  return terminal()
+}
+
+export function isRetryableTransientError(error: unknown): boolean {
+  return decide(error, "stream").retryable
 }
 
 export function delay(attempt: number, error?: MessageV2.APIError) {
-  if (error) {
-    const headers = error.data.responseHeaders
-    if (headers) {
-      const retryAfterMs = headers["retry-after-ms"]
-      if (retryAfterMs) {
-        const parsedMs = Number.parseFloat(retryAfterMs)
-        if (!Number.isNaN(parsedMs)) {
-          return cap(parsedMs)
-        }
-      }
-
-      const retryAfter = headers["retry-after"]
-      if (retryAfter) {
-        const parsedSeconds = Number.parseFloat(retryAfter)
-        if (!Number.isNaN(parsedSeconds)) {
-          // convert seconds to milliseconds
-          return cap(Math.ceil(parsedSeconds * 1000))
-        }
-        // Try parsing as HTTP date format
-        const parsed = Date.parse(retryAfter) - Date.now()
-        if (!Number.isNaN(parsed) && parsed > 0) {
-          return cap(Math.ceil(parsed))
-        }
-      }
-
-      return cap(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1))
-    }
-  }
-
+  const retryAfter = error ? retryAfterFromHeaders(error) : undefined
+  if (retryAfter !== undefined) return retryAfter
   return cap(Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS))
 }
 
+export function retryDelay(
+  attempt: number,
+  decision: RetryDecision,
+  jitterRatio = RETRY_JITTER_RATIO,
+  initialDelayMs = RETRY_INITIAL_DELAY,
+  maxDelayMs = RETRY_MAX_DELAY,
+) {
+  if (decision.retryAfterMs !== undefined) return cap(Math.min(decision.retryAfterMs, maxDelayMs))
+  const base = cap(
+    Math.min(initialDelayMs * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS, maxDelayMs),
+  )
+  if (jitterRatio <= 0) return base
+  const factor = 1 + (Math.random() * 2 - 1) * jitterRatio
+  return cap(Math.round(base * factor))
+}
+
 export function retryable(error: Err) {
-  // context overflow errors should not be retried
-  if (MessageV2.ContextOverflowError.isInstance(error)) return undefined
-
-  // Catch raw Error / network / SSE-timeout BEFORE APIError narrowing.
-  // SessionRetry.policy unwraps Cause<unknown> via opts.parse, but raw
-  // Error instances slip past the APIError check below. Adding this
-  // branch closes that gap. See Spec ③ P2.
-  if (isRetryableTransientError(error as unknown)) {
-    const msg = (error as unknown as Error).message
-    return msg || "Transient network error"
-  }
-
-  if (MessageV2.APIError.isInstance(error)) {
-    const status = error.data.statusCode
-    // Upstream processing failures (e.g. multimodal data corruption) return 400
-    // but are transient — retry them.
-    if (status === 400 && error.data.responseBody?.includes("upstream_error")) return error.data.message
-    // Free-usage exhaustion is delivered as an HTTP 429 with a
-    // `type:FreeUsageLimitError` body that also reads "Rate limit exceeded".
-    // It is a TERMINAL, non-retryable condition — the user must subscribe to
-    // Go. This MUST be checked before the generic 429-retry branch below,
-    // otherwise the 429 branch swallows it into "Too Many Requests" + a
-    // day-long retry-after and the upsell prompt is never shown. See PR #1680.
-    if (error.data.responseBody?.includes("FreeUsageLimitError")) return GO_UPSELL_MESSAGE
-    // Subscription (Go) usage exhaustion is also an HTTP 429 but is likewise
-    // terminal — the plan's quota is spent, retrying just hangs the session.
-    // Exclude it from the generic 429-retry path the same way.
-    if (error.data.responseBody?.includes("SubscriptionUsageLimitError")) return undefined
-    // 429 rate-limits are transient and retryable EVEN when the provider SDK
-    // marked the APIError isRetryable:false (many do, expecting the caller to
-    // honor retry-after). Prior fix (T7) only normalized 429s in the retry-status
-    // and plaintext/JSON-message branches; a 429 APIError with isRetryable:false
-    // fell through the non-retryable bail below (status 429 < 500), was never
-    // retried, and surfaced as a raw blob in the TUI terminal error render
-    // (errorBody prints error.data.message verbatim). Catch it here — by numeric
-    // status OR a rate-limit signal in the message/body — before that bail so it
-    // both retries and shows a clean status. See T18.
-    if (
-      status === 429 ||
-      isRateLimitMessage(error.data.message) ||
-      (typeof error.data.responseBody === "string" && isRateLimitMessage(error.data.responseBody))
-    ) {
-      return "Too Many Requests"
-    }
-    // 5xx errors are transient server failures and should always be retried,
-    // even when the provider SDK doesn't explicitly mark them as retryable.
-    if (!error.data.isRetryable && !(status !== undefined && status >= 500)) return undefined
-    return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message
-  }
-
-  const json = iife(() => {
-    try {
-      if (typeof error.data?.message === "string") {
-        const parsed = JSON.parse(error.data.message)
-        return parsed
-      }
-
-      return JSON.parse(error.data.message)
-    } catch {
-      return undefined
-    }
-  })
-
-  // Check for rate limit patterns in plain text error messages. Skip when the
-  // message is a JSON object string — returning it here would leak the raw blob
-  // into the TUI. Structured bodies are normalized by the JSON branch below.
-  const msg = error.data?.message
-  if (typeof msg === "string" && (!json || typeof json !== "object")) {
-    if (isRateLimitMessage(msg)) {
-      return msg
-    }
-  }
-  if (!json || typeof json !== "object") return undefined
-  const code = typeof json.code === "string" ? json.code : ""
-
-  // Normalize any 429 / too-many-requests JSON shape into a retryable
-  // rate-limit status. Providers disagree on where they put the signal:
-  // top-level `type`/`code`, or nested under `error.{type,code,message}`.
-  const errorCode = String(json.error?.code ?? "")
-  const errorType = typeof json.error?.type === "string" ? json.error.type : ""
-  const errorMessage = typeof json.error?.message === "string" ? json.error.message : ""
-  const is429 = code === "429" || errorCode === "429" || String(json.status ?? "") === "429"
-  if (
-    errorType === "too_many_requests" ||
-    is429 ||
-    isRateLimitMessage(errorMessage) ||
-    (typeof json.message === "string" && isRateLimitMessage(json.message))
-  ) {
-    return "Too Many Requests"
-  }
-  if (code.includes("exhausted") || code.includes("unavailable")) {
-    return "Provider is overloaded"
-  }
-  if (json.type === "error" && errorCode.includes("rate_limit")) {
-    return "Rate Limited"
-  }
+  const result = decide(error, "stream")
+  if (result.retryable || result.message === GO_UPSELL_MESSAGE || result.uiMessage === GO_UPSELL_MESSAGE)
+    return result.uiMessage ?? result.message
   return undefined
 }
 
 export function isGptServerOverloadedError(error: Err): boolean {
   if (!MessageV2.APIError.isInstance(error) || !error.data.responseBody) return false
-  const responseBody = error.data.responseBody
-
-  const body = iife(() => {
-    try {
-      return JSON.parse(responseBody)
-    } catch {
-      return undefined
-    }
-  })
-
+  const body = parseBody(error.data.responseBody)
   return (
     body?.type === "error" &&
     body?.error?.type === "service_unavailable_error" &&
@@ -228,22 +391,72 @@ export function isGptModel(model: { id: string; api: { id: string } }): boolean 
 
 export function policy(opts: {
   parse: (error: unknown) => Err
-  set: (input: { attempt: number; message: string; next: number }) => Effect.Effect<void>
+  set: (input: {
+    attempt: number
+    message: string
+    next: number
+    maxAttempts: number
+    phase: RetryPhase
+    scope: RetryScope
+    kind: RetryKind
+  }) => Effect.Effect<void>
+  phase?: RetryPhase
+  scope?: RetryScope
+  maxRetries?: number
+  maxElapsedMs?: number
+  jitterRatio?: number
+  initialDelayMs?: number
+  budget?: (decision: RetryDecision) => RetryBudget
+  replaySafe?: (decision: RetryDecision) => boolean
+  onTerminal?: (decision: RetryDecision) => Effect.Effect<void>
   silentRetry?: (error: Err) => boolean
 }) {
+  const phase = opts.phase ?? "stream"
+  const scope = opts.scope ?? (phase === "request" ? "request" : "live-step")
+  let startedAt: number | undefined
   return Schedule.fromStepWithMetadata(
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
       const error = opts.parse(meta.input)
-      const message = retryable(error)
-      if (!message) return Cause.done(meta.attempt)
-      if (opts.silentRetry?.(error)) {
-        if (meta.attempt > GPT_OVERLOAD_RETRIES) return Cause.done(meta.attempt)
-        return Effect.succeed([meta.attempt, Duration.zero] as [number, Duration.Duration])
+      const decision = decide(error, phase, scope)
+      if (!decision.retryable) {
+        return opts.onTerminal
+          ? Effect.flatMap(opts.onTerminal(decision), () => Cause.done(meta.attempt))
+          : Cause.done(meta.attempt)
       }
+      const selected = opts.budget?.(decision)
+      const budget: RetryBudget = selected ?? {
+        mode: "bounded",
+        maxRetries: opts.maxRetries ?? (phase === "request" ? REQUEST_MAX_RETRIES : STREAM_MAX_RETRIES),
+        maxElapsedMs: opts.maxElapsedMs ?? (phase === "request" ? REQUEST_RETRY_DEADLINE_MS : STREAM_RETRY_DEADLINE_MS),
+        initialDelayMs: opts.initialDelayMs ?? (phase === "request" ? REQUEST_INITIAL_DELAY_MS : RETRY_INITIAL_DELAY),
+        maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+      }
+      if (
+        opts.replaySafe?.(decision) === false ||
+        (budget.mode === "bounded" && budget.maxRetries !== undefined && meta.attempt > budget.maxRetries)
+      )
+        return Cause.done(meta.attempt)
+      const silent = opts.silentRetry?.(error) === true
+      if (silent && meta.attempt > GPT_OVERLOAD_RETRIES) return Cause.done(meta.attempt)
+      if (silent && meta.attempt === 1)
+        return Effect.succeed([meta.attempt, Duration.zero] as [number, Duration.Duration])
+      const now = Date.now()
+      if (startedAt === undefined) startedAt = now
+      const elapsed = now - startedAt
+      const wait = retryDelay(meta.attempt, decision, opts.jitterRatio, budget.initialDelayMs, budget.maxDelayMs)
+      if (budget.maxElapsedMs > 0 && (elapsed >= budget.maxElapsedMs || wait >= budget.maxElapsedMs - elapsed))
+        return Cause.done(meta.attempt)
       return Effect.gen(function* () {
-        const wait = delay(meta.attempt, MessageV2.APIError.isInstance(error) ? error : undefined)
         const now = yield* Clock.currentTimeMillis
-        yield* opts.set({ attempt: meta.attempt, message, next: now + wait })
+        yield* opts.set({
+          attempt: meta.attempt,
+          message: decision.message,
+          next: now + wait,
+          maxAttempts: budget.maxRetries ?? 0,
+          phase: decision.phase,
+          scope: decision.scope,
+          kind: decision.kind,
+        })
         return [meta.attempt, Duration.millis(wait)] as [number, Duration.Duration]
       })
     }),

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -11,6 +11,7 @@ export const RETRY_INITIAL_DELAY = 2000
 export const RETRY_BACKOFF_FACTOR = 2
 export const RETRY_MAX_DELAY_NO_HEADERS = 30_000
 export const RETRY_MAX_DELAY_MESSAGE = 5 * 60_000
+export const RETRY_MIN_DELAY = 100
 export const RETRY_MAX_DELAY = 2_147_483_647
 export const GPT_OVERLOAD_RETRIES = 3
 export const REQUEST_MAX_RETRIES = 4
@@ -146,8 +147,8 @@ export function resolve(config: RetryConfigSource | undefined, providerID?: stri
 }
 
 export function budgetFor(config: ResolvedRetryConfig, decision: RetryDecision): RetryBudget {
-  if (decision.kind === "network") return config.network
   if (decision.phase === "request") return config.request
+  if (decision.kind === "network") return config.network
   if (decision.scope === "max-candidate") return config.maxCandidate
   if (decision.scope === "max-judge") return config.maxJudge
   if (decision.kind === "server") return config.server
@@ -187,6 +188,10 @@ export function isRateLimitMessage(message: string): boolean {
 
 function cap(ms: number) {
   return Math.min(Math.max(0, ms), RETRY_MAX_DELAY)
+}
+
+function capRetryHint(ms: number) {
+  return Math.min(Math.max(RETRY_MIN_DELAY, ms), RETRY_MAX_DELAY)
 }
 
 function parseBody(input: unknown): Record<string, any> | undefined {
@@ -234,18 +239,17 @@ function responseBodyOf(error: unknown): string | undefined {
 
 function retryAfterValue(value: string): number | undefined {
   const normalized = value.trim()
-  if (/^\d+(?:\.\d+)?$/.test(normalized)) return cap(Math.ceil(Number.parseFloat(normalized) * 1000))
+  if (/^\d+(?:\.\d+)?$/.test(normalized)) return capRetryHint(Math.ceil(Number.parseFloat(normalized) * 1000))
   const date = Date.parse(normalized) - Date.now()
-  return !Number.isNaN(date) && date > 0 ? cap(Math.ceil(date)) : undefined
+  return !Number.isNaN(date) && date > 0 ? capRetryHint(Math.ceil(date)) : undefined
 }
 
 function retryAfterFromHeaders(error: MessageV2.APIError): number | undefined {
   const headers = error.data.responseHeaders
   if (!headers) return undefined
-  const retryAfterMs = headers["retry-after-ms"]
-  if (retryAfterMs) {
-    const parsed = Number.parseFloat(retryAfterMs)
-    if (!Number.isNaN(parsed)) return cap(Math.ceil(parsed))
+  const retryAfterMs = headers["retry-after-ms"]?.trim()
+  if (retryAfterMs && /^\d+(?:\.\d+)?$/.test(retryAfterMs)) {
+    return capRetryHint(Math.ceil(Number.parseFloat(retryAfterMs)))
   }
   const retryAfter = headers["retry-after"]
   return retryAfter ? retryAfterValue(retryAfter) : undefined
@@ -258,8 +262,8 @@ function retryAfterFromMessage(message: string): number | undefined {
   if (!match) return undefined
   const value = Number.parseFloat(match[1])
   const unit = match[2].toLowerCase()
-  const multiplier = unit.startsWith("ms") ? 1 : unit.startsWith("s") ? 1000 : unit.startsWith("m") ? 60_000 : 3_600_000
-  return Math.min(cap(Math.ceil(value * multiplier)), RETRY_MAX_DELAY_MESSAGE)
+  const multiplier = unit === "ms" || unit.startsWith("millisecond") ? 1 : unit.startsWith("second") ? 1000 : unit.startsWith("minute") ? 60_000 : 3_600_000
+  return Math.min(capRetryHint(Math.ceil(value * multiplier)), RETRY_MAX_DELAY_MESSAGE)
 }
 
 function bodySignals(body: Record<string, any> | undefined) {
@@ -330,6 +334,7 @@ export function decide(
     return terminal("Usage limit reached", GO_UPSELL_MESSAGE)
   if (signals.code === "SubscriptionUsageLimitError" || responseBody?.includes("SubscriptionUsageLimitError"))
     return terminal()
+  if (status === 402 || status === 501 || status === 505) return terminal()
   if (signals.code === "stream_read_error" || signals.type === "upstream_error")
     return retry("stream", "stream", signals.message || "Upstream stream read failed")
   if (ProviderError.isRetryableNetworkError(error)) return retry("network")
@@ -345,7 +350,7 @@ export function decide(
   if (isRateLimitMessage(message)) return retry("rate_limit", phase, message)
   if (signals.code.includes("exhausted") || signals.code.includes("unavailable"))
     return retry("server", phase, "Provider is overloaded")
-  if (status !== undefined && (RETRYABLE_HTTP_STATUS.has(status) || (status >= 500 && status <= 599)))
+  if (status !== undefined && (RETRYABLE_HTTP_STATUS.has(status) || (status >= 500 && status <= 599 && status !== 501 && status !== 505)))
     return retry(status === 429 ? "rate_limit" : "server")
   if (MessageV2.APIError.isInstance(error)) {
     if (status === 400 || status === 401 || status === 403 || status === 422) return terminal()
@@ -371,11 +376,11 @@ export function retryDelay(
   initialDelayMs = RETRY_INITIAL_DELAY,
   maxDelayMs = RETRY_MAX_DELAY,
 ) {
-  if (decision.retryAfterMs !== undefined) return cap(Math.min(decision.retryAfterMs, maxDelayMs))
-  const base = cap(Math.min(initialDelayMs * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), maxDelayMs))
+  if (decision.retryAfterMs !== undefined) return Math.min(maxDelayMs, Math.max(RETRY_MIN_DELAY, decision.retryAfterMs))
+  const base = Math.min(maxDelayMs, initialDelayMs * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1))
   if (jitterRatio <= 0) return base
   const factor = 1 + (Math.random() * 2 - 1) * jitterRatio
-  return cap(Math.round(base * factor))
+  return Math.min(maxDelayMs, Math.max(RETRY_MIN_DELAY, Math.round(base * factor)))
 }
 
 export function retryable(error: Err) {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -262,7 +262,7 @@ function retryAfterFromMessage(message: string): number | undefined {
   if (!match) return undefined
   const value = Number.parseFloat(match[1])
   const unit = match[2].toLowerCase()
-  const multiplier = unit === "ms" || unit.startsWith("millisecond") ? 1 : unit.startsWith("second") ? 1000 : unit.startsWith("minute") ? 60_000 : 3_600_000
+  const multiplier = unit === "ms" || unit.startsWith("millisecond") ? 1 : unit === "s" || unit.startsWith("second") ? 1000 : unit === "m" || unit.startsWith("minute") ? 60_000 : 3_600_000
   return Math.min(capRetryHint(Math.ceil(value * multiplier)), RETRY_MAX_DELAY_MESSAGE)
 }
 
@@ -335,6 +335,7 @@ export function decide(
   if (signals.code === "SubscriptionUsageLimitError" || responseBody?.includes("SubscriptionUsageLimitError"))
     return terminal()
   if (status === 402 || status === 501 || status === 505) return terminal()
+  if (status === 404 && (!MessageV2.APIError.isInstance(error) || !error.data.metadata?.providerID?.startsWith("openai"))) return terminal()
   if (signals.code === "stream_read_error" || signals.type === "upstream_error")
     return retry("stream", "stream", signals.message || "Upstream stream read failed")
   if (ProviderError.isRetryableNetworkError(error)) return retry("network")

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -24,7 +24,10 @@ export const NETWORK_MAX_DELAY_MS = 60_000
 export const SERVER_MAX_RETRIES = 8
 export const SERVER_RETRY_DEADLINE_MS = 15 * 60_000
 export const RATE_LIMIT_MAX_RETRIES = 5
-export const UNKNOWN_MAX_RETRIES = 1
+// Provider-declared retryable errors without a known subtype deserve the same
+// recovery window as server capacity errors; unknown means uncatalogued, not terminal.
+export const UNKNOWN_MAX_RETRIES = SERVER_MAX_RETRIES
+export const UNKNOWN_RETRY_DEADLINE_MS = SERVER_RETRY_DEADLINE_MS
 
 export type RetryBudget = {
   mode: "bounded" | "persistent"
@@ -103,7 +106,7 @@ const DEFAULT_RETRY_CONFIG: ResolvedRetryConfig = {
   unknown: {
     mode: "bounded",
     maxRetries: UNKNOWN_MAX_RETRIES,
-    maxElapsedMs: REQUEST_RETRY_DEADLINE_MS,
+    maxElapsedMs: UNKNOWN_RETRY_DEADLINE_MS,
     initialDelayMs: RETRY_INITIAL_DELAY,
     maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
   },

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -125,8 +125,20 @@ const DEFAULT_RETRY_CONFIG: ResolvedRetryConfig = {
 
 function mergeBudget(base: RetryBudget, ...overrides: (RetryBudgetConfig | undefined)[]): RetryBudget {
   const merged = overrides.reduce<RetryBudgetConfig>((result, override) => ({ ...result, ...override }), {})
-  const { deadlineMs, ...rest } = merged
-  const result = { ...base, ...rest, ...(deadlineMs !== undefined ? { maxElapsedMs: deadlineMs } : {}) }
+  const rest = { ...merged }
+  delete rest.deadlineMs
+  delete rest.noDeadline
+  const deadlineOverride = overrides.reduce<RetryBudgetConfig | undefined>(
+    (result, override) =>
+      override && (override.deadlineMs !== undefined || override.noDeadline !== undefined) ? override : result,
+    undefined,
+  )
+  const result = {
+    ...base,
+    ...rest,
+    ...(deadlineOverride?.deadlineMs !== undefined ? { maxElapsedMs: deadlineOverride.deadlineMs } : {}),
+    ...(deadlineOverride?.noDeadline === true ? { maxElapsedMs: 0 } : {}),
+  }
   return result.mode === "persistent" ? { ...result, maxRetries: undefined } : result
 }
 

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -363,12 +363,6 @@ export function isRetryableTransientError(error: unknown): boolean {
   return decide(error, "stream").retryable
 }
 
-export function delay(attempt: number, error?: MessageV2.APIError) {
-  const retryAfter = error ? retryAfterFromHeaders(error) : undefined
-  if (retryAfter !== undefined) return retryAfter
-  return cap(Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS))
-}
-
 export function retryDelay(
   attempt: number,
   decision: RetryDecision,

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -13,12 +13,12 @@ export const RETRY_MAX_DELAY_NO_HEADERS = 30_000
 export const RETRY_MAX_DELAY_MESSAGE = 5 * 60_000
 export const RETRY_MAX_DELAY = 2_147_483_647
 export const GPT_OVERLOAD_RETRIES = 3
-export const REQUEST_MAX_RETRIES = 1
-export const REQUEST_INITIAL_DELAY_MS = 250
+export const REQUEST_MAX_RETRIES = 4
+export const REQUEST_INITIAL_DELAY_MS = 200
 export const STREAM_MAX_RETRIES = 5
 export const REQUEST_RETRY_DEADLINE_MS = 30_000
 export const STREAM_RETRY_DEADLINE_MS = 10 * 60_000
-export const RETRY_JITTER_RATIO = 0.2
+export const RETRY_JITTER_RATIO = 0.1
 export const NETWORK_INITIAL_DELAY_MS = 5000
 export const NETWORK_MAX_DELAY_MS = 60_000
 export const SERVER_MAX_RETRIES = 8
@@ -35,6 +35,7 @@ export type RetryBudget = {
   maxElapsedMs: number
   initialDelayMs: number
   maxDelayMs: number
+  jitterRatio: number
 }
 
 export type RetryConfigSource = {
@@ -61,6 +62,7 @@ const DEFAULT_RETRY_CONFIG: ResolvedRetryConfig = {
     maxElapsedMs: REQUEST_RETRY_DEADLINE_MS,
     initialDelayMs: REQUEST_INITIAL_DELAY_MS,
     maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+    jitterRatio: RETRY_JITTER_RATIO,
   },
   stream: {
     mode: "bounded",
@@ -68,6 +70,7 @@ const DEFAULT_RETRY_CONFIG: ResolvedRetryConfig = {
     maxElapsedMs: STREAM_RETRY_DEADLINE_MS,
     initialDelayMs: RETRY_INITIAL_DELAY,
     maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+    jitterRatio: RETRY_JITTER_RATIO,
   },
   maxCandidate: {
     mode: "bounded",
@@ -75,6 +78,7 @@ const DEFAULT_RETRY_CONFIG: ResolvedRetryConfig = {
     maxElapsedMs: 3 * 60_000,
     initialDelayMs: 500,
     maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+    jitterRatio: RETRY_JITTER_RATIO,
   },
   maxJudge: {
     mode: "bounded",
@@ -82,12 +86,14 @@ const DEFAULT_RETRY_CONFIG: ResolvedRetryConfig = {
     maxElapsedMs: 3 * 60_000,
     initialDelayMs: 500,
     maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+    jitterRatio: RETRY_JITTER_RATIO,
   },
   network: {
     mode: "persistent",
     maxElapsedMs: 0,
     initialDelayMs: NETWORK_INITIAL_DELAY_MS,
     maxDelayMs: NETWORK_MAX_DELAY_MS,
+    jitterRatio: 0,
   },
   server: {
     mode: "bounded",
@@ -95,6 +101,7 @@ const DEFAULT_RETRY_CONFIG: ResolvedRetryConfig = {
     maxElapsedMs: SERVER_RETRY_DEADLINE_MS,
     initialDelayMs: RETRY_INITIAL_DELAY,
     maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+    jitterRatio: RETRY_JITTER_RATIO,
   },
   rateLimit: {
     mode: "bounded",
@@ -102,6 +109,7 @@ const DEFAULT_RETRY_CONFIG: ResolvedRetryConfig = {
     maxElapsedMs: SERVER_RETRY_DEADLINE_MS,
     initialDelayMs: RETRY_INITIAL_DELAY,
     maxDelayMs: RETRY_MAX_DELAY_MESSAGE,
+    jitterRatio: RETRY_JITTER_RATIO,
   },
   unknown: {
     mode: "bounded",
@@ -109,6 +117,7 @@ const DEFAULT_RETRY_CONFIG: ResolvedRetryConfig = {
     maxElapsedMs: UNKNOWN_RETRY_DEADLINE_MS,
     initialDelayMs: RETRY_INITIAL_DELAY,
     maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+    jitterRatio: RETRY_JITTER_RATIO,
   },
   jitterRatio: RETRY_JITTER_RATIO,
 }
@@ -363,9 +372,7 @@ export function retryDelay(
   maxDelayMs = RETRY_MAX_DELAY,
 ) {
   if (decision.retryAfterMs !== undefined) return cap(Math.min(decision.retryAfterMs, maxDelayMs))
-  const base = cap(
-    Math.min(initialDelayMs * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS, maxDelayMs),
-  )
+  const base = cap(Math.min(initialDelayMs * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), maxDelayMs))
   if (jitterRatio <= 0) return base
   const factor = 1 + (Math.random() * 2 - 1) * jitterRatio
   return cap(Math.round(base * factor))
@@ -433,6 +440,7 @@ export function policy(opts: {
         maxElapsedMs: opts.maxElapsedMs ?? (phase === "request" ? REQUEST_RETRY_DEADLINE_MS : STREAM_RETRY_DEADLINE_MS),
         initialDelayMs: opts.initialDelayMs ?? (phase === "request" ? REQUEST_INITIAL_DELAY_MS : RETRY_INITIAL_DELAY),
         maxDelayMs: RETRY_MAX_DELAY_NO_HEADERS,
+        jitterRatio: opts.jitterRatio ?? RETRY_JITTER_RATIO,
       }
       if (
         opts.replaySafe?.(decision) === false ||
@@ -446,7 +454,7 @@ export function policy(opts: {
       const now = Date.now()
       if (startedAt === undefined) startedAt = now
       const elapsed = now - startedAt
-      const wait = retryDelay(meta.attempt, decision, opts.jitterRatio, budget.initialDelayMs, budget.maxDelayMs)
+      const wait = retryDelay(meta.attempt, decision, budget.jitterRatio, budget.initialDelayMs, budget.maxDelayMs)
       if (budget.maxElapsedMs > 0 && (elapsed >= budget.maxElapsedMs || wait >= budget.maxElapsedMs - elapsed))
         return Cause.done(meta.attempt)
       return Effect.gen(function* () {

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -21,8 +21,8 @@ export const RevertInput = z.object({
 export type RevertInput = z.infer<typeof RevertInput>
 
 export interface Interface {
-  readonly revert: (input: RevertInput) => Effect.Effect<Session.Info>
-  readonly unrevert: (input: { sessionID: SessionID }) => Effect.Effect<Session.Info>
+  readonly revert: (input: RevertInput) => Effect.Effect<Session.Info, Session.BusyError>
+  readonly unrevert: (input: { sessionID: SessionID }) => Effect.Effect<Session.Info, Session.BusyError>
   readonly cleanup: (session: Session.Info) => Effect.Effect<void>
 }
 

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -7,8 +7,8 @@ import { SessionID } from "./schema"
 import { SessionStatus } from "./status"
 
 export interface Interface {
-  readonly assertNotBusy: (sessionID: SessionID, agentID?: string) => Effect.Effect<void>
-  readonly start: (sessionID: SessionID, agentID: string, onInterrupt: Effect.Effect<MessageV2.WithParts>, work: Effect.Effect<MessageV2.WithParts>) => Effect.Effect<void>
+  readonly assertNotBusy: (sessionID: SessionID, agentID?: string) => Effect.Effect<void, Session.BusyError>
+  readonly start: (sessionID: SessionID, agentID: string, onInterrupt: Effect.Effect<MessageV2.WithParts>, work: Effect.Effect<MessageV2.WithParts>) => Effect.Effect<void, Session.BusyError>
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly cancelActor: (sessionID: SessionID, agentID: string) => Effect.Effect<void>
   readonly ensureRunning: (
@@ -21,7 +21,7 @@ export interface Interface {
     sessionID: SessionID,
     onInterrupt: Effect.Effect<MessageV2.WithParts>,
     work: Effect.Effect<MessageV2.WithParts>,
-  ) => Effect.Effect<MessageV2.WithParts>
+  ) => Effect.Effect<MessageV2.WithParts, Session.BusyError>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionRunState") {}
@@ -37,7 +37,7 @@ export const layer = Layer.effect(
     const state = yield* InstanceState.make(
       Effect.fn("SessionRunState.state")(function* () {
         const scope = yield* Scope.Scope
-        const runners = new Map<string, Runner.Runner<MessageV2.WithParts>>()
+        const runners = new Map<string, Runner.Runner<MessageV2.WithParts, never, Session.BusyError>>()
         yield* Effect.addFinalizer(
           Effect.fnUntraced(function* () {
             yield* Effect.forEach(runners.values(), (runner) => runner.cancel, {
@@ -61,7 +61,7 @@ export const layer = Layer.effect(
       const existing = data.runners.get(key)
       if (existing) return existing
       const isMain = agentID === "main"
-      const next = Runner.make<MessageV2.WithParts>(data.scope, {
+      const next = Runner.make<MessageV2.WithParts, never, Session.BusyError>(data.scope, {
         label: key,
         onReentryWarn: (info) => elog.warn("runner-reentry", info),
         onIdle: isMain
@@ -74,9 +74,7 @@ export const layer = Layer.effect(
             }),
         onBusy: isMain ? status.set(sessionID, { type: "busy" }) : Effect.void,
         onInterrupt,
-        busy: () => {
-          throw new Session.BusyError(sessionID)
-        },
+        busy: () => new Session.BusyError(sessionID),
       })
       data.runners.set(key, next)
       return next
@@ -85,10 +83,11 @@ export const layer = Layer.effect(
     const assertNotBusy = Effect.fn("SessionRunState.assertNotBusy")(function* (sessionID: SessionID, agentID = "main") {
       const data = yield* InstanceState.get(state)
       const existing = data.runners.get(runnerKey(sessionID, agentID))
-      if (existing?.busy) throw new Session.BusyError(sessionID)
+      if (existing?.busy) yield* Effect.fail(new Session.BusyError(sessionID))
+      return
     })
 
-    const start = Effect.fn("SessionRunState.start")(function* (
+    const start: Interface["start"] = Effect.fn("SessionRunState.start")(function* (
       sessionID: SessionID,
       agentID: string,
       onInterrupt: Effect.Effect<MessageV2.WithParts>,

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -7,7 +7,8 @@ import { SessionID } from "./schema"
 import { SessionStatus } from "./status"
 
 export interface Interface {
-  readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void>
+  readonly assertNotBusy: (sessionID: SessionID, agentID?: string) => Effect.Effect<void>
+  readonly start: (sessionID: SessionID, agentID: string, onInterrupt: Effect.Effect<MessageV2.WithParts>, work: Effect.Effect<MessageV2.WithParts>) => Effect.Effect<void>
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly cancelActor: (sessionID: SessionID, agentID: string) => Effect.Effect<void>
   readonly ensureRunning: (
@@ -81,10 +82,21 @@ export const layer = Layer.effect(
       return next
     })
 
-    const assertNotBusy = Effect.fn("SessionRunState.assertNotBusy")(function* (sessionID: SessionID) {
+    const assertNotBusy = Effect.fn("SessionRunState.assertNotBusy")(function* (sessionID: SessionID, agentID = "main") {
       const data = yield* InstanceState.get(state)
-      const existing = data.runners.get(runnerKey(sessionID, "main"))
+      const existing = data.runners.get(runnerKey(sessionID, agentID))
       if (existing?.busy) throw new Session.BusyError(sessionID)
+    })
+
+    const start = Effect.fn("SessionRunState.start")(function* (
+      sessionID: SessionID,
+      agentID: string,
+      onInterrupt: Effect.Effect<MessageV2.WithParts>,
+      work: Effect.Effect<MessageV2.WithParts>,
+    ) {
+      const active = yield* runner(sessionID, agentID, onInterrupt)
+      yield* active.start(work)
+      return
     })
 
     const cancel = Effect.fn("SessionRunState.cancel")(function* (sessionID: SessionID) {
@@ -126,7 +138,7 @@ export const layer = Layer.effect(
       return yield* (yield* runner(sessionID, "main", onInterrupt)).startShell(work)
     })
 
-    return Service.of({ assertNotBusy, cancel, cancelActor, ensureRunning, startShell })
+    return Service.of({ assertNotBusy, cancel, cancelActor, ensureRunning, start, startShell })
   }),
 )
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -286,6 +286,7 @@ export const Event = {
       sessionID: SessionID.zod,
       messageID: z.string(),
       attempt: z.number().int().min(1),
+      phaseAttempt: z.number().int().min(1),
       // 0 means persistent retry with no fixed attempt cap.
       maxAttempts: z.number().int().min(0),
       phase: z.enum(["request", "stream"]),

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -286,7 +286,11 @@ export const Event = {
       sessionID: SessionID.zod,
       messageID: z.string(),
       attempt: z.number().int().min(1),
-      maxAttempts: z.number().int().min(1),
+      // 0 means persistent retry with no fixed attempt cap.
+      maxAttempts: z.number().int().min(0),
+      phase: z.enum(["request", "stream"]),
+      kind: z.enum(["network", "rate_limit", "server", "stream", "unknown", "terminal"]),
+      scope: z.enum(["request", "live-step", "max-candidate", "max-judge"]),
       reason: z.string(),
       nextDelayMs: z.number().int().nonnegative(),
     }),

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -17,6 +17,10 @@ export const Info = z
       next: z.number(),
     }),
     z.object({
+      type: z.literal("notice"),
+      message: z.string(),
+    }),
+    z.object({
       type: z.literal("busy"),
       message: z.string().optional(),
     }),

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -66,35 +66,38 @@ export const layer = Layer.effect(
     const bus = yield* Bus.Service
 
     const state = yield* InstanceState.make(
-      Effect.fn("SessionStatus.state")(() => Effect.succeed(new Map<SessionID, Info>())),
+      Effect.fn("SessionStatus.state")(() =>
+        Effect.succeed({ statuses: new Map<SessionID, Info>(), retryAttempts: new Map<SessionID, number>() }),
+      ),
     )
 
     const get = Effect.fn("SessionStatus.get")(function* (sessionID: SessionID) {
       const data = yield* InstanceState.get(state)
-      return data.get(sessionID) ?? { type: "idle" as const }
+      return data.statuses.get(sessionID) ?? { type: "idle" as const }
     })
 
     const list = Effect.fn("SessionStatus.list")(function* () {
-      return new Map(yield* InstanceState.get(state))
+      return new Map((yield* InstanceState.get(state)).statuses)
     })
 
     const commit = Effect.fn("SessionStatus.commit")(function* (sessionID: SessionID, status: Info) {
       const data = yield* InstanceState.get(state)
-      const previous = data.get(sessionID)
       const normalized: Info =
         status.type === "retry"
           ? {
               ...status,
-              attempt: previous?.type === "retry" ? previous.attempt + 1 : status.attempt,
+              attempt: data.retryAttempts.get(sessionID) ?? status.attempt,
               phaseAttempt: status.phaseAttempt ?? status.attempt,
             }
           : status
+      if (normalized.type === "retry") data.retryAttempts.set(sessionID, normalized.attempt + 1)
       yield* bus.publish(Event.Status, { sessionID, status: normalized })
       if (normalized.type === "idle") {
         yield* bus.publish(Event.Idle, { sessionID })
-        data.delete(sessionID)
+        data.statuses.delete(sessionID)
+        data.retryAttempts.delete(sessionID)
       } else {
-        data.set(sessionID, normalized)
+        data.statuses.set(sessionID, normalized)
       }
       return normalized
     })

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -13,6 +13,7 @@ export const Info = z
     z.object({
       type: z.literal("retry"),
       attempt: z.number(),
+      phaseAttempt: z.number().optional(),
       message: z.string(),
       next: z.number(),
       phase: z.enum(["request", "stream"]).optional(),
@@ -31,6 +32,7 @@ export const Info = z
     ref: "SessionStatus",
   })
 export type Info = z.infer<typeof Info>
+export type RetryInfo = Extract<Info, { type: "retry" }>
 
 export const Event = {
   Status: BusEvent.define(
@@ -53,6 +55,7 @@ export interface Interface {
   readonly get: (sessionID: SessionID) => Effect.Effect<Info>
   readonly list: () => Effect.Effect<Map<SessionID, Info>>
   readonly set: (sessionID: SessionID, status: Info) => Effect.Effect<void>
+  readonly setRetry: (sessionID: SessionID, status: RetryInfo) => Effect.Effect<number>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionStatus") {}
@@ -75,18 +78,37 @@ export const layer = Layer.effect(
       return new Map(yield* InstanceState.get(state))
     })
 
-    const set = Effect.fn("SessionStatus.set")(function* (sessionID: SessionID, status: Info) {
+    const commit = Effect.fn("SessionStatus.commit")(function* (sessionID: SessionID, status: Info) {
       const data = yield* InstanceState.get(state)
-      yield* bus.publish(Event.Status, { sessionID, status })
-      if (status.type === "idle") {
+      const previous = data.get(sessionID)
+      const normalized: Info =
+        status.type === "retry"
+          ? {
+              ...status,
+              attempt: previous?.type === "retry" ? previous.attempt + 1 : status.attempt,
+              phaseAttempt: status.phaseAttempt ?? status.attempt,
+            }
+          : status
+      yield* bus.publish(Event.Status, { sessionID, status: normalized })
+      if (normalized.type === "idle") {
         yield* bus.publish(Event.Idle, { sessionID })
         data.delete(sessionID)
-        return
+      } else {
+        data.set(sessionID, normalized)
       }
-      data.set(sessionID, status)
+      return normalized
     })
 
-    return Service.of({ get, list, set })
+    const set = Effect.fn("SessionStatus.set")(function* (sessionID: SessionID, status: Info) {
+      yield* commit(sessionID, status)
+    })
+
+    const setRetry = Effect.fn("SessionStatus.setRetry")(function* (sessionID: SessionID, status: RetryInfo) {
+      const normalized = yield* commit(sessionID, status)
+      return normalized.type === "retry" ? normalized.attempt : status.attempt
+    })
+
+    return Service.of({ get, list, set, setRetry })
   }),
 )
 

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -15,6 +15,8 @@ export const Info = z
       attempt: z.number(),
       message: z.string(),
       next: z.number(),
+      phase: z.enum(["request", "stream"]).optional(),
+      scope: z.enum(["request", "live-step", "max-candidate", "max-judge"]).optional(),
     }),
     z.object({
       type: z.literal("notice"),

--- a/packages/opencode/src/task/registry.ts
+++ b/packages/opencode/src/task/registry.ts
@@ -7,6 +7,7 @@ import { TaskTable, TaskEventTable } from "./task.sql"
 import type { Task, TaskEvent } from "./schema"
 import { Created as TaskCreated, Updated as TaskUpdated, type UpdatedKind } from "./events"
 import { RecoverableError } from "@/tool/recoverable"
+import { EffectBridge } from "@/effect"
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -92,6 +93,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
   Effect.gen(function* () {
     const bus = yield* Bus.Service
     const config = yield* Config.Service
+    const bridge = yield* EffectBridge.make()
 
     const cleanupAfter = Effect.fn("TaskRegistry.cleanupAfter")(function* (now: number) {
       const cfg = yield* config.get()
@@ -115,10 +117,10 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
     }
 
     const publishCreated = (task: Task) =>
-      Effect.runFork(bus.publish(TaskCreated, { sessionID: task.session_id, task }))
+      bridge.fork(bus.publish(TaskCreated, { sessionID: task.session_id, task }))
 
     const publishUpdated = (task: Task, kind: UpdatedKind) =>
-      Effect.runFork(bus.publish(TaskUpdated, { sessionID: task.session_id, task, kind }))
+      bridge.fork(bus.publish(TaskUpdated, { sessionID: task.session_id, task, kind }))
 
     const create = Effect.fn("TaskRegistry.create")(function* (input: {
       session_id: SessionID

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -21,6 +21,7 @@ import { TaskRegistry } from "@/task/registry"
 import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { TaskID } from "@/task/schema"
 import { SessionCheckpoint } from "@/session/checkpoint"
+import { EffectBridge } from "@/effect"
 import { inboxServiceRef } from "@/inbox/inbox-ref"
 import { Effect, Deferred } from "effect"
 
@@ -522,6 +523,7 @@ export const ActorTool = Tool.define(
 
       const run = Effect.fn("ActorTool.execute")(function* (input: z.infer<typeof parameters>, ctx: Tool.Context) {
         const op = input.operation
+        const bridge = yield* EffectBridge.make()
         const cfg = yield* config.get()
 
         // When called through exec, subagents may only use `send` to communicate
@@ -843,7 +845,7 @@ export const ActorTool = Tool.define(
         // unlike ActorWaiter, which resolves on the row's first `idle` and would
         // miss the gate's downgrade.
         function cancelHandler() {
-          Effect.runFork(actor.cancel(spawnResult.sessionID, spawnResult.actorID, "graceful"))
+          bridge.fork(actor.cancel(spawnResult.sessionID, spawnResult.actorID, "graceful"))
         }
         const outcome = yield* Effect.acquireUseRelease(
           Effect.sync(() => {

--- a/packages/opencode/src/workflow/runtime.ts
+++ b/packages/opencode/src/workflow/runtime.ts
@@ -318,6 +318,8 @@ export const layer = Layer.effect(
     // lazily below — it reads the per-instance ALS context and returns Effect<Info>
     // with no requirement, so it stays out of the public method types.
     const config = yield* Config.Service
+    const hostBridge = yield* EffectBridge.make()
+    const fork = <A, E, R>(effect: Effect.Effect<A, E, R>) => hostBridge.fork(effect)
     const scope = yield* Scope.Scope
     const runs = new Map<string, RunEntry>()
 
@@ -419,7 +421,7 @@ export const layer = Layer.effect(
         entry.runID,
         setTimeout(() => {
           flushTimers.delete(entry.runID)
-          Effect.runFork(
+          fork(
             WorkflowPersistence.flushCounters({
               runID: entry.runID,
               running: entry.running,
@@ -690,7 +692,7 @@ export const layer = Layer.effect(
         info: { actorID?: string; errorMessage?: string } = {},
       ) => {
         try {
-          Effect.runFork(
+          fork(
             bus
               .publish(WorkflowAgentFailed, {
                 sessionID: input.sessionID,
@@ -1212,16 +1214,16 @@ export const layer = Layer.effect(
         const phaseId = "p" + entry.structure.length
         entry.structure.push({ type: "phase", id: phaseId, title: String(title) })
         entry.currentPhaseId = phaseId
-        Effect.runFork(WorkflowPersistence.recordPhase({ runID, phase: String(title) }).pipe(Effect.ignore))
-        Effect.runFork(WorkflowPersistence.appendJournal(runID, { t: "phase", title: String(title), pass }).pipe(Effect.ignore))
-        Effect.runFork(bus.publish(WorkflowPhase, { sessionID: input.sessionID, runID, title: String(title) }))
+        fork(WorkflowPersistence.recordPhase({ runID, phase: String(title) }).pipe(Effect.ignore))
+        fork(WorkflowPersistence.appendJournal(runID, { t: "phase", title: String(title), pass }).pipe(Effect.ignore))
+        fork(bus.publish(WorkflowPhase, { sessionID: input.sessionID, runID, title: String(title) }))
         return undefined
       }
 
       const logHook: HostFn = (message: unknown) => {
         entry.transcript.push({ kind: "log", text: String(message) })
-        Effect.runFork(WorkflowPersistence.appendJournal(runID, { t: "log", msg: String(message), pass }).pipe(Effect.ignore))
-        Effect.runFork(bus.publish(WorkflowLog, { sessionID: input.sessionID, runID, message: String(message) }))
+        fork(WorkflowPersistence.appendJournal(runID, { t: "log", msg: String(message), pass }).pipe(Effect.ignore))
+        fork(bus.publish(WorkflowLog, { sessionID: input.sessionID, runID, message: String(message) }))
         return undefined
       }
 

--- a/packages/opencode/test/cli/tui/session-status-store.test.ts
+++ b/packages/opencode/test/cli/tui/session-status-store.test.ts
@@ -62,6 +62,13 @@ describe("nextSessionStatus", () => {
     h.dispose()
   })
 
+  test("terminal notices are distinct from retry state", () => {
+    const h = harness()
+    h.apply("ses_6", { type: "notice", message: "usage limit" } as any)
+    expect(h.store.session_status["ses_6"]).toEqual({ type: "notice", message: "usage limit" })
+    h.dispose()
+  })
+
   test("first status for an unseen session is stored as-is", () => {
     const h = harness()
     h.apply("ses_5", { type: "busy", message: "Rebuilding context\u2026" })

--- a/packages/opencode/test/cron/end-to-end.test.ts
+++ b/packages/opencode/test/cron/end-to-end.test.ts
@@ -78,6 +78,7 @@ const stubPrompt = Layer.succeed(
       }),
     recovery: () => Effect.succeed([]),
     resume: () => Effect.die("resume not expected in cron end-to-end test"),
+    resumeBackground: () => Effect.die("resumeBackground not expected in cron end-to-end test"),
     loop: () => Effect.die("loop not expected in end-to-end test"),
     shell: () => Effect.die("shell not expected in end-to-end test"),
     command: () => Effect.die("command not expected in end-to-end test"),

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -4,6 +4,15 @@ import { Runner } from "../../src/effect"
 import { it } from "../lib/effect"
 
 describe("Runner", () => {
+  it.live("start reports busy as a failure instead of a defect", Effect.gen(function* () {
+    const s = yield* Scope.Scope
+    const runner = Runner.make<string>(s)
+    yield* runner.start(Effect.never)
+    const exit = yield* runner.start(Effect.succeed("later")).pipe(Effect.exit)
+    expect(Exit.isFailure(exit)).toBe(true)
+    yield* runner.cancel
+  }))
+
   // --- ensureRunning semantics ---
 
   it.live(

--- a/packages/opencode/test/mcp/sampling-e2e.test.ts
+++ b/packages/opencode/test/mcp/sampling-e2e.test.ts
@@ -1230,7 +1230,7 @@ describe("MCP client-side sampling, end to end", () => {
  *
  * THE SILENCE BOUND IS INJECTED HERE so the suite runs in CI time. That is a
  * property of the tests, not of the proofs: production passes nothing and inherits
- * `DEFAULT_CHUNK_TIMEOUT` (8 minutes), or whatever the operator configured for that
+ * `DEFAULT_CHUNK_TIMEOUT` (5 minutes), or whatever the operator configured for that
  * provider. Sub-second bounds prove the MECHANISM, never that a production value is
  * right; the inherited value is pinned separately by a constant assertion, and no
  * test that finishes in seconds also waits out eight minutes.
@@ -1473,7 +1473,7 @@ describe("sampling deadlines and liveness", () => {
         expect(result.isError).toBe(true)
         // THE CONFIGURED VALUE IS THE ONE REPORTED. Had sampling kept its own
         // default this would read 45_000; had it ignored config it would read
-        // 480_000 and this test would have timed out instead.
+        // 300_000 and this test would have timed out instead.
         const detail = h.samplingOutcomes[0].detail as any
         expect(detail.code).toBe(McpSampling.TIMEOUT_CODE)
         expect(detail.data).toMatchObject({ server: "fixture", phase: "stall", timeout: CONFIGURED })
@@ -1561,7 +1561,7 @@ describe("sampling deadlines and liveness", () => {
     // injected, sampling's silence bound IS the provider layer's, so the two cannot
     // drift apart the way 45 s and 480 s had.
     expect(McpSampling.chunkTimeoutFor({}, PROVIDER_ID)).toBe(DEFAULT_CHUNK_TIMEOUT)
-    expect(DEFAULT_CHUNK_TIMEOUT).toBe(480_000)
+    expect(DEFAULT_CHUNK_TIMEOUT).toBe(300_000)
 
     // AND THE DELETED BOUNDS STAY DELETED. Each was a number with no precedent in
     // this repo, so re-exporting any of them would mean one had come back.
@@ -1583,7 +1583,7 @@ describe("sampling deadlines and liveness", () => {
  *
  * EVERY BOUND HERE IS INJECTED so the suite runs in CI time, exactly as in the
  * block above: production passes none and inherits the provider's `chunkTimeout`
- * (8 minutes by default), with no total bound behind it. Sub-second bounds prove
+ * (5 minutes by default), with no total bound behind it. Sub-second bounds prove
  * the MECHANISM, never that any particular production value is right; the inherited
  * value is pinned separately by the constant assertions, and no test that finishes
  * in seconds also waits out eight minutes.

--- a/packages/opencode/test/mcp/sampling-e2e.test.ts
+++ b/packages/opencode/test/mcp/sampling-e2e.test.ts
@@ -1230,7 +1230,7 @@ describe("MCP client-side sampling, end to end", () => {
  *
  * THE SILENCE BOUND IS INJECTED HERE so the suite runs in CI time. That is a
  * property of the tests, not of the proofs: production passes nothing and inherits
- * `DEFAULT_CHUNK_TIMEOUT` (5 minutes), or whatever the operator configured for that
+ * `DEFAULT_CHUNK_TIMEOUT` (8 minutes), or whatever the operator configured for that
  * provider. Sub-second bounds prove the MECHANISM, never that a production value is
  * right; the inherited value is pinned separately by a constant assertion, and no
  * test that finishes in seconds also waits out eight minutes.
@@ -1473,7 +1473,7 @@ describe("sampling deadlines and liveness", () => {
         expect(result.isError).toBe(true)
         // THE CONFIGURED VALUE IS THE ONE REPORTED. Had sampling kept its own
         // default this would read 45_000; had it ignored config it would read
-        // 300_000 and this test would have timed out instead.
+        // 480_000 and this test would have timed out instead.
         const detail = h.samplingOutcomes[0].detail as any
         expect(detail.code).toBe(McpSampling.TIMEOUT_CODE)
         expect(detail.data).toMatchObject({ server: "fixture", phase: "stall", timeout: CONFIGURED })
@@ -1561,7 +1561,7 @@ describe("sampling deadlines and liveness", () => {
     // injected, sampling's silence bound IS the provider layer's, so the two cannot
     // drift apart the way 45 s and 480 s had.
     expect(McpSampling.chunkTimeoutFor({}, PROVIDER_ID)).toBe(DEFAULT_CHUNK_TIMEOUT)
-    expect(DEFAULT_CHUNK_TIMEOUT).toBe(300_000)
+    expect(DEFAULT_CHUNK_TIMEOUT).toBe(480_000)
 
     // AND THE DELETED BOUNDS STAY DELETED. Each was a number with no precedent in
     // this repo, so re-exporting any of them would mean one had come back.
@@ -1583,7 +1583,7 @@ describe("sampling deadlines and liveness", () => {
  *
  * EVERY BOUND HERE IS INJECTED so the suite runs in CI time, exactly as in the
  * block above: production passes none and inherits the provider's `chunkTimeout`
- * (5 minutes by default), with no total bound behind it. Sub-second bounds prove
+ * (8 minutes by default), with no total bound behind it. Sub-second bounds prove
  * the MECHANISM, never that any particular production value is right; the inherited
  * value is pinned separately by the constant assertions, and no test that finishes
  * in seconds also waits out eight minutes.

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -218,4 +218,14 @@ describe("provider stream error", () => {
       responseBody: JSON.stringify(input),
     })
   })
+
+  test("marks Anthropic overloaded_error events as retryable without an error code", () => {
+    const input = { type: "error", error: { type: "overloaded_error", message: "Overloaded" } }
+    expect(parseStreamError(input)).toStrictEqual({
+      type: "api_error",
+      message: "Overloaded",
+      isRetryable: true,
+      responseBody: JSON.stringify(input),
+    })
+  })
 })

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -180,6 +180,25 @@ describe("provider stream error", () => {
     })
   })
 
+  test("marks upstream stream_read_error events as retryable", () => {
+    const input = {
+      type: "error",
+      sequence_number: 0,
+      error: {
+        type: "upstream_error",
+        code: "stream_read_error",
+        message: "stream_read_error",
+      },
+    }
+
+    expect(parseStreamError(input)).toStrictEqual({
+      type: "api_error",
+      message: input.error.message,
+      isRetryable: true,
+      responseBody: JSON.stringify(input),
+    })
+  })
+
   test("marks OpenAI server_error events as retryable", () => {
     const input = {
       type: "error",

--- a/packages/opencode/test/provider/provider-chunk-timeout.test.ts
+++ b/packages/opencode/test/provider/provider-chunk-timeout.test.ts
@@ -6,8 +6,8 @@ describe("provider timeouts", () => {
     expect(DEFAULT_OPENAI_HEADER_TIMEOUT).toBe(300_000)
   })
 
-  test("DEFAULT_CHUNK_TIMEOUT is 5 minutes (300_000 ms)", () => {
-    expect(DEFAULT_CHUNK_TIMEOUT).toBe(300_000)
+  test("DEFAULT_CHUNK_TIMEOUT is 8 minutes (480_000 ms)", () => {
+    expect(DEFAULT_CHUNK_TIMEOUT).toBe(480_000)
   })
 
   test("user-supplied chunkTimeout (number) takes precedence over default", () => {

--- a/packages/opencode/test/provider/provider-chunk-timeout.test.ts
+++ b/packages/opencode/test/provider/provider-chunk-timeout.test.ts
@@ -6,8 +6,8 @@ describe("provider timeouts", () => {
     expect(DEFAULT_OPENAI_HEADER_TIMEOUT).toBe(300_000)
   })
 
-  test("DEFAULT_CHUNK_TIMEOUT is 8 minutes (480_000 ms)", () => {
-    expect(DEFAULT_CHUNK_TIMEOUT).toBe(480_000)
+  test("DEFAULT_CHUNK_TIMEOUT is 5 minutes (300_000 ms)", () => {
+    expect(DEFAULT_CHUNK_TIMEOUT).toBe(300_000)
   })
 
   test("user-supplied chunkTimeout (number) takes precedence over default", () => {

--- a/packages/opencode/test/session/cron-bridge.integration.test.ts
+++ b/packages/opencode/test/session/cron-bridge.integration.test.ts
@@ -64,6 +64,7 @@ const makeCaptureLayer = (captured: { value: CapturedPrompt[] }) =>
         }),
       recovery: () => Effect.succeed([]),
       resume: () => Effect.die("resume not expected in cron-bridge test"),
+      resumeBackground: () => Effect.die("resumeBackground not expected in cron-bridge test"),
       loop: () => Effect.die("loop not expected in cron-bridge test"),
       shell: () => Effect.die("shell not expected in cron-bridge test"),
       command: () => Effect.die("command not expected in cron-bridge test"),

--- a/packages/opencode/test/session/keepalive.integration.test.ts
+++ b/packages/opencode/test/session/keepalive.integration.test.ts
@@ -70,6 +70,7 @@ const stubPrompt = Layer.succeed(
       }),
     recovery: () => Effect.succeed([]),
     resume: () => Effect.die("resume not expected in keepalive test"),
+    resumeBackground: () => Effect.die("resumeBackground not expected in keepalive test"),
     loop: () => Effect.die("loop not expected in keepalive test"),
     shell: () => Effect.die("shell not expected in keepalive test"),
     command: () => Effect.die("command not expected in keepalive test"),

--- a/packages/opencode/test/session/llm-retry.test.ts
+++ b/packages/opencode/test/session/llm-retry.test.ts
@@ -26,7 +26,7 @@ describe("isTransientCapacityError", () => {
   })
 
   test("returns false for non-retryable HTTP statuses", () => {
-    for (const status of [400, 401, 403, 404, 422]) {
+    for (const status of [400, 401, 403, 404, 422, 501, 505]) {
       const err = Object.assign(new Error("client"), { status })
       expect(isTransientCapacityError(err)).toBe(false)
     }

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -905,7 +905,6 @@ describe("session.llm.stream", () => {
               system: ["You are a helpful assistant."],
               messages: [{ role: "user", content: "Hello" }],
               tools: {},
-              retries: 1,
             })
             .pipe(Stream.runCollect),
         )

--- a/packages/opencode/test/session/max-mode-econnreset.test.ts
+++ b/packages/opencode/test/session/max-mode-econnreset.test.ts
@@ -19,7 +19,7 @@ function expectCandidate(value: Candidate | null | "text-repeat"): Candidate {
  *   3. a non-transient error part falls through to the catch fallback.
  *
  * The mock stream yields synchronously-constructed events, so the only real
- * wall-clock cost is persistentRetrySchedule's first backoff (~500ms/attempt).
+ * wall-clock cost is the coordinator's local max-mode backoff (~500ms/attempt).
  */
 
 const econnreset = () => Object.assign(new Error("socket connection closed unexpectedly"), { code: "ECONNRESET" })
@@ -204,7 +204,7 @@ describe("max-mode defect handling (SSE timeout surfaces as Cause.die)", () => {
 
   const sseTimeout = () => new Error("SSE read timed out")
   // A non-transient defect: not retried, so containment is proven in 1 attempt
-  // without waiting out persistentRetrySchedule's ~8min backoff exhaustion.
+  // without waiting out the coordinator's long backoff exhaustion.
   const fatalDefect = () => new Error("unexpected internal stream failure")
 
   test("candidate contains a transient defect and retries to recovery (no fiber crash)", async () => {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1516,6 +1516,18 @@ describe("session.message-v2.fromError", () => {
     expect(MessageV2.isAuthError(error)).toBe(true)
   })
 
+  test("does not treat an unrelated unauthorized word as authentication", () => {
+    const error = new MessageV2.APIError({ message: "CORS unauthorized origin", statusCode: 403, isRetryable: false }).toObject()
+    expect(MessageV2.isAuthError(error)).toBe(false)
+  })
+
+  test("recognizes explicit authorization-required and access-denied responses", () => {
+    for (const message of ["Authorization required", "Access denied"]) {
+      const error = new MessageV2.APIError({ message, statusCode: 403, isRetryable: false }).toObject()
+      expect(MessageV2.isAuthError(error)).toBe(true)
+    }
+  })
+
   test("does not crash on a RetryError without an errors array", () => {
     const error = new RetryError({ message: "retry failed", reason: "maxRetriesExceeded", errors: [] })
     ;(error as any).errors = undefined

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1504,7 +1504,17 @@ describe("session.message-v2.fromError", () => {
  test("recognizes normalized credential rejection as an auth error", () => {
     const error = new MessageV2.APIError({ message: "Unauthorized", statusCode: 401, isRetryable: false }).toObject()
    expect(MessageV2.isAuthError(error)).toBe(true)
- })
+  })
+
+  test("does not treat a generic 403 permission failure as authentication", () => {
+    const error = new MessageV2.APIError({ message: "Forbidden", statusCode: 403, isRetryable: false }).toObject()
+    expect(MessageV2.isAuthError(error)).toBe(false)
+  })
+
+  test("treats an explicitly invalid 403 credential as authentication", () => {
+    const error = new MessageV2.APIError({ message: "Invalid API key", statusCode: 403, isRetryable: false }).toObject()
+    expect(MessageV2.isAuthError(error)).toBe(true)
+  })
 
   test("does not crash on a RetryError without an errors array", () => {
     const error = new RetryError({ message: "retry failed", reason: "maxRetriesExceeded", errors: [] })

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1516,6 +1516,11 @@ describe("session.message-v2.fromError", () => {
     expect(MessageV2.isAuthError(error)).toBe(true)
   })
 
+  test("treats a bare 403 Unauthorized reason as authentication", () => {
+    const error = new MessageV2.APIError({ message: "Unauthorized", statusCode: 403, isRetryable: false }).toObject()
+    expect(MessageV2.isAuthError(error)).toBe(true)
+  })
+
   test("does not treat an unrelated unauthorized word as authentication", () => {
     const error = new MessageV2.APIError({ message: "CORS unauthorized origin", statusCode: 403, isRetryable: false }).toObject()
     expect(MessageV2.isAuthError(error)).toBe(false)

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { APICallError } from "ai"
+import { APICallError, RetryError } from "ai"
 import { convertToLanguageModelPrompt } from "ai/internal"
 import { MessageV2 } from "../../src/session/message-v2"
 import { ProviderTransform } from "../../src/provider"
@@ -1303,6 +1303,27 @@ describe("session.message-v2.toModelMessage", () => {
 })
 
 describe("session.message-v2.fromError", () => {
+  test("normalizes stream_read_error as a retryable APIError", () => {
+    const input = {
+      type: "error",
+      error: { type: "upstream_error", code: "stream_read_error", message: "stream_read_error" },
+    }
+    const result = MessageV2.fromError(input, { providerID })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+    expect((result as MessageV2.APIError).data.responseBody).toBe(JSON.stringify(input))
+  })
+
+  test("normalizes fetch failed with a retryable network cause", () => {
+    const cause = Object.assign(new Error("socket closed"), { code: "UND_ERR_SOCKET" })
+    const result = MessageV2.fromError(Object.assign(new TypeError("fetch failed"), { cause }), { providerID })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+    expect((result as MessageV2.APIError).data.metadata?.code).toBe("UND_ERR_SOCKET")
+  })
+
   test("serializes context_length_exceeded as ContextOverflowError", () => {
     const input = {
       type: "error",
@@ -1465,5 +1486,30 @@ describe("session.message-v2.fromError", () => {
     const result = MessageV2.fromError(zlibError, { providerID, aborted: true })
 
     expect(result.name).toBe("MessageAbortedError")
+  })
+
+  test("normalizes SSE timeout before the processor retry boundary", () => {
+    const result = MessageV2.fromError(new Error("SSE read timed out"), { providerID })
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+  })
+
+ test("abort cause wins over a retryable network cause", () => {
+   const cause = Object.assign(new Error("socket reset"), { code: "ECONNRESET" })
+   const error = Object.assign(new DOMException("user aborted", "AbortError"), { cause })
+   const result = MessageV2.fromError(error, { providerID })
+   expect(result.name).toBe("MessageAbortedError")
+ })
+
+ test("recognizes normalized credential rejection as an auth error", () => {
+    const error = new MessageV2.APIError({ message: "Unauthorized", statusCode: 401, isRetryable: false }).toObject()
+   expect(MessageV2.isAuthError(error)).toBe(true)
+ })
+
+  test("does not crash on a RetryError without an errors array", () => {
+    const error = new RetryError({ message: "retry failed", reason: "maxRetriesExceeded", errors: [] })
+    ;(error as any).errors = undefined
+    const result = MessageV2.fromError(error, { providerID })
+    expect(result.name).toBe("UnknownError")
   })
 })

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -570,7 +570,7 @@ it.live("session.processor effect tests publish retry status updates", () =>
         const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
         const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
         const states: number[] = []
-        const retryEvents: Array<{ attempt: number; maxAttempts: number; phase: string; kind: string; scope: string }> = []
+        const retryEvents: Array<{ attempt: number; phaseAttempt: number; maxAttempts: number; phase: string; kind: string; scope: string }> = []
         const off = yield* bus.subscribeCallback(SessionStatus.Event.Status, (evt) => {
           if (evt.properties.sessionID !== chat.id) return
           if (evt.properties.status.type === "retry") states.push(evt.properties.status.attempt)
@@ -579,6 +579,7 @@ it.live("session.processor effect tests publish retry status updates", () =>
           if (evt.properties.sessionID !== chat.id) return
           retryEvents.push({
             attempt: evt.properties.attempt,
+            phaseAttempt: evt.properties.phaseAttempt,
             maxAttempts: evt.properties.maxAttempts,
             phase: evt.properties.phase,
             kind: evt.properties.kind,
@@ -613,8 +614,15 @@ it.live("session.processor effect tests publish retry status updates", () =>
 
         expect(value).toBe("continue")
         expect(yield* llm.calls).toBe(3)
-        expect(states).toStrictEqual([1])
-        expect(retryEvents).toStrictEqual([{ attempt: 1, maxAttempts: 8, phase: "stream", kind: "server", scope: "live-step" }])
+        expect(states).toStrictEqual([1, 2])
+        expect(retryEvents).toContainEqual({
+          attempt: 2,
+          phaseAttempt: 1,
+          maxAttempts: 8,
+          phase: "stream",
+          kind: "server",
+          scope: "live-step",
+        })
       }),
     {
       git: true,

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -616,7 +616,10 @@ it.live("session.processor effect tests publish retry status updates", () =>
         expect(states).toStrictEqual([1])
         expect(retryEvents).toStrictEqual([{ attempt: 1, maxAttempts: 8, phase: "stream", kind: "server", scope: "live-step" }])
       }),
-    { git: true, config: (url) => providerCfg(url) },
+    {
+      git: true,
+      config: (url) => ({ ...providerCfg(url), retry: { request: { maxRetries: 1 } } }),
+    },
   ),
 )
 

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -554,24 +554,14 @@ it.live("session.processor effect tests retry recognized structured json errors"
   ),
 )
 
-// TODO: Re-enable after we restructure the retry-status path.
-// Task 1 of docs/superpowers/plans/2026-05-17-retry-and-timeout-tuning.md
-// bumped streamText maxRetries 0→10. AI SDK now consumes 503 (and other
-// transient HTTP errors) inside its own exp-backoff loop, so the outer
-// Effect-based SessionRetry.policy at processor.ts:568 never sees this
-// error and the `type: "retry"` status banner never publishes for the
-// single-503 fixture this test uses. The user-facing contract changed:
-// silent retries during the SDK window, banner only when AI SDK gives
-// up after 10+ retries. A proper rewrite would either inject 11+
-// errors (so AI SDK exhausts then outer retry fires) or use a
-// non-AI-SDK-retryable error path.
-it.live.skip("session.processor effect tests publish retry status updates", () =>
+it.live("session.processor effect tests publish retry status updates", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
         const { processors, session, provider } = yield* boot()
         const bus = yield* Bus.Service
 
+        yield* llm.error(503, { error: "boom" })
         yield* llm.error(503, { error: "boom" })
         yield* llm.text("")
 
@@ -580,9 +570,20 @@ it.live.skip("session.processor effect tests publish retry status updates", () =
         const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
         const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
         const states: number[] = []
+        const retryEvents: Array<{ attempt: number; maxAttempts: number; phase: string; kind: string; scope: string }> = []
         const off = yield* bus.subscribeCallback(SessionStatus.Event.Status, (evt) => {
           if (evt.properties.sessionID !== chat.id) return
           if (evt.properties.status.type === "retry") states.push(evt.properties.status.attempt)
+        })
+        const offRetry = yield* bus.subscribeCallback(Session.Event.RetryAttempt, (evt) => {
+          if (evt.properties.sessionID !== chat.id) return
+          retryEvents.push({
+            attempt: evt.properties.attempt,
+            maxAttempts: evt.properties.maxAttempts,
+            phase: evt.properties.phase,
+            kind: evt.properties.kind,
+            scope: evt.properties.scope,
+          })
         })
         const handle = yield* processors.create({
           assistantMessage: msg,
@@ -608,10 +609,12 @@ it.live.skip("session.processor effect tests publish retry status updates", () =
         })
 
         off()
+        offRetry()
 
         expect(value).toBe("continue")
-        expect(yield* llm.calls).toBe(2)
+        expect(yield* llm.calls).toBe(3)
         expect(states).toStrictEqual([1])
+        expect(retryEvents).toStrictEqual([{ attempt: 1, maxAttempts: 8, phase: "stream", kind: "server", scope: "live-step" }])
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -142,6 +142,7 @@ describe("session.retry.delay", () => {
                 phase: "request",
                 scope: "request",
               })
+              yield* svc.set(sessionID, { type: "busy" })
               const attempt = yield* svc.setRetry(sessionID, {
                 type: "retry",
                 attempt: 1,
@@ -165,6 +166,7 @@ describe("session.retry.delay", () => {
   test("requires explicit noDeadline instead of deadlineMs zero", () => {
     const decode = Schema.decodeUnknownSync(ConfigRetry.Budget)
     expect(() => decode({ deadlineMs: 0 })).toThrow()
+    expect(() => decode({ deadlineMs: 1000, noDeadline: true })).toThrow("deadlineMs and noDeadline cannot be configured together")
     expect(decode({ mode: "persistent", noDeadline: true })).toMatchObject({ noDeadline: true })
     expect(SessionRetry.resolve({ retry: { server: { maxRetries: 2, noDeadline: true } } }).server.maxElapsedMs).toBe(0)
     expect(

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -142,6 +142,7 @@ describe("session.retry.retryable", () => {
     const resolved = SessionRetry.resolve(undefined, "test")
     expect(SessionRetry.budgetFor(resolved, { retryable: true, phase: "stream", scope: "live-step", kind: "network", message: "reset" }).mode).toBe("persistent")
     expect(SessionRetry.budgetFor(resolved, { retryable: true, phase: "request", scope: "request", kind: "server", message: "503" }).maxRetries).toBe(4)
+    expect(SessionRetry.budgetFor(resolved, { retryable: true, phase: "request", scope: "request", kind: "network", message: "reset" }).maxRetries).toBe(4)
     expect(resolved.unknown).toMatchObject({ maxRetries: 8, maxElapsedMs: 15 * 60_000 })
     expect(resolved.request.jitterRatio).toBe(0.1)
     expect(resolved.network.jitterRatio).toBe(0)
@@ -150,6 +151,32 @@ describe("session.retry.retryable", () => {
   test("caps retry-after by the selected budget", () => {
     const decision = { retryable: true, phase: "stream" as const, scope: "live-step" as const, kind: "rate_limit" as const, message: "429", retryAfterMs: 120000 }
     expect(SessionRetry.retryDelay(1, decision, 0, 100, 5000)).toBe(5000)
+  })
+
+  test("parses retry hints with the declared units", () => {
+    const error = new MessageV2.APIError({ message: "Please retry in 1 millisecond", statusCode: 429, isRetryable: false }).toObject()
+    expect(decide(error).retryAfterMs).toBe(100)
+  })
+
+  test("rejects malformed retry-after-ms and floors zero delay", () => {
+    const zero = new MessageV2.APIError({ message: "429", statusCode: 429, isRetryable: false, responseHeaders: { "retry-after-ms": "0" } }).toObject()
+    const garbage = new MessageV2.APIError({ message: "429", statusCode: 429, isRetryable: false, responseHeaders: { "retry-after-ms": "10oops" } }).toObject()
+    const negative = new MessageV2.APIError({ message: "429", statusCode: 429, isRetryable: false, responseHeaders: { "retry-after-ms": "-10" } }).toObject()
+    expect(decide(zero).retryAfterMs).toBe(SessionRetry.RETRY_MIN_DELAY)
+    expect(decide(garbage).retryAfterMs).toBeUndefined()
+    expect(decide(negative).retryAfterMs).toBeUndefined()
+  })
+
+  test("does not retry deterministic 402, 501, or 505 responses", () => {
+    for (const statusCode of [402, 501, 505]) {
+      const error = new MessageV2.APIError({ message: "failure", statusCode, isRetryable: true }).toObject()
+      expect(decide(error)).toMatchObject({ retryable: false, kind: "terminal", statusCode })
+    }
+  })
+
+  test("jitter never exceeds the configured delay ceiling", () => {
+    const decision = { retryable: true, phase: "stream" as const, scope: "live-step" as const, kind: "server" as const, message: "503" }
+    for (let i = 0; i < 100; i++) expect(SessionRetry.retryDelay(1, decision, 1, 100, 100)).toBeLessThanOrEqual(100)
   })
 
   test("uses the 5-to-60-second network backoff without jitter", () => {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -141,13 +141,22 @@ describe("session.retry.retryable", () => {
   test("selects a long network budget without widening request server retries", () => {
     const resolved = SessionRetry.resolve(undefined, "test")
     expect(SessionRetry.budgetFor(resolved, { retryable: true, phase: "stream", scope: "live-step", kind: "network", message: "reset" }).mode).toBe("persistent")
-    expect(SessionRetry.budgetFor(resolved, { retryable: true, phase: "request", scope: "request", kind: "server", message: "503" }).maxRetries).toBe(1)
+    expect(SessionRetry.budgetFor(resolved, { retryable: true, phase: "request", scope: "request", kind: "server", message: "503" }).maxRetries).toBe(4)
     expect(resolved.unknown).toMatchObject({ maxRetries: 8, maxElapsedMs: 15 * 60_000 })
+    expect(resolved.request.jitterRatio).toBe(0.1)
+    expect(resolved.network.jitterRatio).toBe(0)
   })
 
   test("caps retry-after by the selected budget", () => {
     const decision = { retryable: true, phase: "stream" as const, scope: "live-step" as const, kind: "rate_limit" as const, message: "429", retryAfterMs: 120000 }
     expect(SessionRetry.retryDelay(1, decision, 0, 100, 5000)).toBe(5000)
+  })
+
+  test("uses the 5-to-60-second network backoff without jitter", () => {
+    const decision = { retryable: true, phase: "stream" as const, scope: "live-step" as const, kind: "network" as const, message: "connection failed" }
+    const resolved = SessionRetry.resolve(undefined, "test")
+    const budget = SessionRetry.budgetFor(resolved, decision)
+    expect([1, 2, 3, 4, 5].map((attempt) => SessionRetry.retryDelay(attempt, decision, budget.jitterRatio, budget.initialDelayMs, budget.maxDelayMs))).toStrictEqual([5000, 10000, 20000, 40000, 60000])
   })
 
   test("recognizes GPT models by configured or API model ID", () => {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -29,55 +29,55 @@ function wrap(message: unknown): ReturnType<NamedError["toObject"]> {
 describe("session.retry.delay", () => {
   test("caps delay at 30 seconds when headers missing", () => {
     const error = apiError()
-    const delays = Array.from({ length: 10 }, (_, index) => SessionRetry.delay(index + 1, error))
+    const delays = Array.from({ length: 10 }, (_, index) => SessionRetry.retryDelay(index + 1, decide(error), 0, 2000, 30_000))
     expect(delays).toStrictEqual([2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000, 30000])
   })
 
   test("prefers retry-after-ms when shorter than exponential", () => {
     const error = apiError({ "retry-after-ms": "1500" })
-    expect(SessionRetry.delay(4, error)).toBe(1500)
+    expect(SessionRetry.retryDelay(4, decide(error), 0, 2000, SessionRetry.RETRY_MAX_DELAY)).toBe(1500)
   })
 
   test("uses retry-after seconds when reasonable", () => {
     const error = apiError({ "retry-after": "30" })
-    expect(SessionRetry.delay(3, error)).toBe(30000)
+    expect(SessionRetry.retryDelay(3, decide(error), 0, 2000, SessionRetry.RETRY_MAX_DELAY)).toBe(30000)
   })
 
   test("accepts http-date retry-after values", () => {
     const date = new Date(Date.now() + 20000).toUTCString()
     const error = apiError({ "retry-after": date })
-    const d = SessionRetry.delay(1, error)
+    const d = SessionRetry.retryDelay(1, decide(error), 0, 2000, SessionRetry.RETRY_MAX_DELAY)
     expect(d).toBeGreaterThanOrEqual(19000)
     expect(d).toBeLessThanOrEqual(20000)
   })
 
   test("ignores invalid retry hints", () => {
     const error = apiError({ "retry-after": "not-a-number" })
-    expect(SessionRetry.delay(1, error)).toBe(2000)
+    expect(SessionRetry.retryDelay(1, decide(error), 0, 2000, 30_000)).toBe(2000)
   })
 
   test("ignores malformed date retry hints", () => {
     const error = apiError({ "retry-after": "Invalid Date String" })
-    expect(SessionRetry.delay(1, error)).toBe(2000)
+    expect(SessionRetry.retryDelay(1, decide(error), 0, 2000, 30_000)).toBe(2000)
   })
 
   test("ignores past date retry hints", () => {
     const pastDate = new Date(Date.now() - 5000).toUTCString()
     const error = apiError({ "retry-after": pastDate })
-    expect(SessionRetry.delay(1, error)).toBe(2000)
+    expect(SessionRetry.retryDelay(1, decide(error), 0, 2000, 30_000)).toBe(2000)
   })
 
   test("uses retry-after values even when exceeding 10 minutes with headers", () => {
     const error = apiError({ "retry-after": "50" })
-    expect(SessionRetry.delay(1, error)).toBe(50000)
+    expect(SessionRetry.retryDelay(1, decide(error), 0, 2000, SessionRetry.RETRY_MAX_DELAY)).toBe(50000)
 
     const longError = apiError({ "retry-after-ms": "700000" })
-    expect(SessionRetry.delay(1, longError)).toBe(700000)
+    expect(SessionRetry.retryDelay(1, decide(longError), 0, 2000, SessionRetry.RETRY_MAX_DELAY)).toBe(700000)
   })
 
   test("caps oversized header delays to the runtime timer limit", () => {
     const error = apiError({ "retry-after-ms": "999999999999" })
-    expect(SessionRetry.delay(1, error)).toBe(SessionRetry.RETRY_MAX_DELAY)
+    expect(SessionRetry.retryDelay(1, decide(error), 0, 2000, SessionRetry.RETRY_MAX_DELAY)).toBe(SessionRetry.RETRY_MAX_DELAY)
   })
 
   test("policy updates retry status and increments attempts", async () => {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -142,6 +142,7 @@ describe("session.retry.retryable", () => {
     const resolved = SessionRetry.resolve(undefined, "test")
     expect(SessionRetry.budgetFor(resolved, { retryable: true, phase: "stream", scope: "live-step", kind: "network", message: "reset" }).mode).toBe("persistent")
     expect(SessionRetry.budgetFor(resolved, { retryable: true, phase: "request", scope: "request", kind: "server", message: "503" }).maxRetries).toBe(1)
+    expect(resolved.unknown).toMatchObject({ maxRetries: 8, maxElapsedMs: 15 * 60_000 })
   })
 
   test("caps retry-after by the selected budget", () => {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test"
 import type { NamedError } from "@mimo-ai/shared/util/error"
 import { APICallError, RetryError } from "ai"
 import { setTimeout as sleep } from "node:timers/promises"
-import { Effect, Schedule } from "effect"
+import { Effect, Schedule, Schema } from "effect"
+import { ConfigRetry } from "../../src/config/retry"
 import { SessionRetry, decide, isRetryableTransientError, retryable } from "../../src/session/retry"
 import { MessageV2 } from "../../src/session/message-v2"
 import { ProviderID } from "../../src/provider/schema"
@@ -121,6 +122,63 @@ describe("session.retry.delay", () => {
         })
       },
     })
+  })
+
+  test("status retry attempts stay global across request and stream phases", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const sessionID = SessionID.make("session-retry-phase-counter")
+        const result = await AppRuntime.runPromise(
+          SessionStatus.Service.use((svc) =>
+            Effect.gen(function* () {
+              yield* svc.setRetry(sessionID, {
+                type: "retry",
+                attempt: 1,
+                phaseAttempt: 1,
+                message: "request",
+                next: Date.now(),
+                phase: "request",
+                scope: "request",
+              })
+              const attempt = yield* svc.setRetry(sessionID, {
+                type: "retry",
+                attempt: 1,
+                phaseAttempt: 1,
+                message: "stream",
+                next: Date.now(),
+                phase: "stream",
+                scope: "live-step",
+              })
+              const status = yield* svc.get(sessionID)
+              return { attempt, status }
+            }),
+          ),
+        )
+        expect(result.attempt).toBe(2)
+        expect(result.status).toMatchObject({ type: "retry", attempt: 2, phaseAttempt: 1, phase: "stream" })
+      },
+    })
+  })
+
+  test("requires explicit noDeadline instead of deadlineMs zero", () => {
+    const decode = Schema.decodeUnknownSync(ConfigRetry.Budget)
+    expect(() => decode({ deadlineMs: 0 })).toThrow()
+    expect(decode({ mode: "persistent", noDeadline: true })).toMatchObject({ noDeadline: true })
+    expect(SessionRetry.resolve({ retry: { server: { maxRetries: 2, noDeadline: true } } }).server.maxElapsedMs).toBe(0)
+    expect(
+      SessionRetry.resolve(
+        { retry: { server: { noDeadline: true } }, provider: { test: { retry: { server: { deadlineMs: 1000 } } } } },
+        "test",
+      ).server.maxElapsedMs,
+    ).toBe(1000)
+    expect(
+      SessionRetry.resolve(
+        { retry: { server: { deadlineMs: 1000 } }, provider: { test: { retry: { server: { noDeadline: true } } } } },
+        "test",
+      ).server.maxElapsedMs,
+    ).toBe(0)
   })
 })
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -156,6 +156,9 @@ describe("session.retry.retryable", () => {
   test("parses retry hints with the declared units", () => {
     const error = new MessageV2.APIError({ message: "Please retry in 1 millisecond", statusCode: 429, isRetryable: false }).toObject()
     expect(decide(error).retryAfterMs).toBe(100)
+    expect(decide(new MessageV2.APIError({ message: "Please retry in 5s", statusCode: 429, isRetryable: false }).toObject()).retryAfterMs).toBe(5000)
+    expect(decide(new MessageV2.APIError({ message: "Please retry in 5m", statusCode: 429, isRetryable: false }).toObject()).retryAfterMs).toBe(5 * 60_000)
+    expect(decide(new MessageV2.APIError({ message: "Please retry in 1h", statusCode: 429, isRetryable: false }).toObject()).retryAfterMs).toBe(5 * 60_000)
   })
 
   test("rejects malformed retry-after-ms and floors zero delay", () => {
@@ -172,6 +175,13 @@ describe("session.retry.retryable", () => {
       const error = new MessageV2.APIError({ message: "failure", statusCode, isRetryable: true }).toObject()
       expect(decide(error)).toMatchObject({ retryable: false, kind: "terminal", statusCode })
     }
+  })
+
+  test("only retries provider-specific compatible 404 responses", () => {
+    const generic = new MessageV2.APIError({ message: "missing", statusCode: 404, isRetryable: true }).toObject()
+    const compatible = new MessageV2.APIError({ message: "missing", statusCode: 404, isRetryable: true, metadata: { providerID: "openai" } }).toObject()
+    expect(decide(generic)).toMatchObject({ retryable: false, kind: "terminal" })
+    expect(decide(compatible)).toMatchObject({ retryable: true, kind: "unknown" })
   })
 
   test("jitter never exceeds the configured delay ceiling", () => {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -6,6 +6,7 @@ import { Effect, Schedule } from "effect"
 import { SessionRetry, decide, isRetryableTransientError, retryable } from "../../src/session/retry"
 import { MessageV2 } from "../../src/session/message-v2"
 import { ProviderID } from "../../src/provider/schema"
+import { allowsModelNotFoundRetry } from "../../src/provider/error"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
@@ -179,9 +180,11 @@ describe("session.retry.retryable", () => {
 
   test("only retries provider-specific compatible 404 responses", () => {
     const generic = new MessageV2.APIError({ message: "missing", statusCode: 404, isRetryable: true }).toObject()
-    const compatible = new MessageV2.APIError({ message: "missing", statusCode: 404, isRetryable: true, metadata: { providerID: "openai" } }).toObject()
+    const compatible = new MessageV2.APIError({ message: "missing", statusCode: 404, isRetryable: true, metadata: { allow404Retry: "true" } }).toObject()
     expect(decide(generic)).toMatchObject({ retryable: false, kind: "terminal" })
     expect(decide(compatible)).toMatchObject({ retryable: true, kind: "unknown" })
+    expect(allowsModelNotFoundRetry({ api: { npm: "@ai-sdk/openai-compatible" } })).toBe(true)
+    expect(allowsModelNotFoundRetry({ api: { npm: "custom-provider" } })).toBe(false)
   })
 
   test("jitter never exceeds the configured delay ceiling", () => {
@@ -551,7 +554,7 @@ describe("session.message-v2.fromError", () => {
       responseBody: '{"error":"boom"}',
       isRetryable: false,
     })
-    const result = MessageV2.fromError(error, { providerID: ProviderID.make("openai") }) as MessageV2.APIError
+    const result = MessageV2.fromError(error, { providerID: ProviderID.make("openai"), allow404Retry: true }) as MessageV2.APIError
     expect(result.data.isRetryable).toBe(true)
   })
 })

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -245,6 +245,7 @@ describe("session.retry.retryable", () => {
     expect(decide(compatible)).toMatchObject({ retryable: true, kind: "unknown" })
     expect(allowsModelNotFoundRetry({ api: { npm: "@ai-sdk/openai-compatible" } })).toBe(true)
     expect(allowsModelNotFoundRetry({ api: { npm: "custom-provider" } })).toBe(false)
+    expect(allowsModelNotFoundRetry({})).toBe(false)
   })
 
   test("jitter never exceeds the configured delay ceiling", () => {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -3,7 +3,7 @@ import type { NamedError } from "@mimo-ai/shared/util/error"
 import { APICallError, RetryError } from "ai"
 import { setTimeout as sleep } from "node:timers/promises"
 import { Effect, Schedule } from "effect"
-import { SessionRetry, isRetryableTransientError, retryable } from "../../src/session/retry"
+import { SessionRetry, decide, isRetryableTransientError, retryable } from "../../src/session/retry"
 import { MessageV2 } from "../../src/session/message-v2"
 import { ProviderID } from "../../src/provider/schema"
 import { AppRuntime } from "../../src/effect/app-runtime"
@@ -124,6 +124,31 @@ describe("session.retry.delay", () => {
 })
 
 describe("session.retry.retryable", () => {
+  test("resolves persistent network defaults and provider overrides", () => {
+    const resolved = SessionRetry.resolve({
+      retry: {
+        network: { mode: "bounded", maxRetries: 4, initialDelayMs: 100, maxDelayMs: 1000 },
+        stream: { maxRetries: 9 },
+      },
+      provider: {
+        test: { retry: { network: { mode: "persistent", deadlineMs: 60000 }, stream: { maxRetries: 12 } } },
+      },
+    }, "test")
+    expect(resolved.network).toMatchObject({ mode: "persistent", maxRetries: undefined, maxElapsedMs: 60000, initialDelayMs: 100, maxDelayMs: 1000 })
+    expect(resolved.stream.maxRetries).toBe(12)
+  })
+
+  test("selects a long network budget without widening request server retries", () => {
+    const resolved = SessionRetry.resolve(undefined, "test")
+    expect(SessionRetry.budgetFor(resolved, { retryable: true, phase: "stream", scope: "live-step", kind: "network", message: "reset" }).mode).toBe("persistent")
+    expect(SessionRetry.budgetFor(resolved, { retryable: true, phase: "request", scope: "request", kind: "server", message: "503" }).maxRetries).toBe(1)
+  })
+
+  test("caps retry-after by the selected budget", () => {
+    const decision = { retryable: true, phase: "stream" as const, scope: "live-step" as const, kind: "rate_limit" as const, message: "429", retryAfterMs: 120000 }
+    expect(SessionRetry.retryDelay(1, decision, 0, 100, 5000)).toBe(5000)
+  })
+
   test("recognizes GPT models by configured or API model ID", () => {
     expect(SessionRetry.isGptModel({ id: "gpt-5.2", api: { id: "gpt-5.2" } })).toBe(true)
     expect(SessionRetry.isGptModel({ id: "coding-model", api: { id: "gpt-5.2" } })).toBe(true)
@@ -151,7 +176,10 @@ describe("session.retry.retryable", () => {
     expect(
       SessionRetry.isGptServerOverloadedError({
         ...error,
-        data: { ...error.data, responseBody: JSON.stringify({ ...body, error: { ...body.error, code: "server_error" } }) },
+        data: {
+          ...error.data,
+          responseBody: JSON.stringify({ ...body, error: { ...body.error, code: "server_error" } }),
+        },
       }),
     ).toBe(false)
   })
@@ -178,6 +206,7 @@ describe("session.retry.retryable", () => {
             SessionRetry.policy({
               parse: (input) => input as MessageV2.APIError,
               silentRetry: SessionRetry.isGptServerOverloadedError,
+              initialDelayMs: 0,
               set: (info) => Effect.sync(() => visible.push(info.attempt)),
             }),
           ),
@@ -185,7 +214,7 @@ describe("session.retry.retryable", () => {
       ),
     ).rejects.toBe(error)
     expect(attempts).toBe(4)
-    expect(visible).toEqual([])
+    expect(visible).toEqual([2, 3])
   })
 
   test("retries OpenAI server_error stream events", () => {
@@ -537,7 +566,18 @@ describe("isRetryableTransientError", () => {
   })
 
   test("ECONNRESET / EPIPE / ETIMEDOUT codes", () => {
-    for (const code of ["ECONNRESET", "EPIPE", "ETIMEDOUT"]) {
+    for (const code of [
+      "ECONNABORTED",
+      "ECONNREFUSED",
+      "ECONNRESET",
+      "EAI_AGAIN",
+      "EPIPE",
+      "ETIMEDOUT",
+      "UND_ERR_BODY_TIMEOUT",
+      "UND_ERR_CONNECT_TIMEOUT",
+      "UND_ERR_HEADERS_TIMEOUT",
+      "UND_ERR_SOCKET",
+    ]) {
       const err = Object.assign(new Error("network"), { code })
       expect(isRetryableTransientError(err)).toBe(true)
     }
@@ -574,6 +614,18 @@ describe("isRetryableTransientError", () => {
     const err400 = Object.assign(new Error("bad req"), { status: 400 })
     expect(isRetryableTransientError(err400)).toBe(false)
   })
+
+  test("follows a wrapped network cause", () => {
+    const cause = Object.assign(new Error("socket closed"), { code: "UND_ERR_SOCKET" })
+    const error = Object.assign(new TypeError("fetch failed"), { cause })
+    expect(isRetryableTransientError(error)).toBe(true)
+  })
+
+  test("does not retry an aborted request with a network cause", () => {
+    const cause = Object.assign(new Error("socket reset"), { code: "ECONNRESET" })
+    const error = Object.assign(new DOMException("The user aborted the request", "AbortError"), { cause })
+    expect(isRetryableTransientError(error)).toBe(false)
+  })
 })
 
 describe("retryable() with raw Error (Spec ③ P2 regression)", () => {
@@ -590,5 +642,102 @@ describe("retryable() with raw Error (Spec ③ P2 regression)", () => {
   test("non-transient raw Error returns undefined (existing path)", () => {
     const rawErr = new Error("some user mistake")
     expect(retryable(rawErr as unknown as never)).toBeUndefined()
+  })
+})
+
+describe("retry decision and coordinator budget", () => {
+ test("terminal abort wins over a retryable status in its cause chain", () => {
+    const cause = Object.assign(new Error("socket reset"), { code: "ECONNRESET" })
+    const error = Object.assign(new DOMException("user aborted", "AbortError"), { cause, status: 503 })
+   expect(decide(error)).toMatchObject({ retryable: false, kind: "terminal" })
+ })
+
+  test("treats an Undici transport abort as network-transient, not user abort", () => {
+    const error = Object.assign(new Error("request aborted by transport"), { name: "AbortError", code: "UND_ERR_ABORTED" })
+    expect(decide(error)).toMatchObject({ retryable: true, kind: "network" })
+  })
+
+  test("classifies quota exhaustion as terminal instead of a retry", () => {
+    const error = new MessageV2.APIError({
+      message: "Rate limit exceeded",
+      statusCode: 429,
+      isRetryable: false,
+      responseBody: JSON.stringify({ type: "FreeUsageLimitError" }),
+    }).toObject()
+    expect(decide(error)).toMatchObject({ retryable: false, kind: "terminal", uiMessage: SessionRetry.GO_UPSELL_MESSAGE })
+  })
+
+  test("terminal UI notice is emitted without scheduling a retry", async () => {
+    const error = new MessageV2.APIError({
+      message: "Rate limit exceeded",
+      statusCode: 429,
+      isRetryable: false,
+      responseBody: JSON.stringify({ type: "FreeUsageLimitError" }),
+    }).toObject()
+    let attempts = 0
+    let notices = 0
+    const schedule = SessionRetry.policy({
+      onTerminal: (decision) => decision.uiMessage ? Effect.sync(() => notices++) : Effect.void,
+      parse: (input) => input as ReturnType<NamedError["toObject"]>,
+      set: () => Effect.void,
+    })
+    await expect(
+      Effect.runPromise(Effect.suspend(() => { attempts++; return Effect.fail(error) }).pipe(Effect.retry(schedule))),
+    ).rejects.toBe(error)
+    expect(attempts).toBe(1)
+    expect(notices).toBe(1)
+  })
+
+  test("caps natural-language retry delays and recognizes body-only rate limits", () => {
+    const error = new MessageV2.APIError({
+      message: "Try again in 24 hours",
+      statusCode: 429,
+      isRetryable: false,
+      responseBody: JSON.stringify({ error: { code: "rate_limit_error", message: "Try again in 24 hours" } }),
+    }).toObject()
+    expect(decide(error)).toMatchObject({ retryable: true, kind: "rate_limit", retryAfterMs: 5 * 60_000 })
+  })
+
+  test("starts the retry deadline at the first failure, not policy construction", async () => {
+    const error = new MessageV2.APIError({ message: "server", statusCode: 503, isRetryable: false }).toObject()
+    let attempts = 0
+    const schedule = SessionRetry.policy({
+      maxElapsedMs: 10,
+      initialDelayMs: 0,
+      jitterRatio: 0,
+      parse: (input) => input as ReturnType<NamedError["toObject"]>,
+      set: () => Effect.void,
+    })
+    const result = await Effect.runPromise(Effect.suspend(() => Effect.gen(function* () {
+      attempts++
+      if (attempts === 1) { yield* Effect.sleep("20 millis"); return yield* Effect.fail(error) }
+      return "ok"
+    })).pipe(Effect.retry(schedule)))
+    expect(result).toBe("ok")
+    expect(attempts).toBe(2)
+  })
+
+  test("does not schedule a retry after the attempt crossed the side-effect boundary", async () => {
+    const error = new MessageV2.APIError({ message: "server", statusCode: 503, isRetryable: false }).toObject()
+    let attempts = 0
+    let retryEvents = 0
+    const schedule = SessionRetry.policy({
+      phase: "stream",
+      maxRetries: 5,
+      replaySafe: () => false,
+      parse: (input) => input as ReturnType<NamedError["toObject"]>,
+      set: () => Effect.sync(() => retryEvents++),
+    })
+
+    await expect(
+      Effect.runPromise(
+        Effect.suspend(() => {
+          attempts++
+          return Effect.fail(error)
+        }).pipe(Effect.retry(schedule)),
+      ),
+    ).rejects.toBe(error)
+    expect(attempts).toBe(1)
+    expect(retryEvents).toBe(0)
   })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -583,6 +583,9 @@ export type EventSessionRetryAttempt = {
     messageID: string
     attempt: number
     maxAttempts: number
+    phase: "request" | "stream"
+    kind: "network" | "rate_limit" | "server" | "stream" | "unknown" | "terminal"
+    scope: "request" | "live-step" | "max-candidate" | "max-judge"
     reason: string
     nextDelayMs: number
   }
@@ -1841,6 +1844,68 @@ export type ProviderConfig = {
     chunkTimeout?: number
     [key: string]: unknown | string | boolean | number | false | number | false | number | undefined
   }
+  /**
+   * Provider-specific overrides for retry budgets
+   */
+  retry?: {
+    request?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    stream?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    maxCandidate?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    maxJudge?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    network?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    server?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    rateLimit?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    unknown?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    jitterRatio?: number
+  }
   models?: {
     [key: string]: {
       id?: string
@@ -2139,6 +2204,68 @@ export type Config = {
    */
   provider?: {
     [key: string]: ProviderConfig
+  }
+  /**
+   * Retry budgets for provider requests, streams, and long-running network recovery
+   */
+  retry?: {
+    request?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    stream?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    maxCandidate?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    maxJudge?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    network?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    server?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    rateLimit?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    unknown?: {
+      mode?: "bounded" | "persistent"
+      maxRetries?: number
+      deadlineMs?: number
+      initialDelayMs?: number
+      maxDelayMs?: number
+    }
+    jitterRatio?: number
   }
   /**
    * MCP (Model Context Protocol) server configurations

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -772,6 +772,8 @@ export type SessionStatus =
       attempt: number
       message: string
       next: number
+      phase?: "request" | "stream"
+      scope?: "request" | "live-step" | "max-candidate" | "max-judge"
     }
   | {
       type: "notice"

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -774,6 +774,10 @@ export type SessionStatus =
       next: number
     }
   | {
+      type: "notice"
+      message: string
+    }
+  | {
       type: "busy"
       message?: string
     }
@@ -1849,64 +1853,136 @@ export type ProviderConfig = {
    */
   retry?: {
     request?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     stream?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     maxCandidate?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     maxJudge?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     network?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     server?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     rateLimit?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     unknown?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2218,64 +2294,136 @@ export type Config = {
    */
   retry?: {
     request?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     stream?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     maxCandidate?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     maxJudge?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     network?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     server?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     rateLimit?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
     }
     unknown?: {
+      /**
+       * bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline
+       */
       mode?: "bounded" | "persistent"
+      /**
+       * Retries after the initial attempt; 0 disables retries and the maximum is 100
+       */
       maxRetries?: number
+      /**
+       * Wall-clock retry deadline in milliseconds; 0 means no deadline
+       */
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1854,6 +1854,7 @@ export type ProviderConfig = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     stream?: {
       mode?: "bounded" | "persistent"
@@ -1861,6 +1862,7 @@ export type ProviderConfig = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     maxCandidate?: {
       mode?: "bounded" | "persistent"
@@ -1868,6 +1870,7 @@ export type ProviderConfig = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     maxJudge?: {
       mode?: "bounded" | "persistent"
@@ -1875,6 +1878,7 @@ export type ProviderConfig = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     network?: {
       mode?: "bounded" | "persistent"
@@ -1882,6 +1886,7 @@ export type ProviderConfig = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     server?: {
       mode?: "bounded" | "persistent"
@@ -1889,6 +1894,7 @@ export type ProviderConfig = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     rateLimit?: {
       mode?: "bounded" | "persistent"
@@ -1896,6 +1902,7 @@ export type ProviderConfig = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     unknown?: {
       mode?: "bounded" | "persistent"
@@ -1903,6 +1910,7 @@ export type ProviderConfig = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     jitterRatio?: number
   }
@@ -2215,6 +2223,7 @@ export type Config = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     stream?: {
       mode?: "bounded" | "persistent"
@@ -2222,6 +2231,7 @@ export type Config = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     maxCandidate?: {
       mode?: "bounded" | "persistent"
@@ -2229,6 +2239,7 @@ export type Config = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     maxJudge?: {
       mode?: "bounded" | "persistent"
@@ -2236,6 +2247,7 @@ export type Config = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     network?: {
       mode?: "bounded" | "persistent"
@@ -2243,6 +2255,7 @@ export type Config = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     server?: {
       mode?: "bounded" | "persistent"
@@ -2250,6 +2263,7 @@ export type Config = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     rateLimit?: {
       mode?: "bounded" | "persistent"
@@ -2257,6 +2271,7 @@ export type Config = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     unknown?: {
       mode?: "bounded" | "persistent"
@@ -2264,6 +2279,7 @@ export type Config = {
       deadlineMs?: number
       initialDelayMs?: number
       maxDelayMs?: number
+      jitterRatio?: number
     }
     jitterRatio?: number
   }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -582,6 +582,7 @@ export type EventSessionRetryAttempt = {
     sessionID: string
     messageID: string
     attempt: number
+    phaseAttempt: number
     maxAttempts: number
     phase: "request" | "stream"
     kind: "network" | "rate_limit" | "server" | "stream" | "unknown" | "terminal"
@@ -770,6 +771,7 @@ export type SessionStatus =
   | {
       type: "retry"
       attempt: number
+      phaseAttempt?: number
       message: string
       next: number
       phase?: "request" | "stream"
@@ -1864,9 +1866,10 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -1881,9 +1884,10 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -1898,9 +1902,10 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -1915,9 +1920,10 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -1932,9 +1938,10 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -1949,9 +1956,10 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -1966,9 +1974,10 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -1983,9 +1992,10 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -2305,9 +2315,10 @@ export type Config = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -2322,9 +2333,10 @@ export type Config = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -2339,9 +2351,10 @@ export type Config = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -2356,9 +2369,10 @@ export type Config = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -2373,9 +2387,10 @@ export type Config = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -2390,9 +2405,10 @@ export type Config = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -2407,9 +2423,10 @@ export type Config = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number
@@ -2424,9 +2441,10 @@ export type Config = {
        */
       maxRetries?: number
       /**
-       * Wall-clock retry deadline in milliseconds; 0 means no deadline
-       */
+      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+      */
       deadlineMs?: number
+      noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
       jitterRatio?: number

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -14514,7 +14514,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -14530,6 +14530,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -14543,7 +14548,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -14559,6 +14564,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -14572,7 +14582,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -14588,6 +14598,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -14601,7 +14616,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -14617,6 +14632,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -14630,7 +14650,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -14646,6 +14666,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -14659,7 +14684,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -14675,6 +14700,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -14688,7 +14718,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -14704,6 +14734,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -14717,7 +14752,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -14733,6 +14768,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -15324,7 +15364,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -15340,6 +15380,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -15353,7 +15398,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -15369,6 +15414,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -15382,7 +15432,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -15398,6 +15448,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -15411,7 +15466,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -15427,6 +15482,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -15440,7 +15500,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -15456,6 +15516,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -15469,7 +15534,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -15485,6 +15550,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -15498,7 +15568,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -15514,6 +15584,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },
@@ -15527,7 +15602,7 @@
                   "maxRetries": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 9007199254740991
+                    "maximum": 100
                   },
                   "deadlineMs": {
                     "type": "integer",
@@ -15543,6 +15618,11 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "jitterRatio": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 }
               },

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11363,6 +11363,19 @@
             "properties": {
               "type": {
                 "type": "string",
+                "const": "notice"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": ["type", "message"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
                 "const": "busy"
               },
               "message": {
@@ -14508,15 +14521,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -14542,15 +14558,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -14576,15 +14595,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -14610,15 +14632,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -14644,15 +14669,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -14678,15 +14706,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -14712,15 +14743,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -14746,15 +14780,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -15358,15 +15395,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -15392,15 +15432,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -15426,15 +15469,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -15460,15 +15506,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -15494,15 +15543,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -15528,15 +15580,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -15562,15 +15617,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991
@@ -15596,15 +15654,18 @@
                 "type": "object",
                 "properties": {
                   "mode": {
+                    "description": "bounded stops after maxRetries; persistent ignores the retry count and waits until cancellation or deadline",
                     "type": "string",
                     "enum": ["bounded", "persistent"]
                   },
                   "maxRetries": {
+                    "description": "Retries after the initial attempt; 0 disables retries and the maximum is 100",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 100
                   },
                   "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 9007199254740991

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11354,6 +11354,14 @@
               },
               "next": {
                 "type": "number"
+              },
+              "phase": {
+                "type": "string",
+                "enum": ["request", "stream"]
+              },
+              "scope": {
+                "type": "string",
+                "enum": ["request", "live-step", "max-candidate", "max-judge"]
               }
             },
             "required": ["type", "attempt", "message", "next"]

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -14548,16 +14548,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-              "deadlineMs": {
-                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "maximum": 9007199254740991
-              },
-              "noDeadline": {
-                "description": "Disable the wall-clock retry deadline explicitly",
-                "type": "boolean"
-              },
+                  "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
+                  },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14573,6 +14573,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "stream": {
@@ -14589,16 +14592,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-              "deadlineMs": {
-                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "maximum": 9007199254740991
-              },
-              "noDeadline": {
-                "description": "Disable the wall-clock retry deadline explicitly",
-                "type": "boolean"
-              },
+                  "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
+                  },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14614,6 +14617,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "maxCandidate": {
@@ -14630,16 +14636,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-              "deadlineMs": {
-                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "maximum": 9007199254740991
-              },
-              "noDeadline": {
-                "description": "Disable the wall-clock retry deadline explicitly",
-                "type": "boolean"
-              },
+                  "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
+                  },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14655,6 +14661,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "maxJudge": {
@@ -14671,16 +14680,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-              "deadlineMs": {
-                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "maximum": 9007199254740991
-              },
-              "noDeadline": {
-                "description": "Disable the wall-clock retry deadline explicitly",
-                "type": "boolean"
-              },
+                  "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
+                  },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14696,6 +14705,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "network": {
@@ -14712,16 +14724,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-              "deadlineMs": {
-                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "maximum": 9007199254740991
-              },
-              "noDeadline": {
-                "description": "Disable the wall-clock retry deadline explicitly",
-                "type": "boolean"
-              },
+                  "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
+                  },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14737,6 +14749,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "server": {
@@ -14753,16 +14768,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-              "deadlineMs": {
-                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "maximum": 9007199254740991
-              },
-              "noDeadline": {
-                "description": "Disable the wall-clock retry deadline explicitly",
-                "type": "boolean"
-              },
+                  "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
+                  },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14778,6 +14793,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "rateLimit": {
@@ -14794,16 +14812,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-              "deadlineMs": {
-                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "maximum": 9007199254740991
-              },
-              "noDeadline": {
-                "description": "Disable the wall-clock retry deadline explicitly",
-                "type": "boolean"
-              },
+                  "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
+                  },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14819,6 +14837,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "unknown": {
@@ -14835,16 +14856,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-              "deadlineMs": {
-                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "maximum": 9007199254740991
-              },
-              "noDeadline": {
-                "description": "Disable the wall-clock retry deadline explicitly",
-                "type": "boolean"
-              },
+                  "deadlineMs": {
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
+                  },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14860,6 +14881,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "jitterRatio": {
@@ -15479,6 +15503,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "stream": {
@@ -15520,6 +15547,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "maxCandidate": {
@@ -15561,6 +15591,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "maxJudge": {
@@ -15602,6 +15635,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "network": {
@@ -15643,6 +15679,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "server": {
@@ -15684,6 +15723,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "rateLimit": {
@@ -15725,6 +15767,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "unknown": {
@@ -15766,6 +15811,9 @@
                     "minimum": 0,
                     "maximum": 1
                   }
+                },
+                "not": {
+                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "jitterRatio": {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -4010,7 +4010,18 @@
                     "$ref": "#/components/schemas/OutputFormat"
                   },
                   "system": {
+                    "description": "Additional system prompt selected by the session's first user query. Later values are ignored.",
                     "type": "string"
+                  },
+                  "systemMode": {
+                    "description": "Whether the selected system prompt appends to or replaces the agent prompt. Later values are ignored.",
+                    "type": "string",
+                    "enum": ["append", "replace-agent"]
+                  },
+                  "harness": {
+                    "description": "Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
+                    "type": "string",
+                    "enum": ["auto", "codex", "default"]
                   },
                   "variant": {
                     "type": "string"
@@ -4398,6 +4409,196 @@
         ]
       }
     },
+    "/session/{sessionID}/recovery": {
+      "get": {
+        "operationId": "session.recovery",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "agentID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List interrupted turn recovery candidates",
+        "description": "Return the latest incomplete assistant turn that can be resumed without creating a user message.",
+        "responses": {
+          "200": {
+            "description": "Recovery candidates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "assistantMessageID": {
+                        "type": "string",
+                        "pattern": "^msg.*"
+                      },
+                      "parentMessageID": {
+                        "type": "string",
+                        "pattern": "^msg.*"
+                      },
+                      "created": {
+                        "type": "number"
+                      }
+                    },
+                    "required": ["assistantMessageID", "parentMessageID", "created"]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@mimo-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.recovery({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/turn/{assistantMessageID}/resume": {
+      "post": {
+        "operationId": "session.resume",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "assistantMessageID",
+            "schema": {
+              "type": "string",
+              "pattern": "^msg.*"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "agentID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "task_id",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Resume an interrupted turn",
+        "description": "Resume an incomplete assistant turn without creating another user message.",
+        "responses": {
+          "202": {
+            "description": "Resume accepted"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — session resource is busy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConflictError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@mimo-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.resume({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}/prompt_async": {
       "post": {
         "operationId": "session.prompt_async",
@@ -4513,7 +4714,18 @@
                     "$ref": "#/components/schemas/OutputFormat"
                   },
                   "system": {
+                    "description": "Additional system prompt selected by the session's first user query. Later values are ignored.",
                     "type": "string"
+                  },
+                  "systemMode": {
+                    "description": "Whether the selected system prompt appends to or replaces the agent prompt. Later values are ignored.",
+                    "type": "string",
+                    "enum": ["append", "replace-agent"]
+                  },
+                  "harness": {
+                    "description": "Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
+                    "type": "string",
+                    "enum": ["auto", "codex", "default"]
                   },
                   "variant": {
                     "type": "string"
@@ -4650,6 +4862,20 @@
                   },
                   "variant": {
                     "type": "string"
+                  },
+                  "system": {
+                    "description": "Additional system prompt selected by the session's first user command. Later values are ignored.",
+                    "type": "string"
+                  },
+                  "systemMode": {
+                    "description": "Whether the selected system prompt appends to or replaces the agent prompt. Later values are ignored.",
+                    "type": "string",
+                    "enum": ["append", "replace-agent"]
+                  },
+                  "harness": {
+                    "description": "Harness mode selected by the session's first user command. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
+                    "type": "string",
+                    "enum": ["auto", "codex", "default"]
                   },
                   "parts": {
                     "type": "array",
@@ -10623,8 +10849,20 @@
               },
               "maxAttempts": {
                 "type": "integer",
-                "minimum": 1,
+                "minimum": 0,
                 "maximum": 9007199254740991
+              },
+              "phase": {
+                "type": "string",
+                "enum": ["request", "stream"]
+              },
+              "kind": {
+                "type": "string",
+                "enum": ["network", "rate_limit", "server", "stream", "unknown", "terminal"]
+              },
+              "scope": {
+                "type": "string",
+                "enum": ["request", "live-step", "max-candidate", "max-judge"]
               },
               "reason": {
                 "type": "string"
@@ -10635,7 +10873,17 @@
                 "maximum": 9007199254740991
               }
             },
-            "required": ["sessionID", "messageID", "attempt", "maxAttempts", "reason", "nextDelayMs"]
+            "required": [
+              "sessionID",
+              "messageID",
+              "attempt",
+              "maxAttempts",
+              "phase",
+              "kind",
+              "scope",
+              "reason",
+              "nextDelayMs"
+            ]
           }
         },
         "required": ["type", "properties"]
@@ -11764,6 +12012,14 @@
           },
           "system": {
             "type": "string"
+          },
+          "systemMode": {
+            "type": "string",
+            "enum": ["append", "replace-agent"]
+          },
+          "harness": {
+            "type": "string",
+            "enum": ["auto", "codex", "default"]
           },
           "tools": {
             "type": "object",
@@ -13001,6 +13257,24 @@
           "permission": {
             "$ref": "#/components/schemas/PermissionRuleset"
           },
+          "prompt": {
+            "type": "object",
+            "properties": {
+              "system": {
+                "type": "string"
+              },
+              "systemMode": {
+                "default": "append",
+                "type": "string",
+                "enum": ["append", "replace-agent"]
+              },
+              "harness": {
+                "type": "string",
+                "enum": ["auto", "codex", "default"]
+              }
+            },
+            "required": ["harness"]
+          },
           "revert": {
             "type": "object",
             "properties": {
@@ -13523,6 +13797,31 @@
                       }
                     ]
                   },
+                  "prompt": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "system": {
+                            "type": "string"
+                          },
+                          "systemMode": {
+                            "default": "append",
+                            "type": "string",
+                            "enum": ["append", "replace-agent"]
+                          },
+                          "harness": {
+                            "type": "string",
+                            "enum": ["auto", "codex", "default"]
+                          }
+                        },
+                        "required": ["harness"]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
                   "revert": {
                     "anyOf": [
                       {
@@ -13564,6 +13863,7 @@
                   "title",
                   "version",
                   "permission",
+                  "prompt",
                   "revert"
                 ]
               }
@@ -14200,6 +14500,249 @@
             },
             "additionalProperties": {}
           },
+          "retry": {
+            "description": "Provider-specific overrides for retry budgets",
+            "type": "object",
+            "properties": {
+              "request": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "stream": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "maxCandidate": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "maxJudge": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "network": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "server": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "rateLimit": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "unknown": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "jitterRatio": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            }
+          },
           "models": {
             "type": "object",
             "propertyNames": {
@@ -14767,6 +15310,249 @@
               "$ref": "#/components/schemas/ProviderConfig"
             }
           },
+          "retry": {
+            "description": "Retry budgets for provider requests, streams, and long-running network recovery",
+            "type": "object",
+            "properties": {
+              "request": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "stream": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "maxCandidate": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "maxJudge": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "network": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "server": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "rateLimit": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "unknown": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": ["bounded", "persistent"]
+                  },
+                  "maxRetries": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "deadlineMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "initialDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "maxDelayMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "jitterRatio": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            }
+          },
           "mcp": {
             "description": "MCP (Model Context Protocol) server configurations",
             "type": "object",
@@ -14981,7 +15767,7 @@
                 "maximum": 9007199254740991
               },
               "reserved": {
-                "description": "Token buffer for compaction. Leaves enough window to avoid overflow during compaction.",
+                "description": "Token buffer for compaction. Leaves enough window to avoid overflow during compaction (default: up to 33000, capped by the model's maximum output).",
                 "type": "integer",
                 "minimum": 0,
                 "maximum": 9007199254740991
@@ -15945,6 +16731,24 @@
           },
           "permission": {
             "$ref": "#/components/schemas/PermissionRuleset"
+          },
+          "prompt": {
+            "type": "object",
+            "properties": {
+              "system": {
+                "type": "string"
+              },
+              "systemMode": {
+                "default": "append",
+                "type": "string",
+                "enum": ["append", "replace-agent"]
+              },
+              "harness": {
+                "type": "string",
+                "enum": ["auto", "codex", "default"]
+              }
+            },
+            "required": ["harness"]
           },
           "revert": {
             "type": "object",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10847,6 +10847,11 @@
                 "minimum": 1,
                 "maximum": 9007199254740991
               },
+              "phaseAttempt": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 9007199254740991
+              },
               "maxAttempts": {
                 "type": "integer",
                 "minimum": 0,
@@ -10877,6 +10882,7 @@
               "sessionID",
               "messageID",
               "attempt",
+              "phaseAttempt",
               "maxAttempts",
               "phase",
               "kind",
@@ -11347,6 +11353,9 @@
                 "const": "retry"
               },
               "attempt": {
+                "type": "number"
+              },
+              "phaseAttempt": {
                 "type": "number"
               },
               "message": {
@@ -14539,12 +14548,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-                  "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
+              "deadlineMs": {
+                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "noDeadline": {
+                "description": "Disable the wall-clock retry deadline explicitly",
+                "type": "boolean"
+              },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14576,12 +14589,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-                  "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
+              "deadlineMs": {
+                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "noDeadline": {
+                "description": "Disable the wall-clock retry deadline explicitly",
+                "type": "boolean"
+              },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14613,12 +14630,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-                  "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
+              "deadlineMs": {
+                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "noDeadline": {
+                "description": "Disable the wall-clock retry deadline explicitly",
+                "type": "boolean"
+              },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14650,12 +14671,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-                  "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
+              "deadlineMs": {
+                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "noDeadline": {
+                "description": "Disable the wall-clock retry deadline explicitly",
+                "type": "boolean"
+              },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14687,12 +14712,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-                  "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
+              "deadlineMs": {
+                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "noDeadline": {
+                "description": "Disable the wall-clock retry deadline explicitly",
+                "type": "boolean"
+              },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14724,12 +14753,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-                  "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
+              "deadlineMs": {
+                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "noDeadline": {
+                "description": "Disable the wall-clock retry deadline explicitly",
+                "type": "boolean"
+              },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14761,12 +14794,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-                  "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
+              "deadlineMs": {
+                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "noDeadline": {
+                "description": "Disable the wall-clock retry deadline explicitly",
+                "type": "boolean"
+              },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -14798,12 +14835,16 @@
                     "minimum": 0,
                     "maximum": 100
                   },
-                  "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
+              "deadlineMs": {
+                "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "noDeadline": {
+                "description": "Disable the wall-clock retry deadline explicitly",
+                "type": "boolean"
+              },
                   "initialDelayMs": {
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -15414,10 +15455,14 @@
                     "maximum": 100
                   },
                   "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
                     "type": "integer",
-                    "minimum": 0,
+                    "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
                   },
                   "initialDelayMs": {
                     "type": "integer",
@@ -15451,10 +15496,14 @@
                     "maximum": 100
                   },
                   "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
                     "type": "integer",
-                    "minimum": 0,
+                    "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
                   },
                   "initialDelayMs": {
                     "type": "integer",
@@ -15488,10 +15537,14 @@
                     "maximum": 100
                   },
                   "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
                     "type": "integer",
-                    "minimum": 0,
+                    "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
                   },
                   "initialDelayMs": {
                     "type": "integer",
@@ -15525,10 +15578,14 @@
                     "maximum": 100
                   },
                   "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
                     "type": "integer",
-                    "minimum": 0,
+                    "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
                   },
                   "initialDelayMs": {
                     "type": "integer",
@@ -15562,10 +15619,14 @@
                     "maximum": 100
                   },
                   "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
                     "type": "integer",
-                    "minimum": 0,
+                    "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
                   },
                   "initialDelayMs": {
                     "type": "integer",
@@ -15599,10 +15660,14 @@
                     "maximum": 100
                   },
                   "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
                     "type": "integer",
-                    "minimum": 0,
+                    "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
                   },
                   "initialDelayMs": {
                     "type": "integer",
@@ -15636,10 +15701,14 @@
                     "maximum": 100
                   },
                   "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
                     "type": "integer",
-                    "minimum": 0,
+                    "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
                   },
                   "initialDelayMs": {
                     "type": "integer",
@@ -15673,10 +15742,14 @@
                     "maximum": 100
                   },
                   "deadlineMs": {
-                    "description": "Wall-clock retry deadline in milliseconds; 0 means no deadline",
+                    "description": "Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline",
                     "type": "integer",
-                    "minimum": 0,
+                    "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
+                  },
+                  "noDeadline": {
+                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "type": "boolean"
                   },
                   "initialDelayMs": {
                     "type": "integer",


### PR DESCRIPTION
## Summary

This implements a first-principles, layered retry coordinator for provider failures.

- Separates facts from policy with structured `RetryDecision` classification and explicit scopes: request, live-step, max-candidate, and max-judge.
- Gives terminal outcomes priority over transient hints: user aborts, auth failures, quota exhaustion, context overflow, and deterministic client errors do not retry.
- Preserves a separate terminal UI notice for Go quota upsell, so the TUI dialog remains functional without retrying the request.
- Normalizes bounded cause and aggregate chains, including network codes, Undici failures, SSE timeouts, stream-read failures, and safe cause summaries.
- Separates request setup retry from live stream retry; request retries honor `Retry-After`, emit retry events, and use a short bounded delay.
- Strictly parses retry delay values, caps natural-language delays, adds jitter, and starts the retry deadline at the first retryable failure.
- Prevents live-step replay after a tool call crosses the side-effect boundary.
- Makes GPT overload behavior Codex-like: first retry can be silent, later retries are visible.
- Emits retry scope/phase/kind metadata for live and max-mode attempts.
- Distinguishes Undici transport aborts from user aborts and handles malformed/empty `RetryError` safely.
- Fixes normalized ACP auth handling for missing keys and 401/403 credential rejection.
- Updates OpenAPI and SDK retry event types.

## Validation

- Focused retry matrix: 147 passed, 2 skipped, 0 failed.
- SDK typecheck: passed.
- Changed-package typecheck: no errors in the retry/provider/session/ACP files; latest `origin/main` still reports six pre-existing Permission API errors in `src/cli/cmd/run.ts` and `src/cli/cmd/tui/context/local.tsx`.
- Full package test run was attempted but did not produce a result within the execution window; no full-suite result is claimed.
