### PR TITLE
feat(skill): add mate builtin skill for desktop pet creation

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/mate-pet/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mate-pet/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: mate-pet
+description: "Create custom desktop pet (Mate) characters with spritesheet and manifest. Use when the user asks to 'create a pet', 'make a desktop companion', 'design a mate character', 'generate a spritesheet for my pet', or wants to customize their desktop buddy. Generates a WebP spritesheet + manifest.json that can be loaded by MiMo Desktop's Mate system."
+---
+
+# Mate Pet Creator
+
+Create animated desktop pet characters for MiMo Desktop's Mate (桌面伙伴) system.
+
+## Output Structure
+
+A valid custom pet lives in a folder with this structure:
+
+```
+<pet-id>/
+├── manifest.json     # Required — animation metadata
+└── spritesheet.webp  # Required — all animation frames in a grid
+```
+
+The user places this folder in their MiMo Desktop custom pets directory (`userData/pets/<pet-id>/`), then clicks "Refresh" in Settings → Mate to load it.
+
+## Manifest Schema
+
+```json
+{
+  "id": "my-pet",
+  "name": "My Pet",
+  "description": "A cute custom pet",
+  "version": 1,
+  "spritesheet": "spritesheet.webp",
+  "frameWidth": 240,
+  "frameHeight": 240,
+  "columns": 8,
+  "totalFrames": 16,
+  "animations": {
+    "idle": { "row": 0, "frames": 8, "fps": 8, "loop": true }
+  }
+}
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique identifier (kebab-case) |
+| `name` | string | Display name |
+| `version` | number | Always `1` |
+| `spritesheet` | string | Filename of the spritesheet image |
+| `frameWidth` | number | Width of each frame in pixels |
+| `frameHeight` | number | Height of each frame in pixels |
+| `columns` | number | Number of columns in the spritesheet grid |
+| `totalFrames` | number | Total number of frames across all animations |
+| `animations` | object | At minimum must include `idle` |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | string | Shown in settings UI |
+| `anchorX` | number | Horizontal anchor (0–1, default 0.5) for centering |
+
+### Animation Definition
+
+Each animation entry:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `row` | number | Row index in the spritesheet (0-based) |
+| `frames` | number | Number of frames in this animation |
+| `fps` | number | Playback speed (recommended: 6–12) |
+| `loop` | boolean | Whether the animation loops |
+
+The `idle` animation is **required** — it plays by default when the pet is loaded.
+
+## Spritesheet Layout
+
+- Frames are arranged left-to-right, top-to-bottom in a grid.
+- Each row corresponds to one animation (matched by the `row` field in the animation definition).
+- All frames must have identical dimensions (`frameWidth × frameHeight`).
+- Transparent background (alpha channel) is required — the pet window has no background.
+- Recommended frame size: 240×240 px (renders well at 1× scale on desktop).
+- Format: WebP with transparency (lossless or near-lossless for crisp pixel art).
+
+## Workflow
+
+### Step 1: Understand the Character
+
+Ask the user:
+- What animal/creature/character?
+- Art style preference (pixel art, cartoon, flat vector, kawaii)?
+- Any specific colors or features?
+
+### Step 2: Generate the Spritesheet
+
+Use the **image generation** tool (invoke the `image-gen` skill or use any available image generation capability) to create the spritesheet.
+
+Prompt construction guidelines for the image generator:
+- Request a **sprite sheet** with specific grid layout (e.g., "8 frames in a row, 240×240 each")
+- Specify **transparent background**
+- Describe the **idle animation** motion: gentle breathing, blinking, tail wag, etc.
+- Keep the character **centered** in each frame with consistent sizing
+- Style: match the user's preference; default to cute/kawaii if unspecified
+
+If image generation is unavailable, create the spritesheet using SVG-to-WebP conversion:
+1. Generate an SVG with all animation frames arranged in the grid layout
+2. Use a script to convert the SVG to WebP format
+
+### Step 3: Write the Manifest
+
+Generate `manifest.json` with correct dimensions matching the actual spritesheet output.
+
+### Step 4: Deliver
+
+Write both files to the current working directory under a folder named with the pet ID. Tell the user to:
+1. Copy the folder to their MiMo Desktop pets directory
+2. Open Settings → Mate → click Refresh
+3. Select their new pet from the list
+
+## Constraints
+
+- The `idle` animation MUST exist — the system falls back to it.
+- Frame dimensions must be consistent across the entire spritesheet.
+- Keep total file size under 2MB for smooth loading.
+- Pet ID must be unique; if it conflicts with a preset (`koala`, `panda`), the preset wins.
+- Do NOT reference or depend on any external URLs — all assets must be local files.

--- a/packages/opencode/src/skill/builtin/.bundle/mate/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mate/SKILL.md
@@ -94,42 +94,53 @@ Ask the user:
 
 Use the `imagegen` skill to generate the spritesheet image. Construct the prompt with these guidelines:
 - Request a **sprite sheet** with specific grid layout (e.g., "8 frames in a single horizontal row, each frame 240×240 pixels")
-- Specify **transparent background** (PNG with alpha)
+- Specify **transparent background** (alpha channel)
 - Describe the **idle animation** motion: gentle breathing, blinking, tail wag, bobbing, etc.
 - Keep the character **centered** in each frame with consistent sizing
 - Style: match the user's preference; default to cute/kawaii if unspecified
 
-After receiving the generated image, convert it to WebP:
+If the generated image is already WebP, use it directly. If it is PNG or another format, convert to WebP:
 
 ```bash
