### PR TITLE
fix(mcp): show MiMoCode branding in OAuth pages and client registration

### DIFF
--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -16,7 +16,7 @@ function escapeHtml(s: string): string {
 const HTML_SUCCESS = `<!DOCTYPE html>
 <html>
 <head>
-  <title>OpenCode - Authorization Successful</title>
+  <title>MiMoCode - Authorization Successful</title>
   <style>
     body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
     .container { text-align: center; padding: 2rem; }
@@ -27,7 +27,7 @@ const HTML_SUCCESS = `<!DOCTYPE html>
 <body>
   <div class="container">
     <h1>Authorization Successful</h1>
-    <p>You can close this window and return to OpenCode.</p>
+    <p>You can close this window and return to MiMoCode.</p>
   </div>
   <script>setTimeout(() => window.close(), 2000);</script>
 </body>
@@ -36,7 +36,7 @@ const HTML_SUCCESS = `<!DOCTYPE html>
 const HTML_ERROR = (error: string) => `<!DOCTYPE html>
 <html>
 <head>
-  <title>OpenCode - Authorization Failed</title>
+  <title>MiMoCode - Authorization Failed</title>
   <style>
     body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
     .container { text-align: center; padding: 2rem; }

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -44,8 +44,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
   get clientMetadata(): OAuthClientMetadata {
     return {
       redirect_uris: [this.redirectUrl],
-      client_name: "OpenCode",
-      client_uri: "https://opencode.ai",
+      client_name: "MiMoCode",
+      client_uri: "https://mimo.xiaomi.com/mimocode",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -148,7 +148,7 @@ async function refreshAccessToken(refreshToken: string, signal?: AbortSignal | n
 const HTML_SUCCESS = `<!doctype html>
 <html>
   <head>
-    <title>OpenCode - Codex Authorization Successful</title>
+    <title>MiMoCode - Codex Authorization Successful</title>
     <style>
       body {
         font-family:
@@ -179,7 +179,7 @@ const HTML_SUCCESS = `<!doctype html>
   <body>
     <div class="container">
       <h1>Authorization Successful</h1>
-      <p>You can close this window and return to OpenCode.</p>
+      <p>You can close this window and return to MiMoCode.</p>
     </div>
     <script>
       setTimeout(() => window.close(), 2000)
@@ -194,7 +194,7 @@ function escapeHtml(s: string): string {
 const HTML_ERROR = (error: string) => `<!doctype html>
 <html>
   <head>
-    <title>OpenCode - Codex Authorization Failed</title>
+    <title>MiMoCode - Codex Authorization Failed</title>
     <style>
       body {
         font-family:


### PR DESCRIPTION
## Summary

The MCP OAuth flow was still presenting the upstream `OpenCode` name in two user-visible places:

- The local callback pages served after authorization — users saw *"You can close this window and return to OpenCode."* in the browser.
- The `client_name` / `client_uri` sent during dynamic client registration (DCR), which is what the third-party authorization server renders on its consent screen.

The same callback page template had been copied into the Codex plugin, so it carried the identical text.

This replaces the branding with `MiMoCode` and points `client_uri` at `https://mimo.xiaomi.com/mimocode`.

## Changes

- `packages/opencode/src/mcp/oauth-callback.ts` — success/failure page titles and body copy.
- `packages/opencode/src/plugin/codex.ts` — the duplicated Codex callback template, same three spots.
- `packages/opencode/src/mcp/oauth-provider.ts` — `client_name` and `client_uri` in the DCR metadata.

## Note

`client_name` is only sent on **first** dynamic registration. MCP servers that already have stored `clientInfo` will not re-register, so their consent screen keeps showing the old name until that server's auth entry is cleared and authorization is run again. The callback pages take effect immediately.

## Verification

`bun typecheck` passes from `packages/opencode`. The change is string-literal only — no behavioral code paths touched.
