### PR TITLE
fix(actor): drop the unimplemented spawn/run resume and make send→wait reliable

### DIFF
--- a/packages/opencode/src/actor/registry.ts
+++ b/packages/opencode/src/actor/registry.ts
@@ -75,6 +75,11 @@ export interface Interface {
       lastError?: string | undefined
     },
   ) => Effect.Effect<void>
+  // Flip an IDLE actor back to `pending` for the inbox wake path: a queued message
+  // means it has work again, and a row left `idle` lets ActorWaiter resolve on the
+  // PREVIOUS turn's outcome before the woken turn marks itself running. A row that
+  // is not idle is left alone.
+  readonly markPending: (sessionID: SessionID, actorID: string) => Effect.Effect<void>
   readonly updateTurn: (sessionID: SessionID, actorID: string) => Effect.Effect<void>
   readonly updateAgent: (sessionID: SessionID, actorID: string, agent: string) => Effect.Effect<void>
   readonly get: (sessionID: SessionID, actorID: string) => Effect.Effect<Actor | undefined>
@@ -169,6 +174,35 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
       return fromRow(row)
     })
 
+    // Re-read after a status write so the event payload reflects committed row
+    // values rather than the sparse patch, then publish. A row that vanished
+    // between UPDATE and SELECT publishes nothing — a dropped event beats a
+    // misleading one.
+    const publishStatus = Effect.fn("ActorRegistry.publishStatus")(function* (
+      sessionID: SessionID,
+      actorID: string,
+    ) {
+      const row = yield* Effect.sync(() =>
+        Database.use((db) =>
+          db
+            .select()
+            .from(ActorRegistryTable)
+            .where(and(eq(ActorRegistryTable.session_id, sessionID), eq(ActorRegistryTable.actor_id, actorID)))
+            .get(),
+        ),
+      )
+      if (!row) return
+      yield* bus.publish(Events.ActorStatusChanged, {
+        sessionID,
+        actorID,
+        status: row.status,
+        ...(row.last_outcome ? { lastOutcome: row.last_outcome } : {}),
+        turnCount: row.turn_count,
+        lastTurnTime: row.last_turn_time,
+        ...(row.last_error ? { error: row.last_error } : {}),
+      })
+    })
+
     const updateStatus = Effect.fn("ActorRegistry.updateStatus")(function* (
       sessionID: SessionID,
       actorID: string,
@@ -199,30 +233,43 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
             .run(),
         ),
       )
