### PR TITLE
fix(cron): route fires to the creating session and add cron list --all

### DIFF
--- a/packages/opencode/src/cron/cron-task.ts
+++ b/packages/opencode/src/cron/cron-task.ts
@@ -97,6 +97,17 @@ export const getSessionCronTasks = (): CronTask[] => [...SESSION_STORE.values()]
 export const removeSessionCronTasks = (ids: string[]) =>
   ids.forEach((id) => SESSION_STORE.delete(id))
 
+/**
+ * Which session a fire should be injected into.
+ *
+ * The scheduler is a per-process singleton: the first session to mount it owns
+ * the onFire callback, but tasks record who created them. Routing by the
+ * creator keeps session B's recurring job from leaking into session A's
+ * conversation when A happened to mount the scheduler first (#2198).
+ */
+export const fireTargetSessionId = (task: CronTask, fallback: string): string =>
+  task.createdBySessionId ?? fallback
+
 export const findMissedTasks = (tasks: CronTask[], now: number): CronTask[] =>
   tasks.filter((t) => {
     if (t.recurring) return false

--- a/packages/opencode/src/cron/scheduler.ts
+++ b/packages/opencode/src/cron/scheduler.ts
@@ -69,6 +69,13 @@ export type ListFilter = {
   session_id?: string
   kind?: "cron" | "loop"
   durable_only?: boolean
+  /**
+   * List jobs from every session, not just the named one. `cron list` scopes
+   * to the caller by default, which hid other sessions' jobs from `get`/
+   * `delete` (which only filter when --session is passed) — `--all` restores
+   * visibility (#2198).
+   */
+  all?: boolean
 }
 
 export type ArmLoopInput = {
@@ -383,7 +390,7 @@ const makeImpl = (): Interface => {
         ...session.map((t) => ({ ...t, durable: false as const })),
       ]
       return all.filter((t) => {
-        if (filter.session_id && t.createdBySessionId !== filter.session_id) return false
+        if (!filter.all && filter.session_id && t.createdBySessionId !== filter.session_id) return false
         if (filter.kind === "loop" && t.kind !== "loop") return false
         if (filter.kind === "cron" && t.kind === "loop") return false
         if (filter.durable_only && t.durable !== true) return false

--- a/packages/opencode/src/session/cron-bridge.ts
+++ b/packages/opencode/src/session/cron-bridge.ts
@@ -2,6 +2,7 @@ import { Context, Effect, Layer } from "effect"
 import { Scheduler, defaultLayer as SchedulerDefaultLayer, type LoopEndedEvent } from "@/cron/scheduler"
 import type { CronTask } from "@/cron/cron-task"
 import { resolveAtFireTime, isSentinel, resetOnCompaction as resetCronSentinelOnCompaction } from "@/cron/sentinel"
+import { fireTargetSessionId } from "@/cron/cron-task"
 import { listLoopStates, deleteLoopState, resetStrikes, incrementStrikes, getStrikes } from "@/cron/loop-state"
 import { injectScheduledPrompt } from "./prompt"
 import { SessionStatus } from "./status"
@@ -211,6 +212,11 @@ export const layer = Layer.effect(
         if (!handle.gotFirstEvent) handle.loading = initial.type === "busy"
 
         const onFire = (task: CronTask) => {
+          // The scheduler singleton's onFire closes over the FIRST mounter's
+          // sessionID, but the task records who created it. Route the fire to
+          // the creator so a job made by session B never lands in session A's
+          // conversation just because A mounted the scheduler first (#2198).
+          const targetSessionId = fireTargetSessionId(task, sessionID) as typeof sessionID
           // Detached fire-and-forget on the host runtime. We cannot yield* here
           // because the setInterval tick escapes the Effect scope; the host's
           // global runtime materializes the prompt fan-out (same pattern as
@@ -224,7 +230,7 @@ export const layer = Layer.effect(
               AppRuntime.runPromise(
                 Effect.gen(function* () {
                   const resolved = yield* Effect.tryPromise(() =>
-                    resolveAtFireTime(task.prompt, workspaceRoot, sessionID),
+                    resolveAtFireTime(task.prompt, workspaceRoot, targetSessionId),
                   ).pipe(Effect.orElseSucceed(() => task.prompt))
                   // Prepend an ISO fire timestamp so both the user (TUI) and the
                   // model see when each fire happened. Recurring fires especially
@@ -234,7 +240,7 @@ export const layer = Layer.effect(
                   const firedAtISO = new Date().toISOString().replace(/\.\d{3}Z$/, "Z")
                   const value = `[cron fire @ ${firedAtISO}] ${resolved}`
                   yield* injectScheduledPrompt({
-                    sessionID,
+                    sessionID: targetSessionId,
                     value,
                     origin: {
                       kind: "cron",

--- a/packages/opencode/src/tool/cron.shell.txt
+++ b/packages/opencode/src/tool/cron.shell.txt
@@ -25,6 +25,7 @@ Jobs fire only while the REPL is idle; fires queue at 'later' priority.
     cron list
     cron list --kind loop
     cron list --durable-only
+    cron list --all
     cron get <id>
 
 # cancel (alias: cron cancel <id>):

--- a/packages/opencode/src/tool/cron.ts
+++ b/packages/opencode/src/tool/cron.ts
@@ -59,6 +59,7 @@ const listOperation = z.strictObject({
   action: z.literal("list"),
   kind: kindSchema.optional().describe("Filter by job kind."),
   durable_only: z.boolean().optional().describe("Only show durable jobs."),
+  all: z.boolean().optional().describe("List jobs from every session, not just this one."),
   session_id: sessionFlag,
 })
 
@@ -242,10 +243,10 @@ function mapVerb(rawVerb: string | undefined, args: string[], line: number): Eff
       })
     }
     case "list": {
-      const { flags, bools, rest, error } = extractCronFlags(args, ["kind", "session"], ["durable-only"])
+      const { flags, bools, rest, error } = extractCronFlags(args, ["kind", "session"], ["durable-only", "all"])
       if (error) return flagError("list", error, line)
       if (rest.length > 0)
-        return arityError("list", "[--kind cron|loop] [--durable-only] [--session <id>]", rest, line)
+        return arityError("list", "[--kind cron|loop] [--durable-only] [--all] [--session <id>]", rest, line)
       if (flags.kind && flags.kind !== "cron" && flags.kind !== "loop")
         return flagError("list", `--kind must be cron|loop (got '${flags.kind}')`, line)
       return Effect.succeed({
@@ -253,6 +254,7 @@ function mapVerb(rawVerb: string | undefined, args: string[], line: number): Eff
           action: "list" as const,
           ...(flags.kind ? { kind: flags.kind as "cron" | "loop" } : {}),
           ...(bools["durable-only"] ? { durable_only: true } : {}),
+          ...(bools.all ? { all: true } : {}),
           ...(flags.session ? { session_id: flags.session } : {}),
         },
       })
@@ -381,11 +383,18 @@ export const CronTool = Tool.define<typeof parameters, Metadata, Scheduler>(
           session_id: sessionID,
           kind: op.kind,
           durable_only: op.durable_only,
+          all: op.all,
         })
         const lines =
           tasks.length === 0
             ? ["No scheduled jobs."]
-            : tasks.map((t) => `${t.id} ${t.cron} ${t.kind ?? "cron"} — ${t.prompt.slice(0, 60)}`)
+            : tasks.map((t) => {
+                // Under --all the jobs come from several sessions; surface the
+                // creator so the caller can tell them apart (and target
+                // get/delete --session correctly).
+                const owner = op.all && t.createdBySessionId ? ` [${t.createdBySessionId}]` : ""
+                return `${t.id} ${t.cron} ${t.kind ?? "cron"}${owner} — ${t.prompt.slice(0, 60)}`
+              })
         return {
           title: `Jobs: ${tasks.length}`,
           output: lines.join("\n"),

--- a/packages/opencode/src/tool/cron.txt
+++ b/packages/opencode/src/tool/cron.txt
@@ -11,7 +11,9 @@ JSON calls always wrap the action in an `operation` object — see examples belo
 - loop:     self-paced one-shot with keepalive. `delay_seconds` (clamped to
             [60, 3600]) + `prompt` required. Always session-only, always kind=loop.
             Call again each turn to keep the loop alive; omit to end the loop.
-- list:     enumerate active jobs. optional: `kind`, `durable_only`.
+- list:     enumerate active jobs. optional: `kind`, `durable_only`, `all`.
+  `all` lists jobs from every session (default: only this session's jobs) —
+  use it when a job id the user mentions isn't in the default listing.
 - get:      fetch one job by id.
 - delete:   cancel a job by id.
 - rename:   change the prompt body of an existing job.

--- a/packages/opencode/test/cron/cron-task.test.ts
+++ b/packages/opencode/test/cron/cron-task.test.ts
@@ -98,3 +98,19 @@ test("writeCronTasks drops tasks with malformed cron", async () => {
   expect(back.map((t) => t.id)).toEqual(["g1"])
   rmSync(dir, { recursive: true, force: true })
 })
+
+// #2198: the scheduler singleton's onFire closes over the first mounter's
+// session, so fires must be routed by the task's creator, falling back to the
+// mounting session only when the task predates creator tracking.
+test("fireTargetSessionId prefers the task creator over the mounting session", async () => {
+  const { fireTargetSessionId } = await import("@/cron/cron-task")
+  const created = {
+    id: "t1",
+    cron: "*/10 * * * *",
+    prompt: "hi",
+    createdAt: 1,
+    createdBySessionId: "ses_b",
+  }
+  expect(fireTargetSessionId(created, "ses_a")).toBe("ses_b")
+  expect(fireTargetSessionId({ ...created, createdBySessionId: undefined }, "ses_a")).toBe("ses_a")
+})

--- a/packages/opencode/test/cron/scheduler.test.ts
+++ b/packages/opencode/test/cron/scheduler.test.ts
@@ -289,3 +289,46 @@ test("same-tick double-fire: only the first due task fires per tick", async () =
   removeSessionCronTasks(["taskA", "taskB"])
   rmSync(dir, { recursive: true, force: true })
 })
+
+// #2198: `cron list` scopes to the caller while get/delete only filter when
+// --session is passed, so jobs created by another session were invisible to
+// list but reachable by id. `all: true` restores visibility across sessions.
+test("list with all:true returns tasks from every session", async () => {
+  const dir = freshDir()
+  await provided(
+    Effect.gen(function* () {
+      const sched = yield* Scheduler
+      yield* sched.start(baseStartOpts(dir))
+
+      // Session A's durable task lives on disk.
+      yield* sched.add({
+        session_id: "ses_a",
+        cron: "0 9 * * *",
+        prompt: "a-job",
+        recurring: true,
+        durable: true,
+      })
+      // Session B's task lives in the session store.
+      const bTask = yield* sched.add({
+        session_id: "ses_b",
+        cron: "*/10 * * * *",
+        prompt: "b-job",
+        recurring: true,
+        durable: false,
+      })
+
+      const scopedToB = yield* sched.list({ session_id: "ses_b" })
+      expect(scopedToB.map((t) => t.id)).toEqual([bTask.id])
+
+      const everything = yield* sched.list({ all: true })
+      expect(everything.map((t) => t.prompt).sort()).toEqual(["a-job", "b-job"])
+
+      // all:true still honors the other filters.
+      const allLoops = yield* sched.list({ all: true, kind: "loop" })
+      expect(allLoops).toEqual([])
+
+      yield* sched.stop()
+    }),
+  )
+  rmSync(dir, { recursive: true, force: true })
+})

--- a/packages/opencode/test/tool/cron.test.ts
+++ b/packages/opencode/test/tool/cron.test.ts
@@ -329,3 +329,15 @@ describe("cron.execute: schedule sanity warnings", () => {
     expect(out.output).not.toMatch(/rolled|never matches/)
   })
 })
+
+describe("cron.shell.parse: list --all", () => {
+  test("list with --all sets all: true", async () => {
+    const out = await parse(`cron list --all`)
+    expect(out).toEqual([{ operation: { action: "list", all: true } }])
+  })
+
+  test("list --all composes with --kind and --durable-only", async () => {
+    const out = await parse(`cron list --all --kind cron --durable-only`)
+    expect(out).toEqual([{ operation: { action: "list", kind: "cron", durable_only: true, all: true } }])
+  })
+})


### PR DESCRIPTION
{
  "title": "fix(cron): route fires to the creating session and add cron list --all",
  "head": "rekty:fix/cron-session-dispatch",
  "base": "main",
  "body": "Closes #2198\n\nTwo related bugs when multiple sessions share one process:\n\n## 1. Cross-session fire leakage\n\nThe scheduler is a per-process singleton (`if (rt) return`). The first session to mount it owns the `onFire` callback, and every subsequent session silently inherits it — even tasks created by session B land in session A's conversation.\n\n`fireTargetSessionId(task, fallback)` consults `task.createdBySessionId` (which `add()` has been recording since scheduler.ts:298 but nobody read) and falls back to the mounting session only for legacy tasks that lack the field.\n\n## 2. `cron list` scope hides other sessions' jobs\n\n`cron list` defaulted to the caller's session (`session_id: ctx.sessionID`), while `get`/`delete` only filtered on `--session` — so a job id the user could retrieve and cancel was invisible to `cron list`. Adding `--all` to `listOperation` tells the scheduler to skip the session filter entirely. When `all` is requested the owner is surfaced in the output so the caller can target `--session` correctly.\n\n## Changes\n\n| file | what |\n|---|---|\n| `cron/cron-task.ts` | `fireTargetSessionId(task, fallback)` helper |\n| `cron/scheduler.ts` | `ListFilter.all`; `list()` skips session filter when set |\n| `session/cron-bridge.ts` | `onFire` dispatches via `fireTargetSessionId` |\n| `tool/cron.ts` | `--all` on list (JSON + shell); owner shown in output |\n| `tool/cron.txt` / `cron.shell.txt` | document `all` |"
}
