### PR TITLE
fix(actor): drop the unimplemented spawn/run resume argument

### DIFF
--- a/packages/opencode/src/tool/actor.shell.txt
+++ b/packages/opencode/src/tool/actor.shell.txt
@@ -21,13 +21,13 @@ appends them at request time per-agent).
 #   - $vars are preserved as literal text (no expansion)
 
 # DEFAULT — return actor_id immediately, run in the background, stay responsive:
-    actor spawn <subagent_type> "<description>" "<prompt>" [--model <ref>] [--actor <id>] [--command <cmd>] [--context none|state|full] [--output-schema '<json>']
+    actor spawn <subagent_type> "<description>" "<prompt>" [--model <ref>] [--command <cmd>] [--context none|state|full] [--output-schema '<json>']
     # bind it to one of your `task` tool tasks (TID from the `task` tool, e.g. T4):
     actor spawn <subagent_type> "<description>" "<prompt>" --task <TID>
 
 # EXCEPTION — block the whole conversation until done, return the final message inline.
 # Only for a tiny, fast lookup whose answer gates your very next decision this turn:
-    actor run <subagent_type> "<description>" "<prompt>" [--model <ref>] [--actor <id>] [--timeout <ms>] [--command <cmd>] [--context none|state|full] [--output-schema '<json>']
+    actor run <subagent_type> "<description>" "<prompt>" [--model <ref>] [--timeout <ms>] [--command <cmd>] [--context none|state|full] [--output-schema '<json>']
     # bind it to one of your `task` tool tasks (TID from the `task` tool, e.g. T4):
     actor run <subagent_type> "<description>" "<prompt>" --task <TID>
 
@@ -38,7 +38,9 @@ appends them at request time per-agent).
     actor status <actor_id>     # current state without blocking
     actor cancel <actor_id>     # graceful stop
 
-# deliver a message to another actor's inbox (fire-and-forget):
+# deliver a message to another actor's inbox, waking it for another turn. This is how you
+# give follow-up work to a subagent you already have. Returns once queued, not when the
+# woken turn ends; that turn's result arrives as a completion notification:
     actor send <to_actor_id> "<content>" [--session <id>] [--type <t>]
     # to_actor_id: 'main' for a session's main agent, or a subagent id like 'explore-1'
     # --session: target session id (defaults to current); --type: 'text' (default) or 'actor_notification'
@@ -78,8 +80,8 @@ Examples:
 # THE EXCEPTION: a tiny blocking lookup you cannot proceed without in this turn:
     actor run explore "Is the field public API" "Is `retryLimit` re-exported from src/index.ts? yes/no + file:line."
 
