### PR TITLE
fix: gate GPT toolset on resolved API model for mimo

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -566,7 +566,10 @@ export const layer = Layer.effect(
           ? Option.getOrUndefined(yield* Effect.serviceOption(OtelTracer.OtelTracer))
           : undefined
 
-        const system = [PROMPT_GENERATE, ...(usesGPTToolset(resolved.id) ? [PROMPT_GENERATE_GPT] : [])]
+        const system = [
+          PROMPT_GENERATE,
+          ...(usesGPTToolset(resolved.id, undefined, resolved.api.id, resolved.family) ? [PROMPT_GENERATE_GPT] : []),
+        ]
         yield* plugin.trigger("experimental.chat.system.transform", { model: resolved }, { system })
         const existing = yield* InstanceState.useEffect(state, (s) => s.list())
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -27,7 +27,7 @@ import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { isRecord } from "@/util/record"
 import { withStatics } from "@/util/schema"
 import { isFreeApiModel, isFreeApiSunset } from "@/util/free-api-sunset"
-import { usesMimoCodexMode } from "../tool/gpt"
+import { usesMimoResponsesApi } from "../tool/gpt"
 
 import * as ProviderTransform from "./transform"
 import { ModelID, ProviderID } from "./schema"
@@ -329,7 +329,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       Effect.succeed({
         autoload: false,
         async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
-          return usesMimoCodexMode(modelID) ? sdk.responses(modelID) : sdk.languageModel(modelID)
+          return usesMimoResponsesApi(modelID) ? sdk.responses(modelID) : sdk.languageModel(modelID)
         },
         options: {},
       }),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1290,7 +1290,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         return new Set(actor.tools)
       })
       const whitelist = yield* whitelistFor()
-      const useGPTTools = usesGPTToolset(input.model.id, input.harness)
+      const useGPTTools = usesGPTToolset(input.model.id, input.harness, input.model.api.id, input.model.family)
       const execAllowedByWhitelist =
         useGPTTools &&
         !!whitelist &&
