### PR TITLE
fix(codex): allow explicit default harness for GPT

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -165,10 +165,13 @@ export const Flag = {
     return ratio("MIMOCODE_COMPACTION_TRIGGER_RATIO") ?? 0.9
   },
   MIMOCODE_DISABLE_MODELS_FETCH: truthy("MIMOCODE_DISABLE_MODELS_FETCH"),
-  // Defaults to false. When enabled, every model uses the GPT system prompt
-  // and Codex toolset regardless of its model ID.
+  // Defaults to automatic model inference. Explicit true forces every model to
+  // use the GPT system prompt and Codex toolset; explicit false forces even GPT
+  // models to use the default prompt and toolset.
   get MIMOCODE_CODEX_MODE() {
-    return truthy("MIMOCODE_CODEX_MODE")
+    if (truthy("MIMOCODE_CODEX_MODE")) return true
+    if (falsy("MIMOCODE_CODEX_MODE")) return false
+    return undefined
   },
   MIMOCODE_DISABLE_MOUSE: truthy("MIMOCODE_DISABLE_MOUSE"),
   MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT: number("MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT") ?? 3,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -5435,7 +5435,7 @@ export const PromptInput = z.object({
     .enum(["auto", "codex", "default"])
     .optional()
     .describe(
-      "Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
+      "Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference and explicit default forces the native tool schema for non-GPT models. MIMOCODE_CODEX_MODE=false forces the default harness for every model, including GPT.",
     ),
   variant: z.string().optional(),
   parts: z.array(
@@ -5538,7 +5538,7 @@ export const CommandInput = z.object({
     .enum(["auto", "codex", "default"])
     .optional()
     .describe(
-      "Harness mode selected by the session's first user command. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
+      "Harness mode selected by the session's first user command. Later values are ignored. Auto preserves model/process inference and explicit default forces the native tool schema for non-GPT models. MIMOCODE_CODEX_MODE=false forces the default harness for every model, including GPT.",
     ),
   parts: z
     .array(

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -23,7 +23,7 @@ import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { Flag } from "@/flag/flag"
-import { type HarnessMode, isGPTModel } from "@/tool/gpt"
+import { type HarnessMode, isGPTModel, usesGPTToolset } from "@/tool/gpt"
 
 function renderGitResult(result: Git.Result, fallback = "(none)") {
   if (result.exitCode !== 0) return fallback
@@ -33,9 +33,11 @@ function renderGitResult(result: Git.Result, fallback = "(none)") {
 const anthropicEnvironment = new Map<string, string>()
 
 export function provider(model: Provider.Model, harness?: HarnessMode) {
-  if (harness === "codex" || ((harness === undefined || harness === "auto") && Flag.MIMOCODE_CODEX_MODE)) return [PROMPT_GPT]
+  if (usesGPTToolset(model.id, harness, model.api.id, model.family)) return [PROMPT_GPT]
   const prompt = (id: string) => {
-    if (isGPTModel(id)) return PROMPT_GPT
+    // An explicit process override can route GPT here; keep its prompt aligned
+    // with the default tool schema instead of advertising Codex-only tools.
+    if (isGPTModel(id)) return PROMPT_DEFAULT
     if (id.includes("gpt-4") || id.includes("o1") || id.includes("o3")) return PROMPT_BEAST
     if (id.includes("gemini-")) return PROMPT_GEMINI
     if (id.includes("claude")) return PROMPT_ANTHROPIC

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -8,6 +8,13 @@ function codexHarnessOverride(harness?: HarnessMode): boolean | undefined {
   return undefined
 }
 
+function usesCodexMode(harness: HarnessMode | undefined, ...modelIDs: Array<string | undefined>) {
+  const mode = Flag.MIMOCODE_CODEX_MODE
+  if (mode === false) return false
+  if (isGPTModel(...modelIDs)) return true
+  return codexHarnessOverride(harness) ?? mode ?? false
+}
+
 export function isGPTModel(...values: Array<string | undefined>) {
   const ids = values.flatMap((value) => (value ? [value.toLowerCase()] : []))
   if (ids.some((id) => id.includes("gpt-oss"))) return false
@@ -19,8 +26,7 @@ export function isMcpToolSearchEnabled(
   harness: HarnessMode | undefined,
   ...modelIDs: Array<string | undefined>
 ) {
-  if (isGPTModel(...modelIDs)) return true
-  return enabled || (codexHarnessOverride(harness) ?? Flag.MIMOCODE_CODEX_MODE)
+  return enabled || usesCodexMode(harness, ...modelIDs)
 }
 
 export function isMimoModel(...values: Array<string | undefined>) {
@@ -37,7 +43,5 @@ export function usesGPTToolset(
   harness?: HarnessMode,
   ...modelIDs: Array<string | undefined>
 ) {
-  const ids = [modelID, ...modelIDs]
-  if (isGPTModel(...ids)) return true
-  return codexHarnessOverride(harness) ?? Flag.MIMOCODE_CODEX_MODE
+  return usesCodexMode(harness, modelID, ...modelIDs)
 }

--- a/packages/opencode/test/flag/codex-mode-flag.test.ts
+++ b/packages/opencode/test/flag/codex-mode-flag.test.ts
@@ -18,13 +18,13 @@ function read(value?: string) {
 }
 
 describe("MIMOCODE_CODEX_MODE", () => {
-  test("is disabled by default and accepts explicit truthy values", () => {
-    expect(read()).toBe("false")
+  test("uses automatic model inference by default and accepts explicit truthy values", () => {
+    expect(read()).toBe("undefined")
     expect(read("true")).toBe("true")
     expect(read("1")).toBe("true")
   })
 
-  test("false and zero keep Codex mode disabled", () => {
+  test("false and zero explicitly disable Codex mode", () => {
     expect(read("false")).toBe("false")
     expect(read("0")).toBe("false")
   })

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -246,6 +246,18 @@ describe("session.system", () => {
     expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("mimo-v2.6-ptc") }))[0]).toBe(gpt)
   })
 
+  test("disabled Codex mode forces the default prompt for GPT models", () => {
+    const normal = SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("model-default") }))[0]
+    process.env.MIMOCODE_CODEX_MODE = "false"
+
+    expect(SystemPrompt.provider(ProviderTest.model({ id: ModelID.make("gpt-5.4") }))[0]).toBe(normal)
+    expect(
+      SystemPrompt.provider(
+        ProviderTest.model({ id: ModelID.make("deployment-primary"), api: { id: "gpt-5.4" } as never }),
+      )[0],
+    ).toBe(normal)
+  })
+
   test("allows the resolved session mode to override the process harness mode", () => {
     const model = ProviderTest.model({
       id: ModelID.make("claude-sonnet-4-6"),

--- a/packages/opencode/test/tool/gpt.test.ts
+++ b/packages/opencode/test/tool/gpt.test.ts
@@ -49,6 +49,13 @@ describe("isMcpToolSearchEnabled", () => {
     expect(isMcpToolSearchEnabled(false, undefined, "mimo-v2.6-ptc")).toBe(true)
   })
 
+  test("does not force MCP tool search for GPT models when process Codex mode is disabled", () => {
+    process.env.MIMOCODE_CODEX_MODE = "false"
+    expect(isMcpToolSearchEnabled(false, undefined, "gpt-5.2")).toBe(false)
+    expect(isMcpToolSearchEnabled(false, "codex", "claude-opus-4-6")).toBe(false)
+    expect(isMcpToolSearchEnabled(true, undefined, "gpt-5.2")).toBe(true)
+  })
+
   test("allows the resolved session mode to override the process mode", () => {
     expect(isMcpToolSearchEnabled(false, "codex", "claude-opus-4-6")).toBe(true)
     expect(isMcpToolSearchEnabled(false, "codex", "mimo-v2.6")).toBe(true)
@@ -83,6 +90,13 @@ describe("usesGPTToolset", () => {
     expect(usesGPTToolset("claude-opus-4-6")).toBe(true)
     expect(usesGPTToolset("mimo-v2.6")).toBe(true)
     expect(usesGPTToolset("mimo-v2.6-ptc")).toBe(true)
+  })
+
+  test("uses the default toolset for GPT models when process Codex mode is disabled", () => {
+    process.env.MIMOCODE_CODEX_MODE = "false"
+    expect(usesGPTToolset("gpt-5.2")).toBe(false)
+    expect(usesGPTToolset("deployment-primary", undefined, "gpt-5.2", "gpt")).toBe(false)
+    expect(usesGPTToolset("claude-opus-4-6", "codex")).toBe(false)
   })
 
   test("allows the resolved session mode to override the process mode", () => {


### PR DESCRIPTION
## Summary
- treat an unset `MIMOCODE_CODEX_MODE` as automatic model inference
- honor `MIMOCODE_CODEX_MODE=false` for GPT prompts, toolsets, and MCP tool search
- add regression coverage for prompt and tool selection

## Test Plan
- [x] `bun typecheck`
- [x] `bun test test/session/system.test.ts` (16 passed)
- [x] `bun test test/tool/gpt.test.ts` (10 passed)
- [ ] `bun test test/flag/codex-mode-flag.test.ts` (2 tests hit the existing 5s child-process timeout locally)