### PR TITLE
fix(provider): revert xiaomi to standard openai-compatible SDK

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1728,14 +1728,7 @@ const layer: Layer.Layer<
           return wrapSSE(bounded, chunkTimeout, chunkAbortCtl)
         }
 
-        const bundledLoader =
-          model.providerID === "xiaomi" && model.api.npm === "@ai-sdk/openai-compatible"
-            ? () =>
-                import("./sdk/copilot").then(
-                  (module) => (options: any) =>
-                    module.createOpenaiCompatible({ ...options, customToolNames: ["exec"] }),
-                )
-            : BUNDLED_PROVIDERS[model.api.npm]
+        const bundledLoader = BUNDLED_PROVIDERS[model.api.npm]
         if (bundledLoader) {
           log.info("using bundled provider", {
             providerID: model.providerID,


### PR DESCRIPTION
Fixes #2283

## Summary

Revert the xiaomi provider to use the standard `@ai-sdk/openai-compatible` SDK instead of the copilot SDK wrapper. The copilot wrapper uses `reasoning_text` (GitHub Copilot's format) instead of `reasoning_content` (OpenAI-compatible format), which breaks thinking/reasoning block display for xiaomi/mimo models.

## Root cause

After v0.1.13, `provider.ts` added a special case for xiaomi:

```typescript
const bundledLoader =
  model.providerID === "xiaomi" && model.api.npm === "@ai-sdk/openai-compatible"
    ? () =>
        import("./sdk/copilot").then(
          (module) => (options: any) =>
            module.createOpenaiCompatible({ ...options, customToolNames: ["exec"] }),
        )
    : BUNDLED_PROVIDERS[model.api.npm]
```

The copilot SDK's streaming handler looks for `delta.reasoning_text` to emit `reasoning-start`/`reasoning-delta`/`reasoning-end` events. But xiaomi's API returns reasoning content in `delta.reasoning_content` (the standard OpenAI-compatible format). The standard `@ai-sdk/openai-compatible` SDK correctly handles both `reasoning_content` and `reasoning` fields.

## Fix

Remove the xiaomi-specific copilot SDK override. The standard `BUNDLED_PROVIDERS["@ai-sdk/openai-compatible"]` handles `reasoning_content` correctly.

## Verification

- `bun typecheck` passes
- Built binary from v0.1.13 tag (standard SDK) displays Thinking blocks correctly
- Built binary from main branch (copilot SDK) does not display Thinking blocks
- After this fix, main branch binary displays Thinking blocks correctly

## Safety analysis

The `customToolNames: ["exec"]` parameter only affects the Responses API path (`sdk.responses()`). Current xiaomi models (mimo-v2.5, mimo-v2.5-pro) use Chat Completions via `sdk.languageModel()`, which routes to the same `OpenAICompatibleChatLanguageModel` class in both the copilot wrapper and standard SDK. No xiaomi models currently use the Responses API (none contain "ptc" in their model ID). This change is safe for all existing xiaomi models.

---

## 中文摘要

将 xiaomi 提供商恢复为使用标准 `@ai-sdk/openai-compatible` SDK，替换 copilot SDK 包装器。copilot 包装器使用 `reasoning_text`（GitHub Copilot 格式）而非 `reasoning_content`（OpenAI-compatible 格式），导致 xiaomi/mimo 模型的思考/推理块无法显示。

### 根因

v0.1.13 之后，`provider.ts` 为 xiaomi 添加了特殊处理，使用 copilot SDK 包装器并设置 `customToolNames: ["exec"]`。copilot SDK 的流式处理器查找 `delta.reasoning_text` 来发出推理事件，但 xiaomi API 在 `delta.reasoning_content` 中返回推理内容（标准 OpenAI-compatible 格式）。标准 SDK 正确处理 `reasoning_content` 字段。

### 修复方案

移除 xiaomi 专用的 copilot SDK 覆盖，使用标准 `BUNDLED_PROVIDERS["@ai-sdk/openai-compatible"]`。

### 安全性分析

`customToolNames: ["exec"]` 参数仅影响 Responses API 路径。当前 xiaomi 模型（mimo-v2.5、mimo-v2.5-pro）通过 `sdk.languageModel()` 使用 Chat Completions API，在 copilot 包装器和标准 SDK 中都路由到同一个 `OpenAICompatibleChatLanguageModel` 类。目前没有 xiaomi 模型使用 Responses API（模型 ID 中不包含 "ptc"）。此更改对所有现有 xiaomi 模型安全。