### PR TITLE
fix(voice): add ffmpeg fallback for Windows audio recording

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -255,7 +255,7 @@ export function Prompt(props: PromptProps) {
       toast.show({ message: msg, variant: "error" })
       return
     }
-    if (!Voice.isAvailable()) {
+    if (!(await Voice.isAvailable())) {
       toast.show({ message: t("tui.voice.error.no_recorder"), variant: "error" })
       return
     }
@@ -274,7 +274,7 @@ export function Prompt(props: PromptProps) {
 
     let voiceControlChain: Promise<void> = Promise.resolve()
 
-    const handle = Voice.startStreaming({
+    const handle = await Voice.startStreaming({
       onSegment: (segment) => {
         av.pending++
         av.setState("processing")

--- a/packages/opencode/src/cli/cmd/tui/i18n/en.ts
+++ b/packages/opencode/src/cli/cmd/tui/i18n/en.ts
@@ -516,7 +516,7 @@ export const dict: Record<string, string> = {
   "tui.voice.error.no_url": "Provider \"{{provider}}\" has no baseURL configured — set options.baseURL in the provider config",
   "tui.voice.error.no_device": "No microphone/audio device found — please check your system audio settings",
   "tui.voice.error.recorder_failed": "Recording failed",
-  "tui.voice.error.no_recorder": "No recording tool found, please install sox",
+  "tui.voice.error.no_recorder": "No recording tool found — install sox or ffmpeg",
   "tui.voice.error.too_short": "Recording too short",
   "tui.voice.error.network": "Transcription failed, please check your network",
   "tui.voice.error.empty_send": "Nothing to send",

--- a/packages/opencode/src/cli/cmd/tui/util/voice.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/voice.ts
@@ -54,6 +54,36 @@ type Recorder = {
   pipeArgs: () => string[]
 }
 
+let cachedWin32Device: string | null | undefined
+
+async function detectWin32Device(): Promise<string | null> {
+  if (cachedWin32Device !== undefined) return cachedWin32Device
+  try {
+    const proc = Process.spawn(
+      [
+        "powershell",
+        "-NoProfile",
+        "-Command",
+        'Get-CimInstance Win32_SoundDevice | Select -First 1 -ExpandProperty Name',
+      ],
+      { stdout: "pipe", stderr: "ignore", timeout: 5_000 },
+    )
+    let out = ""
+    if (proc.stdout) {
+      for await (const chunk of proc.stdout as AsyncIterable<Buffer>) {
+        out += chunk.toString()
+      }
+    }
+    await proc.exited
+    const name = out.trim()
+    cachedWin32Device = name || null
+    return cachedWin32Device
+  } catch {
+    cachedWin32Device = null
+    return null
+  }
+}
+
 const RECORDERS: Record<string, Array<() => Recorder | null>> = {
   darwin: [
     () =>
@@ -80,7 +110,46 @@ const RECORDERS: Record<string, Array<() => Recorder | null>> = {
       which("sox")
         ? { cmd: "sox", pipeArgs: () => ["-d", "-r", "16000", "-c", "1", "-b", "16", "-t", "raw", "-"] }
         : null,
+    () => {
+      if (!which("ffmpeg")) return null
+      // Resolve the default audio input device via PowerShell so ffmpeg
+      // targets the correct DirectShow device on modern Windows where sox
+      // cannot find a default recording device (issue #2136).
+      const device = cachedWin32Device
+      if (device === null) return null // already tried and failed
+      if (device !== undefined) {
+        // Use cached device name
+        return {
+          cmd: "ffmpeg",
+          pipeArgs: () => [
+            "-hide_banner", "-loglevel", "error",
+            "-f", "dshow", "-i", `audio=${device}`,
+            "-f", "s16le", "-ar", "16000", "-ac", "1", "-",
+          ],
+        }
+      }
+      // Device not yet detected — attempt async detection.
+      // Return null for now; detectRecorderAsync will retry.
+      return null
+    },
   ],
+}
+
+async function detectRecorderAsync(): Promise<Recorder | null> {
+  if (process.platform !== "win32") return null
+  if (!which("ffmpeg")) return null
+  const device = await detectWin32Device()
+  if (!device) return null
+  const recorder: Recorder = {
+    cmd: "ffmpeg",
+    pipeArgs: () => [
+      "-hide_banner", "-loglevel", "error",
+      "-f", "dshow", "-i", `audio=${device}`,
+      "-f", "s16le", "-ar", "16000", "-ac", "1", "-",
+    ],
+  }
+  cachedRecorder = recorder
+  return recorder
 }
 
 let cachedRecorder: Recorder | null | undefined
@@ -99,8 +168,11 @@ function detectRecorder(): Recorder | null {
   return null
 }
 
-export function isAvailable(): boolean {
-  return detectRecorder() !== null
+export async function isAvailable(): Promise<boolean> {
+  if (detectRecorder() !== null) return true
+  // On Windows, try async ffmpeg detection (needs PowerShell device query)
+  const asyncRecorder = await detectRecorderAsync()
+  return asyncRecorder !== null
 }
 
 export type StreamingHandle = {
@@ -111,12 +183,13 @@ export type StreamingHandle = {
   reading: Promise<void>
 }
 
-export function startStreaming(opts: {
+export async function startStreaming(opts: {
   onSegment: (segment: VADSegment) => void
   onActiveChange?: (active: boolean) => void
   onError?: (err: Error) => void
-}): StreamingHandle | null {
-  const recorder = detectRecorder()
+}): Promise<StreamingHandle | null> {
+  let recorder = detectRecorder()
+  if (!recorder) recorder = await detectRecorderAsync()
   if (!recorder) return null
 
   log.info("recording started", { recorder: recorder.cmd })


### PR DESCRIPTION
sox cannot detect default recording devices on modern Windows 10/11, making the /voice feature non-functional (issue #2136). Add ffmpeg as a fallback recorder for win32 using DirectShow audio input, with automatic default device detection via PowerShell.

- Add detectWin32Device() to query default audio device name
- Add ffmpeg recorder candidate for win32 (dshow + s16le output)
- Make isAvailable() and startStreaming() async to support device query
- Update callers in prompt component to await async detection
- Update English error message to mention ffmpeg as alternative

Fixes #2136

### Issue / context (if applicable)

<!--
Link any relevant issue or discussion. For an external contribution that introduces a new feature or significant design change, include the issue where the direction was agreed. Use `Fixes #123` or `Closes #123` only when this PR fully resolves that issue.
-->

### Type of change

Bug fix / New feature / Refactor / Documentation — keep the ones that apply and delete the rest.

### What does this PR do?

Briefly describe the problem, what changed, and why this approach works.

### How did you verify your code works?

What did you test, and how can a reviewer reproduce the result?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
