### PR TITLE
fix(build-node): define MIMOCODE_VERSION for node target

### DIFF
--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -76,6 +76,7 @@ await Bun.build({
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
     OPENCODE_MIGRATIONS: JSON.stringify(migrations),
+    MIMOCODE_VERSION: `'${Script.version}'`,
     MIMOCODE_CHANNEL: `'${Script.channel}'`,
   },
   files: {


### PR DESCRIPTION
## Summary
- `script/build.ts` already burns `MIMOCODE_VERSION` via `Bun.build` `define`
- `script/build-node.ts` (the Node target used by desktop-embedded engine) only defined `MIMOCODE_CHANNEL`, so `InstallationVersion` always fell back to `"local"`
- Add the missing `MIMOCODE_VERSION` define so env `MIMOCODE_VERSION` reaches the bundle the same way as the TUI binary build

## Why
Without this, desktop-embedded builds extract builtin skills under `builtin_skills/local/`. The extract marker only stores version + skill name list, so pin bumps that update skill **content** (same names) are skipped.

## Notes
- This repo only reads `Script.version` (env). Callers pass whatever identity they want; no desktop-specific naming is hardcoded here.
- No behavior change when `MIMOCODE_VERSION` is unset (`Script.version` keeps its existing fallback).

## Test plan
- [x] `MIMOCODE_VERSION=desktop-092e42f bun script/build-node.ts` → `dist/node/node.js` contains `InstallationVersion = "desktop-092e42f"`
- [x] Unset env → still resolves via `Script.version` defaults (channel/version logic unchanged)