### PR TITLE
fix: simplify MiMo model harness selection

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -266,6 +266,7 @@ export type Event = Result["fullStream"] extends AsyncIterable<infer T> ? T : ne
 
 /** Convert per-turn context into the final model-visible user segment. */
 export function turnContextMessages(user: MessageV2.User): ModelMessage[] {
+  if (user.systemMode === "replace-agent") return []
   const context = user.system?.trim()
   if (!context) return []
   return [{
@@ -337,6 +338,8 @@ const live: Layer.Layer<
             : SystemPrompt.agent(input.agent, input.model, input.user.harness)),
           // any custom prompt passed into this call
           ...input.system,
+          // replace-agent is a session system prompt, not per-turn user context
+          ...(input.user.systemMode === "replace-agent" && input.user.system ? [input.user.system] : []),
         ]
           .filter((x) => x)
           .join("\n"),
@@ -489,7 +492,9 @@ const live: Layer.Layer<
       )
       const isWorkflow = language instanceof GitLabWorkflowLanguageModel
       const providerSystem =
-        (isOpenaiOauth || isWorkflow) && input.user.system?.trim() ? [...system, input.user.system] : system
+        input.user.systemMode !== "replace-agent" && (isOpenaiOauth || isWorkflow) && input.user.system?.trim()
+          ? [...system, input.user.system]
+          : system
       if (isOpenaiOauth) options.instructions = providerSystem.join("\n")
       // Reactive prefill-rejection backstop. The PRIMARY mechanism is the
       // proactive guard in ProviderTransform.message()

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -23,7 +23,7 @@ import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { Flag } from "@/flag/flag"
-import { type HarnessMode, isGPTModel, usesMimoDefaultMode, usesMimoResponsesApi } from "@/tool/gpt"
+import { type HarnessMode, isGPTModel } from "@/tool/gpt"
 
 function renderGitResult(result: Git.Result, fallback = "(none)") {
   if (result.exitCode !== 0) return fallback
@@ -33,11 +33,9 @@ function renderGitResult(result: Git.Result, fallback = "(none)") {
 const anthropicEnvironment = new Map<string, string>()
 
 export function provider(model: Provider.Model, harness?: HarnessMode) {
-  if (usesMimoDefaultMode(model.id, model.api.id, model.family)) return [PROMPT_DEFAULT]
   if (harness === "codex" || ((harness === undefined || harness === "auto") && Flag.MIMOCODE_CODEX_MODE)) return [PROMPT_GPT]
   const prompt = (id: string) => {
     if (isGPTModel(id)) return PROMPT_GPT
-    if (usesMimoResponsesApi(id)) return harness === "default" ? PROMPT_DEFAULT : PROMPT_GPT
     if (id.includes("gpt-4") || id.includes("o1") || id.includes("o3")) return PROMPT_BEAST
     if (id.includes("gemini-")) return PROMPT_GEMINI
     if (id.includes("claude")) return PROMPT_ANTHROPIC

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -19,9 +19,8 @@ export function isMcpToolSearchEnabled(
   harness: HarnessMode | undefined,
   ...modelIDs: Array<string | undefined>
 ) {
-  if (usesMimoDefaultMode(...modelIDs)) return enabled
   if (isGPTModel(...modelIDs)) return true
-  return enabled || (codexHarnessOverride(harness) ?? (Flag.MIMOCODE_CODEX_MODE || usesMimoResponsesApi(...modelIDs)))
+  return enabled || (codexHarnessOverride(harness) ?? Flag.MIMOCODE_CODEX_MODE)
 }
 
 export function isMimoModel(...values: Array<string | undefined>) {
@@ -33,17 +32,12 @@ export function usesMimoResponsesApi(...values: Array<string | undefined>) {
   return isMimoModel(...ids) && ids.some((id) => /(?:^|[/_.-])ptc(?:$|[/_.-])/.test(id))
 }
 
-export function usesMimoDefaultMode(...values: Array<string | undefined>) {
-  return isMimoModel(...values) && !usesMimoResponsesApi(...values)
-}
-
 export function usesGPTToolset(
   modelID: string,
   harness?: HarnessMode,
   ...modelIDs: Array<string | undefined>
 ) {
   const ids = [modelID, ...modelIDs]
-  if (usesMimoDefaultMode(...ids)) return false
   if (isGPTModel(...ids)) return true
-  return codexHarnessOverride(harness) ?? (Flag.MIMOCODE_CODEX_MODE || usesMimoResponsesApi(...ids))
+  return codexHarnessOverride(harness) ?? Flag.MIMOCODE_CODEX_MODE
 }

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -705,6 +705,11 @@ it.live("locks system and harness to the first user query", () =>
       const request = JSON.stringify(input)
       expect(request).not.toContain("You are Codex")
       expect(request).toContain("first system prompt")
+      expect(
+        (input.messages as Array<{ role: string; content: unknown }>)
+          .filter((message) => JSON.stringify(message.content).includes("first system prompt"))
+          .map((message) => message.role),
+      ).toEqual(["system"])
       expect((input.tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(["exec"])
 
       yield* prompt.prompt({

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -63,14 +63,14 @@ describe("session.system", () => {
     expect(prompt).not.toContain("gitStatus:")
   })
 
-  test("non-Responses MiMo forces the default prompt even with the Codex harness", () => {
+  test("the explicit harness selects the prompt for MiMo regardless of API transport", () => {
     const gpt = ProviderTest.model({ id: ModelID.make("gpt-5.2"), api: { id: "gpt-5.2" } as never })
     expect(SystemPrompt.provider(gpt, "default")[0]).toContain("You are Codex")
     expect(SystemPrompt.provider(gpt, "default")[0]).toContain("tools.apply_patch")
 
     const mimo = ProviderTest.model({ id: ModelID.make("mimo-v2.6"), api: { id: "mimo-v2.6" } as never })
-    expect(SystemPrompt.provider(mimo, "codex")[0]).not.toContain("You are Codex")
-    expect(SystemPrompt.provider(mimo, "codex")[0]).not.toContain("tools.apply_patch")
+    expect(SystemPrompt.provider(mimo, "codex")[0]).toContain("You are Codex")
+    expect(SystemPrompt.provider(mimo, "codex")[0]).toContain("tools.apply_patch")
     expect(SystemPrompt.provider(mimo, "default")[0]).not.toContain("You are Codex")
     expect(SystemPrompt.provider(mimo, "default")[0]).not.toContain("tools.apply_patch")
 
@@ -79,6 +79,7 @@ describe("session.system", () => {
       api: { id: "mimo-v2.6-ptc" } as never,
     })
     expect(SystemPrompt.provider(responses, "codex")[0]).toContain("You are Codex")
+    expect(SystemPrompt.provider(responses, "default")[0]).not.toContain("You are Codex")
   })
 
   test("renders machine and repository environment only for Claude models", async () => {
@@ -213,7 +214,7 @@ describe("session.system", () => {
     expect(prompt).not.toContain("When possible, prefer parallelization over sequential tool calls")
   })
 
-  test("uses the GPT prompt for Codex and MiMo Responses models and the normal prompt for versioned MiMo models", () => {
+  test("uses the GPT prompt for GPT models and the normal prompt for MiMo models", () => {
     const gpt = SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("gpt-5.4") }))[0]
     const normal = SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("model-default") }))[0]
     const prompts = ["mimo-v2.5", "mimo-v2.5-pro", "mimo-v2.5-pro-ultraspeed", "mimo-v2-pro", "mimo-v2.6"].map(
@@ -227,10 +228,10 @@ describe("session.system", () => {
 
     expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("gpt-5.4-codex") }))[0]).toBe(gpt)
     expect(prompts).toEqual([normal, normal, normal, normal, normal])
-    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6-ptc") }))[0]).toBe(gpt)
+    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6-ptc") }))[0]).toBe(normal)
   })
 
-  test("Codex mode forces the GPT prompt for non-MiMo models", () => {
+  test("Codex mode forces the GPT prompt for every model", () => {
     const gpt = SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("gpt-5.4") }))[0]
     process.env.MIMOCODE_CODEX_MODE = "true"
     const prompt = SystemPrompt.provider(
@@ -241,7 +242,7 @@ describe("session.system", () => {
     )[0]
 
     expect(prompt).toBe(gpt)
-    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6") }))[0]).not.toBe(gpt)
+    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6") }))[0]).toBe(gpt)
     expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6-ptc") }))[0]).toBe(gpt)
   })
 

--- a/packages/opencode/test/session/turn-context-tail.test.ts
+++ b/packages/opencode/test/session/turn-context-tail.test.ts
@@ -25,7 +25,7 @@ const it = testEffect(
   ),
 )
 
-function makeUser(system?: string): MessageV2.User {
+function makeUser(system?: string, systemMode?: MessageV2.User["systemMode"]): MessageV2.User {
   return {
     id: MessageID.ascending(),
     sessionID: SessionID.make("ses_turncontext"),
@@ -34,6 +34,7 @@ function makeUser(system?: string): MessageV2.User {
     agent: "build",
     model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test") },
     system,
+    systemMode,
   } as unknown as MessageV2.User
 }
 
@@ -71,6 +72,16 @@ describe("turnContextMessages", () => {
         role: "user",
         content: "MAX_STEPS\n\n<system-reminder>\nclock\n</system-reminder>",
       }])
+    }),
+  )
+
+  it.effect("replace-agent system never becomes a trailing user reminder", () =>
+    Effect.sync(() => {
+      const user = makeUser("replacement system", "replace-agent")
+      expect(turnContextMessages(user)).toEqual([])
+      expect(appendTurnContext([{ role: "user", content: "question" }], user, true)).toEqual([
+        { role: "user", content: "question" },
+      ])
     }),
   )
 })

--- a/packages/opencode/test/tool/gpt.test.ts
+++ b/packages/opencode/test/tool/gpt.test.ts
@@ -35,28 +35,30 @@ describe("isMcpToolSearchEnabled", () => {
     expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.5-pro-ultraspeed")).toBe(false)
     expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2-pro")).toBe(false)
     expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6")).toBe(false)
-    expect(isMcpToolSearchEnabled(false, undefined, "mimo-ptc-test")).toBe(true)
-    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6-ptc")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-ptc-test")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6-ptc")).toBe(false)
     expect(isMcpToolSearchEnabled(false, undefined, "gpt-5.2")).toBe(true)
     expect(isMcpToolSearchEnabled(false, undefined, "gpt-oss-120b")).toBe(false)
     expect(isMcpToolSearchEnabled(true, undefined, "claude-opus-4-6")).toBe(true)
   })
 
-  test("keeps non-Responses MiMo in default mode when process Codex mode is enabled", () => {
+  test("enables every non-GPT model when process Codex mode is enabled", () => {
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(isMcpToolSearchEnabled(false, undefined, "claude-opus-4-6")).toBe(true)
-    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6")).toBe(true)
     expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6-ptc")).toBe(true)
   })
 
   test("allows the resolved session mode to override the process mode", () => {
     expect(isMcpToolSearchEnabled(false, "codex", "claude-opus-4-6")).toBe(true)
-    expect(isMcpToolSearchEnabled(false, "codex", "mimo-v2.6")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "codex", "mimo-v2.6")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "codex", "mimo-v2.6-ptc")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "auto", "gpt-5.2")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "auto", "claude-opus-4-6")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(isMcpToolSearchEnabled(false, "auto", "claude-opus-4-6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, "auto", "mimo-v2.6")).toBe(true)
+    expect(isMcpToolSearchEnabled(false, "auto", "mimo-v2.6-ptc")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "default", "claude-opus-4-6")).toBe(false)
     expect(isMcpToolSearchEnabled(false, "default", "mimo-v2.6")).toBe(false)
     expect(isMcpToolSearchEnabled(false, "default", "gpt-5.2")).toBe(true)
@@ -65,34 +67,37 @@ describe("isMcpToolSearchEnabled", () => {
 })
 
 describe("usesGPTToolset", () => {
-  test("uses the normal toolset for versioned MiMo models and the GPT toolset for Responses PTC", () => {
+  test("uses the normal toolset for MiMo models regardless of API transport", () => {
     expect(usesGPTToolset("mimo-v2.5")).toBe(false)
     expect(usesGPTToolset("mimo-v2.5-pro")).toBe(false)
     expect(usesGPTToolset("mimo-v2.5-pro-ultraspeed")).toBe(false)
     expect(usesGPTToolset("mimo-v2-pro")).toBe(false)
     expect(usesGPTToolset("mimo-v2.6")).toBe(false)
-    expect(usesGPTToolset("mimo-ptc-test")).toBe(true)
-    expect(usesGPTToolset("mimo-v2.6-ptc")).toBe(true)
+    expect(usesGPTToolset("mimo-ptc-test")).toBe(false)
+    expect(usesGPTToolset("mimo-v2.6-ptc")).toBe(false)
   })
 
-  test("uses the GPT toolset for non-MiMo models in process Codex mode", () => {
+  test("uses the GPT toolset for every non-GPT model in process Codex mode", () => {
     expect(usesGPTToolset("claude-opus-4-6")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(usesGPTToolset("claude-opus-4-6")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6-ptc")).toBe(true)
   })
 
   test("allows the resolved session mode to override the process mode", () => {
     expect(usesGPTToolset("claude-opus-4-6", "codex")).toBe(true)
-    expect(usesGPTToolset("mimo-v2.6", "codex")).toBe(false)
+    expect(usesGPTToolset("mimo-v2.6", "codex")).toBe(true)
     expect(usesGPTToolset("mimo-v2.6-ptc", "codex")).toBe(true)
-    expect(usesGPTToolset("deployment-primary", "codex", "mimo-v2.6", "mimo")).toBe(false)
+    expect(usesGPTToolset("deployment-primary", "codex", "mimo-v2.6", "mimo")).toBe(true)
     expect(usesGPTToolset("deployment-primary", "codex", "mimo-v2.6-ptc", "mimo")).toBe(true)
     expect(usesGPTToolset("gpt-5.2", "auto")).toBe(true)
-    expect(usesGPTToolset("mimo-v2.6-ptc", "auto")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6-ptc", "auto")).toBe(false)
     expect(usesGPTToolset("claude-opus-4-6", "auto")).toBe(false)
     process.env.MIMOCODE_CODEX_MODE = "true"
     expect(usesGPTToolset("claude-opus-4-6", "auto")).toBe(true)
-    expect(usesGPTToolset("mimo-v2.6", "auto")).toBe(false)
+    expect(usesGPTToolset("mimo-v2.6", "auto")).toBe(true)
+    expect(usesGPTToolset("mimo-v2.6-ptc", "auto")).toBe(true)
     expect(usesGPTToolset("claude-opus-4-6", "default")).toBe(false)
     expect(usesGPTToolset("mimo-v2.6", "default")).toBe(false)
     expect(usesGPTToolset("gpt-5.2", "default")).toBe(true)

--- a/packages/opencode/test/tool/registry-invocation-style.test.ts
+++ b/packages/opencode/test/tool/registry-invocation-style.test.ts
@@ -61,28 +61,41 @@ describe("ToolRegistry.tools: invocation style resolution", () => {
     ),
   )
 
-  it.live("keeps non-Responses MiMo on the default toolset even with the Codex harness", () =>
+  it.live("uses the harness rather than MiMo API transport to select the toolset", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const reg = yield* ToolRegistry.Service
         const agents = yield* Agent.Service
         const build = yield* agents.get("build")
-        const normal = yield* reg.tools({
+        const normalDefault = yield* reg.tools({
+          providerID: ProviderID.make("xiaomi"),
+          modelID: ModelID.make("mimo-v2.6"),
+          agent: build,
+        })
+        const responsesDefault = yield* reg.tools({
+          providerID: ProviderID.make("xiaomi"),
+          modelID: ModelID.make("mimo-v2.6-ptc"),
+          agent: build,
+        })
+        const normalCodex = yield* reg.tools({
           providerID: ProviderID.make("xiaomi"),
           modelID: ModelID.make("mimo-v2.6"),
           agent: build,
           harness: "codex",
         })
-        const responses = yield* reg.tools({
+        const responsesCodex = yield* reg.tools({
           providerID: ProviderID.make("xiaomi"),
           modelID: ModelID.make("mimo-v2.6-ptc"),
           agent: build,
           harness: "codex",
         })
 
-        expect(normal.map((tool) => tool.id)).toContain("bash")
-        expect(normal.map((tool) => tool.id)).not.toContain("exec")
-        expect(responses.map((tool) => tool.id)).toEqual(["exec"])
+        expect(normalDefault.map((tool) => tool.id)).toContain("bash")
+        expect(normalDefault.map((tool) => tool.id)).not.toContain("exec")
+        expect(responsesDefault.map((tool) => tool.id)).toContain("bash")
+        expect(responsesDefault.map((tool) => tool.id)).not.toContain("exec")
+        expect(normalCodex.map((tool) => tool.id)).toEqual(["exec"])
+        expect(responsesCodex.map((tool) => tool.id)).toEqual(["exec"])
       }),
     ),
   )


### PR DESCRIPTION
## Summary

Remove the distinction between MiMo default mode and Responses API (PTC) transport when selecting toolset and system prompt. The explicit harness flag (codex/default) is now the single source of truth.

### Changes

- **Remove `usesMimoDefaultMode()`** — no longer needed since MiMo models no longer force the default prompt regardless of harness
- **Gate toolset on harness flag only** — `usesGPTToolset` and `isMcpToolSearchEnabled` no longer check API transport; PTC transport no longer auto-selects the GPT toolset
- **Gate system prompt on harness flag only** — `SystemPrompt.provider` no longer special-cases MiMo Responses API models to the GPT prompt
- **Handle `replace-agent` systemMode** — keep as session system prompt, never as trailing user context
- **Update all affected tests** to reflect the simplified model

### Verification

- All 18 packages pass `tsgo --noEmit` typecheck
- Unit tests updated and passing

### Motivation

Previously, MiMo models had two orthogonal axes controlling behavior: the explicit harness flag AND the API transport type. This created confusing interactions where:
- Non-PTC MiMo models ignored the harness flag entirely
- PTC models auto-selected the GPT toolset even in "default" mode
- `MIMOCODE_CODEX_MODE` env var had different effects depending on transport

The simplified model treats the harness flag as the single switch — clean, predictable, and consistent across all model variants.
