### PR TITLE
fix: default checkpoint writer to fork mode

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -286,7 +286,7 @@ const InfoSchema = Schema.Struct({
       }),
       fork: Schema.optional(Schema.Boolean).annotate({
         description:
-          "Whether to fork the parent agent's message prefix into the writer session for prefix-cache reuse. Requires provider cache-breakpoint support. Default: false.",
+          "Whether to fork the parent agent's message prefix into the writer session for prefix-cache reuse. Requires provider cache-breakpoint support. Default: true.",
       }),
       push_caps: Schema.optional(
         Schema.Struct({

--- a/packages/opencode/src/session/checkpoint.ts
+++ b/packages/opencode/src/session/checkpoint.ts
@@ -749,14 +749,11 @@ export const layer: Layer.Layer<
       //          last_checkpoint_message_id (aligned past tool_use/tool_result).
       // See spec 2026-06-09-checkpoint-writer-child-session-and-no-fork-fallback-design.md §3.
       //
-      // Default-behavior change at this PR: previously the writer always forked
-      // the parent's full prefix (effectively fork: true). The default is now
-      // false (no-fork delta-only). Users on cache-breakpoint providers
-      // (Anthropic) who want to retain the prefix-cache benefit must set
-      // `checkpoint.fork: true` in their config. See the spec at
-      // docs/superpowers/specs/2026-06-09-checkpoint-writer-child-session-and-no-fork-fallback-design.md §4.5.
+      // The writer forks the parent's full prefix by default for prefix-cache
+      // reuse. Users who need cold-start delta-only behavior can set
+      // `checkpoint.fork: false` in their config.
       const cfg = yield* config.get()
-      const forkMode = cfg.checkpoint?.fork ?? false
+      const forkMode = cfg.checkpoint?.fork ?? true
 
       const parentRow = yield* Effect.sync(() =>
         Database.use((d) =>

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/config.md
@@ -123,7 +123,7 @@ The trigger is the model's prompt capacity (`limit.input` when the provider publ
 | `compaction.max_context` | Compact earlier than the model window. One value for all models, or a map keyed `"<providerID>/<modelID>"` (wildcards allowed, longest pattern wins). Values: token count, `"300K"`, `"1M"`, or `"50%"` of the window. Always clamped to the provider cap — can only lower the trigger, never raise it. `0` = no budget. Set it from the TUI with `/context-limit` |
 | `checkpoint.thresholds` | Context-fill triggers, e.g. `["40%","60%","80%"]` |
 | `checkpoint.reserved` | Token buffer for checkpoint ops (default 20000) |
-| `checkpoint.fork` | Fork parent prefix into writer session for cache reuse (default false) |
+| `checkpoint.fork` | Fork parent prefix into writer session for cache reuse (default true) |
 | `checkpoint.push_caps.*` | Per-section token caps for rebuild context (tasks_ledger, focus_task, checkpoint, memory, notes, global, recent_user, …) |
 | `checkpoint.task_archive_days` | Days before done/abandoned tasks filtered out (default 7) |
 | `checkpoint.memory_search_score_floor` | BM25 relative floor for memory search (default 0.15) |

--- a/packages/opencode/test/session/checkpoint-fork-mode.test.ts
+++ b/packages/opencode/test/session/checkpoint-fork-mode.test.ts
@@ -243,7 +243,7 @@ const seedFourMessages = Effect.fn("seedFourMessages")(function* () {
 
 describe("checkpoint writer forkContext shape per mode", () => {
   it.live(
-    "T6: fork:true preserves prefix-cache parent-fork shape (parent agent + slice up to watermark)",
+    "T6: fork unset defaults to prefix-cache parent-fork shape (parent agent + slice up to watermark)",
     provideTmpdirInstance(
       () =>
         Effect.gen(function* () {
@@ -281,7 +281,7 @@ describe("checkpoint writer forkContext shape per mode", () => {
           expect(fc?.system).toEqual(["sys-canned"])
           expect(fc?.watermarkMsgID).toBe(u2.id)
         }),
-      { config: { checkpoint: { fork: true } } },
+      { config: {} },
     ),
   )
 
@@ -515,7 +515,7 @@ describe("checkpoint writer forkContext shape per mode", () => {
           expect(fc).toBeDefined()
           expect(fc?.watermarkMsgID).toBe(u2.id)
         }),
-      // Default config (fork unset) → fork: false. Explicitly setting for clarity.
+      // Explicit fork:false keeps the cold-start delta-only path available.
       { config: { checkpoint: { fork: false } } },
     ),
   )

--- a/packages/opencode/test/skill/mimocode-docs.test.ts
+++ b/packages/opencode/test/skill/mimocode-docs.test.ts
@@ -57,6 +57,13 @@ describe("mimocode-docs provider guidance", () => {
     expect(providers).toContain("Write the recent state only after `mimo models PROVIDER_ID`")
     expect(providers).toContain("Never put the API key, base URL, display name, or combined `provider/model` string")
   })
+
+  test("documents the checkpoint writer fork default", async () => {
+    const config = await Bun.file(path.join(root, "reference/config.md")).text()
+
+    expect(config).toContain("| `checkpoint.fork` | Fork parent prefix into writer session for cache reuse (default true) |")
+    expect(config).not.toContain("| `checkpoint.fork` | Fork parent prefix into writer session for cache reuse (default false) |")
+  })
 })
 
 describe("mimocode-docs TUI troubleshooting", () => {


### PR DESCRIPTION
## Summary

- Default the checkpoint writer to fork mode when `checkpoint.fork` is unset.
- Keep explicit `checkpoint.fork: false` as the cold-start delta-only override.
- Update configuration documentation and regression coverage.

## Validation

- `bun test --timeout 30000 test/config/checkpoint-fork.test.ts test/session/checkpoint-fork-mode.test.ts`
- `bun run lint`
- `bun run typecheck`
