### PR TITLE
fix(session): include MCP tools in the fork/checkpoint request prefix

### DIFF
--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -73,13 +73,24 @@ export interface ForkContext {
    * Tool schema as parent would emit at watermark, captured for invariant
    * verification only. NOT consumed by fork's runLoop for the actual LLM
    * request — that uses `resolveTools(forkAgent)` for executable tools with
-   * dispatch closures. Schema parity is currently enforced because
-   * checkpoint-writer has no `toolAllowlist` (Task 2.6); both paths call
-   * `registry.tools` with equivalent agent inputs and produce identical
-   * schemas. If `toolAllowlist` is ever re-added, this field would still
-   * snapshot parent's schema while the runtime tools would diverge, silently
-   * breaking cache parity. Test guard: `test/agent/agent.test.ts` asserts
-   * `cp.toolAllowlist === undefined` for checkpoint-writer.
+   * dispatch closures. `buildLLMRequestPrefix` reproduces the parent's WIRE tool
+   * set: registry built-ins plus the connected MCP tools that actually reach the
+   * provider. The AI SDK filters wire tools by `activeTools`, so the MCP parity
+   * target is "connected MCP tools that end up in activeTools":
+   *   - Non-GPT toolset: every executable, non-name-clashing MCP tool minus those
+   *     the merged session/agent permission denies or the turn toggles off
+   *     (user.tools). The agent toolAllowlist does NOT prune the wire set, so it
+   *     is not applied.
+   *   - GPT/Codex toolset: MCP tools never enter activeTools (they are reached via
+   *     mcp-tool-search), so the parent emits ZERO MCP definitions and the prefix
+   *     omits them too.
+   * Before MCP was folded in here, this field carried built-ins alone, so the
+   * mere presence of an MCP server diverged the fork prefix from the parent on
+   * the first turn and broke tool-list cache parity (and stripped MCP from
+   * fork:false checkpoint-writer requests, which send this schema directly).
+   * Test guard: `test/session/llm-request-prefix.test.ts` covers MCP inclusion,
+   * deny/toggle pruning, and GPT-toolset omission; `test/agent/agent.test.ts`
+   * asserts `cp.toolAllowlist === undefined` for checkpoint-writer.
    */
   readonly tools: Record<string, AITool>
   /**

--- a/packages/opencode/src/session/llm-request-prefix.ts
+++ b/packages/opencode/src/session/llm-request-prefix.ts
@@ -1,13 +1,16 @@
 import { Effect } from "effect"
-import { tool, jsonSchema, type Tool as AITool } from "ai"
+import { tool, jsonSchema, asSchema, type Tool as AITool } from "ai"
 import z from "zod"
 import { MessageV2 } from "./message-v2"
 import type { SessionID } from "./schema"
-import type { Agent } from "../agent/agent"
+import { Agent } from "../agent/agent"
 import type { Provider } from "../provider"
 import { LLM } from "./llm"
 import { ToolRegistry } from "../tool"
 import { ProviderTransform } from "../provider"
+import { MCP } from "../mcp"
+import { Permission } from "@/permission"
+import { usesGPTToolset } from "@/tool/gpt"
 import type { PromptConfig } from "./session"
 
 /**
@@ -39,9 +42,18 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
    */
   additions: string[]
   prompt?: PromptConfig
+  /**
+   * Session permission ruleset, merged with the agent's own to decide which
+   * MCP tools the wire request drops — the same input `LLM.resolveTools` feeds
+   * to `Agent.runtimePermission` when it prunes the provider tool list. Omitted
+   * (checkpoint capture has no session in scope) means "agent permission only",
+   * which matches the parent whenever the session adds no MCP-scoped deny rule.
+   */
+  sessionPermission?: Permission.Ruleset
 }) {
   const llm = yield* LLM.Service
   const toolRegistry = yield* ToolRegistry.Service
+  const mcp = yield* MCP.Service
 
   // Always use full msgs — slicing is a fork-capture concern that lives at the
   // caller (ForkContext.watermarkMsgID is a boundary marker, not a slice arg).
@@ -85,6 +97,51 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
       description: item.description,
       inputSchema: jsonSchema(schema),
     })
