### PR TITLE
feat(pptx-official): image sourcing decision rules

### DIFF
--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
@@ -238,7 +238,10 @@ work. Keep these in mind:
    argument; bodies carry the evidence.
 3. **Every slide earns its visuals.** A slide without a chart, image, icon,
    or shape is usually a bullet dump. Turn it into a comparison, a stat
-   callout, a diagram, or delete it.
+   callout, a diagram, or delete it. **A "visual" is not necessarily a
+   picture** — a stat callout, a comparison shape, or a well-typeset quote
+   is already a visual. When you do need a picture, see *Image sourcing*
+   below.
 4. **Layouts, not per-slide geometry.** For anything reused (section
    dividers, content pages, quote slides), define a `slide_layout` once and
    apply it. This makes swapping the theme a one-line change instead of a
@@ -253,6 +256,74 @@ work. Keep these in mind:
 7. **Bullets are not the default.** Bullet lists are the failure mode of
    most decks — comparisons, tables, icons-with-labels, and stat callouts
    almost always land better.
+
+## Image sourcing (choose the right channel)
+
+"Every slide earns its visuals" does **not** mean "generate an image for
+every slide." Choose the source based on what the image does. Four channels,
+ordered by preference (lower cost + higher stability first):
+
+**L1 · Draw in code.** Icons via react-icons / iconify. Charts via
+matplotlib / plotly / echarts. Flowcharts, comparisons, org charts via
+shapes + lines. Anything that is a data or concept visualization —
+never fetch or generate an image for this.
+
+**L2 · Cite a real-image URL from memory.** You have URLs to public image
+libraries (Unsplash, Pexels, official CDNs) baked into your training data.
+When a slide needs a **generic real photo** (city skyline, office desk, team
+collaboration, nature, generic stock imagery), reference such a URL directly
+and use `slide.add_picture(url, ...)` (python-pptx supports HTTP URL). Zero
+tool calls. If the URL fails, fall back to L3 or L4.
+
+**L3 · Search the web.** For **specific real things** you cannot reasonably
+know the URL of (a particular company's logo, a specific product's official
+screenshot, a named person's photo) — use `websearch` to find the URL, then
+embed via URL or `webfetch`. Never call `image_gen` for these — a generated
+logo will not look like the real logo.
+
+**L4 · Generate with `image_gen`.** Only for **stylized visuals** — cover
+art, hero backgrounds, illustration-style concept images, brand-mood
+imagery. Budget: **at most 1–2 `image_gen` calls per deck**, typically for
+cover or section dividers. Not for every content slide.
+
+### Decision (run per slide)
+
+1. Does this slide actually need a picture? Often the answer is no — a
+   large stat callout, a comparison shape, a well-typeset quote, or a
+   diagram *is* a visual. Skip pictures when layout + typography carries
+   the message.
+2. If yes, pick the cheapest channel that works:
+   - Data / concept / flow / icon → **L1** (draw in code)
+   - Generic real photo → **L2** (memory URL)
+   - Specific brand / logo / product / person → **L3** (web search)
+   - Stylized cover / hero / illustration → **L4** (`image_gen`)
+3. If a URL fails: L2 → L3 → L4 → shape + text fallback. Never leave a
+   slide blank because an image failed to load.
+
+### Anti-patterns
+
+- **Calling `image_gen` on every content slide.** Slow, expensive,
+  style-inconsistent, visually noisy. A 20-slide deck with 20 generated
+  images is a red flag, not a success.
+- **Generating a logo, celebrity, or product screenshot with `image_gen`.**
+  The output will not resemble the real thing. Use web search (L3).
+- **Executive / status / weekly decks in illustration style.** Work
+  reporting is data + icons + hierarchy, not concept art. Reserve L4 for
+  launch, brand, or hero visuals.
+- **Leaving a slide blank because an image fetch failed.** Always have a
+  shape + text fallback; a well-formatted stat callout is a better slide
+  than an empty one anyway.
+
+### Scene defaults (rough mix per deck type)
+
+| Deck type              | Dominant | Notes                                           |
+|------------------------|----------|-------------------------------------------------|
+| Status / OKR / weekly  | L1 (~90%) | Icons + data charts. Almost no L3 / L4.        |
+| Strategy / proposal    | L1 + L2  | ~60% L1, ~30% L2, ~10% L4 cover.                |
+| Sales / pitch / BP     | L2 + L3  | Customer logos and product shots (L3) matter. 1 L4 cover. |
+| Training / education   | L1 (~80%) | Diagrams and flowcharts win.                   |
+| Launch / brand         | L4-heavy | Visuals are the point. Still limit style drift. |
+| Competitive analysis   | L3-heavy | Logos and screenshots are irreplaceable.        |
 
 ## Typography defaults (safe starting point)
 

--- a/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/pptx-official/SKILL.md
@@ -268,23 +268,67 @@ matplotlib / plotly / echarts. Flowcharts, comparisons, org charts via
 shapes + lines. Anything that is a data or concept visualization —
 never fetch or generate an image for this.
 
-**L2 · Cite a real-image URL from memory.** You have URLs to public image
-libraries (Unsplash, Pexels, official CDNs) baked into your training data.
-When a slide needs a **generic real photo** (city skyline, office desk, team
-collaboration, nature, generic stock imagery), reference such a URL directly
-and use `slide.add_picture(url, ...)` (python-pptx supports HTTP URL). Zero
-tool calls. If the URL fails, fall back to L3 or L4.
+**L2 · Search a stock library, then download the bytes.** When a slide
+needs a **generic real photo** (city skyline, office desk, team
+collaboration, nature, stock imagery), use `websearch` with a
+`site:unsplash.com` / `site:pexels.com` / `site:pixabay.com` query to find
+a real URL, then **download the image to a local file** and pass that path
+to `add_picture` (see *Downloading* below). Do NOT try to pass an HTTP URL
+directly to `add_picture` — python-pptx's `add_picture` only accepts a
+local path or a file-like object; it will NOT fetch a URL for you.
 
-**L3 · Search the web.** For **specific real things** you cannot reasonably
-know the URL of (a particular company's logo, a specific product's official
-screenshot, a named person's photo) — use `websearch` to find the URL, then
-embed via URL or `webfetch`. Never call `image_gen` for these — a generated
-logo will not look like the real logo.
+**L3 · Search a specific source.** For **specific real things** (a
+particular company's logo, a specific product's official screenshot, a
+named person's photo), use `websearch` with a targeted query (e.g.
+`"Acme Inc" logo site:acme.com`, or `<product name> screenshot`) instead of
+a stock-library query, then download the bytes the same way as L2. Never
+call `image_gen` here — a generated logo will not look like the real logo.
+Note: `webfetch` returns text/markdown/html only and cannot deliver binary
+image bytes — use `bash` + `curl` or python `urllib` to download.
 
 **L4 · Generate with `image_gen`.** Only for **stylized visuals** — cover
 art, hero backgrounds, illustration-style concept images, brand-mood
 imagery. Budget: **at most 1–2 `image_gen` calls per deck**, typically for
 cover or section dividers. Not for every content slide.
+
+### Downloading a URL for `add_picture`
+
+Two working patterns. Both keep the file local so `add_picture` can read
+the bytes:
+
+```python
+# Pattern A: download to a temp file, then pass the path
+from urllib.request import Request, urlopen
+from pathlib import Path
+
+def download_image(url: str, dest: Path) -> Path:
+    req = Request(url, headers={"User-Agent": "Mozilla/5.0"})  # some CDNs 403 an empty UA
+    with urlopen(req, timeout=15) as r:
+        dest.write_bytes(r.read())
+    return dest
+
+path = download_image(hit_url, Path("assets/hero.jpg"))
+slide.shapes.add_picture(str(path), Inches(1), Inches(1.5), width=Inches(11))
+```
+
+```python
+# Pattern B: in-memory via BytesIO — no temp file, but same request headers
+from io import BytesIO
+from urllib.request import Request, urlopen
+
+req = Request(hit_url, headers={"User-Agent": "Mozilla/5.0"})
+with urlopen(req, timeout=15) as r:
+    slide.shapes.add_picture(BytesIO(r.read()), Inches(1), Inches(1.5), width=Inches(11))
+```
+
+Or from a bash step:
+
+```bash
+curl -sSL -A "Mozilla/5.0" -o assets/hero.jpg "$URL"
+```
+
+Wrap any download in a try/except: on failure fall through to the next
+channel (L3 → L4) or a shape+text fallback — never leave a slide blank.
 
 ### Decision (run per slide)
 
@@ -294,10 +338,10 @@ cover or section dividers. Not for every content slide.
    the message.
 2. If yes, pick the cheapest channel that works:
    - Data / concept / flow / icon → **L1** (draw in code)
-   - Generic real photo → **L2** (memory URL)
-   - Specific brand / logo / product / person → **L3** (web search)
+   - Generic real photo → **L2** (stock library search + download)
+   - Specific brand / logo / product / person → **L3** (targeted web search + download)
    - Stylized cover / hero / illustration → **L4** (`image_gen`)
-3. If a URL fails: L2 → L3 → L4 → shape + text fallback. Never leave a
+3. If a fetch fails: L2 → L3 → L4 → shape + text fallback. Never leave a
    slide blank because an image failed to load.
 
 ### Anti-patterns
@@ -305,8 +349,16 @@ cover or section dividers. Not for every content slide.
 - **Calling `image_gen` on every content slide.** Slow, expensive,
   style-inconsistent, visually noisy. A 20-slide deck with 20 generated
   images is a red flag, not a success.
+- **Passing an HTTP URL to `add_picture`.** python-pptx will raise
+  `FileNotFoundError` — always download the bytes first (see *Downloading*).
+- **Using `webfetch` to grab image bytes.** `webfetch` returns text only.
+  Use `bash` + `curl` or python `urllib` for binaries.
+- **Making up a stock-library URL from memory.** Unsplash / Pexels CDN
+  paths are opaque hashes — you cannot reliably recall a URL that both
+  exists AND matches the described content. Always search first, then
+  download.
 - **Generating a logo, celebrity, or product screenshot with `image_gen`.**
-  The output will not resemble the real thing. Use web search (L3).
+  The output will not resemble the real thing. Use targeted web search (L3).
 - **Executive / status / weekly decks in illustration style.** Work
   reporting is data + icons + hierarchy, not concept art. Reserve L4 for
   launch, brand, or hero visuals.
@@ -316,13 +368,16 @@ cover or section dividers. Not for every content slide.
 
 ### Scene defaults (rough mix per deck type)
 
+L2/L3 both cost about one `websearch` + one download per image — cheap
+compared to L4, still not free. L1 remains the default.
+
 | Deck type              | Dominant | Notes                                           |
 |------------------------|----------|-------------------------------------------------|
-| Status / OKR / weekly  | L1 (~90%) | Icons + data charts. Almost no L3 / L4.        |
-| Strategy / proposal    | L1 + L2  | ~60% L1, ~30% L2, ~10% L4 cover.                |
-| Sales / pitch / BP     | L2 + L3  | Customer logos and product shots (L3) matter. 1 L4 cover. |
+| Status / OKR / weekly  | L1 (~90%) | Icons + data charts. Almost no L2 / L3 / L4.   |
+| Strategy / proposal    | L1 + L2  | ~60% L1, ~30% L2 (searched stock), ~10% L4 cover. |
+| Sales / pitch / BP     | L2 + L3  | Customer logos and product shots (L3) matter. 1 L4 cover max. |
 | Training / education   | L1 (~80%) | Diagrams and flowcharts win.                   |
-| Launch / brand         | L4-heavy | Visuals are the point. Still limit style drift. |
+| Launch / brand         | L4-heavy | Visuals are the point. Still limit style drift and reuse assets. |
 | Competitive analysis   | L3-heavy | Logos and screenshots are irreplaceable.        |
 
 ## Typography defaults (safe starting point)


### PR DESCRIPTION
## Background

Users reported that PPT generation now frequently calls `image_gen` on nearly every content slide — slow, expensive, style-inconsistent, and visually noisy. Root cause: the skill's principle *"Every slide earns its visuals"* is being read as *"generate an image for every slide"*, and there is no guidance on **where images should come from**.

The `image_gen` tool became available in MiMo Desktop on 2026-07-31 (via the `ImageGenExtension`), and the model started using it as the default sourcing channel — even for logos, real photos, and status decks — because nothing in the pptx-official skill tells it otherwise.

## Change

Add a new `## Image sourcing (choose the right channel)` section under `## Authoring principles`. It defines four channels ordered by cost + stability:

- **L1 · Draw in code** — icons (react-icons), charts (matplotlib), shapes. Default for data/concept/flow/icon.
- **L2 · Cite a real-image URL from memory** — public image library URLs baked into training data (Unsplash, Pexels, CDNs). Zero tool calls. For generic real photos.
- **L3 · Search the web** — `websearch` + URL embedding, for specific brand/logo/product/person.
- **L4 · Generate with `image_gen`** — stylized visuals only (cover art, hero backgrounds, illustration). **Budget: ≤ 1–2 calls per deck.**

Plus:

- Per-slide decision tree ("Does this slide need a picture at all?" → channel selection).
- Failure fallback chain: L2 → L3 → L4 → shape + text (never leave a slide blank).
- Explicit anti-patterns (calling `image_gen` on every slide; generating logos/celebrities; illustration-style status decks).
- Scene default mix table by deck type (status/OKR: 90% L1; sales/pitch: L2+L3; launch/brand: L4-heavy).

Also amend principle #3 to note that a *"visual" is not necessarily a picture* — a stat callout or comparison shape is already a visual — and cross-link to the new section.

## Expected effect

- Status/OKR/weekly decks stop generating illustration-style covers.
- Logos and product screenshots come from web search, not `image_gen`.
- Generic real photos come from memory-cited URLs (Unsplash etc.), not `image_gen`.
- `image_gen` budget: 1–2 per deck, typically for cover/dividers only.
- Fallback chain ensures no blank slides even when a URL fetch fails.

## Testing

- Skill-only prompt patch, no code changes. CLI + MiMo Desktop both consume the same skill file.
- Suggested manual verification: ask the model to produce a status weekly PPT — expect zero `image_gen` calls; ask for a brand launch deck — expect 1–2 `image_gen` calls for cover, rest via L1/L2/L3.

## Related

- Downstream desktop MR will add a cross-repo anchor in `electron/prompts/desktop-base.md` pointing to this section (small, decoupled — this PR is self-sufficient).