### PR TITLE
Features: Add namespaced skill slash commands (parent:name)

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -262,17 +262,21 @@ export const layer = Layer.effect(
       }
 
       for (const item of yield* skill.all()) {
-        if (commands[item.name]) continue
-        commands[item.name] = {
-          name: item.name,
-          description: item.description,
-          source: "skill",
-          bundled: item.bundled,
-          get template() {
-            return item.content
-          },
-          hints: [],
+        const register = (name: string) => {
+          if (commands[name]) return
+          commands[name] = {
+            name,
+            description: item.description,
+            source: "skill",
+            bundled: item.bundled,
+            get template() {
+              return item.content
+            },
+            hints: [],
+          }
         }
+        register(item.name)
+        if (item.namespace) register(`${item.namespace}:${item.name}`)
       }
 
       return {

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -20,6 +20,23 @@ import { extractComposeBundle } from "./compose/extract"
 import { extractBuiltinBundle, OFFICIAL_SKILL_NAMES } from "./builtin/extract"
 
 const log = Log.create({ service: "skill" })
+
+// Parent-folder namespace for nested skills (e.g. skills/ECC/agent-eval -> "ECC").
+// The namespace is the first path segment after the skills/ (or skill/) marker,
+// only when the skill folder is nested at least one level deeper.
+export function deriveNamespace(location: string, name: string): string | undefined {
+  if (name.includes(":")) return undefined
+  const dir = path.dirname(location)
+  const parts = dir.split(path.sep)
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (parts[i] !== "skills" && parts[i] !== "skill") continue
+    const parent = parts[i + 1]
+    // parent must be a real intermediate dir (not the skill folder itself) and a parseable token
+    if (!parent || parent === parts[parts.length - 1] || /\s/.test(parent)) return undefined
+    return parent
+  }
+  return undefined
+}
 const EXTERNAL_DIRS = [".claude", ".agents", ".codex", ".opencode"]
 const EXTERNAL_SKILL_PATTERN = "skills/**/SKILL.md"
 const MIMOCODE_SKILL_PATTERN = "{skill,skills}/**/SKILL.md"

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -47,6 +47,7 @@ export const Info = z.object({
   name: z.string(),
   description: z.string(),
   aliases: z.array(z.string()).optional(),
+  namespace: z.string().optional(),
   location: z.string(),
   content: z.string(),
   // Model reachability, distinct from authorization. When true the model never
@@ -153,6 +154,7 @@ const add = Effect.fnUntraced(function* (state: State, match: string, bundledRoo
     name: parsed.data.name,
     description: parsed.data.description,
     aliases: parsed.data.aliases,
+    namespace: deriveNamespace(match, parsed.data.name),
     location: match,
     content: md.content,
     disable_model_invocation: parsed.data["disable-model-invocation"],

--- a/packages/opencode/test/skill/namespace.test.ts
+++ b/packages/opencode/test/skill/namespace.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
 import { Effect, Layer } from "effect"
+import { Command } from "../../src/command"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { Skill } from "../../src/skill"
 import { deriveNamespace } from "../../src/skill/index"
@@ -15,6 +16,7 @@ withEnv({
 })
 
 const it = testEffect(Layer.mergeAll(Skill.defaultLayer, CrossSpawnSpawner.defaultLayer))
+const commandIt = testEffect(Layer.mergeAll(Command.defaultLayer, CrossSpawnSpawner.defaultLayer))
 
 const loc = (...parts: string[]) => path.join("/home/user/.config/mimocode", ...parts)
 
@@ -65,6 +67,31 @@ describe("namespaced skill discovery", () => {
           const skill = yield* Skill.Service
           const item = (yield* skill.all()).find((s) => s.name === "ns-test-skill")
           expect(item?.namespace).toBe("ECC")
+        }),
+      { git: true },
+    ),
+  )
+})
+
+describe("namespaced skill commands", () => {
+  commandIt.live("registers parent:name slash command for nested skills", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const skillDir = path.join(dir, ".mimocode", "skills", "ECC", "ns-test-skill")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(skillDir, "SKILL.md"),
+              "---\nname: ns-test-skill\ndescription: Test nested skill\n---\n# ns-test-skill\n",
+            ),
+          )
+          const cmd = yield* Command.Service
+          const all = yield* cmd.list()
+          const names = new Set(all.map((c) => c.name))
+          expect(names.has("ns-test-skill")).toBe(true)
+          expect(names.has("ECC:ns-test-skill")).toBe(true)
+          const namespaced = all.find((c) => c.name === "ECC:ns-test-skill")
+          expect(namespaced?.source).toBe("skill")
         }),
       { git: true },
     ),

--- a/packages/opencode/test/skill/namespace.test.ts
+++ b/packages/opencode/test/skill/namespace.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
+import { Effect, Layer } from "effect"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Skill } from "../../src/skill"
 import { deriveNamespace } from "../../src/skill/index"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { withEnv } from "../lib/env"
+
+withEnv({
+  MIMOCODE_DISABLE_EXTERNAL_SKILLS: "true",
+  MIMOCODE_DISABLE_BUILTIN_SKILLS: "true",
+  MIMOCODE_DISABLE_COMPOSE_SKILLS: "true",
+})
+
+const it = testEffect(Layer.mergeAll(Skill.defaultLayer, CrossSpawnSpawner.defaultLayer))
 
 const loc = (...parts: string[]) => path.join("/home/user/.config/mimocode", ...parts)
 