+  }
+
+  // Append MCP tool schemas so the captured prefix carries the same tool set the
+  // parent's real request emits. Before this, MCP was merged ONLY in resolveTools
+  // (the parent path); the prefix here saw built-ins alone, so any MCP server made
+  // ForkContext.tools diverge from the parent on the first turn — breaking the
+  // tool-list prefix cache and stripping MCP from fork:false checkpoint-writer
+  // requests (which send this schema directly).
+  //
+  // The parent's provider-visible MCP set is what the AI SDK actually wires up:
+  // SessionPrompt.resolveTools admits every connected MCP tool into its `tools`
+  // map (prompt.ts:1847) but the SDK's prepareToolsAndToolChoice filters the wire
+  // tools by `activeTools`. So the parity target is exactly "the connected MCP
+  // tools that end up in activeTools":
+  //   - Under the GPT/Codex toolset, MCP tools NEVER enter activeTools — they are
+  //     reached through mcp-tool-search instead (prompt.ts:1705 `&& !useGPTTools`,
+  //     :1918). The parent emits ZERO MCP tool definitions, so the prefix must too:
+  //     skip the whole MCP append.
+  //   - Otherwise MCP tools enter activeTools unless permission-denied or toggled
+  //     off for the turn (user.tools); the agent toolAllowlist does not prune the
+  //     wire set, so it is intentionally not applied here.
+  // MCP.tools() output is TurnContext-independent (context only rides along to the
+  // execute closure for lifecycle notifications), so a minimal session-scoped
+  // context reproduces the parent's schema byte-for-byte.
+  const useGPTTools = usesGPTToolset(input.model.id, lastUser.harness, input.model.api.id, input.model.family)
+  if (!useGPTTools) {
+    const mcpTools = Object.entries(
+      yield* mcp.tools({ sessionId: input.sessionID as string, turnId: lastUser.id, actorId: lastUser.agentID }),
+    ).toSorted(([a], [b]) => a.localeCompare(b))
+    const disabledMcpTools = Permission.disabled(
+      mcpTools.map(([key]) => key),
+      Agent.runtimePermission(input.agent, input.sessionPermission),
+    )
+    for (const [key, item] of mcpTools) {
+      if (!item.execute) continue
+      if (key in tools) continue
+      if (lastUser.tools?.[key] === false) continue
+      if (disabledMcpTools.has(key)) continue
+      const rawSchema = yield* Effect.promise(() => Promise.resolve(asSchema(item.inputSchema).jsonSchema))
+      const schema = ProviderTransform.schema(input.model, rawSchema)
+      tools[key] = tool({
+        description: item.description,
+        inputSchema: jsonSchema(schema),
+      })
+    }
   }
 
   return { system, tools, inheritedMessages }

--- a/packages/opencode/src/session/llm-request-prefix.ts
+++ b/packages/opencode/src/session/llm-request-prefix.ts
@@ -83,7 +83,8 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
     agentID: lastUser.agentID,
   })
 
