### PR TITLE
fix(build): prevent ancestor node_modules bun from hijacking compiled…

### DIFF
--- a/local-install.sh
+++ b/local-install.sh
@@ -39,7 +39,12 @@ esac
 
 (
   cd "$package_dir"
-  bun run build:local
+  # Run the build script directly instead of through the `build:local` package
+  # script: `bun run <package-script>` re-resolves the nested `bun` through a
+  # PATH that has every ancestor node_modules/.bin prepended, so a stray bun
+  # installed above this checkout would hijack the build and embed its own
+  # (possibly broken) runtime into the compiled binary.
+  MIMOCODE_CHANNEL=local MIMOCODE_VERSION=local bun run script/build.ts --single
 )
 
 binary="$package_dir/dist/mimocode-$platform-$arch/bin/mimo"

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -12,6 +12,20 @@ const dir = path.resolve(__dirname, "..")
 
 process.chdir(dir)
 
+// Refuse to build with a bun other than the pinned one. `bun run` prepends every
+// ancestor node_modules/.bin to PATH, so a stray `bun` npm package installed in a
+// directory above this checkout silently hijacks nested `bun` invocations — and a
+// compiled binary inherits that bun's runtime, which has shipped broken (TUI worker
+// RPC hangs on startup) while still passing the `--version` smoke test.
+const pinned = (await Bun.file(path.resolve(dir, "../../package.json")).json()).packageManager?.split("@")[1]
+if (pinned && Bun.version !== pinned) {
+  console.error(
+    `refusing to build: running bun ${Bun.version} (${process.execPath}) but package.json pins bun@${pinned}.\n` +
+      `Check PATH for a stray bun (e.g. a parent directory's node_modules/.bin) or update the packageManager pin.`,
+  )
+  process.exit(1)
+}
+
 await import("./generate.ts")
 
 import { Script } from "@mimo-ai/script"
@@ -204,8 +218,11 @@ process.on("exit", () => {
 
 const binaries: Record<string, string> = {}
 if (!skipInstall) {
-  await $`bun install --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
-  await $`bun install --os="*" --cpu="*" @parcel/watcher@${pkg.dependencies["@parcel/watcher"]}`
+  // process.execPath, not `bun`: a bare `bun` resolves through the PATH described
+  // above. --no-save keeps this build step from rewriting package.json / bun.lock
+  // (e.g. re-pointing every lockfile entry at the locally configured registry).
+  await $`${process.execPath} install --no-save --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
+  await $`${process.execPath} install --no-save --os="*" --cpu="*" @parcel/watcher@${pkg.dependencies["@parcel/watcher"]}`
 }
 for (const item of targets) {
   const name = [


### PR DESCRIPTION
… binary

`bun run <package-script>` prepends every ancestor `node_modules/.bin` to PATH, so a stray npm `bun` package installed above the checkout silently replaces the pinned bun during the build. The compiled binary then embeds that foreign runtime — which can ship broken (e.g. TUI worker RPC hangs on startup while `--version` still passes).

Three defences:

1. `build.ts` now hard-fails when `Bun.version` differs from the root `packageManager` pin, with a diagnostic pointing at the stray binary.
2. The install step uses `process.execPath` instead of bare `bun` and adds `--no-save` so the build never rewrites package.json / bun.lock.
3. `local-install.sh` invokes `bun run script/build.ts --single` directly instead of going through the `build:local` package script, eliminating the second PATH-resolution hop that triggered the hijack.

### Issue / context (if applicable)

<!--
Link any relevant issue or discussion. For an external contribution that introduces a new feature or significant design change, include the issue where the direction was agreed. Use `Fixes #123` or `Closes #123` only when this PR fully resolves that issue.
-->

### Type of change

Bug fix / New feature / Refactor / Documentation — keep the ones that apply and delete the rest.

### What does this PR do?

Briefly describe the problem, what changed, and why this approach works.

### How did you verify your code works?

What did you test, and how can a reviewer reproduce the result?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR
