### PR TITLE
feat(tool): support attachments in plugin tool results

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -200,6 +200,7 @@ export const layer = Layer.effect(
                 const result = yield* Effect.promise(() => def.execute(args as any, pluginCtx))
                 const output = typeof result === "string" ? result : result.output
                 const metadata = typeof result === "string" ? {} : (result.metadata ?? {})
+                const attachments = typeof result === "string" ? undefined : result.attachments
                 const info = yield* agent.get(toolCtx.agent)
                 const out = yield* truncate.output(output, {}, info)
                 return {
@@ -210,6 +211,7 @@ export const layer = Layer.effect(
                     truncated: out.truncated,
                     ...(out.truncated && { outputPath: out.outputPath }),
                   },
+                  ...(attachments?.length && { attachments }),
                 }
               }),
           }

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -27,7 +27,7 @@ type AskInput = {
   metadata: { [key: string]: any }
 }
 
-export type ToolResult = string | { output: string; metadata?: { [key: string]: any } }
+export type ToolResult = string | { output: string; metadata?: { [key: string]: any }; attachments?: { type: "file"; mime: string; url: string; filename?: string }[] }
 
 export function tool<Args extends z.ZodRawShape>(input: {
   description: string


### PR DESCRIPTION
## Summary

- Allow plugin/extension tools to return `attachments` alongside text output
- `ToolResult` type in `@mimo-ai/plugin` now supports optional `attachments` array
- `fromPlugin` in registry passes attachments through to `ExecuteResult`

## Motivation

Desktop's `image_gen` tool generates images and needs to display them inline in the chat UI. The existing `ToolShots` rendering component already handles `attachments` on tool results, but the plugin tool framework (`fromPlugin`) was discarding them. This PR bridges that gap.

## Changes

- `packages/plugin/src/tool.ts`: Add `attachments` to `ToolResult` type
- `packages/opencode/src/tool/registry.ts`: Pass `result.attachments` through in `fromPlugin`

## Test plan

- [ ] Existing tools unaffected (string returns still work as before)
- [ ] Plugin tool returning `{ output, attachments: [{type:"file", mime:"image/png", url:"data:..."}] }` renders inline image in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)