-# spawn/run flags: --actor resume a prior subagent (by actor_id); --timeout ms before
-#   giving up (run only); --command the command that triggered this; --context none|state|full
+# spawn/run flags: --timeout ms before giving up (run only); --command the command that
+#   triggered this; --context none|state|full
 #   (default none); --output-schema a JSON Schema STRING (single-quote it) — forces the
 #   subagent to return a matching object instead of free text.
 

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -64,8 +64,8 @@ function suggestActorVerb(input: string): string | undefined {
 // uses z.string() for subagent_type since the dynamic enum is only needed at
 // Zod validation time (inside execute), not at parse time.
 type ActorShellArgs =
-  | { operation: { action: "run"; subagent_type: string; description: string; prompt: string; model?: string; task_id?: string; actor_id?: string; timeout_ms?: number; command?: string; context?: "none" | "state" | "full"; output_schema?: Record<string, unknown> } }
-  | { operation: { action: "spawn"; subagent_type: string; description: string; prompt: string; model?: string; task_id?: string; actor_id?: string; command?: string; context?: "none" | "state" | "full"; output_schema?: Record<string, unknown> } }
+  | { operation: { action: "run"; subagent_type: string; description: string; prompt: string; model?: string; task_id?: string; timeout_ms?: number; command?: string; context?: "none" | "state" | "full"; output_schema?: Record<string, unknown> } }
+  | { operation: { action: "spawn"; subagent_type: string; description: string; prompt: string; model?: string; task_id?: string; command?: string; context?: "none" | "state" | "full"; output_schema?: Record<string, unknown> } }
   | { operation: { action: "status"; actor_id: string } }
   | { operation: { action: "wait"; actor_id: string; timeout_ms?: number } }
   | { operation: { action: "cancel"; actor_id: string } }
@@ -113,14 +113,23 @@ function extractNamedFlags(
 }
 
 const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefined, args: string[], line: number) {
+  // Named rather than left to fall through: an unknown flag lands in the
+  // positionals, so the model would be told its argument COUNT is wrong.
+  if ((verb === "run" || verb === "spawn") && args.some((a) => a === "--actor" || a.startsWith("--actor="))) {
+    return yield* Effect.fail({
+      kind: "flag" as const,
+      line,
+      detail: `actor: ${verb}: unknown flag --actor. To give more work to a subagent you already have: actor send <actor_id> "<message>".`,
+    })
+  }
   switch (verb) {
     case "run": {
       const { flags, rest } = yield* extractNamedFlags(
         args,
-        ["model", "task", "actor", "timeout", "command", "context", "output-schema"],
+        ["model", "task", "timeout", "command", "context", "output-schema"],
         line,
       )
-      if (rest.length !== 3) return yield* actorArityError("run", '<subagent_type> "<description>" "<prompt>" [--model <ref>] [--task <TID>] [--actor <id>] [--timeout <ms>] [--command <cmd>] [--context none|state|full] [--output-schema <json>]', rest, line)
+      if (rest.length !== 3) return yield* actorArityError("run", '<subagent_type> "<description>" "<prompt>" [--model <ref>] [--task <TID>] [--timeout <ms>] [--command <cmd>] [--context none|state|full] [--output-schema <json>]', rest, line)
       return {
         operation: {
           action: "run" as const,
@@ -129,7 +138,6 @@ const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefin
           prompt: rest[2],
           ...(flags.model ? { model: flags.model } : {}),
           ...(flags.task ? { task_id: flags.task } : {}),
-          ...(flags.actor ? { actor_id: flags.actor } : {}),
           ...(flags.timeout ? { timeout_ms: Number(flags.timeout) } : {}),
           ...(flags.command ? { command: flags.command } : {}),
           ...(flags.context ? { context: flags.context } : {}),
@@ -142,10 +150,10 @@ const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefin
     case "spawn": {
       const { flags, rest } = yield* extractNamedFlags(
         args,
-        ["model", "task", "actor", "command", "context", "output-schema"],
+        ["model", "task", "command", "context", "output-schema"],
         line,
       )
-      if (rest.length !== 3) return yield* actorArityError("spawn", '<subagent_type> "<description>" "<prompt>" [--model <ref>] [--task <TID>] [--actor <id>] [--command <cmd>] [--context none|state|full] [--output-schema <json>]', rest, line)
+      if (rest.length !== 3) return yield* actorArityError("spawn", '<subagent_type> "<description>" "<prompt>" [--model <ref>] [--task <TID>] [--command <cmd>] [--context none|state|full] [--output-schema <json>]', rest, line)
       return {
         operation: {
           action: "spawn" as const,
@@ -154,7 +162,6 @@ const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefin
           prompt: rest[2],
           ...(flags.model ? { model: flags.model } : {}),
           ...(flags.task ? { task_id: flags.task } : {}),
-          ...(flags.actor ? { actor_id: flags.actor } : {}),
           ...(flags.command ? { command: flags.command } : {}),
           ...(flags.context ? { context: flags.context } : {}),
           ...(flags["output-schema"] ? { output_schema: JSON.parse(flags["output-schema"]) } : {}),
@@ -286,7 +293,7 @@ export function recoverActorArgs(rawArgs: unknown): ActorShellArgs | undefined {
     const op: Record<string, unknown> = { action: inferAction(obj), subagent_type, description, prompt }
     // Carry only the optional fields a confused model plausibly puts at top level
     // alongside the bare Task-prior triple. This is a deliberate subset of the
-    // run/spawn schema's optionals (model, actor_id, timeout_ms, command, context,
+    // run/spawn schema's optionals (model, timeout_ms, command, context,
     // task_id, output_schema) — the others (timeout_ms/command/context/output_schema)
     // are dropped here, falling back to their schema defaults. Low risk in practice:
     // the bare shape mimo emits is the 3 required fields, rarely with extras. When
@@ -294,6 +301,12 @@ export function recoverActorArgs(rawArgs: unknown): ActorShellArgs | undefined {
     // it here, or this whitelist silently drifts from the schema.
     if (typeof obj.model === "string") op.model = obj.model
     if (typeof obj.task_id === "string") op.task_id = obj.task_id
+    // actor_id is carried deliberately even though no action accepts it: the
+    // strict schema then rejects the call and the model is told the argument does
+    // not exist. Dropping it here would recover the call into a valid spawn and
+    // hand back a fresh, empty subagent — the exact silent failure that removing
+    // the argument is meant to end, reached through the path a model confused
+    // enough to still pass actor_id is most likely to take.
     if (typeof obj.actor_id === "string") op.actor_id = obj.actor_id
     return { operation: op } as ActorShellArgs
   }
@@ -389,13 +402,6 @@ export const ActorTool = Tool.define(
           .min(1)
           .optional()
           .describe(MODEL_PARAM_DESCRIPTION),
-        actor_id: z
-          .string()
-          .min(1)
-          .optional()
-          .describe(
-            "(optional) If set, resume the specified prior actor session instead of creating a new one. Distinct from the user-task IDs (T1, T2, ...) used by the `task` tool.",
-          ),
         timeout_ms: timeoutField,
         command: z.string().min(1).optional().describe("(optional) The command that triggered this task."),
         context: contextField,
@@ -428,13 +434,6 @@ export const ActorTool = Tool.define(
           .min(1)
           .optional()
           .describe(MODEL_PARAM_DESCRIPTION),
-        actor_id: z
-          .string()
-          .min(1)
-          .optional()
-          .describe(
-            "(optional) If set, resume the specified prior actor session instead of creating a new one.",
-          ),
         command: z.string().min(1).optional().describe("(optional) The command that triggered this task."),
         context: contextField,
         task_id: z
@@ -888,7 +887,7 @@ export const ActorTool = Tool.define(
           metadata: { sessionId: spawnResult.sessionID, actorId: spawnResult.actorID, model } as Record<string, any>,
           output: [
             ...(taskNotice ? [taskNotice, ""] : []),
-            `actor_id: ${spawnResult.actorID} (for resuming to continue this task if needed)`,
+            `actor_id: ${spawnResult.actorID} (to give this subagent more work, \`send\` it another message)`,
             "",
             `<actor_result status="${statusAttr}"${summaryAttr}>`,
             resultText,

--- a/packages/opencode/src/tool/actor.ts
+++ b/packages/opencode/src/tool/actor.ts
@@ -112,18 +112,25 @@ function extractNamedFlags(
   return Effect.succeed({ flags, rest })
 }
 
+// `--actor` is no longer a flag on spawn/run. Reject it only when it appears
+// AFTER the three positionals are accounted for, i.e. where a flag would go —
+// scanning every token would misfire on a prompt/description that is literally
+// "--actor". Returns the teachable failure, or undefined to fall through.
+function rejectActorFlag(verb: string, args: string[], line: number) {
+  const flagIdx = args.findIndex((a) => a === "--actor" || a.startsWith("--actor="))
+  if (flagIdx < 3) return undefined
+  return Effect.fail({
+    kind: "flag" as const,
+    line,
+    detail: `actor: ${verb}: unknown flag --actor. To give more work to a subagent you already have: actor send <actor_id> "<message>".`,
+  })
+}
+
 const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefined, args: string[], line: number) {
-  // Named rather than left to fall through: an unknown flag lands in the
-  // positionals, so the model would be told its argument COUNT is wrong.
-  if ((verb === "run" || verb === "spawn") && args.some((a) => a === "--actor" || a.startsWith("--actor="))) {
-    return yield* Effect.fail({
-      kind: "flag" as const,
-      line,
-      detail: `actor: ${verb}: unknown flag --actor. To give more work to a subagent you already have: actor send <actor_id> "<message>".`,
-    })
-  }
   switch (verb) {
     case "run": {
+      const rejected = rejectActorFlag(verb, args, line)
+      if (rejected) return yield* rejected
       const { flags, rest } = yield* extractNamedFlags(
         args,
         ["model", "task", "timeout", "command", "context", "output-schema"],
@@ -148,6 +155,8 @@ const mapActorVerb = Effect.fn("mapActorVerb")(function* (verb: string | undefin
       } as ActorShellArgs
     }
     case "spawn": {
+      const rejected = rejectActorFlag(verb, args, line)
+      if (rejected) return yield* rejected
       const { flags, rest } = yield* extractNamedFlags(
         args,
         ["model", "task", "command", "context", "output-schema"],
@@ -298,12 +307,13 @@ export function recoverActorArgs(rawArgs: unknown): ActorShellArgs | undefined {
     // are dropped here, falling back to their schema defaults. Low risk in practice:
     // the bare shape mimo emits is the 3 required fields, rarely with extras. When
     // adding an actor schema field, decide whether bare-shape recover should carry
-    // it here, or this whitelist silently drifts from the schema.
+    // it here, or this whitelist silently drifts from the schema. (The actor_id
+    // carry just below is the one deliberate exception — a field NOT in the schema.)
     if (typeof obj.model === "string") op.model = obj.model
     if (typeof obj.task_id === "string") op.task_id = obj.task_id
-    // actor_id is carried deliberately even though no action accepts it: the
-    // strict schema then rejects the call and the model is told the argument does
-    // not exist. Dropping it here would recover the call into a valid spawn and
+    // Carried on purpose even though no action accepts it, so the strict schema
+    // rejects the call and the model is told the argument does not exist. This is
+    // NOT dead code: dropping it would recover the call into a valid spawn and
     // hand back a fresh, empty subagent — the exact silent failure that removing
     // the argument is meant to end, reached through the path a model confused
     // enough to still pass actor_id is most likely to take.

--- a/packages/opencode/src/tool/actor.txt
+++ b/packages/opencode/src/tool/actor.txt
@@ -29,7 +29,7 @@ THE EXCEPTION — `run` blocks the conversation; only for a tiny lookup that gat
           Use it for essentially all delegation: investigation, analysis, review,
           implementation, long searches — anything that takes real time.
           required: subagent_type, description, prompt
-          optional: actor_id, command, context
+          optional: command, context
 - run:    **RARE EXCEPTION.** Same launch, but BLOCKS the whole conversation until
           the subagent finishes; result returned inline. Allowed ONLY when you
           cannot make your very next decision without the result in THIS turn, and
@@ -37,17 +37,18 @@ THE EXCEPTION — `run` blocks the conversation; only for a tiny lookup that gat
           ordinary analysis, review, or implementation work — those go to `spawn`.
           If you are unsure, use `spawn`.
           required: subagent_type, description, prompt
-          optional: actor_id, timeout_ms, command, context
+          optional: timeout_ms, command, context
 - status: poll actor state without blocking. required: actor_id.
           Returns: { status: "pending"|"running"|"idle"|"unknown", actor_id, turnCount, ... }
 - wait:   block until actor completes (success/failure/cancelled) or timeout (default 10 min).
           required: actor_id. optional: timeout_ms.
           Returns: { status, actor_id, result?, error? }
 - cancel: stop a running actor (graceful). required: actor_id. Idempotent.
-- send:   deliver message to another actor's inbox.
+- send:   deliver message to another actor's inbox, waking it for another turn.
           required: to_actor_id, content.
           optional: to_session_id, type (default "text").
           Receiver sees wrapped in <inbox from="..." sent_at="...">...</inbox> at next iteration.
+          Returns once queued, NOT when the woken turn finishes — pair with `wait`.
 
 ## When to use actor
 
@@ -90,7 +91,19 @@ You are the subagent's only briefing — it hasn't seen this conversation.
 
 ## Actor ID vs Task ID
 
-`actor_id` identifies a subagent session (resumable across turns). Task IDs (T1, T2, ...) come from the `task` tool — only pass a `task_id` you got from a `task` tool call this session. If the `task_id` is malformed or unknown, the binding is dropped: the subagent's findings won't be captured to any task, and the tool result tells you so.
+`actor_id` identifies a live subagent. It is returned by `spawn`/`run` and accepted by
+`status`, `wait`, `cancel`, and `send`. Task IDs (T1, T2, ...) come from the `task` tool — only pass a `task_id` you got from a `task` tool call this session. If the `task_id` is malformed or unknown, the binding is dropped: the subagent's findings won't be captured to any task, and the tool result tells you so.
+
+## Following up with an existing subagent
+
+To give more work to a subagent you already have, `send` it a message:
+
+  `{"operation":{"action":"send","to_actor_id":"explore-1","content":"<follow-up>"}}`
+
+`send` appends your message to that subagent's own history and wakes it for another
+turn, so it keeps every prior message and tool output — including a subagent that has
+already gone idle. It returns as soon as the message is queued; the woken turn's
+result reaches you as a completion notification.
 
 ## Binding a subagent to a task
 
@@ -108,10 +121,9 @@ postStop check then becomes a no-op.
 
 ## Usage notes
 
-- **Resume the same subagent**: pass `actor_id` to `spawn`/`run` and the call resumes that subagent's session (continues with its prior messages and tool outputs). Without `actor_id`, a fresh subagent is created.
 - **`spawn` vs `run` result delivery**: `spawn` returns the actor_id immediately; when the background actor finishes, its result appears as a notification in this conversation — your turn does NOT auto-wake to process it; you'll see it the next time you respond to the user. Use `wait` to block on the actor_id explicitly. `run` instead blocks the conversation and returns the result inline — that stall is exactly why it's the exception.
 - **`wait` on persistent peers caveat**: `wait` is designed for ephemeral subagents you spawned via `spawn`/`run`. Persistent peers idle between turns and never produce a "done" outcome on success — `wait` on a peer will block until that peer fails or is cancelled. Use `send` + `status` to coordinate with peers instead.
-- **`send` semantics**: fire-and-forget; returns within ~5 ms regardless of receiver load. The receiver picks the message up at the head of its next runLoop iteration. On unknown `to_actor_id`, `send` returns `{inboxID: null, error: "receiver not found"}` rather than throwing — handle the error path.
+- **`send` semantics**: fire-and-forget; returns within ~5 ms regardless of receiver load. It also WAKES the receiver — an idle subagent runs another turn on its own history, so `send` is how you give one follow-up work. The woken turn's result reaches you as a completion notification, not from the `send` call. On unknown `to_actor_id`, `send` returns `{inboxID: null, error: "receiver not found"}` rather than throwing — handle the error path.
 - Trust the subagent's outputs generally, but the subagent doesn't see your full context (unless you pass `context="full"`); brief it accordingly.
 
 

--- a/packages/opencode/src/tool/actor.txt
+++ b/packages/opencode/src/tool/actor.txt
@@ -48,7 +48,7 @@ THE EXCEPTION — `run` blocks the conversation; only for a tiny lookup that gat
           required: to_actor_id, content.
           optional: to_session_id, type (default "text").
           Receiver sees wrapped in <inbox from="..." sent_at="...">...</inbox> at next iteration.
-          Returns once queued, NOT when the woken turn finishes — pair with `wait`.
+          Returns once queued, not when the woken turn finishes — that turn's result arrives as a completion notification.
 
 ## When to use actor
 

--- a/packages/opencode/test/tool/actor-recover.test.ts
+++ b/packages/opencode/test/tool/actor-recover.test.ts
@@ -19,10 +19,24 @@ describe("recoverActorArgs", () => {
     expect(r.operation.action).toBe("spawn")
   })
 
-  test("optional model/task_id/actor_id carried; junk dropped", () => {
+  test("optional model/task_id carried; junk dropped", () => {
     expect(
       recoverActorArgs({ subagent_type: "explore", description: "d", prompt: "p", model: "lite", task_id: "T4", junk: 1 }),
     ).toEqual({ operation: { action: "run", subagent_type: "explore", description: "d", prompt: "p", model: "lite", task_id: "T4" } })
+  })
+
+  // spawn/run have no resume argument. Recovery must NOT quietly drop a top-level
+  // actor_id: that would lift the call into a valid spawn and hand back a fresh,
+  // empty subagent — the silent failure removing the argument exists to end.
+  // Carrying it through means the strict schema rejects the call instead.
+  test("top-level actor_id is carried through so the schema can reject it", () => {
+    const recovered = recoverActorArgs({
+      subagent_type: "explore",
+      description: "d",
+      prompt: "p",
+      actor_id: "explore-1",
+    }) as { operation: Record<string, unknown> }
+    expect(recovered.operation.actor_id).toBe("explore-1")
   })
 
   test("stringified operation envelope → parsed nested object", () => {

--- a/packages/opencode/test/tool/actor.shell.test.ts
+++ b/packages/opencode/test/tool/actor.shell.test.ts
@@ -250,6 +250,15 @@ describe("actor.shell.parse: full parity flags", () => {
     })
   }
 
+  // A literal "--actor" sitting in a positional (prompt / description) is not the
+  // flag — the guard only fires once the three positionals are filled.
+  test("literal --actor in the prompt positional is not treated as the flag", async () => {
+    const out = await parse('actor run explore "d" "--actor"')
+    expect(out).toEqual([
+      { operation: { action: "run", subagent_type: "explore", description: "d", prompt: "--actor" } },
+    ])
+  })
+
   test("run with --timeout maps to timeout_ms (number)", async () => {
     const out = await parse('actor run explore "d" "p" --timeout 30000')
     expect(out).toEqual([

--- a/packages/opencode/test/tool/actor.shell.test.ts
+++ b/packages/opencode/test/tool/actor.shell.test.ts
@@ -231,12 +231,24 @@ describe("actor.shell.parse: send", () => {
 })
 
 describe("actor.shell.parse: full parity flags", () => {
-  test("run with --actor (resume) maps to actor_id", async () => {
-    const out = await parse('actor run explore "d" "p" --actor explore-1')
-    expect(out).toEqual([
-      { operation: { action: "run", subagent_type: "explore", description: "d", prompt: "p", actor_id: "explore-1" } },
-    ])
-  })
+  // `--actor` is not a flag either verb takes; the failure names it and points at
+  // `send`, rather than reporting a bare arity mismatch from the positionals.
+  for (const script of [
+    'actor run explore "d" "p" --actor explore-1',
+    'actor spawn general "d" "p" --actor general-2 --command "/bg"',
+    'actor spawn general "d" "p" --actor=general-2',
+  ]) {
+    test(`rejects --actor: ${script}`, async () => {
+      const exit = await Effect.runPromise(Effect.exit(parseActorScript(script)))
+      expect(exit._tag).toBe("Failure")
+      const cause: any = (exit as any).cause
+      const fail = cause.reasons?.find?.((r: any) => r._tag === "Fail") ?? cause
+      const err = fail.error ?? fail
+      expect(err.kind).toBe("flag")
+      expect(err.detail).toContain("unknown flag --actor")
+      expect(err.detail).toContain("actor send")
+    })
+  }
 
   test("run with --timeout maps to timeout_ms (number)", async () => {
     const out = await parse('actor run explore "d" "p" --timeout 30000')
@@ -266,10 +278,10 @@ describe("actor.shell.parse: full parity flags", () => {
     ])
   })
 
-  test("spawn with --actor and --command (no timeout on spawn)", async () => {
-    const out = await parse('actor spawn general "d" "p" --actor general-2 --command "/bg"')
+  test("spawn with --command (no timeout on spawn)", async () => {
+    const out = await parse('actor spawn general "d" "p" --command "/bg"')
     expect(out).toEqual([
-      { operation: { action: "spawn", subagent_type: "general", description: "d", prompt: "p", actor_id: "general-2", command: "/bg" } },
+      { operation: { action: "spawn", subagent_type: "general", description: "d", prompt: "p", command: "/bg" } },
     ])
   })
 

--- a/packages/opencode/test/tool/actor.test.ts
+++ b/packages/opencode/test/tool/actor.test.ts
@@ -363,43 +363,6 @@ describe("tool.actor", () => {
     ),
   )
 
-  it.live("execute resumes an existing task session from actor_id", () =>
-    provideTmpdirInstance(() =>
-      Effect.gen(function* () {
-        yield* installMockSpawn()
-        const { chat, assistant } = yield* seed()
-        const tool = yield* ActorTool
-        const def = yield* tool.init()
-
-        const result = yield* def.execute(
-          {
-            operation: {
-              action: "run",
-              description: "inspect bug",
-              prompt: "look into the cache key path",
-              subagent_type: "general",
-              actor_id: "ses_missing", // v9: actor_id in run action is ignored — always creates new
-            },
-          },
-          {
-            sessionID: chat.id,
-            messageID: assistant.id,
-            agent: "build",
-            abort: new AbortController().signal,
-            extra: {},
-            messages: [],
-            metadata: () => Effect.void,
-            ask: () => Effect.void,
-          },
-        )
-
-        // v9: run always creates a new actor under the parent session
-        expect(result.metadata.sessionId).toBe(chat.id)
-        expect(result.output).toContain("actor_id:")
-      }),
-    ),
-  )
-
   it.live("execute asks by default and skips checks when bypassed", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
@@ -451,7 +414,7 @@ describe("tool.actor", () => {
     ),
   )
 
-  it.live("execute creates a child when actor_id does not exist", () =>
+  it.live("execute creates a fresh actor under the parent session and reports its id", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         yield* installMockSpawn()
@@ -466,7 +429,6 @@ describe("tool.actor", () => {
               description: "inspect bug",
               prompt: "look into the cache key path",
               subagent_type: "general",
-              actor_id: "ses_missing",
             },
           },
           {
@@ -481,10 +443,11 @@ describe("tool.actor", () => {
           },
         )
 
-        // v9: run creates a new actor under the parent session (subagent mode)
         expect(result.metadata.sessionId).toBe(chat.id)
         expect(result.metadata.actorId).toBeDefined()
         expect(result.output).toContain(`actor_id: ${result.metadata.actorId}`)
+        // The id is offered for follow-up via send/wait, never for a resume arg.
+        expect(result.output).toContain("send")
       }),
     ),
   )
@@ -620,8 +583,8 @@ describe("Actor tool subagent_type enum (F36)", () => {
 
   // Mirror of the task tool's schema regression test (commit 334cf6708).
   // The pre-discriminated-union schema let the model fill every "optional" string
-  // with "" — including actor_id — which slipped past the runtime guards in some
-  // paths and produced confusing tool errors elsewhere.
+  // with "", which slipped past the runtime guards in some paths and produced
+  // confusing tool errors elsewhere.
   it.live("schema rejects empty strings, unknown fields, and per-action missing required fields", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
@@ -636,8 +599,11 @@ describe("Actor tool subagent_type enum (F36)", () => {
 
         expect(wrap({ operation: { action: "run", description: "", prompt: "y", subagent_type: "general" } }).success).toBe(false)
         expect(wrap({ operation: { action: "run", description: "x", prompt: "", subagent_type: "general" } }).success).toBe(false)
-        expect(wrap({ operation: { action: "run", description: "x", prompt: "y", subagent_type: "general", actor_id: "" } }).success).toBe(false)
         expect(wrap({ operation: { action: "run", description: "x", prompt: "y", subagent_type: "general", junk: "z" } }).success).toBe(false)
+        // spawn/run never resume — actor_id is not part of their schema, so a model
+        // reaching for it gets a validation error instead of a silently fresh actor.
+        expect(wrap({ operation: { action: "run", description: "x", prompt: "y", subagent_type: "general", actor_id: "general-1" } }).success).toBe(false)
+        expect(wrap({ operation: { action: "spawn", description: "x", prompt: "y", subagent_type: "general", actor_id: "general-1" } }).success).toBe(false)
         expect(wrap({ operation: { action: "run", description: "x", prompt: "y" } }).success).toBe(false) // missing subagent_type
         expect(wrap({ operation: { action: "run", prompt: "y", subagent_type: "general" } }).success).toBe(false) // missing description
         expect(wrap({ description: "x", prompt: "y", subagent_type: "general" }).success).toBe(false) // missing operation envelope


### PR DESCRIPTION
## Summary

`actor_id` on `spawn`/`run` was documented as resuming a prior subagent — the description said the call "continues with its prior messages and tool outputs" — but `execute` never read it. `Actor.spawnSubagent` unconditionally calls `allocateActorID`, so a model trying to continue with a subagent it already had silently received a brand-new one with an empty context. The behaviour was even pinned by a test whose title claimed the opposite (`// v9: actor_id in run action is ignored — always creates new` under *"execute resumes an existing task session from actor_id"*).

This removes the argument rather than implementing resume. `send` already appends to a subagent's own history and wakes it for another turn, so the descriptions now point at that instead.

Removal covers every surface: the JSON schema for both actions, the shell `--actor` flag, the `ActorShellArgs` type, and the recovery path. The recovery path is the subtle one — `recoverActorArgs` lifts a bare `{subagent_type, description, prompt}` into a valid operation, and its whitelist would have silently *dropped* a top-level `actor_id`, recovering the call into a valid spawn and reproducing exactly the silent failure being removed. It now carries `actor_id` through so the strict schema rejects the call instead. That path is the one a model confused enough to still pass `actor_id` is most likely to take.

## Known defect, not addressed here (pre-existing, not a regression)

While tracing the above I found that collecting a woken subagent's answer is unreliable, and I want it recorded rather than quietly bundled into this change.

`actor/turn.ts:runTurn` is the only writer of actor `running`/`idle`+outcome and the only publisher of `ActorStatusChanged`, and it wraps only the turns `forkWork` drives. The `actor send` wake path — `Inbox.send` → `SessionPrompt.loop` → `runLoop` — never touches actor status, so for the whole woken turn the registry row still reads `idle`+`success` from the *previous* turn. `ActorWaiter.isWaitResolving` treats any `idle` ephemeral row as finished (`src/actor/waiter.ts:35-38`) and then answers from the slice's last assistant message, so a `wait` issued while the woken turn is still in flight returns the **previous** turn's text.

This is not introduced by this PR: on unmodified `main`, a `send` followed by a `wait` already returns the previous answer whenever the woken turn has not finished yet. It is a race in the idle case and a much wider window when the receiver is mid-turn, because `SessionRunState.ensureRunning` hands back a busy runner's Deferred *discarding* the work it was given (`src/effect/runner.ts:118`), so nothing re-stamps the row for the duration of a full model call.

I attempted the fix in a previous version of this branch and withdrew it: forcing the row out of `idle` only covers an idle receiver, and it disturbed several consumers of actor status (group barriers, TUI tool-part animation, cancelled-outcome bookkeeping). The right signal is whether the receiver still has an undrained inbox row, which is authoritative because `drain` deletes it — that belongs in its own change, scoped to `ActorWaiter`.

Until then, the tool descriptions steer models to the completion notification rather than to `wait` for a woken turn's result, which is the behaviour that does hold today.

## Verification

- `bun typecheck` (packages/opencode) — clean.
- `bun test test/tool/actor.test.ts test/tool/actor.shell.test.ts test/tool/actor-recover.test.ts` — 67 pass / 0 fail.

Test changes: the mis-titled resume test is replaced by strict schema rejections of `actor_id` on both actions; `--actor` on the shell path now fails as a named unknown flag pointing at `send`, instead of a bare arity mismatch from the positionals; and `recoverActorArgs` gains a test pinning that a top-level `actor_id` is carried through to be rejected rather than dropped.
