### PR TITLE
feat(session): add MIMOCODE_COMPACTION_MAX_CONTEXT flag

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -133,6 +133,17 @@ export const Flag = {
     return truthy("MIMOCODE_DISABLE_CHECKPOINT")
   },
   MIMOCODE_DISABLE_AUTOCOMPACT: truthy("MIMOCODE_DISABLE_AUTOCOMPACT"),
+  // Default compaction trigger, used when `compaction.max_context` is not set in
+  // config. Same grammar as that config field: an absolute token count
+  // ("300000"), a shorthand ("300K", "1M"), or a percentage of the model window
+  // ("50%"). Clamped to the model window — it can only lower the trigger, never
+  // raise it. An explicit `compaction.max_context` in config overrides this.
+  // Pairs with MIMOCODE_DISABLE_CHECKPOINT: on the checkpoint-off fallback path
+  // this is how the compaction threshold is tuned via env alone. Read lazily so
+  // tests and in-process embedders can toggle it at runtime.
+  get MIMOCODE_COMPACTION_MAX_CONTEXT() {
+    return process.env["MIMOCODE_COMPACTION_MAX_CONTEXT"]
+  },
   MIMOCODE_DISABLE_MODELS_FETCH: truthy("MIMOCODE_DISABLE_MODELS_FETCH"),
   // Defaults to false. When enabled, every model uses the GPT system prompt
   // and Codex toolset regardless of its model ID.

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -1,4 +1,5 @@
 import type { Config } from "@/config"
+import { Flag } from "@/flag/flag"
 import type { Provider } from "@/provider"
 import { ProviderTransform } from "@/provider"
 import { Log, Token, Wildcard } from "@/util"
@@ -34,7 +35,7 @@ function reserves(input: { cfg: Config.Info; model: Provider.Model }) {
 }
 
 function budget(input: { cfg: Config.Info; model: Provider.Model }, hard: number, reserved: number) {
-  const configured = input.cfg.compaction?.max_context
+  const configured = input.cfg.compaction?.max_context ?? Flag.MIMOCODE_COMPACTION_MAX_CONTEXT
   if (configured === undefined) return undefined
   const key = `${input.model.providerID}/${input.model.id}`
   const raw =


### PR DESCRIPTION
## What

Adds an env-level default for the compaction trigger: `MIMOCODE_COMPACTION_MAX_CONTEXT`. It is used only when `compaction.max_context` is **not** set in config.

## Why

The compaction threshold was tunable solely through the `compaction.max_context` config field. On the checkpoint-off fallback path (`MIMOCODE_DISABLE_CHECKPOINT`), context overflow falls back to plain compaction, but there was no env-only way to adjust *when* that compaction fires. This flag is the natural companion to `MIMOCODE_DISABLE_CHECKPOINT`, letting the threshold be tuned via env alone.

## How

- `src/flag/flag.ts`: new lazy getter `MIMOCODE_COMPACTION_MAX_CONTEXT` returning the raw env string (read at access time so tests/embedders can toggle it).
- `src/session/overflow.ts`: `budget()` now reads `cfg.compaction?.max_context ?? Flag.MIMOCODE_COMPACTION_MAX_CONTEXT`, so the flag flows through the **same** `Token.parseQuantity` grammar and clamping/validation as the config field.

### Grammar (identical to `compaction.max_context`)
- absolute count — `300000`
- shorthand — `300K`, `1M`
- percentage of the model window — `50%`

### Precedence
```
cfg.compaction.max_context   (explicit config — wins)
  ?? MIMOCODE_COMPACTION_MAX_CONTEXT   (env default)
  ?? model window (hard)   (final fallback)
```

Clamped to the model window (can only lower the trigger, never raise it); `0`/`>= hard` → no budget; `<= reserved` or unparseable → ignored with a warn. `compaction.max_context` has no schema default, so the fallback fires whenever the user hasn't explicitly configured it.

### Example
```sh
MIMOCODE_DISABLE_CHECKPOINT=1 MIMOCODE_COMPACTION_MAX_CONTEXT=50% mimocode
```

## Test plan
- [x] `bun typecheck` clean
- [x] `bun test test/session/overflow.test.ts` — 51 pass, 0 fail