### PR TITLE
feat(config): add auto_worktree toggle, default off

### DIFF
--- a/docs/compose/spec/auto-worktree-config-toggle.md
+++ b/docs/compose/spec/auto-worktree-config-toggle.md
@@ -1,0 +1,58 @@
+---
+feature: auto-worktree-config-toggle
+status: delivered
+updated: 2026-08-29
+branch: feat/auto-worktree-config-toggle
+base: be5af909ae
+---
+
+# Auto-Worktree Config Toggle
+
+## Report
+
+**What was built** — Added a top-level optional boolean `auto_worktree` to `Config.Info`. The default is off: omitting the key or setting `false` means the Auto-Worktree Notice is never injected. Setting `true` preserves the previous soft-hint behavior (once per primary root session after a main-worktree mutation). Conflict detection and `POST /experimental/worktree/auto` remain outside this flag. Bundled `mimocode-docs` config table and the generated JS SDK types list the new key.
+
+**Verification** — `bun typecheck` (packages/opencode) PASS; `bun test test/session/auto-worktree-notice.test.ts` PASS 10/10; `bun test test/tool/auto-worktree-scan.test.ts test/tool/auto-worktree-bash-write.test.ts` PASS 47/47; `bun test test/config` PASS 177 + new `test/config/auto-worktree.test.ts` 3/3; `./packages/sdk/js/script/build.ts` regenerated `packages/sdk/js/src/v2/gen/types.gen.ts` including `auto_worktree?: boolean`.
+
+**Journey log**
+
+- Product default flipped from always-on to off; existing notice suite now writes `auto_worktree: true` in `providerConfig` so it keeps testing the on path.
+- Reviewer flagged missing SDK regen: `./packages/sdk/js/script/build.ts` is required after any `Config.Info` schema change; the artifact that updates is `packages/sdk/js/src/v2/gen/types.gen.ts` (openapi.json is not the generated surface for this key).
+- Unit `Config.Info.parse` tests (`test/config/checkpoint-fork.test.ts` pattern) are the local convention for new toggles; integration coverage alone is not enough for review consistency.
+
+## [S1] Problem
+
+The Auto-Worktree Notice is injected unconditionally: every primary root session that mutates a git main worktree gets a once-per-session soft hint (`packages/opencode/src/session/prompt.ts` `insertReminders`). There is no config key, so users who always work on the main worktree — or who already open worktrees themselves — cannot turn the notice off. `mimocode.json` has no corresponding field.
+
+## [S2] Design
+
+Add one top-level optional boolean in `InfoSchema` (`packages/opencode/src/config/config.ts`):
+
+```jsonc
+{
+  "auto_worktree": false   // omit or false = off (default); true = inject the notice
+}
+```
+
+Contract:
+
+- **Default `false` / omitted** — do not inject the Auto-Worktree Notice. This is a deliberate product default: the feature ships off.
+- **`true`** — keep the current soft-hint behavior: once per session, after a completed write or successful git mutation lands in a git MAIN worktree, inject the existing `buildAutoWorktreeNotice` system-reminder on the last user message and set `session.auto_worktree_hint_sent`.
+- Scope is the notice only. `checkConflict` / `POST /experimental/worktree/auto` are unchanged and remain outside this flag.
+- The existing once-per-session gate (`auto_worktree_hint_sent`, `primary` agent, `!parentID`) stays; the flag is an outer gate that skips the entire block when off.
+- When the flag is off, `auto_worktree_hint_sent` is not written and `firstMutatedMainWorktree` is not consulted, so no side effects.
+
+Access path in `insertReminders`: `(yield* config.get()).auto_worktree === true` in the outer condition. Do not change the system prompt.
+
+## [S3] Out of Scope
+
+- Nested `auto_worktree: { notice, create }` shapes, CLI flags, or TUI settings UI.
+- Changing conflict-detection behavior or wiring `POST /worktree/auto` into any host client.
+- Migrating or flipping `auto_worktree_hint_sent` for sessions that already received the notice under the old always-on behavior.
+- Changing notice copy, habit detection, or write-tool detection lists.
+
+## Tasks
+
+- [x] T1: Add `auto_worktree` to config schema — acceptance: `InfoSchema` accepts optional boolean with a description stating default false and notice-only scope; project/global JSON parse with and without the key (covers: S2)
+- [x] T2: Gate the notice injection — acceptance: `insertReminders` skips the entire auto-worktree block when the flag is not `true`; when `true`, existing once-per-session injection still fires (covers: S2; depends: T1)
+- [x] T3: Regression tests — acceptance: tests cover default-off (no notice, no `auto_worktree_hint_sent` write), explicit-on (notice fires as before), and explicit-off; package typecheck for the touched files passes (covers: S2; depends: T2)

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -123,6 +123,10 @@ const InfoSchema = Schema.Struct({
     description:
       "Enable or disable snapshot tracking. When false, filesystem snapshots are not recorded and undoing or reverting will not undo/redo file changes. Defaults to true.",
   }),
