### PR TITLE
fix(websearch): 修复 Token Plan 用户搜索失效——端点硬编码按量计费地址导致 401

### DIFF
--- a/packages/opencode/src/tool/websearch/index.ts
+++ b/packages/opencode/src/tool/websearch/index.ts
@@ -4,6 +4,7 @@ import { HttpClient } from "effect/unstable/http"
 import * as Tool from "../tool"
 import * as McpExa from "../mcp-exa"
 import * as MimoWebsearch from "./mimo"
+import { DEFAULT_BASE_URL } from "./mimo"
 import { Auth } from "@/auth"
 import { Provider } from "@/provider"
 import DESCRIPTION from "./websearch.txt"
@@ -68,16 +69,24 @@ export const WebSearchTool = Tool.define(
                   Effect.gen(function* () {
                     const info = yield* auth.get("xiaomi")
                     if (!info || info.type !== "api") return undefined
+                    // 优先用凭据里的 base_url（Token Plan 用户指向 token-plan-cn 端点），
+                    // 其次模型配置，兜底硬编码默认值
+                    const baseURL = (info.metadata as Record<string, string> | undefined)?.base_url
+                      ?? model.api.url
+                      ?? DEFAULT_BASE_URL
                     return yield* MimoWebsearch.call(
                       http,
-                      model.api.url,
+                      baseURL,
                       info.key,
                       params.query,
                       "mimo-v2.5",
                       timeout ?? "30 seconds",
                     )
                   }),
-                  () => Effect.succeed(undefined),
+                  (cause) => {
+                    console.error("[websearch] xiaomi branch failed:", cause)
+                    return Effect.succeed(undefined)
+                  },
                 )
               : yield* McpExa.call(
                   http,

--- a/packages/opencode/src/tool/websearch/mimo.ts
+++ b/packages/opencode/src/tool/websearch/mimo.ts
@@ -1,7 +1,7 @@
 import { Duration, Effect, Schema, Stream } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
-const DEFAULT_BASE_URL = "https://api.xiaomimimo.com/v1"
+export const DEFAULT_BASE_URL = "https://api.xiaomimimo.com/v1"
 
 export const QUOTA_EXCEEDED =
   "Web search quota exhausted (free tier limit reached). Top up or manage your plan at https://platform.xiaomimimo.com/console/plugin, or use `webfetch` with a relevant URL instead."
@@ -83,6 +83,7 @@ export const call = (
   Effect.gen(function* () {
     const request = HttpClientRequest.post(buildUrl(baseUrl)).pipe(
       HttpClientRequest.setHeader("api-key", apiKey),
+      HttpClientRequest.setHeader("Authorization", `Bearer ${apiKey}`),
       HttpClientRequest.accept("text/event-stream"),
       HttpClientRequest.bodyJsonUnsafe({
         model: modelId,

--- a/packages/opencode/src/tool/websearch/mimo.ts
+++ b/packages/opencode/src/tool/websearch/mimo.ts
@@ -83,7 +83,6 @@ export const call = (
   Effect.gen(function* () {
     const request = HttpClientRequest.post(buildUrl(baseUrl)).pipe(
       HttpClientRequest.setHeader("api-key", apiKey),
-      HttpClientRequest.setHeader("Authorization", `Bearer ${apiKey}`),
       HttpClientRequest.accept("text/event-stream"),
       HttpClientRequest.bodyJsonUnsafe({
         model: modelId,


### PR DESCRIPTION
## 问题

Token Plan（订阅制，tp- 前缀密钥）用户调用 websearch 一律失败，客户端提示配额耗尽 / 请开启插件（`QUOTA_EXCEEDED` / `WEBFETCH_FALLBACK` 文案）。账户余额充足、插件已开启、聊天功能正常。

完整排查过程与证据链：#2280

## 根因

websearch 的请求地址解析绕开了 auth 体系：

- `tool/websearch/mimo.ts` 将 `DEFAULT_BASE_URL` 硬编码为按量计费端点 `https://api.xiaomimimo.com/v1`
- `tool/websearch/index.ts` 传入的 `model.api.url` 是模型构造时的静态配置（解析链无 auth loader 参与），同样指向按量端点
- 聊天功能正常，是因为请求时由 auth loader 动态注入凭据的 `metadata.base_url`（Token Plan 用户为 `https://token-plan-cn.xiaomimimo.com/v1`）
- tp- 密钥仅在 token-plan 端点有效；打到按量端点返回 401，错误被 `catchCause` 静默吞掉，最终展示误导性文案

服务端对照实验（curl 直连）：tp- key + token-plan 端点 ✅ 正常搜索；tp- key + 按量端点 ❌ 401 `invalid_key`。sk- 按量用户恰好与写死端点匹配，因此该问题此前「碰巧正确」。

## 修复

- base URL 优先级：凭据 `metadata.base_url` → `model.api.url` → `DEFAULT_BASE_URL`
- 吞错前 `console.error` 输出真实原因，便于诊断
- 认证方式不变（沿用 `api-key` 头）：已实测确认 token-plan 端点接受 `api-key` 头，无需新增 Authorization 头

向后兼容：sk- 用户的请求与修复前完全一致（仅多了失败日志）。

## 验证

同一 Token Plan 账号，三平台实测：

| 平台 | 官方 v0.1.13 | 本补丁 |
|---|---|---|
| macOS 12 (Intel) | ❌ 复现故障 | ✅ 返回真实搜索结果 |
| Windows | ❌ 复现故障 | ✅ 返回真实搜索结果 |
| macOS Tahoe (Apple Silicon) | ❌ 复现故障 | ✅ 返回真实搜索结果 |

注：三平台实测基于含冗余 Authorization 头的中间版本；最终补丁移除该头，其非必要性已由 curl 实验单独验证（tp- key 仅 `api-key` 头请求 token-plan 端点 ✅ 正常返回）。

## 附带发现（刻意不纳入本 PR 以控制改动范围，建议后续单独处理）

- `cli/cmd/tui/util/voice.ts:29` 存在同款硬编码端点，Token Plan 用户使用语音功能可能遇到相同故障
- Exa 备用路径在客户端静默失败（约 120ms 空返回；服务端 curl 直连正常），建议另行排查

Fixes #2280