### PR TITLE
fix(session): scope replace-agent base override to main/peer actors

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -334,16 +334,35 @@ const live: Layer.Layer<
       agentID?: string
       ephemeral?: boolean
     }) {
+      // "Is this a main/peer actor" — the single judgement two sections below key
+      // on (replace-agent base override + memory instructions). Injected only for
+      // actors whose context the checkpoint flow serves — main + peer. Subagents
+      // (explore/general/…) run in the SHARED sessionID (F37 slices) but are NOT
+      // main/peer; system-spawned actors (checkpoint-writer et al.) and ephemeral
+      // one-shots (title gen) likewise are not. Shares the exact `servesCheckpoint`
+      // judgement with SessionPrune.fireCheckpoints so the "who owns a checkpoint"
+      // and "who is taught about it" (and now "who applies the session base") sets
+      // can never drift apart.
+      const servesCheckpoint =
+        !input.ephemeral && (yield* actorReg.servesCheckpoint(SessionID.make(input.sessionID), input.agentID))
+
+      // replace-agent replaces the PRIMARY line's base prompt with a session-level
+      // system (desktop execution-profile base). It is a main/peer concern: a
+      // subagent shares the sessionID and therefore inherits `systemMode` on the
+      // resolved session prompt, but must keep its OWN `agent.prompt` — else
+      // explore/general/title/… get their identity clobbered by the parent base.
+      // So the base override only fires when this actor `servesCheckpoint`; every
+      // other actor falls back to SystemPrompt.agent(self).
+      const replaceAgent = input.user.systemMode === "replace-agent" && servesCheckpoint
+
       const system: string[] = []
       system.push(
         [
-          ...(input.user.systemMode === "replace-agent"
-            ? []
-            : SystemPrompt.agent(input.agent, input.model, input.user.harness)),
+          ...(replaceAgent ? [] : SystemPrompt.agent(input.agent, input.model, input.user.harness)),
           // any custom prompt passed into this call
           ...input.system,
           // replace-agent is a session system prompt, not per-turn user context
-          ...(input.user.systemMode === "replace-agent" && input.user.system ? [input.user.system] : []),
+          ...(replaceAgent && input.user.system ? [input.user.system] : []),
         ]
           .filter((x) => x)
           .join("\n"),
@@ -354,14 +373,8 @@ const live: Layer.Layer<
       // Project ID is resolved from the ALS-bound Instance with a safe fallback
       // to `ProjectID.global` (mirrors the pattern in session/checkpoint.ts so the
       // path the prompt advertises matches the path the writer actually writes).
-      // Injected only for actors whose context the checkpoint flow serves —
-      // main + peer. Subagents (explore/general/compose) use per-actor compaction
-      // and have no checkpoint duty; system-spawned actors (checkpoint-writer et al.)
-      // are the writers themselves. Shares the exact `servesCheckpoint` judgement
-      // with SessionPrune.fireCheckpoints so the "who owns a checkpoint" and "who is
-      // taught about it" sets can never drift apart. Disabling checkpoints also
-      // disables this memory-system prompt block.
-      const servesCheckpoint = !input.ephemeral && (yield* actorReg.servesCheckpoint(SessionID.make(input.sessionID), input.agentID))
+      // Gated on the shared `servesCheckpoint` judgement above; disabling
+      // checkpoints also disables this memory-system prompt block.
       if (servesCheckpoint && !Flag.MIMOCODE_DISABLE_CHECKPOINT) {
         const projectID =
           (yield* Effect.try({

--- a/packages/opencode/test/session/replace-agent-subagent.test.ts
+++ b/packages/opencode/test/session/replace-agent-subagent.test.ts
@@ -1,0 +1,294 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import path from "path"
+import { Effect, Stream, ManagedRuntime, Layer } from "effect"
+import { LLM } from "../../src/session/llm"
+import { ActorRegistry } from "../../src/actor/registry"
+import { Session as SessionNs } from "../../src/session"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { Filesystem } from "../../src/util"
+import { tmpdir } from "../fixture/fixture"
+import type { Agent } from "../../src/agent/agent"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { AppRuntime } from "../../src/effect/app-runtime"
+
+// [TP-R1-08] Regression: a `replace-agent` session prompt is session-scoped, so
+// its `systemMode` leaks onto every actor's resolved user message. buildSystemArray
+// must NOT let that leak clobber a subagent's own `agent.prompt` — replace-agent is
+// a main/peer concern only. Reuses the HTTP-mock capture approach from
+// llm-system-prompt.test.ts: assert on the assembled `body.messages` system content.
+
+type Capture = { url: URL; headers: Headers; body: Record<string, unknown> }
+
+const queueState = {
+  server: null as ReturnType<typeof Bun.serve> | null,
+  queue: [] as Array<{
+    path: string
+    response: Response
+    resolve: (value: Capture) => void
+  }>,
+}
+
+function deferred<T>() {
+  const result = {} as { promise: Promise<T>; resolve: (value: T) => void }
+  result.promise = new Promise((resolve) => (result.resolve = resolve))
+  return result
+}
+
+function waitRequest(pathname: string, response: Response) {
+  const pending = deferred<Capture>()
+  queueState.queue.push({ path: pathname, response, resolve: pending.resolve })
+  return pending.promise
+}
+
+function createChatStream(text: string) {
+  const payload =
+    [
+      `data: ${JSON.stringify({ id: "x", object: "chat.completion.chunk", choices: [{ delta: { role: "assistant" } }] })}`,
+      `data: ${JSON.stringify({ id: "x", object: "chat.completion.chunk", choices: [{ delta: { content: text } }] })}`,
+      `data: ${JSON.stringify({ id: "x", object: "chat.completion.chunk", choices: [{ delta: {}, finish_reason: "stop" }] })}`,
+      "data: [DONE]",
+    ].join("\n\n") + "\n\n"
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(payload))
+      controller.close()
+    },
+  })
+}
+
+async function loadFixture(providerID: string, modelID: string) {
+  const fixturePath = path.join(import.meta.dir, "../tool/fixtures/models-api.json")
+  const data = await Filesystem.readJson<Record<string, any>>(fixturePath)
+  const provider = data[providerID]
+  if (!provider) throw new Error(`Missing provider in fixture: ${providerID}`)
+  const model = provider.models[modelID]
+  if (!model) throw new Error(`Missing model in fixture: ${modelID}`)
+  return { provider, model }
+}
+
+beforeAll(() => {
+  queueState.server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const next = queueState.queue.shift()
+      if (!next) return new Response("unexpected request", { status: 500 })
+      const url = new URL(req.url)
+      const body = (await req.json()) as Record<string, unknown>
+      next.resolve({ url, headers: req.headers, body })
+      if (!url.pathname.endsWith(next.path)) return new Response("not found", { status: 404 })
+      return next.response
+    },
+  })
+})
+
+beforeEach(() => {
+  queueState.queue.length = 0
+})
+
+afterAll(() => {
+  void queueState.server?.stop()
+})
+
+async function getModel(providerID: ProviderID, modelID: ModelID) {
+  return AppRuntime.runPromise(
+    Effect.gen(function* () {
+      const provider = yield* Provider.Service
+      return yield* provider.getModel(providerID, modelID)
+    }),
+  )
+}
+
+// The parent execution-profile base is injected as a replace-agent session system.
+const PARENT_BASE_MARKER = "PARENT_EXECUTION_PROFILE_BASE_MARKER"
+// A subagent's own identity prompt (what SystemPrompt.agent returns for it).
+const SUBAGENT_PROMPT_MARKER = "EXPLORE_SUBAGENT_IDENTITY_MARKER"
+
+function makeUser(sessionID: SessionID, providerID: string, modelID: ModelID): MessageV2.User {
+  return {
+    id: MessageID.make("user-replace-agent-subagent"),
+    sessionID,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "test",
+    model: { providerID: ProviderID.make(providerID), modelID },
+    // Session-scoped replace-agent prompt: resolvePrompt returns this to EVERY
+    // actor in the session, main or subagent alike.
+    system: PARENT_BASE_MARKER,
+    systemMode: "replace-agent",
+  } satisfies MessageV2.User
+}
+
+function makeAgent(prompt: string): Agent.Info {
+  return {
+    name: "explore",
+    mode: "subagent",
+    prompt,
+    options: {},
+    permission: [{ permission: "*", pattern: "*", action: "allow" }],
+  } satisfies Agent.Info
+}
+
+function tmpConfig(providerID: string, baseURL: string) {
+  return JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    enabled_providers: [providerID],
+    provider: {
+      [providerID]: { options: { apiKey: "test-key", baseURL } },
+    },
+  })
+}
+
+describe("session.llm replace-agent — actor scope [TP-R1-08]", () => {
+  test("subagent keeps its own agent.prompt (replace-agent does NOT leak the parent base)", async () => {
+    const server = queueState.server!
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hi"), { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "mimocode.json"), tmpConfig(providerID, `${server.url.origin}/v1`))
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(fixture.model.id))
+        const sessionRt = ManagedRuntime.make(SessionNs.defaultLayer)
+        let sessionID: SessionID
+        try {
+          const info = await sessionRt.runPromise(SessionNs.Service.use((svc) => svc.create({})))
+          sessionID = info.id
+        } finally {
+          await sessionRt.dispose()
+        }
+
+        // Register a subagent actor (explore) in this session. servesCheckpoint()
+        // must judge it NOT main/peer, so replace-agent should not apply to it.
+        const regRt = ManagedRuntime.make(ActorRegistry.defaultLayer)
+        try {
+          await regRt.runPromise(
+            ActorRegistry.Service.use((svc) =>
+              svc.register({
+                sessionID,
+                actorID: "explore-1",
+                mode: "subagent",
+                agent: "explore",
+                description: "explore subagent fixture",
+                contextMode: "full",
+                background: false,
+                lifecycle: "ephemeral",
+              }),
+            ),
+          )
+        } finally {
+          await regRt.dispose()
+        }
+
+        const rt = ManagedRuntime.make(Layer.mergeAll(LLM.defaultLayer))
+        try {
+          await rt.runPromise(
+            LLM.Service.use((svc) =>
+              svc
+                .stream({
+                  user: makeUser(sessionID, providerID, resolved.id),
+                  sessionID,
+                  model: resolved,
+                  agent: makeAgent(SUBAGENT_PROMPT_MARKER),
+                  system: [],
+                  messages: [{ role: "user", content: "Hello" }],
+                  tools: {},
+                  agentID: "explore-1",
+                })
+                .pipe(Stream.runDrain),
+            ),
+          )
+        } finally {
+          await rt.dispose()
+        }
+
+        const capture = await request
+        const allSys = (capture.body.messages as Array<{ role: string; content: string }>)
+          .filter((m) => m.role === "system")
+          .map((m) => m.content)
+          .join("\n")
+        // The subagent's own identity prompt survives...
+        expect(allSys).toContain(SUBAGENT_PROMPT_MARKER)
+        // ...and the parent execution-profile base did NOT clobber it.
+        expect(allSys).not.toContain(PARENT_BASE_MARKER)
+      },
+    })
+  })
+
+  test("main agent (no agentID) — replace-agent still applies the parent base and skips agent.prompt", async () => {
+    const server = queueState.server!
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hi"), { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "mimocode.json"), tmpConfig(providerID, `${server.url.origin}/v1`))
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(fixture.model.id))
+        const sessionRt = ManagedRuntime.make(SessionNs.defaultLayer)
+        let sessionID: SessionID
+        try {
+          const info = await sessionRt.runPromise(SessionNs.Service.use((svc) => svc.create({})))
+          sessionID = info.id
+        } finally {
+          await sessionRt.dispose()
+        }
+
+        const rt = ManagedRuntime.make(Layer.mergeAll(LLM.defaultLayer))
+        try {
+          await rt.runPromise(
+            LLM.Service.use((svc) =>
+              svc
+                .stream({
+                  user: makeUser(sessionID, providerID, resolved.id),
+                  sessionID,
+                  model: resolved,
+                  // Main agent carries a prompt too; replace-agent must skip it.
+                  agent: makeAgent(SUBAGENT_PROMPT_MARKER),
+                  system: [],
+                  messages: [{ role: "user", content: "Hello" }],
+                  tools: {},
+                })
+                .pipe(Stream.runDrain),
+            ),
+          )
+        } finally {
+          await rt.dispose()
+        }
+
+        const capture = await request
+        const allSys = (capture.body.messages as Array<{ role: string; content: string }>)
+          .filter((m) => m.role === "system")
+          .map((m) => m.content)
+          .join("\n")
+        // Main line keeps existing replace-agent behavior: parent base in, agent.prompt out.
+        expect(allSys).toContain(PARENT_BASE_MARKER)
+        expect(allSys).not.toContain(SUBAGENT_PROMPT_MARKER)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Problem

`replace-agent` replaces the **primary line's** base prompt with a session-level system prompt (used by MiMo Desktop to inject the execution-profile base). But `resolvePrompt` keys `{system, systemMode}` **only by `sessionID`**, so the first user message's `systemMode: "replace-agent"` leaks onto *every* actor in that session — including subagents spawned via the Task tool (`explore` / `general` / `plan-subagent`) and system-spawned actors (`checkpoint-writer` / title-gen / …).

`buildSystemArray` then skipped `SystemPrompt.agent(...)` whenever it saw `replace-agent`, so a **subagent lost its own `agent.prompt`** and inherited the parent base instead: `explore` stopped being read-only-search, title-gen stopped being title-gen, etc. Their identity/discipline prompt was clobbered.

## Fix

Gate the base override on the **same** `servesCheckpoint(sessionID, agentID)` judgement the memory-instructions block already uses:

- **main / peer** actor → apply `replace-agent` (existing behavior: skip `SystemPrompt.agent`, inject `user.system` as the session system prompt).
- **subagent / system-spawned / ephemeral** actor → fall back to `SystemPrompt.agent(self)` and do **not** receive the parent `user.system`.

`servesCheckpoint` is hoisted above both sites so "who owns a checkpoint", "who is taught about it", and now "who applies the session base" share one judgement and can never drift apart. `buildSystemArray` remains the single choke point (shared by `runLoop` via `buildLLMRequestPrefix` and by `stream()`); no per-actor branching was added elsewhere.

`turnContextMessages` and the `stream()` OAuth/Workflow provider branches already do the right thing for subagents (they don't append the parent `user.system`), so they're untouched.

## Test

`test/session/replace-agent-subagent.test.ts` (HTTP-mock capture, same approach as `llm-system-prompt.test.ts`):

1. **subagent** (actor `mode: subagent`) — assembled system contains the subagent's own `agent.prompt`, and does **not** contain the parent base.
2. **main agent** (no `agentID`) — unchanged: parent base present, `agent.prompt` skipped.

```
bun test test/session/replace-agent-subagent.test.ts   # 2 pass, 0 fail
```

Pre-push typecheck green (12/12).