### PR TITLE
fix(session): match list directory filter case-insensitively on Windows

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -8,7 +8,7 @@ import { type ProviderMetadata, type LanguageModelUsage } from "ai"
 import { Flag } from "../flag/flag"
 import { InstallationVersion } from "../installation/version"
 
-import { Database, NotFoundError, eq, and, gte, isNull, desc, like, inArray, lt } from "../storage"
+import { Database, NotFoundError, eq, and, gte, isNull, desc, like, inArray, lt, sql } from "../storage"
 import { SyncEvent } from "../sync"
 import type { SQL } from "../storage"
 import { PartTable, SessionTable, MessageTable } from "./session.sql"
@@ -924,6 +924,11 @@ export const defaultLayer = layer.pipe(
   Layer.provide(Storage.defaultLayer),
 )
 
+function directoryEq(directory: string) {
+  if (process.platform !== "win32") return eq(SessionTable.directory, directory)
+  return sql`lower(${SessionTable.directory}) = lower(${directory})`
+}
+
 export function* list(input?: {
   directory?: string
   workspaceID?: WorkspaceID
@@ -940,7 +945,7 @@ export function* list(input?: {
   }
   if (!Flag.MIMOCODE_EXPERIMENTAL_WORKSPACES) {
     if (input?.directory) {
-      conditions.push(eq(SessionTable.directory, input.directory))
+      conditions.push(directoryEq(input.directory))
     }
   }
   if (input?.roots) {
@@ -981,7 +986,7 @@ export function* listGlobal(input?: {
   const conditions: SQL[] = []
 
   if (input?.directory) {
-    conditions.push(eq(SessionTable.directory, input.directory))
+    conditions.push(directoryEq(input.directory))
   }
   if (input?.roots) {
     conditions.push(isNull(SessionTable.parent_id))

--- a/packages/opencode/test/server/global-session-list.test.ts
+++ b/packages/opencode/test/server/global-session-list.test.ts
@@ -79,6 +79,27 @@ describe("session.listGlobal", () => {
     expect(allIds).toContain(archived.id)
   })
 
+  test("matches a directory that only differs in casing on Windows", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const created = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => svc.create({ title: "global-case-probe" }),
+    })
+
+    const variant =
+      tmp.path === tmp.path.toUpperCase() ? tmp.path.toLowerCase() : tmp.path.toUpperCase()
+
+    const flipped = [...svc.listGlobal({ directory: variant, limit: 200 })].map(
+      (session) => session.id,
+    )
+    if (process.platform === "win32") {
+      expect(flipped).toContain(created.id)
+    } else {
+      expect(flipped).not.toContain(created.id)
+    }
+  })
+
   test("supports cursor pagination", async () => {
     await using tmp = await tmpdir({ git: true })
 

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -45,6 +45,28 @@ describe("session.list", () => {
     })
   })
 
+  test("matches a directory that only differs in casing on Windows", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const created = await svc.create({ title: "case-probe" })
+        const variant =
+          tmp.path === tmp.path.toUpperCase() ? tmp.path.toLowerCase() : tmp.path.toUpperCase()
+
+        const exact = [...svc.list({ directory: tmp.path })].map((s) => s.id)
+        expect(exact).toContain(created.id)
+
+        const flipped = [...svc.list({ directory: variant })].map((s) => s.id)
+        if (process.platform === "win32") {
+          expect(flipped).toContain(created.id)
+        } else {
+          expect(flipped).not.toContain(created.id)
+        }
+      },
+    })
+  })
+
   test("filters root sessions", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({


### PR DESCRIPTION
### Issue / context (if applicable)

Fixes #2086

### Type of change

Bug fix

### What does this PR do?

`Session.list` and `Session.listGlobal` filtered by `directory` with exact string equality (`eq(SessionTable.directory, input.directory)`). On Windows the same project opened with different path casing — `D:\Work\proj` vs `d:\work\proj`, which happens after a folder rename or a differently-cased drive mapping — produced zero rows, so every prior session vanished from the session switcher even though `project_id` is stable across renames (it is a cached UUID in `.git/mimocode-project-id`).

The fix folds case in SQL on win32 only:

```ts
function directoryEq(directory: string) {
  if (process.platform !== "win32") return eq(SessionTable.directory, directory)
  return sql`lower(${SessionTable.directory}) = lower(${directory})`
}
```

SQLite's `lower()` folds ASCII letters and leaves everything else untouched, so this matches exactly the practical case-insensitivity of Windows paths: two directories compare equal iff they differ only in `A-Z` casing, while non-Latin path segments (which have no case pairs) are unaffected. POSIX platforms keep exact equality, preserving their case-sensitive semantics.

### How did you verify your code works?

- Added regression tests to both surfaces with a case-flipped copy of the temp directory:
  - `test/server/session-list.test.ts` - "matches a directory that only differs in casing on Windows"
  - `test/server/global-session-list.test.ts` - same scenario for `listGlobal`
  Both expect a match on `win32` and no match on other platforms.
- Locally (Windows): both new tests pass; `bun test test/server/global-session-list.test.ts` is 4/4 green. `tsgo --noEmit` over `packages/opencode` is clean.
- Local-timeout note for reviewers on slow machines: bun's default 5s per-test cap is tight here. On this box, pristine `upstream/main` already times out `filters by directory` in a full-file run (reproduced twice), while `filters root sessions` / `filters by search term` passed pristine (~2-3s each) but timed out during one loaded run WITH this branch - those two tests never pass `directory`, so they do not exercise the changed code path at all. Attributing their red to local load, not this diff; happy to rerun anything a reviewer wants, and CI is the authoritative arbiter.

To reproduce manually: create a session in a project, then launch with the same path in different casing and open the session switcher - history now shows.

### Screenshots / recordings

Not a UI change (no markup touched); behavior visible in the session list data.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
