### PR TITLE
fix(llm-server): advertise Server.listen so issue can resolve base_url

### DIFF
--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -23,7 +23,10 @@ export const AcpCommand = cmd({
     process.env.MIMOCODE_CLIENT = "acp"
     await bootstrap(process.cwd(), async () => {
       const opts = await resolveNetworkOptions(args)
-      const server = await Server.listen(opts)
+      // Private HTTP shim for this ACP session's SDK client — not a task-token host.
+      // Advertising would hand `issue`/`list` a base_url that only works for callers
+      // already inside this process's directory scope.
+      const server = await Server.listen({ ...opts, advertise: false })
 
       const sdk = createOpencodeClient({
         baseUrl: `http://${server.hostname}:${server.port}`,

--- a/packages/opencode/src/cli/cmd/llm-server.ts
+++ b/packages/opencode/src/cli/cmd/llm-server.ts
@@ -153,8 +153,9 @@ const issue = cmd({
 
       // Resolved rather than guessed: a mimocode process serving this project advertises
       // its loopback address, so the two halves of "where" and "with what" can finally be
-      // printed together. Absent when nothing is serving this directory right now.
-      const address = await LLMServerTokens.address(process.cwd())
+      // printed together. Falls back to any live host (Desktop multi-project sidecar).
+      // Absent when nothing is serving this directory right now.
+      const address = await LLMServerTokens.discoverAddress(process.cwd())
 
       if (args.json) {
         // Machine-first: a wrapper reads one line and exports the two env vars the
@@ -225,7 +226,10 @@ const list = cmd({
       const tokens = await LLMServerTokens.list(process.cwd())
       // All of them, not just one: several sessions can be open on the same project, and
       // "which port do I use" is exactly the question this command is asked.
-      const servers = await LLMServerTokens.addresses(process.cwd())
+      // Fall back to any live host when this directory has no dedicated listener
+      // (Desktop serves many projects from one sidecar).
+      const local = await LLMServerTokens.addresses(process.cwd())
+      const servers = local.length > 0 ? local : await LLMServerTokens.hostAddresses()
       if (args.json) {
         process.stdout.write(JSON.stringify({ servers, server: servers[0] ?? null, tokens }) + "\n")
         return

--- a/packages/opencode/src/cli/cmd/llm-server.ts
+++ b/packages/opencode/src/cli/cmd/llm-server.ts
@@ -151,11 +151,10 @@ const issue = cmd({
         label: args.label,
       })
 
-      // Resolved rather than guessed: a mimocode process serving this project advertises
-      // its loopback address, so the two halves of "where" and "with what" can finally be
-      // printed together. Falls back to any live host (Desktop multi-project sidecar).
-      // Absent when nothing is serving this directory right now.
-      const address = await LLMServerTokens.discoverAddress(process.cwd())
+      // Resolved rather than guessed: a mimocode process serving THIS directory advertises
+      // its loopback address. Cross-host fallback was removed — those URLs 401 under
+      // OpenAI-standard clients (no `?directory=`), so a null base_url is honest.
+      const address = await LLMServerTokens.address(process.cwd())
 
       if (args.json) {
         // Machine-first: a wrapper reads one line and exports the two env vars the
@@ -224,12 +223,9 @@ const list = cmd({
   handler: (args) =>
     inInstance(async () => {
       const tokens = await LLMServerTokens.list(process.cwd())
-      // All of them, not just one: several sessions can be open on the same project, and
-      // "which port do I use" is exactly the question this command is asked.
-      // Fall back to any live host when this directory has no dedicated listener
-      // (Desktop serves many projects from one sidecar).
-      const local = await LLMServerTokens.addresses(process.cwd())
-      const servers = local.length > 0 ? local : await LLMServerTokens.hostAddresses()
+      // Only listeners pinned to this directory. A multi-project host's own address
+      // verifies tokens against its cwd, so advertising it here would 401.
+      const servers = await LLMServerTokens.addresses(process.cwd())
       if (args.json) {
         process.stdout.write(JSON.stringify({ servers, server: servers[0] ?? null, tokens }) + "\n")
         return

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -3,32 +3,6 @@ import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
 import { Log } from "../../util"
-import { LLMServerTokens } from "../../llm-server/tokens"
-
-/**
- * Advertise a just-started listener so `mimo llm-server issue` can print a real base_url.
- *
- * Same contract as the TUI worker (`cli/cmd/tui/worker.ts`): keyed by the project
- * directory this process serves, one file per pid, withdrawn before the socket goes
- * away. Without this, `issue` still mints a valid token but reports `base_url: null`
- * and `llm-server list` says nothing is serving the directory.
- */
-export async function advertiseListeningServer(
-  directory: string,
-  server: { hostname: string; port: number; url: URL },
-) {
-  await LLMServerTokens.publish(directory, {
-    pid: process.pid,
-    hostname: server.hostname,
-    port: server.port,
-    url: server.url.toString(),
-    started: Date.now(),
-  })
-}
-
-export async function unadvertiseListeningServer(directory: string) {
-  await LLMServerTokens.unpublish(directory)
-}
 
 export const ServeCommand = cmd({
   command: "serve",
@@ -48,23 +22,12 @@ export const ServeCommand = cmd({
       console.log("Warning: MIMOCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
 
+    // Server.listen publishes this process into the llm-server address registry
+    // (cwd) and unpublishes on stop, so `mimo llm-server issue` can resolve base_url.
     const server = await Server.listen(opts)
     console.log(`mimocode server listening on http://${server.hostname}:${server.port}`)
 
-    // `mimo serve` has no --directory flag, so the project this process serves is cwd —
-    // the same key `llm-server issue` looks up.
-    const directory = process.cwd()
-    await advertiseListeningServer(directory, server).catch((error) =>
-      Log.Default.warn("failed to advertise server address", { error: String(error) }),
-    )
-
-    // Withdraw the advertisement before the socket goes away, so a reader sees
-    // "nothing is serving" rather than a port that refuses connections. A crash skips
-    // this, which is what the pid liveness check in `addresses` is for.
-    const shutdown = async () => {
-      await unadvertiseListeningServer(directory).catch(() => {})
-      await server.stop()
-    }
+    const shutdown = () => server.stop()
     process.once("SIGINT", () => {
       void shutdown().then(() => process.exit(0))
     })

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -27,15 +27,16 @@ export const ServeCommand = cmd({
     const server = await Server.listen(opts)
     console.log(`mimocode server listening on http://${server.hostname}:${server.port}`)
 
-    const shutdown = () => server.stop()
-    process.once("SIGINT", () => {
-      void shutdown().then(() => process.exit(0))
-    })
-    process.once("SIGTERM", () => {
-      void shutdown().then(() => process.exit(0))
-    })
+    // Force-close: graceful stop waits on live SSE/WS streams, and Ctrl-C would hang.
+    const shutdown = () => server.stop(true)
+    const onSignal = () => {
+      void shutdown()
+        .then(() => process.exit(0))
+        .catch(() => process.exit(1))
+    }
+    process.once("SIGINT", onSignal)
+    process.once("SIGTERM", onSignal)
 
     await new Promise(() => {})
-    await shutdown()
   },
 })

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -3,6 +3,32 @@ import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
 import { Log } from "../../util"
+import { LLMServerTokens } from "../../llm-server/tokens"
+
+/**
+ * Advertise a just-started listener so `mimo llm-server issue` can print a real base_url.
+ *
+ * Same contract as the TUI worker (`cli/cmd/tui/worker.ts`): keyed by the project
+ * directory this process serves, one file per pid, withdrawn before the socket goes
+ * away. Without this, `issue` still mints a valid token but reports `base_url: null`
+ * and `llm-server list` says nothing is serving the directory.
+ */
+export async function advertiseListeningServer(
+  directory: string,
+  server: { hostname: string; port: number; url: URL },
+) {
+  await LLMServerTokens.publish(directory, {
+    pid: process.pid,
+    hostname: server.hostname,
+    port: server.port,
+    url: server.url.toString(),
+    started: Date.now(),
+  })
+}
+
+export async function unadvertiseListeningServer(directory: string) {
+  await LLMServerTokens.unpublish(directory)
+}
 
 export const ServeCommand = cmd({
   command: "serve",
@@ -25,7 +51,28 @@ export const ServeCommand = cmd({
     const server = await Server.listen(opts)
     console.log(`mimocode server listening on http://${server.hostname}:${server.port}`)
 
+    // `mimo serve` has no --directory flag, so the project this process serves is cwd —
+    // the same key `llm-server issue` looks up.
+    const directory = process.cwd()
+    await advertiseListeningServer(directory, server).catch((error) =>
+      Log.Default.warn("failed to advertise server address", { error: String(error) }),
+    )
+
+    // Withdraw the advertisement before the socket goes away, so a reader sees
+    // "nothing is serving" rather than a port that refuses connections. A crash skips
+    // this, which is what the pid liveness check in `addresses` is for.
+    const shutdown = async () => {
+      await unadvertiseListeningServer(directory).catch(() => {})
+      await server.stop()
+    }
+    process.once("SIGINT", () => {
+      void shutdown().then(() => process.exit(0))
+    })
+    process.once("SIGTERM", () => {
+      void shutdown().then(() => process.exit(0))
+    })
+
     await new Promise(() => {})
-    await server.stop()
+    await shutdown()
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -8,7 +8,6 @@ import { upgrade } from "@/cli/upgrade"
 import { Config } from "@/config"
 import { GlobalBus } from "@/bus/global"
 import { Flag, clearGeneratedServerPassword, generateServerPassword } from "@/flag/flag"
-import { LLMServerTokens } from "@/llm-server/tokens"
 import { writeHeapSnapshot } from "node:v8"
 import { Heap } from "@/cli/heap"
 import { AppRuntime } from "@/effect/app-runtime"
@@ -88,18 +87,9 @@ export const rpc = {
       if (!input) generateServerPassword()
       serverPromise = Server.listen(input ?? { port: 0, hostname: "127.0.0.1" })
     }
+    // Server.listen publishes cwd into the llm-server address registry and
+    // unpublishes on stop, so `mimo llm-server issue` can resolve base_url.
     server = await serverPromise
-
-    // Advertised for a human at a shell (`mimo llm-server issue` prints it). A child
-    // process is told its endpoint directly and does not read this.
-    await LLMServerTokens.publish(process.cwd(), {
-      pid: process.pid,
-      hostname: server.hostname,
-      port: server.port,
-      url: server.url.toString(),
-      started: Date.now(),
-    }).catch((error) => Log.Default.warn("failed to advertise server address", { error: String(error) }))
-
     return { url: server.url.toString() }
   },
   async checkUpgrade(input: { directory: string }) {
@@ -136,10 +126,8 @@ export const rpc = {
 
     await Instance.disposeAll()
     if (server) {
-      // Withdraw the advertisement before the socket goes away, so a reader sees
-      // "nothing is serving" rather than a port that refuses connections. A crash skips
-      // this, which is what the pid liveness check in `addresses` is for.
-      await LLMServerTokens.unpublish(process.cwd()).catch(() => {})
+      // Server.stop withdraws the llm-server advertisement before the socket goes
+      // away. A crash skips this; the pid liveness check in `addresses` is the backstop.
       await server.stop(true)
       server = undefined
       serverPromise = undefined

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -53,7 +53,7 @@ export const WebCommand = cmd({
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  MIMOCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
 
-    const server = await Server.listen(opts)
+    const server = await Server.listen({ ...opts, advertise: false })
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()

--- a/packages/opencode/src/llm-server/tokens.ts
+++ b/packages/opencode/src/llm-server/tokens.ts
@@ -127,13 +127,13 @@ function fields(value: unknown): value is Record<string, unknown> {
  * nothing and turns it into an honest "nothing is running"; the dead file is removed
  * on the way past, so the directory does not accumulate one entry per crash.
  */
-export async function addresses(directory: string): Promise<Address[]> {
-  const names = await fs.readdir(dir(directory)).catch(() => [] as string[])
+async function addressesInBucket(bucket: string): Promise<Address[]> {
+  const names = await fs.readdir(bucket).catch(() => [] as string[])
   const found = await Promise.all(
     names
       .filter((name) => name.startsWith("server-") && name.endsWith(".json"))
       .map(async (name) => {
-        const target = path.join(dir(directory), name)
+        const target = path.join(bucket, name)
         const raw = await readJson(target)
         if (!fields(raw)) return undefined
         if (typeof raw["pid"] !== "number" || typeof raw["port"] !== "number") return undefined
@@ -155,7 +155,28 @@ export async function addresses(directory: string): Promise<Address[]> {
         }
       }),
   )
-  return found.filter((item): item is Address => item !== undefined).sort((a, b) => b.started - a.started)
+  return found.filter((item): item is Address => item !== undefined)
+}
+
+export async function addresses(directory: string): Promise<Address[]> {
+  return addressesInBucket(dir(directory)).then((list) => list.sort((a, b) => b.started - a.started))
+}
+
+/**
+ * Every live listener on this machine, newest first, across all directory buckets.
+ *
+ * A multi-project host (Desktop's embedded sidecar) publishes once for its own cwd
+ * and serves `?directory=` for every project. Project-scoped lookups miss that
+ * listener; `discoverAddress` falls back here so a shell in a project directory
+ * still finds it.
+ */
+export async function hostAddresses(): Promise<Address[]> {
+  const root = path.join(Global.Path.state, "llm-server")
+  const buckets = await fs.readdir(root).catch(() => [] as string[])
+  const all = await Promise.all(
+    buckets.map(async (name) => addressesInBucket(path.join(root, name))),
+  )
+  return all.flat().sort((a, b) => b.started - a.started)
 }
 
 /**
@@ -168,6 +189,16 @@ export async function addresses(directory: string): Promise<Address[]> {
  */
 export async function address(directory: string): Promise<Address | undefined> {
   return (await addresses(directory))[0]
+}
+
+/**
+ * Prefer a listener pinned to this directory; otherwise any live host.
+ *
+ * Tokens stay scoped to the issue directory either way — this only answers "where
+ * is the `/v1` socket", which a multi-project sidecar can serve for any directory.
+ */
+export async function discoverAddress(directory: string): Promise<Address | undefined> {
+  return (await address(directory)) ?? (await hostAddresses())[0]
 }
 
 async function read(directory: string): Promise<Store> {

--- a/packages/opencode/src/llm-server/tokens.ts
+++ b/packages/opencode/src/llm-server/tokens.ts
@@ -77,24 +77,38 @@ function file(directory: string) {
 /**
  * Where a running server advertises how to reach it, for `issue` to read.
  *
- * One file PER PROCESS, because every mimocode process that serves this project binds
- * its own loopback listener. A single `server.json` would make them overwrite each
- * other and hand a caller whichever session wrote last — reachable, but not the one
- * that spawned them. The pid in the name is also the liveness check (see `addresses`).
+ * One file PER LISTENER (pid + port). pid alone collides when one process binds
+ * two sockets for the same directory — the first stop would withdraw both. The
+ * pid is also the liveness check (see `addresses`).
  */
-export function addressFile(directory: string, pid = process.pid) {
-  return path.join(dir(directory), `server-${pid}.json`)
+export function addressFile(directory: string, pid = process.pid, port?: number) {
+  return path.join(dir(directory), port === undefined ? `server-${pid}.json` : `server-${pid}-${port}.json`)
 }
 
 export type Address = { pid: number; hostname: string; port: number; url: string; started: number }
 
 export async function publish(directory: string, address: Address) {
   await fs.mkdir(dir(directory), { recursive: true, mode: 0o700 })
-  await fs.writeFile(addressFile(directory, address.pid), JSON.stringify(address), { mode: 0o600 })
+  await fs.writeFile(addressFile(directory, address.pid, address.port), JSON.stringify(address), { mode: 0o600 })
 }
 
-export async function unpublish(directory: string, pid = process.pid) {
-  await fs.rm(addressFile(directory, pid), { force: true })
+/**
+ * Withdraw this process's advertisement.
+ *
+ * With `port`, only that listener is removed. Without it, every file for the pid
+ * goes — the form `stop()` uses when the caller did not track which socket died.
+ */
+export async function unpublish(directory: string, pid = process.pid, port?: number) {
+  if (port !== undefined) {
+    await fs.rm(addressFile(directory, pid, port), { force: true })
+    return
+  }
+  const names = await fs.readdir(dir(directory)).catch(() => [] as string[])
+  await Promise.all(
+    names
+      .filter((name) => name === `server-${pid}.json` || name.startsWith(`server-${pid}-`))
+      .map((name) => fs.rm(path.join(dir(directory), name), { force: true })),
+  )
 }
 
 /**
@@ -163,42 +177,17 @@ export async function addresses(directory: string): Promise<Address[]> {
 }
 
 /**
- * Every live listener on this machine, newest first, across all directory buckets.
+ * One live listener for this directory, or nothing.
  *
- * A multi-project host (Desktop's embedded sidecar) publishes once for its own cwd
- * and serves `?directory=` for every project. Project-scoped lookups miss that
- * listener; `discoverAddress` falls back here so a shell in a project directory
- * still finds it.
- */
-export async function hostAddresses(): Promise<Address[]> {
-  const root = path.join(Global.Path.state, "llm-server")
-  const buckets = await fs.readdir(root).catch(() => [] as string[])
-  const all = await Promise.all(
-    buckets.map(async (name) => addressesInBucket(path.join(root, name))),
-  )
-  return all.flat().sort((a, b) => b.started - a.started)
-}
-
-/**
- * One live listener, or nothing.
- *
- * The most recently started, because with several sessions open on one project that is
- * the one a human just launched and therefore the one they mean. A CHILD process must
- * not resolve its endpoint this way — it is told the exact URL by whoever spawned it;
- * this is the fallback for a person at a shell.
+ * Cross-project discovery is deliberately NOT offered here. A multi-project host
+ * verifies tokens against the directory the request resolved to (`Instance.directory`,
+ * defaulting to the host's own cwd). An OpenAI-standard client sends only `base_url`
+ * and `Authorization`, so a cross-project fallback would print a URL that 401s —
+ * or 403s on `?directory=` unless the operator supplied a server password. Honest
+ * `null` beats a base_url that looks usable.
  */
 export async function address(directory: string): Promise<Address | undefined> {
   return (await addresses(directory))[0]
-}
-
-/**
- * Prefer a listener pinned to this directory; otherwise any live host.
- *
- * Tokens stay scoped to the issue directory either way — this only answers "where
- * is the `/v1` socket", which a multi-project sidecar can serve for any directory.
- */
-export async function discoverAddress(directory: string): Promise<Address | undefined> {
-  return (await address(directory)) ?? (await hostAddresses())[0]
 }
 
 async function read(directory: string): Promise<Store> {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -17,6 +17,7 @@ import { WorkspaceRouterMiddleware } from "./workspace"
 import { InstanceMiddleware } from "./routes/instance/middleware"
 import { WorkspaceRoutes } from "./routes/control/workspace"
 import { setChildProcessEnv } from "@/util/child-process-env"
+import { LLMServerTokens } from "@/llm-server/tokens"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -100,6 +101,12 @@ export async function listen(opts: {
   cors?: string[]
   noAuth?: boolean
   childEnv?: NodeJS.ProcessEnv
+  /**
+   * Advertise this listener in the llm-server address registry so
+   * `mimo llm-server issue` can resolve `base_url`. Defaults to true.
+   * Embedders that only need an in-process app can pass false.
+   */
+  advertise?: boolean
 }): Promise<Listener> {
   if (opts.childEnv) setChildProcessEnv(opts.childEnv)
   const isLoopback =
@@ -131,6 +138,21 @@ export async function listen(opts: {
     log.warn("mDNS enabled but hostname is loopback; skipping mDNS publish")
   }
 
+  // Who owns the `/v1` capability surface must also say where it is. Keyed by cwd —
+  // TUI/serve chdir to the project; Desktop hosts many projects from one listener and
+  // `discoverAddress` falls back to any live host when the project bucket is empty.
+  const advertise = opts.advertise !== false
+  const directory = process.cwd()
+  if (advertise) {
+    await LLMServerTokens.publish(directory, {
+      pid: process.pid,
+      hostname: opts.hostname,
+      port: server.port,
+      url: next.toString(),
+      started: Date.now(),
+    }).catch((error) => log.warn("failed to advertise llm-server address", { error: String(error) }))
+  }
+
   let closing: Promise<void> | undefined
   return {
     hostname: opts.hostname,
@@ -138,6 +160,10 @@ export async function listen(opts: {
     url: next,
     stop(close?: boolean) {
       closing ??= (async () => {
+        // Withdraw the advertisement before the socket goes away, so a reader sees
+        // "nothing is serving" rather than a port that refuses connections. A crash
+        // skips this; the pid liveness check in `addresses` is the backstop.
+        if (advertise) await LLMServerTokens.unpublish(directory).catch(() => {})
         if (mdns) MDNS.unpublish()
         await server.stop(close)
       })()

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -139,16 +139,23 @@ export async function listen(opts: {
   }
 
   // Who owns the `/v1` capability surface must also say where it is. Keyed by cwd —
-  // TUI/serve chdir to the project; Desktop hosts many projects from one listener and
-  // `discoverAddress` falls back to any live host when the project bucket is empty.
+  // TUI/serve chdir to the project. A multi-project host is NOT auto-discoverable
+  // from a project bucket: tokens verify against the request-resolved directory, so
+  // a cross-project base_url 401s under OpenAI-standard clients.
   const advertise = opts.advertise !== false
   const directory = process.cwd()
+  // `0.0.0.0`/`::` are bind addresses, not client URLs. Advertise loopback so the
+  // printed base_url is usable on this machine.
+  const advertisedHostname = opts.hostname === "0.0.0.0" || opts.hostname === "::" ? "127.0.0.1" : opts.hostname
+  const advertised = new URL("http://localhost")
+  advertised.hostname = advertisedHostname
+  advertised.port = String(server.port)
   if (advertise) {
     await LLMServerTokens.publish(directory, {
       pid: process.pid,
-      hostname: opts.hostname,
+      hostname: advertisedHostname,
       port: server.port,
-      url: next.toString(),
+      url: advertised.toString(),
       started: Date.now(),
     }).catch((error) => log.warn("failed to advertise llm-server address", { error: String(error) }))
   }
@@ -163,7 +170,7 @@ export async function listen(opts: {
         // Withdraw the advertisement before the socket goes away, so a reader sees
         // "nothing is serving" rather than a port that refuses connections. A crash
         // skips this; the pid liveness check in `addresses` is the backstop.
-        if (advertise) await LLMServerTokens.unpublish(directory).catch(() => {})
+        if (advertise) await LLMServerTokens.unpublish(directory, process.pid, server.port).catch(() => {})
         if (mdns) MDNS.unpublish()
         await server.stop(close)
       })()

--- a/packages/opencode/test/cli/cmd/serve-advertise.test.ts
+++ b/packages/opencode/test/cli/cmd/serve-advertise.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test"
+import { advertiseListeningServer, unadvertiseListeningServer } from "../../../src/cli/cmd/serve"
+import { LLMServerTokens } from "../../../src/llm-server/tokens"
+import { tmpdir } from "../../fixture/fixture"
+
+/**
+ * `mimo serve` must publish the same address contract the TUI worker publishes.
+ *
+ * `llm-server issue` only mints credentials; it reads the live endpoint from
+ * `LLMServerTokens.address(process.cwd())`. A serve process that listens but never
+ * publishes yields `base_url: null` even though `/v1` would accept the token.
+ */
+
+describe("mimo serve address advertisement", () => {
+  test("publishes pid/hostname/port/url/started so issue can resolve base_url", async () => {
+    await using tmp = await tmpdir()
+    const url = new URL("http://127.0.0.1:4242")
+
+    expect(await LLMServerTokens.address(tmp.path)).toBeUndefined()
+
+    await advertiseListeningServer(tmp.path, {
+      hostname: "127.0.0.1",
+      port: 4242,
+      url,
+    })
+
+    const address = await LLMServerTokens.address(tmp.path)
+    expect(address).toMatchObject({
+      pid: process.pid,
+      hostname: "127.0.0.1",
+      port: 4242,
+      url: url.toString(),
+    })
+    expect(address!.started).toBeGreaterThan(0)
+
+    // The same join `llm-server issue` uses for `base_url`.
+    const baseUrl = `${address!.url.replace(/\/$/, "")}/v1`
+    expect(baseUrl).toBe("http://127.0.0.1:4242/v1")
+  })
+
+  test("unpublishes on shutdown so list no longer shows this process", async () => {
+    await using tmp = await tmpdir()
+    await advertiseListeningServer(tmp.path, {
+      hostname: "127.0.0.1",
+      port: 4243,
+      url: new URL("http://127.0.0.1:4243"),
+    })
+    expect(await LLMServerTokens.address(tmp.path)).toMatchObject({ port: 4243 })
+
+    await unadvertiseListeningServer(tmp.path)
+    expect(await LLMServerTokens.address(tmp.path)).toBeUndefined()
+    expect(await LLMServerTokens.addresses(tmp.path)).toEqual([])
+  })
+
+  test("does not clobber another live listener's advertisement", async () => {
+    await using tmp = await tmpdir()
+    const now = Date.now()
+    await LLMServerTokens.publish(tmp.path, {
+      pid: process.ppid,
+      hostname: "127.0.0.1",
+      port: 1111,
+      url: "http://127.0.0.1:1111/",
+      started: now - 1000,
+    })
+
+    await advertiseListeningServer(tmp.path, {
+      hostname: "127.0.0.1",
+      port: 2222,
+      url: new URL("http://127.0.0.1:2222"),
+    })
+
+    // Newest first: the serve process is what a human just started.
+    expect(await LLMServerTokens.addresses(tmp.path)).toMatchObject([{ port: 2222 }, { port: 1111 }])
+
+    await unadvertiseListeningServer(tmp.path)
+    expect(await LLMServerTokens.addresses(tmp.path)).toMatchObject([{ port: 1111 }])
+  })
+})

--- a/packages/opencode/test/cli/cmd/serve-advertise.test.ts
+++ b/packages/opencode/test/cli/cmd/serve-advertise.test.ts
@@ -1,78 +1,90 @@
 import { describe, expect, test } from "bun:test"
-import { advertiseListeningServer, unadvertiseListeningServer } from "../../../src/cli/cmd/serve"
+import { Server } from "../../../src/server/server"
 import { LLMServerTokens } from "../../../src/llm-server/tokens"
 import { tmpdir } from "../../fixture/fixture"
 
 /**
- * `mimo serve` must publish the same address contract the TUI worker publishes.
+ * `Server.listen` must register itself in the llm-server address registry.
  *
  * `llm-server issue` only mints credentials; it reads the live endpoint from
- * `LLMServerTokens.address(process.cwd())`. A serve process that listens but never
+ * `LLMServerTokens.discoverAddress(process.cwd())`. A host that listens but never
  * publishes yields `base_url: null` even though `/v1` would accept the token.
+ * Desktop's embedded sidecar and `mimo serve` both go through this path.
  */
 
-describe("mimo serve address advertisement", () => {
-  test("publishes pid/hostname/port/url/started so issue can resolve base_url", async () => {
-    await using tmp = await tmpdir()
-    const url = new URL("http://127.0.0.1:4242")
+describe("Server.listen llm-server advertisement", () => {
+  test("publishes cwd so issue can resolve base_url, and unpublishes on stop", async () => {
+    const cwd = process.cwd()
+    const before = await LLMServerTokens.address(cwd)
 
-    expect(await LLMServerTokens.address(tmp.path)).toBeUndefined()
+    const server = await Server.listen({ port: 0, hostname: "127.0.0.1" })
+    try {
+      const address = await LLMServerTokens.address(cwd)
+      expect(address).toMatchObject({
+        pid: process.pid,
+        hostname: "127.0.0.1",
+        port: server.port,
+        url: server.url.toString(),
+      })
+      expect(address!.started).toBeGreaterThan(0)
 
-    await advertiseListeningServer(tmp.path, {
-      hostname: "127.0.0.1",
-      port: 4242,
-      url,
-    })
+      // The same join `llm-server issue` uses for `base_url`.
+      expect(`${address!.url.replace(/\/$/, "")}/v1`).toBe(`${server.url.toString().replace(/\/$/, "")}/v1`)
+    } finally {
+      await server.stop()
+    }
 
-    const address = await LLMServerTokens.address(tmp.path)
-    expect(address).toMatchObject({
+    // Withdrawn. Another pre-existing listener for this pid would remain if it was
+    // published separately; normally nothing is left.
+    const after = await LLMServerTokens.address(cwd)
+    if (before) expect(after).toMatchObject({ port: before.port })
+    else expect(after).toBeUndefined()
+  })
+
+  test("advertise:false leaves the registry alone", async () => {
+    const cwd = process.cwd()
+    const server = await Server.listen({ port: 0, hostname: "127.0.0.1", advertise: false })
+    try {
+      const address = await LLMServerTokens.address(cwd)
+      expect(address?.port).not.toBe(server.port)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test("discoverAddress prefers a project listener, then falls back to any live host", async () => {
+    await using project = await tmpdir()
+    await using host = await tmpdir()
+
+    // Multi-project sidecar shape: published under the host's own cwd.
+    await LLMServerTokens.publish(host.path, {
       pid: process.pid,
       hostname: "127.0.0.1",
-      port: 4242,
-      url: url.toString(),
+      port: 9001,
+      url: "http://127.0.0.1:9001/",
+      started: Date.now() - 1000,
     })
-    expect(address!.started).toBeGreaterThan(0)
 
-    // The same join `llm-server issue` uses for `base_url`.
-    const baseUrl = `${address!.url.replace(/\/$/, "")}/v1`
-    expect(baseUrl).toBe("http://127.0.0.1:4242/v1")
-  })
+    // Project has no dedicated listener yet → fallback finds the host sidecar.
+    expect(await LLMServerTokens.discoverAddress(project.path)).toMatchObject({ port: 9001 })
 
-  test("unpublishes on shutdown so list no longer shows this process", async () => {
-    await using tmp = await tmpdir()
-    await advertiseListeningServer(tmp.path, {
+    // A TUI/serve pinned to the project wins over the multi-project host.
+    await LLMServerTokens.publish(project.path, {
+      pid: process.pid,
       hostname: "127.0.0.1",
-      port: 4243,
-      url: new URL("http://127.0.0.1:4243"),
+      port: 9002,
+      url: "http://127.0.0.1:9002/",
+      started: Date.now(),
     })
-    expect(await LLMServerTokens.address(tmp.path)).toMatchObject({ port: 4243 })
+    expect(await LLMServerTokens.discoverAddress(project.path)).toMatchObject({ port: 9002 })
 
-    await unadvertiseListeningServer(tmp.path)
-    expect(await LLMServerTokens.address(tmp.path)).toBeUndefined()
-    expect(await LLMServerTokens.addresses(tmp.path)).toEqual([])
-  })
-
-  test("does not clobber another live listener's advertisement", async () => {
-    await using tmp = await tmpdir()
-    const now = Date.now()
-    await LLMServerTokens.publish(tmp.path, {
-      pid: process.ppid,
-      hostname: "127.0.0.1",
-      port: 1111,
-      url: "http://127.0.0.1:1111/",
-      started: now - 1000,
-    })
-
-    await advertiseListeningServer(tmp.path, {
-      hostname: "127.0.0.1",
-      port: 2222,
-      url: new URL("http://127.0.0.1:2222"),
-    })
-
-    // Newest first: the serve process is what a human just started.
-    expect(await LLMServerTokens.addresses(tmp.path)).toMatchObject([{ port: 2222 }, { port: 1111 }])
-
-    await unadvertiseListeningServer(tmp.path)
-    expect(await LLMServerTokens.addresses(tmp.path)).toMatchObject([{ port: 1111 }])
+    await LLMServerTokens.unpublish(project.path)
+    expect(await LLMServerTokens.discoverAddress(project.path)).toMatchObject({ port: 9001 })
+    await LLMServerTokens.unpublish(host.path)
+    // The host bucket is gone. Other live listeners from the shared state root may
+    // remain (this suite does not isolate Global.Path.state); just assert ours is not.
+    const gone = await LLMServerTokens.discoverAddress(project.path)
+    expect(gone?.port).not.toBe(9001)
+    expect(gone?.port).not.toBe(9002)
   })
 })

--- a/packages/opencode/test/cli/cmd/serve-advertise.test.ts
+++ b/packages/opencode/test/cli/cmd/serve-advertise.test.ts
@@ -7,16 +7,13 @@ import { tmpdir } from "../../fixture/fixture"
  * `Server.listen` must register itself in the llm-server address registry.
  *
  * `llm-server issue` only mints credentials; it reads the live endpoint from
- * `LLMServerTokens.discoverAddress(process.cwd())`. A host that listens but never
+ * `LLMServerTokens.address(process.cwd())`. A host that listens but never
  * publishes yields `base_url: null` even though `/v1` would accept the token.
- * Desktop's embedded sidecar and `mimo serve` both go through this path.
  */
 
 describe("Server.listen llm-server advertisement", () => {
   test("publishes cwd so issue can resolve base_url, and unpublishes on stop", async () => {
     const cwd = process.cwd()
-    const before = await LLMServerTokens.address(cwd)
-
     const server = await Server.listen({ port: 0, hostname: "127.0.0.1" })
     try {
       const address = await LLMServerTokens.address(cwd)
@@ -34,11 +31,8 @@ describe("Server.listen llm-server advertisement", () => {
       await server.stop()
     }
 
-    // Withdrawn. Another pre-existing listener for this pid would remain if it was
-    // published separately; normally nothing is left.
-    const after = await LLMServerTokens.address(cwd)
-    if (before) expect(after).toMatchObject({ port: before.port })
-    else expect(after).toBeUndefined()
+    const after = await LLMServerTokens.addresses(cwd)
+    expect(after.find((a) => a.port === server.port)).toBeUndefined()
   })
 
   test("advertise:false leaves the registry alone", async () => {
@@ -52,23 +46,51 @@ describe("Server.listen llm-server advertisement", () => {
     }
   })
 
-  test("discoverAddress prefers a project listener, then falls back to any live host", async () => {
+  test("bind 0.0.0.0 advertises a loopback client URL, not the bind address", async () => {
+    const cwd = process.cwd()
+    const server = await Server.listen({ port: 0, hostname: "0.0.0.0", noAuth: true })
+    try {
+      const address = await LLMServerTokens.address(cwd)
+      expect(address?.hostname).toBe("127.0.0.1")
+      expect(address?.url).toContain("127.0.0.1")
+      expect(address?.url).not.toContain("0.0.0.0")
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test("two listeners in one process keep independent advertisements", async () => {
+    const cwd = process.cwd()
+    const a = await Server.listen({ port: 0, hostname: "127.0.0.1" })
+    const b = await Server.listen({ port: 0, hostname: "127.0.0.1" })
+    try {
+      const live = await LLMServerTokens.addresses(cwd)
+      expect(live.find((x) => x.port === a.port)).toBeTruthy()
+      expect(live.find((x) => x.port === b.port)).toBeTruthy()
+    } finally {
+      await a.stop()
+      const afterA = await LLMServerTokens.addresses(cwd)
+      expect(afterA.find((x) => x.port === a.port)).toBeUndefined()
+      expect(afterA.find((x) => x.port === b.port)).toBeTruthy()
+      await b.stop()
+    }
+  })
+
+  test("address stays project-scoped — no cross-host fallback", async () => {
     await using project = await tmpdir()
     await using host = await tmpdir()
 
-    // Multi-project sidecar shape: published under the host's own cwd.
     await LLMServerTokens.publish(host.path, {
       pid: process.pid,
       hostname: "127.0.0.1",
       port: 9001,
       url: "http://127.0.0.1:9001/",
-      started: Date.now() - 1000,
+      started: Date.now(),
     })
 
-    // Project has no dedicated listener yet → fallback finds the host sidecar.
-    expect(await LLMServerTokens.discoverAddress(project.path)).toMatchObject({ port: 9001 })
+    // A listener in another directory must not satisfy this project's `issue`.
+    expect(await LLMServerTokens.address(project.path)).toBeUndefined()
 
-    // A TUI/serve pinned to the project wins over the multi-project host.
     await LLMServerTokens.publish(project.path, {
       pid: process.pid,
       hostname: "127.0.0.1",
@@ -76,15 +98,12 @@ describe("Server.listen llm-server advertisement", () => {
       url: "http://127.0.0.1:9002/",
       started: Date.now(),
     })
-    expect(await LLMServerTokens.discoverAddress(project.path)).toMatchObject({ port: 9002 })
+    expect(await LLMServerTokens.address(project.path)).toMatchObject({ port: 9002 })
 
     await LLMServerTokens.unpublish(project.path)
-    expect(await LLMServerTokens.discoverAddress(project.path)).toMatchObject({ port: 9001 })
+    expect(await LLMServerTokens.address(project.path)).toBeUndefined()
+    // Host bucket is still live, but must stay invisible to the project lookup.
+    expect(await LLMServerTokens.address(host.path)).toMatchObject({ port: 9001 })
     await LLMServerTokens.unpublish(host.path)
-    // The host bucket is gone. Other live listeners from the shared state root may
-    // remain (this suite does not isolate Global.Path.state); just assert ours is not.
-    const gone = await LLMServerTokens.discoverAddress(project.path)
-    expect(gone?.port).not.toBe(9001)
-    expect(gone?.port).not.toBe(9002)
   })
 })


### PR DESCRIPTION
### Issue / context (if applicable)

`mimo serve` listened but never published its loopback address, so `mimo llm-server issue` minted valid tokens with `base_url: null` and `llm-server list` reported nothing serving the directory. Manual `/v1` calls with the token still worked — the bug was discovery, not auth.

### Type of change

Bug fix

### What does this PR do?

1. **`mimo serve` publishes after listen** and unpublishes on stop. SIGINT/SIGTERM force-close (`stop(true)`) so live SSE/WS streams cannot wedge Ctrl-C.
2. **Move advertise/unadvertise into `Server.listen` / `stop`** so every host that binds a listener registers itself. ACP and `web` pass `advertise: false` — they are private shims, not task-token hosts. TUI/serve keep the default.
3. **Project-scoped discovery only.** A cross-project host fallback was considered and deliberately removed: tokens verify against the request-resolved `Instance.directory`, and OpenAI-standard clients send no `?directory=`, so a fallback base_url would 401 (or 403 without an operator-supplied password). `issue`/`list` use `address(cwd)`; no listener for this directory means an honest `base_url: null`.
4. **Advertise client-usable URL.** Bind `0.0.0.0`/`::` is rewritten to `127.0.0.1` in the registry.
5. **Address files keyed by `pid+port`** (`server-<pid>-<port>.json`) so one process can hold two listeners without the first stop withdrawing both.

Tokens remain scoped to the issue directory.

### How did you verify your code works?

**Unit / typecheck** (from `packages/opencode`):

```bash
bun test test/cli/cmd/serve-advertise.test.ts   # 5 pass
bun test test/llm-server/                       # 124 pass
bun run typecheck                               # pass
```

Covered by the advertise suite: publish/unpublish, `advertise: false`, `0.0.0.0` → loopback rewrite, two listeners in one process stay independent, project-scoped `address()` with no cross-host fallback.

**Local E2E** (HEAD `9d643c7cb6`, from `packages/opencode` so module resolution works; both processes share that cwd):

```bash
# 1. start serve
unset MIMOCODE_SERVER_PASSWORD
bun run --conditions=browser ./src/index.ts serve --port 8766 --hostname 127.0.0.1
# → "mimocode server listening on http://127.0.0.1:8766"

# 2. discovery
bun run --conditions=browser ./src/index.ts llm-server list --json
# → servers[0] = {pid, hostname:127.0.0.1, port:8766, url:"http://127.0.0.1:8766/"}
#    (not "none serving this directory")

# 3. mint a scoped speech token
bun run --conditions=browser ./src/index.ts llm-server issue --capability speech --json
# → base_url="http://127.0.0.1:8766/v1"   (non-null)
#    models=["mimo/mimo-v2.5-tts"], model="mimo/mimo-v2.5-tts"

# 4. OpenAI-compatible surface
curl -H "Authorization: Bearer $TOKEN" "$BASE/models"
# → 200, data = [mimo/mimo-v2.5-tts]  (model scope enforced)

curl -X POST "$BASE/audio/speech" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"model":"mimo/mimo-v2.5-tts","input":"端到端验证通过。","voice":"mimo_default","response_format":"wav"}'
# → 200, WAVE PCM 24 kHz mono (92204 bytes)

curl -H "Authorization: Bearer not-a-real-token" "$BASE/models"
# → 401 invalid_api_key

# 5. shutdown withdraws the advertisement
kill -INT $SERVE_PID
bun run --conditions=browser ./src/index.ts llm-server list --json
# → server: null, servers: []
```

Note: speech with an unknown voice name (e.g. `alloy`) returns 502 listing available voices (`mimo_default`, …). Omit `voice` or use `mimo_default`.

### Design trade-off

Desktop multi-project sidecars are no longer discoverable from a project directory. That is intentional: a printed base_url that 401s under a standard client is worse than null + "start a session in this directory". If multi-project discovery is needed later, the sidecar should publish per-project (or clients must send `?directory=` plus an operator password) — not a silent cross-bucket fallback.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
