### PR TITLE
fix(actor): auto-Resume once after a retryable settle (main-agent parity)

### DIFF
--- a/docs/compose/spec/actor-resume-parity.md
+++ b/docs/compose/spec/actor-resume-parity.md
@@ -1,0 +1,39 @@
+---
+feature: actor-resume-parity
+status: in-progress
+updated: 2026-08-31
+branch: fix/actor-resume-parity
+commits: # filled at delivery
+---
+
+# Actor resume parity with main agent
+
+## Report
+
+## [S1] Problem
+
+Background actors (`Actor.spawn` subagents) share the main agent's session-level retry ladder (`session/retry.ts`). When that budget exhausts on a transient API error (e.g. `rate_limit_check_failed` 500), the assistant settles with an error and **no** `time.completed` — the same shape the engine exposes as a `/recovery` candidate and the desktop Resume path continues.
+
+Main agent: user can hit Resume → `SessionPrompt.resume` continues the interrupted turn.
+
+Actor: `runAgentLoop` immediately raised `AssistantSettledError` and failed the actor. Parent got a terminal `failed` notification; work died even though a resumable recovery candidate was sitting there.
+
+## [S2] Design
+
+- **Do not invent a spawn-layer retry budget.** Actor LLM calls already go through `sessionPrompt.prompt` → the shared retry policy. Parity means: after a retryable settle, use the **same** recovery turn as main (`SessionPrompt.resume` on the recovery candidate), not a divergent re-run loop.
+- `runAgentLoop` loops at most **once**:
+  1. `prompt` → if assistant has error and `classifyAssistantError(...).retryable` → attempt `resume(assistantMessageID)`.
+  2. If `resume` succeeds, take its result as the turn output.
+  3. If `resume` fails (NotFound / Busy / …), fall back to `AssistantSettledError` with the **original** classification — resume unavailability must not mask the cause.
+  4. Second retryable settle (or non-retryable) still fails with classification.
+- Non-retryable failures (overflow / auth / aborted) are unchanged: fail immediately, no resume attempt.
+
+## [S3] Out of Scope
+
+- Changing session-level retry budgets or classification tables.
+- Auto-resume loops larger than one attempt.
+- Desktop Resume UI (covered by mimo-desktop `session-resume` D16c).
+
+## Tasks
+- [ ] T1: runAgentLoop auto-Resume once for retryable settled errors — acceptance: transient 429 settle + successful resume → actor outcome success; resume unavailable → original APIError classification preserved (covers: S2)
+- [ ] T2: regression tests in spawn.test.ts — acceptance: existing classification tests still pass; new auto-resume success test passes (covers: S2; depends: T1)

--- a/docs/compose/spec/actor-resume-parity.md
+++ b/docs/compose/spec/actor-resume-parity.md
@@ -1,14 +1,20 @@
 ---
 feature: actor-resume-parity
-status: in-progress
+status: delivered
 updated: 2026-08-31
 branch: fix/actor-resume-parity
-commits: # filled at delivery
+commits: 91b2eb204a..1b481df6e3
 ---
 
 # Actor resume parity with main agent
 
 ## Report
