### PR TITLE
fix(provider): treat missing finish_reason as stop, not other

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
@@ -3,6 +3,14 @@ import type { LanguageModelV3FinishReason } from "@ai-sdk/provider"
 export function mapOpenAICompatibleFinishReason(
   finishReason: string | null | undefined,
 ): LanguageModelV3FinishReason["unified"] {
+  // Some gateways (e.g. opencode.ai/zen/go/v1 serving muse-spark) never send a
+  // finish_reason: absent in streaming chunks, null in non-streaming. That is a
+  // normal completion, not an anomaly — treating it as "other" flags every
+  // response from such models as degraded (#2173). Only an unrecognized
+  // non-empty value falls through to "other".
+  if (finishReason == null) {
+    return "stop"
+  }
   switch (finishReason) {
     case "stop":
       return "stop"

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -342,7 +342,10 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
       unified: ReturnType<typeof mapOpenAICompatibleFinishReason>
       raw: string | undefined
     } = {
-      unified: "other",
+      // Gateways that never send a finish_reason (e.g. muse-spark via
+      // opencode.ai/zen/go/v1) deliver complete responses — assume "stop"
+      // unless a chunk says otherwise, so they are not flagged degraded (#2173).
+      unified: "stop",
       raw: undefined,
     }
     const usage: {

--- a/packages/opencode/test/provider/copilot/map-openai-compatible-finish-reason.test.ts
+++ b/packages/opencode/test/provider/copilot/map-openai-compatible-finish-reason.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, mock, test } from "bun:test"
+import type { LanguageModelV3Prompt } from "@ai-sdk/provider"
+import { mapOpenAICompatibleFinishReason } from "@/provider/sdk/copilot/chat/map-openai-compatible-finish-reason"
+import { OpenAICompatibleChatLanguageModel } from "@/provider/sdk/copilot/chat/openai-compatible-chat-language-model"
+
+// Gateways such as opencode.ai/zen/go/v1 (serving muse-spark) never send a
+// finish_reason: absent from streaming chunks, null in non-streaming. A
+// missing value is a normal completion, so it must map to "stop" — only an
+// unrecognized non-empty value is "other" (#2173).
+describe("mapOpenAICompatibleFinishReason", () => {
+  test("maps a missing finish_reason to stop", () => {
+    expect(mapOpenAICompatibleFinishReason(null)).toBe("stop")
+    expect(mapOpenAICompatibleFinishReason(undefined)).toBe("stop")
+  })
+
+  test("maps recognized values unchanged", () => {
+    expect(mapOpenAICompatibleFinishReason("stop")).toBe("stop")
+    expect(mapOpenAICompatibleFinishReason("length")).toBe("length")
+    expect(mapOpenAICompatibleFinishReason("content_filter")).toBe("content-filter")
+    expect(mapOpenAICompatibleFinishReason("tool_calls")).toBe("tool-calls")
+    expect(mapOpenAICompatibleFinishReason("function_call")).toBe("tool-calls")
+  })
+
+  test("still flags unrecognized non-empty values as other", () => {
+    expect(mapOpenAICompatibleFinishReason("weird_reason")).toBe("other")
+  })
+})
+
+const TEST_PROMPT: LanguageModelV3Prompt = [{ role: "user", content: [{ type: "text", text: "Hello" }] }]
+
+// muse-spark-style stream: content deltas arrive but no chunk ever carries a
+// finish_reason, and the stream just ends after [DONE].
+const MUSE_SPARK_FIXTURE = [
+  `data: {"id":"chatcmpl-muse","object":"chat.completion.chunk","created":1756000000,"model":"muse-spark-1.2-contributor","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}`,
+  `data: {"id":"chatcmpl-muse","object":"chat.completion.chunk","created":1756000000,"model":"muse-spark-1.2-contributor","choices":[{"index":0,"delta":{"content":" there"}}]}`,
+  `data: [DONE]`,
+]
+
+async function convertReadableStreamToArray<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader()
+  const result: T[] = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result.push(value)
+  }
+  return result
+}
+
+describe("doStream without finish_reason", () => {
+  test("completes with finish=stop when the gateway never sends one", async () => {
+    const fetchFn = mock(async () => {
+      const body = new ReadableStream({
+        start(controller) {
+          for (const chunk of MUSE_SPARK_FIXTURE) {
+            controller.enqueue(new TextEncoder().encode(chunk + "\n\n"))
+          }
+          controller.close()
+        },
+      })
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    })
+
+    const model = new OpenAICompatibleChatLanguageModel("muse-spark-1.2-contributor", {
+      provider: "copilot.chat",
+      url: () => "https://api.test.com/chat/completions",
+      headers: () => ({ Authorization: "Bearer test-token" }),
+      fetch: fetchFn as any,
+    })
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    })
+
+    const parts = await convertReadableStreamToArray(stream)
+    const finish = parts.find((p) => p.type === "finish")
+
+    expect(finish).toMatchObject({ type: "finish", finishReason: { unified: "stop" } })
+  })
+})


### PR DESCRIPTION
{
  "title": "fix(provider): treat missing finish_reason as stop, not other",
  "head": "rekty:fix/null-finish-reason-graceful",
  "base": "main",
  "body": "Closes #2173\n\n## Problem\n\nGateways such as `opencode.ai/zen/go/v1` (serving `muse-spark-1.2-contributor`) never send a `finish_reason`: absent from streaming chunks, `null` in non-streaming. Both mapping paths treated that as an anomaly:\n\n1. `mapOpenAICompatibleFinishReason(null)` fell through the `switch` to `default` → `\"other\"`\n2. The streaming parser seeded `finishReason.unified` with `\"other\"`\n\nSo every complete response from such models was flagged **degraded / think-only**.\n\n## Fix\n\nA missing or `null` `finish_reason` is a normal completion:\n\n- `map-openai-compatible-finish-reason.ts`: early-return `\"stop\"` on `null`/`undefined` before the `switch` (with a comment naming the gateway)\n- `openai-compatible-chat-language-model.ts`: seed the streaming accumulator with `\"stop\"` instead of `\"other\"`\n\nUnrecognized **non-empty** values still fall through to `\"other\"`, and models that do send a proper `finish_reason` (`deepseek-v4-pro`, `glm-5`, ...) override as before.\n\n## Verification\n\n- New tests: `mapOpenAICompatibleFinishReason` null/undefined → `stop`, recognized values unchanged, unknown non-empty → `other`, plus a full `doStream` fixture (muse-spark-style, no `finish_reason` in any chunk) asserting `finish=stop`\n- `bun test` — 4 new + 11 existing copilot chat tests pass\n- `tsgo --noEmit` — clean\n\ncc @MiMoHardFather @wqymi @yanyihan-xiaomi — could one of you approve the CI workflow runs for this fork PR? Thanks!"
}
