### PR TITLE
fix(permission): same-session subagents inherit parent grants

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,15 +37,49 @@ jobs:
       # runtime-worktree.test.ts excluded from shards: its deadline-fired test
       # deadlocks when run after other tests (QuickJS WASM state leak).
       # It runs separately below in an isolated process.
+      #
+      # stdio-exit-observe.test.ts excluded from shards: it needs the real
+      # ObservingStdioTransport. lifecycle.test.ts mock.module's that path
+      # process-wide, so sharing a bun test process with it always breaks
+      # these tests. Same isolation pattern as runtime-worktree.
+      #
+      # Sharding is path-hash, NOT list position: `NR % n` on the sorted file
+      # list reassigns every later file when one is added/removed, which
+      # reshuffles process-wide mocks and breaks order-sensitive tests
+      # (e.g. mcp/sampling-e2e). hash(path) % n keeps each file's shard
+      # independent of its neighbors.
+      #
+      # Scope: this stabilizes shard membership and isolates the one pair that
+      # actually broke. It is NOT a general mock.module isolation scheme —
+      # other files that mock.module still share a bun test process with their
+      # shard neighbors. If a new mock lands on the same hash bucket as a test
+      # that needs the real implementation, isolate that file the same way as
+      # runtime-worktree / stdio-exit-observe rather than assuming hash-sharding
+      # alone is enough.
       - name: Run unit tests (shard ${{ matrix.shard }})
         timeout-minutes: 8
         working-directory: packages/opencode
         run: |
-          find test -name '*.test.ts' ! -name 'runtime-worktree.test.ts' | sort > /tmp/test-files.txt
           shard=${{ matrix.shard }}
           idx=${shard%/*}
           n=${shard#*/}
-          files=$(awk -v i="$idx" -v n="$n" 'NR % n == i - 1' /tmp/test-files.txt)
+          files=$(while IFS= read -r f; do
+            h=$(printf '%s' "$f" | cksum | awk '{print $1}')
+            if [ $((h % n)) -eq $((idx - 1)) ]; then
+              printf '%s\n' "$f"
+            fi
+          done < <(find test -name '*.test.ts' \
+            ! -name 'runtime-worktree.test.ts' \
+            ! -name 'stdio-exit-observe.test.ts' | sort))
+          # Empty shard: `bun test` with no file args discovers everything,
+          # including the excluded isolation files. Skip instead of running
+          # the whole suite in this leg.
+          if [ -z "${files//[[:space:]]/}" ]; then
+            echo "shard $shard is empty, skipping"
+            mkdir -p .artifacts/unit
+            printf '<?xml version="1.0" encoding="UTF-8"?><testsuites/>\n' > .artifacts/unit/junit.xml
+            exit 0
+          fi
           mkdir -p .artifacts/unit
           bun test $files --timeout 120000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml
 
@@ -62,3 +96,11 @@ jobs:
         timeout-minutes: 3
         working-directory: packages/opencode
         run: bun test test/workflow/runtime-worktree.test.ts -t 'deadline-fired' --timeout 120000
+
+      # Run stdio-exit-observe in isolation (shard 4/4 only): needs the real
+      # ObservingStdioTransport, which lifecycle.test.ts mock.module's away.
+      - name: Run stdio-exit-observe test (isolated)
+        if: matrix.shard == '4/4'
+        timeout-minutes: 2
+        working-directory: packages/opencode
+        run: bun test test/mcp/stdio-exit-observe.test.ts --timeout 120000

