### PR TITLE
feat(session): freeze the per-session system prefix in a persistent snapshot

### DIFF
--- a/packages/opencode/migration/20260829000000_session_prefix_snapshot/migration.sql
+++ b/packages/opencode/migration/20260829000000_session_prefix_snapshot/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `session_prefix_snapshot` (
+  `session_id` text NOT NULL REFERENCES `session`(`id`) ON DELETE CASCADE,
+  `profile_key` text NOT NULL,
+  `system` text NOT NULL,
+  `system_hash` text NOT NULL,
+  `tools_hash` text NOT NULL,
+  `watermark_message_id` text NOT NULL,
+  `revision` integer NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  PRIMARY KEY(`session_id`, `profile_key`)
+);

--- a/packages/opencode/src/session/llm-request-prefix.ts
+++ b/packages/opencode/src/session/llm-request-prefix.ts
@@ -42,6 +42,8 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
    * then instruction files. Caller is responsible for the ordering and content.
    */
   additions: string[]
+  /** Frozen Session/Fork system; bypasses all system regeneration when present. */
+  prebuiltSystem?: string[]
   prompt?: PromptConfig
   /**
    * Collapse post-checkpoint rebuild tails into an activity log. Enable for the
@@ -74,14 +76,16 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
     : (lastUserMsg.info as MessageV2.User)
 
   // Build system using LLM.buildSystemArray (single source of truth shared with stream())
-  const system = yield* llm.buildSystemArray({
-    agent: input.agent,
-    model: input.model,
-    system: input.additions,
-    user: lastUser,
-    sessionID: input.sessionID as string,
-    agentID: lastUser.agentID,
-  })
+  const system =
+    input.prebuiltSystem ??
+    (yield* llm.buildSystemArray({
+      agent: input.agent,
+      model: input.model,
+      system: input.additions,
+      user: lastUser,
+      sessionID: input.sessionID as string,
+      agentID: lastUser.agentID,
+    }))
 
   // Resolve tools using parent agent's permission and toolAllowlist
   const toolDefs = yield* toolRegistry.tools({

--- a/packages/opencode/src/session/prefix-snapshot.ts
+++ b/packages/opencode/src/session/prefix-snapshot.ts
@@ -1,0 +1,165 @@
+import { createHash } from "node:crypto"
+import type { Tool as AITool } from "ai"
+import { Effect } from "effect"
+import { and, Database, eq } from "@/storage"
+import type { Permission } from "@/permission"
+import type { MessageID, SessionID } from "./schema"
+import { SessionPrefixSnapshotTable } from "./session.sql"
+
+export type Info = typeof SessionPrefixSnapshotTable.$inferSelect
+
+type Profile = {
+  providerID: string
+  modelID: string
+  agent: string
+  agentID: string
+  harness: string
+  systemMode: string
+  system: string
+  permission: Permission.Ruleset
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return JSON.stringify(value)
+  if (typeof value === "number") return Number.isFinite(value) ? JSON.stringify(value) : "null"
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`
+  if (typeof value !== "object") return "null"
+  return `{${Object.keys(value)
+    .toSorted()
+    .flatMap((key) => {
+      const item = (value as Record<string, unknown>)[key]
+      if (item === undefined || typeof item === "function" || typeof item === "symbol") return []
+      return [`${JSON.stringify(key)}:${stableStringify(item)}`]
+    })
+    .join(",")}}`
+}
+
+function hash(value: unknown) {
+  return createHash("sha256").update(stableStringify(value)).digest("hex")
+}
+
+export function profileKey(input: Profile) {
+  return hash(input)
+}
+
+export function systemHash(system: string[]) {
+  return hash(system)
+}
+
+export function toolsHash(tools: Record<string, AITool>, activeTools: string[]) {
+  return hash(
+    activeTools.toSorted().flatMap((name) => {
+      const item = tools[name]
+      return item ? [{ name, description: item.description, inputSchema: item.inputSchema }] : []
+    }),
+  )
+}
+
+export const get = Effect.fn("SessionPrefixSnapshot.get")(function* (sessionID: SessionID, key: string) {
+  return yield* Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .select()
+        .from(SessionPrefixSnapshotTable)
+        .where(
+          and(
+            eq(SessionPrefixSnapshotTable.session_id, sessionID),
+            eq(SessionPrefixSnapshotTable.profile_key, key),
+          ),
+        )
+        .get(),
+    ),
+  )
+})
+
+export const pin = Effect.fn("SessionPrefixSnapshot.pin")(function* (input: {
+  sessionID: SessionID
+  profileKey: string
+  system: string[]
+  toolsHash: string
+  watermarkMessageID: MessageID
+}) {
+  const now = Date.now()
+  yield* Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .insert(SessionPrefixSnapshotTable)
+        .values({
+          session_id: input.sessionID,
+          profile_key: input.profileKey,
+          system: input.system,
+          system_hash: systemHash(input.system),
+          tools_hash: input.toolsHash,
+          watermark_message_id: input.watermarkMessageID,
+          revision: 1,
+          created_at: now,
+          updated_at: now,
+        })
+        .onConflictDoNothing()
+        .run(),
+    ),
+  )
+  const snapshot = yield* get(input.sessionID, input.profileKey)
+  if (!snapshot) return yield* Effect.die(new Error("Failed to read pinned session prefix snapshot"))
+  return snapshot
+})
+
+export const rotate = Effect.fn("SessionPrefixSnapshot.rotate")(function* (input: {
+  sessionID: SessionID
+  profileKey: string
+  system: string[]
+  toolsHash: string
+  watermarkMessageID: MessageID
+}) {
+  const current = yield* get(input.sessionID, input.profileKey)
+  if (!current) return yield* pin(input)
+  yield* Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .update(SessionPrefixSnapshotTable)
+        .set({
+          system: input.system,
+          system_hash: systemHash(input.system),
+          tools_hash: input.toolsHash,
+          watermark_message_id: input.watermarkMessageID,
+          revision: current.revision + 1,
+          updated_at: Date.now(),
+        })
+        .where(
+          and(
+            eq(SessionPrefixSnapshotTable.session_id, input.sessionID),
+            eq(SessionPrefixSnapshotTable.profile_key, input.profileKey),
+          ),
+        )
+        .run(),
+    ),
+  )
+  const snapshot = yield* get(input.sessionID, input.profileKey)
+  if (!snapshot) return yield* Effect.die(new Error("Failed to read rotated session prefix snapshot"))
+  return snapshot
+})
+
+export const advance = Effect.fn("SessionPrefixSnapshot.advance")(function* (input: {
+  sessionID: SessionID
+  profileKey: string
+  revision: number
+  watermarkMessageID: MessageID
+}) {
+  yield* Effect.sync(() =>
+    Database.use((db) =>
+      db
+        .update(SessionPrefixSnapshotTable)
+        .set({ watermark_message_id: input.watermarkMessageID, updated_at: Date.now() })
+        .where(
+          and(
+            eq(SessionPrefixSnapshotTable.session_id, input.sessionID),
+            eq(SessionPrefixSnapshotTable.profile_key, input.profileKey),
+            eq(SessionPrefixSnapshotTable.revision, input.revision),
+          ),
+        )
+        .run(),
+    ),
+  )
+})
+
+export * as SessionPrefixSnapshot from "./prefix-snapshot"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -140,6 +140,7 @@ import {
 } from "@/tool/mcp-tool-search"
 import { isMcpToolSearchEnabled, usesGPTToolset } from "@/tool/gpt"
 import { GPT_TOP_LEVEL_TOOLS } from "@/tool/tool-script-ref"
+import { SessionPrefixSnapshot } from "./prefix-snapshot"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -487,30 +488,43 @@ export const layer = Layer.effect(
         if (!captureSession) return empty
         const capturePrompt = yield* sessions.resolvePrompt({ sessionID: input.sessionID })
         const captureMessages = input.msgs as MessageV2.WithParts[]
-        const [env, skills, instructions] = yield* Effect.all([
-          Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
-            ? sys.environment(model, captureSession.time.created, capturePrompt.harness)
-            : Effect.succeed([]),
-          sys.skills({
-            ...ag,
-            permission: Agent.runtimePermission(ag, captureSession.permission),
-          }),
-          instruction.system().pipe(Effect.orDie),
-        ])
-        // (checkpoint-writer never requests json_schema output, so STRUCTURED_OUTPUT_SYSTEM_PROMPT
-        // is not included; parent's runLoop adds it conditionally based on user.format)
-        // Must stay byte-identical to the runLoop's additions for Anthropic prefix-cache parity.
-        const additions = [
-          ...env,
-          ...(skills ? [skills] : []),
-          ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
-        ]
+        const captureUser = captureMessages.findLast((message) => message.info.role === "user")
+        if (!captureUser || captureUser.info.role !== "user") return empty
+        const runtimePermission = Agent.runtimePermission(ag, captureSession.permission)
+        const key = SessionPrefixSnapshot.profileKey({
+          providerID: model.providerID,
+          modelID: model.id,
+          agent: ag.name,
+          agentID: captureUser.info.agentID ?? "main",
+          harness: capturePrompt.harness,
+          systemMode: capturePrompt.systemMode,
+          system: capturePrompt.system ?? "",
+          permission: runtimePermission,
+        })
+        const frozen = yield* SessionPrefixSnapshot.get(input.sessionID, key)
+        const additions = frozen
+          ? []
+          : yield* Effect.gen(function* () {
+              const [env, skills, instructions] = yield* Effect.all([
+                Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+                  ? sys.environment(model, captureSession.time.created, capturePrompt.harness)
+                  : Effect.succeed([]),
+                sys.skills({ ...ag, permission: runtimePermission }),
+                instruction.system().pipe(Effect.orDie),
+              ])
+              return [
+                ...env,
+                ...(skills ? [skills] : []),
+                ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
+              ]
+            })
         const prefix = yield* buildLLMRequestPrefix({
           sessionID: input.sessionID,
           agent: ag,
           model,
           msgs: captureMessages,
           additions,
+          prebuiltSystem: frozen?.system,
           prompt: capturePrompt,
         }).pipe(
           Effect.provideService(LLM.Service, llm),
@@ -4407,35 +4421,41 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "continue" as const
             }
 
-            const [env, skills, instructions] = yield* Effect.all([
-              Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
-                ? sys.environment(model, session.time.created, sessionPrompt.harness)
-                : Effect.succeed([]),
-              sys.skills({
-                ...agent,
-                permission: Agent.runtimePermission(agent, session.permission),
-              }),
-              instruction.system().pipe(Effect.orDie),
-            ])
-            // Surface which instruction files (CLAUDE.md, AGENTS.md, ...) were loaded.
-            // Only for primary sessions (subagents would be noisy) and once per session.
-            if (!session.parentID && !instructionsNotified.has(sessionID)) {
-              instructionsNotified.add(sessionID)
-              const worktree = (yield* InstanceState.context).worktree
-              const files = Array.from(instructions.paths, (p) => Instruction.display(p, worktree))
-              if (files.length > 0) {
-                yield* bus.publish(TuiEvent.InstructionsLoaded, { files }).pipe(Effect.ignore)
+            const runtimePermission = Agent.runtimePermission(agent, session.permission)
+            const prefixProfileKey = SessionPrefixSnapshot.profileKey({
+              providerID: model.providerID,
+              modelID: model.id,
+              agent: agent.name,
+              agentID: lastUser.agentID ?? "main",
+              harness: sessionPrompt.harness,
+              systemMode: sessionPrompt.systemMode,
+              system: sessionPrompt.system ?? "",
+              permission: runtimePermission,
+            })
+            const frozen = yield* SessionPrefixSnapshot.get(sessionID, prefixProfileKey)
+            const currentAdditions = Effect.fnUntraced(function* () {
+              const [env, skills, instructions] = yield* Effect.all([
+                Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
+                  ? sys.environment(model, session.time.created, sessionPrompt.harness)
+                  : Effect.succeed([]),
+                sys.skills({ ...agent, permission: runtimePermission }),
+                instruction.system().pipe(Effect.orDie),
+              ])
+              if (!session.parentID && !instructionsNotified.has(sessionID)) {
+                instructionsNotified.add(sessionID)
+                const worktree = (yield* InstanceState.context).worktree
+                const files = Array.from(instructions.paths, (path) => Instruction.display(path, worktree))
+                if (files.length > 0) {
+                  yield* bus.publish(TuiEvent.InstructionsLoaded, { files }).pipe(Effect.ignore)
+                }
               }
-            }
-            // Instruction files ship by default; the runtime environment block is opt-in
-            // (`env` is already empty unless MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT is set) and the
-            // instruction block is opt-out via MIMOCODE_DISABLE_INSTRUCTIONS.
-            const additions = [
-              ...env,
-              ...(format.type === "json_schema" ? [STRUCTURED_OUTPUT_SYSTEM_PROMPT] : []),
-              ...(skills ? [skills] : []),
-              ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
-            ]
+              return [
+                ...env,
+                ...(format.type === "json_schema" ? [STRUCTURED_OUTPUT_SYSTEM_PROMPT] : []),
+                ...(skills ? [skills] : []),
+                ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
+              ]
+            })
             // Note: `buildLLMRequestPrefix` also returns a `tools` field, but we
             // intentionally don't use it here — the `tools` variable from `resolveTools`
             // (set earlier via `handle.process({tools: ...})`) carries `execute` closures
@@ -4445,23 +4465,59 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // Main runLoop: no watermark — LLM must see the full msgs list,
             // including this turn's intermediate assistant turns (tool reads,
             // task creates, etc.) so each step doesn't replay from the bare
-            // user prompt. The watermark is for fork capture only (frozen
-            // snapshot of parent-view at spawn time).
-            const { system: prebuiltSystem, inheritedMessages: modelMsgs } =
-              yield* buildLLMRequestPrefix({
+            // user prompt. Snapshot watermarks are boundary metadata, never a
+            // reason to slice the main request history.
+            const initialPrefix = yield* buildLLMRequestPrefix({
+              sessionID,
+              agent,
+              model,
+              msgs,
+              additions: frozen ? [] : yield* currentAdditions(),
+              prebuiltSystem: frozen?.system,
+              prompt: sessionPrompt,
+              // Rebuild tails collapse into an activity log so hollow
+              // tool_results never look like a live transcript (anti-hallucination).
+              collapseCheckpointTail: true,
+            }).pipe(
+              Effect.provideService(LLM.Service, llm),
+              Effect.provideService(ToolRegistry.Service, registry),
+            )
+            const currentToolsHash = SessionPrefixSnapshot.toolsHash(tools, activeTools)
+            const resolvedPrefix = yield* Effect.gen(function* () {
+              if (!frozen) {
+                const snapshot = yield* SessionPrefixSnapshot.pin({
+                  sessionID,
+                  profileKey: prefixProfileKey,
+                  system: initialPrefix.system,
+                  toolsHash: currentToolsHash,
+                  watermarkMessageID: lastUser.id,
+                })
+                return { prefix: initialPrefix, snapshot }
+              }
+              if (frozen.tools_hash === currentToolsHash) return { prefix: initialPrefix, snapshot: frozen }
+              const prefix = yield* buildLLMRequestPrefix({
                 sessionID,
                 agent,
                 model,
                 msgs,
-                additions,
+                additions: yield* currentAdditions(),
                 prompt: sessionPrompt,
-                // Rebuild tails collapse into an activity log so hollow
-                // tool_results never look like a live transcript (anti-hallucination).
                 collapseCheckpointTail: true,
               }).pipe(
                 Effect.provideService(LLM.Service, llm),
                 Effect.provideService(ToolRegistry.Service, registry),
               )
+              const snapshot = yield* SessionPrefixSnapshot.rotate({
+                sessionID,
+                profileKey: prefixProfileKey,
+                system: prefix.system,
+                toolsHash: currentToolsHash,
+                watermarkMessageID: lastUser.id,
+              })
+              return { prefix, snapshot }
+            })
+            const prebuiltSystem = resolvedPrefix.prefix.system
+            const modelMsgs = resolvedPrefix.prefix.inheritedMessages
             lastSystemPrompt = prebuiltSystem
             const cfg = yield* config.get()
             const maxModeCfg = cfg.experimental?.maxMode
@@ -4474,9 +4530,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               permission: session.permission,
               sessionID,
               parentSessionID: session.parentID,
-              // system: additions is preserved for non-LLM consumers of StreamInput (e.g.,
-              // MessageV2.User.system for logging/replay); llm.stream itself uses prebuiltSystem.
-              system: additions,
+              system: [],
               prebuiltSystem,
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
               mergeTurnContextIntoLastUser: true,
@@ -4578,6 +4632,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   .pipe(Effect.ignore),
               ),
             )
+
+            if (handle.message.time.completed && !handle.message.error) {
+              yield* SessionPrefixSnapshot.advance({
+                sessionID,
+                profileKey: prefixProfileKey,
+                revision: resolvedPrefix.snapshot.revision,
+                watermarkMessageID: handle.message.id,
+              })
+            }
 
             if (
               result === "continue" &&

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -53,6 +53,25 @@ export const SessionTable = sqliteTable(
   ],
 )
 
+export const SessionPrefixSnapshotTable = sqliteTable(
+  "session_prefix_snapshot",
+  {
+    session_id: text()
+      .$type<SessionID>()
+      .notNull()
+      .references(() => SessionTable.id, { onDelete: "cascade" }),
+    profile_key: text().notNull(),
+    system: text({ mode: "json" }).$type<string[]>().notNull(),
+    system_hash: text().notNull(),
+    tools_hash: text().notNull(),
+    watermark_message_id: text().$type<MessageID>().notNull(),
+    revision: integer().notNull(),
+    created_at: integer().notNull(),
+    updated_at: integer().notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.session_id, table.profile_key] })],
+)
+
 export const MessageTable = sqliteTable(
   "message",
   {

--- a/packages/opencode/test/session/prefix-snapshot.test.ts
+++ b/packages/opencode/test/session/prefix-snapshot.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test"
+import { jsonSchema, tool } from "ai"
+import { Instance } from "../../src/project/instance"
+import { Session as SessionNs } from "../../src/session"
+import { SessionPrefixSnapshot } from "../../src/session/prefix-snapshot"
+import { MessageID } from "../../src/session/schema"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { tmpdir } from "../fixture/fixture"
+
+describe("session prefix snapshot", () => {
+  test("pins, rotates, advances, and cascades with its session", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await AppRuntime.runPromise(SessionNs.Service.use((service) => service.create({})))
+        const key = SessionPrefixSnapshot.profileKey({
+          providerID: "test",
+          modelID: "test-model",
+          agent: "build",
+          agentID: "main",
+          harness: "auto",
+          systemMode: "append",
+          system: "",
+          permission: [],
+        })
+        const firstWatermark = MessageID.ascending()
+        const first = await AppRuntime.runPromise(
+          SessionPrefixSnapshot.pin({
+            sessionID: session.id,
+            profileKey: key,
+            system: ["first"],
+            toolsHash: "tools-1",
+            watermarkMessageID: firstWatermark,
+          }),
+        )
+        expect(first).toMatchObject({
+          revision: 1,
+          system: ["first"],
+          tools_hash: "tools-1",
+          watermark_message_id: firstWatermark,
+        })
+
+        const pinned = await AppRuntime.runPromise(
+          SessionPrefixSnapshot.pin({
+            sessionID: session.id,
+            profileKey: key,
+            system: ["ignored"],
+            toolsHash: "ignored",
+            watermarkMessageID: MessageID.ascending(),
+          }),
+        )
+        expect(pinned).toEqual(first)
+
+        const rotated = await AppRuntime.runPromise(
+          SessionPrefixSnapshot.rotate({
+            sessionID: session.id,
+            profileKey: key,
+            system: ["second"],
+            toolsHash: "tools-2",
+            watermarkMessageID: firstWatermark,
+          }),
+        )
+        expect(rotated).toMatchObject({ revision: 2, system: ["second"], tools_hash: "tools-2" })
+
+        const finalWatermark = MessageID.ascending()
+        await AppRuntime.runPromise(
+          SessionPrefixSnapshot.advance({
+            sessionID: session.id,
+            profileKey: key,
+            revision: 1,
+            watermarkMessageID: MessageID.ascending(),
+          }),
+        )
+        await AppRuntime.runPromise(
+          SessionPrefixSnapshot.advance({
+            sessionID: session.id,
+            profileKey: key,
+            revision: 2,
+            watermarkMessageID: finalWatermark,
+          }),
+        )
+        expect(await AppRuntime.runPromise(SessionPrefixSnapshot.get(session.id, key))).toMatchObject({
+          revision: 2,
+          watermark_message_id: finalWatermark,
+        })
+
+        await AppRuntime.runPromise(SessionNs.Service.use((service) => service.remove(session.id)))
+        expect(await AppRuntime.runPromise(SessionPrefixSnapshot.get(session.id, key))).toBeUndefined()
+      },
+    })
+  })
+
+  test("profile and tool hashes are stable across key order", () => {
+    const permission = [{ permission: "*", pattern: "*", action: "allow" as const }]
+    const key = SessionPrefixSnapshot.profileKey({
+      providerID: "p",
+      modelID: "m",
+      agent: "build",
+      agentID: "main",
+      harness: "auto",
+      systemMode: "append",
+      system: "",
+      permission,
+    })
+    expect(key).toBe(
+      SessionPrefixSnapshot.profileKey({
+        permission,
+        systemMode: "append",
+        system: "",
+        harness: "auto",
+        agentID: "main",
+        agent: "build",
+        modelID: "m",
+        providerID: "p",
+      }),
+    )
+    expect(key).not.toBe(
+      SessionPrefixSnapshot.profileKey({
+        providerID: "p",
+        modelID: "other",
+        agent: "build",
+        agentID: "main",
+        harness: "auto",
+        systemMode: "append",
+        system: "",
+        permission,
+      }),
+    )
+    const first = {
+      beta: tool({ description: "b", inputSchema: jsonSchema({ type: "object", properties: {} }) }),
+      alpha: tool({ description: "a", inputSchema: jsonSchema({ type: "object", properties: {} }) }),
+    }
+    const second = { alpha: first.alpha, beta: first.beta }
+    expect(SessionPrefixSnapshot.toolsHash(first, ["beta", "alpha"])).toBe(
+      SessionPrefixSnapshot.toolsHash(second, ["alpha", "beta"]),
+    )
+  })
+})

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -59,6 +59,8 @@ import { testEffect } from "../lib/effect"
 import { reply, TestLLMServer } from "../lib/llm-server"
 import { Inbox } from "../../src/inbox"
 import { Metrics } from "../../src/metrics"
+import { Database, eq } from "../../src/storage"
+import { SessionPrefixSnapshotTable } from "../../src/session/session.sql"
 
 void Log.init({ print: false })
 
@@ -1085,6 +1087,73 @@ it.live(
           expect(system).toContain("Skills available in this session:")
           expect(system.indexOf("Skills available in this session:")).toBeLessThan(system.indexOf(marker))
           expect(system.trim().endsWith(marker)).toBe(true)
+        }),
+        { git: true, config: providerCfg },
+      ),
+    ),
+  30_000,
+)
+
+it.live(
+  "reuses the frozen system prefix for later queries in the same session",
+  () =>
+    withoutDynamicSystemPrompt(() =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const file = path.join(Instance.directory, "AGENTS.md")
+          yield* Effect.promise(() => Bun.write(file, "PREFIX_INSTRUCTION_V1"))
+          const chat = yield* sessions.create({
+            title: "Frozen prefix",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+
+          yield* llm.text("first")
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "first query" }],
+          })
+          yield* Effect.promise(() => Bun.write(file, "PREFIX_INSTRUCTION_V2"))
+          yield* llm.text("second")
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "second query" }],
+          })
+
+          const inputs = yield* llm.inputs
+          const systems = inputs.slice(0, 2).map((input) =>
+            ((input.messages ?? []) as { role: string; content: unknown }[])
+              .flatMap((message) =>
+                message.role === "system" && typeof message.content === "string" ? [message.content] : [],
+              )
+              .join("\n"),
+          )
+          expect(systems).toHaveLength(2)
+          expect(systems[0]).toContain("PREFIX_INSTRUCTION_V1")
+          expect(systems[1]).toBe(systems[0])
+          expect(systems[1]).not.toContain("PREFIX_INSTRUCTION_V2")
+
+          const snapshots = yield* Effect.sync(() =>
+            Database.use((db) =>
+              db
+                .select()
+                .from(SessionPrefixSnapshotTable)
+                .where(eq(SessionPrefixSnapshotTable.session_id, chat.id))
+                .all(),
+            ),
+          )
+          const messages = yield* sessions.messages({ sessionID: chat.id })
+          const lastAssistant = messages.findLast((message) => message.info.role === "assistant")
+          expect(snapshots).toHaveLength(1)
+          expect(snapshots[0]).toMatchObject({
+            revision: 1,
+            watermark_message_id: lastAssistant?.info.id,
+          })
         }),
         { git: true, config: providerCfg },
       ),

--- a/packages/opencode/test/session/prompt-skill-command-multi.test.ts
+++ b/packages/opencode/test/session/prompt-skill-command-multi.test.ts
@@ -251,10 +251,10 @@ describe("skill command with additional mentions", () => {
     30_000,
   )
 
-  // [TP-R14-02][TP-R14-04][TP-R14-05] A changed catalog replaces the system-tail
-  // catalog on the next request without rewriting user history.
+  // [TP-R14-02][TP-R14-04][TP-R14-05] A session keeps its first system-tail
+  // catalog even when the registry changes.
   it.live(
-    "refreshes a changed system catalog without rewriting history",
+    "keeps the session catalog frozen after a registry reload",
     () =>
       provideTmpdirServer(
         Effect.fnUntraced(function* ({ dir, llm }) {
@@ -297,7 +297,7 @@ describe("skill command with additional mentions", () => {
           const request = JSON.stringify((yield* llm.inputs)[1].messages ?? [])
           expect(request.match(/Skills available in this session:/g)).toHaveLength(1)
           expect(request).toContain("<name>skill-alpha</name>")
-          expect(request).toContain("<name>skill-beta</name>")
+          expect(request).not.toContain("<name>skill-beta</name>")
 
           yield* sessions.remove(session.id)
         }),


### PR DESCRIPTION
> Stacked on #2287 (skill catalogs in the system tail) — retarget to `main` once that merges.

## What

Adds a `session_prefix_snapshot` table and freezes each session's system prefix at its first query. Later queries with the same profile reuse the pinned bytes verbatim (`prebuiltSystem`), bypassing all system regeneration.

## Behavior

- **First query** of a (session, profile) builds the full system array and pins it (revision 1) with the current tools hash and a watermark.
- **Same profile later** → the frozen bytes are sent verbatim; mid-session AGENTS.md edits or skill-registry reloads no longer shift an existing session's prefix or invalidate the provider prefix cache. Survives process restarts (SQLite).
- **Profile change** (provider/model/agent/agentID/harness/systemMode/prompt.system/permission) → a separate row is pinned; switching back reuses the earlier frozen row.
- **Tool-schema change under the same profile** (e.g. MCP availability, `StructuredOutput` for json_schema turns) → the row rotates: system rebuilt from current additions, revision incremented.
- **Watermark** advances to each completed, non-errored assistant step, guarded by revision so a stale writer can't move a rotated row.
- **Checkpoint fork capture** resolves the same profile key and reuses the frozen system for byte parity with the parent request.
- **Cascade delete** with the session (FK + `PRAGMA foreign_keys = ON`).

## Known gaps (deliberate scope cuts, flagged for follow-up)

- **Orchestrator fleet roster is frozen too** — the roster in `buildSystemArray` was designed to refresh per request; with a frozen prefix it stays at its first-query state (usually empty). Orchestrator is experimental/opt-in (`MIMOCODE_EXPERIMENTAL_ORCHESTRATOR`), so no mainline impact; the proper fix is moving the roster out of the system prefix (it is prefix-cache-hostile regardless).
- `experimental.chat.system.transform` plugin hook only runs at pin/rotate time, not per request.
- Resumed sessions no longer publish the `InstructionsLoaded` TUI notice (additions aren't recomputed on the frozen path).
- The frozen guarantee intentionally yields on every rotation: a tools change re-reads AGENTS.md/skills. This is also what keeps `STRUCTURED_OUTPUT_SYSTEM_PROMPT` correct across json/non-json turns (their tools hashes differ).

## Tests

- `test/session/prefix-snapshot.test.ts` — pin/rotate/advance semantics, key stability across object-key order, cascade on session delete.
- `prompt-effect.test.ts` — end-to-end: second query's system is byte-identical to the first, AGENTS.md edit doesn't leak, single row at revision 1 with watermark on the last assistant.
- `prompt-skill-command-multi.test.ts` — session catalog stays frozen after a registry reload.

`bun typecheck` clean; targeted test files pass from `packages/opencode`.