### PR TITLE
fix(session): fire compaction at a flat 90% of the context window

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -24,6 +24,16 @@ function nonNegativeNumber(key: string) {
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined
 }
 
+// A fraction in (0, 1], written either as a decimal ("0.85") or a percentage
+// ("85%"). Values outside the range — and anything unparseable — yield undefined
+// so the caller keeps its own default.
+function ratio(key: string) {
+  const value = process.env[key]?.trim()
+  if (!value) return undefined
+  const parsed = value.endsWith("%") ? Number(value.slice(0, -1)) / 100 : Number(value)
+  return Number.isFinite(parsed) && parsed > 0 && parsed <= 1 ? parsed : undefined
+}
+
 const MIMOCODE_EXPERIMENTAL = truthy("MIMOCODE_EXPERIMENTAL")
 
 // Defaults to false. When enabled, mimocode runs in pure-mimo mode:
@@ -143,6 +153,16 @@ export const Flag = {
   // tests and in-process embedders can toggle it at runtime.
   get MIMOCODE_COMPACTION_MAX_CONTEXT() {
     return process.env["MIMOCODE_COMPACTION_MAX_CONTEXT"]
+  },
+  // Fraction of the working window at which compaction fires; the remaining
+  // headroom is what the summary generation gets to write into. Accepts a decimal
+  // ("0.85") or a percentage ("85%"); anything unparseable or outside (0, 1] is
+  // ignored and the 0.9 default stands. Applies on top of whatever window
+  // `compaction.max_context` / MIMOCODE_COMPACTION_MAX_CONTEXT resolved to, so
+  // the two compose rather than override each other. Read lazily so tests and
+  // in-process embedders can toggle it at runtime.
+  get MIMOCODE_COMPACTION_TRIGGER_RATIO() {
+    return ratio("MIMOCODE_COMPACTION_TRIGGER_RATIO") ?? 0.9
   },
   MIMOCODE_DISABLE_MODELS_FETCH: truthy("MIMOCODE_DISABLE_MODELS_FETCH"),
   // Defaults to false. When enabled, every model uses the GPT system prompt

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -12,11 +12,11 @@ const COMPACTION_BUFFER = 33_000
 // summary outputs based on production telemetry of summary token counts.
 const OUTPUT_CAP = 20_000
 
-// Compaction fires when usage reaches this fraction of the working window,
-// leaving the remaining headroom for the summary generation. 0.9 keeps the
+// Compaction fires when usage reaches a fraction of the working window, leaving
+// the remaining headroom for the summary generation. The default 0.9 keeps the
 // trigger at a flat 90% of the model's context regardless of window size,
-// instead of a fixed token reserve that punishes small windows.
-const COMPACTION_TRIGGER_RATIO = 0.9
+// instead of a fixed token reserve that punishes small windows. Override with
+// MIMOCODE_COMPACTION_TRIGGER_RATIO.
 
 const log = Log.create({ service: "session.overflow" })
 const warned = new Set<string>()
@@ -87,7 +87,7 @@ export function contextWindow(input: { cfg: Config.Info; model: Provider.Model }
   return {
     hard,
     effective,
-    usable: Math.floor(effective * COMPACTION_TRIGGER_RATIO),
+    usable: Math.floor(effective * Flag.MIMOCODE_COMPACTION_TRIGGER_RATIO),
     source: configured === undefined ? "model" : "config",
   }
 }

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -12,6 +12,12 @@ const COMPACTION_BUFFER = 33_000
 // summary outputs based on production telemetry of summary token counts.
 const OUTPUT_CAP = 20_000
 
+// Compaction fires when usage reaches this fraction of the working window,
+// leaving the remaining headroom for the summary generation. 0.9 keeps the
+// trigger at a flat 90% of the model's context regardless of window size,
+// instead of a fixed token reserve that punishes small windows.
+const COMPACTION_TRIGGER_RATIO = 0.9
+
 const log = Log.create({ service: "session.overflow" })
 const warned = new Set<string>()
 
@@ -20,7 +26,7 @@ export type Window = {
   hard: number
   /** Working window after the user's `compaction.max_context` budget is applied. */
   effective: number
-  /** Token count at which compaction fires (effective minus reserves). */
+  /** Token count at which compaction fires (a fixed fraction of `effective`). */
   usable: number
   source: "model" | "config"
 }
@@ -81,7 +87,7 @@ export function contextWindow(input: { cfg: Config.Info; model: Provider.Model }
   return {
     hard,
     effective,
-    usable: Math.max(0, effective - reserved),
+    usable: Math.floor(effective * COMPACTION_TRIGGER_RATIO),
     source: configured === undefined ? "model" : "config",
   }
 }

--- a/packages/opencode/test/session/overflow.test.ts
+++ b/packages/opencode/test/session/overflow.test.ts
@@ -107,7 +107,8 @@ describe("isOverflow", () => {
   test("returns true when token count exceeds usable context", () => {
     const model = createModel({ context: 100_000, output: 32_000 })
     const cfg = mockCfg()
-    const tokens = { input: 75_000, output: 5_000, reasoning: 0, cache: { read: 0, write: 0 } } as any
+    // usable = floor(100K * 0.9) = 90K; 88K + 5K = 93K exceeds it
+    const tokens = { input: 88_000, output: 5_000, reasoning: 0, cache: { read: 0, write: 0 } } as any
     expect(isOverflow({ cfg, tokens, model })).toBe(true)
   })
 
@@ -121,7 +122,8 @@ describe("isOverflow", () => {
   test("includes cache.read in token count", () => {
     const model = createModel({ context: 100_000, output: 32_000 })
     const cfg = mockCfg()
-    const tokens = { input: 60_000, output: 10_000, reasoning: 0, cache: { read: 10_000, write: 0 } } as any
+    // usable = floor(100K * 0.9) = 90K; 60K + 10K + 25K cache.read = 95K exceeds it
+    const tokens = { input: 60_000, output: 10_000, reasoning: 0, cache: { read: 25_000, write: 0 } } as any
     expect(isOverflow({ cfg, tokens, model })).toBe(true)
   })
 
@@ -159,68 +161,29 @@ describe("isOverflow", () => {
     expect(isOverflow({ cfg, tokens, model })).toBe(false)
   })
 
-  // ─── Bug reproduction tests ───────────────────────────────────────────
-  // These tests demonstrate that when limit.input is set, isOverflow()
-  // does not subtract any headroom for the next model response. This means
-  // compaction only triggers AFTER we've already consumed the full input
-  // budget, leaving zero room for the next API call's output tokens.
-  //
-  // Compare: without limit.input, usable = context - output (reserves space).
-  // With limit.input, usable = limit.input (reserves nothing).
-  //
-  // Related issues: #10634, #8089, #11086, #12621
-  // Open PRs: #6875, #12924
+  // The compaction trigger is a flat fraction of the window (see
+  // COMPACTION_TRIGGER_RATIO), so it reserves headroom uniformly whether or not
+  // the model publishes a dedicated input cap. This removes the old asymmetry
+  // where a limit.input model triggered compaction later than an equivalent
+  // model without one (issues #10634, #8089, #11086, #12621).
 
-  test("BUG: no headroom when limit.input is set — compaction should trigger near boundary but does not", () => {
-    // Simulate Claude with prompt caching: input limit = 200K, output limit = 32K
+  test("reserves headroom via the flat ratio when limit.input is set", () => {
     const model = createModel({ context: 200_000, input: 200_000, output: 32_000 })
     const cfg = mockCfg()
-
-    // We've used 198K tokens total. Only 2K under the input limit.
-    // On the next turn, the full conversation (198K) becomes input,
-    // plus the model needs room to generate output — this WILL overflow.
+    // usable = floor(200K * 0.9) = 180K. 180K + 15K + 3K = 198K exceeds it, so
+    // compaction fires while ~2K of real headroom remains for the next output.
     const tokens = { input: 180_000, output: 15_000, reasoning: 0, cache: { read: 3_000, write: 0 } } as any
-    // count = 180K + 3K + 15K = 198K
-    // usable = limit.input = 200K (no output subtracted!)
-    // 198K > 200K = false → no compaction triggered
-
-    // WITHOUT limit.input: usable = 200K - 32K = 168K, and 198K > 168K = true ✓
-    // WITH limit.input: usable = 200K, and 198K > 200K = false ✗
-
-    // With 198K used and only 2K headroom, the next turn will overflow.
-    // Compaction MUST trigger here.
     expect(isOverflow({ cfg, tokens, model })).toBe(true)
   })
 
-  test("BUG: without limit.input, same token count correctly triggers compaction", () => {
-    // Same model but without limit.input — uses context - output instead
-    const model = createModel({ context: 200_000, output: 32_000 })
-    const cfg = mockCfg()
-
-    // Same token usage as above
-    const tokens = { input: 180_000, output: 15_000, reasoning: 0, cache: { read: 3_000, write: 0 } } as any
-    // count = 198K
-    // usable = context - output = 200K - 32K = 168K
-    // 198K > 168K = true → compaction correctly triggered
-
-    expect(isOverflow({ cfg, tokens, model })).toBe(true) // ← Correct: headroom is reserved
-  })
-
-  test("BUG: asymmetry — limit.input model allows 30K more usage before compaction than equivalent model without it", () => {
-    // Two models with identical context/output limits, differing only in limit.input
+  test("limit.input and no-limit models trigger at the same point", () => {
     const withInputLimit = createModel({ context: 200_000, input: 200_000, output: 32_000 })
     const withoutInputLimit = createModel({ context: 200_000, output: 32_000 })
     const cfg = mockCfg()
-
-    // 170K total tokens — well above context-output (168K) but below input limit (200K)
+    // Both resolve hard = 200K → usable = 180K, so they agree exactly.
     const tokens = { input: 166_000, output: 10_000, reasoning: 0, cache: { read: 5_000, write: 0 } } as any
-
-    const withLimit = isOverflow({ cfg, tokens, model: withInputLimit })
-    const withoutLimit = isOverflow({ cfg, tokens, model: withoutInputLimit })
-
-    // Both models have identical real capacity — they should agree:
-    expect(withLimit).toBe(true) // should compact (170K leaves no room for 32K output)
-    expect(withoutLimit).toBe(true) // correctly compacts (170K > 168K)
+    expect(isOverflow({ cfg, tokens, model: withInputLimit })).toBe(true)
+    expect(isOverflow({ cfg, tokens, model: withoutInputLimit })).toBe(true)
   })
 
   test("returns false when model context limit is 0", () => {
@@ -572,28 +535,20 @@ describe("SessionNs.getUsage", () => {
 })
 
 describe("usable", () => {
-  test("caps output reservation at 20K when model.limit.output is larger", () => {
-    // 200K context with 32K output — without the cap, usable would be 200K - 32K = 168K.
-    // With OUTPUT_CAP=20K, usable should be 200K - 20K - reserved.
-    const model = createModel({ context: 200_000, output: 32_000 })
-    const cfg = mockCfg() // reserved defaults to min(33K, 32K) = 32K
-    expect(usable({ cfg, model })).toBe(148_000) // 200K - 20K (output cap) - 32K (reserved)
+  test("is a flat 90% of the model window regardless of output size", () => {
+    // The trigger is a fixed fraction of the window now, so output size no
+    // longer shrinks it — a 32K-output model and an 8K-output model with the
+    // same context share the same 90% trigger.
+    const big = createModel({ context: 200_000, output: 32_000 })
+    const small = createModel({ context: 200_000, output: 8_000 })
+    expect(usable({ cfg: mockCfg(), model: big })).toBe(180_000) // floor(200K * 0.9)
+    expect(usable({ cfg: mockCfg(), model: small })).toBe(180_000)
   })
 
-  test("does not cap when model.limit.output is below 20K", () => {
-    // 100K context with 8K output — output cap (20K) does not bite.
-    // usable should be 100K - 8K - reserved.
-    const model = createModel({ context: 100_000, output: 8_000 })
-    const cfg = mockCfg() // reserved defaults to min(33K, 8K) = 8K
-    expect(usable({ cfg, model })).toBe(84_000) // 100K - 8K (raw output, below cap) - 8K (reserved)
-  })
-
-  test("respects user-configured cfg.compaction.reserved", () => {
-    // 200K context, output 32K, user sets reserved=5K explicitly.
-    // usable = 200K - min(32K, 20K) - 5K = 175K
+  test("cfg.compaction.reserved no longer shrinks the trigger", () => {
+    // reserved only gates config-budget validation now; the trigger stays 90%.
     const model = createModel({ context: 200_000, output: 32_000 })
-    const cfg = mockCfg({ reserved: 5_000 })
-    expect(usable({ cfg, model })).toBe(175_000)
+    expect(usable({ cfg: mockCfg({ reserved: 5_000 }), model })).toBe(180_000)
   })
 })
 
@@ -603,11 +558,11 @@ describe("compaction.max_context", () => {
 
   test("no budget configured leaves the model window untouched", () => {
     const model = large()
-    expect(usable({ cfg: mockCfg(), model })).toBe(889_000)
+    expect(usable({ cfg: mockCfg(), model })).toBe(829_800)
     expect(contextWindow({ cfg: mockCfg(), model })).toEqual({
       hard: 922_000,
       effective: 922_000,
-      usable: 889_000,
+      usable: 829_800,
       source: "model",
     })
   })
@@ -618,19 +573,19 @@ describe("compaction.max_context", () => {
     expect(contextWindow({ cfg, model })).toEqual({
       hard: 922_000,
       effective: 300_000,
-      usable: 267_000,
+      usable: 270_000,
       source: "config",
     })
-    const tokens = { input: 267_000, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } as any
+    const tokens = { input: 270_000, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } as any
     expect(isOverflow({ cfg, tokens, model })).toBe(true)
-    const under = { input: 266_999, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } as any
+    const under = { input: 269_999, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } as any
     expect(isOverflow({ cfg, tokens: under, model })).toBe(false)
   })
 
   test("accepts a plain token count and a percentage", () => {
     const model = large()
-    expect(usable({ cfg: mockCfg({ max_context: 500_000 }), model })).toBe(467_000)
-    expect(usable({ cfg: mockCfg({ max_context: "50%" }), model })).toBe(428_000)
+    expect(usable({ cfg: mockCfg({ max_context: 500_000 }), model })).toBe(450_000)
+    expect(usable({ cfg: mockCfg({ max_context: "50%" }), model })).toBe(414_900)
   })
 
   test("never raises the window above the provider cap", () => {
@@ -639,26 +594,26 @@ describe("compaction.max_context", () => {
     expect(contextWindow({ cfg, model })).toEqual({
       hard: 128_000,
       effective: 128_000,
-      usable: 95_232,
+      usable: 115_200,
       source: "model",
     })
   })
 
   test("matches per-model keys with wildcards, longest pattern wins", () => {
     const cfg = mockCfg({ max_context: { "test/gpt-5*": "300K", "test/gpt-5.6": "200K" } })
-    expect(usable({ cfg, model: large() })).toBe(167_000)
-    expect(usable({ cfg, model: createModel({ context: 1_050_000, input: 922_000, id: "gpt-5.4" }) })).toBe(267_000)
+    expect(usable({ cfg, model: large() })).toBe(180_000)
+    expect(usable({ cfg, model: createModel({ context: 1_050_000, input: 922_000, id: "gpt-5.4" }) })).toBe(270_000)
   })
 
   test("ignores keys that match no model", () => {
     const cfg = mockCfg({ max_context: { "openai/gpt-4o": "100K" } })
-    expect(usable({ cfg, model: large() })).toBe(889_000)
+    expect(usable({ cfg, model: large() })).toBe(829_800)
   })
 
   test("ignores a budget that leaves no room for the reserves", () => {
     const model = large()
-    expect(usable({ cfg: mockCfg({ max_context: 20_000 }), model })).toBe(889_000)
-    expect(usable({ cfg: mockCfg({ max_context: "not-a-budget" }), model })).toBe(889_000)
+    expect(usable({ cfg: mockCfg({ max_context: 20_000 }), model })).toBe(829_800)
+    expect(usable({ cfg: mockCfg({ max_context: "not-a-budget" }), model })).toBe(829_800)
   })
 
   test("keeps overflow handling disabled when the model reports no window", () => {
@@ -701,29 +656,32 @@ describe("util.token.parseQuantity", () => {
 describe("compaction.max_context reset sentinel", () => {
   test("0 restores the model window without a warning path", () => {
     const model = createModel({ context: 1_050_000, input: 922_000, id: "gpt-5.6" })
-    expect(usable({ cfg: mockCfg({ max_context: { "test/gpt-5.6": 0 } as any }), model })).toBe(889_000)
+    expect(usable({ cfg: mockCfg({ max_context: { "test/gpt-5.6": 0 } as any }), model })).toBe(829_800)
     expect(contextWindow({ cfg: mockCfg({ max_context: 0 }), model }).source).toBe("model")
     // The picker writes a number, but a hand-edited config may carry the string form.
-    expect(usable({ cfg: mockCfg({ max_context: { "test/gpt-5.6": "0" } }), model })).toBe(889_000)
-    expect(usable({ cfg: mockCfg({ max_context: "" }), model })).toBe(889_000)
+    expect(usable({ cfg: mockCfg({ max_context: { "test/gpt-5.6": "0" } }), model })).toBe(829_800)
+    expect(usable({ cfg: mockCfg({ max_context: "" }), model })).toBe(829_800)
   })
 })
 
-describe("degenerate windows", () => {
-  test("usable collapses to 0 when the window cannot cover the reserves", () => {
-    // 8K window with an 8K output limit: reserved 8K + output reserve 8K > window.
-    // UI code must not divide by this (see tui/util/model.contextWindow).
+describe("small windows", () => {
+  test("the trigger stays proportional instead of collapsing to 0", () => {
+    // The old fixed-reserve formula could drive usable to 0 on a tiny window
+    // (reserved 8K + output 8K > 8K window). The flat 90% fraction keeps a
+    // usable trigger no matter how small the window is.
     const model = createModel({ context: 8_192, output: 8_192 })
     expect(contextWindow({ cfg: mockCfg(), model })).toEqual({
       hard: 8_192,
       effective: 8_192,
-      usable: 0,
+      usable: 7_372, // floor(8_192 * 0.9)
       source: "model",
     })
   })
 
-  test("a reserved larger than the window also collapses to 0", () => {
+  test("an oversized cfg.compaction.reserved no longer zeroes the trigger", () => {
+    // reserved only gates config-budget validation now, so a huge value leaves
+    // the model window's 90% trigger intact.
     const model = createModel({ context: 200_000, output: 32_000 })
-    expect(usable({ cfg: mockCfg({ reserved: 500_000 }), model })).toBe(0)
+    expect(usable({ cfg: mockCfg({ reserved: 500_000 }), model })).toBe(180_000)
   })
 })

--- a/packages/opencode/test/session/overflow.test.ts
+++ b/packages/opencode/test/session/overflow.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
 import { contextPressureLevel, contextWindow, isOverflow, pressureLevel, usable } from "../../src/session/overflow"
 import { Token } from "../../src/util"
 import { Session as SessionNs } from "../../src/session"
@@ -162,10 +162,10 @@ describe("isOverflow", () => {
   })
 
   // The compaction trigger is a flat fraction of the window (see
-  // COMPACTION_TRIGGER_RATIO), so it reserves headroom uniformly whether or not
-  // the model publishes a dedicated input cap. This removes the old asymmetry
-  // where a limit.input model triggered compaction later than an equivalent
-  // model without one (issues #10634, #8089, #11086, #12621).
+  // Flag.MIMOCODE_COMPACTION_TRIGGER_RATIO), so it reserves headroom uniformly
+  // whether or not the model publishes a dedicated input cap. This removes the
+  // old asymmetry where a limit.input model triggered compaction later than an
+  // equivalent model without one (issues #10634, #8089, #11086, #12621).
 
   test("reserves headroom via the flat ratio when limit.input is set", () => {
     const model = createModel({ context: 200_000, input: 200_000, output: 32_000 })
@@ -549,6 +549,43 @@ describe("usable", () => {
     // reserved only gates config-budget validation now; the trigger stays 90%.
     const model = createModel({ context: 200_000, output: 32_000 })
     expect(usable({ cfg: mockCfg({ reserved: 5_000 }), model })).toBe(180_000)
+  })
+})
+
+describe("MIMOCODE_COMPACTION_TRIGGER_RATIO", () => {
+  afterEach(() => {
+    delete process.env["MIMOCODE_COMPACTION_TRIGGER_RATIO"]
+  })
+
+  test("a decimal moves the trigger", () => {
+    process.env["MIMOCODE_COMPACTION_TRIGGER_RATIO"] = "0.75"
+    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(150_000)
+  })
+
+  test("a percentage is equivalent to the decimal", () => {
+    process.env["MIMOCODE_COMPACTION_TRIGGER_RATIO"] = "75%"
+    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(150_000)
+  })
+
+  test("1 lets usage fill the whole working window", () => {
+    process.env["MIMOCODE_COMPACTION_TRIGGER_RATIO"] = "1"
+    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(200_000)
+  })
+
+  test("applies on top of the max_context budget rather than replacing it", () => {
+    process.env["MIMOCODE_COMPACTION_TRIGGER_RATIO"] = "0.5"
+    const model = createModel({ context: 200_000 })
+    expect(contextWindow({ cfg: mockCfg({ max_context: "100K" }), model })).toEqual({
+      hard: 200_000,
+      effective: 100_000,
+      usable: 50_000,
+      source: "config",
+    })
+  })
+
+  test.each(["0", "-0.5", "1.5", "150%", "abc", ""])("ignores %p and keeps the 0.9 default", (value) => {
+    process.env["MIMOCODE_COMPACTION_TRIGGER_RATIO"] = value
+    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(180_000)
   })
 })
 


### PR DESCRIPTION
## What

Change the compaction trigger from a reserve-based formula to a flat fraction of the working window:

```
usable = floor(effective * 0.9)
```

Compaction now fires when usage reaches **90% of the model's context window**, leaving the top 10% as headroom for summary generation.

## Why

The old trigger was `usable = max(0, effective - reserved)`, where `reserved` grew with the model's output window (up to ~53K = `COMPACTION_BUFFER` 33K + capped output 20K):

- **Small windows**: the reserve could swallow most or all of the window, collapsing the trigger toward 0 and forcing near-constant compaction (a 8K window could end up with a trigger of ~0).
- **Large windows**: it left an arbitrary, output-size-dependent gap — two models with the same context but different output caps triggered at different points.

A flat 90% is proportional regardless of window size and output cap, and never collapses on small windows.

## Change

- `overflow.ts`: `usable` is now `floor(effective * COMPACTION_TRIGGER_RATIO)` with `COMPACTION_TRIGGER_RATIO = 0.9`. `reserved` is retained **only** to gate `compaction.max_context` budget validation in `budget()`; it no longer shrinks the usable window.
- `compaction.max_context` budgets, wildcards, and reset sentinel are unaffected — the budget still sets `effective`, and the 90% ratio applies on top of it.

## Tests

`test/session/overflow.test.ts` updated to assert the flat-ratio behavior — **49 pass / 0 fail**. Covers: flat 90% regardless of output size, `reserved` no longer shrinking the trigger, small-window proportionality (8192 → 7372), and all existing `max_context` budget/wildcard/sentinel cases recomputed against the ratio.

`bun typecheck` clean.