-  // Resolve tools using parent agent's permission and toolAllowlist
+  // Built-in tool schemas via the parent agent's registry view (its toolAllowlist
+  // and harness gate which built-ins appear here); MCP tools are appended below.
   const toolDefs = yield* toolRegistry.tools({
     modelID: input.model.id,
     providerID: input.model.providerID,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -449,9 +449,11 @@ export const layer = Layer.effect(
           msgs: captureMessages,
           additions,
           prompt: capturePrompt,
+          sessionPermission: captureSession.permission,
         }).pipe(
           Effect.provideService(LLM.Service, llm),
           Effect.provideService(ToolRegistry.Service, registry),
+          Effect.provideService(MCP.Service, mcp),
           Effect.catch(() => Effect.succeed(empty)),
         )
         return { ...prefix, parentPermission: ag.permission }
@@ -4324,8 +4326,11 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
             // intentionally don't use it here — the `tools` variable from `resolveTools`
             // (set earlier via `handle.process({tools: ...})`) carries `execute` closures
             // the AI SDK needs for runtime tool dispatch, while `buildLLMRequestPrefix`
-            // produces schema-only tools. Schema bytes match between both paths (both call
-            // registry.tools with identical args), so prefix cache parity holds.
+            // produces schema-only tools. The two schema sets match because the prefix
+            // builder reproduces the wire tool set exactly: registry built-ins plus every
+            // connected MCP tool, minus the ones permission-denied or toggled off for the
+            // turn (it reads the same session.permission + lastUser.tools the parent uses).
+            // So prefix cache parity holds even when MCP servers are connected.
             // Main runLoop: no watermark — LLM must see the full msgs list,
             // including this turn's intermediate assistant turns (tool reads,
             // task creates, etc.) so each step doesn't replay from the bare
@@ -4339,9 +4344,11 @@ If this task is a simple fix, Q&A, or read-only operation, you can skip this not
                 msgs,
                 additions,
                 prompt: sessionPrompt,
+                sessionPermission: session.permission,
               }).pipe(
                 Effect.provideService(LLM.Service, llm),
                 Effect.provideService(ToolRegistry.Service, registry),
+                Effect.provideService(MCP.Service, mcp),
               )
             lastSystemPrompt = prebuiltSystem
             const cfg = yield* config.get()

--- a/packages/opencode/test/session/llm-request-prefix.test.ts
+++ b/packages/opencode/test/session/llm-request-prefix.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { Layer, ManagedRuntime } from "effect"
+import { Effect, Layer, ManagedRuntime } from "effect"
+import { tool, jsonSchema, type Tool as AITool } from "ai"
 import { Instance } from "../../src/project/instance"
 import { Session as SessionNs } from "../../src/session"
 import { LLM } from "../../src/session/llm"
@@ -8,6 +9,7 @@ import { MessageID, PartID } from "../../src/session/schema"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import { buildLLMRequestPrefix } from "../../src/session/llm-request-prefix"
 import { ToolRegistry } from "../../src/tool"
+import { MCP } from "../../src/mcp"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
 import { ProviderTest } from "../fake/provider"
@@ -15,27 +17,82 @@ import type { Agent } from "../../src/agent/agent"
 
 void Log.init({ print: false })
 