--- a/packages/opencode/src/agent/config.ts
+++ b/packages/opencode/src/agent/config.ts
@@ -45,16 +45,22 @@ export function resolveInvalidOutputPolicy(input: {
  *  - system agent -> non-interactive (auto-deny, no human to answer)
  *  - orchestrator peer (background + mode:peer + has a parent) -> forward the ask
  *    for approval (interactive, with the parent session as approval route)
- *  - other background WITH a parent (e.g. actor run/spawn subagents) ->
- *    non-interactive but INHERIT: reuse the parent session's already-held grants
- *    (auto-allow granted paths, fail-closed on ungranted ones — never hang)
- *  - background without a parent -> non-interactive (auto-deny)
+ *  - other background WITH a parent session id (child-session peers, or
+ *    same-session actor subagents via sessionID) -> non-interactive but INHERIT:
+ *    reuse the parent session's already-held grants (auto-allow granted paths,
+ *    fail-closed on ungranted ones — never hang)
+ *  - background with neither sessionParentID nor (for mode:subagent) sessionID
+ *    -> non-interactive (auto-deny)
  *  - normal foreground -> interactive
  *  Pure function so the gate is unit-testable without a full prompt turn.
  */
 export function decideAskRouting(input: {
   askActor?: { agent: string; background: boolean; mode: string; parentActorID?: string }
   sessionParentID?: string
+  /** Current session id. Same-session actor subagents share the parent session
+   *  (sessionParentID is empty on a root session); their grants are published
+   *  under this id, so it is the inherit parent for that case. */
+  sessionID?: string
   agentName: string
   // When false, orchestrator-peer forwarding is disabled (feature flag off) and
   // a peer falls back to the background auto-deny path.
@@ -72,12 +78,29 @@ export function decideAskRouting(input: {
   if (isOrchestratorPeer && input.sessionParentID) {
     return { interactive: true, forward: { parentSessionID: input.sessionParentID } }
   }
-  // Ordinary background subagent that has a parent session: don't fail closed
-  // outright — let it inherit the permissions the parent already holds a grant
-  // for. Still non-interactive (no human attached); the ask consults the parent
-  // snapshot and auto-allows only genuinely-granted paths, else fails closed.
-  if (input.askActor?.background && input.sessionParentID) {
-    return { interactive: false, inherit: { parentSessionID: input.sessionParentID } }
+  // Ordinary background subagent: don't fail closed outright — let it inherit
+  // the permissions the parent already holds a grant for. Still non-interactive
+  // (no human attached); the ask consults the parent snapshot and auto-allows
+  // only genuinely-granted paths, else fails closed.
+  //
+  // Inherit parent resolution:
+  // - child-session peer (orchestrator worker): session.parentID points at the
+  //   orchestrator session that published the grants.
+  // - same-session actor spawn/run subagent: they share the parent session, so
+  //   session.parentID is empty on a root session. Grants were published under
+  //   the current session id — use that. Without this, same-session actor
+  //   subagents silently skipped inherit and only skip-all could save them.
+  //
+  // sessionID fallback is subagent-only on purpose: a peer without
+  // sessionParentID is a broken registration (its parent is the orchestrator
+  // session). Looking up the peer's own session as "parent" would silently
+  // broaden that edge; keep it fail-closed.
+  if (input.askActor?.background) {
+    const inheritParent = input.sessionParentID
+      ?? (input.askActor.mode === "subagent" ? input.sessionID : undefined)
+    if (inheritParent) {
+      return { interactive: false, inherit: { parentSessionID: inheritParent } }
+    }
   }
   return { interactive: !input.askActor?.background }
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1520,6 +1520,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
           : undefined,
         sessionParentID: input.session.parentID,
+        sessionID: input.session.id,
         agentName: input.agent.name,
         orchestratorEnabled: Flag.MIMOCODE_EXPERIMENTAL_ORCHESTRATOR,
       })

--- a/packages/opencode/test/agent/ask-routing.test.ts
+++ b/packages/opencode/test/agent/ask-routing.test.ts
@@ -49,10 +49,11 @@ describe("decideAskRouting", () => {
     expect(r.forward).toEqual({ parentSessionID: "ses_orchestrator" })
   })
 
-  test("background subagent WITH parent (mode:subagent) -> non-interactive + inherit", () => {
+  test("background subagent WITH parent (mode:subagent) -> non-interactive + inherit parent session", () => {
     const r = decideAskRouting({
       askActor: { agent: "general", background: true, mode: "subagent" },
       sessionParentID: "ses_parent",
+      sessionID: "ses_child",
       agentName: "general",
     })
     expect(r.interactive).toBe(false)
@@ -60,7 +61,21 @@ describe("decideAskRouting", () => {
     expect(r.inherit).toEqual({ parentSessionID: "ses_parent" })
   })
 
-  test("background subagent WITHOUT parent -> non-interactive, no inherit (auto-deny)", () => {
+  test("same-session background subagent (root session, no parentID) -> inherit current session", () => {
+    // Actor spawn/run subagents share the parent session. Grants are
+    // published under the current session id, not session.parentID.
+    const r = decideAskRouting({
+      askActor: { agent: "general", background: true, mode: "subagent" },
+      sessionParentID: undefined,
+      sessionID: "ses_main",
+      agentName: "general",
+    })
+    expect(r.interactive).toBe(false)
+    expect(r.forward).toBeUndefined()
+    expect(r.inherit).toEqual({ parentSessionID: "ses_main" })
+  })
+
+  test("background subagent with neither parent id nor sessionID -> non-interactive, no inherit (auto-deny)", () => {
     const r = decideAskRouting({
       askActor: { agent: "general", background: true, mode: "subagent" },
       sessionParentID: undefined,
@@ -77,14 +92,17 @@ describe("decideAskRouting", () => {
     expect(r.forward).toBeUndefined()
   })
 
-  test("peer WITHOUT a parent -> not forwarded (falls to background auto-deny)", () => {
+  test("peer WITHOUT a parent session -> not forwarded (falls to background auto-deny)", () => {
     const r = decideAskRouting({
       askActor: { agent: "build", background: true, mode: "peer" },
       sessionParentID: undefined,
+      sessionID: "ses_peer",
       agentName: "build",
     })
     expect(r.interactive).toBe(false)
     expect(r.forward).toBeUndefined()
+    // sessionID fallback is subagent-only; a peer must not inherit its own session.
+    expect(r.inherit).toBeUndefined()
   })
 
   test("orchestrator disabled (flag off) -> peer does NOT forward, auto-denies", () => {

--- a/packages/opencode/test/permission/inherit.test.ts
+++ b/packages/opencode/test/permission/inherit.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect } from "bun:test"
-import { Effect, Layer } from "effect"
+import { Effect, Fiber, Layer } from "effect"
 import { Bus } from "../../src/bus"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { Permission } from "../../src/permission"
@@ -85,6 +85,53 @@ describe("Permission.ask parent-grant inheritance", () => {
         expect(asked).toBe(0)
         expect((yield* perm.list()).length).toBe(0)
       }),
+    ),
+  )
+
+  it.live(
+    "same-session actor subagent inherits parent always-grant",
+    provideTmpdirInstance(() =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const perm = yield* Permission.Service
+          // Parent asks and the user replies always — writes instance approved and
+          // refreshes the parent-grant snapshot under the shared session id.
+          const fiber = yield* perm
+            .ask({
+              permission: "bash" as never,
+              patterns: ["git status"],
+              always: ["git status"],
+              metadata: {},
+              sessionID: "ses_main" as never,
+              ruleset: [],
+              tool: { messageID: "msg_p" as never, callID: "call_p" },
+            })
+            .pipe(Effect.forkScoped)
+          while ((yield* perm.list()).length === 0) {
+            yield* Effect.promise(() => Bun.sleep(10))
+          }
+          const [pending] = yield* perm.list()
+          yield* perm.reply({ requestID: pending.id, reply: "always" })
+          yield* Fiber.await(fiber)
+
+          // Same-session subagent: decideAskRouting inherits under the shared
+          // session id. Still non-interactive; the always-grant auto-allows.
+          const result = yield* perm
+            .ask({
+              permission: "bash" as never,
+              patterns: ["git status"],
+              always: ["*"],
+              metadata: {},
+              sessionID: "ses_main" as never,
+              ruleset: [],
+              tool: { messageID: "msg_c" as never, callID: "call_c" },
+              interactive: false,
+              inherit: { parentSessionID: "ses_main" },
+            })
+            .pipe(Effect.exit)
+          expect(result._tag).toBe("Success")
+        }),
+      ),
     ),
   )
 
@@ -220,6 +267,117 @@ describe("Permission.ask explicit grant-approval reaches a background subagent",
           .ask(childAsk(["rm -rf /"], { permission: "bash_delete" as never }))
           .pipe(Effect.exit)
         expect(result._tag).toBe("Failure")
+      }),
+    ),
+  )
+})
+
+/**
+ * Background subagent ask shape after decideAskRouting:
+ * interactive:false, inherit: { parentSessionID: current session } when the
+ * actor row is a background subagent with a session id.
+ */
+function subagentAsk(extra?: Partial<Parameters<Permission.Interface["ask"]>[0]>) {
+  return {
+    permission: "bash" as never,
+    patterns: ["wc -l /tmp/foo"],
+    always: ["*"],
+    metadata: {},
+    sessionID: "ses_main" as never,
+    ruleset: [],
+    tool: { messageID: "msg_a" as never, callID: "call_a" },
+    interactive: false as boolean,
+    inherit: { parentSessionID: "ses_main" },
+    ...extra,
+  }
+}
+
+describe("skip-all inheritance for background subagents", () => {
+  it.live(
+    "skipAll=true + production inherit shape → auto-allow, no human ask",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        yield* perm.setSkipAll(true)
+        let asked = 0
+        const unsub = Bus.subscribe(Permission.Event.Asked, () => {
+          asked += 1
+        })
+        // Production routing always attaches inherit. skip-all must still win
+        // even when the parent snapshot has no matching allow.
+        const result = yield* perm.ask(subagentAsk()).pipe(Effect.exit)
+        unsub()
+        expect(result._tag).toBe("Success")
+        expect(asked).toBe(0)
+        expect((yield* perm.list()).length).toBe(0)
+      }),
+    ),
+  )
+
+  it.live(
+    "skipAll=false + inherit, parent grant does not cover the pattern → fail-closed",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        expect(yield* perm.skipAll()).toBe(false)
+        // Distinct parent session so the child's own setParentGrants write under
+        // ses_main cannot clobber the grant we are testing against.
+        forwardRef.setParentGrants("ses_parent", {
+          ruleset: [],
+          approved: [{ permission: "bash", pattern: "git status", action: "allow" }],
+        })
+        const result = yield* perm
+          .ask(
+            subagentAsk({
+              inherit: { parentSessionID: "ses_parent" },
+            }),
+          )
+          .pipe(Effect.exit)
+        expect(result._tag).toBe("Failure")
+        if (result._tag === "Failure") {
+          expect(String(result.cause)).toContain("PermissionDeniedError")
+        }
+      }),
+    ),
+  )
+
+  it.live(
+    "skipAll=false + inherit to session with empty snapshot → still fail-closed",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        // No prior always-grant under ses_main. The child's own ask() publishes
+        // an empty snapshot first, then inherit finds nothing to allow.
+        const result = yield* perm.ask(subagentAsk()).pipe(Effect.exit)
+        expect(result._tag).toBe("Failure")
+      }),
+    ),
+  )
+
+  it.live(
+    "full access does not appear in inherit snapshot: ruleset stays ask",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const perm = yield* Permission.Service
+        // Simulate full-access mode: skip-all on, parent ruleset still ask.
+        yield* perm.setSkipAll(true)
+        // Parent ask publishes grants; skip-all auto-allows before approved is written.
+        yield* perm
+          .ask({
+            permission: "bash" as never,
+            patterns: ["wc -l /tmp/foo"],
+            always: ["*"],
+            metadata: {},
+            sessionID: "ses_main" as never,
+            ruleset: [],
+            tool: { messageID: "msg_p" as never, callID: "call_p" },
+          })
+          .pipe(Effect.exit)
+        // Child with inherit only (skip-all OFF) must NOT be saved by inherit,
+        // because full access never wrote an allow into the parent snapshot.
+        yield* perm.setSkipAll(false)
+        const child = yield* perm.ask(subagentAsk()).pipe(Effect.exit)
+        expect(child._tag).toBe("Failure")
       }),
     ),
   )


