### PR TITLE
feat(session): move skill catalogs from user messages to the system tail

### DIFF
--- a/packages/opencode/migration/20260829000000_session_prefix_snapshot/migration.sql
+++ b/packages/opencode/migration/20260829000000_session_prefix_snapshot/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `session_prefix_snapshot` (
+  `session_id` text NOT NULL REFERENCES `session`(`id`) ON DELETE CASCADE,
+  `profile_key` text NOT NULL,
+  `system` text NOT NULL,
+  `system_hash` text NOT NULL,
+  `tools_hash` text NOT NULL,
+  `watermark_message_id` text NOT NULL,
+  `revision` integer NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  PRIMARY KEY(`session_id`, `profile_key`)
+);

--- a/packages/opencode/src/session/llm-request-prefix.ts
+++ b/packages/opencode/src/session/llm-request-prefix.ts
@@ -42,6 +42,8 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
    * then instruction files. Caller is responsible for the ordering and content.
    */
   additions: string[]
+  /** Frozen Session/Fork system; bypasses all system regeneration when present. */
+  prebuiltSystem?: string[]
   prompt?: PromptConfig
   /**
    * Collapse post-checkpoint rebuild tails into an activity log. Enable for the
@@ -74,14 +76,16 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
     : (lastUserMsg.info as MessageV2.User)
 
   // Build system using LLM.buildSystemArray (single source of truth shared with stream())
-  const system = yield* llm.buildSystemArray({
-    agent: input.agent,
-    model: input.model,
-    system: input.additions,
-    user: lastUser,
-    sessionID: input.sessionID as string,
-    agentID: lastUser.agentID,
-  })
+  const system =
+    input.prebuiltSystem ??
+    (yield* llm.buildSystemArray({
+      agent: input.agent,
+      model: input.model,
+      system: input.additions,
+      user: lastUser,
+      sessionID: input.sessionID as string,
+      agentID: lastUser.agentID,
+    }))
 
   // Resolve tools using parent agent's permission and toolAllowlist
   const toolDefs = yield* toolRegistry.tools({

--- a/packages/opencode/src/session/llm-request-prefix.ts
+++ b/packages/opencode/src/session/llm-request-prefix.ts
@@ -38,9 +38,8 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
   model: Provider.Model
   msgs: MessageV2.WithParts[]
   /**
-   * Caller-built system parts to splice into the system array (after agent.prompt
-   * and before memory instructions). Currently env, skills, instructions in that
-   * order. Caller is responsible for the ordering and content.
+   * Caller-built system-tail parts. Currently environment/format, skill reminder,
+   * then instruction files. Caller is responsible for the ordering and content.
    */
   additions: string[]
   prompt?: PromptConfig

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -358,11 +358,11 @@ const live: Layer.Layer<
       const system: string[] = []
       system.push(
         [
-          ...(replaceAgent ? [] : SystemPrompt.agent(input.agent, input.model, input.user.harness)),
-          // any custom prompt passed into this call
-          ...input.system,
-          // replace-agent is a session system prompt, not per-turn user context
-          ...(replaceAgent && input.user.system ? [input.user.system] : []),
+          // replace-agent is the session's base system prompt, so it must occupy
+          // the same leading position as the agent prompt it replaces.
+          ...(replaceAgent && input.user.system
+            ? [input.user.system]
+            : SystemPrompt.agent(input.agent, input.model, input.user.harness)),
         ]
           .filter((x) => x)
           .join("\n"),
@@ -433,13 +433,15 @@ const live: Layer.Layer<
         if (lines.length > 0) system.push(`${ROSTER_HEADER}\n${lines.join("\n")}`)
       }
 
-      // Plugins still see the multi-part array (base prompt as [0], memory as a
-      // trailing element) so hooks that index or append parts keep working.
+      // Plugins transform the stable base before the caller-controlled tail.
       yield* plugin.trigger(
         "experimental.chat.system.transform",
         { sessionID: input.sessionID, model: input.model },
         { system },
       )
+
+      // Keep skill reminders at the tail and instruction files after them.
+      system.push(...input.system)
 
       // Collapse to a single system message. The historical 2-part split existed
       // only to keep a byte-stable cache prefix separate from the memory block's

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -28,7 +28,7 @@ import {
   toolAttachmentFilename,
   toolAttachmentPlaceholder,
 } from "./tool-attachment"
-import { isLegacySkillCatalogReminder, isSkillCatalogSnapshot } from "./skill-catalog"
+import { isSkillCatalogReminder } from "./skill-catalog"
 import { collapseCheckpointTail } from "./tail-digest"
 
 /** Error shape thrown by Bun's fetch() when gzip/br decompression fails mid-stream */
