### PR TITLE
fix(acp): accept concurrent prompts while session is busy

### DIFF
--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -1131,18 +1131,6 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
 
-        // Pre-check: bail with 409 Conflict if the session's main runner is busy
-        // with another request. Without this guard, ensureRunning silently queues
-        // the new work behind the existing runner (which may be a zombie from a
-        // SIGKILL'd previous client), causing the new client to hang for the
-        // duration of the old runner's retry envelope. Caller's recovery path:
-        // POST /:sessionID/abort to free the runner, then retry this POST.
-        await runRequest(
-          "SessionRoutes.prompt.assertNotBusy",
-          c,
-          SessionRunState.Service.use((svc) => svc.assertNotBusy(sessionID)),
-        )
-
         c.status(200)
         c.header("Content-Type", "application/json")
         return stream(c, async (stream) => {


### PR DESCRIPTION
## Problem

The ACP client can send a second `session/prompt` while a tool is running. In v0.1.13, `packages/opencode/src/server/routes/instance/session.ts` rejects the request with `SessionRunState.assertNotBusy` (HTTP 409). The ACP SDK caller does not surface that 409 as an error, so the prompt becomes a silent no-op.

The opencode v1.18.16 handler accepts the prompt and delegates to `promptSvc.prompt`; its `Runner.ensureRunning` preserves ordering and merges the new user message into the active runner.

## Fix

Remove only the `/message` route pre-check. Keep `Runner.ensureRunning` unchanged so concurrent prompts are serialized by the existing runner and are available to the next tool boundary.

## Evidence

Using an isolated ACP probe with a deterministic OpenAI-compatible SSE endpoint and four sequential `bash` tool calls:

- Before patch: four-tool run plus cross-turn follow-up dropped the marker from every model request.
- After patch: marker appears in request 4 (after the second tool) and remains visible in request 7 after `end_turn` (B/B').
- Concurrent marker control: sending `MARKER_A_1` and `MARKER_B_2` together produced both markers in request 4+, ordered A-before-B. Sending only A produced A=true/B=false, proving the detector.

A prior attempt to transplant opencode `runUntilIdle` was insufficient: it delayed ACP response completion but could not recover a prompt already rejected by this route gate.

The ACP client should also surface HTTP 409 responses instead of resolving them as an empty success; that is tracked separately in downstream issue #4489.