-# Convert PNG to lossless WebP preserving transparency
+# Convert to lossless WebP preserving transparency
 cwebp -lossless -q 100 spritesheet.png -o spritesheet.webp
 ```
 
-If `cwebp` is not available, use `sips` (macOS built-in):
+If `cwebp` is not available, check for `sips` (macOS Ventura+ supports WebP export):
 
 ```bash
-# macOS fallback — sips can export to formats supported by ImageIO
-sips -s format png spritesheet.png --out spritesheet.webp 2>/dev/null \
-  || cp spritesheet.png spritesheet.webp
+sips -s format webp spritesheet.png --out spritesheet.webp
 ```
 
-If `imagegen` is unavailable (skill not enabled or image generation fails), fall back to generating pixel-art frames directly as SVG, then rasterize:
+If neither tool is available, instruct the user to install one:
+
+```
+brew install webp   # provides cwebp
+```
+
+Do NOT silently rename a PNG to .webp — the file must have valid WebP encoding (RIFF/WEBP header). If conversion genuinely cannot be performed, fail explicitly and tell the user what tool to install.
+
+If `imagegen` is unavailable (skill not enabled or image generation fails), fall back to generating pixel-art frames directly as SVG, then rasterize. Compute dimensions from the manifest:
 
 ```bash