-function makeAgent(): Agent.Info {
+function makeAgent(overrides: Partial<Agent.Info> = {}): Agent.Info {
   return {
     name: "build",
     mode: "primary",
     options: {},
     permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    ...overrides,
   } satisfies Agent.Info
 }
 
-const testLayer = Layer.mergeAll(SessionNs.defaultLayer, LLM.defaultLayer, ToolRegistry.defaultLayer)
+// A stand-in MCP.Service that returns a fixed tool set, mirroring the pattern in
+// prompt-effect.test.ts. `MCP.tools()` output is context-independent, so a fixed
+// map faithfully reproduces what the real service hands resolveTools.
+function mcpLayer(tools: (context?: MCP.TurnContext) => Record<string, AITool> = () => ({})) {
+  return Layer.succeed(
+    MCP.Service,
+    MCP.Service.of({
+      status: () => Effect.succeed({}),
+      clients: () => Effect.succeed({}),
+      tools: (context) => Effect.sync(() => tools(context)),
+      prompts: () => Effect.succeed({}),
+      resources: () => Effect.succeed({}),
+      add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+      connect: () => Effect.void,
+      disconnect: () => Effect.void,
+      getPrompt: () => Effect.succeed(undefined),
+      readResource: () => Effect.succeed(undefined),
+      startAuth: () => Effect.die("unexpected MCP auth"),
+      authenticate: () => Effect.die("unexpected MCP auth"),
+      finishAuth: () => Effect.die("unexpected MCP auth"),
+      removeAuth: () => Effect.void,
+      supportsOAuth: () => Effect.succeed(false),
+      hasStoredTokens: () => Effect.succeed(false),
+      getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+    }),
+  )
+}
+
+function mcpTool(description: string): AITool {
+  // Real MCP tools always carry an execute closure (convertMcpTool); the prefix
+  // builder mirrors resolveTools in skipping non-executable entries, so the
+  // fixture must provide one to reflect a genuine connected server.
+  return tool({
+    description,
+    inputSchema: jsonSchema({ type: "object", properties: {}, additionalProperties: false }),
+    execute: async () => ({ output: "" }),
+  })
+}
+
+// A non-GPT model: GPT-family models route MCP through mcp-tool-search and
+// collapse built-ins behind the `exec` gateway, which is not the case the dump
+// showed (MiMo model listing exa_* tools directly). Use a plain id so the prefix
+// enumerates built-ins and MCP tools the same way the parent request does.
+function nonGptModel() {
+  const id = ModelID.make("mimo-v2.5-pro")
+  return ProviderTest.model({ id, api: { id, url: "https://example.com", npm: "@ai-sdk/openai" } })
+}
+
+function testLayer(mcp = mcpLayer()) {
+  return Layer.mergeAll(SessionNs.defaultLayer, LLM.defaultLayer, ToolRegistry.defaultLayer, mcp)
+}
 
 async function withServices(
   directory: string,
   fn: (
-    rt: ManagedRuntime.ManagedRuntime<SessionNs.Service | LLM.Service | ToolRegistry.Service, never>,
+    rt: ManagedRuntime.ManagedRuntime<
+      SessionNs.Service | LLM.Service | ToolRegistry.Service | MCP.Service,
+      never
+    >,
   ) => Promise<void>,
+  mcp = mcpLayer(),
 ) {
   return Instance.provide({
     directory,
     fn: async () => {
-      const rt = ManagedRuntime.make(testLayer)
+      const rt = ManagedRuntime.make(testLayer(mcp))
       try {
         await fn(rt)
       } finally {
@@ -44,6 +101,41 @@ async function withServices(
       }
     },
   })
+}
+
+async function seedUserMessage(
+  rt: ManagedRuntime.ManagedRuntime<SessionNs.Service, never>,
+  tools: Record<string, boolean> = {},
+) {
+  const session = await rt.runPromise(SessionNs.Service.use((svc) => svc.create({})))
+  const userID = MessageID.ascending()
+  await rt.runPromise(
+    SessionNs.Service.use((svc) =>
+      svc.updateMessage({
+        id: userID,
+        sessionID: session.id,
+        role: "user",
+        time: { created: Date.now() },
+        agent: "build",
+        model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test") },
+        tools,
+        mode: "",
+      } as unknown as MessageV2.Info),
+    ),
+  )
+  await rt.runPromise(
+    SessionNs.Service.use((svc) =>
+      svc.updatePart({
+        id: PartID.ascending(),
+        sessionID: session.id,
+        messageID: userID,
+        type: "text",
+        text: "hello",
+      }),
+    ),
+  )
+  const msgs = await rt.runPromise(SessionNs.Service.use((svc) => svc.messages({ sessionID: session.id })))
+  return { session, msgs }
 }
 
 describe("buildLLMRequestPrefix", () => {
@@ -196,5 +288,125 @@ describe("buildLLMRequestPrefix", () => {
       expect(r2.inheritedMessages.slice(0, r1.inheritedMessages.length)).toEqual(r1.inheritedMessages)
       expect(r3.inheritedMessages.slice(0, r2.inheritedMessages.length)).toEqual(r2.inheritedMessages)
     })
+  })
+
+  test("captured prefix includes connected MCP tools (fork/checkpoint parity with parent)", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const mcp = mcpLayer(() => ({
+      exa_web_search_exa: mcpTool("Search the web"),
+      exa_web_fetch_exa: mcpTool("Fetch a URL"),
+    }))
+    await withServices(
+      tmp.path,
+      async (rt) => {
+        const { session, msgs } = await seedUserMessage(rt)
+        const prefix = await rt.runPromise(
+          buildLLMRequestPrefix({
+            sessionID: session.id,
+            agent: makeAgent(),
+            model: nonGptModel(),
+            msgs,
+            additions: [],
+          }),
+        )
+        // The two MCP tools must be present alongside the built-ins — before the
+        // fix the prefix carried built-ins only, so ForkContext.tools diverged
+        // from the parent's resolveTools() the moment any MCP server existed.
+        expect(Object.keys(prefix.tools)).toContain("exa_web_search_exa")
+        expect(Object.keys(prefix.tools)).toContain("exa_web_fetch_exa")
+        expect(Object.keys(prefix.tools).length).toBeGreaterThan(2)
+      },
+      mcp,
+    )
+  })
+
+  test("captured prefix drops MCP tools denied by the merged permission ruleset", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const mcp = mcpLayer(() => ({
+      exa_web_search_exa: mcpTool("Search the web"),
+      exa_web_fetch_exa: mcpTool("Fetch a URL"),
+    }))
+    await withServices(
+      tmp.path,
+      async (rt) => {
+        const { session, msgs } = await seedUserMessage(rt)
+        const prefix = await rt.runPromise(
+          buildLLMRequestPrefix({
+            sessionID: session.id,
+            agent: makeAgent({
+              permission: [
+                { permission: "*", pattern: "*", action: "allow" },
+                { permission: "exa_web_fetch_exa", pattern: "*", action: "deny" },
+              ],
+            }),
+            model: nonGptModel(),
+            msgs,
+            additions: [],
+          }),
+        )
+        expect(Object.keys(prefix.tools)).toContain("exa_web_search_exa")
+        expect(Object.keys(prefix.tools)).not.toContain("exa_web_fetch_exa")
+      },
+      mcp,
+    )
+  })
+
+  test("captured prefix drops MCP tools toggled off for the turn", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const mcp = mcpLayer(() => ({
+      exa_web_search_exa: mcpTool("Search the web"),
+      exa_web_fetch_exa: mcpTool("Fetch a URL"),
+    }))
+    await withServices(
+      tmp.path,
+      async (rt) => {
+        // The prefix builder reads the per-turn toggle from the last user
+        // message's `tools` map, the same field LLM.resolveTools prunes the
+        // parent's wire set by — so the fork prefix drops it identically.
+        const { session, msgs } = await seedUserMessage(rt, { exa_web_fetch_exa: false })
+        const prefix = await rt.runPromise(
+          buildLLMRequestPrefix({
+            sessionID: session.id,
+            agent: makeAgent(),
+            model: nonGptModel(),
+            msgs,
+            additions: [],
+          }),
+        )
+        expect(Object.keys(prefix.tools)).toContain("exa_web_search_exa")
+        expect(Object.keys(prefix.tools)).not.toContain("exa_web_fetch_exa")
+      },
+      mcp,
+    )
+  })
+
+  test("captured prefix omits MCP tools under the GPT/Codex toolset (parent reaches them via mcp-tool-search, not the wire)", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const mcp = mcpLayer(() => ({
+      exa_web_search_exa: mcpTool("Search the web"),
+      exa_web_fetch_exa: mcpTool("Fetch a URL"),
+    }))
+    await withServices(
+      tmp.path,
+      async (rt) => {
+        const { session, msgs } = await seedUserMessage(rt)
+        const prefix = await rt.runPromise(
+          buildLLMRequestPrefix({
+            sessionID: session.id,
+            agent: makeAgent(),
+            // Default ProviderTest model id is "gpt-5.2" → usesGPTToolset === true.
+            model: ProviderTest.model(),
+            msgs,
+            additions: [],
+          }),
+        )
+        // Under the GPT toolset MCP tools never enter activeTools (they go through
+        // mcp-tool-search), so the parent emits zero MCP definitions on the wire.
+        // The prefix must match — listing them here would re-break cache parity.
+        expect(Object.keys(prefix.tools)).not.toContain("exa_web_search_exa")
+        expect(Object.keys(prefix.tools)).not.toContain("exa_web_fetch_exa")
+      },
+      mcp,
+    )
   })
 })


