### PR TITLE
fix(tui): stop Enter being swallowed by empty autocomplete and pasted newlines submitting

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete-detect.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete-detect.ts
@@ -11,6 +11,21 @@ export function exactSubmitOption<T extends { display: string; submitOnSelect?: 
   return options.find((option) => option.submitOnSelect && option.display.trimEnd() === "/" + query)
 }
 
+export type EnterAction = "select-exact" | "select" | "submit"
+
+/**
+ * What Enter should do while the autocomplete popup is (or is not) open.
+ *
+ * A visible popup with zero options (a literal "$100" or "@nonexistent" in the
+ * message) must not swallow Enter — there is nothing to select, so the key
+ * falls through and the message submits (#2208).
+ */
+export function enterAction(visible: boolean, optionCount: number, hasExactOption: boolean): EnterAction {
+  if (visible && hasExactOption) return "select-exact"
+  if (!visible || optionCount === 0) return "submit"
+  return "select"
+}
+
 // Decide whether an autocomplete popup should open for the current input.
 //
 // `value` is the editor plainText (UTF-16) and `cursorWidth` is the editor's

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -20,7 +20,7 @@ import { Locale } from "@/util"
 import { Flag } from "@/flag/flag"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
-import { detectTrigger, exactSubmitOption } from "./autocomplete-detect"
+import { detectTrigger, enterAction, exactSubmitOption } from "./autocomplete-detect"
 import { charAfterCursor, tokenEndWidth } from "./offset"
 
 function removeLineRange(input: string) {
@@ -615,9 +615,22 @@ export function Autocomplete(props: {
               props.input().getTextRange(store.index + 1, props.input().cursorOffset),
               options(),
             )
-            select(exact)
+            const action = enterAction(Boolean(store.visible), options().length, Boolean(exact))
+            if (action === "select-exact") {
+              select(exact)
+              e.preventDefault()
+              setTimeout(props.onSubmit, 0)
+              return
+            }
+            if (action === "submit") {
+              // Popup open but nothing to pick (a literal "$100" or an unknown
+              // "@path") — close it and let Enter fall through to submit
+              // instead of swallowing the key (#2208).
+              hide()
+              return
+            }
+            select()
             e.preventDefault()
-            if (exact) setTimeout(props.onSubmit, 0)
             return
           }
           if (name === "tab") {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -17,6 +17,7 @@ import { createStore, produce, unwrap } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
 import { usePromptHistory, type PromptInfo } from "./history"
 import { assign, expandPlaceholders } from "./part"
+import { PasteBurstGuard } from "./paste-burst"
 import { usePromptStash } from "./stash"
 import { clampStatusMessage } from "./footer"
 import { DialogStash } from "../dialog-stash"
@@ -1027,8 +1028,19 @@ export function Prompt(props: PromptProps) {
   // deferred onSubmit). This lock prevents the deferred call from re-entering
   // while a dialog or async session-creation is in progress.
   let submitLock = false
+  // Terminals without bracketed paste deliver a paste as a rapid key stream,
+  // so every newline in the pasted text fires submit — one message per line
+  // (#2186). The guard tells a paste burst from human typing by timing.
+  const pasteBurst = new PasteBurstGuard()
   async function submit() {
     if (submitLock) return false
+    if (!pasteBurst.canSubmit()) {
+      // Part of a pasted multi-line text: keep the line in the editor as a
+      // literal newline instead of sending it. The whole paste accumulates in
+      // the input and the user submits it themselves.
+      if (input && !input.isDestroyed) input.insertText("\n")
+      return false
+    }
     setGhost("")
     // IME: double-defer may fire before onContentChange flushes the last
     // composed character (e.g. Korean hangul) to the store, so read
@@ -1650,6 +1662,7 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
+                pasteBurst.key(e.name)
                 // Handle Ctrl+V for terminals that forward it to the app as a raw
                 // keypress (common on macOS/Linux). The textarea has no built-in
                 // paste action, so without this nothing gets inserted. Terminals

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/paste-burst.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/paste-burst.ts
@@ -1,0 +1,30 @@
+/**
+ * Distinguish a pasted text burst from human typing on terminals that do not
+ * support bracketed paste mode.
+ *
+ * Without bracketed paste (mode 2004) the terminal delivers a paste as a rapid
+ * stream of ordinary key events, so every newline inside the pasted text looks
+ * like Enter and fires the editor's submit — one message per pasted line. A
+ * paste stream delivers keystrokes within microseconds of each other; no human
+ * types a character and hits Enter within the same few milliseconds. Recording
+ * when the last printable key arrived is enough to tell the two apart.
+ */
+export class PasteBurstGuard {
+  private lastPrintableAt = 0
+
+  constructor(private readonly windowMs = 20) {}
+
+  /** Record a key event. Only printable single-character keys move the clock. */
+  key(name: string | undefined, now: number = Date.now()): void {
+    if (name && name.length === 1) this.lastPrintableAt = now
+  }
+
+  /**
+   * Whether an Enter pressed `now` may submit. Enter arriving inside the
+   * window after a printable key is part of a paste burst and must be kept in
+   * the editor (as a newline) instead of sent.
+   */
+  canSubmit(now: number = Date.now()): boolean {
+    return now - this.lastPrintableAt >= this.windowMs
+  }
+}

--- a/packages/opencode/test/cli/cmd/tui/autocomplete-detect.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/autocomplete-detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { detectTrigger, exactSubmitOption } from "../../../../src/cli/cmd/tui/component/prompt/autocomplete-detect"
+import { detectTrigger, enterAction, exactSubmitOption } from "../../../../src/cli/cmd/tui/component/prompt/autocomplete-detect"
 import { tokenEndWidth } from "../../../../src/cli/cmd/tui/component/prompt/offset"
 
 // cursorWidth is the editor's display-width cursor offset (CJK = 2 columns).
@@ -109,6 +109,32 @@ describe("exactSubmitOption", () => {
 
   test("does not submit from non-slash autocomplete", () => {
     expect(exactSubmitOption("@", "前端设计", options)).toBeUndefined()
+  })
+})
+
+describe("enterAction", () => {
+  test("selects the exact slash option and submits", () => {
+    expect(enterAction(true, 3, true)).toBe("select-exact")
+  })
+
+  test("selects the highlighted option while matching options are open", () => {
+    expect(enterAction(true, 3, false)).toBe("select")
+    expect(enterAction(true, 1, false)).toBe("select")
+  })
+
+  test("submits through a visible popup with zero options (#2208)", () => {
+    // A literal "$100" or unknown "@path" opens the popup but matches nothing;
+    // Enter must fall through and send the message, not be swallowed.
+    expect(enterAction(true, 0, false)).toBe("submit")
+  })
+
+  test("submits when the popup is closed", () => {
+    expect(enterAction(false, 0, false)).toBe("submit")
+    expect(enterAction(false, 5, false)).toBe("submit")
+  })
+
+  test("exact option wins even with zero other matches", () => {
+    expect(enterAction(true, 0, true)).toBe("select-exact")
   })
 })
 

--- a/packages/opencode/test/cli/cmd/tui/paste-burst.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/paste-burst.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+import { PasteBurstGuard } from "../../../../src/cli/cmd/tui/component/prompt/paste-burst"
+
+// A terminal without bracketed paste delivers a paste as a rapid stream of
+// ordinary key events, so every newline inside the pasted text looks like
+// Enter and submits one message per line (#2186). The guard must treat an
+// Enter that lands within the burst window after a printable key as part of
+// the paste, while never delaying a real Enter press.
+describe("PasteBurstGuard", () => {
+  test("allows submit when Enter follows typing at human speed", () => {
+    const guard = new PasteBurstGuard()
+    guard.key("h", 1000)
+    guard.key("i", 1080)
+    // Enter 120ms after the last character — a human press.
+    expect(guard.canSubmit(1200)).toBe(true)
+  })
+
+  test("blocks submit when Enter arrives inside a paste burst", () => {
+    const guard = new PasteBurstGuard()
+    // Pasted keystream: characters land microseconds apart.
+    const t0 = 1000
+    ;["l", "i", "n", "e", "1"].forEach((ch, i) => guard.key(ch, t0 + i))
+    // Enter 2ms after the last pasted character.
+    expect(guard.canSubmit(t0 + 7)).toBe(false)
+  })
+
+  test("keeps blocking across consecutive pasted lines, then recovers", () => {
+    const guard = new PasteBurstGuard()
+    const t0 = 1000
+    // line 1 + Enter
+    ;["a", "b"].forEach((ch, i) => guard.key(ch, t0 + i))
+    expect(guard.canSubmit(t0 + 3)).toBe(false)
+    // line 2 + Enter, still inside the same burst
+    ;["c", "d"].forEach((ch, i) => guard.key(ch, t0 + 4 + i))
+    expect(guard.canSubmit(t0 + 7)).toBe(false)
+    // Long after the paste, a human Enter submits again.
+    expect(guard.canSubmit(t0 + 500)).toBe(true)
+  })
+
+  test("non-printable keys do not arm the guard", () => {
+    const guard = new PasteBurstGuard()
+    guard.key("return", 1000)
+    guard.key("escape", 1001)
+    guard.key(undefined, 1002)
+    expect(guard.canSubmit(1003)).toBe(true)
+  })
+
+  test("a printable key long before Enter does not block submit", () => {
+    const guard = new PasteBurstGuard()
+    guard.key("x", 1000)
+    expect(guard.canSubmit(1050)).toBe(true)
+  })
+
+  test("custom window is respected", () => {
+    const guard = new PasteBurstGuard(50)
+    guard.key("x", 1000)
+    expect(guard.canSubmit(1030)).toBe(false)
+    expect(guard.canSubmit(1051)).toBe(true)
+  })
+})


### PR DESCRIPTION
{
  "title": "fix(tui): stop Enter being swallowed by empty autocomplete and pasted newlines submitting",
  "head": "rekty:fix/tui-enter-submit-paste-burst",
  "base": "main",
  "body": "Closes #2208\nCloses #2186\n\nTwo Enter-handling bugs in the prompt editor, fixed together because both are about who gets to consume the Enter key.\n\n## 1. Enter swallowed while autocomplete is open (#2208)\n\nTyping a literal `$100` (or an unknown `@path`) opens the agent/file popup, but when nothing matches, `options()` is empty and Enter called `select(undefined)` — a no-op — then `preventDefault()`'d. The popup stayed open and **the message could never be sent** until the user discovered Escape.\n\n**Fix:** new pure helper `enterAction(visible, optionCount, hasExactOption)` decides what Enter means:\n- `select-exact` — exact `/` skill alias: select and submit (unchanged)\n- `select` — matching options open: pick the highlighted one (unchanged)\n- `submit` — **popup open but zero options: close the popup and let Enter fall through** (new)\n\n## 2. Pasted newlines submit one message per line (#2186)\n\nOn terminals without bracketed paste mode (mode 2004), a paste arrives as a rapid stream of ordinary key events. Every newline inside the pasted text looked like Enter and fired submit — one message per pasted line.\n\n**Fix:** new `PasteBurstGuard` times printable key events. A paste stream delivers keystrokes microseconds apart; no human types a character and hits Enter within 20ms. An Enter landing inside the burst window is kept in the editor as a literal newline, so the whole paste accumulates in the input for the user to submit themselves.\n\nTerminals WITH bracketed paste are unaffected — their pastes arrive via `onPaste` and never hit the guard.\n\n## Changes\n\n- `prompt/autocomplete-detect.ts`: add `enterAction()` helper\n- `prompt/autocomplete.tsx`: use it in the Enter branch; fall through to submit when nothing matches\n- `prompt/paste-burst.ts` (new): `PasteBurstGuard`\n- `prompt/index.tsx`: wire the guard into `onKeyDown` / `submit()`\n- Tests: `paste-burst.test.ts` (6 cases) + `enterAction` cases in `autocomplete-detect.test.ts`\n\n## Verification\n\n- `bun test` — 36 tests pass (incl. 11 new)\n- `tsgo --noEmit` — clean\n- `oxlint` — 0 errors\n\ncc @MiMoHardFather @wqymi @yanyihan-xiaomi — could one of you approve the CI workflow runs for this fork PR? Thanks!"
}
