### PR TITLE
feat(session): project compaction as a summary plus compression-time tail

### DIFF
--- a/packages/opencode/migration/20260831000000_session_prefix_tools/migration.sql
+++ b/packages/opencode/migration/20260831000000_session_prefix_tools/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `session_prefix_snapshot` ADD `tools` text;

--- a/packages/opencode/src/agent/prompt/compaction.txt
+++ b/packages/opencode/src/agent/prompt/compaction.txt
@@ -1,9 +1,23 @@
-You are an anchored context summarization assistant for coding sessions.
-
-Summarize only the conversation history you are given. The newest turns may be kept verbatim outside your summary, so focus on the older context that still matters for continuing the work.
-
-If the prompt includes a <previous-summary> block, treat it as the current anchored summary. Update it with the new history by preserving still-true details, removing stale details, and merging in new facts.
-
-Always follow the exact output structure requested by the user prompt. Keep every section, preserve exact file paths and identifiers when known, and prefer terse bullets over paragraphs.
-
-Do not answer the conversation itself. Do not mention that you are summarizing, compacting, or merging context. Respond in the same language as the conversation.
+You have been working on the task described above but have not yet completed it. Write a continuation summary that will allow you (or another instance of yourself) to resume work efficiently in a future context window where the conversation history will be replaced with this summary. Your summary should be structured, concise, and actionable. Include:
+1. Task Overview
+The user's core request and success criteria
+Any clarifications or constraints they specified
+2. Current State
+What has been completed so far
+Files created, modified, or analyzed (with paths if relevant)
+Key outputs or artifacts produced
+3. Important Discoveries
+Technical constraints or requirements uncovered
+Decisions made and their rationale
+Errors encountered and how they were resolved
+What approaches were tried that didn't work (and why)
+4. Next Steps
+Specific actions needed to complete the task
+Any blockers or open questions to resolve
+Priority order if multiple steps remain
+5. Context to Preserve
+User preferences or style requirements
+Domain-specific details that aren't obvious
+Any promises made to the user
+Be concise but complete—err on the side of including information that would prevent duplicate work or repeated mistakes. Write in a way that enables immediate resumption of the task.
+Wrap your summary in <summary></summary> tags.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -256,10 +256,11 @@ const InfoSchema = Schema.Struct({
       }),
       tail_turns: Schema.optional(NonNegativeInt).annotate({
         description:
-          "Number of recent user turns, including their following assistant/tool responses, to keep verbatim during compaction (default: 2)",
+          "Deprecated compatibility setting. Projected compaction now keeps only whole API rounds that arrive while compaction is running.",
       }),
       preserve_recent_tokens: Schema.optional(NonNegativeInt).annotate({
-        description: "Maximum number of tokens from recent turns to preserve verbatim after compaction",
+        description:
+          "Deprecated compatibility setting. Compression-time API rounds now use a fixed 40000-token hard budget.",
       }),
       reserved: Schema.optional(NonNegativeInt).annotate({
         description:

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -15,9 +15,10 @@ import { NotFoundError } from "@/storage"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect, Layer, Context } from "effect"
 import { InstanceState } from "@/effect"
-import { isOverflow as overflow, usable } from "./overflow"
+import { isOverflow as overflow } from "./overflow"
 import { makeRuntime } from "@/effect/run-service"
 import { fn } from "@/util/fn"
+import path from "path"
 
 const log = Log.create({ service: "session.compaction" })
 
@@ -38,38 +39,186 @@ export const Event = {
 export const PRUNE_MINIMUM = 20_000
 export const PRUNE_PROTECT = 40_000
 const PRUNE_PROTECTED_TOOLS = ["skill"]
-const DEFAULT_TAIL_TURNS = 2
-const MIN_PRESERVE_RECENT_TOKENS = 2_000
-const MAX_PRESERVE_RECENT_TOKENS = 8_000
-type Turn = {
-  start: number
-  end: number
-  id: MessageID
+export const COMPACTION_TAIL_BUDGET = 40_000
+export const COMPACTION_TOOL_RESULT_LIMIT = 8_000
+const FILE_MANIFEST_LIMIT = 5
+const TAIL_SHRINK_METADATA = "compaction_tail_shrunk_tokens"
+
+type CompactionTrigger = "manual" | "automatic" | "provider-overflow"
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return
+  return value as Record<string, unknown>
 }
 
-function preserveRecentBudget(input: { cfg: Config.Info; model: Provider.Model }) {
-  return (
-    input.cfg.compaction?.preserve_recent_tokens ??
-    Math.min(MAX_PRESERVE_RECENT_TOKENS, Math.max(MIN_PRESERVE_RECENT_TOKENS, Math.floor(usable(input) * 0.25)))
+function string(value: unknown) {
+  return typeof value === "string" ? value : undefined
+}
+
+function number(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function relativeFile(file: string, worktree: string) {
+  return (path.isAbsolute(file) ? path.relative(worktree, file) : file).replaceAll("\\", "/")
+}
+
+function xmlText(value: string) {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+}
+
+function readLabel(part: MessageV2.ToolPart) {
+  if (part.state.status !== "completed") return "read"
+  const offset = number(part.state.input.offset) ?? 1
+  const range = part.state.output.match(/Showing lines (\d+)-(\d+)/)
+  const contentEnd = Array.from(part.state.output.matchAll(/(?:^|\n)(\d+):/g)).at(-1)?.[1]
+  const end = range?.[2] ?? contentEnd
+  if (offset === 1 && part.state.metadata.truncated !== true && (part.state.output.includes("(End of file") || !end))
+    return "read: full"
+  return end ? `read: lines ${offset}-${end}` : `read: from line ${offset}`
+}
+
+export function buildFileManifest(messages: MessageV2.WithParts[], env: { worktree: string }) {
+  const touched = new Map<string, { path: string; events: string[] }>()
+  const add = (file: string | undefined, event: string) => {
+    if (!file) return undefined
+    const normalized = relativeFile(file, env.worktree)
+    if (!normalized) return undefined
+    const current = touched.get(normalized) ?? { path: normalized, events: [] }
+    if (current.events.at(-1) !== event) current.events.push(event)
+    touched.delete(normalized)
+    touched.set(normalized, current)
+    return normalized
+  }
+
+  for (const message of messages) {
+    const mutatedFiles = new Set<string>()
+    for (const part of message.parts) {
+      if (part.type === "patch") {
+        for (const file of part.files) {
+          if (mutatedFiles.has(relativeFile(file, env.worktree))) continue
+          add(file, "edited")
+        }
+        continue
+      }
+      if (part.type !== "tool" || part.state.status !== "completed") continue
+      const inputPath =
+        string(part.state.input.file_path) ?? string(part.state.input.path) ?? string(part.state.input.notebook_path)
+      if (part.tool === "read") {
+        add(inputPath, readLabel(part))
+        continue
+      }
+      if (part.tool === "apply_patch" && Array.isArray(part.state.metadata.files)) {
+        for (const item of part.state.metadata.files) {
+          const file = record(item)
+          if (!file) continue
+          const normalized = add(
+            string(file.relativePath) ?? string(file.filePath),
+            file.type === "add" ? "written" : "edited",
+          )
+          if (normalized) mutatedFiles.add(normalized)
+        }
+        continue
+      }
+      if (!["write", "edit", "multiedit", "notebook_edit", "str_replace"].includes(part.tool)) continue
+      const metadataPath = string(part.state.metadata.filepath) ?? string(record(part.state.metadata.filediff)?.file)
+      const written =
+        (part.tool === "write" && part.state.metadata.exists === false) ||
+        (part.tool === "edit" && part.state.input.old_string === "")
+      const file = add(inputPath ?? metadataPath, written ? "written" : "edited")
+      if (file) mutatedFiles.add(file)
+    }
+  }
+
+  const files = Array.from(touched.values()).slice(-FILE_MANIFEST_LIMIT)
+  if (!files.length) return
+  return [
+    "## Attachments",
+    "",
+    "<files-touched>",
+    "These files were read or edited earlier in this session. Their contents have been",
+    "removed from context — re-read any file you need before editing it.",
+    "",
+    ...files.map((file) => `- ${xmlText(file.path)} (${file.events.slice(-3).join(", then ")})`),
+    "</files-touched>",
+  ].join("\n")
+}
+
+export function groupByApiRound(messages: MessageV2.WithParts[]) {
+  return messages.reduce<MessageV2.WithParts[][]>((rounds, message) => {
+    if (message.info.role === "user" || rounds.length === 0) {
+      rounds.push([message])
+      return rounds
+    }
+    rounds.at(-1)!.push(message)
+    return rounds
+  }, [])
+}
+
+export function shrinkLargeToolResults(messages: MessageV2.WithParts[]) {
+  return messages.map(
+    (message): MessageV2.WithParts => ({
+      info: message.info,
+      parts: message.parts.map((part) => {
+        if (part.type !== "tool" || part.state.status !== "completed") return part
+        const tokens = Token.estimate(part.state.output)
+        if (tokens <= COMPACTION_TOOL_RESULT_LIMIT) return part
+        return {
+          ...part,
+          state: {
+            ...part.state,
+            output: `[Tool result omitted during compaction: ${tokens} tokens. Re-run "${part.tool}" if this result is needed.]`,
+            providerOutput: undefined,
+            attachments: undefined,
+            metadata: { ...part.state.metadata, [TAIL_SHRINK_METADATA]: tokens },
+          },
+        }
+      }),
+    }),
   )
 }
 
-function turns(messages: MessageV2.WithParts[]) {
-  const result: Turn[] = []
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i]
-    if (msg.info.role !== "user") continue
-    if (msg.parts.some((part) => part.type === "compaction")) continue
-    result.push({
-      start: i,
-      end: messages.length,
-      id: msg.info.id,
-    })
+export const buildTail = Effect.fn("SessionCompaction.buildTail")(function* (input: {
+  messages: MessageV2.WithParts[]
+  model: Provider.Model
+  budget?: number
+}) {
+  const rounds = groupByApiRound(input.messages)
+  const kept: MessageV2.WithParts[][] = []
+  let used = 0
+  for (let i = rounds.length - 1; i >= 0; i--) {
+    const round = shrinkLargeToolResults(rounds[i])
+    const cost = Token.estimate(
+      JSON.stringify(yield* Effect.promise(() => MessageV2.toModelMessages(round, input.model))),
+    )
+    if (used + cost > (input.budget ?? COMPACTION_TAIL_BUDGET)) break
+    kept.unshift(round)
+    used += cost
   }
-  for (let i = 0; i < result.length - 1; i++) {
-    result[i].end = result[i + 1].start
-  }
-  return result
+  return kept.flat()
+})
+
+function compactedToolCalls(messages: MessageV2.WithParts[]) {
+  return messages.flatMap((message) =>
+    message.parts.flatMap((part) => {
+      if (part.type !== "tool" || part.state.status !== "completed") return []
+      const tokens = number(part.state.metadata[TAIL_SHRINK_METADATA])
+      return tokens === undefined ? [] : [{ call_id: part.callID, tokens }]
+    }),
+  )
+}
+
+export function buildSummaryMessage(summary: string, trigger: CompactionTrigger, hasTail: boolean) {
+  return [
+    `<conversation-summary trigger="${trigger}">`,
+    "The earlier conversation has been compacted into the summary below.",
+    hasTail
+      ? "Complete API rounds that arrived while compaction was running follow this summary."
+      : "No additional API rounds arrived while compaction was running.",
+    "",
+    summary.trim(),
+    "</conversation-summary>",
+  ].join("\n")
 }
 
 export interface Interface {
@@ -124,55 +273,6 @@ export const layer: Layer.Layer<
       model: Provider.Model
     }) {
       return overflow({ cfg: yield* config.get(), tokens: input.tokens, model: input.model })
-    })
-
-    const estimate = Effect.fn("SessionCompaction.estimate")(function* (input: {
-      messages: MessageV2.WithParts[]
-      model: Provider.Model
-    }) {
-      const msgs = yield* MessageV2.toModelMessagesEffect(input.messages, input.model)
-      return Token.estimate(JSON.stringify(msgs))
-    })
-
-    const select = Effect.fn("SessionCompaction.select")(function* (input: {
-      messages: MessageV2.WithParts[]
-      cfg: Config.Info
-      model: Provider.Model
-    }) {
-      const limit = input.cfg.compaction?.tail_turns ?? DEFAULT_TAIL_TURNS
-      if (limit <= 0) return { head: input.messages, tail_start_id: undefined }
-      const budget = preserveRecentBudget({ cfg: input.cfg, model: input.model })
-      const all = turns(input.messages)
-      if (!all.length) return { head: input.messages, tail_start_id: undefined }
-      const recent = all.slice(-limit)
-      const sizes = yield* Effect.forEach(
-        recent,
-        (turn) =>
-          estimate({
-            messages: input.messages.slice(turn.start, turn.end),
-            model: input.model,
-          }),
-        { concurrency: 1 },
-      )
-      if (sizes.at(-1)! > budget) {
-        log.info("tail fallback", { budget, size: sizes.at(-1) })
-        return { head: input.messages, tail_start_id: undefined }
-      }
-
-      let total = 0
-      let keep: Turn | undefined
-      for (let i = recent.length - 1; i >= 0; i--) {
-        const size = sizes[i]
-        if (total + size > budget) break
-        total += size
-        keep = recent[i]
-      }
-
-      if (!keep || keep.start === 0) return { head: input.messages, tail_start_id: undefined }
-      return {
-        head: input.messages.slice(0, keep.start),
-        tail_start_id: keep.id,
-      }
     })
 
     // goes backwards through parts until there are PRUNE_PROTECT tokens worth of tool
@@ -238,6 +338,7 @@ export const layer: Layer.Layer<
       overflow?: boolean
       agentID?: string
     }) {
+      const snapshotLen = input.messages.length
       const parentIdx = input.messages.findLastIndex((m) => m.info.id === input.parentID)
       const parent = parentIdx >= 0 ? input.messages[parentIdx] : undefined
       if (!parent || parent.info.role !== "user") {
@@ -301,45 +402,16 @@ export const layer: Layer.Layer<
       const model = agent.model
         ? yield* provider.getModel(agent.model.providerID, agent.model.modelID)
         : yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
-      const cfg = yield* config.get()
       const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
-      const selected = yield* select({
-        messages: history,
-        cfg,
-        model,
-      })
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",
         { sessionID: input.sessionID },
         { context: [], prompt: undefined },
       )
-      const defaultPrompt = `When constructing the summary, try to stick to this template:
----
-## Goal
-
-[What goal(s) is the user trying to accomplish?]
-
-## Instructions
-
-- [What important instructions did the user give you that are relevant]
-- [If there is a plan or spec, include information about it so next agent can continue using it]
-
-## Discoveries
-
-[What notable things were learned during this conversation that would be useful for the next agent to know when continuing the work]
-
-## Accomplished
-
-[What work has been completed, what work is still in progress, and what work is left?]
-
-## Relevant files / directories
-
-[Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
----`
-
-      const prompt = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
-      const msgs = structuredClone(selected.head)
+      const prompt =
+        compacting.prompt ?? ["Write the continuation summary now.", ...compacting.context].join("\n\n")
+      const msgs = structuredClone(history)
       yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
       const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, { stripMedia: true })
       const ctx = yield* InstanceState.context
@@ -420,10 +492,39 @@ export const layer: Layer.Layer<
       )
         return yield* rollback("Compaction produced no usable summary")
 