+
+**What was built** — `Actor.runAgentLoop` now treats a retryable settled assistant error the same way the main agent's Resume path does: one automatic `SessionPrompt.resume` on the recovery candidate. If resume succeeds the actor completes with that turn's output; if resume is unavailable the original `AssistantSettledError` classification is preserved. Non-retryable failures (overflow / auth / aborted) still fail immediately. No spawn-layer retry budget was added.
+
+**Verification** — `cd packages/opencode && bun test test/actor/spawn.test.ts` → 32 pass (includes new auto-resume success test; existing classification tests still pass). `bun run typecheck` clean.
+
+**Journey log** — User required actor retry strategy to match main agent, not a divergent spawn re-run. Shared session retry already applies via `sessionPrompt.prompt`; the real gap was missing auto-resume after exhaust. `resumeBackground` is fire-and-forget and cannot return the resumed turn, so blocking `SessionPrompt.resume` is the correct parity call. Mock assistants must omit `time.completed` to be recovery candidates (engine pin PR #2279).
 
 ## [S1] Problem
 
@@ -35,5 +41,5 @@ Actor: `runAgentLoop` immediately raised `AssistantSettledError` and failed the 
 - Desktop Resume UI (covered by mimo-desktop `session-resume` D16c).
 
 ## Tasks
-- [ ] T1: runAgentLoop auto-Resume once for retryable settled errors — acceptance: transient 429 settle + successful resume → actor outcome success; resume unavailable → original APIError classification preserved (covers: S2)
-- [ ] T2: regression tests in spawn.test.ts — acceptance: existing classification tests still pass; new auto-resume success test passes (covers: S2; depends: T1)
+- [x] T1: runAgentLoop auto-Resume once for retryable settled errors — acceptance: transient 429 settle + successful resume → actor outcome success; resume unavailable → original APIError classification preserved (covers: S2)
+- [x] T2: regression tests in spawn.test.ts — acceptance: existing classification tests still pass; new auto-resume success test passes (covers: S2; depends: T1)

--- a/packages/opencode/src/actor/spawn.ts
+++ b/packages/opencode/src/actor/spawn.ts
@@ -338,38 +338,79 @@ export const layer = Layer.effect(
       provenance?: MessageV2.Provenance
       format?: MessageV2.OutputFormat
     }) {
-      const result = yield* sessionPrompt.prompt({
-        sessionID: input.sessionID,
-        agent: input.agentType,
-        agentID: input.actorID,
-        source: input.source,
-        provenance: input.provenance,
-        model: input.model,
-        task_id: input.task_id,
-        parts: [{ type: "text", text: input.task }],
-        ...(input.format ? { format: input.format } : {}),
-      })
+      // Main-agent parity: after the shared session-level retry budget exhausts, a
+      // retryable settled assistant is left without time.completed and becomes a
+      // /recovery candidate — the desktop Resume path calls POST resume on it.
+      // Background actors previously hard-failed at that point, so the work died
+      // even though the same recovery turn was sitting there. Auto-Resume once
+      // (same SessionPrompt.resume the user would trigger) before settling as failed.
+      let result: MessageV2.WithParts | undefined
+      let resumedOnce = false
+      while (true) {
+        if (resumedOnce && result?.info.role === "assistant") {
+          // Resume failure (Busy/NotFound/…) must not replace the original settle:
+          // fall through to AssistantSettledError with the first classification.
+          const next = yield* sessionPrompt
+            .resume({
+              sessionID: input.sessionID,
+              assistantMessageID: result.info.id,
+              agentID: input.actorID,
+              task_id: input.task_id,
+            })
+            .pipe(Effect.catch(() => Effect.succeed(undefined)))
+          if (!next) {
+            return yield* Effect.fail(
+              new AssistantSettledError(
+                `Actor assistant failed: ${result.info.error?.name ?? "APIError"}`,
+                classifyAssistantError(
+                  result.info.error ??
+                    new MessageV2.APIError({
+                      message: "Actor resume unavailable",
+                      statusCode: 500,
+                      isRetryable: false,
+                    }).toObject(),
+                ),
+              ),
+            )
+          }
+          result = next
+        } else {
+          result = yield* sessionPrompt.prompt({
+            sessionID: input.sessionID,
+            agent: input.agentType,
+            agentID: input.actorID,
+            source: input.source,
+            provenance: input.provenance,
+            model: input.model,
+            task_id: input.task_id,
+            parts: [{ type: "text", text: input.task }],
+            ...(input.format ? { format: input.format } : {}),
+          })
+        }
+        const info = result?.info
+        if (info?.role !== "assistant" || !info.error) break
+        const failure = classifyAssistantError(info.error)
+        if (!failure.retryable || resumedOnce) {
+          // Classify HERE: `info.error` is the persisted, already-normalized named
+          // error. Downstream (forkWork's onFailure) only has Cause.pretty's string,
+          // so re-deriving the class there would mean re-parsing prose.
+          return yield* Effect.fail(
+            new AssistantSettledError(`Actor assistant failed: ${info.error.name}`, failure),
+          )
+        }
+        resumedOnce = true
+        // loop: SessionPrompt.resume continues the interrupted recovery candidate
+      }
       // structured output (json_schema) takes precedence over finalText: when the
       // child produced a validated object it IS the authoritative result and the
       // last text part (often a pre-tool-call preamble) is dropped to avoid
       // duplicating the result downstream. See spec §5.2.
-      const info = (result as MessageV2.WithParts | undefined)?.info
-      if (info?.role === "assistant" && info.error) {
-        // Classify HERE: `info.error` is the persisted, already-normalized named
-        // error. Downstream (forkWork's onFailure) only has Cause.pretty's string,
-        // so re-deriving the class there would mean re-parsing prose.
-        return yield* Effect.fail(
-          new AssistantSettledError(
-            `Actor assistant failed: ${info.error.name}`,
-            classifyAssistantError(info.error),
-          ),
-        )
-      }
+      const info = result?.info
       const structured = info?.role === "assistant" ? info.structured : undefined
       const finalText =
         structured !== undefined
           ? undefined
-          : (result as MessageV2.WithParts | undefined)?.parts.findLast(
+          : result?.parts.findLast(
               (p): p is Extract<MessageV2.Part, { type: "text" }> => p.type === "text",
             )?.text
       return { finalText, structured }

--- a/packages/opencode/test/actor/spawn.test.ts
+++ b/packages/opencode/test/actor/spawn.test.ts
@@ -121,7 +121,10 @@ const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const run = SessionRunState.layer.pipe(Layer.provide(status))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
 
-function makeLayer(opts?: { settledError: () => NonNullable<MessageV2.Assistant["error"]> | undefined }) {
+function makeLayer(opts?: {
+  settledError: () => NonNullable<MessageV2.Assistant["error"]> | undefined
+  resumeAfterSettled?: () => boolean
+}) {
   const deps = Layer.mergeAll(
     Session.defaultLayer,
     Snapshot.defaultLayer,
@@ -187,7 +190,7 @@ function makeLayer(opts?: { settledError: () => NonNullable<MessageV2.Assistant[
   return Layer.mergeAll(
     TestLLMServer.layer,
     Actor.layer.pipe(
-      Layer.provideMerge(opts?.settledError ? settledPromptLayer(opts.settledError, prompt) : prompt),
+      Layer.provideMerge(opts?.settledError ? settledPromptLayer(opts.settledError, prompt, opts.resumeAfterSettled) : prompt),
       Layer.provide(Worktree.defaultLayer),
       Layer.provideMerge(taskRegistry),
       Layer.provide(TaskRegistry.defaultLayer),
@@ -209,6 +212,7 @@ function makeLayer(opts?: { settledError: () => NonNullable<MessageV2.Assistant[
 function settledPromptLayer<A, E, R>(
   settledError: () => NonNullable<MessageV2.Assistant["error"]> | undefined,
   real: Layer.Layer<A, E, R>,
+  resumeAfterSettled?: () => boolean,
 ) {
   return Layer.effect(
     SessionPrompt.Service,
@@ -225,7 +229,9 @@ function settledPromptLayer<A, E, R>(
             sessionID: input.sessionID,
             agentID: input.agentID,
             role: "assistant",
-            time: { created: Date.now(), completed: Date.now() },
+            // No time.completed: this is a recovery candidate, matching the engine
+            // pin that keeps errored assistants resumable (PR #2279).
+            time: { created: Date.now() },
             error: settled,
             parentID: MessageID.ascending(),
             modelID: ModelID.make("test-model"),
@@ -237,6 +243,41 @@ function settledPromptLayer<A, E, R>(
             tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
           }
           return Effect.succeed({ info, parts: [] } satisfies MessageV2.WithParts)
+        },
+        // Classification tests leave this unset: resume hits the real service (NotFound)
+        // and runAgentLoop falls back to AssistantSettledError. The parity test sets it
+        // so the auto-Resume path succeeds once.
+        resume: (input) => {
+          if (resumeAfterSettled?.() === true) {
+            const info: MessageV2.Assistant = {
+              id: MessageID.ascending(),
+              sessionID: input.sessionID,
+              agentID: input.agentID ?? "main",
+              role: "assistant",
+              time: { created: Date.now(), completed: Date.now() },
+              parentID: MessageID.ascending(),
+              modelID: ModelID.make("test-model"),
+              providerID: ProviderID.make("test"),
+              mode: "build",
+              agent: "build",
+              path: { cwd: process.cwd(), root: process.cwd() },
+              cost: 0,
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            }
+            return Effect.succeed({
+              info,
+              parts: [
+                {
+                  id: PartID.ascending(),
+                  sessionID: input.sessionID,
+                  messageID: info.id,
+                  type: "text",
+                  text: "resumed ok",
+                },
+              ],
+            } satisfies MessageV2.WithParts)
+          }
+          return inner.resume(input)
         },
       })
     }),
@@ -1461,7 +1502,10 @@ describe("Actor.spawn return-format injection (F21)", () => {
 // AgentOutcome. Nothing here hand-builds an outcome object.
 // ---------------------------------------------------------------------------
 let settled: NonNullable<MessageV2.Assistant["error"]> | undefined
-const itSettled = testEffect(makeLayer({ settledError: () => settled }))
+let allowResumeAfterSettled = false
+const itSettled = testEffect(
+  makeLayer({ settledError: () => settled, resumeAfterSettled: () => allowResumeAfterSettled }),
+)
 
 describe("AgentOutcome failure classification", () => {
   itSettled.live("a transient provider failure is classified retryable/transient", () =>
@@ -1597,6 +1641,41 @@ describe("AgentOutcome failure classification", () => {
         // present on a settled-assistant-error failure.
         if (outcome.status === "failure") expect(outcome.failure == null).toBe(true)
         else expect(outcome.status).toBe("success")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+
+  itSettled.live("a transient settle auto-Resumes once (main-agent parity) and succeeds", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        allowResumeAfterSettled = true
+        try {
+          const actor = yield* Actor.Service
+          const session = yield* Session.Service
+          const parent = yield* session.create({
+            title: "x",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          settled = new MessageV2.APIError(
+            { message: "Too Many Requests", statusCode: 429, isRetryable: true },
+          ).toObject()
+          const result = yield* actor.spawn({
+            mode: "subagent",
+            sessionID: parent.id,
+            agentType: "build",
+            task: "t",
+            context: "none",
+            tools: ["read"],
+            background: false,
+            model: ref,
+          })
+          const outcome = yield* Deferred.await(result.outcome)
+          expect(outcome.status).toBe("success")
+        } finally {
+          allowResumeAfterSettled = false
+          settled = undefined
+        }
       }),
       { git: true, config: providerCfg },
     ),


### PR DESCRIPTION
## Summary
Background actors already share the main agent's session-level retry ladder. When that budget exhausts on a transient API error, the assistant is a /recovery candidate — the same path desktop Resume continues — but runAgentLoop immediately hard-failed the actor.

This change auto-calls SessionPrompt.resume once on a retryable settle. If resume is unavailable, the original AssistantSettledError classification is preserved. Non-retryable failures unchanged. No spawn-layer retry budget.

Spec: docs/compose/spec/actor-resume-parity.md

## Verification
- packages/opencode bun test test/actor/spawn.test.ts → 32 pass
- typecheck clean