### PR TITLE
chore(prompt): rewrite Tools section as Using your tools guidance

### DIFF
--- a/packages/opencode/src/session/prompt/default.txt
+++ b/packages/opencode/src/session/prompt/default.txt
@@ -76,18 +76,18 @@ The last layer always wins. That is how plan mode guarantees its write-block sur
 
 Decisions are `allow` / `ask` / `deny`. By default `read` of `*.env` / `*.env.*` is `ask`, `question` is `deny` (allowed only for primary agents), and `external_directory` reads outside the project tree are `ask` except for whitelisted skill directories. Treat secrets carefully even when the tool would let you read them.
 
-### Tools
-
-The tool registry lives in `packages/opencode/src/tool/`. Each tool is a `.ts` implementation paired with a `.txt` prompt visible to the model. Functional groups:
-- **File**: `read`, `edit`, `multiedit`, `write` (via `apply_patch`), `notebook-edit`
-- **Search**: `glob`, `grep`, `codesearch`
-- **Shell**: `bash`, `bash-interactive`
-- **Knowledge**: `webfetch`, `websearch`, `memory`, `history`, `lsp`
-- **Orchestration**: `actor` (spawn subagent), `task` (plan tracking), `workflow` (multi-agent scripts), `skill` (invoke a skill)
-- **Mode / safety**: `plan-exit`, `question`
-
-Prefer dedicated tools over shelling out (`bash cat / find / grep / sed`). The tool layer adds read-state tracking, truncation, recoverable-error wrapping, memory-path guards, and permission evaluation that raw shell commands bypass. All file writes route through a single `ctx.ask({ permission: "edit" })`, so one rule governs every write path.
-
+# Using your tools
+ - Prefer the dedicated file/search tools over shelling out (bash cat/find/grep/sed).
+   The tool layer adds read-state tracking, output truncation, recoverable-error
+   wrapping, memory-path guards, and permission evaluation that raw shell bypasses.
+   Your exact tool surface varies by model — use what's listed, don't assume a name.
+ - Use the `task` tool for any work of roughly 3+ steps: register steps up front,
+   `start` immediately before each, `done` immediately after. Never batch completions.
+ - Delegate with the `actor` tool. `spawn` is the default (background, parallel,
+   result arrives as a notification); `run` blocks the whole turn and is the rare
+   exception. Valid subagent_type values are listed in the actor tool description.
+ - Call multiple independent tools in one response; sequence only real dependencies.
+ 
 ### Tasks vs subagents vs workflows
 
 Three orchestration primitives that look similar but serve different goals — pick deliberately:


### PR DESCRIPTION
## Summary
- Replace the static tool-registry inventory in the default system prompt with actionable usage guidance
- Prefer dedicated tools over shelling out, track multi-step work with `task`, delegate with `actor`, and batch independent tool calls
- Note that the exact tool surface varies by model instead of assuming a fixed registry path

## Verification
- `bun turbo typecheck` passed via pre-push hook (12/12 packages)