### PR TITLE
session: keep errored assistants as recovery candidates

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -782,7 +782,12 @@ export const layer: Layer.Layer<
             state: MessageV2.abortedToolState(part.state),
           })
         }
-        ctx.assistantMessage.time.completed = Date.now()
+        // 有 error = 没完成 = 留在 /recovery 候选集里。不管错误类型(瞬态/终态/用户中止),
+        // 只要消息带 error,就不写 completed,让 resume 端点能找到它。
+        // 正常完成(无 error)才标记 completed。
+        if (!ctx.assistantMessage.error) {
+          ctx.assistantMessage.time.completed = Date.now()
+        }
         yield* session.updateMessage(ctx.assistantMessage)
       })
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2835,9 +2835,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       for (const m of msgs) {
         if (m.info.role !== "assistant") continue
         if (m.info.time?.completed) continue
-        // 有 error 的 assistant 是故意不写 completed 的(留给 /recovery 做 resume 候选),
-        // 不是孤儿,不该被清扫。
-        if (m.info.error) continue
+        // Errored assistants are intentionally left without time.completed so
+        // /recovery can find them. Keep them recoverable on the background
+        // path (age-guarded). But when immediate=true the user is actively
+        // sending a new message — that act abandons the old turn, so finalize
+        // it like any other orphan. This prevents the TUI pending memo from
+        // locking onto a stale errored assistant and rendering every later
+        // message as stuck QUEUED.
+        if (m.info.error && !immediate) continue
         const created = m.info.time?.created ?? 0
         if (!immediate && now - created < ORPHAN_AGE_MS) continue
         m.info.time = { ...m.info.time, completed: now }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2835,6 +2835,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       for (const m of msgs) {
         if (m.info.role !== "assistant") continue
         if (m.info.time?.completed) continue
+        // 有 error 的 assistant 是故意不写 completed 的(留给 /recovery 做 resume 候选),
+        // 不是孤儿,不该被清扫。
+        if (m.info.error) continue
         const created = m.info.time?.created ?? 0
         if (!immediate && now - created < ORPHAN_AGE_MS) continue
         m.info.time = { ...m.info.time, completed: now }


### PR DESCRIPTION
## Problem

cleanup() unconditionally stamps time.completed on every exit path. Any assistant that ended with an error — regardless of type — becomes invisible to /recovery, so the resume endpoint cannot find a candidate.

## Fix

- **processor.ts**: Skip writing time.completed whenever the message carries an error. No error-type discrimination — an errored message is incomplete, period. The decision of whether to surface a resume button to the user belongs to the UI layer, not the data layer.
- **prompt.ts**: sweepOrphanAssistants now skips messages with an error. They are intentionally left incomplete for recovery and are not orphans.

## Design rationale

This aligns with the Codex model: resume eligibility is determined by structure (is there an incomplete message?), not by error classification. The previous approach of gating on isRetryableTransientError was overly narrow — auth errors, context overflows, and model unavailability can all benefit from resume once the underlying condition is resolved.

## Testing

- tsgo --noEmit passes in packages/opencode