-      // Re-read so the event payload reflects committed row values (not the
-      // sparse patch). Skip publish if the row vanished between UPDATE and
-      // SELECT — a dropped event beats a misleading one.
-      const row = yield* Effect.sync(() =>
+      yield* publishStatus(sessionID, actorID)
+    })
+
+    const markPending = Effect.fn("ActorRegistry.markPending")(function* (sessionID: SessionID, actorID: string) {
+      const now = Date.now()
+      // Guarded in the WHERE clause, not read-then-write: a turn that starts
+      // between a read and an update would otherwise have its `running` status
+      // clobbered back to `pending`.
+      //
+      // last_activity_time moves too, and it has to: deriveLiveness measures a
+      // pending row against that timestamp, so a long-idle actor woken by a
+      // message would otherwise read as `stalled` (or past the abandon bound,
+      // `idle`) the instant it is queued, and the watchdog would announce it as
+      // quiet for however long it sat idle. A queued message IS activity on this
+      // actor's slice — drain turns it into a real user message part.
+      const moved = yield* Effect.sync(() =>
         Database.use((db) =>
           db
-            .select()
-            .from(ActorRegistryTable)
+            .update(ActorRegistryTable)
+            .set({ status: "pending", last_activity_time: now, time_updated: now })
             .where(
-              and(eq(ActorRegistryTable.session_id, sessionID), eq(ActorRegistryTable.actor_id, actorID)),
+              and(
+                eq(ActorRegistryTable.session_id, sessionID),
+                eq(ActorRegistryTable.actor_id, actorID),
+                eq(ActorRegistryTable.status, "idle"),
+              ),
             )
+            .returning()
             .get(),
         ),
       )
-      if (!row) return
-      yield* bus.publish(Events.ActorStatusChanged, {
-        sessionID,
-        actorID,
-        status: row.status,
-        ...(row.last_outcome ? { lastOutcome: row.last_outcome } : {}),
-        turnCount: row.turn_count,
-        lastTurnTime: row.last_turn_time,
-        ...(row.last_error ? { error: row.last_error } : {}),
-      })
+      // Announce a transition only when one happened. RETURNING is what makes that
+      // knowable: the guarded update is also a no-op for a row that was already
+      // running, or already pending — `main` rows are registered pending and never
+      // leave it, and they receive every subagent notification.
+      if (!moved) return
+      yield* publishStatus(sessionID, actorID)
     })
 
     const updateTurn = Effect.fn("ActorRegistry.updateTurn")(function* (sessionID: SessionID, actorID: string) {
@@ -512,6 +559,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
     return Service.of({
       register,
       updateStatus,
+      markPending,
       updateTurn,
       updateAgent,
       get,

--- a/packages/opencode/src/actor/registry.ts
+++ b/packages/opencode/src/actor/registry.ts
@@ -174,23 +174,26 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
       return fromRow(row)
     })
 
-    // Re-read after a status write so the event payload reflects committed row
-    // values rather than the sparse patch, then publish. A row that vanished
-    // between UPDATE and SELECT publishes nothing — a dropped event beats a
-    // misleading one.
+    // Publish a status event from COMMITTED row values rather than a sparse patch.
+    // Callers that already hold the updated row (RETURNING) pass it and save the
+    // read; the rest re-select. A row that vanished publishes nothing — a dropped
+    // event beats a misleading one.
     const publishStatus = Effect.fn("ActorRegistry.publishStatus")(function* (
       sessionID: SessionID,
       actorID: string,
+      committed?: ActorRow,
     ) {
-      const row = yield* Effect.sync(() =>
-        Database.use((db) =>
-          db
-            .select()
-            .from(ActorRegistryTable)
-            .where(and(eq(ActorRegistryTable.session_id, sessionID), eq(ActorRegistryTable.actor_id, actorID)))
-            .get(),
-        ),
-      )
+      const row =
+        committed ??
+        (yield* Effect.sync(() =>
+          Database.use((db) =>
+            db
+              .select()
+              .from(ActorRegistryTable)
+              .where(and(eq(ActorRegistryTable.session_id, sessionID), eq(ActorRegistryTable.actor_id, actorID)))
+              .get(),
+          ),
+        ))
       if (!row) return
       yield* bus.publish(Events.ActorStatusChanged, {
         sessionID,
@@ -252,7 +255,19 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
         Database.use((db) =>
           db
             .update(ActorRegistryTable)
-            .set({ status: "pending", last_activity_time: now, time_updated: now })
+            .set({
+              status: "pending",
+              last_activity_time: now,
+              time_updated: now,
+              // The previous turn's terminal fields describe a turn that is over.
+              // Left behind they travel with the pending row through fromRow into
+              // every consumer — `session` renders "pending (last outcome:
+              // failure)" and `actor status` reports a stale lastError for an actor
+              // that is about to run again.
+              last_outcome: null,
+              last_error: null,
+              time_completed: null,
+            })
             .where(
               and(
                 eq(ActorRegistryTable.session_id, sessionID),
@@ -269,7 +284,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service> = Layer.effect(
       // running, or already pending — `main` rows are registered pending and never
       // leave it, and they receive every subagent notification.
       if (!moved) return
-      yield* publishStatus(sessionID, actorID)
+      yield* publishStatus(sessionID, actorID, moved)
     })
 
     const updateTurn = Effect.fn("ActorRegistry.updateTurn")(function* (sessionID: SessionID, actorID: string) {

--- a/packages/opencode/src/actor/schema.ts
+++ b/packages/opencode/src/actor/schema.ts
@@ -36,9 +36,12 @@ export const Actor = z
     tools: ToolWhitelist.optional(),
     lastTurnTime: z.number(),
     turnCount: z.number(),
-    // Last part write for this actor's slice. Optional because the column is
-    // nullable — see actor.sql.ts. This is the liveness evidence; lastTurnTime
-    // and turnCount are step bookkeeping and are NOT read by deriveLiveness.
+    // Newest evidence that something is happening on this actor's slice: a part
+    // write (session/projectors.ts), or a message queued for it
+    // (ActorRegistry.markPending), so a woken actor is not judged against the
+    // silence that preceded it. Optional because the column is nullable — see
+    // actor.sql.ts. This is the liveness evidence; lastTurnTime and turnCount are
+    // step bookkeeping and are NOT read by deriveLiveness.
     lastActivityTime: z.number().optional(),
     lastError: z.string().optional(),
     time: z.object({

--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -13,7 +13,7 @@ import { Permission } from "@/permission"
 import type { Actor, SpawnMode, ContextMode, ToolWhitelist, Lifecycle } from "@/actor/schema"
 import { deriveLiveness, DEFAULT_LIVENESS_STALL_MS } from "@/actor/schema"
 import * as ActorEvents from "@/actor/events"
-import { runTurn } from "@/actor/turn"
+import { runTurn, assistantSettledMessage } from "@/actor/turn"
 import { spawnRef } from "@/actor/spawn-ref"
 import { SYSTEM_SPAWNED_AGENT_TYPES } from "@/agent/config"
 import { Bus } from "@/bus"
@@ -360,7 +360,7 @@ export const layer = Layer.effect(
         // so re-deriving the class there would mean re-parsing prose.
         return yield* Effect.fail(
           new AssistantSettledError(
-            `Actor assistant failed: ${info.error.name}`,
+            assistantSettledMessage(info.error.name),
             classifyAssistantError(info.error),
           ),
         )

--- a/packages/opencode/src/actor/turn.ts
+++ b/packages/opencode/src/actor/turn.ts
@@ -2,6 +2,15 @@ import { Cause, Effect, Exit } from "effect"
 import { ActorRegistry } from "@/actor/registry"
 import type { SessionID } from "@/session/schema"
 
+/**
+ * Message an actor turn carries when it settled with an assistant-level error.
+ * Shared because two carriers raise it — actor/spawn.ts for the turns forkWork
+ * drives, session/prompt.ts for the ones it does not — and both are read back
+ * through Cause.pretty into the same registry column and the same AgentOutcome
+ * string, so the two must not drift.
+ */
+export const assistantSettledMessage = (errorName: string) => `Actor assistant failed: ${errorName}`
+
 export const runTurn = <A, E>(
   sessionID: SessionID,
   actorID: string,

--- a/packages/opencode/src/inbox/inbox.ts
+++ b/packages/opencode/src/inbox/inbox.ts
@@ -177,6 +177,13 @@ export const layer: Layer.Layer<
       // not affect delivery.
       const promptRef = sessionPromptRef.current
       if (promptRef) {
+        // Take the receiver out of `idle` BEFORE forking. The fork means send
+        // returns while the woken turn has not started yet, and a sender that
+        // immediately `wait`s on this receiver would otherwise hit ActorWaiter's
+        // fast path on a row still showing the PREVIOUS turn's idle+success and
+        // be handed that turn's result. Guarded to idle rows, so a receiver that
+        // is already running (its own turn will drain this row) is untouched.
+        yield* reg.markPending(input.receiverSessionID, input.receiverActorID)
         yield* promptRef
           .loop({
             sessionID: input.receiverSessionID,

--- a/packages/opencode/src/inbox/inbox.ts
+++ b/packages/opencode/src/inbox/inbox.ts
@@ -17,6 +17,13 @@ const log = Log.create({ service: "inbox" })
 
 const GC_TTL_MS = 7 * 24 * 60 * 60 * 1000
 export const MAX_DRAIN_PER_TURN = 100
+/**
+ * How many times Inbox.send's wake fiber will drive a turn while its row is still
+ * undrained. More than one because the first attempt can be swallowed (see the
+ * wake loop); bounded because a receiver that genuinely cannot drain — drain
+ * finding no model source, for instance — must not spin.
+ */
+export const WAKE_ATTEMPTS = 3
 
 /** Delete inbox rows whose created_at is at or before cutoffMs. Unit-testable without layer reset. */
 export function gcInboxRows(cutoffMs: number) {
@@ -177,23 +184,63 @@ export const layer: Layer.Layer<
       // not affect delivery.
       const promptRef = sessionPromptRef.current
       if (promptRef) {
-        // Take the receiver out of `idle` BEFORE forking. The fork means send
-        // returns while the woken turn has not started yet, and a sender that
-        // immediately `wait`s on this receiver would otherwise hit ActorWaiter's
-        // fast path on a row still showing the PREVIOUS turn's idle+success and
-        // be handed that turn's result. Guarded to idle rows, so a receiver that
-        // is already running (its own turn will drain this row) is untouched.
-        yield* reg.markPending(input.receiverSessionID, input.receiverActorID)
-        yield* promptRef
-          .loop({
-            sessionID: input.receiverSessionID,
-            agentID: input.receiverActorID,
-            // Woken turns notify their parent on completion. The spawn turn goes
-            // through SessionPrompt.prompt (no flag) so forkWork.notify remains
-            // the sole notifier for turn 1 — no double-notify.
-            notifyParentOnComplete: true,
+        const undrained = Effect.sync(() =>
+          Database.use((db) =>
+            db
+              .select({ id: InboxTable.id })
+              .from(InboxTable)
+              .where(
+                and(
+                  eq(InboxTable.receiver_session_id, input.receiverSessionID),
+                  eq(InboxTable.receiver_actor_id, input.receiverActorID),
+                ),
+              )
+              .limit(1)
+              .all(),
+          ),
+        )
+        // Drive turns until this row is gone. One attempt is not enough: the
+        // registry can read `idle` while the receiver's Runner has not yet flipped
+        // to Idle — the previous turn commits its status inside runTurn's
+        // uninterruptible block, which finishes before Runner.finishRun runs — and
+        // in that window ensureRunning hands back the in-flight Deferred WITHOUT
+        // executing the turn we asked for. The row would then sit `pending` with
+        // this message undrained until something unrelated happened to run, and a
+        // `wait` on it would block to its timeout. Awaiting the reused Deferred
+        // means the previous turn IS over once loop returns, so the next attempt
+        // starts a real turn. markPending repeats because that finished turn wrote
+        // the row back to idle.
+        const wake = Effect.gen(function* () {
+          for (let attempt = 0; attempt < WAKE_ATTEMPTS; attempt++) {
+            yield* reg.markPending(input.receiverSessionID, input.receiverActorID)
+            yield* promptRef
+              .loop({
+                sessionID: input.receiverSessionID,
+                agentID: input.receiverActorID,
+                // Woken turns notify their parent on completion. The spawn turn goes
+                // through SessionPrompt.prompt (no flag) so forkWork.notify remains
+                // the sole notifier for turn 1 — no double-notify.
+                notifyParentOnComplete: true,
+              })
+              .pipe(Effect.ignore)
+            if ((yield* undrained).length === 0) return
+          }
+          log.warn("inbox.send: row still undrained after wake attempts", {
+            receiverActorID: input.receiverActorID,
+            attempts: WAKE_ATTEMPTS,
           })
-          .pipe(Effect.ignore, Effect.forkIn(scope))
+        })
+        // markPending must land before send returns, so a caller that immediately
+        // `wait`s cannot catch the row still showing the PREVIOUS turn's
+        // idle+success and be handed that turn's result. Uninterruptible so the
+        // pair is atomic: interrupting between the mark and the fork would leave a
+        // row claiming queued work with nothing scheduled to consume it.
+        yield* Effect.uninterruptible(
+          Effect.gen(function* () {
+            yield* reg.markPending(input.receiverSessionID, input.receiverActorID)
+            yield* wake.pipe(Effect.forkIn(scope))
+          }),
+        )
       } else {
         // Test fixtures / renderer-only paths can run without SessionPrompt.
         // Row is durable; will be drained on next runLoop iteration.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -108,7 +108,7 @@ import { TaskRegistry } from "@/task/registry"
 import { EffectBridge } from "@/effect"
 import { Team } from "@/team"
 import { ActorRegistry } from "@/actor/registry"
-import { runTurn } from "@/actor/turn"
+import { runTurn, assistantSettledMessage } from "@/actor/turn"
 import { Metrics } from "@/metrics"
 import { resolveInvocationStyle, type ToolStyleConfig } from "../tool/invocation-style"
 import { ToolResultError } from "../tool/result-error"
@@ -375,18 +375,18 @@ export interface ResumeTurnInput {
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionPrompt") {}
 
 /**
- * Carries an errored final message across runTurn's failure channel so a woken
- * actor turn is recorded with the outcome it actually had. Exists only because
- * runLoop surfaces a settled assistant error as a success value; see the raise
- * site in `loop`. Deliberately a plain Error subclass, matching the equivalent
+ * Carries an errored final message across runTurn's failure channel so an actor
+ * turn is recorded with the outcome it actually had. Exists only because runLoop
+ * surfaces a settled assistant error as a success value; see the raise site in
+ * `actorTurn`. Deliberately a plain Error subclass, matching the equivalent
  * carrier in actor/spawn.ts, so Cause.pretty renders the same human string.
  */
-class WokenTurnSettledError extends Error {
+class ActorTurnSettledError extends Error {
   constructor(
     readonly final: MessageV2.WithParts,
     errorName: string,
   ) {
-    super(`Actor assistant failed: ${errorName}`)
+    super(assistantSettledMessage(errorName))
   }
 }
 
@@ -4743,51 +4743,63 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
       },
     )
 
+    // Move an actor turn through the actor status machine (running → idle+outcome,
+    // publishing ActorStatusChanged). Every actor turn needs this; forkWork already
+    // provides it for the turns it drives (spawn, preStop, the completion gate,
+    // postStop), so this covers the ones reached any other way — the inbox wake and
+    // the two resume entry points. Without it the row keeps the PREVIOUS turn's
+    // terminal state for the whole turn, which is exactly what ActorWaiter's fast
+    // path reads as finished before answering from the slice's last assistant
+    // message.
+    //
+    // `main` is returned unchanged: it owns no actor row.
+    //
+    // The result must be handed to whatever starts the turn (ensureRunning /
+    // start) rather than wrapped around that call, because Runner returns a busy
+    // runner's Deferred WITHOUT executing work — a turn already in flight must not
+    // be re-stamped by a second caller.
+    const actorTurn = (sessionID: SessionID, agentID: string, work: Effect.Effect<MessageV2.WithParts>) =>
+      agentID === "main"
+        ? work
+        : runTurn(
+            sessionID,
+            agentID,
+            // runTurn derives the outcome from its work's exit, but a settled
+            // assistant error arrives as a SUCCESS value: runLoop returns the
+            // errored message and only branches on it to report "failed" to the
+            // parent. spawn's runAgentLoop raises it for the same reason; without
+            // this the failed turn is recorded, and answered to a waiting sender,
+            // as idle+success.
+            work.pipe(
+              Effect.flatMap((final) =>
+                final.info.role === "assistant" && final.info.error
+                  ? Effect.fail(new ActorTurnSettledError(final, final.info.error.name))
+                  : Effect.succeed(final),
+              ),
+            ),
+          ).pipe(
+            Effect.provideService(ActorRegistry.Service, actorRegistry),
+            // Status is written; hand the message back so an errored turn still
+            // returns it, exactly as an unwrapped turn does.
+            Effect.catch((failed) => Effect.succeed(failed.final)),
+          )
+
     const loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
       "SessionPrompt.loop",
     )(function* (input: z.infer<typeof LoopInput>) {
       const agentID = input.agentID ?? "main"
       const work = runLoop(input.sessionID, agentID, input.task_id, input.notifyParentOnComplete, input.titleLocale)
-      // An inbox-woken actor turn has to move through the actor status machine
-      // like a spawn turn does, because forkWork's runTurn wraps the spawn call,
-      // not this loop. Left unwrapped, the row keeps the PREVIOUS turn's
-      // idle+success for the whole woken turn and ActorWaiter's fast path answers
-      // with that turn's assistant text.
-      //
-      // Two constraints on where the wrapper goes. It is gated on the wake flag
-      // rather than on a non-main agentID because SessionPrompt.prompt also ends
-      // in loop(), which forkWork ALREADY wraps: nesting them lets the inner one
-      // publish idle+success before runAgentLoop reads the assistant error and
-      // fails the outer. And it sits INSIDE the work handed to ensureRunning
-      // because Runner returns a busy runner's Deferred without executing work,
-      // so a turn already in flight is never re-stamped by a second caller.
-      const woken = runTurn(
-        input.sessionID,
-        agentID,
-        // runTurn reads the actor's outcome off its work Effect's exit, but a
-        // settled assistant error reaches us as a SUCCESS value — runLoop returns
-        // the errored message and only branches on it to report "failed" to the
-        // parent. Raising it here is what spawn's runAgentLoop does for the same
-        // reason (AssistantSettledError), and without it the failed turn would be
-        // recorded, and answered to a waiting sender, as idle+success.
-        work.pipe(
-          Effect.flatMap((final) =>
-            final.info.role === "assistant" && final.info.error
-              ? Effect.fail(new WokenTurnSettledError(final, final.info.error.name))
-              : Effect.succeed(final),
-          ),
-        ),
-      ).pipe(
-        Effect.provideService(ActorRegistry.Service, actorRegistry),
-        // Status is written; hand the message back so an errored woken turn still
-        // returns it, exactly as an unwrapped loop does.
-        Effect.catch((failed) => Effect.succeed(failed.final)),
-      )
       return yield* state.ensureRunning(
         input.sessionID,
         agentID,
         lastAssistant(input.sessionID, agentID),
-        input.notifyParentOnComplete && agentID !== "main" ? woken : work,
+        // Only the inbox-woken turn is wrapped, even though every actor turn needs
+        // the status machine: SessionPrompt.prompt also ends in loop(), and
+        // forkWork ALREADY wraps that whole call in runTurn. Nesting them lets the
+        // inner one publish idle+success before runAgentLoop reads the assistant
+        // error and fails the outer, so the wake flag — set only by Inbox.send — is
+        // what distinguishes "this turn is not already inside a runTurn".
+        input.notifyParentOnComplete ? actorTurn(input.sessionID, agentID, work) : work,
       )
     })
 
@@ -5119,15 +5131,19 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
         input.sessionID,
         agentID,
         lastAssistant(input.sessionID, agentID),
-        runLoop(input.sessionID, agentID, input.task_id, undefined, input.titleLocale).pipe(
-          Effect.ensuring(
-            abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID }).pipe(
-              Effect.catchCause((cause) =>
-                elog.warn("recovered-assistant-abandon-failed", {
-                  sessionID: input.sessionID,
-                  messageID: input.assistantMessageID,
-                  cause,
-                }),
+        actorTurn(
+          input.sessionID,
+          agentID,
+          runLoop(input.sessionID, agentID, input.task_id, undefined, input.titleLocale).pipe(
+            Effect.ensuring(
+              abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID }).pipe(
+                Effect.catchCause((cause) =>
+                  elog.warn("recovered-assistant-abandon-failed", {
+                    sessionID: input.sessionID,
+                    messageID: input.assistantMessageID,
+                    cause,
+                  }),
+                ),
               ),
             ),
           ),
@@ -5150,15 +5166,19 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
         input.sessionID,
         agentID,
         lastAssistant(input.sessionID, agentID),
-        runLoop(input.sessionID, agentID, input.task_id, undefined, input.titleLocale).pipe(
-          Effect.ensuring(
-            abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID }).pipe(
-              Effect.catchCause((cause) =>
-                elog.warn("recovered-assistant-abandon-failed", {
-                  sessionID: input.sessionID,
-                  messageID: input.assistantMessageID,
-                  cause,
-                }),
+        actorTurn(
+          input.sessionID,
+          agentID,
+          runLoop(input.sessionID, agentID, input.task_id, undefined, input.titleLocale).pipe(
+            Effect.ensuring(
+              abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID }).pipe(
+                Effect.catchCause((cause) =>
+                  elog.warn("recovered-assistant-abandon-failed", {
+                    sessionID: input.sessionID,
+                    messageID: input.assistantMessageID,
+                    cause,
+                  }),
+                ),
               ),
             ),
           ),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -108,6 +108,7 @@ import { TaskRegistry } from "@/task/registry"
 import { EffectBridge } from "@/effect"
 import { Team } from "@/team"
 import { ActorRegistry } from "@/actor/registry"
+import { runTurn } from "@/actor/turn"
 import { Metrics } from "@/metrics"
 import { resolveInvocationStyle, type ToolStyleConfig } from "../tool/invocation-style"
 import { ToolResultError } from "../tool/result-error"
@@ -372,6 +373,22 @@ export interface ResumeTurnInput {
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionPrompt") {}
+
+/**
+ * Carries an errored final message across runTurn's failure channel so a woken
+ * actor turn is recorded with the outcome it actually had. Exists only because
+ * runLoop surfaces a settled assistant error as a success value; see the raise
+ * site in `loop`. Deliberately a plain Error subclass, matching the equivalent
+ * carrier in actor/spawn.ts, so Cause.pretty renders the same human string.
+ */
+class WokenTurnSettledError extends Error {
+  constructor(
+    readonly final: MessageV2.WithParts,
+    errorName: string,
+  ) {
+    super(`Actor assistant failed: ${errorName}`)
+  }
+}
 
 export const layer = Layer.effect(
   Service,
@@ -4730,11 +4747,47 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
       "SessionPrompt.loop",
     )(function* (input: z.infer<typeof LoopInput>) {
       const agentID = input.agentID ?? "main"
+      const work = runLoop(input.sessionID, agentID, input.task_id, input.notifyParentOnComplete, input.titleLocale)
+      // An inbox-woken actor turn has to move through the actor status machine
+      // like a spawn turn does, because forkWork's runTurn wraps the spawn call,
+      // not this loop. Left unwrapped, the row keeps the PREVIOUS turn's
+      // idle+success for the whole woken turn and ActorWaiter's fast path answers
+      // with that turn's assistant text.
+      //
+      // Two constraints on where the wrapper goes. It is gated on the wake flag
+      // rather than on a non-main agentID because SessionPrompt.prompt also ends
+      // in loop(), which forkWork ALREADY wraps: nesting them lets the inner one
+      // publish idle+success before runAgentLoop reads the assistant error and
+      // fails the outer. And it sits INSIDE the work handed to ensureRunning
+      // because Runner returns a busy runner's Deferred without executing work,
+      // so a turn already in flight is never re-stamped by a second caller.
+      const woken = runTurn(
+        input.sessionID,
+        agentID,
+        // runTurn reads the actor's outcome off its work Effect's exit, but a
+        // settled assistant error reaches us as a SUCCESS value — runLoop returns
+        // the errored message and only branches on it to report "failed" to the
+        // parent. Raising it here is what spawn's runAgentLoop does for the same
+        // reason (AssistantSettledError), and without it the failed turn would be
+        // recorded, and answered to a waiting sender, as idle+success.
+        work.pipe(
+          Effect.flatMap((final) =>
+            final.info.role === "assistant" && final.info.error
+              ? Effect.fail(new WokenTurnSettledError(final, final.info.error.name))
+              : Effect.succeed(final),
+          ),
+        ),
+      ).pipe(
+        Effect.provideService(ActorRegistry.Service, actorRegistry),
+        // Status is written; hand the message back so an errored woken turn still
+        // returns it, exactly as an unwrapped loop does.
+        Effect.catch((failed) => Effect.succeed(failed.final)),
+      )
       return yield* state.ensureRunning(
         input.sessionID,
         agentID,
         lastAssistant(input.sessionID, agentID),
-        runLoop(input.sessionID, agentID, input.task_id, input.notifyParentOnComplete, input.titleLocale),
+        input.notifyParentOnComplete && agentID !== "main" ? woken : work,
       )
     })
 

--- a/packages/opencode/src/tool/actor.shell.txt
+++ b/packages/opencode/src/tool/actor.shell.txt
@@ -21,13 +21,13 @@ appends them at request time per-agent).
 #   - $vars are preserved as literal text (no expansion)
 
 # DEFAULT — return actor_id immediately, run in the background, stay responsive:
-    actor spawn <subagent_type> "<description>" "<prompt>" [--model <ref>] [--actor <id>] [--command <cmd>] [--context none|state|full] [--output-schema '<json>']
+    actor spawn <subagent_type> "<description>" "<prompt>" [--model <ref>] [--command <cmd>] [--context none|state|full] [--output-schema '<json>']
     # bind it to one of your `task` tool tasks (TID from the `task` tool, e.g. T4):
     actor spawn <subagent_type> "<description>" "<prompt>" --task <TID>
 
 # EXCEPTION — block the whole conversation until done, return the final message inline.
 # Only for a tiny, fast lookup whose answer gates your very next decision this turn:
-    actor run <subagent_type> "<description>" "<prompt>" [--model <ref>] [--actor <id>] [--timeout <ms>] [--command <cmd>] [--context none|state|full] [--output-schema '<json>']
+    actor run <subagent_type> "<description>" "<prompt>" [--model <ref>] [--timeout <ms>] [--command <cmd>] [--context none|state|full] [--output-schema '<json>']
     # bind it to one of your `task` tool tasks (TID from the `task` tool, e.g. T4):
     actor run <subagent_type> "<description>" "<prompt>" --task <TID>
 
@@ -38,8 +38,11 @@ appends them at request time per-agent).
     actor status <actor_id>     # current state without blocking
     actor cancel <actor_id>     # graceful stop
 
-# deliver a message to another actor's inbox (fire-and-forget):
+# deliver a message to another actor's inbox, waking it for another turn. This is how you
+# give follow-up work to a subagent you already spawned — spawn/run NEVER resume one, they
+# always create a fresh subagent. Returns once queued, so pair it with `wait` for the answer:
     actor send <to_actor_id> "<content>" [--session <id>] [--type <t>]
+    actor wait <to_actor_id>    # ...then block for the woken turn's result
     # to_actor_id: 'main' for a session's main agent, or a subagent id like 'explore-1'
     # --session: target session id (defaults to current); --type: 'text' (default) or 'actor_notification'
     # (--task is NOT valid here — it applies only to spawn/run for tying a subagent to a task_id)
@@ -78,8 +81,8 @@ Examples:
 # THE EXCEPTION: a tiny blocking lookup you cannot proceed without in this turn:
     actor run explore "Is the field public API" "Is `retryLimit` re-exported from src/index.ts? yes/no + file:line."
 
-# spawn/run flags: --actor resume a prior subagent (by actor_id); --timeout ms before
-#   giving up (run only); --command the command that triggered this; --context none|state|full
+# spawn/run flags: --timeout ms before giving up (run only); --command the command that
+#   triggered this; --context none|state|full
 #   (default none); --output-schema a JSON Schema STRING (single-quote it) — forces the
 #   subagent to return a matching object instead of free text.
 

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -64,8 +64,8 @@ function suggestActorVerb(input: string): string | undefined {
 // uses z.string() for subagent_type since the dynamic enum is only needed at
 // Zod validation time (inside execute), not at parse time.
 type ActorShellArgs =
-  | { operation: { action: "run"; subagent_type: string; description: string; prompt: string; model?: string; task_id?: string; actor_id?: string; timeout_ms?: number; command?: string; context?: "none" | "state" | "full"; output_schema?: Record<string, unknown> } }
-  | { operation: { action: "spawn"; subagent_type: string; description: string; prompt: string; model?: string; task_id?: string; actor_id?: string; command?: string; context?: "none" | "state" | "full"; output_schema?: Record<string, unknown> } }
+  | { operation: { action: "run"; subagent_type: string; description: string; prompt: string; model?: string; task_id?: string; timeout_ms?: number; command?: string; context?: "none" | "state" | "full"; output_schema?: Record<string, unknown> } }
+  | { operation: { action: "spawn"; subagent_type: string; description: string; prompt: string; model?: string; task_id?: string; command?: string; context?: "none" | "state" | "full"; output_schema?: Record<string, unknown> } }
   | { operation: { action: "status"; actor_id: string } }
   | { operation: { action: "wait"; actor_id: string; timeout_ms?: number } }
   | { operation: { action: "cancel"; actor_id: string } }
@@ -113,14 +113,24 @@ function extractNamedFlags(
 }
 
 const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefined, args: string[], line: number) {
+  // spawn/run dropped their resume argument. Without this, `--actor <id>` just
+  // falls through to the positionals and reports an arity mismatch, which tells a
+  // model the count is wrong rather than that the concept is gone.
+  if ((verb === "run" || verb === "spawn") && args.some((a) => a === "--actor" || a.startsWith("--actor="))) {
+    return yield* Effect.fail({
+      kind: "flag" as const,
+      line,
+      detail: `actor: ${verb}: --actor is not supported — ${verb} always starts a fresh subagent. To give more work to one you already have: actor send <actor_id> "<message>" then actor wait <actor_id>.`,
+    })
+  }
   switch (verb) {
     case "run": {
       const { flags, rest } = yield* extractNamedFlags(
         args,
-        ["model", "task", "actor", "timeout", "command", "context", "output-schema"],
+        ["model", "task", "timeout", "command", "context", "output-schema"],
         line,
       )
-      if (rest.length !== 3) return yield* actorArityError("run", '<subagent_type> "<description>" "<prompt>" [--model <ref>] [--task <TID>] [--actor <id>] [--timeout <ms>] [--command <cmd>] [--context none|state|full] [--output-schema <json>]', rest, line)
+      if (rest.length !== 3) return yield* actorArityError("run", '<subagent_type> "<description>" "<prompt>" [--model <ref>] [--task <TID>] [--timeout <ms>] [--command <cmd>] [--context none|state|full] [--output-schema <json>]', rest, line)
       return {
         operation: {
           action: "run" as const,
@@ -129,7 +139,6 @@ const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefin
           prompt: rest[2],
           ...(flags.model ? { model: flags.model } : {}),
           ...(flags.task ? { task_id: flags.task } : {}),
-          ...(flags.actor ? { actor_id: flags.actor } : {}),
           ...(flags.timeout ? { timeout_ms: Number(flags.timeout) } : {}),
           ...(flags.command ? { command: flags.command } : {}),
           ...(flags.context ? { context: flags.context } : {}),
@@ -142,10 +151,10 @@ const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefin
     case "spawn": {
       const { flags, rest } = yield* extractNamedFlags(
         args,
-        ["model", "task", "actor", "command", "context", "output-schema"],
+        ["model", "task", "command", "context", "output-schema"],
         line,
       )
-      if (rest.length !== 3) return yield* actorArityError("spawn", '<subagent_type> "<description>" "<prompt>" [--model <ref>] [--task <TID>] [--actor <id>] [--command <cmd>] [--context none|state|full] [--output-schema <json>]', rest, line)
+      if (rest.length !== 3) return yield* actorArityError("spawn", '<subagent_type> "<description>" "<prompt>" [--model <ref>] [--task <TID>] [--command <cmd>] [--context none|state|full] [--output-schema <json>]', rest, line)
       return {
         operation: {
           action: "spawn" as const,
@@ -154,7 +163,6 @@ const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefin
           prompt: rest[2],
           ...(flags.model ? { model: flags.model } : {}),
           ...(flags.task ? { task_id: flags.task } : {}),
-          ...(flags.actor ? { actor_id: flags.actor } : {}),
           ...(flags.command ? { command: flags.command } : {}),
           ...(flags.context ? { context: flags.context } : {}),
           ...(flags["output-schema"] ? { output_schema: JSON.parse(flags["output-schema"]) } : {}),
@@ -286,7 +294,7 @@ export function recoverActorArgs(rawArgs: unknown): ActorShellArgs | undefined {
     const op: Record<string, unknown> = { action: inferAction(obj), subagent_type, description, prompt }
     // Carry only the optional fields a confused model plausibly puts at top level
     // alongside the bare Task-prior triple. This is a deliberate subset of the
-    // run/spawn schema's optionals (model, actor_id, timeout_ms, command, context,
+    // run/spawn schema's optionals (model, timeout_ms, command, context,
     // task_id, output_schema) — the others (timeout_ms/command/context/output_schema)
     // are dropped here, falling back to their schema defaults. Low risk in practice:
     // the bare shape mimo emits is the 3 required fields, rarely with extras. When
@@ -294,7 +302,6 @@ export function recoverActorArgs(rawArgs: unknown): ActorShellArgs | undefined {
     // it here, or this whitelist silently drifts from the schema.
     if (typeof obj.model === "string") op.model = obj.model
     if (typeof obj.task_id === "string") op.task_id = obj.task_id
-    if (typeof obj.actor_id === "string") op.actor_id = obj.actor_id
     return { operation: op } as ActorShellArgs
   }
   return undefined
@@ -389,13 +396,6 @@ export const ActorTool = Tool.define(
           .min(1)
           .optional()
           .describe(MODEL_PARAM_DESCRIPTION),
-        actor_id: z
-          .string()
-          .min(1)
-          .optional()
-          .describe(
-            "(optional) If set, resume the specified prior actor session instead of creating a new one. Distinct from the user-task IDs (T1, T2, ...) used by the `task` tool.",
-          ),
         timeout_ms: timeoutField,
         command: z.string().min(1).optional().describe("(optional) The command that triggered this task."),
         context: contextField,
@@ -428,13 +428,6 @@ export const ActorTool = Tool.define(
           .min(1)
           .optional()
           .describe(MODEL_PARAM_DESCRIPTION),
-        actor_id: z
-          .string()
-          .min(1)
-          .optional()
-          .describe(
-            "(optional) If set, resume the specified prior actor session instead of creating a new one.",
-          ),
         command: z.string().min(1).optional().describe("(optional) The command that triggered this task."),
         context: contextField,
         task_id: z
@@ -888,7 +881,7 @@ export const ActorTool = Tool.define(
           metadata: { sessionId: spawnResult.sessionID, actorId: spawnResult.actorID, model } as Record<string, any>,
           output: [
             ...(taskNotice ? [taskNotice, ""] : []),
-            `actor_id: ${spawnResult.actorID} (for resuming to continue this task if needed)`,
+            `actor_id: ${spawnResult.actorID} (to follow up on this task, send it another message with \`send\`, then \`wait\` on the same id)`,
             "",
             `<actor_result status="${statusAttr}"${summaryAttr}>`,
             resultText,

--- a/packages/opencode/src/tool/actor.txt
+++ b/packages/opencode/src/tool/actor.txt
@@ -29,7 +29,7 @@ THE EXCEPTION — `run` blocks the conversation; only for a tiny lookup that gat
           Use it for essentially all delegation: investigation, analysis, review,
           implementation, long searches — anything that takes real time.
           required: subagent_type, description, prompt
-          optional: actor_id, command, context
+          optional: command, context
 - run:    **RARE EXCEPTION.** Same launch, but BLOCKS the whole conversation until
           the subagent finishes; result returned inline. Allowed ONLY when you
           cannot make your very next decision without the result in THIS turn, and
@@ -37,17 +37,18 @@ THE EXCEPTION — `run` blocks the conversation; only for a tiny lookup that gat
           ordinary analysis, review, or implementation work — those go to `spawn`.
           If you are unsure, use `spawn`.
           required: subagent_type, description, prompt
-          optional: actor_id, timeout_ms, command, context
+          optional: timeout_ms, command, context
 - status: poll actor state without blocking. required: actor_id.
           Returns: { status: "pending"|"running"|"idle"|"unknown", actor_id, turnCount, ... }
 - wait:   block until actor completes (success/failure/cancelled) or timeout (default 10 min).
           required: actor_id. optional: timeout_ms.
           Returns: { status, actor_id, result?, error? }
 - cancel: stop a running actor (graceful). required: actor_id. Idempotent.
-- send:   deliver message to another actor's inbox.
+- send:   deliver message to another actor's inbox, waking it for another turn.
           required: to_actor_id, content.
           optional: to_session_id, type (default "text").
           Receiver sees wrapped in <inbox from="..." sent_at="...">...</inbox> at next iteration.
+          Returns once queued, NOT when the woken turn finishes — pair with `wait`.
 
 ## When to use actor
 
@@ -90,7 +91,29 @@ You are the subagent's only briefing — it hasn't seen this conversation.
 
 ## Actor ID vs Task ID
 
-`actor_id` identifies a subagent session (resumable across turns). Task IDs (T1, T2, ...) come from the `task` tool — only pass a `task_id` you got from a `task` tool call this session. If the `task_id` is malformed or unknown, the binding is dropped: the subagent's findings won't be captured to any task, and the tool result tells you so.
+`actor_id` identifies a live subagent. It is returned by `spawn`/`run` and accepted by
+`status`, `wait`, `cancel`, and `send` — never by `spawn`/`run` themselves: those two
+ALWAYS create a fresh subagent. To give more work to a subagent you already have, see
+"Following up with an existing subagent". Task IDs (T1, T2, ...) come from the `task` tool — only pass a `task_id` you got from a `task` tool call this session. If the `task_id` is malformed or unknown, the binding is dropped: the subagent's findings won't be captured to any task, and the tool result tells you so.
+
+## Following up with an existing subagent
+
+There is no "resume" argument on `spawn`/`run`. Passing an `actor_id` to either is
+rejected, and re-spawning the same `subagent_type` gives you a NEW subagent with an
+empty context — it has never seen the earlier task or its findings.
+
+To continue with a subagent you already spawned, send it a message and then wait on it:
+
+  1. `{"operation":{"action":"send","to_actor_id":"explore-1","content":"<follow-up>"}}`
+  2. `{"operation":{"action":"wait","actor_id":"explore-1"}}`
+
+`send` appends your message to that subagent's own history and wakes it for another
+turn, so it keeps every prior message and tool output. `wait` then blocks until THAT
+turn finishes and returns its result. `send` alone is fire-and-forget: without a
+following `wait` (or a later `status`), you never see what the subagent produced.
+
+This works for a subagent that has already gone idle — waking it is exactly what
+`send` is for.
 
 ## Binding a subagent to a task
 
@@ -108,10 +131,10 @@ postStop check then becomes a no-op.
 
 ## Usage notes
 
-- **Resume the same subagent**: pass `actor_id` to `spawn`/`run` and the call resumes that subagent's session (continues with its prior messages and tool outputs). Without `actor_id`, a fresh subagent is created.
+- **No resume argument**: `spawn`/`run` ALWAYS create a fresh subagent; neither accepts an `actor_id`. To hand more work to a subagent you already have, use `send` then `wait` — see "Following up with an existing subagent".
 - **`spawn` vs `run` result delivery**: `spawn` returns the actor_id immediately; when the background actor finishes, its result appears as a notification in this conversation — your turn does NOT auto-wake to process it; you'll see it the next time you respond to the user. Use `wait` to block on the actor_id explicitly. `run` instead blocks the conversation and returns the result inline — that stall is exactly why it's the exception.
 - **`wait` on persistent peers caveat**: `wait` is designed for ephemeral subagents you spawned via `spawn`/`run`. Persistent peers idle between turns and never produce a "done" outcome on success — `wait` on a peer will block until that peer fails or is cancelled. Use `send` + `status` to coordinate with peers instead.
-- **`send` semantics**: fire-and-forget; returns within ~5 ms regardless of receiver load. The receiver picks the message up at the head of its next runLoop iteration. On unknown `to_actor_id`, `send` returns `{inboxID: null, error: "receiver not found"}` rather than throwing — handle the error path.
+- **`send` semantics**: fire-and-forget; returns within ~5 ms regardless of receiver load. It also WAKES the receiver — an idle subagent runs another turn on its own history, so `send` is the way to give it follow-up work. Because the call returns before that turn finishes, follow it with `wait` on the same id when you need the answer. On unknown `to_actor_id`, `send` returns `{inboxID: null, error: "receiver not found"}` rather than throwing — handle the error path.
 - Trust the subagent's outputs generally, but the subagent doesn't see your full context (unless you pass `context="full"`); brief it accordingly.
 
 

--- a/packages/opencode/test/actor/poststop-progress-write-permission.repro.test.ts
+++ b/packages/opencode/test/actor/poststop-progress-write-permission.repro.test.ts
@@ -372,6 +372,10 @@ describe("postStop progress.md is gated by the subagent's write permission", () 
       }),
       { git: true, config: providerCfg },
     ),
+    // A spawn turn, a completion-gate re-entry and a postStop re-entry, each a
+    // full round trip, plus the journal write. The default 5s budget is not enough
+    // and this sat right on it.
+    30_000,
   )
 
   // CONTRAST (scripted LLM): the SAME path with `explore` (read-only). explore's "*":deny

--- a/packages/opencode/test/actor/poststop-progress-write-permission.repro.test.ts
+++ b/packages/opencode/test/actor/poststop-progress-write-permission.repro.test.ts
@@ -339,7 +339,22 @@ describe("postStop progress.md is gated by the subagent's write permission", () 
         })
         expect(result.actorID).toBe("general-1")
 
-        yield* Deferred.await(result.outcome).pipe(Effect.timeout("30 seconds"))
+        const outcome = yield* Deferred.await(result.outcome).pipe(Effect.timeout("30 seconds"))
+
+        // Which turn the caller is answered WITH, across a spawn that ran extra
+        // rounds. The outcome is resolved after the completion gate and before the
+        // fire-and-forget postStop loop, so:
+        //   - the body is the gate re-entry's text plus the gate's own
+        //     reconciliation suffix, NOT the postStop turn's text;
+        //   - reportedStatus is the gate's downgrade (T1 left actionable), NOT the
+        //     "success" the model self-reported.
+        // postStop still ran — progress.md below proves it — it just does not get
+        // to redefine what the spawn returned.
+        expect(outcome.status).toBe("success")
+        if (outcome.status !== "success") throw new Error("expected success")
+        expect(outcome.finalText).toContain("**Incomplete tasks**: T1")
+        expect(outcome.finalText).not.toContain("wrote progress.md")
+        expect(outcome.reportedStatus).toBe("partial")
 
         const fs = yield* AppFileSystem.Service
         const exists = yield* fs.existsSafe(target)

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -1,7 +1,7 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { FetchHttpClient } from "effect/unstable/http"
 import { afterEach, describe, expect } from "bun:test"
-import { Deferred, Effect, Layer } from "effect"
+import { Deferred, Effect, Layer, Schedule } from "effect"
 import { and, eq } from "drizzle-orm"
 import { Agent as AgentSvc } from "../../src/agent/agent"
 import { Bus } from "../../src/bus"
@@ -1600,5 +1600,231 @@ describe("AgentOutcome failure classification", () => {
       }),
       { git: true, config: providerCfg },
     ),
+  )
+})
+
+describe("send then wait on a subagent", () => {
+  // The follow-up flow the actor tool now points models at: `send` a message to a
+  // subagent that already went idle, then `wait` on the same actor_id.
+  //
+  // forkWork wraps only the SPAWN turn in runTurn, so an inbox-woken turn used to
+  // leave the registry row exactly as the previous turn left it — idle+success.
+  // That is precisely the state ActorWaiter's fast path reads as "done", and it
+  // then answers from the slice's last assistant message, i.e. the PREVIOUS
+  // turn's text. This pins the row's honesty across a woken turn instead: queued
+  // ⇒ pending, running ⇒ running, finished ⇒ idle with a fresh turn recorded.
+  // Holding the woken turn's LLM response open makes the in-flight window
+  // deterministic rather than timing-dependent.
+  it.live(
+    "a woken turn moves the registry row off the previous turn's idle",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          const actor = yield* Actor.Service
+          const sessions = yield* Session.Service
+          const reg = yield* ActorRegistry.Service
+          const inbox = inboxServiceRef.current!
+
+          const parent = yield* sessions.create({
+            title: "send-then-wait parent",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+
+          const settled = Effect.gen(function* () {
+            const row = yield* reg.get(parent.id, "build-1")
+            if (row?.status !== "idle") return yield* Effect.fail("not idle yet" as const)
+            return row
+          }).pipe(Effect.retry({ schedule: Schedule.spaced("100 millis"), times: 60 }), Effect.orDie)
+
+          // Turn 1 — spawn, then settle. `outcome` resolves BEFORE the
+          // fire-and-forget postStop loop, which runs turns of its own, so wait
+          // for the row to read idle rather than racing postStop for the next
+          // queued LLM reply.
+          yield* llm.text("FIRST ANSWER")
+          const spawned = yield* actor.spawn({
+            mode: "subagent",
+            sessionID: parent.id,
+            agentType: "build",
+            task: "initial task",
+            context: "none",
+            tools: ["read"],
+            background: false,
+            model: ref,
+          })
+          expect((yield* Deferred.await(spawned.outcome)).status).toBe("success")
+          const before = yield* settled
+
+          // Turn 2 — hold the woken turn's reply so it is provably mid-flight.
+          const release = yield* Deferred.make<void>()
+          yield* llm.hold("SECOND ANSWER", Effect.runPromise(Deferred.await(release)))
+
+          yield* inbox.send({
+            receiverSessionID: parent.id,
+            receiverActorID: spawned.actorID,
+            senderSessionID: parent.id,
+            senderActorID: "main",
+            content: "follow-up question",
+          })
+
+          // Immediately after send — the window where `wait` used to hand back
+          // the previous turn's answer. Anything but idle keeps wait honest.
+          expect((yield* reg.get(parent.id, spawned.actorID))?.status).not.toBe("idle")
+
+          // Mid-flight, once the woken turn has actually started.
+          yield* Effect.gen(function* () {
+            const row = yield* reg.get(parent.id, spawned.actorID)
+            if (row?.status !== "running") return yield* Effect.fail("not running yet" as const)
+          }).pipe(Effect.retry({ schedule: Schedule.spaced("100 millis"), times: 60 }), Effect.orDie)
+
+          yield* Deferred.succeed(release, undefined)
+
+          const after = yield* settled
+          expect(after.lastOutcome).toBe("success")
+          expect(after.turnCount).toBeGreaterThan(before.turnCount)
+
+          const msgs = yield* sessions.messages({ sessionID: parent.id, agentID: spawned.actorID })
+          const last = msgs.findLast((m) => m.info.role === "assistant")
+          const text = last?.parts.findLast((p): p is Extract<typeof p, { type: "text" }> => p.type === "text")?.text
+          expect(text).toContain("SECOND ANSWER")
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30_000,
+  )
+
+  // runLoop surfaces a settled assistant error as a SUCCESS value — it returns the
+  // errored message and only branches on it to notify the parent — so the woken
+  // turn's wrapper has to raise it, or runTurn records idle+success and a waiting
+  // sender is told a failed turn succeeded.
+  it.live(
+    "an errored woken turn is recorded as a failure",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          const actor = yield* Actor.Service
+          const sessions = yield* Session.Service
+          const reg = yield* ActorRegistry.Service
+          const inbox = inboxServiceRef.current!
+
+          const parent = yield* sessions.create({
+            title: "errored wake parent",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+
+          const settledIdle = Effect.gen(function* () {
+            const row = yield* reg.get(parent.id, "build-1")
+            if (row?.status !== "idle") return yield* Effect.fail("not idle yet" as const)
+            return row
+          }).pipe(Effect.retry({ schedule: Schedule.spaced("100 millis"), times: 60 }), Effect.orDie)
+
+          yield* llm.text("FIRST ANSWER")
+          const spawned = yield* actor.spawn({
+            mode: "subagent",
+            sessionID: parent.id,
+            agentType: "build",
+            task: "initial task",
+            context: "none",
+            tools: ["read"],
+            background: false,
+            model: ref,
+          })
+          expect((yield* Deferred.await(spawned.outcome)).status).toBe("success")
+          expect((yield* settledIdle).lastOutcome).toBe("success")
+
+          // A 400 is the deterministic case: SessionRetry refuses it, so the turn
+          // settles with a persisted assistant error instead of retrying forever.
+          yield* llm.error(400, { error: { message: "woken turn boom" } })
+          yield* inbox.send({
+            receiverSessionID: parent.id,
+            receiverActorID: spawned.actorID,
+            senderSessionID: parent.id,
+            senderActorID: "main",
+            content: "follow-up that will fail",
+          })
+
+          const after = yield* Effect.gen(function* () {
+            const row = yield* reg.get(parent.id, spawned.actorID)
+            if (row?.status !== "idle" || row.lastOutcome === undefined) {
+              return yield* Effect.fail("not settled yet" as const)
+            }
+            return row
+          }).pipe(
+            Effect.retry({ schedule: Schedule.spaced("100 millis"), times: 100 }),
+            Effect.orDie,
+          )
+          expect(after.lastOutcome).toBe("failure")
+          expect(after.lastError).toContain("Actor assistant failed")
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30_000,
+  )
+})
+
+describe("SessionPrompt.loop actor status wrapping", () => {
+  // SessionPrompt.prompt itself ends in loop(), and forkWork already wraps that
+  // whole call in runTurn. So the actor-status wrapper inside loop is gated on the
+  // inbox wake flag: applying it to every non-main agentID would nest two runTurns
+  // around a spawn turn, and the inner one would publish idle+success before
+  // runAgentLoop inspects the assistant error and fails the outer.
+  //
+  // Seeding idle+failure makes the gate observable: a loop that must NOT touch
+  // actor status leaves that outcome alone, whereas a wrapped one overwrites it
+  // with the success its own turn produced.
+  it.live(
+    "a loop without the wake flag leaves actor status untouched",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const reg = yield* ActorRegistry.Service
+
+          const parent = yield* sessions.create({
+            title: "loop gate parent",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          yield* reg.register({
+            sessionID: parent.id,
+            actorID: "build-9",
+            mode: "subagent",
+            parentActorID: undefined,
+            agent: "build",
+            description: "gate probe",
+            contextMode: "none",
+            contextWatermark: undefined,
+            background: true,
+            lifecycle: "ephemeral",
+          })
+          yield* reg.updateStatus(parent.id, "build-9", { status: "idle", lastOutcome: "failure", lastError: "boom" })
+
+          // A pending user message for the loop to answer, in this actor's slice.
+          yield* sessions.updateMessage({
+            id: MessageID.ascending(),
+            role: "user" as const,
+            sessionID: parent.id,
+            agentID: "build-9",
+            time: { created: Date.now() },
+            agent: "build",
+            model: ref,
+          })
+          yield* sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: (yield* sessions.messages({ sessionID: parent.id, agentID: "build-9" })).at(-1)!.info.id,
+            sessionID: parent.id,
+            type: "text" as const,
+            text: "answer me",
+          })
+
+          yield* llm.text("LOOP ANSWER")
+          yield* prompt.loop({ sessionID: parent.id, agentID: "build-9" })
+
+          const row = yield* reg.get(parent.id, "build-9")
+          expect(row?.status).toBe("idle")
+          expect(row?.lastOutcome).toBe("failure")
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30_000,
   )
 })

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -59,6 +59,7 @@ import { TestLLMServer } from "../lib/llm-server"
 import { reply } from "../lib/llm-server"
 import { Inbox } from "../../src/inbox"
 import { inboxServiceRef } from "../../src/inbox/inbox-ref"
+import { InboxTable } from "../../src/inbox/inbox.sql"
 import { Flag } from "../../src/flag/flag"
 
 afterEach(async () => {
@@ -1686,6 +1687,96 @@ describe("send then wait on a subagent", () => {
           const last = msgs.findLast((m) => m.info.role === "assistant")
           const text = last?.parts.findLast((p): p is Extract<typeof p, { type: "text" }> => p.type === "text")?.text
           expect(text).toContain("SECOND ANSWER")
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30_000,
+  )
+
+  // End-to-end cover for a send that lands while the receiver is mid-turn: the
+  // wake's ensureRunning finds the runner busy and returns the in-flight Deferred
+  // instead of starting a turn, so delivery rests on the running turn draining the
+  // row itself. Whatever path consumes it, the message must not be left queued and
+  // the actor must settle. (The narrow variant where the registry reads idle before
+  // the Runner flips lives in test/inbox/wake-matrix.test.ts, which can stub the
+  // loop; it is unreachable from out here, inside one fiber's uninterruptible tail.)
+  it.live(
+    "a send that lands mid-turn is still drained and settles",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          const actor = yield* Actor.Service
+          const sessions = yield* Session.Service
+          const reg = yield* ActorRegistry.Service
+          const inbox = inboxServiceRef.current!
+
+          const parent = yield* sessions.create({
+            title: "busy runner parent",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+
+          // Hold the spawn turn open, send into it, then release: the send is
+          // processed while the receiver's runner is provably occupied.
+          const release = yield* Deferred.make<void>()
+          yield* llm.hold("FIRST ANSWER", Effect.runPromise(Deferred.await(release)))
+          // Replies for the woken turn (and any postStop follow-up).
+          yield* llm.text("SECOND ANSWER")
+          yield* llm.text("THIRD ANSWER")
+
+          const spawned = yield* actor.spawn({
+            mode: "subagent",
+            sessionID: parent.id,
+            agentType: "build",
+            task: "initial task",
+            context: "none",
+            tools: ["read"],
+            background: true,
+            model: ref,
+          })
+
+          yield* Effect.gen(function* () {
+            const row = yield* reg.get(parent.id, spawned.actorID)
+            if (row?.status !== "running") return yield* Effect.fail("not running yet" as const)
+          }).pipe(Effect.retry({ schedule: Schedule.spaced("100 millis"), times: 60 }), Effect.orDie)
+
+          yield* inbox.send({
+            receiverSessionID: parent.id,
+            receiverActorID: spawned.actorID,
+            senderSessionID: parent.id,
+            senderActorID: "main",
+            content: "follow-up while busy",
+          })
+          yield* Deferred.succeed(release, undefined)
+
+          // The message must be consumed and the actor must settle — not sit
+          // `pending` with an undrained row.
+          yield* Effect.gen(function* () {
+            const rows = yield* Effect.sync(() =>
+              Database.use((db) =>
+                db
+                  .select({ id: InboxTable.id })
+                  .from(InboxTable)
+                  .where(
+                    and(
+                      eq(InboxTable.receiver_session_id, parent.id),
+                      eq(InboxTable.receiver_actor_id, spawned.actorID),
+                    ),
+                  )
+                  .all(),
+              ),
+            )
+            if (rows.length > 0) return yield* Effect.fail("still queued" as const)
+            const row = yield* reg.get(parent.id, spawned.actorID)
+            if (row?.status !== "idle") return yield* Effect.fail("not settled" as const)
+            return row
+          }).pipe(Effect.retry({ schedule: Schedule.spaced("100 millis"), times: 150 }), Effect.orDie)
+
+          // And the follow-up really reached the model as a turn of its own.
+          const msgs = yield* sessions.messages({ sessionID: parent.id, agentID: spawned.actorID })
+          const texts = msgs.flatMap((m) =>
+            m.parts.flatMap((p) => (p.type === "text" ? [p.text] : [])),
+          )
+          expect(texts.some((t) => t.includes("follow-up while busy"))).toBe(true)
         }),
         { git: true, config: providerCfg },
       ),

--- a/packages/opencode/test/actor/status-event-payload.test.ts
+++ b/packages/opencode/test/actor/status-event-payload.test.ts
@@ -101,6 +101,71 @@ describe("actor.status event payload", () => {
     })
   })
 
+  test("markPending publishes only on a real idle -> pending transition", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withRegistry(tmp.path, async (rt) => {
+      const parent = await rt.runPromise(Session.Service.use((s) => s.create()))
+      const sid = parent.id
+
+      await rt.runPromise(
+        ActorRegistry.Service.use((reg) =>
+          reg.register({
+            sessionID: sid,
+            actorID: "explore-1",
+            mode: "subagent",
+            parentActorID: undefined,
+            agent: "explore",
+            description: "explore",
+            contextMode: "none",
+            contextWatermark: undefined,
+            background: false,
+            lifecycle: "ephemeral",
+          }),
+        ),
+      )
+
+      const events: Array<z.infer<typeof ActorStatusChanged.properties>> = []
+      const unsubscribe = await rt.runPromise(
+        Bus.Service.use((bus) =>
+          bus.subscribeCallback(ActorStatusChanged, (evt) => {
+            events.push(evt.properties)
+          }),
+        ),
+      )
+      try {
+        const markPending = () =>
+          rt.runPromise(ActorRegistry.Service.use((reg) => reg.markPending(sid, "explore-1")))
+
+        // Registered rows start `pending`, which is also the steady state of a
+        // `main` row — the receiver of every subagent notification. No transition,
+        // so nothing to announce.
+        await markPending()
+        await new Promise((r) => setTimeout(r, 50))
+        expect(events.length).toBe(0)
+
+        await rt.runPromise(
+          ActorRegistry.Service.use((reg) =>
+            reg.updateStatus(sid, "explore-1", { status: "idle", lastOutcome: "success" }),
+          ),
+        )
+        await new Promise((r) => setTimeout(r, 50))
+        expect(events.length).toBe(1)
+
+        await markPending()
+        await new Promise((r) => setTimeout(r, 50))
+        expect(events.length).toBe(2)
+        expect(events[1].status).toBe("pending")
+
+        // Already pending — no second announcement.
+        await markPending()
+        await new Promise((r) => setTimeout(r, 50))
+        expect(events.length).toBe(2)
+      } finally {
+        unsubscribe()
+      }
+    })
+  })
+
   test("updateStatus against non-existent actor publishes no event", async () => {
     await using tmp = await tmpdir({ git: true })
     await withRegistry(tmp.path, async (rt) => {

--- a/packages/opencode/test/actor/waiter.test.ts
+++ b/packages/opencode/test/actor/waiter.test.ts
@@ -281,13 +281,21 @@ describe("ActorWaiter — woken turn (send then wait)", () => {
           lifecycle: "ephemeral",
         })
 
-        // Turn 1 settled.
+        // Turn 1 settled — as a FAILURE, so the revived row's fields are visibly
+        // the new turn's rather than the finished one's.
         yield* seedAssistantText(parent.id, "explore-1", "FIRST ANSWER")
-        yield* registry.updateStatus(parent.id, "explore-1", { status: "idle", lastOutcome: "success" })
+        yield* registry.updateStatus(parent.id, "explore-1", {
+          status: "idle",
+          lastOutcome: "failure",
+          lastError: "previous turn blew up",
+        })
 
         // Inbox.send's pre-wake step.
         yield* registry.markPending(parent.id, "explore-1")
-        expect((yield* registry.get(parent.id, "explore-1"))?.status).toBe("pending")
+        const queued = yield* registry.get(parent.id, "explore-1")
+        expect(queued?.status).toBe("pending")
+        expect(queued?.lastOutcome).toBeUndefined()
+        expect(queued?.lastError).toBeUndefined()
 
         // `wait` subscribes first, then the woken turn runs on the main fiber —
         // wrapped the way SessionPrompt.loop now wraps it.
@@ -389,6 +397,9 @@ describe("ActorWaiter — woken turn (send then wait)", () => {
         const live = yield* registry.liveness(parent.id, "explore-1")
         expect(live?.actor.status).toBe("pending")
         expect(live?.liveness).toBe("progressing")
+        // The finished turn's terminal fields must not travel with the revived row.
+        expect(live?.actor.lastOutcome).toBeUndefined()
+        expect(live?.actor.time.completed).toBeUndefined()
       }),
     ),
   )

--- a/packages/opencode/test/actor/waiter.test.ts
+++ b/packages/opencode/test/actor/waiter.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect } from "bun:test"
-import { Effect, Layer } from "effect"
+import { Effect, Fiber, Layer } from "effect"
 import { Bus } from "../../src/bus"
 import { Session as SessionNs } from "../../src/session"
 import { SessionID, MessageID, PartID } from "../../src/session/schema"
 import { ActorRegistry } from "../../src/actor/registry"
+import { DEFAULT_LIVENESS_ABANDON_MS } from "../../src/actor/schema"
+import { ActorRegistryTable } from "../../src/actor/actor.sql"
+import { Database, and, eq } from "../../src/storage"
 import { ActorWaiter } from "../../src/actor/waiter"
+import { runTurn } from "../../src/actor/turn"
 import { Instance } from "../../src/project/instance"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -240,6 +244,151 @@ describe("ActorWaiter — lifecycle predicate (Plan 3 / Task 3)", () => {
         expect(snap.status).toBe("idle")
         expect(snap.lastOutcome).toBe("success")
         expect(snap.result).toBe("result from slow path")
+      }),
+    ),
+  )
+})
+
+// The send-then-wait follow-up path, assembled from the two pieces that make it
+// work: Inbox.send's markPending (an actor with a queued message is no longer
+// idle) and SessionPrompt.loop wrapping the woken turn in runTurn (so it moves
+// running → idle+outcome and publishes, exactly like a spawn turn).
+//
+// Without markPending, wait's fast path sees the row still idle+ephemeral from
+// the PREVIOUS turn and answers from the slice's last assistant message — the
+// previous turn's text. Without the runTurn wrapper, nothing ever publishes the
+// woken turn's completion, so a subscribed wait can only time out.
+describe("ActorWaiter — woken turn (send then wait)", () => {
+  it.live(
+    "a queued-message actor is not wait-resolving, and wait returns the woken turn's result",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* SessionNs.Service
+        const registry = yield* ActorRegistry.Service
+        const waiter = yield* ActorWaiter.Service
+
+        const parent = yield* sessions.create({ title: "parent" })
+        yield* registry.register({
+          sessionID: parent.id,
+          actorID: "explore-1",
+          mode: "subagent",
+          parentActorID: undefined,
+          agent: "explore",
+          description: "explore task",
+          contextMode: "none",
+          contextWatermark: undefined,
+          background: true,
+          lifecycle: "ephemeral",
+        })
+
+        // Turn 1 settled.
+        yield* seedAssistantText(parent.id, "explore-1", "FIRST ANSWER")
+        yield* registry.updateStatus(parent.id, "explore-1", { status: "idle", lastOutcome: "success" })
+
+        // Inbox.send's pre-wake step.
+        yield* registry.markPending(parent.id, "explore-1")
+        expect((yield* registry.get(parent.id, "explore-1"))?.status).toBe("pending")
+
+        // `wait` subscribes first, then the woken turn runs on the main fiber —
+        // wrapped the way SessionPrompt.loop now wraps it.
+        const waiting = yield* waiter
+          .wait({ sessionID: parent.id, actor_id: "explore-1", timeout_ms: 5000 })
+          .pipe(Effect.forkScoped)
+        yield* Effect.sleep("100 millis")
+        yield* runTurn(
+          parent.id,
+          "explore-1",
+          // runTurn takes a self-contained work Effect, so hand it the session
+          // service the seed needs.
+          seedAssistantText(parent.id, "explore-1", "SECOND ANSWER").pipe(
+            Effect.provideService(SessionNs.Service, sessions),
+          ),
+        ).pipe(Effect.provideService(ActorRegistry.Service, registry))
+
+        const snap = yield* Fiber.join(waiting)
+
+        expect(snap.status).toBe("idle")
+        expect(snap.lastOutcome).toBe("success")
+        expect(snap.result).toBe("SECOND ANSWER")
+      }),
+    ),
+  )
+
+  it.live(
+    "markPending leaves a running actor alone",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* SessionNs.Service
+        const registry = yield* ActorRegistry.Service
+
+        const parent = yield* sessions.create({ title: "parent" })
+        yield* registry.register({
+          sessionID: parent.id,
+          actorID: "explore-1",
+          mode: "subagent",
+          parentActorID: undefined,
+          agent: "explore",
+          description: "explore task",
+          contextMode: "none",
+          contextWatermark: undefined,
+          background: true,
+          lifecycle: "ephemeral",
+        })
+        yield* registry.updateStatus(parent.id, "explore-1", { status: "running" })
+
+        yield* registry.markPending(parent.id, "explore-1")
+
+        expect((yield* registry.get(parent.id, "explore-1"))?.status).toBe("running")
+      }),
+    ),
+  )
+
+  it.live(
+    "waking a long-idle actor does not read as stalled",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* SessionNs.Service
+        const registry = yield* ActorRegistry.Service
+
+        const parent = yield* sessions.create({ title: "parent" })
+        yield* registry.register({
+          sessionID: parent.id,
+          actorID: "explore-1",
+          mode: "subagent",
+          parentActorID: undefined,
+          agent: "explore",
+          description: "explore task",
+          contextMode: "none",
+          contextWatermark: undefined,
+          background: true,
+          lifecycle: "ephemeral",
+        })
+        yield* seedAssistantText(parent.id, "explore-1", "answered ages ago")
+        yield* registry.updateStatus(parent.id, "explore-1", { status: "idle", lastOutcome: "success" })
+
+        // Its last real activity predates both the stall and the abandon bound,
+        // which is the normal state of a subagent the parent comes back to later.
+        const longAgo = Date.now() - 3 * DEFAULT_LIVENESS_ABANDON_MS
+        yield* Effect.sync(() =>
+          Database.use((db) =>
+            db
+              .update(ActorRegistryTable)
+              .set({ last_activity_time: longAgo, time_created: longAgo })
+              .where(
+                and(
+                  eq(ActorRegistryTable.session_id, parent.id),
+                  eq(ActorRegistryTable.actor_id, "explore-1"),
+                ),
+              )
+              .run(),
+          ),
+        )
+
+        yield* registry.markPending(parent.id, "explore-1")
+
+        const live = yield* registry.liveness(parent.id, "explore-1")
+        expect(live?.actor.status).toBe("pending")
+        expect(live?.liveness).toBe("progressing")
       }),
     ),
   )

--- a/packages/opencode/test/inbox/wake-matrix.test.ts
+++ b/packages/opencode/test/inbox/wake-matrix.test.ts
@@ -6,6 +6,11 @@ import { Session } from "../../src/session"
 import { Bus } from "../../src/bus"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
+import { sessionPromptRef } from "../../src/inbox/inbox-ref"
+import { WAKE_ATTEMPTS } from "../../src/inbox/inbox"
+import { InboxTable } from "../../src/inbox/inbox.sql"
+import { Database, eq, and } from "../../src/storage"
+import { MessageV2 } from "../../src/session/message-v2"
 
 const base = Layer.mergeAll(Session.defaultLayer, ActorRegistry.defaultLayer, Bus.defaultLayer)
 const testLayer = Inbox.layer.pipe(Layer.provide(base), Layer.provideMerge(base))
@@ -136,6 +141,83 @@ describe("Inbox.send wake matrix (Plan 2 / Task 7)", () => {
 
       expect(result.actorID).toBe("ghost")
       expect(result.sessionID).toBe(session.id)
+    })
+  })
+
+  // The wake is allowed to be a no-op: SessionRunState.ensureRunning hands back a
+  // busy runner's Deferred WITHOUT executing the turn we asked for, which happens
+  // when the registry already reads `idle` but the receiver's Runner has not yet
+  // flipped to Idle. A single-shot wake would leave the row queued forever and any
+  // `wait` on it blocking to its timeout, so send drives further turns while the
+  // row survives. Stubbing the loop ref is what makes "the turn did not run"
+  // reproducible — the real window is inside one fiber's uninterruptible tail.
+  test("wake retries while the row survives a turn that did not consume it", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withInbox(tmp.path, async (rt) => {
+      const session = await rt.runPromise(Session.Service.use((s) => s.create()))
+      await rt.runPromise(
+        ActorRegistry.Service.use((reg) =>
+          reg.register({
+            sessionID: session.id,
+            actorID: "explore-1",
+            mode: "subagent",
+            parentActorID: undefined,
+            agent: "explore",
+            description: "test",
+            contextMode: "none",
+            contextWatermark: undefined,
+            background: true,
+            lifecycle: "ephemeral",
+          }),
+        ),
+      )
+      await rt.runPromise(
+        ActorRegistry.Service.use((reg) =>
+          reg.updateStatus(session.id, "explore-1", { status: "idle", lastOutcome: "success" }),
+        ),
+      )
+
+      let calls = 0
+      const previous = sessionPromptRef.current
+      // First call models the swallowed turn (nothing drains); the second behaves
+      // like a real turn and consumes the row.
+      sessionPromptRef.current = {
+        loop: () =>
+          Effect.sync(() => {
+            calls += 1
+            if (calls >= 2) {
+              Database.use((db) =>
+                db
+                  .delete(InboxTable)
+                  .where(
+                    and(
+                      eq(InboxTable.receiver_session_id, session.id),
+                      eq(InboxTable.receiver_actor_id, "explore-1"),
+                    ),
+                  )
+                  .run(),
+              )
+            }
+            return undefined as unknown as MessageV2.WithParts
+          }),
+      }
+      try {
+        await rt.runPromise(
+          Inbox.Service.use((inbox) =>
+            inbox.send({
+              receiverSessionID: session.id,
+              receiverActorID: "explore-1",
+              content: "follow-up",
+            }),
+          ),
+        )
+        // The wake fiber is detached; give it room to run both attempts.
+        await new Promise((r) => setTimeout(r, 300))
+        expect(calls).toBe(2)
+        expect(calls).toBeLessThanOrEqual(WAKE_ATTEMPTS)
+      } finally {
+        sessionPromptRef.current = previous
+      }
     })
   })
 })

--- a/packages/opencode/test/session/bootstrap-skip-system.test.ts
+++ b/packages/opencode/test/session/bootstrap-skip-system.test.ts
@@ -28,6 +28,7 @@ const stubActorRegistry = Layer.succeed(
   ActorRegistry.Service.of({
     register: () => Effect.die("not used"),
     updateStatus: () => Effect.void,
+    markPending: () => Effect.void,
     updateTurn: () => Effect.void,
     updateAgent: () => Effect.void,
     get: () => Effect.succeed(undefined),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1007,6 +1007,87 @@ it.live("serializes concurrent first-query pinning", () =>
   ),
 )
 
+// A resumed turn belongs to the actor status machine just like a spawned or an
+// inbox-woken one: resume/resumeBackground reach runLoop without passing through
+// forkWork's runTurn, so an unwrapped resume left the row carrying the outcome of
+// the turn that had been interrupted. ActorWaiter's fast path reads exactly that
+// as "finished" and answers from the slice's last assistant message.
+it.live("resume moves a subagent's actor status off the interrupted turn's outcome", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const reg = yield* ActorRegistry.Service
+      const chat = yield* sessions.create({
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* reg.register({
+        sessionID: chat.id,
+        actorID: "explore-1",
+        mode: "subagent",
+        parentActorID: undefined,
+        agent: "explore",
+        description: "interrupted probe",
+        contextMode: "none",
+        contextWatermark: undefined,
+        background: true,
+        lifecycle: "ephemeral",
+      })
+      // How an interrupted turn leaves the row.
+      yield* reg.updateStatus(chat.id, "explore-1", {
+        status: "idle",
+        lastOutcome: "failure",
+        lastError: "interrupted",
+      })
+
+      // A resumable turn in the subagent's own slice: a user message plus an
+      // assistant with no `finish`.
+      const userMsg = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        role: "user" as const,
+        sessionID: chat.id,
+        agentID: "explore-1",
+        agent: "explore",
+        model: ref,
+        time: { created: Date.now() },
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: userMsg.id,
+        sessionID: chat.id,
+        type: "text" as const,
+        text: "look into it",
+      })
+      const assistantID = MessageID.ascending()
+      yield* sessions.updateMessage({
+        id: assistantID,
+        role: "assistant" as const,
+        parentID: userMsg.id,
+        sessionID: chat.id,
+        agentID: "explore-1",
+        mode: "build",
+        agent: "explore",
+        cost: 0,
+        path: { cwd: "/tmp", root: "/tmp" },
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        time: { created: Date.now() },
+      })
+
+      yield* llm.text("RESUMED ANSWER")
+      yield* prompt.resume({ sessionID: chat.id, assistantMessageID: assistantID, agentID: "explore-1" })
+
+      const row = yield* reg.get(chat.id, "explore-1")
+      expect(row?.status).toBe("idle")
+      expect(row?.lastOutcome).toBe("success")
+      expect(row?.lastError).toBeUndefined()
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("resume continues an incomplete assistant without creating or rewriting a user message", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {

--- a/packages/opencode/test/tool/actor.shell.test.ts
+++ b/packages/opencode/test/tool/actor.shell.test.ts
@@ -231,12 +231,25 @@ describe("actor.shell.parse: send", () => {
 })
 
 describe("actor.shell.parse: full parity flags", () => {
-  test("run with --actor (resume) maps to actor_id", async () => {
-    const out = await parse('actor run explore "d" "p" --actor explore-1')
-    expect(out).toEqual([
-      { operation: { action: "run", subagent_type: "explore", description: "d", prompt: "p", actor_id: "explore-1" } },
-    ])
-  })
+  // spawn/run always create a fresh subagent — there is no resume flag, and the
+  // rejection names the replacement rather than reporting a bare arity mismatch.
+  for (const script of [
+    'actor run explore "d" "p" --actor explore-1',
+    'actor spawn general "d" "p" --actor general-2 --command "/bg"',
+    'actor spawn general "d" "p" --actor=general-2',
+  ]) {
+    test(`rejects --actor: ${script}`, async () => {
+      const exit = await Effect.runPromise(Effect.exit(parseActorScript(script)))
+      expect(exit._tag).toBe("Failure")
+      const cause: any = (exit as any).cause
+      const fail = cause.reasons?.find?.((r: any) => r._tag === "Fail") ?? cause
+      const err = fail.error ?? fail
+      expect(err.kind).toBe("flag")
+      expect(err.detail).toContain("--actor is not supported")
+      expect(err.detail).toContain("actor send")
+      expect(err.detail).toContain("actor wait")
+    })
+  }
 
   test("run with --timeout maps to timeout_ms (number)", async () => {
     const out = await parse('actor run explore "d" "p" --timeout 30000')
@@ -266,10 +279,10 @@ describe("actor.shell.parse: full parity flags", () => {
     ])
   })
 
-  test("spawn with --actor and --command (no timeout on spawn)", async () => {
-    const out = await parse('actor spawn general "d" "p" --actor general-2 --command "/bg"')
+  test("spawn with --command (no timeout on spawn)", async () => {
+    const out = await parse('actor spawn general "d" "p" --command "/bg"')
     expect(out).toEqual([
-      { operation: { action: "spawn", subagent_type: "general", description: "d", prompt: "p", actor_id: "general-2", command: "/bg" } },
+      { operation: { action: "spawn", subagent_type: "general", description: "d", prompt: "p", command: "/bg" } },
     ])
   })
 

--- a/packages/opencode/test/tool/actor.test.ts
+++ b/packages/opencode/test/tool/actor.test.ts
@@ -363,43 +363,6 @@ describe("tool.actor", () => {
     ),
   )
 
-  it.live("execute resumes an existing task session from actor_id", () =>
-    provideTmpdirInstance(() =>
-      Effect.gen(function* () {
-        yield* installMockSpawn()
-        const { chat, assistant } = yield* seed()
-        const tool = yield* ActorTool
-        const def = yield* tool.init()
-
-        const result = yield* def.execute(
-          {
-            operation: {
-              action: "run",
-              description: "inspect bug",
-              prompt: "look into the cache key path",
-              subagent_type: "general",
-              actor_id: "ses_missing", // v9: actor_id in run action is ignored — always creates new
-            },
-          },
-          {
-            sessionID: chat.id,
-            messageID: assistant.id,
-            agent: "build",
-            abort: new AbortController().signal,
-            extra: {},
-            messages: [],
-            metadata: () => Effect.void,
-            ask: () => Effect.void,
-          },
-        )
-
-        // v9: run always creates a new actor under the parent session
-        expect(result.metadata.sessionId).toBe(chat.id)
-        expect(result.output).toContain("actor_id:")
-      }),
-    ),
-  )
-
   it.live("execute asks by default and skips checks when bypassed", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
@@ -451,7 +414,7 @@ describe("tool.actor", () => {
     ),
   )
 
-  it.live("execute creates a child when actor_id does not exist", () =>
+  it.live("execute creates a fresh actor under the parent session and reports its id", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         yield* installMockSpawn()
@@ -466,7 +429,6 @@ describe("tool.actor", () => {
               description: "inspect bug",
               prompt: "look into the cache key path",
               subagent_type: "general",
-              actor_id: "ses_missing",
             },
           },
           {
@@ -481,10 +443,11 @@ describe("tool.actor", () => {
           },
         )
 
-        // v9: run creates a new actor under the parent session (subagent mode)
         expect(result.metadata.sessionId).toBe(chat.id)
         expect(result.metadata.actorId).toBeDefined()
         expect(result.output).toContain(`actor_id: ${result.metadata.actorId}`)
+        // The id is offered for follow-up via send/wait, never for a resume arg.
+        expect(result.output).toContain("send")
       }),
     ),
   )
@@ -620,8 +583,8 @@ describe("Actor tool subagent_type enum (F36)", () => {
 
   // Mirror of the task tool's schema regression test (commit 334cf6708).
   // The pre-discriminated-union schema let the model fill every "optional" string
-  // with "" — including actor_id — which slipped past the runtime guards in some
-  // paths and produced confusing tool errors elsewhere.
+  // with "", which slipped past the runtime guards in some paths and produced
+  // confusing tool errors elsewhere.
   it.live("schema rejects empty strings, unknown fields, and per-action missing required fields", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
@@ -636,8 +599,11 @@ describe("Actor tool subagent_type enum (F36)", () => {
 
         expect(wrap({ operation: { action: "run", description: "", prompt: "y", subagent_type: "general" } }).success).toBe(false)
         expect(wrap({ operation: { action: "run", description: "x", prompt: "", subagent_type: "general" } }).success).toBe(false)
-        expect(wrap({ operation: { action: "run", description: "x", prompt: "y", subagent_type: "general", actor_id: "" } }).success).toBe(false)
         expect(wrap({ operation: { action: "run", description: "x", prompt: "y", subagent_type: "general", junk: "z" } }).success).toBe(false)
+        // spawn/run never resume — actor_id is not part of their schema, so a model
+        // reaching for it gets a validation error instead of a silently fresh actor.
+        expect(wrap({ operation: { action: "run", description: "x", prompt: "y", subagent_type: "general", actor_id: "general-1" } }).success).toBe(false)
+        expect(wrap({ operation: { action: "spawn", description: "x", prompt: "y", subagent_type: "general", actor_id: "general-1" } }).success).toBe(false)
         expect(wrap({ operation: { action: "run", description: "x", prompt: "y" } }).success).toBe(false) // missing subagent_type
         expect(wrap({ operation: { action: "run", prompt: "y", subagent_type: "general" } }).success).toBe(false) // missing description
         expect(wrap({ description: "x", prompt: "y", subagent_type: "general" }).success).toBe(false) // missing operation envelope


### PR DESCRIPTION
## Summary

Two defects behind one user-visible symptom: a model trying to continue with a subagent it already spawned got a brand-new empty one, and when it used the flow that *does* work (`send`) the follow-up result was unreliable.

**`actor_id` on spawn/run was a promise with no implementation.** `src/tool/actor.ts` accepted it and described it as "resume the specified prior actor session instead of creating a new one", but `execute` never read `op.actor_id` — `Actor.spawnSubagent` unconditionally calls `allocateActorID` (max+1). An old test pinned the real behaviour (`// v9: actor_id in run action is ignored`) while its title claimed it resumed. Per maintainer decision this shrinks the contract rather than implementing resume: the argument is gone from the JSON schema, the shell `--actor` flag, `ActorShellArgs` and `recoverActorArgs`, and both description files now document the `send` → `wait` follow-up flow. `--actor` on the shell path fails with a named error pointing at the replacement instead of a bare arity mismatch.

**An inbox-woken turn bypassed the actor status machine.** `actor/turn.ts:runTurn` is the only writer of actor `running`/`idle`+outcome and the only publisher of `ActorStatusChanged`, and it wrapped only the spawn turn (plus preStop/gate/postStop) inside `forkWork`. The `actor send` wake path is `Inbox.send → SessionPrompt.loop → runLoop` and never touched actor status, so for the whole woken turn the registry row still read `idle+success` from the **previous** turn — precisely what `ActorWaiter`'s fast path treats as finished, at which point it answers from the slice's last assistant message. A `wait` issued while the woken turn was still in flight therefore returned the *previous* turn's answer. It was a race, not a hard failure: if the woken turn had already finished, the same fast path returned the correct new answer, which is why the flow appeared to work much of the time.

The fix has two halves. `Inbox.send` calls the new `ActorRegistry.markPending` — a `WHERE status='idle'` guarded update — before the fork-and-forget wake, closing the window where `send` returns before the woken turn marks itself running. And `SessionPrompt.loop` wraps a woken turn in `runTurn`. Two constraints on that wrapper, both found by review:

- It is gated on the inbox wake flag rather than on a non-`main` `agentID`, because `SessionPrompt.prompt` also ends in `loop()` and `forkWork` already wraps that call. Nesting them let the inner `runTurn` publish `idle+success` before `runAgentLoop` read the assistant error and failed the outer.
- It raises a settled assistant error itself, because `runLoop` returns one as a **success value** (it returns the errored message and only branches on `finalIsError` to notify the parent). Without that, a failed woken turn was recorded — and reported to a waiting sender — as `idle+success`.

`markPending` also advances `last_activity_time`: `deriveLiveness` measures a `pending` row against that timestamp, so a subagent idle longer than the stall bound would have been announced as stalled the instant a message queued it. It publishes only on a real transition (via `RETURNING`), since `main` rows sit at `pending` permanently and receive every subagent notification.

## Subagent completion semantics are unchanged

Verified explicitly, since preStop/gate/postStop each run extra turns and the "did it finish" / "which turn's text is returned" answers are load-bearing. All three of `forkWork`'s `runTurn` call sites are unaffected by the new wrapper — they reach `loop` without the wake flag. `test/actor/poststop-progress-write-permission.repro.test.ts` now pins the attribution across a spawn that ran a gate re-entry *and* a postStop turn: the outcome carries the gate turn's text plus the gate's reconciliation suffix and its `partial` downgrade, and not the postStop turn's text. **That assertion passes against unmodified `src/` as well**, which is what demonstrates the semantics were not moved.

## Verification

- `bun typecheck` (packages/opencode) — clean.
- `bun test test/actor/ test/inbox/ test/tool/actor.test.ts test/tool/actor.shell.test.ts` — 262 pass / 2 skip / 0 fail.
- `bun test test/session/` — 964 pass / 25 skip / 1 todo / 0 fail.
- Every new regression test was confirmed to fail with its corresponding fix reverted: the woken-turn state trajectory, the ungated wrapper (`lastOutcome` became `success`), the unraised assistant error (same), and the liveness write (read `idle`).

## Known gaps, deliberately not addressed

- `resume`/`resumeBackground` run actor turns without the status machine.
- When the registry reads `idle` but the Runner is still busy, `ensureRunning` returns the in-flight Deferred without executing work, so the row can sit at `pending` until the next turn writes it.
- `ActorRegistry.defaultLayer` and `ActorWaiter.defaultLayer` each build a private Bus, and Effect 4 beta layer memoization does not span `Layer.mergeAll` branches without a shared MemoMap (production shares one via `ManagedRuntime.make(AppLayer, { memoMap })`). This is why the end-to-end test asserts the registry trajectory while the waiter-level assertions live in `waiter.test.ts`, and it is very likely the real cause of the long-skipped slow-path test there — that test passes when run alone.
