### PR TITLE
test(session): retune the auto-overflow fixture for the flat 90% trigger

### DIFF
--- a/packages/opencode/test/session/auto-overflow-writer-first.test.ts
+++ b/packages/opencode/test/session/auto-overflow-writer-first.test.ts
@@ -200,13 +200,24 @@ function writerThatFails(): SpawnImpl {
 }
 
 // Shrink the usable window so a seeded token count trips
-// SessionOverflow.isOverflow deterministically. reserves() = compaction.reserved
-// (100) + a 20_000 output reservation (this model publishes no limit.input), so
-// max_context must exceed ~20_100 to be honoured at all. It must ALSO leave
-// usable > 13_000, or SessionPrune.resolveThresholds refuses the window
-// ("too small for checkpoints"). 40_000 satisfies both: usable = 40_000 -
-// 20_100 = 19_900, against the seeded 50_000 tokens.
-function mimocodeConfig(baseURL: string, maxContext = 40_000, checkpoint?: { thresholds: string[]; reserved: number }) {
+// SessionOverflow.isOverflow deterministically. The trigger is a flat fraction
+// of the working window — `usable = floor(max_context * ratio)`, ratio being
+// MIMOCODE_COMPACTION_TRIGGER_RATIO (default 0.9) — so max_context alone decides
+// it, as long as it exceeds reserves() = compaction.reserved (100) + a 20_000
+// output reservation (this model publishes no limit.input); below that, budget()
+// ignores it and the model's own million-token window applies. 40_000 puts the
+// trigger at 36_000, well under the 50_000 tokens every turn below reports.
+//
+// The empty checkpoint ladder is declared rather than inferred: SessionPrune
+// only consults defaultThresholdsFor when `thresholds` is absent, so passing []
+// keeps fireCheckpoints out of the way regardless of the window. That is what
+// makes the writer counts asserted below attributable to the overflow path
+// alone.
+function mimocodeConfig(
+  baseURL: string,
+  maxContext = 40_000,
+  checkpoint: { thresholds: string[]; reserved: number } = { thresholds: [], reserved: 100 },
+) {
   return JSON.stringify({
     $schema: "https://opencode.ai/config.json",
     enabled_providers: ["alibaba"],
@@ -358,7 +369,7 @@ describe("Auto context overflow: write a checkpoint before degrading to compacti
     async () => {
       const llm = startUsageLLM([
         { text: "initialized", promptTokens: 1_000 },
-        { text: "high-usage reply", promptTokens: 25_000 },
+        { text: "high-usage reply", promptTokens: 50_000 },
         { text: "reply after rebuild", promptTokens: 1_000 },
       ])
       let writerCalls = 0
@@ -461,9 +472,9 @@ describe("Auto context overflow: write a checkpoint before degrading to compacti
                   agent: "build",
                 })
 
-                // usable = 50K - 20.1K reserves = 29.9K. The single 24K
-                // checkpoint threshold is below it, so 25K must write a
-                // checkpoint without rebuilding before the 29.9K trigger.
+                // usable = floor(50K * 0.9) = 45K. The single 24K checkpoint
+                // threshold is below it, so 25K must write a checkpoint
+                // without rebuilding before the 45K trigger.
                 const first = yield* Effect.promise(() => seedUserMessage(info.id, "earlier question"))
                 yield* Effect.promise(() => seedFinishedAssistant(info.id, first.id, 25_000))
 


### PR DESCRIPTION
## Summary

The `test` job on main has been red since #2263 landed, with exactly one failure across the whole suite: "a completed high-usage turn is rebuilt exactly once" in `packages/opencode/test/session/auto-overflow-writer-first.test.ts`, failing on `expect(checkpoints).toHaveLength(1)` with 0 received. `lint` and `typecheck` stayed green throughout.

The cause is a fixture that went stale with the trigger formula, not a product regression. 957bc463 moved the compaction/overflow trigger from `usable = effective - reserves()` to `usable = floor(effective * MIMOCODE_COMPACTION_TRIGGER_RATIO)` (default 0.9). This file squeezed the window with `max_context: 40_000` against `reserves() = 20_100` for a usable window of 19_900, and the scripted high-usage turn in that one case reported only 25_000 prompt tokens. Under the new formula usable is 36_000, so that turn no longer crosses the trigger: the overflow branch never runs and no checkpoint boundary lands. The other cases that need to overflow seed 50_000 tokens, still above 36_000, and the one case that must stay below the trigger carries its own `max_context`, which is why only this one broke.

Changes:

- The high-usage turn now reports 50_000 tokens, matching the seeds used by the other overflowing cases, so every case that needs to cross the trigger clears it by ~14K instead of depending on where the ratio happens to land. Crucially the overflow still fires from the step-finish usage check inside the same prompt that reports it (`processor.ts` → `Result "overflow"` → `rebuildEnsuringCheckpoint`), which is the only window in which the test has its stub writer bound.
- The empty checkpoint ladder is now declared as `checkpoint.thresholds: []` rather than falling out of usable sitting below `defaultThresholdsFor`'s 25_000 floor — `SessionPrune` only consults the defaults when the key is absent. The writer count does not depend on the default ladder today either way; declaring it removes the implicit coupling to window arithmetic so the assertion cannot drift with the ratio.
- Comments still describing the old reserve arithmetic are updated to the ratio formula.

No assertion was removed or relaxed, and no `src` file is touched.

## Verification

From `packages/opencode`:

- `bun test test/session/auto-overflow-writer-first.test.ts` → 6 pass / 0 fail (before: 5 pass / 1 fail)
- `bun test test/session/overflow.test.ts test/session/prune.test.ts test/session/rebuild-boundary-model-context.test.ts test/session/compaction-agent-scope.test.ts` → 81 pass / 0 fail
- `bun typecheck` → clean
- Drift probes: `MIMOCODE_COMPACTION_TRIGGER_RATIO=0.97` → 6 pass (that ratio reproduced the exact main failure signature before this change); at `=0.5` only "crossing the final checkpoint threshold…" fails, which follows from that case's own premise that the trigger sits strictly above its seeded 25_000 turn.
- CI on this branch is green. `unit (shard 4/4)` first failed on an unrelated hang in `test/effect/runner.test.ts:123` ("cancel interrupts running work", 12ms on main runs, 120s timeout here on a slow runner); it passes locally and passed on rerun.
- prettier already reports this file as unformatted on main (line 347, untouched here), and the CI lint job runs oxlint only.
