### PR TITLE
fix(tui): recover the session route when the session fails to load

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -180,14 +180,12 @@ export function tui(input: {
                   <UiI18nBridge>
                 <ToastProvider>
                   <RouteProvider
-                    initialRoute={
-                      input.args.continue
-                        ? {
-                            type: "session",
-                            sessionID: "dummy",
-                          }
-                        : undefined
-                    }
+                    // `-c` starts on Home and the resolver effect below
+                    // navigates to the resumed session once the session list
+                    // lands. Seeding a placeholder session route here used to
+                    // mount the session page against an id that cannot exist,
+                    // which rendered black until the real navigation landed.
+                    initialRoute={undefined}
                   >
                     <TuiConfigProvider config={input.config}>
                       <SDKProvider

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -259,10 +259,19 @@ export function Session() {
 
   createEffect(async () => {
     const previousWorkspace = project.workspace.current()
-    const result = await sdk.client.session.get({ sessionID: route.sessionID }, { throwOnError: true })
+    const sessionID = route.sessionID
+    // No `throwOnError` here on purpose: with it, a nonexistent or malformed
+    // id REJECTS and the rejection escapes this async effect, leaving the
+    // route mounted on an unloadable session that renders black (#1936).
+    // Without it the client resolves `{ data: undefined }`, which the guard
+    // below turns into a toast plus a hop back to Home.
+    const result = await sdk.client.session.get({ sessionID })
+    // Route liveness: the user may have navigated away while the request was
+    // in flight; stale work must never touch the newly selected route.
+    if (route.sessionID !== sessionID) return
     if (!result.data) {
       toast.show({
-        message: `Session not found: ${route.sessionID}`,
+        message: `Session not found: ${sessionID}`,
         variant: "error",
       })
       navigate({ type: "home" })
@@ -291,6 +300,7 @@ export function Session() {
         .actors({ sessionID }, { throwOnError: true })
         .then((res) => res.data as SessionActorInput[] | undefined),
     )
+    if (route.sessionID !== sessionID) return
     if (!verdict.renderable) {
       toast.show({
         message: `Cannot open session: ${verdict.reason}`,
@@ -311,7 +321,9 @@ export function Session() {
         await sync.bootstrap({ fatal: false })
       } catch (e) {}
     }
-    await sync.session.sync(route.sessionID)
+    if (route.sessionID !== sessionID) return
+    await sync.session.sync(sessionID)
+    if (route.sessionID !== sessionID) return
     if (scroll) scroll.scrollBy(100_000)
   })
 


### PR DESCRIPTION
## Problem / Summary

`mimo -s <malformed-or-unknown-id>` black-screened the TUI. The session route's entry `session.get` ran with `throwOnError: true`, so a 404 arrived as a **rejection** that escaped the async effect ? no toast, no navigation, the route stayed mounted on an unloadable session. The existing `if (!result.data)` guard was unreachable for exactly the case it was written for (this client resolves `{ data: undefined }` on HTTP errors *only without* that flag).

## What changed

1. **routes/session/index.tsx** ? drop `throwOnError` from the entry fetch so a missing session flows into the existing not-found guard (toast + navigate Home). Add route-liveness checks after every await in the effect so stale work cannot touch a newly selected route.
2. **app.tsx** ? `-c` no longer seeds a `"dummy"` session route; it starts on Home and the existing resolver navigates once the real session is resolved (the #1809 entry path).

## Testing

- `tsgo --noEmit` clean on `packages/opencode`
- Manual reasoning against the repro from #1936 (`-s 'ses_...?'`): the 404 now resolves to `data: undefined`, hits the not-found toast, and lands back on Home
- Full local test suite blocked by a Windows-native build limit (`tree-sitter-powershell` node-gyp); requesting CI verdict

Fixes #1936
