### PR TITLE
feat(session): decouple instruction-file injection from the dynamic system prompt flag

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -276,10 +276,21 @@ export const Flag = {
   // enable try-best loop detection, automatic turn pausing, and handoff UI.
   MIMOCODE_ENABLE_TRY_BEST_HANDOFF: truthy("MIMOCODE_ENABLE_TRY_BEST_HANDOFF"),
 
-  // Defaults to false. Opt in to append runtime-derived environment and
-  // instruction-file content to the model's system prompt.
+  // Defaults to false. Opt in to append the runtime-derived environment block
+  // (working directory, platform, shell, git status/branch/commits) to the model's
+  // system prompt. Instruction files (AGENTS.md / CLAUDE.md) are appended
+  // regardless — suppress the whole block with MIMOCODE_DISABLE_INSTRUCTIONS, or
+  // individual sources with MIMOCODE_DISABLE_PROJECT_CONFIG /
+  // MIMOCODE_DISABLE_CLAUDE_CODE_PROMPT.
   get MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT() {
     return truthy("MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT")
+  },
+
+  // Defaults to false (enabled): instruction-file content (AGENTS.md / CLAUDE.md)
+  // is appended to the model's system prompt. Set MIMOCODE_DISABLE_INSTRUCTIONS=true
+  // to drop the whole instruction block regardless of which files resolve.
+  get MIMOCODE_DISABLE_INSTRUCTIONS() {
+    return truthy("MIMOCODE_DISABLE_INSTRUCTIONS")
   },
 
   // Defaults to false. The edit tool does pure exact-string matching with

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -327,6 +327,49 @@ const PREDICT_SYSTEM = `You predict the single most likely next message a user w
 
 const PREDICT_NUDGE = `Based on the conversation above, write the user's most likely next message:`
 
+const isSyntheticPart = (part: MessageV2.Part) => "synthetic" in part && part.synthetic === true
+
+/**
+ * Builds the context `predict` feeds the model, or `undefined` when the session
+ * is not in a predictable state.
+ *
+ * Up to 3 most recent real user queries (chronological) plus the assistant turn
+ * that answered the newest one — that turn carries the tool outputs and final
+ * text. Earlier assistant turns are dropped to keep the prompt small.
+ *
+ * Synthetic parts are stripped from the user queries. `insertReminders` persists
+ * the authoritative skills catalog snapshot and auto-loaded SKILL.md bodies onto
+ * the user message, and `toModelMessages` replays every non-ignored part, so
+ * keeping them here would dwarf the real queries and pull a small model toward
+ * echoing harness instructions instead of predicting what the user would type.
+ */
+export function predictContext(history: readonly MessageV2.WithParts[]) {
+  const real = (m: MessageV2.WithParts) => m.info.role === "user" && !m.parts.every(isSyntheticPart)
+  const userIdx = history.findLastIndex(real)
+  if (userIdx === -1) return
+
+  // Only the assistant turn that actually answered this user message counts.
+  // Bail if that turn is still running (an incomplete assistant after it), so we
+  // never pair the newest prompt with a stale/older result.
+  const assistants = history
+    .slice(userIdx + 1)
+    .filter((m): m is MessageV2.WithParts & { info: MessageV2.Assistant } => m.info.role === "assistant")
+  if (assistants.length === 0) return
+  if (assistants.some((m) => m.info.time.completed === undefined)) return
+  const assistant = assistants[assistants.length - 1]
+
+  return {
+    assistant,
+    messages: [
+      ...history
+        .filter(real)
+        .slice(-3)
+        .map((m) => ({ ...m, parts: m.parts.filter((p) => !isSyntheticPart(p)) })),
+      assistant,
+    ],
+  }
+}
+
 const OUTPUT_LENGTH_CONTINUATION_LIMIT = Flag.MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT
 const INVALID_OUTPUT_CONTINUATION_LIMIT = Flag.MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT
 const TEXT_TOOL_CALL_RETRY_LIMIT = Flag.MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT
@@ -441,7 +484,8 @@ export const layer = Layer.effect(
         ])
         // (checkpoint-writer never requests json_schema output, so STRUCTURED_OUTPUT_SYSTEM_PROMPT
         // is not included; parent's runLoop adds it conditionally based on user.format)
