### PR TITLE
fix: resolve project ID for non-git directories

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -213,10 +213,11 @@ export const layer: Layer.Layer<
         const dotgit = dotgitMatches[0]
 
         if (!dotgit) {
+          const id = resolveProjectId(directory)
           return {
-            id: ProjectID.global,
-            worktree: "/",
-            sandbox: "/",
+            id,
+            worktree: directory,
+            sandbox: directory,
             vcs: fakeVcs,
           }
         }


### PR DESCRIPTION
## Summary

Fixes #902, #354, #2012

When no `.git` directory is found, `fromDirectory()` returned `ProjectID.global` immediately, skipping `resolveProjectId()` which already handles non-git directories by creating `.mimocode-project-id` with a unique UUID.

This caused **all non-git projects to share the same `global` project memory**, preventing memory isolation between different working directories.

## Root Cause

In `packages/opencode/src/project/project.ts`, the `fromDirectory()` function:

```typescript
if (!dotgit) {
  return {
    id: ProjectID.global,  // ← always global
    worktree: "/",
    sandbox: "/",
    vcs: fakeVcs,
  }
}
```

The `resolveProjectId()` function in `project-id.ts` already has logic for non-git directories:

```typescript
// Non-git path
const localFile = path.join(workingDir, ".mimocode-project-id")
const cached = readFileTrimmedOrNull(localFile)
if (cached) return ProjectID.make(cached)
const newId = crypto.randomUUID()
fs.writeFileSync(localFile, newId)  // ← creates the file
return ProjectID.make(newId)
```

But this code was **dead code** — never reached because `fromDirectory()` returned early with `ProjectID.global`.

## Fix

Call `resolveProjectId(directory)` for non-git directories:

```typescript
if (!dotgit) {
  const id = resolveProjectId(directory)
  return {
    id,
    worktree: directory,
    sandbox: directory,
    vcs: fakeVcs,
  }
}
```

This creates `.mimocode-project-id` in the working directory with a unique UUID, giving each directory its own project memory at `memory/projects/<uuid>/MEMORY.md`.

## Impact

- Non-git directories now get isolated project memory
- Existing `.mimocode-project-id` files are preserved (read before write)
- Git repositories are unaffected (existing code path)
- `MIMOCODE_DISABLE_GIT` flag still returns `ProjectID.global` as before

## Testing

- [x] `bun typecheck` passes
- [x] Manual verification: non-git directory creates `.mimocode-project-id` and gets unique project ID
- [x] Tested with Bun 1.3.14 (required version per `packageManager` in package.json)

## Build Notes

- Build command: `bun run build:local` (from repo root)
- Bun version: **1.3.14** (required, do NOT use 1.4.0 — causes runtime hangs)
- Output: `packages/opencode/dist/mimocode-linux-x64/bin/mimo`

---

## 中文摘要

修复 #902、#354、#2012

当工作目录没有 `.git` 时，`fromDirectory()` 直接返回 `ProjectID.global`，跳过了 `resolveProjectId()` 中已有的为非 git 目录创建 `.mimocode-project-id` 的逻辑。

这导致**所有非 git 项目共享同一个 `global` 项目记忆**，无法实现不同工作目录之间的记忆隔离。

### 根因

`project.ts` 中的 `fromDirectory()` 函数在未找到 `.git` 时立即返回 `ProjectID.global`，而 `project-id.ts` 中的 `resolveProjectId()` 虽然已有处理非 git 目录的代码（创建 `.mimocode-project-id` 文件），但该代码从未被执行——属于死代码。

### 修复

对非 git 目录调用 `resolveProjectId(directory)`，在工作目录下创建 `.mimocode-project-id` 文件并生成唯一 UUID，使每个目录拥有独立的项目记忆 `memory/projects/<uuid>/MEMORY.md`。

### 影响

- 非 git 目录现在拥有独立的项目记忆
- 已有的 `.mimocode-project-id` 文件会被保留（先读后写）
- Git 仓库不受影响（走原有代码路径）
- `MIMOCODE_DISABLE_GIT` 标志仍返回 `ProjectID.global`

### 构建说明

- 构建命令：`bun run build:local`（在仓库根目录执行）
- Bun 版本：**1.3.14**（必需，不要使用 1.4.0 — 会导致运行时挂起）
- 输出：`packages/opencode/dist/mimocode-linux-x64/bin/mimo`