@@ -1394,6 +1394,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       // facing schema allowlist and stays compact in Codex mode.
       for (const item of yield* registry.registered({
         modelID: input.model.id,
+        apiModelID: input.model.api.id,
+        family: input.model.family,
         providerID: input.model.providerID,
         agent: input.agent,
         harness: input.harness,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -23,7 +23,7 @@ import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { Flag } from "@/flag/flag"
-import { type HarnessMode, isGPTModel, usesMimoCodexMode } from "@/tool/gpt"
+import { type HarnessMode, isGPTModel, usesMimoDefaultMode, usesMimoResponsesApi } from "@/tool/gpt"
 
 function renderGitResult(result: Git.Result, fallback = "(none)") {
   if (result.exitCode !== 0) return fallback
@@ -33,10 +33,11 @@ function renderGitResult(result: Git.Result, fallback = "(none)") {
 const anthropicEnvironment = new Map<string, string>()
 
 export function provider(model: Provider.Model, harness?: HarnessMode) {
+  if (usesMimoDefaultMode(model.id, model.api.id, model.family)) return [PROMPT_DEFAULT]
   if (harness === "codex" || ((harness === undefined || harness === "auto") && Flag.MIMOCODE_CODEX_MODE)) return [PROMPT_GPT]
   const prompt = (id: string) => {
     if (isGPTModel(id)) return PROMPT_GPT
-    if (usesMimoCodexMode(id)) return harness === "default" ? PROMPT_DEFAULT : PROMPT_GPT
+    if (usesMimoResponsesApi(id)) return harness === "default" ? PROMPT_DEFAULT : PROMPT_GPT
     if (id.includes("gpt-4") || id.includes("o1") || id.includes("o3")) return PROMPT_BEAST
     if (id.includes("gemini-")) return PROMPT_GEMINI
     if (id.includes("claude")) return PROMPT_ANTHROPIC

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -19,17 +19,31 @@ export function isMcpToolSearchEnabled(
   harness: HarnessMode | undefined,
   ...modelIDs: Array<string | undefined>
 ) {
+  if (usesMimoDefaultMode(...modelIDs)) return enabled
   if (isGPTModel(...modelIDs)) return true
-  return enabled || (codexHarnessOverride(harness) ?? (Flag.MIMOCODE_CODEX_MODE || usesMimoCodexMode(...modelIDs)))
+  return enabled || (codexHarnessOverride(harness) ?? (Flag.MIMOCODE_CODEX_MODE || usesMimoResponsesApi(...modelIDs)))
 }
 
-export function usesMimoCodexMode(...values: Array<string | undefined>) {
+export function isMimoModel(...values: Array<string | undefined>) {
+  return values.some((value) => value && /(?:^|[/_-])mimo(?:$|[/_.-])/i.test(value))
+}
+
+export function usesMimoResponsesApi(...values: Array<string | undefined>) {
   const ids = values.flatMap((value) => (value ? [value.toLowerCase()] : []))
-  if (ids.some((id) => /(?:^|[/])mimo-v2\.5(?:-pro)?$/.test(id))) return false
-  return ids.some((id) => /(?:^|[/_-])mimo(?:$|[/_.-])/.test(id))
+  return isMimoModel(...ids) && ids.some((id) => /(?:^|[/_.-])ptc(?:$|[/_.-])/.test(id))
 }
 
-export function usesGPTToolset(modelID: string, harness?: HarnessMode) {
-  if (isGPTModel(modelID)) return true
-  return codexHarnessOverride(harness) ?? (Flag.MIMOCODE_CODEX_MODE || usesMimoCodexMode(modelID))
+export function usesMimoDefaultMode(...values: Array<string | undefined>) {
+  return isMimoModel(...values) && !usesMimoResponsesApi(...values)
+}
+
+export function usesGPTToolset(
+  modelID: string,
+  harness?: HarnessMode,
+  ...modelIDs: Array<string | undefined>
+) {
+  const ids = [modelID, ...modelIDs]
+  if (usesMimoDefaultMode(...ids)) return false
+  if (isGPTModel(...ids)) return true
+  return codexHarnessOverride(harness) ?? (Flag.MIMOCODE_CODEX_MODE || usesMimoResponsesApi(...ids))
 }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -123,12 +123,16 @@ export interface Interface {
   readonly tools: (model: {
     providerID: ProviderID
     modelID: ModelID
+    apiModelID?: string
+    family?: string
     agent: Agent.Info
     harness?: HarnessMode
   }) => Effect.Effect<Tool.Def[]>
   readonly registered: (model: {
     providerID: ProviderID
     modelID: ModelID
+    apiModelID?: string
+    family?: string
     agent: Agent.Info
     harness?: HarnessMode
   }) => Effect.Effect<Tool.Def[]>
@@ -364,10 +368,12 @@ export const layer = Layer.effect(
     const available = Effect.fn("ToolRegistry.available")(function* (input: {
       providerID: ProviderID
       modelID: ModelID
+      apiModelID?: string
+      family?: string
       agent: Agent.Info
       harness?: HarnessMode
     }) {
-      const useGPTTools = usesGPTToolset(input.modelID, input.harness)
+      const useGPTTools = usesGPTToolset(input.modelID, input.harness, input.apiModelID, input.family)
       let filtered = (yield* all()).filter((tool) => {
         if (tool.id === ToolScriptTool.id) return useGPTTools || Flag.MIMOCODE_ENABLE_EXEC_TOOL
         if (tool.id === CodeSearchTool.id || tool.id === WebSearchTool.id) {
@@ -446,7 +452,14 @@ export const layer = Layer.effect(
       input ? available(input).pipe(Effect.map((result) => result.filtered)) : all()
 
     const definitions = Effect.fn("ToolRegistry.definitions")(function* (
-      input: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info; harness?: HarnessMode },
+      input: {
+        providerID: ProviderID
+        modelID: ModelID
+        apiModelID?: string
+        family?: string
+        agent: Agent.Info
+        harness?: HarnessMode
+      },
       includeHidden: boolean,
     ) {
       const availableTools = yield* available(input)

--- a/packages/opencode/src/tool/tool-script-ref.ts
+++ b/packages/opencode/src/tool/tool-script-ref.ts
@@ -16,6 +16,8 @@ export const toolScriptRegistry: {
     | ((input?: {
         providerID: ProviderID
         modelID: ModelID
+        apiModelID?: string
+        family?: string
         agent: Agent.Info
         harness?: HarnessMode
       }) => Effect.Effect<Tool.Def[]>)

--- a/packages/opencode/src/tool/tool-script.ts
+++ b/packages/opencode/src/tool/tool-script.ts
@@ -594,7 +594,9 @@ export const ToolScriptTool = Tool.define(
           const getDefs = toolScriptRegistry.current
           if (!getDefs) throw new Error("exec tool registry unavailable")
           const agentInfo = yield* agents.get(ctx.agent)
-          const model = ctx.extra?.model as { id: ModelID; providerID: ProviderID } | undefined
+          const model = ctx.extra?.model as
+            | { id: ModelID; providerID: ProviderID; api?: { id: string }; family?: string }
+            | undefined
           const harness = ctx.extra?.harness as HarnessMode | undefined
           const whitelist = Array.isArray(ctx.extra?.toolWhitelist)
             ? new Set(ctx.extra.toolWhitelist.filter((id): id is string => typeof id === "string"))
@@ -602,7 +604,14 @@ export const ToolScriptTool = Tool.define(
           const defs = (
             yield* getDefs(
               model
-                ? { providerID: model.providerID, modelID: model.id, agent: agentInfo, harness }
+                ? {
+                    providerID: model.providerID,
+                    modelID: model.id,
+                    apiModelID: model.api?.id,
+                    family: model.family,
+                    agent: agentInfo,
+                    harness,
+                  }
                 : undefined,
             )
           ).filter((def) => !TOOL_SCRIPT_EXCLUDED.has(def.id) && (!whitelist || whitelist.has(def.id)))

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1563,7 +1563,7 @@ test("xiaomi models use the Responses harness for free-form exec PTC", async () 
   })
 })
 
-test("xiaomi models outside PTC mode stay on Chat Completions", async () => {
+test("xiaomi models outside PTC mode stay on Chat Completions regardless of version", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -1576,6 +1576,11 @@ test("xiaomi models outside PTC mode stay on Chat Completions", async () => {
               models: {
                 "mimo-v2.5": {
                   name: "MiMo V2.5",
+                  tool_call: true,
+                  limit: { context: 8192, output: 2048 },
+                },
+                "mimo-v2.6": {
+                  name: "MiMo V2.6",
                   tool_call: true,
                   limit: { context: 8192, output: 2048 },
                 },
@@ -1593,9 +1598,11 @@ test("xiaomi models outside PTC mode stay on Chat Completions", async () => {
       set("XIAOMI_API_KEY", "test-key")
     },
     fn: async () => {
-      const model = await getModel(ProviderID.make("xiaomi"), ModelID.make("mimo-v2.5"))
-      const language = await getLanguage(model)
-      expect(language.provider).toBe("xiaomi.chat")
+      const models = await Promise.all(
+        ["mimo-v2.5", "mimo-v2.6"].map((id) => getModel(ProviderID.make("xiaomi"), ModelID.make(id))),
+      )
+      const languages = await Promise.all(models.map((model) => getLanguage(model)))
+      expect(languages.map((language) => language.provider)).toEqual(["xiaomi.chat", "xiaomi.chat"])
     },
   })
 })

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -63,15 +63,22 @@ describe("session.system", () => {
     expect(prompt).not.toContain("gitStatus:")
   })
 
-  test("GPT ignores harness while explicit default overrides MiMo Codex inference", () => {
+  test("non-Responses MiMo forces the default prompt even with the Codex harness", () => {
     const gpt = ProviderTest.model({ id: ModelID.make("gpt-5.2"), api: { id: "gpt-5.2" } as never })
     expect(SystemPrompt.provider(gpt, "default")[0]).toContain("You are Codex")
     expect(SystemPrompt.provider(gpt, "default")[0]).toContain("tools.apply_patch")
 
     const mimo = ProviderTest.model({ id: ModelID.make("mimo-v2.6"), api: { id: "mimo-v2.6" } as never })
-    expect(SystemPrompt.provider(mimo, "codex")[0]).toContain("You are Codex")
+    expect(SystemPrompt.provider(mimo, "codex")[0]).not.toContain("You are Codex")
+    expect(SystemPrompt.provider(mimo, "codex")[0]).not.toContain("tools.apply_patch")
     expect(SystemPrompt.provider(mimo, "default")[0]).not.toContain("You are Codex")
     expect(SystemPrompt.provider(mimo, "default")[0]).not.toContain("tools.apply_patch")
+
+    const responses = ProviderTest.model({
+      id: ModelID.make("mimo-v2.6-ptc"),
+      api: { id: "mimo-v2.6-ptc" } as never,
+    })
+    expect(SystemPrompt.provider(responses, "codex")[0]).toContain("You are Codex")
   })
 
   test("renders machine and repository environment only for Claude models", async () => {
@@ -206,10 +213,10 @@ describe("session.system", () => {
     expect(prompt).not.toContain("When possible, prefer parallelization over sequential tool calls")
   })
 
-  test("uses the GPT prompt for Codex models and the normal prompt for MiMo v2.5 models", () => {
+  test("uses the GPT prompt for Codex and MiMo Responses models and the normal prompt for versioned MiMo models", () => {
     const gpt = SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("gpt-5.4") }))[0]
     const normal = SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("model-default") }))[0]
-    const prompts = ["mimo-v2.5", "mimo-v2.5-pro"].map(
+    const prompts = ["mimo-v2.5", "mimo-v2.5-pro", "mimo-v2.5-pro-ultraspeed", "mimo-v2-pro", "mimo-v2.6"].map(
       (id) =>
         SystemPrompt.provider(
           ProviderTest.model({
@@ -219,11 +226,11 @@ describe("session.system", () => {
     )
 
     expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("gpt-5.4-codex") }))[0]).toBe(gpt)
-    expect(prompts).toEqual([normal, normal])
-    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6") }))[0]).toBe(gpt)
+    expect(prompts).toEqual([normal, normal, normal, normal, normal])
+    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6-ptc") }))[0]).toBe(gpt)
   })
 
-  test("Codex mode forces the GPT prompt for non-GPT models", () => {
+  test("Codex mode forces the GPT prompt for non-MiMo models", () => {
     const gpt = SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("gpt-5.4") }))[0]
     process.env.MIMOCODE_CODEX_MODE = "true"
     const prompt = SystemPrompt.provider(
@@ -234,6 +241,8 @@ describe("session.system", () => {
     )[0]
 
     expect(prompt).toBe(gpt)
+    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6") }))[0]).not.toBe(gpt)
+    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6-ptc") }))[0]).toBe(gpt)
   })
 
   test("allows the resolved session mode to override the process harness mode", () => {

--- a/packages/opencode/test/tool/gpt.test.ts
+++ b/packages/opencode/test/tool/gpt.test.ts
@@ -32,19 +32,27 @@ describe("isMcpToolSearchEnabled", () => {
     expect(isMcpToolSearchEnabled(false, undefined, "claude-opus-4-6")).toBe(false)
     expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.5")).toBe(false)
     expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.5-pro")).toBe(false)
-    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.5-pro-ultraspeed")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2-pro")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-ptc-test")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6-ptc")).toBe(true)
     expect(isMcpToolSearchEnabled(false, undefined, "gpt-5.2")).toBe(true)
     expect(isMcpToolSearchEnabled(false, undefined, "gpt-oss-120b")).toBe(false)
     expect(isMcpToolSearchEnabled(true, undefined, "claude-opus-4-6")).toBe(true)
   })
 
-  test("is enabled for non-GPT models in Codex mode", () => {
+  test("keeps non-Responses MiMo in default mode when process Codex mode is enabled", () => {
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(isMcpToolSearchEnabled(false, undefined, "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6-ptc")).toBe(true)
   })
 
   test("allows the resolved session mode to override the process mode", () => {
     expect(isMcpToolSearchEnabled(false, "codex", "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, "codex", "mimo-v2.6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "codex", "mimo-v2.6-ptc")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "auto", "gpt-5.2")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "auto", "claude-opus-4-6")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
@@ -57,13 +65,17 @@ describe("isMcpToolSearchEnabled", () => {
 })
 
 describe("usesGPTToolset", () => {
-  test("uses the normal toolset for MiMo v2.5 models", () => {
+  test("uses the normal toolset for versioned MiMo models and the GPT toolset for Responses PTC", () => {
     expect(usesGPTToolset("mimo-v2.5")).toBe(false)
     expect(usesGPTToolset("mimo-v2.5-pro")).toBe(false)
-    expect(usesGPTToolset("mimo-v2.6")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.5-pro-ultraspeed")).toBe(false)
+    expect(usesGPTToolset("mimo-v2-pro")).toBe(false)
+    expect(usesGPTToolset("mimo-v2.6")).toBe(false)
+    expect(usesGPTToolset("mimo-ptc-test")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6-ptc")).toBe(true)
   })
 
-  test("uses the GPT toolset for every model in Codex mode", () => {
+  test("uses the GPT toolset for non-MiMo models in process Codex mode", () => {
     expect(usesGPTToolset("claude-opus-4-6")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(usesGPTToolset("claude-opus-4-6")).toBe(true)
@@ -71,11 +83,16 @@ describe("usesGPTToolset", () => {
 
   test("allows the resolved session mode to override the process mode", () => {
     expect(usesGPTToolset("claude-opus-4-6", "codex")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6", "codex")).toBe(false)
+    expect(usesGPTToolset("mimo-v2.6-ptc", "codex")).toBe(true)
+    expect(usesGPTToolset("deployment-primary", "codex", "mimo-v2.6", "mimo")).toBe(false)
+    expect(usesGPTToolset("deployment-primary", "codex", "mimo-v2.6-ptc", "mimo")).toBe(true)
     expect(usesGPTToolset("gpt-5.2", "auto")).toBe(true)
-    expect(usesGPTToolset("mimo-v2.6", "auto")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6-ptc", "auto")).toBe(true)
     expect(usesGPTToolset("claude-opus-4-6", "auto")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(usesGPTToolset("claude-opus-4-6", "auto")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6", "auto")).toBe(false)
     expect(usesGPTToolset("claude-opus-4-6", "default")).toBe(false)
     expect(usesGPTToolset("mimo-v2.6", "default")).toBe(false)
     expect(usesGPTToolset("gpt-5.2", "default")).toBe(true)

--- a/packages/opencode/test/tool/registry-invocation-style.test.ts
+++ b/packages/opencode/test/tool/registry-invocation-style.test.ts
@@ -62,6 +62,32 @@ describe("ToolRegistry.tools: invocation style resolution", () => {
     ),
   )
 
+  it.live("keeps non-Responses MiMo on the default toolset even with the Codex harness", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const reg = yield* ToolRegistry.Service
+        const agents = yield* Agent.Service
+        const build = yield* agents.get("build")
+        const normal = yield* reg.tools({
+          providerID: ProviderID.make("xiaomi"),
+          modelID: ModelID.make("mimo-v2.6"),
+          agent: build,
+          harness: "codex",
+        })
+        const responses = yield* reg.tools({
+          providerID: ProviderID.make("xiaomi"),
+          modelID: ModelID.make("mimo-v2.6-ptc"),
+          agent: build,
+          harness: "codex",
+        })
+
+        expect(normal.map((tool) => tool.id)).toContain("bash")
+        expect(normal.map((tool) => tool.id)).not.toContain("exec")
+        expect(responses.map((tool) => tool.id)).toEqual(["exec"])
+      }),
+    ),
+  )
+
   it.live.skip("exposes exec by default only to GPT models", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Mimo mode detection previously keyed off the logical model ID only. This change gates the GPT/Codex toolset on the **resolved API model** (`apiModelID` + `family`), so:

- Mimo models using the default (non-responses) API now correctly get the default toolset and prompt — including newer versions like `mimo-v2.6`.
- Only mimo models whose resolved api model id uses the responses API (`ptc`) opt into the GPT/Codex toolset.

## Changes

- `gpt.ts`: add `isMimoModel` / `usesMimoDefaultMode` / `usesMimoResponsesApi` (renamed from `usesMimoCodexMode`); `usesGPTToolset` returns `false` for default-mode mimo
- Thread `apiModelID` and `family` through tool registry (`registry.ts`, `tool-script-ref.ts`, `tool-script.ts`), session prompt (`prompt.ts`), agent system prompt (`agent.ts`, `system.ts`), and provider responses selection (`provider.ts`)
- Tests: cover `mimo-v2.6` staying on Chat Completions, updated gpt/registry/system expectations

## Verification

- `bun test` on affected files: 114 pass, 4 skip (1 pre-existing network-timeout flake in `provider loaded from env variable` passes in isolation)