### PR DESCRIPTION
## Summary

`buildLLMRequestPrefix` (the single source that builds a fork's — and a `fork:false` checkpoint-writer's — LLM request prefix) assembled its tool set from **registry built-ins only**, while the parent's real request merges MCP tools in `SessionPrompt.resolveTools`. So the moment any MCP server is configured, `ForkContext.tools` diverged from the parent on the **first turn**:

- The tool-list prefix cache misses immediately (the tools array differs).
- A `fork:false` checkpoint-writer sends this schema directly, so it runs **without the MCP tools** the parent has.

The `ForkContext.tools` JSDoc even documented the (wrong) assumption behind this — "both paths call `registry.tools` … so schema parity holds" — which silently omitted MCP.

This was surfaced by dumping a checkpoint-writer request vs. the equivalent non-checkpointed request: the rebuilt request was missing the two `exa_*` MCP tools that the parent carried.

## What changed

`buildLLMRequestPrefix` now reproduces the parent's **provider-visible** MCP set, matching both toolset modes:

- **Non-GPT toolset** — append every connected, executable, non-name-clashing MCP tool, minus those the merged session/agent permission denies or the turn toggles off (`user.tools`). The agent `toolAllowlist` does **not** prune the wire set, so it is deliberately not applied.
- **GPT/Codex toolset** — MCP tools never enter `activeTools` (they are reached through `mcp-tool-search`), so the parent emits **zero** MCP definitions on the wire; the prefix skips the MCP append entirely to match.