-      if (compactionPart && selected.tail_start_id && compactionPart.tail_start_id !== selected.tail_start_id) {
+      if (compactionPart) {
+        const current = yield* session.messages({
+          sessionID: input.sessionID,
+          agentID: input.agentID ?? "main",
+        })
+        const arrived = current.slice(snapshotLen).filter((message) => message.info.id !== msg.id)
+        const tail = yield* buildTail({
+          messages: arrived,
+          model: yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID),
+        })
+        const summary = MessageV2.parts(msg.id)
+          .filter((part): part is MessageV2.TextPart => part.type === "text")
+          .map((part) => part.text)
+          .join("\n")
+        const trigger: CompactionTrigger = input.overflow ? "provider-overflow" : input.auto ? "automatic" : "manual"
         yield* session.updatePart({
           ...compactionPart,
-          tail_start_id: selected.tail_start_id,
+          projection: {
+            version: 1,
+            summary_message_id: msg.id,
+            summary: buildSummaryMessage(summary, trigger, tail.length > 0),
+            manifest: buildFileManifest(
+              scoped.slice(
+                0,
+                scoped.findIndex((message) => message.info.id === input.parentID),
+              ),
+              { worktree: ctx.worktree },
+            ),
+            trigger,
+            tail_start_id: tail.at(0)?.info.id,
+            tail_end_id: arrived.at(-1)?.info.id,
+            compacted_tool_calls: compactedToolCalls(tail),
+          },
         })
       }
 

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -496,7 +496,7 @@ export const layer: Layer.Layer<
         sessionID: input.sessionID,
         tools: frozen?.tools ? SessionPrefixSnapshot.restoreTools(frozen.tools) : {},
         activeTools: frozen?.tools?.map((item) => item.name),
-        toolChoice: "none",
+        toolChoice: "auto",
         system: [],
         prebuiltSystem: frozen?.system,
         messages: [...modelMessages, summaryRequest],

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -19,6 +19,7 @@ import { isOverflow as overflow } from "./overflow"
 import { makeRuntime } from "@/effect/run-service"
 import { fn } from "@/util/fn"
 import path from "path"
+import { SessionPrefixSnapshot } from "./prefix-snapshot"
 
 const log = Log.create({ service: "session.compaction" })
 
@@ -356,19 +357,11 @@ export const layer: Layer.Layer<
       }
       const compactionPart = parent.parts.find((part): part is MessageV2.CompactionPart => part.type === "compaction")
 
-      // Truncate history at the previous compaction boundary so a repeat
-      // compaction summarizes [previous summary + messages since], not the full raw
-      // history (which would grow unboundedly and overflow the compaction model).
-      // Only compaction boundaries are used — checkpoint boundaries inject a
-      // lossy rebuild and compaction benefits from seeing the full window since
-      // the last compaction (including any checkpoint rebuild text in between).
-      const boundaryIdx = input.messages.findLastIndex(
-        (m, i) =>
-          i < parentIdx &&
-          m.info.role === "user" &&
-          m.parts.some((p) => p.type === "compaction"),
-      )
-      const scoped = boundaryIdx >= 0 ? input.messages.slice(boundaryIdx) : input.messages
+      // Reuse the effective conversation before this synthetic boundary without
+      // restoring raw history removed by an earlier compaction or checkpoint.
+      const scoped = compactionPart
+        ? [...MessageV2.filterCompacted([...input.messages.slice(0, parentIdx)].reverse()), parent]
+        : input.messages
 
       let messages = scoped
       let replay:
@@ -399,10 +392,42 @@ export const layer: Layer.Layer<
       }
 
       const agent = yield* agents.get("compaction")
-      const model = agent.model
-        ? yield* provider.getModel(agent.model.providerID, agent.model.modelID)
-        : yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
       const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
+      const requestUser = history.findLast(
+        (message): message is MessageV2.WithParts & { info: MessageV2.User } => message.info.role === "user",
+      )
+      if (!requestUser) {
+        log.warn("compaction history has no user message", { sessionID: input.sessionID })
+        yield* session.removeMessage({ sessionID: input.sessionID, messageID: input.parentID })
+        return "stop" as const
+      }
+      const parentAgent = yield* agents.get(requestUser.info.agent)
+      const parentModel = yield* provider.getModel(requestUser.info.model.providerID, requestUser.info.model.modelID)
+      const parentSession = yield* session.get(input.sessionID)
+      const profileKey = SessionPrefixSnapshot.profileKey({
+        providerID: parentModel.providerID,
+        modelID: parentModel.id,
+        agent: parentAgent.name,
+        agentID: requestUser.info.agentID ?? "main",
+        harness: promptConfig.harness,
+        systemMode: promptConfig.systemMode,
+        system: promptConfig.system ?? "",
+        permission: Agent.runtimePermission(parentAgent, parentSession.permission),
+      })
+      const frozen = yield* SessionPrefixSnapshot.get(input.sessionID, profileKey)
+      if (!frozen) {
+        log.warn("compaction prefix snapshot missing", { sessionID: input.sessionID, profileKey })
+      }
+      if (frozen && !frozen.tools) {
+        log.warn("compaction prefix snapshot missing advertised tools", {
+          sessionID: input.sessionID,
+          profileKey,
+        })
+      }
+      const model =
+        input.overflow && agent.model
+          ? yield* provider.getModel(agent.model.providerID, agent.model.modelID)
+          : parentModel
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",
@@ -410,10 +435,17 @@ export const layer: Layer.Layer<
         { context: [], prompt: undefined },
       )
       const prompt =
-        compacting.prompt ?? ["Write the continuation summary now.", ...compacting.context].join("\n\n")
+        compacting.prompt ??
+        [agent.prompt, ...compacting.context]
+          .filter((item): item is string => !!item)
+          .join("\n\n")
       const msgs = structuredClone(history)
       yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
-      const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, { stripMedia: true })
+      const modelMessages = yield* MessageV2.toModelMessagesEffect(
+        msgs,
+        model,
+        input.overflow ? { stripMedia: true } : { collapseCheckpointTail: true },
+      )
       const ctx = yield* InstanceState.context
       const msg: MessageV2.Assistant = {
         id: MessageID.ascending(),
@@ -423,7 +455,7 @@ export const layer: Layer.Layer<
         agentID: input.agentID ?? undefined,
         mode: "compaction",
         agent: "compaction",
-        variant: userMessage.model.variant,
+        variant: requestUser.info.model.variant,
         summary: true,
         path: {
           cwd: ctx.directory,
@@ -448,19 +480,27 @@ export const layer: Layer.Layer<
         sessionID: input.sessionID,
         model,
       })
+      const summaryRequest = {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: prompt }],
+      }
       const result = yield* processor.process({
-        user: userMessage,
-        agent,
+        user: {
+          ...requestUser.info,
+          system: promptConfig.system,
+          systemMode: promptConfig.systemMode,
+          harness: promptConfig.harness,
+        },
+        agent: parentAgent,
+        permission: parentSession.permission,
         sessionID: input.sessionID,
-        tools: {},
+        tools: frozen?.tools ? SessionPrefixSnapshot.restoreTools(frozen.tools) : {},
+        activeTools: frozen?.tools?.map((item) => item.name),
+        toolChoice: "none",
         system: [],
-        messages: [
-          ...modelMessages,
-          {
-            role: "user",
-            content: [{ type: "text", text: prompt }],
-          },
-        ],
+        prebuiltSystem: frozen?.system,
+        messages: [...modelMessages, summaryRequest],
+        mergeTurnContextBeforeLastMessage: true,
         model,
       })
 
@@ -478,7 +518,9 @@ export const layer: Layer.Layer<
         processor.message.error = new MessageV2.ContextOverflowError({
           message: replay
             ? "Conversation history too large to compact - exceeds model context limit"
-            : "Session too large to compact - context exceeds model limit even after stripping media",
+            : input.overflow
+              ? "Session too large to compact - context exceeds model limit even after stripping media"
+              : "Session too large to compact - context exceeds model limit at the message boundary",
         }).toObject()
         processor.message.finish = "error"
         yield* session.updateMessage(processor.message)
@@ -500,7 +542,7 @@ export const layer: Layer.Layer<
         const arrived = current.slice(snapshotLen).filter((message) => message.info.id !== msg.id)
         const tail = yield* buildTail({
           messages: arrived,
-          model: yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID),
+          model: parentModel,
         })
         const summary = MessageV2.parts(msg.id)
           .filter((part): part is MessageV2.TextPart => part.type === "text")
@@ -513,13 +555,7 @@ export const layer: Layer.Layer<
             version: 1,
             summary_message_id: msg.id,
             summary: buildSummaryMessage(summary, trigger, tail.length > 0),
-            manifest: buildFileManifest(
-              scoped.slice(
-                0,
-                scoped.findIndex((message) => message.info.id === input.parentID),
-              ),
-              { worktree: ctx.worktree },
-            ),
+            manifest: buildFileManifest(history, { worktree: ctx.worktree }),
             trigger,
             tail_start_id: tail.at(0)?.info.id,
             tail_end_id: arrived.at(-1)?.info.id,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -250,6 +250,8 @@ export type StreamInput = {
   toolChoice?: "auto" | "required" | "none"
   agentID?: string
   mergeTurnContextIntoLastUser?: boolean
+  /** Keep an appended control prompt last while applying provider-specific turn context to the conversation before it. */
+  mergeTurnContextBeforeLastMessage?: boolean
   ephemeral?: boolean
   requestID?: string
 }
@@ -285,6 +287,19 @@ export function appendTurnContext(messages: ModelMessage[], user: MessageV2.User
     return [...messages, ...context]
   }
   return [...messages.slice(0, -1), { ...last, content: last.content + "\n\n" + context[0].content }]
