### PR TITLE
fix(actor): scope fork contexts by session

### DIFF
--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -275,7 +275,7 @@ export interface SpawnResult {
 export interface Interface {
   readonly spawn: (input: SpawnInput) => Effect.Effect<SpawnResult>
   readonly cancel: (sessionID: SessionID, actorID: string, mode: "graceful" | "forced") => Effect.Effect<void>
-  readonly getForkContext: (actorID: string) => Effect.Effect<ForkContext | undefined>
+  readonly getForkContext: (sessionID: SessionID, actorID: string) => Effect.Effect<ForkContext | undefined>
   /**
    * Run ONE stall-watchdog scan pass synchronously (the same body the background
    * fiber repeats every WATCHDOG_SCAN_INTERVAL_MS). Exposed for deterministic
@@ -307,6 +307,7 @@ export const layer = Layer.effect(
     // (contextMode = "full"). Read by fork's runLoop (see prompt.ts) and
     // cleared on terminal status. Fiber tracking moved to SessionRunState.
     const forkContexts = new Map<string, ForkContext>()
+    const forkContextKey = (sessionID: SessionID, actorID: string) => sessionID + ":" + actorID
 
     // Actors whose cancel() has begun, keyed "sessionID:actorID". Populated
     // BEFORE the fiber is interrupted so forkWork's onSuccess/onFailure notify
@@ -724,7 +725,7 @@ export const layer = Layer.effect(
                   lastFinalText = newTurn.finalText
                 }
 
-                yield* Effect.sync(() => forkContexts.delete(input.actorID))
+                yield* Effect.sync(() => forkContexts.delete(forkContextKey(input.sessionID, input.actorID)))
               }),
             onFailure: (cause) =>
               Effect.gen(function* () {
@@ -743,7 +744,7 @@ export const layer = Layer.effect(
                     ? { status: "cancelled" as const }
                     : { status: "failure" as const, error, ...(failure ? { failure } : {}) },
                 )
-                yield* Effect.sync(() => forkContexts.delete(input.actorID))
+                yield* Effect.sync(() => forkContexts.delete(forkContextKey(input.sessionID, input.actorID)))
               }),
           }),
         )
@@ -797,7 +798,7 @@ export const layer = Layer.effect(
         tools: input.tools,
       })
       if (input.forkContext) {
-        forkContexts.set(child.id, input.forkContext) // peer's actorID === child.id
+        forkContexts.set(forkContextKey(child.id, child.id), input.forkContext) // peer's actorID === child.id
       }
       const { fiber, outcome } = yield* forkWork({
         sessionID: child.id,
@@ -843,7 +844,7 @@ export const layer = Layer.effect(
       if (input.onActorID) yield* Effect.sync(() => input.onActorID!(actorID)).pipe(Effect.ignore)
 
       if (input.forkContext) {
-        forkContexts.set(actorID, input.forkContext)
+        forkContexts.set(forkContextKey(input.sessionID, actorID), input.forkContext)
       }
 
       // Auto-inject return-format instruction for lifecycle-managed subagents.
@@ -949,11 +950,11 @@ export const layer = Layer.effect(
           .updateStatus(sessionID, actorID, { status: "idle", lastOutcome: "cancelled" })
           .pipe(Effect.ignore)
         yield* notifyTerminal(sessionID, actorID, actor, "cancelled")
-        yield* Effect.sync(() => forkContexts.delete(actorID))
+        yield* Effect.sync(() => forkContexts.delete(forkContextKey(sessionID, actorID)))
       })
 
-    const getForkContext = Effect.fn("Actor.getForkContext")(function* (actorID: string) {
-      return forkContexts.get(actorID)
+    const getForkContext = Effect.fn("Actor.getForkContext")(function* (sessionID: SessionID, actorID: string) {
+      return forkContexts.get(forkContextKey(sessionID, actorID))
     })
 
     // === T40 stall watchdog ===

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4064,7 +4064,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // If forkCtx is missing (race / cleanup bug / spawn skipped), fail the
             // actor so the next prune turn can spawn a fresh fork.
             if (isForkAgent) {
-              const forkCtxEffect = spawnRef.current?.getForkContext(lastUser.agentID!)
+              const forkCtxEffect = spawnRef.current?.getForkContext(sessionID, lastUser.agentID!)
               const forkCtx = forkCtxEffect ? yield* forkCtxEffect : undefined
               if (!forkCtx) {
                 yield* slog.warn("fork agent runLoop: missing forkContext, failing actor", {

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -893,7 +893,7 @@ describe("Actor forkContext lifecycle", () => {
         })
 
         // Before cancel: forkContext must be present.
-        const before = yield* actor.getForkContext(result.actorID)
+        const before = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(before).toBeDefined()
         expect(before?.system).toEqual(["test-system"])
 
@@ -901,8 +901,66 @@ describe("Actor forkContext lifecycle", () => {
         yield* actor.cancel(result.sessionID, result.actorID, "forced")
 
         // After cancel: forkContext must be gone.
-        const after = yield* actor.getForkContext(result.actorID)
+        const after = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(after).toBeUndefined()
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  it.live("keeps forkContexts isolated when actor ids repeat across sessions", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const actor = yield* Actor.Service
+        const session = yield* Session.Service
+        const first = yield* session.create({ title: "first fork context" })
+        const second = yield* session.create({ title: "second fork context" })
+        yield* llm.hang
+
+        const firstResult = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: first.id,
+          agentType: "explore",
+          task: "first",
+          context: "full",
+          tools: [],
+          background: true,
+          model: ref,
+          forkContext: {
+            system: ["first-system"],
+            tools: {},
+            inheritedMessages: [],
+            parentPermission: [],
+            watermarkMsgID: MessageID.ascending(),
+            model: ref,
+          },
+        })
+        const secondResult = yield* actor.spawn({
+          mode: "subagent",
+          sessionID: second.id,
+          agentType: "explore",
+          task: "second",
+          context: "full",
+          tools: [],
+          background: true,
+          model: ref,
+          forkContext: {
+            system: ["second-system"],
+            tools: {},
+            inheritedMessages: [],
+            parentPermission: [],
+            watermarkMsgID: MessageID.ascending(),
+            model: ref,
+          },
+        })
+
+        expect(firstResult.actorID).toBe(secondResult.actorID)
+        expect((yield* actor.getForkContext(firstResult.sessionID, firstResult.actorID))?.system).toEqual(["first-system"])
+        expect((yield* actor.getForkContext(secondResult.sessionID, secondResult.actorID))?.system).toEqual(["second-system"])
+
+        yield* actor.cancel(firstResult.sessionID, firstResult.actorID, "forced")
+        expect((yield* actor.getForkContext(secondResult.sessionID, secondResult.actorID))?.system).toEqual(["second-system"])
+        yield* actor.cancel(secondResult.sessionID, secondResult.actorID, "forced")
       }),
       { git: true, config: providerCfg },
     ),
@@ -944,7 +1002,7 @@ describe("mode × contextMode matrix", () => {
           forkContext: fakeForkCtx,
         })
 
-        const ctx = yield* actor.getForkContext(result.actorID)
+        const ctx = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(ctx).toBeDefined()
         expect(ctx?.system).toEqual(["test-system"])
 
@@ -979,7 +1037,7 @@ describe("mode × contextMode matrix", () => {
           // no forkContext
         })
 
-        const ctx = yield* actor.getForkContext(result.actorID)
+        const ctx = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(ctx).toBeUndefined()
 
         yield* actor.cancel(result.sessionID, result.actorID, "forced")
@@ -1015,7 +1073,7 @@ describe("mode × contextMode matrix", () => {
 
         // For peer, result.actorID === child.id (the new session id)
         expect(result.actorID).not.toBe(parent.id)
-        const ctx = yield* actor.getForkContext(result.actorID)
+        const ctx = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(ctx).toBeDefined()
         expect(ctx?.system).toEqual(["test-system"])
 
@@ -1050,7 +1108,7 @@ describe("mode × contextMode matrix", () => {
           // no forkContext
         })
 
-        const ctx = yield* actor.getForkContext(result.actorID)
+        const ctx = yield* actor.getForkContext(result.sessionID, result.actorID)
         expect(ctx).toBeUndefined()
 
         yield* actor.cancel(result.sessionID, result.actorID, "forced")

--- a/packages/opencode/test/inbox/fork-agent-compat.test.ts
+++ b/packages/opencode/test/inbox/fork-agent-compat.test.ts
@@ -315,7 +315,7 @@ describe("Fork-agent inbox compat (Plan 4 / Task 5)", () => {
         const forkActorID = result.actorID
 
         // Tier 2 — structural: capture forkContext BEFORE inbox send.
-        const forkCtxBefore = yield* actor.getForkContext(forkActorID)
+        const forkCtxBefore = yield* actor.getForkContext(parent.id, forkActorID)
         expect(forkCtxBefore).toBeDefined()
         expect(forkCtxBefore?.system).toEqual(["inherited-system-prompt"])
         expect(forkCtxBefore?.inheritedMessages).toHaveLength(2)
@@ -356,7 +356,7 @@ describe("Fork-agent inbox compat (Plan 4 / Task 5)", () => {
 
         // Tier 2 — structural: forkContext must still have the exact same
         // inheritedMessages snapshot. Drain must not touch forkContexts.
-        const forkCtxAfter = yield* actor.getForkContext(forkActorID)
+        const forkCtxAfter = yield* actor.getForkContext(parent.id, forkActorID)
         expect(forkCtxAfter).toBeDefined()
         expect(forkCtxAfter?.inheritedMessages).toStrictEqual(forkCtxBefore?.inheritedMessages)
         expect(forkCtxAfter?.system).toEqual(["inherited-system-prompt"])

--- a/packages/opencode/test/session/classify-integration.test.ts
+++ b/packages/opencode/test/session/classify-integration.test.ts
@@ -368,7 +368,7 @@ describe("classifier routing — integration", () => {
                 model: { providerID: ProviderID.make("alibaba"), modelID: ModelID.make("qwen-plus") },
               }
               spawnRef.current = {
-                getForkContext: (id: string) => Effect.succeed(id === forkActorID ? forkCtx : undefined),
+                getForkContext: (_sessionID: string, id: string) => Effect.succeed(id === forkActorID ? forkCtx : undefined),
                 spawn: () => Effect.die("spawn not used in fork-gate test"),
                 cancel: () => Effect.die("cancel not used in fork-gate test"),
               } as unknown as NonNullable<typeof spawnRef.current>
@@ -443,7 +443,7 @@ describe("classifier routing — integration", () => {
                 model: { providerID: ProviderID.make("alibaba"), modelID: ModelID.make("qwen-plus") },
               }
               spawnRef.current = {
-                getForkContext: (id: string) => Effect.succeed(id === forkActorID ? forkCtx : undefined),
+                getForkContext: (_sessionID: string, id: string) => Effect.succeed(id === forkActorID ? forkCtx : undefined),
                 spawn: () => Effect.die("spawn not used in fork content-filter test"),
                 cancel: () => Effect.die("cancel not used in fork content-filter test"),
               } as unknown as NonNullable<typeof spawnRef.current>


### PR DESCRIPTION
## Summary
- Scope in-memory fork context snapshots by session and actor ID.
- Keep fork context lookup and terminal cleanup aligned with the owning session.
- Add regression coverage for repeated actor IDs across concurrent sessions.

## Verification
- bun run typecheck
- bun test --timeout 120000 test/actor/spawn.test.ts -t "keeps forkContexts isolated when actor ids repeat across sessions"
- bun test --timeout 120000 test/session/auto-overflow-writer-first.test.ts test/session/checkpoint-fork-mode.test.ts
- bun test --timeout 120000 test/inbox/fork-agent-compat.test.ts test/session/classify-integration.test.ts