+  auto_worktree: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "Enable the once-per-session Auto-Worktree Notice when a primary root session mutates a git main worktree. Defaults to false (notice is off). When true, inject the existing soft-hint system-reminder; when false or omitted, inject nothing. Scope is the notice only — conflict detection and experimental worktree auto-create are not gated by this flag.",
+  }),
   // User-facing plugin config is stored as Specs; provenance gets attached later while configs are merged.
   plugin: Schema.optional(Schema.mutable(Schema.Array(ConfigPlugin.Spec))),
   share: Schema.optional(Schema.Literals(["manual", "auto", "disabled"])).annotate({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1160,9 +1160,10 @@ export const layer = Layer.effect(
       const composeModeMsg = input.messages.find(
         (msg) => msg.info.role === "user" && msg.info.agent === "compose",
       )
+      const cfg = yield* config.get()
       if (composeModeMsg) {
         const ctx = yield* InstanceState.context
-        const composeCfg = (yield* config.get()).compose
+        const composeCfg = cfg.compose
         const docsDir = ConfigCompose.resolveDocsDir(ctx.worktree, composeCfg)
         const text = PROMPT_COMPOSE
           .replace("{{compose_docs_dir}}", `Save compose skill outputs: specs in \`${path.join(docsDir, "specs")}\`, plans in \`${path.join(docsDir, "plans")}\`, reports in \`${path.join(docsDir, "reports")}\`.`)
@@ -1182,9 +1183,14 @@ export const layer = Layer.effect(
       // to a non-git scratch dir that `cd`s into another project's main checkout
       // still hits. Injected as a user-side system-reminder and persisted via
       // auto_worktree_hint_sent so compaction/rebuild cannot re-inject. Never
-      // touches the system prompt. Nested branch: insertReminders cannot
-      // early-return without skipping the skill/plan reminders that follow.
-      if (input.agent.mode === "primary" && !input.session.parentID) {
+      // touches the system prompt. Gated by config.auto_worktree (default false).
+      // Nested branch: insertReminders cannot early-return without skipping the
+      // skill/plan reminders that follow.
+      if (
+        input.agent.mode === "primary" &&
+        !input.session.parentID &&
+        cfg.auto_worktree === true
+      ) {
         const alreadySent = yield* Effect.sync(() => isAutoWorktreeHintSent(input.session.id))
         if (!alreadySent) {
           if (sessionHasAutoWorktreeNotice(input.messages)) {

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/config.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/config.md
@@ -157,6 +157,7 @@ The trigger is the model's prompt capacity (`limit.input` when the provider publ
 | `autoupdate` | `true` / `false` / `"notify"` |
 | `share` | `"manual"` / `"auto"` / `"disabled"` |
 | `snapshot` | Filesystem snapshot tracking for undo/redo (default true) |
+| `auto_worktree` | Auto-Worktree Notice on main-worktree writes (default false) |
 | `logLevel` | Log verbosity |
 | `server` | Config for `mimo serve` |
 | `enterprise.url` | Enterprise endpoint |

--- a/packages/opencode/test/config/auto-worktree.test.ts
+++ b/packages/opencode/test/config/auto-worktree.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { Config } from "../../src/config"
+
+describe("config.auto_worktree", () => {
+  test("absent when the key is omitted (default off)", () => {
+    expect(Config.Info.parse({}).auto_worktree).toBeUndefined()
+  })
+
+  test("accepts boolean value", () => {
+    expect(Config.Info.parse({ auto_worktree: true }).auto_worktree).toBe(true)
+    expect(Config.Info.parse({ auto_worktree: false }).auto_worktree).toBe(false)
+  })
+
+  test("rejects non-boolean values", () => {
+    expect(() => Config.Info.parse({ auto_worktree: "yes" })).toThrow()
+  })
+})

--- a/packages/opencode/test/session/auto-worktree-notice.test.ts
+++ b/packages/opencode/test/session/auto-worktree-notice.test.ts
@@ -25,10 +25,12 @@ function run<A, E>(fx: Effect.Effect<A, E, SessionPrompt.Service | Session.Servi
   )
 }
 
-function providerConfig(origin: string) {
+function providerConfig(origin: string, opts?: { auto_worktree?: boolean }) {
   return {
     $schema: "https://opencode.ai/config.json",
     enabled_providers: ["aw-test"],
+    // Product default is off; on-path tests pass auto_worktree: true explicitly.
+    ...(opts?.auto_worktree !== undefined ? { auto_worktree: opts.auto_worktree } : {}),
     provider: {
       "aw-test": {
         name: "AW Test",
@@ -73,7 +75,10 @@ describe("session.prompt auto-worktree first-write notice", () => {
       await using tmp = await tmpdir({
         git: true,
         init: async (dir) => {
-          await Bun.write(path.join(dir, "mimocode.json"), JSON.stringify(providerConfig(stub.origin)))
+          await Bun.write(
+            path.join(dir, "mimocode.json"),
+            JSON.stringify(providerConfig(stub.origin, { auto_worktree: true })),
+          )
           await seedLinkedWorktree(dir)
         },
       })
@@ -161,7 +166,10 @@ describe("session.prompt auto-worktree first-write notice", () => {
       await using tmp = await tmpdir({
         git: true,
         init: async (dir) => {
-          await Bun.write(path.join(dir, "mimocode.json"), JSON.stringify(providerConfig(stub.origin)))
+          await Bun.write(
+            path.join(dir, "mimocode.json"),
+            JSON.stringify(providerConfig(stub.origin, { auto_worktree: true })),
+          )
         },
       })
       expect(repoHasLinkedWorktrees(tmp.path)).toBe(false)
@@ -261,7 +269,10 @@ describe("session.prompt auto-worktree first-write notice", () => {
       await using tmp = await tmpdir({
         git: true,
         init: async (dir) => {
-          await Bun.write(path.join(dir, "mimocode.json"), JSON.stringify(providerConfig(stub.origin)))
+          await Bun.write(
+            path.join(dir, "mimocode.json"),
+            JSON.stringify(providerConfig(stub.origin, { auto_worktree: true })),
+          )
           await seedLinkedWorktree(dir)
         },
       })
@@ -394,7 +405,10 @@ describe("session.prompt auto-worktree first-write notice", () => {
       await using scratch = await tmpdir({
         outsideGit: true,
         init: async (dir) => {
-          await Bun.write(path.join(dir, "mimocode.json"), JSON.stringify(providerConfig(stub.origin)))
+          await Bun.write(
+            path.join(dir, "mimocode.json"),
+            JSON.stringify(providerConfig(stub.origin, { auto_worktree: true })),
+          )
         },
       })
 
@@ -463,7 +477,10 @@ describe("session.prompt auto-worktree first-write notice", () => {
       await using tmp = await tmpdir({
         git: true,
         init: async (dir) => {
-          await Bun.write(path.join(dir, "mimocode.json"), JSON.stringify(providerConfig(stub.origin)))
+          await Bun.write(
+            path.join(dir, "mimocode.json"),
+            JSON.stringify(providerConfig(stub.origin, { auto_worktree: true })),
+          )
           await seedLinkedWorktree(dir)
         },
       })
@@ -541,7 +558,10 @@ describe("session.prompt auto-worktree first-write notice", () => {
       await using tmp = await tmpdir({
         git: true,
         init: async (dir) => {
-          await Bun.write(path.join(dir, "mimocode.json"), JSON.stringify(providerConfig(stub.origin)))
+          await Bun.write(
+            path.join(dir, "mimocode.json"),
+            JSON.stringify(providerConfig(stub.origin, { auto_worktree: true })),
+          )
           await seedLinkedWorktree(dir)
         },
       })
@@ -597,4 +617,65 @@ describe("session.prompt auto-worktree first-write notice", () => {
     },
     20_000,
   )
+})
+
+describe("session.prompt auto_worktree config gate", () => {
+  test.each([
+    ["omitted", undefined],
+    ["false", false],
+  ] as const)("auto_worktree %s is off — no notice after a main-worktree write", async (_label, value) => {
+    const stub = startScriptedLLMServer([
+      {
+        lines: toolCallResponse({
+          id: "call_write_off",
+          name: "write",
+          args: JSON.stringify({ file_path: "off.txt", content: "off\n" }),
+        }),
+      },
+      { lines: textStopResponse("done-off") },
+    ])
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "mimocode.json"),
+            JSON.stringify(providerConfig(stub.origin, value === false ? { auto_worktree: false } : undefined)),
+          )
+          await seedLinkedWorktree(dir)
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const prompt = yield* SessionPrompt.Service
+              const sessions = yield* Session.Service
+              const session = yield* sessions.create({
+                title: `aw off ${_label}`,
+                permission: [{ permission: "*", pattern: "*", action: "allow" }],
+              })
+
+              yield* prompt.prompt({
+                sessionID: session.id,
+                agent: "build",
+                parts: [{ type: "text", text: "Create off.txt" }],
+              })
+
+              const msgs = yield* sessions.messages({ sessionID: session.id })
+              const userMsgs = msgs.filter((m) => m.info.role === "user")
+              expect(noticeParts(userMsgs[0])).toHaveLength(0)
+              expect(isAutoWorktreeHintSent(session.id)).toBe(false)
+
+              yield* sessions.remove(session.id)
+            }),
+          ),
+      })
+    } finally {
+      void stub.stop()
+    }
+  })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1333,6 +1333,7 @@ export type CheckpointPart = {
   checkpointDir: string
   checkpointNumber: number
   coveredUpTo: string
+  digestUpTo?: string
 }
 
 export type CompactionPart = {
@@ -1866,9 +1867,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1884,9 +1888,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1902,9 +1909,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1920,9 +1930,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1938,9 +1951,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1956,9 +1972,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1974,9 +1993,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1992,9 +2014,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2214,6 +2239,10 @@ export type Config = {
    * Enable or disable snapshot tracking. When false, filesystem snapshots are not recorded and undoing or reverting will not undo/redo file changes. Defaults to true.
    */
   snapshot?: boolean
+  /**
+   * Enable the once-per-session Auto-Worktree Notice when a primary root session mutates a git main worktree. Defaults to false (notice is off). When true, inject the existing soft-hint system-reminder; when false or omitted, inject nothing. Scope is the notice only — conflict detection and experimental worktree auto-create are not gated by this flag.
+   */
+  auto_worktree?: boolean
   plugin?: Array<
     | string
     | [
@@ -2315,9 +2344,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2333,9 +2365,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2351,9 +2386,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2369,9 +2407,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2387,9 +2428,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2405,9 +2449,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2423,9 +2470,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2441,9 +2491,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2564,7 +2617,7 @@ export type Config = {
      */
     reserved?: number
     /**
-     * Whether to fork the parent agent's message prefix into the writer session for prefix-cache reuse. Requires provider cache-breakpoint support. Default: false.
+     * Whether to fork the parent agent's message prefix into the writer session for prefix-cache reuse. Requires provider cache-breakpoint support. Default: true.
      */
     fork?: boolean
     /**
@@ -2727,6 +2780,23 @@ export type Config = {
        * Consecutive edit or verify actions without progress before pausing (default 4).
        */
       action_streak?: number
+    }
+    /**
+     * Loop-streak request-layer recovery (experimental).
+     */
+    loop_streak_recovery?: {
+      /**
+       * Crop repeated thinking/tool streaks from the next request and inject a recovery note.
+       */
+      enabled?: boolean
+      /**
+       * Consecutive identical streak keys required to trigger (default 3).
+       */
+      trigger_count?: number
+      /**
+       * Max assistant messages cropped from the trailing streak (default 64).
+       */
+      max_span?: number
     }
     /**
      * Timeout in milliseconds for model context protocol (MCP) requests
@@ -5216,7 +5286,7 @@ export type SessionPromptData = {
     format?: OutputFormat
     /**
      * BCP 47 locale used for automatic title generation.
-    */
+     */
     titleLocale?: string
     /**
      * Additional system prompt selected by the session's first user query. Later values are ignored.
@@ -5525,7 +5595,7 @@ export type SessionPromptAsyncData = {
     format?: OutputFormat
     /**
      * BCP 47 locale used for automatic title generation.
-    */
+     */
     titleLocale?: string
     /**
      * Additional system prompt selected by the session's first user query. Later values are ignored.
@@ -5583,7 +5653,7 @@ export type SessionCommandData = {
     command: string
     /**
      * BCP 47 locale used for automatic title generation.
-    */
+     */
     titleLocale?: string
     variant?: string
     /**

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2289,6 +2289,64 @@
         ]
       }
     },
+    "/experimental/worktree/auto": {
+      "post": {
+        "operationId": "worktree.auto",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Auto-create worktree on conflict",
+        "description": "Check for conflicts and auto-create a worktree if needed.",
+        "responses": {
+          "200": {
+            "description": "Worktree info or null",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/Worktree"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@mimo-ai/sdk\"\n\nconst client = createOpencodeClient()\nawait client.worktree.auto({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/experimental/title": {
       "post": {
         "operationId": "experimental.title.generate",
@@ -2412,64 +2470,6 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@mimo-ai/sdk\"\n\nconst client = createOpencodeClient()\nawait client.experimental.title.generate({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/experimental/worktree/auto": {
-      "post": {
-        "operationId": "worktree.auto",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "Auto-create worktree on conflict",
-        "description": "Check for conflicts and auto-create a worktree if needed.",
-        "responses": {
-          "200": {
-            "description": "Worktree info or null",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/Worktree"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@mimo-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.worktree.auto({\n  ...\n})"
           }
         ]
       }
@@ -4791,203 +4791,6 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@mimo-ai/sdk\"\n\nconst client = createOpencodeClient()\nawait client.session.resume({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/session/{sessionID}/recovery": {
-      "get": {
-        "operationId": "session.recovery",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          },
-          {
-            "in": "query",
-            "name": "agentID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "List interrupted turn recovery candidates",
-        "description": "Return the latest incomplete assistant turn that can be resumed without creating a user message.",
-        "responses": {
-          "200": {
-            "description": "Recovery candidates",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "assistantMessageID": {
-                        "type": "string",
-                        "pattern": "^msg.*"
-                      },
-                      "parentMessageID": {
-                        "type": "string",
-                        "pattern": "^msg.*"
-                      },
-                      "created": {
-                        "type": "number"
-                      }
-                    },
-                    "required": ["assistantMessageID", "parentMessageID", "created"]
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@mimo-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.recovery({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/session/{sessionID}/turn/{assistantMessageID}/resume": {
-      "post": {
-        "operationId": "session.resume",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          },
-          {
-            "in": "path",
-            "name": "assistantMessageID",
-            "schema": {
-              "type": "string",
-              "pattern": "^msg.*"
-            },
-            "required": true
-          },
-          {
-            "in": "query",
-            "name": "agentID",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "task_id",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "titleLocale",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "Resume an interrupted turn",
-        "description": "Resume an incomplete assistant turn without creating another user message.",
-        "responses": {
-          "202": {
-            "description": "Resume accepted"
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict — session resource is busy",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConflictError"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@mimo-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.resume({\n  ...\n})"
           }
         ]
       }
@@ -13441,6 +13244,10 @@
           "coveredUpTo": {
             "type": "string",
             "pattern": "^msg.*"
+          },
+          "digestUpTo": {
+            "type": "string",
+            "pattern": "^msg.*"
           }
         },
         "required": ["id", "sessionID", "messageID", "type", "checkpointDir", "checkpointNumber", "coveredUpTo"]
@@ -14956,7 +14763,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -14974,9 +14781,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "stream": {
@@ -15000,7 +14804,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -15018,9 +14822,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "maxCandidate": {
@@ -15044,7 +14845,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -15062,9 +14863,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "maxJudge": {
@@ -15088,7 +14886,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -15106,9 +14904,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "network": {
@@ -15132,7 +14927,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -15150,9 +14945,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "server": {
@@ -15176,7 +14968,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -15194,9 +14986,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "rateLimit": {
@@ -15220,7 +15009,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -15238,9 +15027,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "unknown": {
@@ -15264,7 +15050,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -15282,9 +15068,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "jitterRatio": {
@@ -15697,6 +15480,10 @@
             "description": "Enable or disable snapshot tracking. When false, filesystem snapshots are not recorded and undoing or reverting will not undo/redo file changes. Defaults to true.",
             "type": "boolean"
           },
+          "auto_worktree": {
+            "description": "Enable the once-per-session Auto-Worktree Notice when a primary root session mutates a git main worktree. Defaults to false (notice is off). When true, inject the existing soft-hint system-reminder; when false or omitted, inject nothing. Scope is the notice only — conflict detection and experimental worktree auto-create are not gated by this flag.",
+            "type": "boolean"
+          },
           "plugin": {
             "type": "array",
             "items": {
@@ -15886,7 +15673,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -15904,9 +15691,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "stream": {
@@ -15930,7 +15714,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -15948,9 +15732,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "maxCandidate": {
@@ -15974,7 +15755,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -15992,9 +15773,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "maxJudge": {
@@ -16018,7 +15796,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -16036,9 +15814,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "network": {
@@ -16062,7 +15837,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -16080,9 +15855,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "server": {
@@ -16106,7 +15878,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -16124,9 +15896,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "rateLimit": {
@@ -16150,7 +15919,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -16168,9 +15937,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "unknown": {
@@ -16194,7 +15960,7 @@
                     "maximum": 9007199254740991
                   },
                   "noDeadline": {
-                    "description": "Disable the wall-clock retry deadline explicitly",
+                    "description": "Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets",
                     "type": "boolean"
                   },
                   "initialDelayMs": {
@@ -16212,9 +15978,6 @@
                     "minimum": 0,
                     "maximum": 1
                   }
-                },
-                "not": {
-                  "required": ["deadlineMs", "noDeadline"]
                 }
               },
               "jitterRatio": {
@@ -16497,7 +16260,7 @@
                 "maximum": 9007199254740991
               },
               "fork": {
-                "description": "Whether to fork the parent agent's message prefix into the writer session for prefix-cache reuse. Requires provider cache-breakpoint support. Default: false.",
+                "description": "Whether to fork the parent agent's message prefix into the writer session for prefix-cache reuse. Requires provider cache-breakpoint support. Default: true.",
                 "type": "boolean"
               },
               "push_caps": {
@@ -16718,6 +16481,28 @@
                   },
                   "action_streak": {
                     "description": "Consecutive edit or verify actions without progress before pausing (default 4).",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "loop_streak_recovery": {
+                "description": "Loop-streak request-layer recovery (experimental).",
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "description": "Crop repeated thinking/tool streaks from the next request and inject a recovery note.",
+                    "type": "boolean"
+                  },
+                  "trigger_count": {
+                    "description": "Consecutive identical streak keys required to trigger (default 3).",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "max_span": {
+                    "description": "Max assistant messages cropped from the trailing streak (default 64).",
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991


### PR DESCRIPTION
## Summary

Adds a top-level optional boolean `auto_worktree` so the once-per-session Auto-Worktree Notice can be turned on. **Default is off**: omitting the key or setting `false` injects nothing. Setting `true` keeps the previous soft-hint behavior after a primary root session mutates a git main worktree.

Scope is the notice only — conflict detection and `POST /experimental/worktree/auto` are unchanged.

```jsonc
{
  "auto_worktree": true
}
```

## Changes

- `packages/opencode/src/config/config.ts` — optional boolean on `InfoSchema` (default false, notice-only description)
- `packages/opencode/src/session/prompt.ts` — outer gate in `insertReminders`; non-`true` skips the whole block with no side effects
- Tests: original notice suite writes `auto_worktree: true`; new default-off / explicit-off integration tests; `Config.Info.parse` unit tests
- Docs: bundled `mimocode-docs` config table + compose spec `docs/compose/spec/auto-worktree-config-toggle.md`
- SDK: regenerated `packages/sdk/js/src/v2/gen/types.gen.ts` via `./packages/sdk/js/script/build.ts`

## Verification

- `bun typecheck` (packages/opencode) — PASS (also on rebased base `be5af909ae`)
- `bun test test/session/auto-worktree-notice.test.ts` — 10/10
- `bun test test/tool/auto-worktree-scan.test.ts test/tool/auto-worktree-bash-write.test.ts` — 47/47
- `bun test test/config` — 177 pass + new `test/config/auto-worktree.test.ts` 3/3
- Independent review: all AC met, no critical findings