### PR TITLE
fix: restrict subagent actor calls to send action only

### DIFF
--- a/packages/opencode/src/tool/actor.shell.txt
+++ b/packages/opencode/src/tool/actor.shell.txt
@@ -1,5 +1,10 @@
 Launch a subagent for complex multi-step tasks autonomously.
 
+Subagent restriction: when running as a subagent, you can ONLY use
+`actor send` to communicate with the parent. All other actions (spawn, run,
+cancel, status, wait, models) are restricted to primary agents. Use
+`actor send main "..."` to report progress or findings.
+
 `actor spawn` is THE DEFAULT: it returns an actor_id immediately, so subagents run in
 PARALLEL in the background and you keep responding to the user. `actor run` BLOCKS the
 whole conversation until the subagent finishes and is a rare exception.

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -524,6 +524,21 @@ export const ActorTool = Tool.define(
         const op = input.operation
         const cfg = yield* config.get()
 
+        // When called through exec, subagents may only use `send` to communicate
+        // with the parent. All other actions (spawn, run, cancel, status, wait,
+        // models) are restricted to primary agents. Peer actors have a primary
+        // agent type so they are unaffected by this guard.
+        if (ctx.extra?.fromExec) {
+          const caller = yield* agent.get(ctx.agent)
+          if (caller?.mode === "subagent" && op.action !== "send") {
+            return yield* Effect.fail(
+              new RecoverableError(
+                `Subagents can only use actor send to communicate with the parent agent. You are running as "${caller.name}"; use actor send with to_actor_id="main" to report progress or findings.`,
+              ),
+            )
+          }
+        }
+
         // Helper: "actor belongs to another session OR doesn't exist" response.
         // Same response for both cases — don't leak the difference (POSIX: you can
         // only reap your own children).

--- a/packages/opencode/src/tool/actor.txt
+++ b/packages/opencode/src/tool/actor.txt
@@ -1,5 +1,10 @@
 Launch a new actor (subagent) to handle complex, multi-step tasks autonomously.
 
+**Subagent restriction:** When you are running as a subagent, you can ONLY use
+`actor send` to communicate with the parent agent. Other actions (spawn, run,
+cancel, etc.) are restricted to primary agents. Use `actor send` with
+to_actor_id="main" to report progress, findings, or blockers to the parent.
+
 JSON calls wrap the action payload inside an `operation` object; `action` is the discriminator field.
 
 **`spawn` is the DEFAULT.** It launches the subagent in the BACKGROUND and returns

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -788,6 +788,7 @@ export const ToolScriptTool = Tool.define(
             publishProgress({ immediate: subParts.length === 1 })
             const subCtx = {
               ...ctx,
+              extra: { ...ctx.extra, fromExec: true },
               callID,
               // Capture nested metadata in its own record. Forwarding it to the
               // outer context would replace exec's title and lose sibling calls.

--- a/packages/opencode/test/tool/actor.test.ts
+++ b/packages/opencode/test/tool/actor.test.ts
@@ -23,12 +23,126 @@ import type { SpawnInput, AgentOutcome } from "../../src/actor/spawn"
 import { Team } from "../../src/team"
 import { Truncate } from "../../src/tool"
 import { ToolRegistry } from "../../src/tool"
+import { RecoverableError } from "../../src/tool/recoverable"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 let prevSpawnRef: typeof spawnRef.current
 beforeAll(() => {
   prevSpawnRef = spawnRef.current
+})
+
+describe("Actor tool fromExec guard", () => {
+  it.live("subagent calling spawn via exec receives RecoverableError", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        yield* installMockSpawn()
+        const { chat, assistant } = yield* seed()
+        const tool = yield* ActorTool
+        const def = yield* tool.init()
+
+        const exit = yield* Effect.exit(def.execute(
+          {
+            operation: {
+              action: "spawn",
+              description: "nested spawn attempt",
+              prompt: "should be blocked",
+              subagent_type: "general",
+            },
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "general",
+            abort: new AbortController().signal,
+            extra: { fromExec: true },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        ))
+
+        expect(exit._tag).toBe("Failure")
+        if (exit._tag === "Failure") {
+          const causeStr = String(exit.cause)
+          expect(causeStr).toContain("Subagents can only use actor send")
+        }
+      }),
+    ),
+  )
+
+  it.live("subagent calling send via exec is allowed", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const tool = yield* ActorTool
+        const def = yield* tool.init()
+
+        const exit = yield* Effect.exit(def.execute(
+          {
+            operation: {
+              action: "send",
+              to_actor_id: "ses_nonexistent",
+              content: "hello",
+            },
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "general",
+            abort: new AbortController().signal,
+            extra: { fromExec: true },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        ))
+
+        // send is not blocked by the fromExec guard — it reaches the inbox service
+        // (which is not set up in this test, so we get an inbox error, not a guard error)
+        expect(exit._tag).toBe("Failure")
+        if (exit._tag === "Failure") {
+          const causeStr = String(exit.cause)
+          expect(causeStr).toContain("Inbox service unavailable")
+          expect(causeStr).not.toContain("Subagents can only use actor send")
+        }
+      }),
+    ),
+  )
+
+  it.live("primary agent calling spawn via exec is not blocked", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        yield* installMockSpawn()
+        const { chat, assistant } = yield* seed()
+        const tool = yield* ActorTool
+        const def = yield* tool.init()
+
+        const result = yield* def.execute(
+          {
+            operation: {
+              action: "spawn",
+              description: "legitimate spawn",
+              prompt: "go do something",
+              subagent_type: "general",
+            },
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { fromExec: true },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        expect(result.metadata.sessionId).toBe(chat.id)
+      }),
+    ),
+  )
 })
 
 afterEach(async () => {

--- a/packages/opencode/test/tool/tool-script.test.ts
+++ b/packages/opencode/test/tool/tool-script.test.ts
@@ -938,6 +938,26 @@ return r.output;`,
     expect(result.metadata.status).toBe("completed")
     expect(result.output).toContain("navigated: https://example.com")
   })
+
+  test("sets fromExec flag in subCtx so downstream tools can detect exec origin", async () => {
+    let capturedExtra: Record<string, unknown> | undefined
+    const probeDef: Tool.Def = {
+      id: "probe",
+      description: "fake probe",
+      parameters: z.object({}),
+      execute: (_args: any, ctx: any) => {
+        capturedExtra = ctx.extra
+        return Effect.succeed({ title: "probe", output: "ok", metadata: {} })
+      },
+    }
+    const result = await runToolScript(
+      `return await tools.probe({})`,
+      [probeDef],
+    )
+    expect(result.metadata.status).toBe("completed")
+    expect(capturedExtra).toBeDefined()
+    expect(capturedExtra!.fromExec).toBe(true)
+  })
 })
 
 describe("renderToolScriptDeclarations", () => {


### PR DESCRIPTION
## Summary

Subagents can reach `actor` through `exec` (actor was removed from `TOOL_SCRIPT_EXCLUDED` in a prior merge), but without a runtime guard they could spawn nested subagents via exec.

## Changes

- **`tool-script.ts`**: inject `extra: { ...ctx.extra, fromExec: true }` into the `subCtx` constructed for exec-dispatched tool calls, so downstream tools can detect they are being called from an exec sandbox
- **`actor.ts`**: add a `fromExec` check — when the caller is a subagent, only the `send` action is permitted; all other actions (spawn, run, cancel, etc.) fail with a clear error
- **`actor.txt`**: document the subagent restriction

## Design

The `ToolRegistry.available` already masks `actor` out of every subagent schema. This runtime guard is the defence-in-depth layer: it blocks spawn/run/cancel even if a stale prompt-cached schema or hand-rolled call site attempts them through `exec`.

The `fromExec` flag is set in `tool-script.ts` when constructing the `subCtx` for each exec-dispatched tool call, ensuring the guard in `actor.ts` actually triggers.