-        const additions = Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT ? [...env, ...instructions.content] : []
+        // Must stay byte-identical to the runLoop's additions for Anthropic prefix-cache parity.
+        const additions = [...env, ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content)]
         const prefix = yield* buildLLMRequestPrefix({
           sessionID: input.sessionID,
           agent: ag,
@@ -983,46 +1027,24 @@ export const layer = Layer.effect(
       const cfg = yield* config.get()
       if (cfg.experimental?.predict_next_prompt === false) return ""
 
-      const history = yield* sessions.messages({ sessionID: input.sessionID, agentID: "main" })
-      const real = (m: MessageV2.WithParts) =>
-        m.info.role === "user" && !m.parts.every((p) => "synthetic" in p && p.synthetic)
-      const userIdx = history.findLastIndex(real)
-      if (userIdx === -1) return ""
-      const lastUser = history[userIdx]
-      if (lastUser.info.role !== "user") return ""
-
-      // Only the assistant turn that actually answered this user message counts.
-      // Bail if that turn is still running (an incomplete assistant after it),
-      // so we never pair the newest prompt with a stale/older result.
-      const assistants = history
-        .slice(userIdx + 1)
-        .filter((m): m is MessageV2.WithParts & { info: MessageV2.Assistant } => m.info.role === "assistant")
-      if (assistants.length === 0) return ""
-      if (assistants.some((m) => m.info.time.completed === undefined)) return ""
-      const lastAssistant = assistants[assistants.length - 1]
-
-      // Context fed to the prediction: up to 3 most recent user queries
-      // (chronological) plus the latest assistant turn (which carries tool
-      // outputs + final assistant text). Earlier assistant turns are dropped
-      // to keep the prompt small.
-      const recentUsers = history.filter(real).slice(-3)
-      const contextMsgs = [...recentUsers, lastAssistant]
+      const context = predictContext(yield* sessions.messages({ sessionID: input.sessionID, agentID: "main" }))
+      if (!context) return ""
 
       const base = yield* agents.get("title")
       if (!base) return ""
       const mdl = base.modelRef
-        ? yield* provider.resolveModelRef(base.modelRef, lastAssistant.info.providerID)
+        ? yield* provider.resolveModelRef(base.modelRef, context.assistant.info.providerID)
         : base.model
           ? yield* provider.getModel(base.model.providerID, base.model.modelID)
-          : ((yield* provider.getSmallModel(lastAssistant.info.providerID)) ??
-            (yield* provider.getModel(lastAssistant.info.providerID, lastAssistant.info.modelID)))
+          : ((yield* provider.getSmallModel(context.assistant.info.providerID)) ??
+            (yield* provider.getModel(context.assistant.info.providerID, context.assistant.info.modelID)))
 
       // Side-channel call: bypass llm.stream so prediction stays out of the
       // session trajectory and never triggers session-coupled plugin hooks
       // (chat.params, chat.headers, system.transform, memory instructions,
       // x-session-affinity). Still publishes Metrics.ModelCall so the
       // prediction cost shows up in analytics.
-      const msgs = yield* MessageV2.toModelMessagesEffect(contextMsgs, mdl, { stripMedia: true })
+      const msgs = yield* MessageV2.toModelMessagesEffect(context.messages, mdl, { stripMedia: true })
       const language = yield* provider.getLanguage(mdl)
       const wrapped = wrapLanguageModel({
         model: language,
@@ -4293,8 +4315,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 yield* bus.publish(TuiEvent.InstructionsLoaded, { files }).pipe(Effect.ignore)
               }
             }
+            // Instruction files ship by default; the runtime environment block is opt-in
+            // (`env` is already empty unless MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT is set) and the
+            // instruction block is opt-out via MIMOCODE_DISABLE_INSTRUCTIONS.
             const additions = [
-              ...(Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT ? [...env, ...instructions.content] : []),
+              ...env,
+              ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
               ...(format.type === "json_schema" ? [STRUCTURED_OUTPUT_SYSTEM_PROMPT] : []),
             ]
             // Auto-worktree: inject hint on first assistant-less turn if conflict detected.

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -106,11 +106,12 @@ function withSh<A, E, R>(fx: () => Effect.Effect<A, E, R>) {
   )
 }
 
-function withoutDynamicSystemPrompt<A, E, R>(fx: () => Effect.Effect<A, E, R>) {
+function dynamicSystemPrompt<A, E, R>(value: string | undefined, fx: () => Effect.Effect<A, E, R>) {
   return Effect.acquireUseRelease(
     Effect.sync(() => {
       const previous = process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
-      delete process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+      if (value === undefined) delete process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+      else process.env.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT = value
       return previous
     }),
     () => fx(),
@@ -121,6 +122,9 @@ function withoutDynamicSystemPrompt<A, E, R>(fx: () => Effect.Effect<A, E, R>) {
       }),
   )
 }
+
+const withoutDynamicSystemPrompt = <A, E, R>(fx: () => Effect.Effect<A, E, R>) => dynamicSystemPrompt(undefined, fx)
+const withDynamicSystemPrompt = <A, E, R>(fx: () => Effect.Effect<A, E, R>) => dynamicSystemPrompt("true", fx)
 
 function toolPart(parts: MessageV2.Part[]) {
   return parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
@@ -1047,7 +1051,7 @@ it.live("resume continues an incomplete assistant without creating or rewriting 
   ),
 )
 
-it.live("loop does not inject dynamic system prompt additions", () =>
+it.live("loop injects instruction files but not the dynamic environment block", () =>
   withoutDynamicSystemPrompt(() =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {
@@ -1072,7 +1076,39 @@ it.live("loop does not inject dynamic system prompt additions", () =>
 
         const inputs = JSON.stringify(yield* llm.inputs)
         expect(inputs).not.toContain("Working directory:")
-        expect(inputs).not.toContain(marker)
+        expect(inputs).toContain(marker)
+      }),
+      { git: true, config: providerCfg },
+    ),
+  ),
+)
+
+it.live("loop injects the dynamic environment block only when the flag is set", () =>
+  withDynamicSystemPrompt(() =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const marker = "dynamic-instruction-marker"
+        yield* Effect.promise(() => Bun.write(path.join(Instance.directory, "AGENTS.md"), marker))
+        const chat = yield* sessions.create({
+          title: "With cwd",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* prompt.prompt({
+          sessionID: chat.id,
+          agent: "build",
+          model: ref,
+          noReply: true,
+          parts: [{ type: "text", text: "hello" }],
+        })
+        yield* llm.text("world")
+
+        yield* prompt.loop({ sessionID: chat.id })
+
+        const inputs = JSON.stringify(yield* llm.inputs)
+        expect(inputs).toContain("Working directory:")
+        expect(inputs).toContain(marker)
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -7,7 +7,7 @@ import { Instance } from "../../src/project/instance"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
-import { SessionPrompt, sanitizeGeneratedTitle, titleContext, titleInputText, titlePromptText, truncateTitle } from "../../src/session/prompt"
+import { SessionPrompt, predictContext, sanitizeGeneratedTitle, titleContext, titleInputText, titlePromptText, truncateTitle } from "../../src/session/prompt"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
 import { startScriptedLLMServer, toolCallResponse } from "../lib/scripted-llm-server"
@@ -61,6 +61,87 @@ describe("title helpers", () => {
     expect(sanitizeGeneratedTitle("<think>内部推理，不应成为标题</think>\n修复会话标题生成")).toBe("修复会话标题生成")
     expect(sanitizeGeneratedTitle("<think>我可以调用 <tool_call>read</tool_call>，但最终直接生成标题</think>\n重构认证流程")).toBe("重构认证流程")
     expect(sanitizeGeneratedTitle("<think>只有推理，没有最终标题</think>")).toBeUndefined()
+  })
+})
+
+describe("predictContext", () => {
+  const user = (parts: MessageV2.Part[]) => ({ info: { role: "user" }, parts }) as unknown as MessageV2.WithParts
+  const assistant = (completed: number | undefined) =>
+    ({
+      info: { role: "assistant", providerID: "p", modelID: "m", time: { completed } },
+      parts: [{ type: "text", text: "done" }],
+    }) as unknown as MessageV2.WithParts
+
+  test("strips the skills catalog and auto-loaded SKILL.md bodies from user queries", () => {
+    const context = predictContext([
+      user([
+        {
+          type: "text",
+          text: "<system-reminder>\nAuthoritative skills catalog snapshot v2:\n…\n</system-reminder>",
+          synthetic: true,
+        },
+        { type: "text", text: "重构 predict 的上下文构建" },
+        {
+          type: "text",
+          text: '<system-reminder>\n<skill_content name="dataviz">\n…\n</skill_content>\n</system-reminder>',
+          synthetic: true,
+        },
+      ] as MessageV2.Part[]),
+      assistant(1),
+    ])
+    expect(context?.messages[0].parts.map((p) => (p.type === "text" ? p.text : p.type))).toEqual([
+      "重构 predict 的上下文构建",
+    ])
+    expect(JSON.stringify(context?.messages)).not.toContain("system-reminder")
+  })
+
+  test("keeps non-synthetic parts that are not plain text", () => {
+    const context = predictContext([
+      user([
+        { type: "text", text: "看这张图", synthetic: false },
+        { type: "file", mime: "image/png", url: "data:image/png;base64,AA==", filename: "diagram.png" },
+      ] as MessageV2.Part[]),
+      assistant(1),
+    ])
+    expect(context?.messages[0].parts).toHaveLength(2)
+  })
+
+  test("caps at the 3 most recent user queries plus the answering assistant turn", () => {
+    const context = predictContext([
+      user([{ type: "text", text: "one" }] as MessageV2.Part[]),
+      user([{ type: "text", text: "two" }] as MessageV2.Part[]),
+      user([{ type: "text", text: "three" }] as MessageV2.Part[]),
+      user([{ type: "text", text: "four" }] as MessageV2.Part[]),
+      assistant(1),
+    ])
+    expect(context?.messages).toHaveLength(4)
+    expect(context?.messages.slice(0, 3).map((m) => m.parts.map((p) => (p.type === "text" ? p.text : "")))).toEqual([
+      ["two"],
+      ["three"],
+      ["four"],
+    ])
+  })
+
+  test("bails when the answering assistant turn is still running", () => {
+    expect(
+      predictContext([user([{ type: "text", text: "hi" }] as MessageV2.Part[]), assistant(undefined)]),
+    ).toBeUndefined()
+  })
+
+  test("bails with no user query, and when the newest user message is synthetic-only", () => {
+    expect(predictContext([assistant(1)])).toBeUndefined()
+    expect(
+      predictContext([user([{ type: "text", text: "sys", synthetic: true }] as MessageV2.Part[]), assistant(1)]),
+    ).toBeUndefined()
+  })
+
+  test("does not mutate the stored parts", () => {
+    const parts = [
+      { type: "text", text: "real" },
+      { type: "text", text: "reminder", synthetic: true },
+    ] as MessageV2.Part[]
+    predictContext([user(parts), assistant(1)])
+    expect(parts).toHaveLength(2)
   })
 })
 


### PR DESCRIPTION
## Summary
- Instruction files (AGENTS.md / CLAUDE.md) are now appended to the system prompt **by default**, decoupled from `MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT` which remains opt-in for the runtime environment block only.
- Added `MIMOCODE_DISABLE_INSTRUCTIONS` flag to independently suppress instruction-file injection.
- Extracted `predictContext` from the inline predict helper into a standalone exported function with dedicated unit tests.

## Test plan
- [x] Existing test updated: `loop injects instruction files but not the dynamic environment block`
- [x] New integration test: `loop injects the dynamic environment block only when the flag is set`
- [x] New unit tests for `predictContext` covering synthetic stripping, 3-message cap, running-assistant bail, empty/synthetic-only bail, and immutability