### PR TITLE
fix(ci): shard unit tests by path hash, not list position

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,15 +37,25 @@ jobs:
       # runtime-worktree.test.ts excluded from shards: its deadline-fired test
       # deadlocks when run after other tests (QuickJS WASM state leak).
       # It runs separately below in an isolated process.
+      #
+      # Sharding is path-hash, NOT list position: `NR % n` on the sorted file
+      # list reassigns every later file when one is added/removed, which
+      # reshuffles process-wide mocks and breaks order-sensitive tests
+      # (e.g. mcp/sampling-e2e). hash(path) % n keeps each file's shard
+      # independent of its neighbors.
       - name: Run unit tests (shard ${{ matrix.shard }})
         timeout-minutes: 8
         working-directory: packages/opencode
         run: |
-          find test -name '*.test.ts' ! -name 'runtime-worktree.test.ts' | sort > /tmp/test-files.txt
           shard=${{ matrix.shard }}
           idx=${shard%/*}
           n=${shard#*/}
-          files=$(awk -v i="$idx" -v n="$n" 'NR % n == i - 1' /tmp/test-files.txt)
+          files=$(while IFS= read -r f; do
+            h=$(printf '%s' "$f" | cksum | awk '{print $1}')
+            if [ $((h % n)) -eq $((idx - 1)) ]; then
+              printf '%s\n' "$f"
+            fi
+          done < <(find test -name '*.test.ts' ! -name 'runtime-worktree.test.ts' | sort))
           mkdir -p .artifacts/unit
           bun test $files --timeout 120000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml
 


### PR DESCRIPTION
## Summary
- Unit CI shards used `NR % n` over the sorted test-file list.
- Adding or removing **one** test file reassigns every later file, reshuffling process-wide mocks in the same `bun test` process and breaking order-sensitive files (observed with `test/mcp/sampling-e2e.test.ts`).
- Hash each path independently (`cksum(path) % n`) so a new test file only occupies one shard.

## Verified locally
- 476 files still partition into exactly 4 shards, no overlap.
- Inserting a new path moves **0** existing files.
- Shard sizes ~134/126/109/107 (cksum is not perfectly uniform; still within the 8m timeout at current ~4–5m shard runtimes).

## Note
This is a one-time migration: relative to today's `NR % n` layout, all four shards will reshuffle on merge. If another file is already composition-sensitive beyond sampling-e2e, this PR will surface it once — after that, adding test files is safe.

## Test plan
- [x] Local partition + insertion-stability script
- [ ] CI unit shards 1–4 on this PR