@@ -687,7 +687,6 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 ) {
   const result: UIMessage[] = []
   const toolNames = new Set<string>()
-  let legacySkillCatalogSeen = false
   const source = options?.collapseCheckpointTail ? collapseCheckpointTail(input) : input
 
   const toModelOutput = (options: { toolCallId: string; input: unknown; output: unknown }) => {
@@ -748,20 +747,11 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         parts: [],
       }
       result.push(userMessage)
-      const parts = msg.parts.toSorted((a, b) => {
-        const aSnapshot = a.type === "text" && a.synthetic === true && isSkillCatalogSnapshot(a.text)
-        const bSnapshot = b.type === "text" && b.synthetic === true && isSkillCatalogSnapshot(b.text)
-        if (aSnapshot !== bSnapshot) return Number(bSnapshot) - Number(aSnapshot)
-        const aLegacy = a.type === "text" && a.synthetic === true && isLegacySkillCatalogReminder(a.text)
-        const bLegacy = b.type === "text" && b.synthetic === true && isLegacySkillCatalogReminder(b.text)
-        return Number(aLegacy) - Number(bLegacy)
-      })
-      for (const part of parts) {
+      for (const part of msg.parts) {
         if (part.type === "text") {
-          if (part.synthetic && isLegacySkillCatalogReminder(part.text)) {
-            if (legacySkillCatalogSeen || part.ignored) continue
-            legacySkillCatalogSeen = true
-          }
+          // Skill catalogs moved to the system tail. Suppress snapshots persisted
+          // by older versions so resumed sessions do not receive a duplicate user-side catalog.
+          if (part.synthetic && isSkillCatalogReminder(part.text)) continue
           if (!part.ignored)
             userMessage.parts.push({
               type: "text",

--- a/packages/opencode/src/session/prefix-snapshot.ts
+++ b/packages/opencode/src/session/prefix-snapshot.ts
@@ -1,0 +1,165 @@
+import { createHash } from "node:crypto"
+import type { Tool as AITool } from "ai"
+import { Effect } from "effect"
+import { and, Database, eq } from "@/storage"
+import type { Permission } from "@/permission"
+import type { MessageID, SessionID } from "./schema"
+import { SessionPrefixSnapshotTable } from "./session.sql"
+
+export type Info = typeof SessionPrefixSnapshotTable.$inferSelect
+
+type Profile = {
+  providerID: string
+  modelID: string
+  agent: string
+  agentID: string
+  harness: string
+  systemMode: string
+  system: string
+  permission: Permission.Ruleset
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return JSON.stringify(value)
+  if (typeof value === "number") return Number.isFinite(value) ? JSON.stringify(value) : "null"
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`
+  if (typeof value !== "object") return "null"
+  return `{${Object.keys(value)
+    .toSorted()
+    .flatMap((key) => {
+      const item = (value as Record<string, unknown>)[key]
+      if (item === undefined || typeof item === "function" || typeof item === "symbol") return []
+      return [`${JSON.stringify(key)}:${stableStringify(item)}`]
+    })
+    .join(",")}}`
+}
+
+function hash(value: unknown) {
+  return createHash("sha256").update(stableStringify(value)).digest("hex")
+}
+
+export function profileKey(input: Profile) {
+  return hash(input)
+}
+
+export function systemHash(system: string[]) {
+  return hash(system)
+}
+
+export function toolsHash(tools: Record<string, AITool>, activeTools: string[]) {
+  return hash(
+    activeTools.toSorted().flatMap((name) => {
+      const item = tools[name]
+      return item ? [{ name, description: item.description, inputSchema: item.inputSchema }] : []
+    }),
+  )
+}
+
+export const get = Effect.fn("SessionPrefixSnapshot.get")(function* (sessionID: SessionID, key: string) {
+  return yield* Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .select()
+        .from(SessionPrefixSnapshotTable)
+        .where(
+          and(
+            eq(SessionPrefixSnapshotTable.session_id, sessionID),
+            eq(SessionPrefixSnapshotTable.profile_key, key),
+          ),
+        )
+        .get(),
+    ),
+  )
+})
+
+export const pin = Effect.fn("SessionPrefixSnapshot.pin")(function* (input: {
+  sessionID: SessionID
+  profileKey: string
+  system: string[]
+  toolsHash: string
+  watermarkMessageID: MessageID
+}) {
+  const now = Date.now()
+  yield* Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .insert(SessionPrefixSnapshotTable)
+        .values({
+          session_id: input.sessionID,
+          profile_key: input.profileKey,
+          system: input.system,
+          system_hash: systemHash(input.system),
+          tools_hash: input.toolsHash,
+          watermark_message_id: input.watermarkMessageID,
+          revision: 1,
+          created_at: now,
+          updated_at: now,
+        })
+        .onConflictDoNothing()
+        .run(),
+    ),
+  )
+  const snapshot = yield* get(input.sessionID, input.profileKey)
+  if (!snapshot) return yield* Effect.die(new Error("Failed to read pinned session prefix snapshot"))
+  return snapshot
+})
+
+export const rotate = Effect.fn("SessionPrefixSnapshot.rotate")(function* (input: {
+  sessionID: SessionID
+  profileKey: string
+  system: string[]
+  toolsHash: string
+  watermarkMessageID: MessageID
+}) {
+  const current = yield* get(input.sessionID, input.profileKey)
+  if (!current) return yield* pin(input)
+  yield* Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .update(SessionPrefixSnapshotTable)
+        .set({
+          system: input.system,
+          system_hash: systemHash(input.system),
+          tools_hash: input.toolsHash,
+          watermark_message_id: input.watermarkMessageID,
+          revision: current.revision + 1,
+          updated_at: Date.now(),
+        })
+        .where(
+          and(
+            eq(SessionPrefixSnapshotTable.session_id, input.sessionID),
+            eq(SessionPrefixSnapshotTable.profile_key, input.profileKey),
+          ),
+        )
+        .run(),
+    ),
+  )
+  const snapshot = yield* get(input.sessionID, input.profileKey)
+  if (!snapshot) return yield* Effect.die(new Error("Failed to read rotated session prefix snapshot"))
+  return snapshot
+})
+
+export const advance = Effect.fn("SessionPrefixSnapshot.advance")(function* (input: {
+  sessionID: SessionID
+  profileKey: string
+  revision: number
+  watermarkMessageID: MessageID
+}) {
+  yield* Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .update(SessionPrefixSnapshotTable)
+        .set({ watermark_message_id: input.watermarkMessageID, updated_at: Date.now() })
+        .where(
+          and(
+            eq(SessionPrefixSnapshotTable.session_id, input.sessionID),
+            eq(SessionPrefixSnapshotTable.profile_key, input.profileKey),
+            eq(SessionPrefixSnapshotTable.revision, input.revision),
+          ),
+        )
+        .run(),
+    ),
+  )
+})
+
+export * as SessionPrefixSnapshot from "./prefix-snapshot"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -140,6 +140,7 @@ import {
 } from "@/tool/mcp-tool-search"
 import { isMcpToolSearchEnabled, usesGPTToolset } from "@/tool/gpt"
 import { GPT_TOP_LEVEL_TOOLS } from "@/tool/tool-script-ref"
+import { SessionPrefixSnapshot } from "./prefix-snapshot"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -487,30 +488,43 @@ export const layer = Layer.effect(
         if (!captureSession) return empty
         const capturePrompt = yield* sessions.resolvePrompt({ sessionID: input.sessionID })
         const captureMessages = input.msgs as MessageV2.WithParts[]
-        const [env, skills, instructions] = yield* Effect.all([
-          Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
-            ? sys.environment(model, captureSession.time.created, capturePrompt.harness)
-            : Effect.succeed([]),
-          sys.skills({
-            ...ag,
-            permission: Agent.runtimePermission(ag, captureSession.permission),
-          }),
-          instruction.system().pipe(Effect.orDie),
-        ])
-        // (checkpoint-writer never requests json_schema output, so STRUCTURED_OUTPUT_SYSTEM_PROMPT
-        // is not included; parent's runLoop adds it conditionally based on user.format)
-        // Must stay byte-identical to the runLoop's additions for Anthropic prefix-cache parity.
-        const additions = [
-          ...env,
-          ...(skills ? [skills] : []),
-          ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
-        ]
+        const captureUser = captureMessages.findLast((message) => message.info.role === "user")
+        if (!captureUser || captureUser.info.role !== "user") return empty
+        const runtimePermission = Agent.runtimePermission(ag, captureSession.permission)
+        const key = SessionPrefixSnapshot.profileKey({
+          providerID: model.providerID,
+          modelID: model.id,
+          agent: ag.name,
+          agentID: captureUser.info.agentID ?? "main",
+          harness: capturePrompt.harness,
+          systemMode: capturePrompt.systemMode,
+          system: capturePrompt.system ?? "",
+          permission: runtimePermission,
+        })
+        const frozen = yield* SessionPrefixSnapshot.get(input.sessionID, key)
+        const additions = frozen
+          ? []
+          : yield* Effect.gen(function* () {
+              const [env, skills, instructions] = yield* Effect.all([
+                Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+                  ? sys.environment(model, captureSession.time.created, capturePrompt.harness)
+                  : Effect.succeed([]),
+                sys.skills({ ...ag, permission: runtimePermission }),
+                instruction.system().pipe(Effect.orDie),
+              ])
+              return [
+                ...env,
+                ...(skills ? [skills] : []),
+                ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
+              ]
+            })
         const prefix = yield* buildLLMRequestPrefix({
           sessionID: input.sessionID,
           agent: ag,
           model,
           msgs: captureMessages,
           additions,
+          prebuiltSystem: frozen?.system,
           prompt: capturePrompt,
         }).pipe(
           Effect.provideService(LLM.Service, llm),
@@ -4407,35 +4421,41 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "continue" as const
             }
 
-            const [env, skills, instructions] = yield* Effect.all([
-              Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
-                ? sys.environment(model, session.time.created, sessionPrompt.harness)
-                : Effect.succeed([]),
-              sys.skills({
-                ...agent,
-                permission: Agent.runtimePermission(agent, session.permission),
-              }),
-              instruction.system().pipe(Effect.orDie),
-            ])
-            // Surface which instruction files (CLAUDE.md, AGENTS.md, ...) were loaded.
-            // Only for primary sessions (subagents would be noisy) and once per session.
-            if (!session.parentID && !instructionsNotified.has(sessionID)) {
-              instructionsNotified.add(sessionID)
-              const worktree = (yield* InstanceState.context).worktree
-              const files = Array.from(instructions.paths, (p) => Instruction.display(p, worktree))
-              if (files.length > 0) {
-                yield* bus.publish(TuiEvent.InstructionsLoaded, { files }).pipe(Effect.ignore)
+            const runtimePermission = Agent.runtimePermission(agent, session.permission)
+            const prefixProfileKey = SessionPrefixSnapshot.profileKey({
+              providerID: model.providerID,
+              modelID: model.id,
+              agent: agent.name,
+              agentID: lastUser.agentID ?? "main",
+              harness: sessionPrompt.harness,
+              systemMode: sessionPrompt.systemMode,
+              system: sessionPrompt.system ?? "",
+              permission: runtimePermission,
+            })
+            const frozen = yield* SessionPrefixSnapshot.get(sessionID, prefixProfileKey)
+            const currentAdditions = Effect.fnUntraced(function* () {
+              const [env, skills, instructions] = yield* Effect.all([
+                Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+                  ? sys.environment(model, session.time.created, sessionPrompt.harness)
+                  : Effect.succeed([]),
+                sys.skills({ ...agent, permission: runtimePermission }),
+                instruction.system().pipe(Effect.orDie),
+              ])
+              if (!session.parentID && !instructionsNotified.has(sessionID)) {
+                instructionsNotified.add(sessionID)
+                const worktree = (yield* InstanceState.context).worktree
+                const files = Array.from(instructions.paths, (path) => Instruction.display(path, worktree))
+                if (files.length > 0) {
+                  yield* bus.publish(TuiEvent.InstructionsLoaded, { files }).pipe(Effect.ignore)
+                }
               }
-            }
-            // Instruction files ship by default; the runtime environment block is opt-in
-            // (`env` is already empty unless MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT is set) and the
-            // instruction block is opt-out via MIMOCODE_DISABLE_INSTRUCTIONS.
-            const additions = [
-              ...env,
-              ...(format.type === "json_schema" ? [STRUCTURED_OUTPUT_SYSTEM_PROMPT] : []),
-              ...(skills ? [skills] : []),
-              ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
-            ]
+              return [
+                ...env,
+                ...(format.type === "json_schema" ? [STRUCTURED_OUTPUT_SYSTEM_PROMPT] : []),
+                ...(skills ? [skills] : []),
+                ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
+              ]
+            })
             // Note: `buildLLMRequestPrefix` also returns a `tools` field, but we
             // intentionally don't use it here — the `tools` variable from `resolveTools`
             // (set earlier via `handle.process({tools: ...})`) carries `execute` closures
@@ -4445,23 +4465,59 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // Main runLoop: no watermark — LLM must see the full msgs list,
             // including this turn's intermediate assistant turns (tool reads,
             // task creates, etc.) so each step doesn't replay from the bare
-            // user prompt. The watermark is for fork capture only (frozen
-            // snapshot of parent-view at spawn time).
-            const { system: prebuiltSystem, inheritedMessages: modelMsgs } =
-              yield* buildLLMRequestPrefix({
+            // user prompt. Snapshot watermarks are boundary metadata, never a
+            // reason to slice the main request history.
+            const initialPrefix = yield* buildLLMRequestPrefix({
+              sessionID,
+              agent,
+              model,
+              msgs,
+              additions: frozen ? [] : yield* currentAdditions(),
+              prebuiltSystem: frozen?.system,
+              prompt: sessionPrompt,
+              // Rebuild tails collapse into an activity log so hollow
+              // tool_results never look like a live transcript (anti-hallucination).
+              collapseCheckpointTail: true,
+            }).pipe(
+              Effect.provideService(LLM.Service, llm),
+              Effect.provideService(ToolRegistry.Service, registry),
+            )
+            const currentToolsHash = SessionPrefixSnapshot.toolsHash(tools, activeTools)
+            const resolvedPrefix = yield* Effect.gen(function* () {
+              if (!frozen) {
+                const snapshot = yield* SessionPrefixSnapshot.pin({
+                  sessionID,
+                  profileKey: prefixProfileKey,
+                  system: initialPrefix.system,
+                  toolsHash: currentToolsHash,
+                  watermarkMessageID: lastUser.id,
+                })
+                return { prefix: initialPrefix, snapshot }
+              }
+              if (frozen.tools_hash === currentToolsHash) return { prefix: initialPrefix, snapshot: frozen }
+              const prefix = yield* buildLLMRequestPrefix({
                 sessionID,
                 agent,
                 model,
                 msgs,
-                additions,
+                additions: yield* currentAdditions(),
                 prompt: sessionPrompt,
-                // Rebuild tails collapse into an activity log so hollow
-                // tool_results never look like a live transcript (anti-hallucination).
                 collapseCheckpointTail: true,
               }).pipe(
                 Effect.provideService(LLM.Service, llm),
                 Effect.provideService(ToolRegistry.Service, registry),
               )
+              const snapshot = yield* SessionPrefixSnapshot.rotate({
+                sessionID,
+                profileKey: prefixProfileKey,
+                system: prefix.system,
+                toolsHash: currentToolsHash,
+                watermarkMessageID: lastUser.id,
+              })
+              return { prefix, snapshot }
+            })
+            const prebuiltSystem = resolvedPrefix.prefix.system
+            const modelMsgs = resolvedPrefix.prefix.inheritedMessages
             lastSystemPrompt = prebuiltSystem
             const cfg = yield* config.get()
             const maxModeCfg = cfg.experimental?.maxMode
@@ -4474,9 +4530,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               permission: session.permission,
               sessionID,
               parentSessionID: session.parentID,
-              // system: additions is preserved for non-LLM consumers of StreamInput (e.g.,
-              // MessageV2.User.system for logging/replay); llm.stream itself uses prebuiltSystem.
-              system: additions,
+              system: [],
               prebuiltSystem,
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
               mergeTurnContextIntoLastUser: true,
@@ -4578,6 +4632,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   .pipe(Effect.ignore),
               ),
             )
+
+            if (handle.message.time.completed && !handle.message.error) {
+              yield* SessionPrefixSnapshot.advance({
+                sessionID,
+                profileKey: prefixProfileKey,
+                revision: resolvedPrefix.snapshot.revision,
+                watermarkMessageID: handle.message.id,
+              })
+            }
 
             if (
               result === "continue" &&

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1,6 +1,5 @@
 import path from "path"
 import os from "os"
-import { createHash } from "node:crypto"
 import z from "zod"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
@@ -141,11 +140,6 @@ import {
 } from "@/tool/mcp-tool-search"
 import { isMcpToolSearchEnabled, usesGPTToolset } from "@/tool/gpt"
 import { GPT_TOP_LEVEL_TOOLS } from "@/tool/tool-script-ref"
-import {
-  canonicalSkillCatalog,
-  isSkillCatalogSnapshot,
-  skillCatalogSnapshotVersion,
-} from "./skill-catalog"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -493,16 +487,24 @@ export const layer = Layer.effect(
         if (!captureSession) return empty
         const capturePrompt = yield* sessions.resolvePrompt({ sessionID: input.sessionID })
         const captureMessages = input.msgs as MessageV2.WithParts[]
-        const [env, instructions] = yield* Effect.all([
+        const [env, skills, instructions] = yield* Effect.all([
           Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
             ? sys.environment(model, captureSession.time.created, capturePrompt.harness)
             : Effect.succeed([]),
+          sys.skills({
+            ...ag,
+            permission: Agent.runtimePermission(ag, captureSession.permission),
+          }),
           instruction.system().pipe(Effect.orDie),
         ])
         // (checkpoint-writer never requests json_schema output, so STRUCTURED_OUTPUT_SYSTEM_PROMPT
         // is not included; parent's runLoop adds it conditionally based on user.format)
         // Must stay byte-identical to the runLoop's additions for Anthropic prefix-cache parity.
-        const additions = [...env, ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content)]
+        const additions = [
+          ...env,
+          ...(skills ? [skills] : []),
+          ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
+        ]
         const prefix = yield* buildLLMRequestPrefix({
           sessionID: input.sessionID,
           agent: ag,
@@ -1141,49 +1143,6 @@ export const layer = Layer.effect(
         ...input.agent,
         permission: Agent.runtimePermission(input.agent, input.session.permission),
       }
-      const actor = userMessage.info.agentID
-        ? yield* actorRegistry
-            .get(input.session.id, userMessage.info.agentID)
-            .pipe(Effect.orElseSucceed(() => undefined))
-        : undefined
-      const inheritsSkillCatalog =
-        actor?.contextMode === "full" && (actor.mode === "subagent" || actor.mode === "peer")
-      // A full-context fork already receives the parent's frozen model-message prefix,
-      // including its authoritative skills snapshot. Injecting again into the fork's
-      // own task message duplicates the catalog and moves static content past the query.
-      const skills = inheritsSkillCatalog ? undefined : yield* sys.skills(runtimeAgent)
-      if (skills) {
-        const canonicalCatalog = canonicalSkillCatalog(skills)
-        const catalogVersion = createHash("sha256").update(canonicalCatalog).digest("hex")
-        const latestVersion = input.messages
-          .flatMap((message) =>
-            message.parts.flatMap((part) => {
-              if (part.type !== "text" || !part.synthetic || part.ignored || !isSkillCatalogSnapshot(part.text)) return []
-              return skillCatalogSnapshotVersion(part.metadata) ?? []
-            }),
-          )
-          .at(-1)
-        if (latestVersion !== catalogVersion) {
-          const catalogText = [
-            "<system-reminder>",
-            "Authoritative skills catalog snapshot v2:",
-            "When multiple snapshots exist, the last one is authoritative.",
-            canonicalCatalog,
-            "</system-reminder>",
-          ].join("\n")
-          const part = yield* sessions.updatePart({
-            id: PartID.ascending(),
-            messageID: userMessage.info.id,
-            sessionID: userMessage.info.sessionID,
-            type: "text",
-            text: catalogText,
-            synthetic: true,
-            metadata: { skillCatalog: { schema: 2, version: catalogVersion } },
-          })
-          userMessage.parts.unshift(part)
-        }
-      }
-
       const composeModeMsg = input.messages.find(
         (msg) => msg.info.role === "user" && msg.info.agent === "compose",
       )
@@ -4448,10 +4407,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "continue" as const
             }
 
-            const [env, instructions] = yield* Effect.all([
+            const [env, skills, instructions] = yield* Effect.all([
               Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
                 ? sys.environment(model, session.time.created, sessionPrompt.harness)
                 : Effect.succeed([]),
+              sys.skills({
+                ...agent,
+                permission: Agent.runtimePermission(agent, session.permission),
+              }),
               instruction.system().pipe(Effect.orDie),
             ])
             // Surface which instruction files (CLAUDE.md, AGENTS.md, ...) were loaded.
@@ -4469,8 +4432,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // instruction block is opt-out via MIMOCODE_DISABLE_INSTRUCTIONS.
             const additions = [
               ...env,
-              ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
               ...(format.type === "json_schema" ? [STRUCTURED_OUTPUT_SYSTEM_PROMPT] : []),
+              ...(skills ? [skills] : []),
+              ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
             ]
             // Note: `buildLLMRequestPrefix` also returns a `tools` field, but we
             // intentionally don't use it here — the `tools` variable from `resolveTools`

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -53,6 +53,25 @@ export const SessionTable = sqliteTable(
   ],
 )
 
+export const SessionPrefixSnapshotTable = sqliteTable(
+  "session_prefix_snapshot",
+  {
+    session_id: text()
+      .$type<SessionID>()
+      .notNull()
+      .references(() => SessionTable.id, { onDelete: "cascade" }),
+    profile_key: text().notNull(),
+    system: text({ mode: "json" }).$type<string[]>().notNull(),
+    system_hash: text().notNull(),
+    tools_hash: text().notNull(),
+    watermark_message_id: text().$type<MessageID>().notNull(),
+    revision: integer().notNull(),
+    created_at: integer().notNull(),
+    updated_at: integer().notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.session_id, table.profile_key] })],
+)
+
 export const MessageTable = sqliteTable(
   "message",
   {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -131,7 +131,7 @@ function basePart(messageID: string, id: string) {
 }
 
 describe("session.message-v2.toModelMessage", () => {
-  test("keeps one legacy skills catalog in its historical model position", async () => {
+  test("suppresses legacy user-side skill catalogs", async () => {
     const input: MessageV2.WithParts[] = [
       {
         info: userInfo("m-skills-first"),
@@ -171,17 +171,13 @@ describe("session.message-v2.toModelMessage", () => {
         content: [
           { type: "text", text: "hello" },
           { type: "text", text: "<system-reminder>other</system-reminder>" },
-          {
-            type: "text",
-            text: "<system-reminder>\nSkills available in this session:\nFIRST\n</system-reminder>",
-          },
         ],
       },
       { role: "user", content: [{ type: "text", text: "continue" }] },
     ])
   })
 
-  test("keeps every authoritative skills snapshot before its user query", async () => {
+  test("suppresses persisted skill snapshots after catalogs move to system", async () => {
     const firstSnapshot = [
       "<system-reminder>",
       "Authoritative skills catalog snapshot v2:",
@@ -209,20 +205,8 @@ describe("session.message-v2.toModelMessage", () => {
     ]
 
     expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
-      {
-        role: "user",
-        content: [
-          { type: "text", text: firstSnapshot },
-          { type: "text", text: "hello" },
-        ],
-      },
-      {
-        role: "user",
-        content: [
-          { type: "text", text: secondSnapshot },
-          { type: "text", text: "continue" },
-        ],
-      },
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      { role: "user", content: [{ type: "text", text: "continue" }] },
     ])
   })
 

--- a/packages/opencode/test/session/prefix-snapshot.test.ts
+++ b/packages/opencode/test/session/prefix-snapshot.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test"
+import { jsonSchema, tool } from "ai"
+import { Instance } from "../../src/project/instance"
+import { Session as SessionNs } from "../../src/session"
+import { SessionPrefixSnapshot } from "../../src/session/prefix-snapshot"
+import { MessageID } from "../../src/session/schema"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { tmpdir } from "../fixture/fixture"
+
+describe("session prefix snapshot", () => {
+  test("pins, rotates, advances, and cascades with its session", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await AppRuntime.runPromise(SessionNs.Service.use((service) => service.create({})))
+        const key = SessionPrefixSnapshot.profileKey({
+          providerID: "test",
+          modelID: "test-model",
+          agent: "build",
+          agentID: "main",
+          harness: "auto",
+          systemMode: "append",
+          system: "",
+          permission: [],
+        })
+        const firstWatermark = MessageID.ascending()
+        const first = await AppRuntime.runPromise(
+          SessionPrefixSnapshot.pin({
+            sessionID: session.id,
+            profileKey: key,
+            system: ["first"],
+            toolsHash: "tools-1",
+            watermarkMessageID: firstWatermark,
+          }),
+        )
+        expect(first).toMatchObject({
+          revision: 1,
+          system: ["first"],
+          tools_hash: "tools-1",
+          watermark_message_id: firstWatermark,
+        })
+
+        const pinned = await AppRuntime.runPromise(
+          SessionPrefixSnapshot.pin({
+            sessionID: session.id,
+            profileKey: key,
+            system: ["ignored"],
+            toolsHash: "ignored",
+            watermarkMessageID: MessageID.ascending(),
+          }),
+        )
+        expect(pinned).toEqual(first)
+
+        const rotated = await AppRuntime.runPromise(
+          SessionPrefixSnapshot.rotate({
+            sessionID: session.id,
+            profileKey: key,
+            system: ["second"],
+            toolsHash: "tools-2",
+            watermarkMessageID: firstWatermark,
+          }),
+        )
+        expect(rotated).toMatchObject({ revision: 2, system: ["second"], tools_hash: "tools-2" })
+
+        const finalWatermark = MessageID.ascending()
+        await AppRuntime.runPromise(
+          SessionPrefixSnapshot.advance({
+            sessionID: session.id,
+            profileKey: key,
+            revision: 1,
+            watermarkMessageID: MessageID.ascending(),
+          }),
+        )
+        await AppRuntime.runPromise(
+          SessionPrefixSnapshot.advance({
+            sessionID: session.id,
+            profileKey: key,
+            revision: 2,
+            watermarkMessageID: finalWatermark,
+          }),
+        )
+        expect(await AppRuntime.runPromise(SessionPrefixSnapshot.get(session.id, key))).toMatchObject({
+          revision: 2,
+          watermark_message_id: finalWatermark,
+        })
+
+        await AppRuntime.runPromise(SessionNs.Service.use((service) => service.remove(session.id)))
+        expect(await AppRuntime.runPromise(SessionPrefixSnapshot.get(session.id, key))).toBeUndefined()
+      },
+    })
+  })
+
+  test("profile and tool hashes are stable across key order", () => {
+    const permission = [{ permission: "*", pattern: "*", action: "allow" as const }]
+    const key = SessionPrefixSnapshot.profileKey({
+      providerID: "p",
+      modelID: "m",
+      agent: "build",
+      agentID: "main",
+      harness: "auto",
+      systemMode: "append",
+      system: "",
+      permission,
+    })
+    expect(key).toBe(
+      SessionPrefixSnapshot.profileKey({
+        permission,
+        systemMode: "append",
+        system: "",
+        harness: "auto",
+        agentID: "main",
+        agent: "build",
+        modelID: "m",
+        providerID: "p",
+      }),
+    )
+    expect(key).not.toBe(
+      SessionPrefixSnapshot.profileKey({
+        providerID: "p",
+        modelID: "other",
+        agent: "build",
+        agentID: "main",
+        harness: "auto",
+        systemMode: "append",
+        system: "",
+        permission,
+      }),
+    )
+    const first = {
+      beta: tool({ description: "b", inputSchema: jsonSchema({ type: "object", properties: {} }) }),
+      alpha: tool({ description: "a", inputSchema: jsonSchema({ type: "object", properties: {} }) }),
+    }
+    const second = { alpha: first.alpha, beta: first.beta }
+    expect(SessionPrefixSnapshot.toolsHash(first, ["beta", "alpha"])).toBe(
+      SessionPrefixSnapshot.toolsHash(second, ["alpha", "beta"]),
+    )
+  })
+})

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -59,6 +59,8 @@ import { testEffect } from "../lib/effect"
 import { reply, TestLLMServer } from "../lib/llm-server"
 import { Inbox } from "../../src/inbox"
 import { Metrics } from "../../src/metrics"
+import { Database, eq } from "../../src/storage"
+import { SessionPrefixSnapshotTable } from "../../src/session/session.sql"
 
 void Log.init({ print: false })
 
@@ -1085,6 +1087,73 @@ it.live(
           expect(system).toContain("Skills available in this session:")
           expect(system.indexOf("Skills available in this session:")).toBeLessThan(system.indexOf(marker))
           expect(system.trim().endsWith(marker)).toBe(true)
+        }),
+        { git: true, config: providerCfg },
+      ),
+    ),
+  30_000,
+)
+
+it.live(
+  "reuses the frozen system prefix for later queries in the same session",
+  () =>
+    withoutDynamicSystemPrompt(() =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const file = path.join(Instance.directory, "AGENTS.md")
+          yield* Effect.promise(() => Bun.write(file, "PREFIX_INSTRUCTION_V1"))
+          const chat = yield* sessions.create({
+            title: "Frozen prefix",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+
+          yield* llm.text("first")
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "first query" }],
+          })
+          yield* Effect.promise(() => Bun.write(file, "PREFIX_INSTRUCTION_V2"))
+          yield* llm.text("second")
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "second query" }],
+          })
+
+          const inputs = yield* llm.inputs
+          const systems = inputs.slice(0, 2).map((input) =>
+            ((input.messages ?? []) as { role: string; content: unknown }[])
+              .flatMap((message) =>
+                message.role === "system" && typeof message.content === "string" ? [message.content] : [],
+              )
+              .join("\n"),
+          )
+          expect(systems).toHaveLength(2)
+          expect(systems[0]).toContain("PREFIX_INSTRUCTION_V1")
+          expect(systems[1]).toBe(systems[0])
+          expect(systems[1]).not.toContain("PREFIX_INSTRUCTION_V2")
+
+          const snapshots = yield* Effect.sync(() =>
+            Database.use((db) =>
+              db
+                .select()
+                .from(SessionPrefixSnapshotTable)
+                .where(eq(SessionPrefixSnapshotTable.session_id, chat.id))
+                .all(),
+            ),
+          )
+          const messages = yield* sessions.messages({ sessionID: chat.id })
+          const lastAssistant = messages.findLast((message) => message.info.role === "assistant")
+          expect(snapshots).toHaveLength(1)
+          expect(snapshots[0]).toMatchObject({
+            revision: 1,
+            watermark_message_id: lastAssistant?.info.id,
+          })
         }),
         { git: true, config: providerCfg },
       ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1051,36 +1051,45 @@ it.live("resume continues an incomplete assistant without creating or rewriting 
   ),
 )
 
-it.live("loop injects instruction files but not the dynamic environment block", () =>
-  withoutDynamicSystemPrompt(() =>
-    provideTmpdirServer(
-      Effect.fnUntraced(function* ({ llm }) {
-        const prompt = yield* SessionPrompt.Service
-        const sessions = yield* Session.Service
-        const marker = "dynamic-instruction-marker"
-        yield* Effect.promise(() => Bun.write(path.join(Instance.directory, "AGENTS.md"), marker))
-        const chat = yield* sessions.create({
-          title: "No cwd",
-          permission: [{ permission: "*", pattern: "*", action: "allow" }],
-        })
-        yield* prompt.prompt({
-          sessionID: chat.id,
-          agent: "build",
-          model: ref,
-          noReply: true,
-          parts: [{ type: "text", text: "hello" }],
-        })
-        yield* llm.text("world")
+it.live(
+  "loop injects instruction files but not the dynamic environment block",
+  () =>
+    withoutDynamicSystemPrompt(() =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const marker = "dynamic-instruction-marker"
+          yield* Effect.promise(() => Bun.write(path.join(Instance.directory, "AGENTS.md"), marker))
+          const chat = yield* sessions.create({
+            title: "No cwd",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            noReply: true,
+            parts: [{ type: "text", text: "hello" }],
+          })
+          yield* llm.text("world")
 
-        yield* prompt.loop({ sessionID: chat.id })
+          yield* prompt.loop({ sessionID: chat.id })
 
-        const inputs = JSON.stringify(yield* llm.inputs)
-        expect(inputs).not.toContain("Working directory:")
-        expect(inputs).toContain(marker)
-      }),
-      { git: true, config: providerCfg },
+          const inputs = yield* llm.inputs
+          const serialized = JSON.stringify(inputs)
+          const system = ((inputs[0].messages ?? []) as { role: string; content: unknown }[])
+            .flatMap((message) => message.role === "system" && typeof message.content === "string" ? [message.content] : [])
+            .join("\n")
+          expect(serialized).not.toContain("Working directory:")
+          expect(system).toContain("Skills available in this session:")
+          expect(system.indexOf("Skills available in this session:")).toBeLessThan(system.indexOf(marker))
+          expect(system.trim().endsWith(marker)).toBe(true)
+        }),
+        { git: true, config: providerCfg },
+      ),
     ),
-  ),
+  30_000,
 )
 
 it.live("loop injects the dynamic environment block only when the flag is set", () =>

--- a/packages/opencode/test/session/prompt-skill-command-multi.test.ts
+++ b/packages/opencode/test/session/prompt-skill-command-multi.test.ts
@@ -46,6 +46,7 @@ describe("skill command with additional mentions", () => {
       provideTmpdirServer(
         Effect.fnUntraced(function* ({ dir, llm }) {
           yield* writeSkill(dir, "skill-profile", "PROFILE_SKILL_MARKER")
+          yield* Effect.promise(() => Bun.write(path.join(dir, "AGENTS.md"), "PROFILE_INSTRUCTION_MARKER"))
           yield* llm.text("ok")
 
           const prompt = yield* SessionPrompt.Service
@@ -77,6 +78,12 @@ describe("skill command with additional mentions", () => {
           })
           const request = (yield* llm.inputs)[0]
           expect(JSON.stringify(request)).toContain("COMMAND_SYSTEM_MARKER")
+          const system = ((request.messages ?? []) as { role: string; content: unknown }[])
+            .flatMap((message) => message.role === "system" && typeof message.content === "string" ? [message.content] : [])
+            .join("\n")
+          expect(system.indexOf("COMMAND_SYSTEM_MARKER")).toBeLessThan(system.indexOf("Skills available in this session:"))
+          expect(system.indexOf("Skills available in this session:")).toBeLessThan(system.indexOf("PROFILE_INSTRUCTION_MARKER"))
+          expect(system.trim().endsWith("PROFILE_INSTRUCTION_MARKER")).toBe(true)
           expect((request.tools as Array<Record<string, unknown>>).map((tool) =>
             typeof tool.function === "object" && tool.function && "name" in tool.function
               ? String(tool.function.name)
@@ -126,10 +133,10 @@ describe("skill command with additional mentions", () => {
           const messages = (request.messages ?? []) as { role: string; content: unknown }[]
           const system = JSON.stringify(messages.filter((message) => message.role === "system"))
           const users = JSON.stringify(messages.filter((message) => message.role === "user"))
-          expect(system).not.toContain("Skills available in this session:")
+          expect(system).toContain("Skills available in this session:")
           expect(system).not.toContain("ALPHA_BODY_MARKER")
           expect(system).not.toContain("BETA_BODY_MARKER")
-          expect(users).toContain("Skills available in this session:")
+          expect(users).not.toContain("Skills available in this session:")
           expect(users).toContain("ALPHA_BODY_MARKER")
           expect(users).toContain("BETA_BODY_MARKER")
 
@@ -173,10 +180,15 @@ describe("skill command with additional mentions", () => {
           expect(visible.map((p) => (p.type === "text" ? p.text : ""))).toContain("/skill-alpha")
 
           const text = user!.parts.flatMap((p) => (p.type === "text" ? [p.text] : [])).join("\n")
-          expect(text).toContain("Skills available in this session:")
+          expect(text).not.toContain("Skills available in this session:")
           expect(text).toContain('<system-reminder>\n<skill_content name="skill-alpha">')
           expect(text).not.toContain("BETA_BODY_MARKER")
           expect(text).not.toContain("explicitly referenced multiple skills")
+
+          const system = JSON.stringify(
+            (((yield* llm.inputs)[0].messages ?? []) as { role: string }[]).filter((message) => message.role === "system"),
+          )
+          expect(system).toContain("Skills available in this session:")
 
           yield* sessions.remove(session.id)
         }),
@@ -185,10 +197,10 @@ describe("skill command with additional mentions", () => {
     30_000,
   )
 
-  // [TP-R14-01][TP-R14-03] An unchanged catalog is injected once, stays before
-  // the first query after DB rehydration, and never triggers slash mentions from its own descriptions.
+  // [TP-R14-01][TP-R14-03] An unchanged catalog stays in the system tail and
+  // never triggers slash mentions from its own descriptions.
   it.live(
-    "keeps one versioned catalog before user content across turns",
+    "keeps one system catalog across turns without persisting it as user content",
     () =>
       provideTmpdirServer(
         Effect.fnUntraced(function* ({ dir, llm }) {
@@ -218,9 +230,7 @@ describe("skill command with additional mentions", () => {
           const requests = yield* llm.inputs
           const second = JSON.stringify(requests[1].messages ?? [])
           expect(second.match(/Skills available in this session:/g)).toHaveLength(1)
-          expect(second.indexOf("Authoritative skills catalog snapshot v2:")).toBeLessThan(
-            second.indexOf("/skill-alpha"),
-          )
+          expect(second).not.toContain("Authoritative skills catalog snapshot v2:")
           expect(second).toContain("ALPHA_BODY_MARKER")
           expect(second).not.toContain("BETA_BODY_MARKER")
 
@@ -231,13 +241,7 @@ describe("skill command with additional mentions", () => {
                 part.type === "text" && !part.ignored && part.text.includes("Skills available in this session:"),
             ),
           )
-          expect(catalogs).toHaveLength(1)
-          const catalog = catalogs[0]?.type === "text" ? catalogs[0] : undefined
-          expect(catalog?.text ?? "").not.toContain("Catalog-Version")
-          expect(catalog?.metadata?.skillCatalog).toMatchObject({ schema: 2 })
-          expect((catalog?.metadata?.skillCatalog as { version?: string } | undefined)?.version).toMatch(
-            /^[a-f0-9]{64}$/,
-          )
+          expect(catalogs).toHaveLength(0)
           expect(second).not.toContain("Catalog-Version")
 
           yield* sessions.remove(session.id)
@@ -247,10 +251,10 @@ describe("skill command with additional mentions", () => {
     30_000,
   )
 
-  // [TP-R14-02][TP-R14-04][TP-R14-05] A changed catalog appends a full snapshot
-  // to the new turn. The prior snapshot remains byte-for-byte untouched and both reach the model.
+  // [TP-R14-02][TP-R14-04][TP-R14-05] A changed catalog replaces the system-tail
+  // catalog on the next request without rewriting user history.
   it.live(
-    "appends a changed catalog snapshot without rewriting history",
+    "refreshes a changed system catalog without rewriting history",
     () =>
       provideTmpdirServer(
         Effect.fnUntraced(function* ({ dir, llm }) {
@@ -269,12 +273,9 @@ describe("skill command with additional mentions", () => {
             parts: [{ type: "text", text: "first request" }],
           })
 
-          const before = (yield* sessions.messages({ sessionID: session.id })).flatMap((message) =>
-            message.parts.filter(
-              (part) => part.type === "text" && part.text.includes("Authoritative skills catalog snapshot v2:"),
-            ),
-          )[0]
-          expect(before).toBeDefined()
+          const firstRequest = JSON.stringify((yield* llm.inputs)[0].messages ?? [])
+          expect(firstRequest).toContain("<name>skill-alpha</name>")
+          expect(firstRequest).not.toContain("<name>skill-beta</name>")
 
           yield* writeSkill(dir, "skill-beta", "BETA_BODY_MARKER")
           yield* registry.reload()
@@ -286,26 +287,17 @@ describe("skill command with additional mentions", () => {
             parts: [{ type: "text", text: "second request" }],
           })
 
-          const after = (yield* sessions.messages({ sessionID: session.id })).flatMap((message) =>
+          const catalogs = (yield* sessions.messages({ sessionID: session.id })).flatMap((message) =>
             message.parts.filter(
-              (part) => part.type === "text" && part.text.includes("Authoritative skills catalog snapshot v2:"),
+              (part) => part.type === "text" && part.text.includes("Skills available in this session:"),
             ),
           )
-          expect(after).toHaveLength(2)
-          expect(after[0]).toEqual(before)
-          expect(after.every((part) => part.type !== "text" || !part.ignored)).toBe(true)
-          expect(after[0]?.type === "text" ? after[0].text : "").not.toContain("<name>skill-beta</name>")
-          expect(after[1]?.type === "text" ? after[1].text : "").toContain("<name>skill-beta</name>")
+          expect(catalogs).toHaveLength(0)
 
           const request = JSON.stringify((yield* llm.inputs)[1].messages ?? [])
-          expect(request.match(/Authoritative skills catalog snapshot v2:/g)).toHaveLength(2)
-          expect(request).not.toContain("Catalog-Version")
-          expect(request.indexOf("Authoritative skills catalog snapshot v2:")).toBeLessThan(
-            request.indexOf("first request"),
-          )
-          expect(request.lastIndexOf("Authoritative skills catalog snapshot v2:")).toBeLessThan(
-            request.indexOf("second request"),
-          )
+          expect(request.match(/Skills available in this session:/g)).toHaveLength(1)
+          expect(request).toContain("<name>skill-alpha</name>")
+          expect(request).toContain("<name>skill-beta</name>")
 
           yield* sessions.remove(session.id)
         }),
@@ -435,8 +427,8 @@ describe("skill command with additional mentions", () => {
 
           // ...but the catalog the model reads must not list it, so the model
           // cannot pick it up on its own in a later turn.
-          const catalog = user!.parts.flatMap((p) =>
-            p.type === "text" && p.text.includes("Skills available in this session:") ? [p.text] : [],
+          const catalog = (((yield* llm.inputs)[0].messages ?? []) as { role: string; content: unknown }[]).flatMap(
+            (message) => message.role === "system" && typeof message.content === "string" ? [message.content] : [],
           )
           expect(catalog).toHaveLength(1)
           expect(catalog[0]).toContain("<name>skill-alpha</name>")

--- a/packages/opencode/test/session/prompt-skill-command-multi.test.ts
+++ b/packages/opencode/test/session/prompt-skill-command-multi.test.ts
@@ -251,10 +251,10 @@ describe("skill command with additional mentions", () => {
     30_000,
   )
 
-  // [TP-R14-02][TP-R14-04][TP-R14-05] A changed catalog replaces the system-tail
-  // catalog on the next request without rewriting user history.
+  // [TP-R14-02][TP-R14-04][TP-R14-05] A session keeps its first system-tail
+  // catalog even when the registry changes.
   it.live(
-    "refreshes a changed system catalog without rewriting history",
+    "keeps the session catalog frozen after a registry reload",
     () =>
       provideTmpdirServer(
         Effect.fnUntraced(function* ({ dir, llm }) {
@@ -297,7 +297,7 @@ describe("skill command with additional mentions", () => {
           const request = JSON.stringify((yield* llm.inputs)[1].messages ?? [])
           expect(request.match(/Skills available in this session:/g)).toHaveLength(1)
           expect(request).toContain("<name>skill-alpha</name>")
-          expect(request).toContain("<name>skill-beta</name>")
+          expect(request).not.toContain("<name>skill-beta</name>")
 
           yield* sessions.remove(session.id)
         }),


### PR DESCRIPTION
## Summary
- Inject the skills catalog into the system prompt tail (after environment, before instruction files) instead of persisting synthetic user-side parts.
- Suppress legacy user-side catalogs on resume so older sessions do not receive a duplicate catalog.
- Plugins now transform the stable base before the caller-controlled tail is appended.
- `replace-agent` prompts occupy the same leading position as the agent prompt they replace.
- Update session tests to assert system-tail catalog ordering and no user-side persistence.

## Verification
- `bun turbo typecheck` passed on push.
- Updated tests cover: system-tail ordering (skills before instructions), no user-side catalog persistence, legacy snapshot suppression, and refresh-on-change without history rewrite.