@@ -34,4 +48,25 @@ describe("deriveNamespace", () => {
       deriveNamespace(path.join("/home/user/.mimo-skills", "ECC", "agent-eval", "SKILL.md"), "agent-eval"),
     ).toBeUndefined()
   })
+})
+
+describe("namespaced skill discovery", () => {
+  it.live("derives namespace from a nested .mimocode skill", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const skillDir = path.join(dir, ".mimocode", "skills", "ECC", "ns-test-skill")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(skillDir, "SKILL.md"),
+              "---\nname: ns-test-skill\ndescription: Test nested skill\n---\n# ns-test-skill\n",
+            ),
+          )
+          const skill = yield* Skill.Service
+          const item = (yield* skill.all()).find((s) => s.name === "ns-test-skill")
+          expect(item?.namespace).toBe("ECC")
+        }),
+      { git: true },
+    ),
+  )
 })

--- a/packages/opencode/test/skill/namespace.test.ts
+++ b/packages/opencode/test/skill/namespace.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { deriveNamespace } from "../../src/skill/index"
+
+const loc = (...parts: string[]) => path.join("/home/user/.config/mimocode", ...parts)
+
+describe("deriveNamespace", () => {
+  test("top-level skill has no namespace", () => {
+    expect(deriveNamespace(loc("skills", "agent-eval", "SKILL.md"), "agent-eval")).toBeUndefined()
+  })
+
+  test("parent folder becomes the namespace", () => {
+    expect(deriveNamespace(loc("skills", "ECC", "agent-eval", "SKILL.md"), "agent-eval")).toBe("ECC")
+  })
+
+  test("deep nesting uses the first segment after skills/", () => {
+    expect(deriveNamespace(loc("skills", "ECC", "tools", "agent-eval", "SKILL.md"), "agent-eval")).toBe("ECC")
+  })
+
+  test("singular skill/ marker works", () => {
+    expect(deriveNamespace(loc("skill", "ECC", "agent-eval", "SKILL.md"), "agent-eval")).toBe("ECC")
+  })
+
+  test("name containing a colon gets no namespace", () => {
+    expect(deriveNamespace(loc("skills", "ECC", "agent-eval", "SKILL.md"), "compose:plan")).toBeUndefined()
+  })
+
+  test("namespace with whitespace is rejected", () => {
+    expect(deriveNamespace(loc("skills", "My Group", "agent-eval", "SKILL.md"), "agent-eval")).toBeUndefined()
+  })
+
+  test("no skills/ marker yields no namespace", () => {
+    expect(
+      deriveNamespace(path.join("/home/user/.mimo-skills", "ECC", "agent-eval", "SKILL.md"), "agent-eval"),
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
###Issue / context (if applicable)
No related issue. This is an external contribution introducing a new feature; the design direction was agreed during a brainstorming session on the fork (path-derived parent namespace, server-side registration — see "What does this PR do?").
###Type of change
New feature
###What does this PR do?
Problem: When a skill is organized as {root}/skills/{parent}/{subskill}/SKILL.md (e.g. MIMOCODE_CONFIG/skills/ECC/agent-eval), the TUI could only invoke it by its frontmatter name (/agent-eval). There was no way to address a nested skill by its parent namespace, and a /parent:subskill style invocation fell through to a normal prompt.
###What changed:
- packages/opencode/src/skill/index.ts
  - New pure function deriveNamespace(location, name) — the parent folder is the first path segment after the skills//skill/ marker, only when the skill directory is nested at least one level deeper. It is skipped when the name already contains : (e.g. compose:plan) or the namespace contains whitespace.
  - Info gains an optional namespace field, populated during discovery.
- packages/opencode/src/command/index.ts — registers an additional {namespace}:{name} skill command (same source: "skill", template, bundled), skipped if the name is already taken.
- packages/opencode/test/skill/namespace.test.ts (new) — unit tests for deriveNamespace plus discovery/command integration tests.
Why this approach works: The namespace is derived purely from the skill's file path (nothing is hardcoded) and applies uniformly to all skill sources (config dirs, external dirs, skills.paths, bundled). Because the TUI autocomplete and slash resolution match server commands by exact name, the new /{namespace}:{name} command is surfaced, searchable, and executable with zero client-side changes — while /{name} keeps working for backward compatibility. This follows the existing compose:plan naming precedent already handled end-to-end for :-containing command names.
###How did you verify your code works?
- bun typecheck (packages/opencode) — clean.
- bun test test/skill — 94 pass (includes the 9 new namespace.test.ts cases: 7 deriveNamespace unit tests + discovery + command registration integration tests).
- bun test test/command — 6 pass (regression for the command-registration change).

**A reviewer can reproduce with:**
cd packages/opencode
bun test test/skill/namespace.test.ts
bun test test/skill test/command
bun typecheck

Behavioral check: place a skill at {config}/skills/ECC/agent-eval/SKILL.md; both /agent-eval and /ECC:agent-eval are listed in the TUI / autocomplete and invoke the skill via session.command.
###Screenshots / recordings
Not a UI change — no screenshot required.
###Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR