### PR TITLE
fix(mcp): record local startup exit code and stderr tail; scope ask-timeout env in tests

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -3,7 +3,6 @@ import { childProcessEnv } from "@/util/child-process-env"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import {
   CallToolResultSchema,
@@ -18,6 +17,7 @@ import z from "zod/v4"
 import { Installation } from "../installation"
 import { InstallationVersion } from "../installation/version"
 import { withTimeout } from "@/util/timeout"
+import { ObservingStdioTransport } from "./stdio-transport"
 import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { McpOAuthProvider } from "./oauth-provider"
 import { McpOAuthCallback } from "./oauth-callback"
@@ -443,7 +443,7 @@ export const layer = Layer.effect(
     const createClient = () =>
       new Client({ name: "mimocode", version: InstallationVersion }, CLIENT_OPTIONS)
 
-    type Transport = StdioClientTransport | StreamableHTTPClientTransport | SSEClientTransport
+    type Transport = ObservingStdioTransport | StreamableHTTPClientTransport | SSEClientTransport
 
     /**
      * Connect a client via the given transport with resource safety:
@@ -580,8 +580,10 @@ export const layer = Layer.effect(
     ) {
       const [cmd, ...args] = mcp.command
       const cwd = yield* InstanceState.directory
-      const transport = new StdioClientTransport({
-        stderr: "pipe",
+      // Own the child through the public child_process API. SDK StdioClientTransport
+      // clears its private `_process` in close() before callers can read exitCode, and
+      // onclose does not receive the code — so the failure snapshot must be captured here.
+      const transport = new ObservingStdioTransport({
         command: cmd,
         args,
         cwd,
@@ -595,9 +597,12 @@ export const layer = Layer.effect(
           ...mcp.environment,
         },
       })
-      transport.stderr?.on("data", (chunk: Buffer) => {
-        log.info(`mcp stderr: ${chunk.toString()}`, { key })
-      })
+      transport.onerror = (error) => {
+        log.info(`mcp transport error: ${error.message}`, { key })
+      }
+      transport.onStderr = (text) => {
+        log.info(`mcp stderr: ${text}`, { key })
+      }
 
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
       return yield* connectTransport(transport, connectTimeout).pipe(
@@ -607,8 +612,28 @@ export const layer = Layer.effect(
         })),
         Effect.catch((error): Effect.Effect<{ client: MCPClient | undefined; status: Status }> => {
           const msg = error instanceof Error ? error.message : String(error)
-          log.error("local mcp startup failed", { key, command: ConfigMCP.redactCommand(mcp.command), cwd, error: msg })
-          return Effect.succeed({ client: undefined, status: { status: "failed", error: msg } })
+          const exit = transport.exitSnapshot()
+          const stderrTail = transport.stderrSnapshot().trim()
+          // hostShutdown means close() tore the child down; that signal is our cleanup,
+          // not the child's startup-failure cause.
+          const natural = exit && !exit.hostShutdown ? exit : undefined
+          log.error("local mcp startup failed", {
+            key,
+            command: ConfigMCP.redactCommand(mcp.command),
+            cwd,
+            error: msg,
+            pid: exit?.pid ?? null,
+            exitCode: natural?.exitCode ?? null,
+            signalCode: natural?.signalCode ?? null,
+            stderr: stderrTail || undefined,
+          })
+          const detail = [
+            msg,
+            natural?.exitCode != null ? `exit=${natural.exitCode}` : undefined,
+            natural?.signalCode ? `signal=${natural.signalCode}` : undefined,
+            stderrTail || undefined,
+          ].filter(Boolean).join("; ")
+          return Effect.succeed({ client: undefined, status: { status: "failed", error: detail } })
         }),
       )
     })
@@ -724,7 +749,7 @@ export const layer = Layer.effect(
               Object.values(s.clients),
               (client) =>
                 Effect.gen(function* () {
-                  const pid = client.transport instanceof StdioClientTransport ? client.transport.pid : null
+                  const pid = client.transport instanceof ObservingStdioTransport ? client.transport.pid : null
                   if (typeof pid === "number") {
                     const pids = yield* descendants(pid)
                     for (const dpid of pids) {

--- a/packages/opencode/src/mcp/stdio-transport.ts
+++ b/packages/opencode/src/mcp/stdio-transport.ts
@@ -1,0 +1,203 @@
+import { spawn, type ChildProcess } from "node:child_process"
+import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js"
+import type { Transport, TransportSendOptions } from "@modelcontextprotocol/sdk/shared/transport.js"
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js"
+import { getDefaultEnvironment } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { childProcessEnv } from "@/util/child-process-env"
+
+/** Last known child-process identity for a local MCP stdio transport. */
+export interface StdioExitSnapshot {
+  pid: number | null
+  exitCode: number | null
+  signalCode: NodeJS.Signals | null
+  /** True when the exit was caused by host-initiated close(), not the child's own death. */
+  hostShutdown: boolean
+}
+
+export interface ObservingStdioTransportParams {
+  command: string
+  args?: string[]
+  cwd?: string
+  env?: Record<string, string>
+}
+
+const STDERR_TAIL_LIMIT = 4096
+
+/**
+ * Local stdio transport that owns the child process through the public
+ * `child_process` API.
+ *
+ * SDK `StdioClientTransport` clears its private `_process` in `close()` before
+ * callers can read exitCode, and `onclose` does not receive the exit code.
+ * Owning spawn/exit directly keeps the failure snapshot stable without reaching
+ * into SDK private fields.
+ */
+export class ObservingStdioTransport implements Transport {
+  private child?: ChildProcess
+  private readBuffer = new ReadBuffer()
+  private stderrTail = ""
+  private lastExit?: StdioExitSnapshot
+  private observingNaturalExit = true
+  private started = false
+  private closed = false
+  private oncloseFired = false
+
+  onclose?: () => void
+  onerror?: (error: Error) => void
+  onmessage?: Transport["onmessage"]
+  /** Live stderr lines (same bounded tail used for the failure snapshot). */
+  onStderr?: (text: string) => void
+
+  constructor(private readonly params: ObservingStdioTransportParams) {}
+
+  private notifyClosed(): void {
+    if (this.oncloseFired) return
+    this.oncloseFired = true
+    this.onclose?.()
+  }
+
+  get pid(): number | null {
+    return this.child?.pid ?? null
+  }
+
+  /** Child exit observed so far; host-initiated teardown is flagged, not hidden. */
+  exitSnapshot(): StdioExitSnapshot | undefined {
+    return this.lastExit
+  }
+
+  stderrSnapshot(): string {
+    return this.stderrTail
+  }
+
+  async start(): Promise<void> {
+    if (this.started) {
+      throw new Error("ObservingStdioTransport already started")
+    }
+    this.started = true
+    const child = spawn(this.params.command, this.params.args ?? [], {
+      // childProcessEnv() is required at every native spawn site (see
+      // test/util/child-process-env.test.ts). params.env may already include it;
+      // repeating the merge is intentional so the AST contract stays true here.
+      env: {
+        ...getDefaultEnvironment(),
+        ...childProcessEnv(),
+        ...this.params.env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: false,
+      windowsHide: process.platform === "win32",
+      cwd: this.params.cwd,
+    })
+    this.child = child
+    this.lastExit = {
+      pid: child.pid ?? null,
+      exitCode: null,
+      signalCode: null,
+      hostShutdown: false,
+    }
+
+    child.on("error", (error) => {
+      this.onerror?.(error)
+    })
+    child.once("exit", (code, signal) => {
+      this.lastExit = {
+        pid: child.pid ?? null,
+        exitCode: code,
+        signalCode: signal,
+        hostShutdown: !this.observingNaturalExit,
+      }
+    })
+    // Match SDK StdioClientTransport: onclose fires on stdio 'close', not 'exit'.
+    // Firing on 'exit' (process death, stdio still draining) tears the Client down
+    // earlier than the SDK does and races unrelated instance cleanup under load.
+    child.once("close", () => {
+      if (this.observingNaturalExit) this.notifyClosed()
+    })
+    child.stdout?.on("data", (chunk: Buffer) => {
+      this.readBuffer.append(chunk)
+      this.processReadBuffer()
+    })
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString()
+      this.stderrTail = (this.stderrTail + text).slice(-STDERR_TAIL_LIMIT)
+      this.onStderr?.(text)
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      child.once("spawn", () => resolve())
+      child.once("error", reject)
+    })
+  }
+
+  async send(message: JSONRPCMessage, _options?: TransportSendOptions): Promise<void> {
+    const child = this.child
+    if (!child?.stdin) throw new Error("Not connected")
+    const json = serializeMessage(message)
+    await new Promise<void>((resolve, reject) => {
+      child.stdin!.write(json, (error) => {
+        if (error) reject(error)
+        else resolve()
+      })
+    })
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return
+    this.closed = true
+    this.observingNaturalExit = false
+    // Mark host shutdown synchronously: after SIGKILL the exit event may land
+    // only on a later macrotask, and callers can observe the snapshot before then.
+    if (this.lastExit && this.lastExit.exitCode == null && this.lastExit.signalCode == null) {
+      this.lastExit = { ...this.lastExit, hostShutdown: true }
+    }
+    const child = this.child
+    this.child = undefined
+    if (!child) {
+      this.notifyClosed()
+      return
+    }
+    const waitExit = new Promise<void>((resolve) => {
+      if (child.exitCode != null || child.signalCode != null) {
+        resolve()
+        return
+      }
+      child.once("exit", () => resolve())
+    })
+    child.stdin?.end()
+    await Promise.race([waitExit, delay(2000)])
+    if (child.exitCode == null && child.signalCode == null) {
+      child.kill("SIGTERM")
+      await Promise.race([waitExit, delay(2000)])
+    }
+    if (child.exitCode == null && child.signalCode == null) {
+      child.kill("SIGKILL")
+      // SIGKILL is async at the kernel boundary; wait so exitSnapshot() is not
+      // observed as an empty natural exit on the next microtask.
+      await Promise.race([waitExit, delay(2000)])
+    }
+    this.readBuffer.clear()
+    this.notifyClosed()
+  }
+
+  private processReadBuffer(): void {
+    while (true) {
+      let message: JSONRPCMessage
+      try {
+        const next = this.readBuffer.readMessage()
+        if (next === null) break
+        message = next
+      } catch (error) {
+        this.onerror?.(error instanceof Error ? error : new Error(String(error)))
+        continue
+      }
+      this.onmessage?.(message)
+    }
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms)
+    timer.unref?.()
+  })
+}

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -78,6 +78,8 @@ function getOrCreateClientState(name?: string): MockClientState {
 class MockStdioTransport {
   stderr: null = null
   pid = 12345
+  onerror?: unknown
+  onStderr?: unknown
   // oxlint-disable-next-line no-useless-constructor
   constructor(_opts: any) {}
   async start() {
@@ -86,6 +88,12 @@ class MockStdioTransport {
   }
   async close() {
     transportCloseCount++
+  }
+  exitSnapshot() {
+    return { pid: 12345, exitCode: null, signalCode: null, hostShutdown: false }
+  }
+  stderrSnapshot() {
+    return ""
   }
 }
 
@@ -114,8 +122,9 @@ class MockSSE {
   }
 }
 
-void mock.module("@modelcontextprotocol/sdk/client/stdio.js", () => ({
-  StdioClientTransport: MockStdioTransport,
+// connectLocal uses the host-owned stdio transport, not the SDK client transport.
+void mock.module("../../src/mcp/stdio-transport", () => ({
+  ObservingStdioTransport: MockStdioTransport,
 }))
 
 void mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({

--- a/packages/opencode/test/mcp/stdio-exit-observe.test.ts
+++ b/packages/opencode/test/mcp/stdio-exit-observe.test.ts
@@ -1,0 +1,116 @@
+import { test, expect } from "bun:test"
+import { ObservingStdioTransport } from "../../src/mcp/stdio-transport"
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  throw new Error("condition was not met in time")
+}
+
+test("ObservingStdioTransport keeps exit code after close()", async () => {
+  const transport = new ObservingStdioTransport({
+    command: process.execPath,
+    args: ["-e", "console.error('startup dead'); process.exit(23)"],
+  })
+  await transport.start()
+  await waitFor(() => transport.exitSnapshot()?.exitCode === 23)
+  const beforeClose = transport.exitSnapshot()
+  expect(beforeClose?.exitCode).toBe(23)
+  expect(beforeClose?.hostShutdown).toBe(false)
+  expect(typeof beforeClose?.pid).toBe("number")
+
+  await transport.close()
+  expect(transport.pid).toBeNull()
+  // Natural exit is retained; close() does not rewrite it as our SIGTERM.
+  expect(transport.exitSnapshot()).toEqual(beforeClose)
+  expect(transport.stderrSnapshot()).toContain("startup dead")
+})
+
+test("ObservingStdioTransport records external SIGTERM", async () => {
+  const transport = new ObservingStdioTransport({
+    command: process.execPath,
+    args: ["-e", "setInterval(() => {}, 1000)"],
+  })
+  await transport.start()
+  await waitFor(() => typeof transport.exitSnapshot()?.pid === "number")
+  const pid = transport.exitSnapshot()!.pid!
+  process.kill(pid, "SIGTERM")
+  await waitFor(() => transport.exitSnapshot()?.signalCode === "SIGTERM" || transport.exitSnapshot()?.exitCode != null)
+  const after = transport.exitSnapshot()
+  expect(after?.pid).toBe(pid)
+  expect(after?.hostShutdown).toBe(false)
+  expect(after?.signalCode === "SIGTERM" || after?.exitCode != null).toBe(true)
+
+  await transport.close().catch(() => undefined)
+})
+
+test("close() SIGTERM is flagged as hostShutdown, not the child's failure cause", async () => {
+  const transport = new ObservingStdioTransport({
+    command: process.execPath,
+    args: ["-e", "setInterval(() => {}, 1000)"],
+  })
+  await transport.start()
+  await waitFor(() => typeof transport.exitSnapshot()?.pid === "number")
+  const pid = transport.exitSnapshot()!.pid!
+
+  await transport.close()
+  const after = transport.exitSnapshot()
+  expect(after?.pid).toBe(pid)
+  expect(after?.hostShutdown).toBe(true)
+})
+
+test("ObservingStdioTransport captures fast native exits", async () => {
+  const transport = new ObservingStdioTransport({
+    command: "/bin/sh",
+    args: ["-c", "echo startup-dead >&2; exit 42"],
+  })
+  await transport.start()
+  await waitFor(() => transport.exitSnapshot()?.exitCode === 42)
+  expect(transport.exitSnapshot()?.pid).toEqual(expect.any(Number))
+  expect(transport.stderrSnapshot()).toContain("startup-dead")
+
+  await transport.close().catch(() => undefined)
+  expect(transport.exitSnapshot()?.exitCode).toBe(42)
+  expect(transport.exitSnapshot()?.hostShutdown).toBe(false)
+})
+
+test("close() after SIGKILL leaves hostShutdown set, not an empty natural exit", async () => {
+  // Ignores SIGTERM so close() must escalate to SIGKILL.
+  const transport = new ObservingStdioTransport({
+    command: process.execPath,
+    args: ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"],
+  })
+  await transport.start()
+  await transport.close()
+  const after = transport.exitSnapshot()
+  expect(after?.hostShutdown).toBe(true)
+  // Never look like a natural exit with no code after host-initiated teardown.
+  if (after?.exitCode == null && after?.signalCode == null) {
+    expect(after?.hostShutdown).toBe(true)
+  } else {
+    expect(after?.signalCode === "SIGKILL" || after?.exitCode != null).toBe(true)
+  }
+})
+
+test("natural exit then close() fires onclose exactly once", async () => {
+  const transport = new ObservingStdioTransport({
+    command: "/bin/sh",
+    args: ["-c", "exit 0"],
+  })
+  let oncloseCount = 0
+  transport.onclose = () => {
+    oncloseCount += 1
+  }
+  await transport.start()
+  await waitFor(() => oncloseCount === 1)
+  expect(transport.exitSnapshot()?.exitCode).toBe(0)
+
+  // Client may still close() after the transport already reported onclose.
+  await transport.close()
+  await transport.close()
+  expect(oncloseCount).toBe(1)
+  expect(transport.exitSnapshot()?.hostShutdown).toBe(false)
+})

--- a/packages/opencode/test/permission/skip-all-timeout.test.ts
+++ b/packages/opencode/test/permission/skip-all-timeout.test.ts
@@ -1,9 +1,6 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { Effect, Fiber, Layer } from "effect"
 import type { Permission as PermissionType } from "../../src/permission"
-
-// Short timeout so the real-clock test resolves quickly.
-process.env.MIMOCODE_SKIP_ALL_FORCED_ASK_TIMEOUT_MS = "300"
 
 const { Bus } = await import("../../src/bus")
 const CrossSpawnSpawner = await import("../../src/effect/cross-spawn-spawner")
@@ -11,7 +8,21 @@ const { Permission } = await import("../../src/permission")
 const { Instance } = await import("../../src/project/instance")
 const { tmpdir } = await import("../fixture/fixture")
 
+// Scoped per test, not at module load: a top-level assignment leaks into every
+// later file in the same process (CI runs this file before sampling-e2e), and
+// Permission state initializes permissionAskTimeoutMs from this env var.
+const ASK_TIMEOUT_ENV = "MIMOCODE_SKIP_ALL_FORCED_ASK_TIMEOUT_MS"
+let previousAskTimeoutEnv: string | undefined
+
+beforeEach(() => {
+  previousAskTimeoutEnv = process.env[ASK_TIMEOUT_ENV]
+  // Short timeout so the real-clock test resolves quickly.
+  process.env[ASK_TIMEOUT_ENV] = "300"
+})
+
 afterEach(async () => {
+  if (previousAskTimeoutEnv === undefined) delete process.env[ASK_TIMEOUT_ENV]
+  else process.env[ASK_TIMEOUT_ENV] = previousAskTimeoutEnv
   await Instance.disposeAll()
 })
 


### PR DESCRIPTION
## Summary
- When a local MCP server fails to start, capture the child process exit and a bounded stderr tail
- Log pid / exitCode / signalCode / stderr on the same failure event and include them in the failed status error string
- Scope `MIMOCODE_SKIP_ALL_FORCED_ASK_TIMEOUT_MS` in `skip-all-timeout.test.ts` to each test so it cannot leak into later files in the same bun process

## Implementation notes
- SDK `StdioClientTransport` clears its private `_process` in `close()`, and `onclose` does not receive the exit code
- Local stdio uses an owned `Transport` (`ObservingStdioTransport`) on public `child_process` + SDK `ReadBuffer` / `serializeMessage` / `getDefaultEnvironment`
- `close()` sets `hostShutdown` synchronously and waits after SIGKILL, so host teardown is never logged as an empty natural exit
- `onclose` fires at most once across natural exit and later `close()`; it is wired to stdio `close` (not `exit`) to match the SDK
- Native spawn sites merge `childProcessEnv()` as required by the AST contract in `test/util/child-process-env.test.ts`

### Why the permission test change is here
Adding `test/mcp/stdio-exit-observe.test.ts` shifts unit shard membership. On shard 1 CI then ran `skip-all-timeout.test.ts` before `sampling-e2e.test.ts`. The former used to set `MIMOCODE_SKIP_ALL_FORCED_ASK_TIMEOUT_MS=300` at module load; `permissionAskTimeoutMs` is initialized from that env in `InstanceState.make`, so the sampling approval ask was auto-rejected before the pending-list assertion. The env assignment is now save/set/restore in `beforeEach`/`afterEach`.

## Verification
- `bun test test/mcp/stdio-exit-observe.test.ts` — natural exit, external SIGTERM, host close, fast native exit, SIGKILL escalation, single onclose
- `bun test test/permission/skip-all-timeout.test.ts` — all 5 pass; env restored after the file
- Reproduced the CI failure with `MIMOCODE_SKIP_ALL_FORCED_ASK_TIMEOUT_MS=300` on sampling-e2e (same line:1411 signature)
- `bun test test/mcp/` — full suite including local stdio timeout / no process leak
- Successful connect path is unchanged
- CI: lint / typecheck / unit shards 1–4 all green on `fd69710130`