### PR TITLE
fix(config): tolerate bare permission words in MIMOCODE_PERMISSION env var

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -971,7 +971,29 @@ export const layer = Layer.effect(
         }
 
         if (Flag.MIMOCODE_PERMISSION) {
-          result.permission = mergeDeep(result.permission ?? {}, JSON.parse(Flag.MIMOCODE_PERMISSION))
+          const raw = Flag.MIMOCODE_PERMISSION
+          let parsed: Record<string, unknown>
+          try {
+            parsed = JSON.parse(raw)
+          } catch {
+            // Tolerate bare action words like "allow" / "ask" / "deny" which
+            // are the only documented permission actions.  A bare word is not
+            // valid JSON, but it is a common mistake (e.g. `setx MIMOCODE_PERMISSION allow`).
+            const bare = raw.trim().toLowerCase()
+            if (bare === "allow" || bare === "ask" || bare === "deny") {
+              parsed = { "*": bare } as ConfigPermission.Info
+              console.warn(
+                `[config] MIMOCODE_PERMISSION="${raw}" is not valid JSON — treating as { "*": "${bare}" }. ` +
+                `Use JSON syntax for future: MIMOCODE_PERMISSION='"${bare}"'`,
+              )
+            } else {
+              throw new Error(
+                `MIMOCODE_PERMISSION must be valid JSON (e.g. '"allow"') — got bare word '${raw}'. ` +
+                `Hint: wrap the value in quotes: MIMOCODE_PERMISSION='"${raw}"'`,
+              )
+            }
+          }
+          result.permission = mergeDeep(result.permission ?? {}, parsed)
         }
 
         if (result.tools) {


### PR DESCRIPTION
## Summary

Wraps `JSON.parse(MIMOCODE_PERMISSION)` in a try/catch so bare words like `allow` (a common mistake from `setx MIMOCODE_PERMISSION allow`) no longer crash every subcommand.

## Problem

Setting `MIMOCODE_PERMISSION=allow` as a bare word (without JSON quotes) crashes MiMoCode at startup on every subcommand with `JSON Parse error: Unexpected identifier "allow"` — including headless ones like `debug` and `session list`. Recovery requires manually editing the Windows registry.

## Fix

1. Tolerate bare words `allow`, `ask`, `deny` → treat as `{ "*": value }` with a warning
2. Other bare words → clear error message with hint on correct syntax
3. Valid JSON values → work exactly as before (no behavior change)

**Changed:** 1 file, +23/−1 (`packages/opencode/src/config/config.ts`)

Closes #2170

CC @MiMoHardFather @wqymi @yanyihan-xiaomi — please approve CI runs for first-time contributor. 🙏