### PR TITLE
fix(tui): clamp terminal foreground in light mode to prevent whitish text

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -584,9 +584,20 @@ export function tint(base: RGBA, overlay: RGBA, alpha: number): RGBA {
 
 function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
-  const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
+  let fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
   const transparent = RGBA.fromValues(bg.r, bg.g, bg.b, 0)
   const isDark = mode == "dark"
+
+  // In light mode, if the terminal foreground is too light (close to white),
+  // clamp it to a dark color so text remains readable against light backgrounds.
+  // This fixes Windows Terminal light themes where the default foreground is
+  // near-white, causing invisible "whitish" text in the TUI (#2144).
+  if (!isDark) {
+    const fgLum = fg.r * 255 * 0.299 + fg.g * 255 * 0.587 + fg.b * 255 * 0.114
+    if (fgLum > 180) {
+      fg = RGBA.fromHex("#1a1a1a")
+    }
+  }
 
   const col = (i: number) => {
     const value = colors.palette[i]


### PR DESCRIPTION
## Summary

Adds a luminance guard in `generateSystem()` so that when the terminal foreground color is near-white (luminance > 180) in light mode, it is clamped to `#1a1a1a`.

## Problem

When using the "system" theme in light mode on Windows Terminal, the TUI uses the terminal's native foreground color as the text color.  Many Windows Terminal light themes set the foreground to near-white, making all text invisible against the light background (issue #2144).

## Fix

After resolving the terminal foreground color, check its luminance in light mode. If it is too light (> 180), replace it with `#1a1a1a` — a safe, high-contrast dark gray.  Dark mode is unaffected.

**Changed:** 1 file, +12/−1 (`packages/opencode/src/cli/cmd/tui/context/theme.tsx`)

Closes #2144

CC @MiMoHardFather @wqymi @yanyihan-xiaomi — please approve CI runs for first-time contributor. 🙏