+}
+
+function appendTurnContextBeforeLastMessage(messages: ModelMessage[], user: MessageV2.User) {
+  const tail = messages.at(-1)
+  if (!tail) return appendTurnContext(messages, user, true)
+  const head = messages.slice(0, -1)
+  const userIndex = head.findLastIndex((message) => message.role === "user")
+  if (userIndex < 0) return appendTurnContext(messages, user, true)
+  return [
+    ...appendTurnContext(head.slice(0, userIndex + 1), user, true),
+    ...head.slice(userIndex + 1),
+    tail,
+  ]
 }
 
 export interface Interface {
@@ -530,7 +545,9 @@ const live: Layer.Layer<
       const requestMessages = input.dropAssistantPrefill
         ? ProviderTransform.dropTrailingAssistantPrefill(input.messages)
         : input.messages
-      const requestMessagesWithContext = appendTurnContext(requestMessages, input.user, input.mergeTurnContextIntoLastUser)
+      const requestMessagesWithContext = input.mergeTurnContextBeforeLastMessage
+        ? appendTurnContextBeforeLastMessage(requestMessages, input.user)
+        : appendTurnContext(requestMessages, input.user, input.mergeTurnContextIntoLastUser)
       const messages = isOpenaiOauth
         ? requestMessages
         : isWorkflow

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -656,7 +656,7 @@ function compactionProjection(messages: WithParts[]) {
   if (tailEndIdx < 0) return messages.slice(boundaryIdx)
 
   const observed = after.slice(0, tailEndIdx + 1)
-  const summary = observed.find((message) => message.info.id === projection.summary_message_id)
+  const summary = after.find((message) => message.info.id === projection.summary_message_id)
   const tailStartIdx = projection.tail_start_id
     ? observed.findIndex((message) => message.info.id === projection.tail_start_id)
     : -1

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -278,10 +278,32 @@ export const CompactionPart = PartBase.extend({
   type: z.literal("compaction"),
   auto: z.boolean(),
   overflow: z.boolean().optional(),
-  // ID of the user message marking the start of the preserved-tail (verbatim
-  // recent-turns kept after summarization). Optional: when undefined, no tail
-  // was preserved (entire history was summarized).
+  // Legacy pre-compaction tail marker. New projections keep only messages that
+  // arrive while the summary is being generated; see `projection` below.
   tail_start_id: MessageID.zod.optional(),
+  projection: z
+    .object({
+      version: z.literal(1),
+      summary_message_id: MessageID.zod,
+      summary: z.string(),
+      manifest: z.string().optional(),
+      trigger: z.enum(["manual", "automatic", "provider-overflow"]),
+      // The observed compression-time range. `tail_start_id` is the first
+      // whole API round retained inside that range; when omitted, the range was
+      // over budget and is dropped. Messages newer than `tail_end_id` are normal
+      // post-compaction traffic and always stay live.
+      tail_start_id: MessageID.zod.optional(),
+      tail_end_id: MessageID.zod.optional(),
+      compacted_tool_calls: z
+        .array(
+          z.object({
+            call_id: z.string(),
+            tokens: z.number().int().nonnegative(),
+          }),
+        )
+        .optional(),
+    })
+    .optional(),
 }).meta({
   ref: "CompactionPart",
 })
@@ -609,6 +631,67 @@ export const WithParts = z.object({
 })
 export type WithParts = z.infer<typeof WithParts>
 
+// Apply the newest v1 compaction boundary as a context projection while keeping
+// its persisted assistant summary in the internal message stream. API
+// conversion below re-roles that summary as user context; runLoop still sees
+// the real assistant row for terminal-step control flow.
+function compactionProjection(messages: WithParts[]) {
+  const boundaryIdx = messages.findLastIndex(
+    (message) =>
+      message.info.role === "user" &&
+      message.parts.some((part) => part.type === "compaction" && part.projection?.version === 1),
+  )
+  if (boundaryIdx < 0) return messages
+
+  const boundary = messages[boundaryIdx]
+  const projection = boundary.parts.find(
+    (part): part is CompactionPart => part.type === "compaction" && part.projection?.version === 1,
+  )?.projection
+  if (!projection) return messages
+
+  const after = messages.slice(boundaryIdx + 1)
+  if (!projection.tail_end_id) return messages.slice(boundaryIdx)
+
+  const tailEndIdx = after.findIndex((message) => message.info.id === projection.tail_end_id)
+  if (tailEndIdx < 0) return messages.slice(boundaryIdx)
+
+  const observed = after.slice(0, tailEndIdx + 1)
+  const summary = observed.find((message) => message.info.id === projection.summary_message_id)
+  const tailStartIdx = projection.tail_start_id
+    ? observed.findIndex((message) => message.info.id === projection.tail_start_id)
+    : -1
+  const compacted = new Map((projection.compacted_tool_calls ?? []).map((item) => [item.call_id, item.tokens]))
+  const shrink = (message: WithParts): WithParts => ({
+    info: message.info,
+    parts: message.parts.map((part) => {
+      if (part.type !== "tool" || part.state.status !== "completed") return part
+      const tokens = compacted.get(part.callID)
+      if (tokens === undefined) return part
+      return {
+        ...part,
+        state: {
+          ...part.state,
+          output: `[Tool result omitted during compaction: ${tokens} tokens. Re-run "${part.tool}" if this result is needed.]`,
+          providerOutput: undefined,
+          attachments: undefined,
+        },
+      }
+    }),
+  })
+
+  return [
+    boundary,
+    ...(summary ? [summary] : []),
+    ...(tailStartIdx < 0
+      ? []
+      : observed
+          .slice(tailStartIdx)
+          .filter((message) => message.info.id !== projection.summary_message_id)
+          .map(shrink)),
+    ...after.slice(tailEndIdx + 1).filter((message) => message.info.id !== projection.summary_message_id),
+  ]
+}
+
 const Cursor = z.object({
   id: MessageID.zod,
   time: z.number(),
@@ -687,7 +770,16 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 ) {
   const result: UIMessage[] = []
   const toolNames = new Set<string>()
-  const source = options?.collapseCheckpointTail ? collapseCheckpointTail(input) : input
+  const source = compactionProjection(options?.collapseCheckpointTail ? collapseCheckpointTail(input) : input)
+  const projection = source
+    .flatMap((message) =>
+      message.info.role === "user"
+        ? message.parts.flatMap((part) =>
+            part.type === "compaction" && part.projection?.version === 1 ? [part.projection] : [],
+          )
+        : [],
+    )
+    .at(-1)
 
   const toModelOutput = (options: { toolCallId: string; input: unknown; output: unknown }) => {
     const output = options.output
@@ -740,6 +832,18 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
   for (const msg of source) {
     if (msg.parts.length === 0) continue
 
+    if (projection && msg.info.id === projection.summary_message_id) {
+      result.push({
+        id: msg.info.id,
+        role: "user",
+        parts: [
+          { type: "text", text: projection.summary },
+          ...(projection.manifest ? [{ type: "text" as const, text: projection.manifest }] : []),
+        ],
+      })
+      continue
+    }
+
     if (msg.info.role === "user") {
       const userMessage: UIMessage = {
         id: msg.info.id,
@@ -781,7 +885,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
             text: "Summary of previous conversation from checkpoint files:",
           })
         }
-        if (part.type === "compaction") {
+        if (part.type === "compaction" && !part.projection) {
           userMessage.parts.push({
             type: "text" as const,
             text: "Summary of previous conversation:",
@@ -1104,7 +1208,7 @@ export function filterCompacted(msgs: Iterable<WithParts>) {
     if (msg.info.role === "user" && msg.parts.some((p) => p.type === "checkpoint" || p.type === "compaction")) break
   }
   result.reverse()
-  return result
+  return compactionProjection(result)
 }
 
 export const filterCompactedEffect = Effect.fnUntraced(function* (

--- a/packages/opencode/src/session/prefix-snapshot.ts
+++ b/packages/opencode/src/session/prefix-snapshot.ts
@@ -1,10 +1,11 @@
 import { createHash } from "node:crypto"
-import type { Tool as AITool } from "ai"
+import { jsonSchema, tool, type Tool as AITool } from "ai"
+import { asSchema } from "@ai-sdk/provider-utils"
 import { Effect } from "effect"
 import { and, Database, eq } from "@/storage"
 import type { Permission } from "@/permission"
 import type { MessageID, SessionID } from "./schema"
-import { SessionPrefixSnapshotTable } from "./session.sql"
+import { SessionPrefixSnapshotTable, type SessionPrefixToolSnapshot } from "./session.sql"
 
 export type Info = typeof SessionPrefixSnapshotTable.$inferSelect
 
@@ -55,6 +56,32 @@ export function toolsHash(tools: Record<string, AITool>, activeTools: string[]) 
   )
 }
 
+export async function snapshotTools(tools: Record<string, AITool>, activeTools: string[]) {
+  return Promise.all(
+    activeTools.flatMap((name) => {
+      const item = tools[name]
+      if (!item) return []
+      return [
+        Promise.resolve(asSchema(item.inputSchema).jsonSchema).then(
+          (input_schema): SessionPrefixToolSnapshot => ({ name, description: item.description, input_schema }),
+        ),
+      ]
+    }),
+  )
+}
+
+export function restoreTools(items: SessionPrefixToolSnapshot[]) {
+  return Object.fromEntries(
+    items.map((item) => [
+      item.name,
+      tool({
+        description: item.description,
+        inputSchema: jsonSchema(item.input_schema),
+      }),
+    ]),
+  )
+}
+
 export const get = Effect.fn("SessionPrefixSnapshot.get")(function* (sessionID: SessionID, key: string) {
   return yield* Effect.sync(() =>
     Database.use((db) =>
@@ -77,6 +104,7 @@ export const pin = Effect.fn("SessionPrefixSnapshot.pin")(function* (input: {
   profileKey: string
   system: string[]
   toolsHash: string
+  tools: SessionPrefixToolSnapshot[]
   watermarkMessageID: MessageID
 }) {
   const now = Date.now()
@@ -90,6 +118,7 @@ export const pin = Effect.fn("SessionPrefixSnapshot.pin")(function* (input: {
           system: input.system,
           system_hash: systemHash(input.system),
           tools_hash: input.toolsHash,
+          tools: input.tools,
           watermark_message_id: input.watermarkMessageID,
           revision: 1,
           created_at: now,
@@ -109,6 +138,7 @@ export const rotate = Effect.fn("SessionPrefixSnapshot.rotate")(function* (input
   profileKey: string
   system: string[]
   toolsHash: string
+  tools: SessionPrefixToolSnapshot[]
   watermarkMessageID: MessageID
 }) {
   const current = yield* get(input.sessionID, input.profileKey)
@@ -121,6 +151,7 @@ export const rotate = Effect.fn("SessionPrefixSnapshot.rotate")(function* (input
           system: input.system,
           system_hash: systemHash(input.system),
           tools_hash: input.toolsHash,
+          tools: input.tools,
           watermark_message_id: input.watermarkMessageID,
           revision: current.revision + 1,
           updated_at: Date.now(),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4483,6 +4483,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               Effect.provideService(ToolRegistry.Service, registry),
             )
             const currentToolsHash = SessionPrefixSnapshot.toolsHash(tools, activeTools)
+            const currentTools = yield* Effect.promise(() => SessionPrefixSnapshot.snapshotTools(tools, activeTools))
             const resolvedPrefix = yield* Effect.gen(function* () {
               if (!frozen) {
                 const snapshot = yield* SessionPrefixSnapshot.pin({
@@ -4490,11 +4491,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   profileKey: prefixProfileKey,
                   system: initialPrefix.system,
                   toolsHash: currentToolsHash,
+                  tools: currentTools,
                   watermarkMessageID: lastUser.id,
                 })
                 return { prefix: initialPrefix, snapshot }
               }
-              if (frozen.tools_hash === currentToolsHash) return { prefix: initialPrefix, snapshot: frozen }
+              if (frozen.tools && frozen.tools_hash === currentToolsHash) return { prefix: initialPrefix, snapshot: frozen }
               const prefix = yield* buildLLMRequestPrefix({
                 sessionID,
                 agent,
@@ -4512,6 +4514,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 profileKey: prefixProfileKey,
                 system: prefix.system,
                 toolsHash: currentToolsHash,
+                tools: currentTools,
                 watermarkMessageID: lastUser.id,
               })
               return { prefix, snapshot }

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -6,6 +6,7 @@ import type { Permission } from "../permission"
 import type { ProjectID } from "../project/schema"
 import type { SessionID, MessageID, PartID } from "./schema"
 import type { WorkspaceID } from "../control-plane/schema"
+import type { JSONSchema7 } from "@ai-sdk/provider"
 import { Timestamps } from "../storage/schema.sql"
 
 type PartData = Omit<MessageV2.Part, "id" | "sessionID" | "messageID">
@@ -53,6 +54,12 @@ export const SessionTable = sqliteTable(
   ],
 )
 
+export type SessionPrefixToolSnapshot = {
+  name: string
+  description?: string
+  input_schema: JSONSchema7
+}
+
 export const SessionPrefixSnapshotTable = sqliteTable(
   "session_prefix_snapshot",
   {
@@ -64,6 +71,7 @@ export const SessionPrefixSnapshotTable = sqliteTable(
     system: text({ mode: "json" }).$type<string[]>().notNull(),
     system_hash: text().notNull(),
     tools_hash: text().notNull(),
+    tools: text({ mode: "json" }).$type<SessionPrefixToolSnapshot[]>(),
     watermark_message_id: text().$type<MessageID>().notNull(),
     revision: integer().notNull(),
     created_at: integer().notNull(),

--- a/packages/opencode/test/session/auto-overflow-writer-first.test.ts
+++ b/packages/opencode/test/session/auto-overflow-writer-first.test.ts
@@ -633,38 +633,62 @@ describe("Auto context overflow: write a checkpoint before degrading to compacti
           init: (dir) => Bun.write(path.join(dir, "mimocode.json"), mimocodeConfig(llm.origin)),
         })
 
-        await withSpawnRef(writer, () =>
-          Instance.provide({
-            directory: tmp.path,
-            fn: () =>
-              run(
-                Effect.gen(function* () {
-                  const prompt = yield* SessionPrompt.Service
-                  const sessions = yield* Session.Service
-                  const info = yield* sessions.create({ title: "auto-overflow-compaction" })
+        await Instance.provide({
+          directory: tmp.path,
+          fn: () =>
+            run(
+              Effect.gen(function* () {
+                const prompt = yield* SessionPrompt.Service
+                const sessions = yield* Session.Service
+                const info = yield* sessions.create({ title: "auto-overflow-compaction" })
 
-                  const first = yield* Effect.promise(() => seedUserMessage(info.id, "earlier question"))
-                  yield* Effect.promise(() => seedFinishedAssistant(info.id, first.id, 50_000))
+                yield* prompt.prompt({
+                  sessionID: info.id,
+                  parts: [{ type: "text", text: "initialize the actor layer" }],
+                  agent: "build",
+                })
 
-                  yield* prompt.prompt({
+                const first = yield* Effect.promise(() => seedUserMessage(info.id, "earlier question"))
+                yield* Effect.promise(() => seedFinishedAssistant(info.id, first.id, 50_000))
+
+                // SessionPrompt layer initialization installs the real actor
+                // implementation, so bind the failing writer only after the
+                // service has resolved. This keeps the test independent of
+                // earlier tests having initialized the shared spawn ref.
+                const previous = spawnRef.current
+                spawnRef.current = writer
+                yield* prompt
+                  .prompt({
                     sessionID: info.id,
                     parts: [{ type: "text", text: "next question that overflows" }],
                     agent: "build",
                   })
+                  .pipe(
+                    Effect.ensuring(
+                      Effect.sync(() => {
+                        spawnRef.current = previous
+                      }),
+                    ),
+                  )
 
-                  const after = yield* sessions.messages({ sessionID: info.id })
+                const after = yield* sessions.messages({ sessionID: info.id })
 
-                  // Writer failed and no checkpoint existed → degrade.
-                  const compactions = after.filter((m) => m.parts.some((p) => p.type === "compaction"))
-                  expect(compactions.length).toBe(1)
+                // Writer failed and no checkpoint existed → degrade.
+                const compactions = after.filter((m) => m.parts.some((p) => p.type === "compaction"))
+                expect(compactions.length).toBe(1)
+                const boundary = compactions[0].parts.find(
+                  (part): part is MessageV2.CompactionPart => part.type === "compaction",
+                )
+                expect(boundary?.projection?.version).toBe(1)
+                expect(boundary?.projection?.summary).toContain("<conversation-summary")
+                expect(boundary?.projection?.trigger).toBe("automatic")
 
-                  // No checkpoint boundary, because no checkpoint was written.
-                  const checkpoints = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
-                  expect(checkpoints.length).toBe(0)
-                }),
-              ),
-          }),
-        )
+                // No checkpoint boundary, because no checkpoint was written.
+                const checkpoints = after.filter((m) => m.parts.some((p) => p.type === "checkpoint"))
+                expect(checkpoints.length).toBe(0)
+              }),
+            ),
+        })
       } finally {
         await llm.stop()
       }

--- a/packages/opencode/test/session/compaction-projection.test.ts
+++ b/packages/opencode/test/session/compaction-projection.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { buildFileManifest, buildSummaryMessage, buildTail, shrinkLargeToolResults } from "../../src/session/compaction"
+import type { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { ProviderTest } from "../fake/provider"
+
+const sessionID = SessionID.make("ses_test")
+
+function user(id: string, text: string): MessageV2.WithParts {
+  return {
+    info: {
+      id: MessageID.make(id),
+      sessionID,
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test") },
+    },
+    parts: [
+      {
+        id: PartID.ascending(),
+        sessionID,
+        messageID: MessageID.make(id),
+        type: "text",
+        text,
+      },
+    ],
+  }
+}
+
+function assistant(id: string, parentID: string, parts: MessageV2.Part[]): MessageV2.WithParts {
+  return {
+    info: {
+      id: MessageID.make(id),
+      sessionID,
+      role: "assistant",
+      parentID: MessageID.make(parentID),
+      time: { created: 2 },
+      modelID: ModelID.make("test"),
+      providerID: ProviderID.make("test"),
+      mode: "build",
+      agent: "build",
+      path: { cwd: "/repo", root: "/repo" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts,
+  }
+}
+
+function tool(id: string, tool: string, input: Record<string, unknown>, output: string, metadata = {}) {
+  return {
+    id: PartID.ascending(),
+    sessionID,
+    messageID: MessageID.make(id),
+    type: "tool",
+    tool,
+    callID: `call-${id}`,
+    state: {
+      status: "completed",
+      input,
+      output,
+      title: tool,
+      metadata,
+      time: { start: 1, end: 2 },
+    },
+  } satisfies MessageV2.ToolPart
+}
+
+describe("compaction projection", () => {
+  test("file manifest describes read ranges and write intent without file contents", () => {
+    const messages = [
+      assistant("msg_read", "msg_parent", [
+        tool(
+          "msg_read",
+          "read",
+          { file_path: "/repo/src/auth/token.ts", offset: 120, limit: 141 },
+          "120: secret-content\n260: final-line\n\n(Showing lines 120-260 of 500)",
+          { truncated: true },
+        ),
+      ]),
+      assistant("msg_edit", "msg_parent", [
+        tool("msg_edit", "edit", { file_path: "/repo/src/auth/token.ts", old_string: "a", new_string: "b" }, "ok"),
+      ]),
+      assistant("msg_write", "msg_parent", [
+        tool("msg_write", "write", { file_path: "/repo/tests/auth.test.ts" }, "ok", { exists: false }),
+        {
+          id: PartID.ascending(),
+          sessionID,
+          messageID: MessageID.make("msg_write"),
+          type: "patch",
+          hash: "hash",
+          files: ["/repo/tests/auth.test.ts"],
+        },
+      ]),
+    ]
+
+    const manifest = buildFileManifest(messages, { worktree: "/repo" })!
+    expect(manifest).toContain("## Attachments")
+    expect(manifest).toContain("<files-touched>")
+    expect(manifest).toContain("src/auth/token.ts (read: lines 120-260, then edited)")
+    expect(manifest).toContain("tests/auth.test.ts (written)")
+    expect(manifest).not.toContain("tests/auth.test.ts (written, then edited)")
+    expect(manifest).toContain("re-read any file you need before editing it")
+    expect(manifest).not.toContain("secret-content")
+  })
+
+  test("tail keeps newest whole rounds and never cuts a round in half", async () => {
+    const oldUser = user("msg_old_user", "x".repeat(4_000))
+    const oldAssistant = assistant("msg_old_assistant", "msg_old_user", [])
+    const newUser = user("msg_new_user", "new")
+    const newAssistant = assistant("msg_new_assistant", "msg_new_user", [])
+    const text = newUser.parts.find((part): part is MessageV2.TextPart => part.type === "text")!
+    text.metadata = { internal_only: "x".repeat(4_000) }
+    const tail = await Effect.runPromise(
+      buildTail({
+        messages: [oldUser, oldAssistant, newUser, newAssistant],
+        model: ProviderTest.model(),
+        budget: 300,
+      }),
+    )
+
+    expect(tail.map((message) => message.info.id)).toEqual([newUser.info.id, newAssistant.info.id])
+    expect(JSON.stringify([newUser, newAssistant]).length).toBeGreaterThan(4_000)
+  })
+
+  test("large tool results become metadata-rich placeholders", () => {
+    const message = assistant("msg_tool", "msg_parent", [
+      tool("msg_tool", "read", { file_path: "/repo/large.log" }, "x".repeat(40_000)),
+    ])
+    const shrunk = shrinkLargeToolResults([message])[0].parts[0]
+    expect(shrunk.type).toBe("tool")
+    if (shrunk.type !== "tool" || shrunk.state.status !== "completed") return
+    expect(shrunk.state.output).toContain("Tool result omitted during compaction: 10000 tokens")
+    expect(shrunk.state.output).toContain('Re-run "read"')
+    expect(shrunk.state.metadata.compaction_tail_shrunk_tokens).toBe(10_000)
+  })
+
+  test("summary wrapper records trigger and tail presence without an unreadable transcript path", () => {
+    const message = buildSummaryMessage("## Goal\nShip it", "provider-overflow", true)
+    expect(message).toContain('trigger="provider-overflow"')
+    expect(message).toContain("Complete API rounds")
+    expect(message).toContain("## Goal")
+    expect(message).not.toContain("transcript-path")
+    expect(message).not.toContain("mimocode.db")
+  })
+})

--- a/packages/opencode/test/session/prefix-snapshot.test.ts
+++ b/packages/opencode/test/session/prefix-snapshot.test.ts
@@ -31,6 +31,7 @@ describe("session prefix snapshot", () => {
             profileKey: key,
             system: ["first"],
             toolsHash: "tools-1",
+            tools: [],
             watermarkMessageID: firstWatermark,
           }),
         )
@@ -47,6 +48,7 @@ describe("session prefix snapshot", () => {
             profileKey: key,
             system: ["ignored"],
             toolsHash: "ignored",
+            tools: [],
             watermarkMessageID: MessageID.ascending(),
           }),
         )
@@ -58,6 +60,7 @@ describe("session prefix snapshot", () => {
             profileKey: key,
             system: ["second"],
             toolsHash: "tools-2",
+            tools: [],
             watermarkMessageID: firstWatermark,
           }),
         )

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -914,7 +914,7 @@ it.live("persists auto as its own harness mode", () =>
   ),
 )
 
-it.live("restores the pinned prompt after compaction without sending it to the summarizer", () =>
+it.live("uses the frozen system and appends the compaction prompt to the existing conversation", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {
       const prompt = yield* SessionPrompt.Service
@@ -923,7 +923,7 @@ it.live("restores the pinned prompt after compaction without sending it to the s
       const chat = yield* sessions.create({ title: "Compaction prompt" })
       const marker = "SESSION_SYSTEM_MUST_SKIP_COMPACTION"
 
-      const first = yield* prompt.prompt({
+      yield* prompt.prompt({
         sessionID: chat.id,
         agent: "build",
         model: ref,
@@ -934,20 +934,59 @@ it.live("restores the pinned prompt after compaction without sending it to the s
         parts: [{ type: "text", text: "first query" }],
       })
 
+      yield* llm.text("before compaction")
+      yield* prompt.loop({ sessionID: chat.id })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "second query kept verbatim" }],
+      })
+      yield* llm.text("second answer kept verbatim")
+      yield* prompt.loop({ sessionID: chat.id })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "third query kept verbatim" }],
+      })
+      yield* llm.text("third answer kept verbatim")
+      yield* prompt.loop({ sessionID: chat.id })
+      const beforeRequest = (yield* llm.inputs)[2]
+
+      yield* compaction.create({
+        sessionID: chat.id,
+        agent: "compaction",
+        model: ref,
+        auto: false,
+      })
+      const snapshot = yield* sessions.messages({ sessionID: chat.id })
+      const boundary = snapshot.at(-1)!
       yield* llm.text("summary")
       expect(
         yield* compaction.process({
-          parentID: first.info.id,
-          messages: yield* sessions.messages({ sessionID: chat.id }),
+          parentID: boundary.info.id,
+          messages: snapshot,
           sessionID: chat.id,
           auto: false,
         }),
       ).toBe("continue")
-      const compactionRequest = JSON.stringify((yield* llm.inputs)[0])
-      expect(compactionRequest).not.toContain(marker)
-      expect(compactionRequest).toContain("1. Task Overview")
-      expect(compactionRequest).toContain("Write the continuation summary now.")
-      expect(compactionRequest).not.toContain("When constructing the summary")
+      const compactionRequest = (yield* llm.inputs)[3]
+      expect(compactionRequest.model).toBe(ref.modelID)
+      expect(compactionRequest.messages).toBeArray()
+      expect(beforeRequest.messages).toBeArray()
+      if (!Array.isArray(compactionRequest.messages) || !Array.isArray(beforeRequest.messages)) return
+      expect(compactionRequest.messages.slice(0, beforeRequest.messages.length)).toEqual(beforeRequest.messages)
+      expect((compactionRequest.tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(
+        (beforeRequest.tools as Array<Record<string, unknown>>).map(wireToolName),
+      )
+      expect(compactionRequest.tool_choice).toBe("none")
+      expect(JSON.stringify(compactionRequest)).toContain(marker)
+      expect(JSON.stringify(compactionRequest)).toContain("third answer kept verbatim")
+      expect(JSON.stringify(compactionRequest)).toContain("1. Task Overview")
+      expect(JSON.stringify(compactionRequest)).not.toContain("When constructing the summary")
 
       yield* prompt.prompt({
         sessionID: chat.id,
@@ -959,14 +998,145 @@ it.live("restores the pinned prompt after compaction without sending it to the s
       yield* llm.text("continued")
       yield* prompt.loop({ sessionID: chat.id })
 
-      const request = (yield* llm.inputs)[1]
-      expect(JSON.stringify(request)).toContain(marker)
+      const request = (yield* llm.inputs)[4]
+      const serialized = JSON.stringify(request)
+      expect(serialized).toContain(marker)
+      expect(serialized).toContain("summary")
+      expect(serialized).not.toContain("first query")
+      expect(serialized).not.toContain("second query kept verbatim")
+      expect(serialized).not.toContain("third query kept verbatim")
       expect((request.tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(["exec"])
       expect((yield* sessions.get(chat.id)).prompt).toEqual({
         system: marker,
         systemMode: "replace-agent",
         harness: "codex",
       })
+    }),
+    {
+      git: true,
+      config: (url) => ({
+        ...providerCfg(url),
+        agent: { compaction: { model: "test/gpt-5-test" } },
+      }),
+    },
+  ),
+)
+
+it.live("provider-overflow compaction uses its configured model and strips media", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const compaction = yield* SessionCompaction.Service
+      const chat = yield* sessions.create({ title: "Overflow compaction" })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [
+          { type: "text", text: "inspect this image" },
+          { type: "file", mime: "image/png", url: "data:image/png;base64,QUFBQQ==", filename: "large.png" },
+        ],
+      })
+      yield* compaction.create({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        auto: true,
+        overflow: true,
+      })
+      const snapshot = yield* sessions.messages({ sessionID: chat.id })
+      yield* llm.text("overflow summary")
+      expect(
+        yield* compaction.process({
+          parentID: snapshot.at(-1)!.info.id,
+          messages: snapshot,
+          sessionID: chat.id,
+          auto: true,
+          overflow: true,
+        }),
+      ).toBe("continue")
+
+      const request = (yield* llm.inputs)[0]
+      expect(request.model).toBe(mcpRef.modelID)
+      expect(request.messages).toBeArray()
+      if (!Array.isArray(request.messages)) return
+      expect(JSON.stringify(request.messages[0])).not.toContain("You have been working on the task described above")
+      expect(JSON.stringify(request.messages.at(-1))).toContain("1. Task Overview")
+      expect(JSON.stringify(request)).toContain("[Attached image/png: large.png]")
+      expect(JSON.stringify(request)).not.toContain("QUFBQQ==")
+    }),
+    {
+      git: true,
+      config: (url) => ({
+        ...providerCfg(url),
+        agent: { compaction: { model: "test/gpt-5-test" } },
+      }),
+    },
+  ),
+)
+
+it.live("empty compaction removes its boundary without calling the model", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const sessions = yield* Session.Service
+      const compaction = yield* SessionCompaction.Service
+      const chat = yield* sessions.create({ title: "Empty compaction" })
+      yield* compaction.create({ sessionID: chat.id, agent: "build", model: ref, auto: false })
+      const snapshot = yield* sessions.messages({ sessionID: chat.id })
+
+      expect(
+        yield* compaction.process({
+          parentID: snapshot.at(-1)!.info.id,
+          messages: snapshot,
+          sessionID: chat.id,
+          auto: false,
+        }),
+      ).toBe("stop")
+      expect(yield* sessions.messages({ sessionID: chat.id })).toEqual([])
+      expect(yield* llm.calls).toBe(0)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("compaction preserves the parent's appended turn context", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const compaction = yield* SessionCompaction.Service
+      const chat = yield* sessions.create({ title: "Compaction turn context" })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        system: "APPENDED_TURN_CONTEXT",
+        systemMode: "append",
+        parts: [{ type: "text", text: "first query" }],
+      })
+      yield* llm.text("first answer")
+      yield* prompt.loop({ sessionID: chat.id })
+      const before = (yield* llm.inputs)[0]
+      yield* compaction.create({ sessionID: chat.id, agent: "build", model: ref, auto: false })
+      const snapshot = yield* sessions.messages({ sessionID: chat.id })
+      yield* llm.text("summary")
+      expect(
+        yield* compaction.process({
+          parentID: snapshot.at(-1)!.info.id,
+          messages: snapshot,
+          sessionID: chat.id,
+          auto: false,
+        }),
+      ).toBe("continue")
+
+      const compacting = (yield* llm.inputs)[1]
+      expect(compacting.messages).toBeArray()
+      expect(before.messages).toBeArray()
+      if (!Array.isArray(compacting.messages) || !Array.isArray(before.messages)) return
+      expect(compacting.messages.slice(0, before.messages.length)).toEqual(before.messages)
     }),
     { git: true, config: providerCfg },
   ),
@@ -981,29 +1151,15 @@ it.live("persists the process-time compaction projection from the real snapshot 
       const providers = yield* ProviderSvc.Service
       const model = yield* providers.getModel(ref.providerID, ref.modelID)
       const chat = yield* sessions.create({ title: "Compaction projection" })
-      const first = yield* prompt.prompt({
+      yield* prompt.prompt({
         sessionID: chat.id,
         agent: "build",
         model: ref,
         noReply: true,
         parts: [{ type: "text", text: "inspect and edit auth" }],
       })
-      const history = yield* sessions.updateMessage({
-        id: MessageID.ascending(),
-        sessionID: chat.id,
-        agentID: "main",
-        role: "assistant" as const,
-        parentID: first.info.id,
-        time: { created: Date.now(), completed: Date.now() },
-        modelID: ref.modelID,
-        providerID: ref.providerID,
-        mode: "build",
-        agent: "build",
-        path: { cwd: dir, root: dir },
-        cost: 0,
-        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-        finish: "stop",
-      })
+      yield* llm.text("prepared")
+      const history = yield* prompt.loop({ sessionID: chat.id })
       const authPath = path.join(dir, "src/auth.ts")
       for (const [tool, input, output, metadata] of [
         [
@@ -1017,7 +1173,7 @@ it.live("persists the process-time compaction projection from the real snapshot 
         yield* sessions.updatePart({
           id: PartID.ascending(),
           sessionID: chat.id,
-          messageID: history.id,
+          messageID: history.info.id,
           type: "tool",
           tool,
           callID: `call-${tool}`,

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -982,7 +982,8 @@ it.live("uses the frozen system and appends the compaction prompt to the existin
       expect((compactionRequest.tools as Array<Record<string, unknown>>).map(wireToolName)).toEqual(
         (beforeRequest.tools as Array<Record<string, unknown>>).map(wireToolName),
       )
-      expect(compactionRequest.tool_choice).toBe("none")
+      expect(compactionRequest.tools).toEqual(beforeRequest.tools)
+      expect(compactionRequest.tool_choice).toBe(beforeRequest.tool_choice)
       expect(JSON.stringify(compactionRequest)).toContain(marker)
       expect(JSON.stringify(compactionRequest)).toContain("third answer kept verbatim")
       expect(JSON.stringify(compactionRequest)).toContain("1. Task Overview")

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -943,7 +943,11 @@ it.live("restores the pinned prompt after compaction without sending it to the s
           auto: false,
         }),
       ).toBe("continue")
-      expect(JSON.stringify((yield* llm.inputs)[0])).not.toContain(marker)
+      const compactionRequest = JSON.stringify((yield* llm.inputs)[0])
+      expect(compactionRequest).not.toContain(marker)
+      expect(compactionRequest).toContain("1. Task Overview")
+      expect(compactionRequest).toContain("Write the continuation summary now.")
+      expect(compactionRequest).not.toContain("When constructing the summary")
 
       yield* prompt.prompt({
         sessionID: chat.id,
@@ -963,6 +967,161 @@ it.live("restores the pinned prompt after compaction without sending it to the s
         systemMode: "replace-agent",
         harness: "codex",
       })
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("persists the process-time compaction projection from the real snapshot and arrived tail", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ dir, llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const compaction = yield* SessionCompaction.Service
+      const providers = yield* ProviderSvc.Service
+      const model = yield* providers.getModel(ref.providerID, ref.modelID)
+      const chat = yield* sessions.create({ title: "Compaction projection" })
+      const first = yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "inspect and edit auth" }],
+      })
+      const history = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        sessionID: chat.id,
+        agentID: "main",
+        role: "assistant" as const,
+        parentID: first.info.id,
+        time: { created: Date.now(), completed: Date.now() },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        mode: "build",
+        agent: "build",
+        path: { cwd: dir, root: dir },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        finish: "stop",
+      })
+      const authPath = path.join(dir, "src/auth.ts")
+      for (const [tool, input, output, metadata] of [
+        [
+          "read",
+          { file_path: authPath, offset: 10, limit: 11 },
+          "10: before\n20: after\n\n(Showing lines 10-20 of 100)",
+          { truncated: true },
+        ],
+        ["edit", { file_path: authPath, old_string: "before", new_string: "after" }, "ok", {}],
+      ] as const) {
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          sessionID: chat.id,
+          messageID: history.id,
+          type: "tool",
+          tool,
+          callID: `call-${tool}`,
+          state: {
+            status: "completed",
+            input,
+            output,
+            title: tool,
+            metadata,
+            time: { start: Date.now(), end: Date.now() },
+          },
+        })
+      }
+
+      yield* compaction.create({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        auto: false,
+        agentID: "main",
+      })
+      const snapshot = yield* sessions.messages({ sessionID: chat.id, agentID: "main" })
+      const boundary = snapshot.at(-1)!
+      const release = defer<void>()
+      yield* llm.hold("PROCESS_SUMMARY", release.promise)
+      const processing = yield* compaction
+        .process({
+          parentID: boundary.info.id,
+          messages: snapshot,
+          sessionID: chat.id,
+          auto: false,
+          agentID: "main",
+        })
+        .pipe(Effect.forkChild)
+      yield* llm.wait(1)
+
+      const tailUser = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        sessionID: chat.id,
+        agentID: "main",
+        role: "user" as const,
+        time: { created: Date.now() },
+        agent: "build",
+        model: ref,
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        sessionID: chat.id,
+        messageID: tailUser.id,
+        type: "text",
+        text: "arrived during compaction",
+      })
+      const tailAssistant = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        sessionID: chat.id,
+        agentID: "main",
+        role: "assistant" as const,
+        parentID: tailUser.id,
+        time: { created: Date.now(), completed: Date.now() },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        mode: "build",
+        agent: "build",
+        path: { cwd: dir, root: dir },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        finish: "stop",
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        sessionID: chat.id,
+        messageID: tailAssistant.id,
+        type: "tool",
+        tool: "read",
+        callID: "call-large-tail",
+        state: {
+          status: "completed",
+          input: { file_path: path.join(dir, "large.log") },
+          output: "x".repeat(40_000),
+          title: "read",
+          metadata: {},
+          time: { start: Date.now(), end: Date.now() },
+        },
+      })
+
+      release.resolve(undefined)
+      expect(yield* Fiber.join(processing)).toBe("continue")
+
+      const messages = yield* sessions.messages({ sessionID: chat.id, agentID: "main" })
+      const part = messages
+        .flatMap((message) => message.parts)
+        .find((part): part is MessageV2.CompactionPart => part.type === "compaction")!
+      expect(part.projection?.tail_start_id).toBe(tailUser.id)
+      expect(part.projection?.tail_end_id).toBe(tailAssistant.id)
+      expect(part.projection?.compacted_tool_calls).toEqual([{ call_id: "call-large-tail", tokens: 10_000 }])
+      expect(part.projection?.manifest).toContain("src/auth.ts (read: lines 10-20, then edited)")
+      expect(part.projection?.summary).toContain("PROCESS_SUMMARY")
+
+      const modelMessages = JSON.stringify(
+        yield* MessageV2.toModelMessagesEffect(MessageV2.filterCompacted([...messages].reverse()), model),
+      )
+      expect(modelMessages.match(/PROCESS_SUMMARY/g)).toHaveLength(1)
+      expect(modelMessages).toContain("arrived during compaction")
+      expect(modelMessages).toContain("Tool result omitted during compaction: 10000 tokens")
     }),
     { git: true, config: providerCfg },
   ),

--- a/packages/opencode/test/session/rebuild-boundary-model-context.test.ts
+++ b/packages/opencode/test/session/rebuild-boundary-model-context.test.ts
@@ -8,11 +8,13 @@ import { SessionID, MessageID, PartID } from "../../src/session/schema"
 // future "let's make rebuild look like compaction" refactor cannot silently
 // change what the model receives:
 //
-//   compaction — boundary user message carries only a `compaction` part, which
-//     becomes the bare label "Summary of previous conversation:"
-//     (message-v2.ts). The actual summary text lives in a SEPARATE
-//     `summary: true` assistant message written by processCompaction
-//     (compaction.ts), and that assistant turn is NOT filtered out.
+//   legacy compaction — boundary user message becomes the bare label "Summary
+//     of previous conversation:" and the following assistant carries the text.
+//
+//   projected compaction — boundary is API-invisible metadata. The persisted
+//     summary assistant stays available for UI/control flow, but its API-facing
+//     projection is a user summary followed by a file manifest and whole rounds
+//     that arrived while compaction was running.
 //
 //   rebuild — boundary user message carries a `checkpoint` part (label
 //     "Summary of previous conversation from checkpoint files:") PLUS the
@@ -172,5 +174,73 @@ describe("context boundaries: what reaches the model", () => {
     ])
 
     expect(window.map((m) => String(m.info.id))).toEqual([boundaryID, summaryID])
+  })
+
+  test("projected compaction sends summary manifest and only the retained compression-time rounds", async () => {
+    const boundaryID = "m-compaction-boundary"
+    const summaryID = "m-compaction-summary"
+    const droppedID = "m-tail-dropped"
+    const keptID = "m-tail-kept"
+    const keptAssistantID = "m-tail-kept-assistant"
+    const futureID = "m-future"
+    const chronological: MessageV2.WithParts[] = [
+      {
+        info: userInfo(boundaryID),
+        parts: [
+          {
+            ...basePart(boundaryID, "p1"),
+            type: "compaction",
+            auto: true,
+            projection: {
+              version: 1,
+              summary_message_id: MessageID.make(summaryID),
+              summary: "<conversation-summary>WRAPPED SUMMARY</conversation-summary>",
+              manifest: "<files-touched>src/auth.ts (edited)</files-touched>",
+              trigger: "automatic",
+              tail_start_id: MessageID.make(keptID),
+              tail_end_id: MessageID.make(keptAssistantID),
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: summaryAssistantInfo(summaryID, boundaryID),
+        parts: [{ ...basePart(summaryID, "p2"), type: "text", text: "RAW SUMMARY" }] as MessageV2.Part[],
+      },
+      {
+        info: userInfo(droppedID),
+        parts: [{ ...basePart(droppedID, "p3"), type: "text", text: "DROP THIS ROUND" }] as MessageV2.Part[],
+      },
+      {
+        info: userInfo(keptID),
+        parts: [{ ...basePart(keptID, "p4"), type: "text", text: "KEEP THIS USER" }] as MessageV2.Part[],
+      },
+      {
+        info: { ...summaryAssistantInfo(keptAssistantID, keptID), summary: undefined, agent: "build", mode: "build" },
+        parts: [{ ...basePart(keptAssistantID, "p5"), type: "text", text: "KEEP THIS ASSISTANT" }] as MessageV2.Part[],
+      },
+      {
+        info: userInfo(futureID),
+        parts: [{ ...basePart(futureID, "p6"), type: "text", text: "KEEP FUTURE" }] as MessageV2.Part[],
+      },
+    ]
+
+    expect(MessageV2.filterCompacted([...chronological].reverse()).map((message) => String(message.info.id))).toEqual([
+      boundaryID,
+      summaryID,
+      keptID,
+      keptAssistantID,
+      futureID,
+    ])
+
+    const rendered = JSON.stringify(await MessageV2.toModelMessages(chronological, model))
+    expect(rendered).toContain("WRAPPED SUMMARY")
+    expect(rendered).toContain("files-touched")
+    expect(rendered).toContain("KEEP THIS USER")
+    expect(rendered).toContain("KEEP THIS ASSISTANT")
+    expect(rendered).toContain("KEEP FUTURE")
+    expect(rendered).not.toContain("RAW SUMMARY")
+    expect(rendered).not.toContain("DROP THIS ROUND")
+    expect(rendered).not.toContain("Summary of previous conversation:")
   })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1333,6 +1333,7 @@ export type CheckpointPart = {
   checkpointDir: string
   checkpointNumber: number
   coveredUpTo: string
+  digestUpTo?: string
 }
 
 export type CompactionPart = {
@@ -1343,6 +1344,19 @@ export type CompactionPart = {
   auto: boolean
   overflow?: boolean
   tail_start_id?: string
+  projection?: {
+    version: 1
+    summary_message_id: string
+    summary: string
+    manifest?: string
+    trigger: "manual" | "automatic" | "provider-overflow"
+    tail_start_id?: string
+    tail_end_id?: string
+    compacted_tool_calls?: Array<{
+      call_id: string
+      tokens: number
+    }>
+  }
 }
 
 export type Part =
@@ -1866,9 +1880,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1884,9 +1901,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1902,9 +1922,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1920,9 +1943,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1938,9 +1964,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1956,9 +1985,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1974,9 +2006,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -1992,9 +2027,12 @@ export type ProviderConfig = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2315,9 +2353,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2333,9 +2374,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2351,9 +2395,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2369,9 +2416,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2387,9 +2437,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2405,9 +2458,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2423,9 +2479,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2441,9 +2500,12 @@ export type Config = {
        */
       maxRetries?: number
       /**
-      * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
-      */
+       * Wall-clock retry deadline in milliseconds; use noDeadline for an explicit unlimited deadline
+       */
       deadlineMs?: number
+      /**
+       * Disable the wall-clock retry deadline explicitly; maxRetries still applies to bounded budgets
+       */
       noDeadline?: boolean
       initialDelayMs?: number
       maxDelayMs?: number
@@ -2533,11 +2595,11 @@ export type Config = {
      */
     prune?: boolean
     /**
-     * Number of recent user turns, including their following assistant/tool responses, to keep verbatim during compaction (default: 2)
+     * Deprecated compatibility setting. Projected compaction now keeps only whole API rounds that arrive while compaction is running.
      */
     tail_turns?: number
     /**
-     * Maximum number of tokens from recent turns to preserve verbatim after compaction
+     * Deprecated compatibility setting. Compression-time API rounds now use a fixed 40000-token hard budget.
      */
     preserve_recent_tokens?: number
     /**
@@ -2564,7 +2626,7 @@ export type Config = {
      */
     reserved?: number
     /**
-     * Whether to fork the parent agent's message prefix into the writer session for prefix-cache reuse. Requires provider cache-breakpoint support. Default: false.
+     * Whether to fork the parent agent's message prefix into the writer session for prefix-cache reuse. Requires provider cache-breakpoint support. Default: true.
      */
     fork?: boolean
     /**
@@ -2727,6 +2789,23 @@ export type Config = {
        * Consecutive edit or verify actions without progress before pausing (default 4).
        */
       action_streak?: number
+    }
+    /**
+     * Loop-streak request-layer recovery (experimental).
+     */
+    loop_streak_recovery?: {
+      /**
+       * Crop repeated thinking/tool streaks from the next request and inject a recovery note.
+       */
+      enabled?: boolean
+      /**
+       * Consecutive identical streak keys required to trigger (default 3).
+       */
+      trigger_count?: number
+      /**
+       * Max assistant messages cropped from the trailing streak (default 64).
+       */
+      max_span?: number
     }
     /**
      * Timeout in milliseconds for model context protocol (MCP) requests
@@ -5216,7 +5295,7 @@ export type SessionPromptData = {
     format?: OutputFormat
     /**
      * BCP 47 locale used for automatic title generation.
-    */
+     */
     titleLocale?: string
     /**
      * Additional system prompt selected by the session's first user query. Later values are ignored.
@@ -5525,7 +5604,7 @@ export type SessionPromptAsyncData = {
     format?: OutputFormat
     /**
      * BCP 47 locale used for automatic title generation.
-    */
+     */
     titleLocale?: string
     /**
      * Additional system prompt selected by the session's first user query. Later values are ignored.
@@ -5583,7 +5662,7 @@ export type SessionCommandData = {
     command: string
     /**
      * BCP 47 locale used for automatic title generation.
-    */
+     */
     titleLocale?: string
     variant?: string
     /**


### PR DESCRIPTION
## Summary
- Replace pre-compaction verbatim-turn selection with a v1 compaction projection that keeps only whole API rounds arriving while the summary is generated.
- Re-role the persisted assistant summary as user context, attach a files-touched manifest, and shrink oversized tail tool results under a 40K budget.
- Keep legacy compaction rendering for records without a projection, and regenerate SDK types for the new `CompactionPart.projection` shape.

## Test plan
- [ ] `cd packages/opencode && bun test test/session/compaction-projection.test.ts test/session/prompt-effect.test.ts test/session/rebuild-boundary-model-context.test.ts test/session/auto-overflow-writer-first.test.ts`
- [ ] Confirm a manual `/compact` writes a projection with `trigger: "manual"` and a wrapped `<conversation-summary>`.
- [ ] Confirm automatic overflow compaction persists compression-time tail IDs and omits oversized tool results from the next model request.
- [ ] Confirm sessions compacted before this change still render the legacy "Summary of previous conversation:" path.


Made with [Cursor](https://cursor.com)