-# Rasterize SVG spritesheet to PNG via rsvg-convert (if available)
-rsvg-convert -w 1920 -h 240 spritesheet.svg -o spritesheet.png
+# Calculate actual spritesheet dimensions from manifest
+WIDTH=$((frameWidth * columns))
+HEIGHT=$((frameHeight * rows))  # rows = max animation row index + 1
+
+# Rasterize SVG to PNG, then convert to WebP
+rsvg-convert -w $WIDTH -h $HEIGHT spritesheet.svg -o spritesheet.png
 cwebp -lossless spritesheet.png -o spritesheet.webp
 ```
 
-As a last resort, output the SVG file directly and instruct the user to convert it manually or use an online converter.
+As a last resort, output the SVG file directly and instruct the user to convert it manually.
 
 ### Step 3: Write the Manifest
 
 Generate `manifest.json` with correct dimensions matching the actual spritesheet output. Verify:
 - `frameWidth × columns` = spritesheet total width
-- `frameHeight × (totalFrames / columns)` = spritesheet total height
+- `frameHeight × (max animation row index + 1)` = spritesheet total height
 - `animations.idle` exists with valid `row`, `frames`, `fps`, `loop`
+- Each animation's `frames` ≤ `columns` (frames per row cannot exceed grid columns)
 
 ### Step 4: Deliver
 

--- a/packages/opencode/src/skill/builtin/.bundle/mate/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mate/SKILL.md
@@ -92,28 +92,50 @@ Ask the user:
 
 ### Step 2: Generate the Spritesheet
 
-Use the **image generation** tool (invoke the `image-gen` skill or use any available image generation capability) to create the spritesheet.
-
-Prompt construction guidelines for the image generator:
-- Request a **sprite sheet** with specific grid layout (e.g., "8 frames in a row, 240×240 each")
-- Specify **transparent background**
-- Describe the **idle animation** motion: gentle breathing, blinking, tail wag, etc.
+Use the `imagegen` skill to generate the spritesheet image. Construct the prompt with these guidelines:
+- Request a **sprite sheet** with specific grid layout (e.g., "8 frames in a single horizontal row, each frame 240×240 pixels")
+- Specify **transparent background** (PNG with alpha)
+- Describe the **idle animation** motion: gentle breathing, blinking, tail wag, bobbing, etc.
 - Keep the character **centered** in each frame with consistent sizing
 - Style: match the user's preference; default to cute/kawaii if unspecified
 
-If image generation is unavailable, create the spritesheet using SVG-to-WebP conversion:
-1. Generate an SVG with all animation frames arranged in the grid layout
-2. Use a script to convert the SVG to WebP format
+After receiving the generated image, convert it to WebP:
+
+```bash
+# Convert PNG to lossless WebP preserving transparency
+cwebp -lossless -q 100 spritesheet.png -o spritesheet.webp
+```
+
+If `cwebp` is not available, use `sips` (macOS built-in):
+
+```bash
+# macOS fallback — sips can export to formats supported by ImageIO
+sips -s format png spritesheet.png --out spritesheet.webp 2>/dev/null \
+  || cp spritesheet.png spritesheet.webp
+```
+
+If `imagegen` is unavailable (skill not enabled or image generation fails), fall back to generating pixel-art frames directly as SVG, then rasterize:
+
+```bash
+# Rasterize SVG spritesheet to PNG via rsvg-convert (if available)
+rsvg-convert -w 1920 -h 240 spritesheet.svg -o spritesheet.png
+cwebp -lossless spritesheet.png -o spritesheet.webp
+```
+
+As a last resort, output the SVG file directly and instruct the user to convert it manually or use an online converter.
 
 ### Step 3: Write the Manifest
 
-Generate `manifest.json` with correct dimensions matching the actual spritesheet output.
+Generate `manifest.json` with correct dimensions matching the actual spritesheet output. Verify:
+- `frameWidth × columns` = spritesheet total width
+- `frameHeight × (totalFrames / columns)` = spritesheet total height
+- `animations.idle` exists with valid `row`, `frames`, `fps`, `loop`
 
 ### Step 4: Deliver
 
 Write both files to the current working directory under a folder named with the pet ID. Tell the user to:
-1. Copy the folder to their MiMo Desktop pets directory
-2. Open Settings → Mate → click Refresh
+1. Copy the folder to their MiMo Desktop pets directory (Settings → Mate → click "Open Folder" to find it)
+2. Click "Refresh" in Settings → Mate
 3. Select their new pet from the list
 
 ## Constraints

--- a/packages/opencode/src/skill/builtin/.bundle/mate/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mate-pet
+name: mate
 description: "Create custom desktop pet (Mate) characters with spritesheet and manifest. Use when the user asks to 'create a pet', 'make a desktop companion', 'design a mate character', 'generate a spritesheet for my pet', or wants to customize their desktop buddy. Generates a WebP spritesheet + manifest.json that can be loaded by MiMo Desktop's Mate system."
 ---
 


### PR DESCRIPTION
## Summary

- Add `mate` builtin skill to `.bundle/` that guides users through creating custom desktop pet characters
- The skill knows the manifest.json schema, spritesheet layout requirements (WebP grid, transparent background, animation rows)
- Instructs the model to use `imagegen` skill for asset generation, with concrete fallback chain (SVG rasterize via rsvg-convert/cwebp/sips)
- Covers the full workflow: character design → spritesheet generation → manifest creation → delivery to user's pets directory

## Dependencies

This skill pairs with the Desktop Mate feature (mimo-desktop worktree `thinking-collapse`, pending MR). The skill generates valid asset files that the Desktop Mate loader consumes. Merge order:
1. This PR can merge first — the skill is self-contained and produces standalone files
2. Desktop Mate MR lands separately — adds the loader that consumes these files

Users invoking `/mate` before Desktop Mate ships will still get a valid pet folder with spritesheet + manifest; they just won't have the "Refresh" button to load it until the Desktop feature lands.

## Review responses

1. **~~image-gen skill doesn't exist~~** → Fixed: now references `imagegen` (the actual market-distributed skill name visible in Desktop's skill list)
2. **Desktop Mate system not in main yet** → Correct, it's on a parallel branch. The skill output is a standalone folder (manifest.json + spritesheet.webp) — it's valid regardless of whether the consumer exists yet. Added note above about merge order.
3. **~~SVG-to-WebP fallback handwavy~~** → Fixed: added concrete commands (`cwebp -lossless`, `sips` macOS fallback, `rsvg-convert`) with explicit fallback chain. Last resort = output SVG + tell user to convert manually.

## Test plan

- [x] `bun test` passes (skill is a static .md, no logic changes)
- [x] Typecheck passes (confirmed via pre-push hook)
- [ ] After next mimocode build, invoke `/mate` → skill loads and guides through pet creation
- [ ] With `imagegen` enabled, generated spritesheet is valid WebP with transparency
- [ ] Without `imagegen`, fallback produces SVG → WebP via system tools
- [ ] Generated manifest.json validates against Desktop's `isValidManifest()` schema