The per-turn toggle is read from the last user message's `tools` map — the same input `LLM.resolveTools` uses — so the parent runLoop and the checkpoint-capture closure share one source and cannot drift.

Also corrects the `ForkContext.tools` JSDoc (`spawn.ts`) and the parent runLoop comment (`prompt.ts`) to describe the real two-layer wire tool set (`SessionPrompt.resolveTools` admits all connected MCP → the AI SDK filters by `activeTools`) instead of the old "both call registry.tools" claim.

## Why the two-mode split

The wire tool set the AI SDK sends is `tools` filtered by `activeTools` (`prepareToolsAndToolChoice`). `SessionPrompt.resolveTools` puts every connected MCP tool into the `tools` map (`prompt.ts:1847`), but under the GPT toolset those tools never join `activeTools` (`prompt.ts:1705` `&& !useGPTTools`, `:1918`), so the parent emits none. Listing them in the prefix would re-break parity — hence the `usesGPTToolset` guard.

## Verification

- `bun typecheck` (packages/opencode) — **0 errors**.
- `bun test test/session/llm-request-prefix.test.ts` — **4 pass, 2 skip, 0 fail**. New tests: MCP tools included (non-GPT), permission-deny excluded, per-turn toggle excluded, GPT/Codex toolset omits MCP.
- `bun test test/session/checkpoint-fork-mode.test.ts test/agent/agent.test.ts test/session/replace-agent-subagent.test.ts test/inbox/fork-agent-compat.test.ts` — **all pass**, no regressions.
- Note: `test/session/auto-overflow-writer-first.test.ts "rebuilt exactly once"` fails on `origin/main` unmodified (verified via `git stash`); it is a pre-existing baseline failure being fixed separately and is unrelated to this change.