### PR DESCRIPTION
## Summary
- `decideAskRouting` only consulted `session.parentID`, which is empty on a root session.
- Actor spawn/run subagents share the parent session, so they skipped `inherit` and fail-closed on every ask unless instance `skip-all` was already on.
- Fall back to the current session id when resolving the inherit parent (`mode: subagent` only).
- Add unit coverage for same-session inherit and for skip-all inheritance of background subagents.
- Unit CI shards were position-based (`NR % n`); adding one test file reshuffled every later file and broke order-sensitive tests (`mcp/sampling-e2e`). Switch sharding to `cksum(path) % n`.
- Isolate `mcp/stdio-exit-observe.test.ts` from the shared bun process: it needs the real `ObservingStdioTransport`, which `lifecycle.test.ts` `mock.module`s process-wide.

## Scope
Full access still depends on instance `skip-all`. This PR does not change that path; it only restores inheritance for paths the parent already approved.

## Test plan
- [x] `test/agent/ask-routing.test.ts`
- [x] `test/permission/inherit.test.ts` (same-session always-grant + skip-all cases)
- [x] Local hash-shard partition: insert moves 0 existing files
- [x] `stdio-exit-observe` passes in isolation
- [x] CI unit shards 1–4 on this PR
- [x] Live TUI smoke: parent `Always allow` on `external_directory`, then same-session `general` spawn writes the same directory with no second ask and no hang

## Live verification
Drived the TUI from this branch (`bun dev`, throwaway workspace, no `skip-all`):

1. Parent `write` outside the worktree raised one `external_directory` ask for `/tmp/.../ext/*`.
2. User chose **Allow always**.
3. `actor spawn` a `general` subagent; it `write`d `/tmp/.../ext/sub.txt`.
4. Worker log shows exactly **one** `service=permission ... asking` for the whole run.
5. Subagent write completed in 8ms (`tool=write ... ok=true`); parent then `actor wait`ed and finished.

Before this change the same-session subagent skipped `inherit` and fail-closed, so `sub.txt` would not be created.
