### PR TITLE
session: keep unfinished work when a follow-up arrives mid-loop

### DIFF
--- a/docs/compose/spec/mid-turn-steer-hint.md
+++ b/docs/compose/spec/mid-turn-steer-hint.md
@@ -10,7 +10,7 @@ commits: d17e176ba1..fa396138c7ae863acd8e201dc8f119ea79730974
 
 ## Report
 
-**What was built** — At the `runLoop` message-load checkpoint, on the **new-user branch** only (`lastUser.id > lastAssistant.id`), inject a short in-memory `<system-reminder>` when that user is a mid-turn steer: real prose written while the prior same-session assistant was still open. Anchor to the last real user so `inbox.drain` synthetics cannot hide a steer. Multi-steer pile-up is named by count only. Ordinary sequential turns after a finished reply never fire. No desktop UI, Runner, or compose-next skill changes.
+**What was built** — At the `runLoop` message-load checkpoint, inject a short in-memory `<system-reminder>` when this loop has already taken a step (`step ≥ 1`) and a newer real user appeared (`lastUser.id > lastAssistant.id`) — i.e. a mid-turn steer picked up at a tool-call gap. Anchor to the last real user so `inbox.drain` synthetics cannot hide a steer. Multi-steer pile-up is named by count only. `step === 0` turns never fire. No desktop UI, Runner, or compose-next skill changes.
 
 **Verification** — From `packages/opencode` in the worktree: `bun typecheck` PASS. `bun test test/session/steer-hint.test.ts` — 13 pass. `bun test test/session/steer-multi.integration.test.ts` — PASS. `bun test test/session/prompt-effect.test.ts -t "uses the frozen system and appends the compaction prompt"` — PASS.
 
@@ -33,22 +33,15 @@ True mid-turn steer is picked up in the **gap between tool-call steps** (the loo
 
 ### Steer definition
 
-From the `runLoop` state machine:
+Loop-local, not a timestamp guess:
 
-- `lastUser.id > lastAssistant.id` → **new-user branch** (loop will create an assistant for this user). This is the only steer-pickup moment.
-- `lastUser.id < lastAssistant.id` → continue-assistant branch. The user is already the current turn's user — not a pending steer.
+- `step === 0`: this runLoop just started — not a steer.
+- `step ≥ 1` and `lastUser.id > lastAssistant.id`: the loop was already running and a newer user appeared (picked up at a tool-call gap) — **steer**.
+- `step ≥ 1` and `lastUser.id < lastAssistant.id`: continuing the current assistant — the user is that turn's user, not a new steer.
 
-A **steer** is a real user on the new-user branch that:
+Also require real (non-synthetic, non-ignored) user prose. Synthetic-only users (inbox.drain, goal re-entry, auto-continue) never count. Anchor to `lastRealUserMessage` so a newer synthetic user cannot hide a real steer.
 
-1. Has non-synthetic, non-ignored text prose.
-2. Was created while the previous **same-session** assistant was still open:  
-   `assistant.time.created ≤ user.time.created` and (`assistant.time.completed` unset or `user.time.created ≤ assistant.time.completed`).
-
-Or several real users stacked after the last same-session assistant.
-
-Parent assistants inherited via `contextFrom` (different `sessionID`) do not count.
-
-Synthetic-only users (inbox.drain, goal re-entry, auto-continue) never count as steers. The hint anchors to `lastRealUserMessage` so a newer synthetic user cannot hide a real steer.
+Several real users stacked after the last same-session assistant share the hint (count only). Parent assistants from `contextFrom` (different `sessionID`) do not make a fork's first task a steer (that path is `step === 0`).
 
 ### Injection point
 

--- a/docs/compose/spec/mid-turn-steer-hint.md
+++ b/docs/compose/spec/mid-turn-steer-hint.md
@@ -10,7 +10,7 @@ commits: d17e176ba1..fa396138c7ae863acd8e201dc8f119ea79730974
 
 ## Report
 
-**What was built** — At the `runLoop` message-load checkpoint, inject a short in-memory `<system-reminder>` only for **unanswered mid-turn steers**: real user prose written while the prior same-session assistant was still open, with no later assistant yet answering it. Anchor to the last real user so `inbox.drain` synthetics cannot hide a steer. Once an assistant exists after that user it is the current turn and is not re-injected. Multi-steer pile-up is named by count only (bodies stay in the transcript). Ordinary sequential turns after a finished reply never fire (keeps the frozen model-request prefix). No desktop UI, Runner, or compose-next skill changes.
+**What was built** — At the `runLoop` message-load checkpoint, on the **new-user branch** only (`lastUser.id > lastAssistant.id`), inject a short in-memory `<system-reminder>` when that user is a mid-turn steer: real prose written while the prior same-session assistant was still open. Anchor to the last real user so `inbox.drain` synthetics cannot hide a steer. Multi-steer pile-up is named by count only. Ordinary sequential turns after a finished reply never fire. No desktop UI, Runner, or compose-next skill changes.
 
 **Verification** — From `packages/opencode` in the worktree: `bun typecheck` PASS. `bun test test/session/steer-hint.test.ts` — 13 pass. `bun test test/session/steer-multi.integration.test.ts` — PASS. `bun test test/session/prompt-effect.test.ts -t "uses the frozen system and appends the compaction prompt"` — PASS.
 
@@ -33,20 +33,22 @@ True mid-turn steer is picked up in the **gap between tool-call steps** (the loo
 
 ### Steer definition
 
-A **steer** is a real user message that:
+From the `runLoop` state machine:
+
+- `lastUser.id > lastAssistant.id` → **new-user branch** (loop will create an assistant for this user). This is the only steer-pickup moment.
+- `lastUser.id < lastAssistant.id` → continue-assistant branch. The user is already the current turn's user — not a pending steer.
+
+A **steer** is a real user on the new-user branch that:
 
 1. Has non-synthetic, non-ignored text prose.
 2. Was created while the previous **same-session** assistant was still open:  
    `assistant.time.created ≤ user.time.created` and (`assistant.time.completed` unset or `user.time.created ≤ assistant.time.completed`).
-3. Is still **unanswered**: no same-session assistant exists **after** it in the transcript.
 
-Once an assistant exists after that user, it is the current turn (same status as the first user of that turn) — not a pending steer.
+Or several real users stacked after the last same-session assistant.
 
 Parent assistants inherited via `contextFrom` (different `sessionID`) do not count.
 
 Synthetic-only users (inbox.drain, goal re-entry, auto-continue) never count as steers. The hint anchors to `lastRealUserMessage` so a newer synthetic user cannot hide a real steer.
-
-Several real users stacked after the last same-session assistant all count as pending.
 
 ### Injection point
 

--- a/docs/compose/spec/mid-turn-steer-hint.md
+++ b/docs/compose/spec/mid-turn-steer-hint.md
@@ -1,0 +1,82 @@
+---
+feature: mid-turn-steer-hint
+status: delivered
+updated: 2026-09-01
+branch: mid-turn-steer-hint
+commits: d17e176ba1..fa396138c7ae863acd8e201dc8f119ea79730974
+---
+
+# Mid-turn Steer Hint
+
+## Report
+
+**What was built** — At the `runLoop` message-load checkpoint, inject a short in-memory `<system-reminder>` only for **unanswered mid-turn steers**: real user prose written while the prior same-session assistant was still open, with no later assistant yet answering it. Anchor to the last real user so `inbox.drain` synthetics cannot hide a steer. Once an assistant exists after that user it is the current turn and is not re-injected. Multi-steer pile-up is named by count only (bodies stay in the transcript). Ordinary sequential turns after a finished reply never fire (keeps the frozen model-request prefix). No desktop UI, Runner, or compose-next skill changes.
+
+**Verification** — From `packages/opencode` in the worktree: `bun typecheck` PASS. `bun test test/session/steer-hint.test.ts` — 13 pass. `bun test test/session/steer-multi.integration.test.ts` — PASS. `bun test test/session/prompt-effect.test.ts -t "uses the frozen system and appends the compaction prompt"` — PASS.
+
+**Journey log**
+
+1. First attempt scoped the hint to compose-next skill body — wrong product surface. Correct surface is general mimocode steer at the loop message checkpoint.
+2. Sequential-turn injection broke compaction frozen-prefix equality; tightened to mid-turn / stacked only.
+3. Review + design discussion: steer is only a user written while the prior assistant is open; once an assistant answers it, it is the current turn (like user1). Unanswered + open-window + last-real-user anchor.
+4. Integration test must poll the DB for steers before releasing the first LLM step — wall-clock sleep races under CI load.
+
+## [S1] Problem
+
+When a user message is sent while the session runner is busy (`prompt_async`), the engine persists the user message first; `ensureRunning` waits on the existing runner. On the next `runLoop` iteration the new message becomes `lastUser` and can be treated as a wholesale task switch.
+
+Models routinely abandon in-progress work. Example session `ses_-ffe5fa415ff27ffeUQ7TFo3dF`: tool-name research was dropped for "帮我安装一下" and later chrome/IAB notes, although the user expected addition, not replacement.
+
+True mid-turn steer is picked up in the **gap between tool-call steps** (the loop reloads messages after a non-final step). Desktop `followup=queue` drains one follow-up at a time after idle; multi-message mid-turn pile-up is several `prompt_async` calls while busy.
+
+## [S2] Design
+
+### Steer definition
+
+A **steer** is a real user message that:
+
+1. Has non-synthetic, non-ignored text prose.
+2. Was created while the previous **same-session** assistant was still open:  
+   `assistant.time.created ≤ user.time.created` and (`assistant.time.completed` unset or `user.time.created ≤ assistant.time.completed`).
+3. Is still **unanswered**: no same-session assistant exists **after** it in the transcript.
+
+Once an assistant exists after that user, it is the current turn (same status as the first user of that turn) — not a pending steer.
+
+Parent assistants inherited via `contextFrom` (different `sessionID`) do not count.
+
+Synthetic-only users (inbox.drain, goal re-entry, auto-continue) never count as steers. The hint anchors to `lastRealUserMessage` so a newer synthetic user cannot hide a real steer.
+
+Several real users stacked after the last same-session assistant all count as pending.
+
+### Injection point
+
+At the `runLoop` message-load checkpoint, attach an **in-memory** synthetic `<system-reminder>` to the last real user message when `shouldInjectSteerHint` is true. Not persisted. Reload each iteration prevents stacking. Do not rewrite user prose or invent a second message.
+
+### Hint text
+
+- One pending:  
+  `This user message comes after earlier work in the conversation — keep that work unless the message clearly replaces it.`
+- N > 1 pending:  
+  `There are N unanswered user messages after your last reply (including this one), already in order above. Handle all of them together. Keep earlier work unless one of them clearly replaces it.`
+
+No compose-next coupling. No re-embedding of message bodies.
+
+### Out of engine paths
+
+- No desktop followup UI / settings change.
+- No `prompt_async` / `assertNotBusy` / Runner semantic change.
+- No compose-next skill body change.
+
+## [S3] Out of Scope
+
+- Changing when steer vs queue is used.
+- Interrupting the in-flight runner when a steer arrives.
+- Persisting structured intent-class decisions.
+- Localizing the reminder body.
+- Changing inbox.drain content.
+
+## Tasks
+
+- [x] T1: Add `session/steer-hint.ts` (detector + notice + last-real-user anchor) — acceptance: unit tests for first-turn skip, sequential skip, open-window fire, unanswered skip when assistant follows, stacked fire, synthetic anchor (covers: S2)
+- [x] T2: Wire into `runLoop` message checkpoint on last real user — acceptance: in-memory only; frozen-prefix compaction test still passes (covers: S2)
+- [x] T3: Multi-steer integration test — acceptance: holds first LLM step until two steers are in the DB, then asserts unanswered-count hint (covers: S2)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3709,13 +3709,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
           }
 
-          // Follow-up intent: only on the loop's new-user branch (steer pickup).
+          // Follow-up intent: loop-local steer pickup (step ≥ 1 + new lastUser).
           // Anchor to the last real user so inbox.drain synthetics cannot hide it.
-          // In-memory only — msgs reload each iteration.
           const lastRealUserForSteer = lastRealUserMessage(msgs)
           if (
             lastRealUserForSteer &&
-            shouldInjectSteerHint({ messages: msgs, lastUser: lastRealUserForSteer, lastAssistant })
+            shouldInjectSteerHint({ messages: msgs, lastUser: lastRealUserForSteer, lastAssistant, step })
           ) {
             lastRealUserForSteer.parts.push({
               id: PartID.ascending(),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -141,7 +141,12 @@ import {
 import { isMcpToolSearchEnabled, usesGPTToolset } from "@/tool/gpt"
 import { GPT_TOP_LEVEL_TOOLS } from "@/tool/tool-script-ref"
 import { SessionPrefixSnapshot } from "./prefix-snapshot"
-import { buildSteerHint, pendingUserMessages, shouldInjectSteerHint } from "./steer-hint"
+import {
+  buildSteerHint,
+  lastRealUserMessage,
+  pendingUserMessages,
+  shouldInjectSteerHint,
+} from "./steer-hint"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -3704,14 +3709,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
           }
 
-          // Follow-up intent: real user prose after same-session assistant work.
-          // In-memory only — msgs reload each iteration. Multi-message case only
-          // names the unanswered set; bodies stay in the transcript (no re-embed).
-          const lastUserMsgForSteer = msgs.findLast((m) => m.info.id === lastUser.id)
-          if (lastUserMsgForSteer && shouldInjectSteerHint(msgs, lastUserMsgForSteer)) {
-            lastUserMsgForSteer.parts.push({
+          // Follow-up intent: only unanswered mid-turn steers (real user prose
+          // written while the prior assistant was still open). Anchor to the
+          // last real user — a newer synthetic inbox.drain user must not hide it.
+          // In-memory only — msgs reload each iteration.
+          const lastRealUserForSteer = lastRealUserMessage(msgs)
+          if (lastRealUserForSteer && shouldInjectSteerHint(msgs, lastRealUserForSteer)) {
+            lastRealUserForSteer.parts.push({
               id: PartID.ascending(),
-              messageID: lastUserMsgForSteer.info.id,
+              messageID: lastRealUserForSteer.info.id,
               sessionID,
               type: "text" as const,
               synthetic: true,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -141,6 +141,7 @@ import {
 import { isMcpToolSearchEnabled, usesGPTToolset } from "@/tool/gpt"
 import { GPT_TOP_LEVEL_TOOLS } from "@/tool/tool-script-ref"
 import { SessionPrefixSnapshot } from "./prefix-snapshot"
+import { buildSteerHint, pendingUserMessages, shouldInjectSteerHint } from "./steer-hint"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -3701,6 +3702,21 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 ].join("\n"),
               })
             }
+          }
+
+          // Follow-up intent: real user prose after same-session assistant work.
+          // In-memory only — msgs reload each iteration. Multi-message case only
+          // names the unanswered set; bodies stay in the transcript (no re-embed).
+          const lastUserMsgForSteer = msgs.findLast((m) => m.info.id === lastUser.id)
+          if (lastUserMsgForSteer && shouldInjectSteerHint(msgs, lastUserMsgForSteer)) {
+            lastUserMsgForSteer.parts.push({
+              id: PartID.ascending(),
+              messageID: lastUserMsgForSteer.info.id,
+              sessionID,
+              type: "text" as const,
+              synthetic: true,
+              text: buildSteerHint(pendingUserMessages(msgs).length),
+            })
           }
 
           const lastAssistantMsg = msgs.findLast(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3709,12 +3709,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
           }
 
-          // Follow-up intent: only unanswered mid-turn steers (real user prose
-          // written while the prior assistant was still open). Anchor to the
-          // last real user — a newer synthetic inbox.drain user must not hide it.
+          // Follow-up intent: only on the loop's new-user branch (steer pickup).
+          // Anchor to the last real user so inbox.drain synthetics cannot hide it.
           // In-memory only — msgs reload each iteration.
           const lastRealUserForSteer = lastRealUserMessage(msgs)
-          if (lastRealUserForSteer && shouldInjectSteerHint(msgs, lastRealUserForSteer)) {
+          if (
+            lastRealUserForSteer &&
+            shouldInjectSteerHint({ messages: msgs, lastUser: lastRealUserForSteer, lastAssistant })
+          ) {
             lastRealUserForSteer.parts.push({
               id: PartID.ascending(),
               messageID: lastRealUserForSteer.info.id,

--- a/packages/opencode/src/session/steer-hint.ts
+++ b/packages/opencode/src/session/steer-hint.ts
@@ -20,19 +20,40 @@ export function pendingUserMessages(messages: MessageV2.WithParts[]): MessageV2.
 }
 
 /**
- * True when the current last user message is real prose after same-session
- * assistant work. First turn never fires. Synthetic-only last users never
- * fire. Parent assistants inherited via contextFrom (different sessionID)
- * do not count.
+ * True when the current last user message is a mid-turn steer:
+ * - several real user messages are stacked after the last same-session assistant, or
+ * - this user message was created while that assistant was still open
+ *   (created before assistant.time.completed).
+ *
+ * Ordinary sequential turns after a finished reply do NOT fire — they are a
+ * normal new task and must not rewrite the frozen model-request prefix.
+ * First turn never fires. Synthetic-only last users never fire. Parent
+ * assistants inherited via contextFrom (different sessionID) do not count.
  */
 export function shouldInjectSteerHint(messages: MessageV2.WithParts[], lastUser: MessageV2.WithParts): boolean {
   if (lastUser.info.role !== "user") return false
   if (!hasRealUserText(lastUser)) return false
   const lastUserIdx = messages.findLastIndex((m) => m.info.id === lastUser.info.id)
   if (lastUserIdx < 0) return false
-  return messages
-    .slice(0, lastUserIdx)
-    .some((m) => m.info.role === "assistant" && m.info.sessionID === lastUser.info.sessionID)
+
+  const pending = pendingUserMessages(messages)
+  if (pending.length > 1) return true
+
+  const priorAssistants = messages.slice(0, lastUserIdx).filter(
+    (m): m is MessageV2.WithParts & { info: MessageV2.Assistant } =>
+      m.info.role === "assistant" && m.info.sessionID === lastUser.info.sessionID,
+  )
+  const lastAsst = priorAssistants.at(-1)
+  if (!lastAsst) return false
+
+  const userCreated = lastUser.info.time?.created
+  const asstCreated = lastAsst.info.time.created
+  const asstCompleted = lastAsst.info.time.completed
+  if (userCreated == null) return false
+  if (userCreated < asstCreated) return false
+  // Sequential new turn after a finished reply.
+  if (asstCompleted != null && userCreated > asstCompleted) return false
+  return true
 }
 
 /**

--- a/packages/opencode/src/session/steer-hint.ts
+++ b/packages/opencode/src/session/steer-hint.ts
@@ -24,57 +24,32 @@ export function pendingUserMessages(messages: MessageV2.WithParts[]): MessageV2.
   return messages.slice(lastAssistantIdx + 1).filter((m) => m.info.role === "user" && hasRealUserText(m))
 }
 
-function isSameSessionAssistant(
-  m: MessageV2.WithParts,
-  sessionID: string,
-): m is MessageV2.WithParts & { info: MessageV2.Assistant } {
-  return m.info.role === "assistant" && m.info.sessionID === sessionID
-}
-
 /**
- * Steer pickup = the agent loop's "new user" branch: lastUser.id >
- * lastAssistant.id. At that moment lastUser cannot already be answered —
- * if it were, the loop would be in the continue-assistant branch.
+ * Steer pickup is a loop-local fact, not a timestamp guess:
  *
- * Fire only when that new user is real prose and was written while the
- * previous same-session assistant was still open (true mid-turn steer),
- * or when several real users are stacked after the last assistant.
+ * - step 0: this runLoop just started (first message of a turn).
+ * - step ≥ 1 and lastUser.id > lastAssistant.id: the loop was already running
+ *   and a newer user appeared — a mid-turn steer (picked up at a tool-call gap).
+ * - step ≥ 1 and lastUser.id < lastAssistant.id: continuing the current
+ *   assistant; the user is that turn's user, not a new steer.
  *
- * Ordinary sequential turns after a finished reply do NOT fire.
  * Synthetic-only users never count. Parent assistants from contextFrom
- * (different sessionID) do not count.
+ * (different sessionID) do not count. Caller passes the last REAL user so
+ * inbox.drain synthetics cannot hide a steer.
  */
 export function shouldInjectSteerHint(input: {
   messages: MessageV2.WithParts[]
   lastUser: MessageV2.WithParts
   lastAssistant: MessageV2.Assistant | undefined
+  step: number
 }): boolean {
-  const { messages, lastUser, lastAssistant } = input
+  const { messages, lastUser, lastAssistant, step } = input
+  if (step < 1) return false
   if (lastUser.info.role !== "user") return false
   if (!hasRealUserText(lastUser)) return false
-
-  // State machine: only the new-user branch is a steer pickup.
   if (lastAssistant && lastAssistant.sessionID === lastUser.info.sessionID && lastUser.info.id < lastAssistant.id) {
     return false
   }
-
-  const lastUserIdx = messages.findLastIndex((m) => m.info.id === lastUser.info.id)
-  if (lastUserIdx < 0) return false
-
-  if (pendingUserMessages(messages).length > 1) return true
-
-  const lastAsst = messages
-    .slice(0, lastUserIdx)
-    .filter((m) => isSameSessionAssistant(m, lastUser.info.sessionID))
-    .at(-1)
-  if (!lastAsst) return false
-
-  const userCreated = lastUser.info.time?.created
-  const asstCreated = lastAsst.info.time.created
-  const asstCompleted = lastAsst.info.time.completed
-  if (userCreated == null) return false
-  if (userCreated < asstCreated) return false
-  if (asstCompleted != null && userCreated > asstCompleted) return false
   return true
 }
 

--- a/packages/opencode/src/session/steer-hint.ts
+++ b/packages/opencode/src/session/steer-hint.ts
@@ -1,0 +1,49 @@
+import type { MessageV2 } from "./message-v2"
+
+export const STEER_HINT_MARKER = "Follow-up intent"
+
+export function hasRealUserText(message: MessageV2.WithParts): boolean {
+  return message.parts.some(
+    (part) => part.type === "text" && !part.synthetic && !part.ignored && part.text.trim().length > 0,
+  )
+}
+
+/**
+ * Real user messages after the newest same-session assistant — unanswered
+ * follow-ups. Already present in the conversation; the hint only names the set.
+ */
+export function pendingUserMessages(messages: MessageV2.WithParts[]): MessageV2.WithParts[] {
+  const lastAssistantIdx = messages.findLastIndex(
+    (m) => m.info.role === "assistant" && m.info.sessionID === messages.at(-1)?.info.sessionID,
+  )
+  return messages.slice(lastAssistantIdx + 1).filter((m) => m.info.role === "user" && hasRealUserText(m))
+}
+
+/**
+ * True when the current last user message is real prose after same-session
+ * assistant work. First turn never fires. Synthetic-only last users never
+ * fire. Parent assistants inherited via contextFrom (different sessionID)
+ * do not count.
+ */
+export function shouldInjectSteerHint(messages: MessageV2.WithParts[], lastUser: MessageV2.WithParts): boolean {
+  if (lastUser.info.role !== "user") return false
+  if (!hasRealUserText(lastUser)) return false
+  const lastUserIdx = messages.findLastIndex((m) => m.info.id === lastUser.info.id)
+  if (lastUserIdx < 0) return false
+  return messages
+    .slice(0, lastUserIdx)
+    .some((m) => m.info.role === "assistant" && m.info.sessionID === lastUser.info.sessionID)
+}
+
+/**
+ * Attached to lastUser. Does not re-embed message bodies (they are already in
+ * the transcript after the last assistant reply) — only names how many
+ * unanswered user messages that set has.
+ */
+export function buildSteerHint(pendingCount: number): string {
+  const body =
+    pendingCount <= 1
+      ? "This user message comes after earlier work in the conversation — keep that work unless the message clearly replaces it."
+      : `There are ${pendingCount} unanswered user messages after your last reply (including this one), already in order above. Handle all of them together. Keep earlier work unless one of them clearly replaces it.`
+  return ["<system-reminder>", STEER_HINT_MARKER, "", body, "</system-reminder>"].join("\n")
+}

--- a/packages/opencode/src/session/steer-hint.ts
+++ b/packages/opencode/src/session/steer-hint.ts
@@ -8,6 +8,11 @@ export function hasRealUserText(message: MessageV2.WithParts): boolean {
   )
 }
 
+/** Last user message that still has real (non-synthetic) prose. */
+export function lastRealUserMessage(messages: MessageV2.WithParts[]): MessageV2.WithParts | undefined {
+  return messages.findLast((m) => m.info.role === "user" && hasRealUserText(m))
+}
+
 /**
  * Real user messages after the newest same-session assistant — unanswered
  * follow-ups. Already present in the conversation; the hint only names the set.
@@ -19,31 +24,44 @@ export function pendingUserMessages(messages: MessageV2.WithParts[]): MessageV2.
   return messages.slice(lastAssistantIdx + 1).filter((m) => m.info.role === "user" && hasRealUserText(m))
 }
 
+function sameSessionAssistantsAfter(
+  messages: MessageV2.WithParts[],
+  fromIdx: number,
+  sessionID: string,
+): boolean {
+  return messages
+    .slice(fromIdx + 1)
+    .some((m) => m.info.role === "assistant" && m.info.sessionID === sessionID)
+}
+
 /**
- * True when the current last user message is a mid-turn steer:
- * - several real user messages are stacked after the last same-session assistant, or
- * - this user message was created while that assistant was still open
- *   (created before assistant.time.completed).
+ * Steer = a real user message written while the previous same-session assistant
+ * was still open, and still unanswered (no later same-session assistant).
  *
- * Ordinary sequential turns after a finished reply do NOT fire — they are a
- * normal new task and must not rewrite the frozen model-request prefix.
- * First turn never fires. Synthetic-only last users never fire. Parent
- * assistants inherited via contextFrom (different sessionID) do not count.
+ * - Ordinary sequential turns after a finished reply do NOT fire.
+ * - Once an assistant exists after this user, it is the current turn (like the
+ *   first user of that turn) — not a pending steer.
+ * - Several stacked real users after the last assistant all count as pending.
+ * - Synthetic-only users (inbox.drain, goal re-entry, …) never count.
+ * - Parent assistants from contextFrom (different sessionID) do not count.
  */
 export function shouldInjectSteerHint(messages: MessageV2.WithParts[], lastUser: MessageV2.WithParts): boolean {
   if (lastUser.info.role !== "user") return false
   if (!hasRealUserText(lastUser)) return false
   const lastUserIdx = messages.findLastIndex((m) => m.info.id === lastUser.info.id)
   if (lastUserIdx < 0) return false
+  if (sameSessionAssistantsAfter(messages, lastUserIdx, lastUser.info.sessionID)) return false
 
   const pending = pendingUserMessages(messages)
   if (pending.length > 1) return true
 
-  const priorAssistants = messages.slice(0, lastUserIdx).filter(
-    (m): m is MessageV2.WithParts & { info: MessageV2.Assistant } =>
-      m.info.role === "assistant" && m.info.sessionID === lastUser.info.sessionID,
-  )
-  const lastAsst = priorAssistants.at(-1)
+  const lastAsst = messages
+    .slice(0, lastUserIdx)
+    .filter(
+      (m): m is MessageV2.WithParts & { info: MessageV2.Assistant } =>
+        m.info.role === "assistant" && m.info.sessionID === lastUser.info.sessionID,
+    )
+    .at(-1)
   if (!lastAsst) return false
 
   const userCreated = lastUser.info.time?.created
@@ -51,15 +69,13 @@ export function shouldInjectSteerHint(messages: MessageV2.WithParts[], lastUser:
   const asstCompleted = lastAsst.info.time.completed
   if (userCreated == null) return false
   if (userCreated < asstCreated) return false
-  // Sequential new turn after a finished reply.
   if (asstCompleted != null && userCreated > asstCompleted) return false
   return true
 }
 
 /**
- * Attached to lastUser. Does not re-embed message bodies (they are already in
- * the transcript after the last assistant reply) — only names how many
- * unanswered user messages that set has.
+ * Attached to the last real user message. Does not re-embed message bodies —
+ * only names how many unanswered user messages that set has.
  */
 export function buildSteerHint(pendingCount: number): string {
   const body =

--- a/packages/opencode/src/session/steer-hint.ts
+++ b/packages/opencode/src/session/steer-hint.ts
@@ -14,8 +14,8 @@ export function lastRealUserMessage(messages: MessageV2.WithParts[]): MessageV2.
 }
 
 /**
- * Real user messages after the newest same-session assistant — unanswered
- * follow-ups. Already present in the conversation; the hint only names the set.
+ * Real user messages after the newest same-session assistant — the pending
+ * set the loop is about to pick up.
  */
 export function pendingUserMessages(messages: MessageV2.WithParts[]): MessageV2.WithParts[] {
   const lastAssistantIdx = messages.findLastIndex(
@@ -24,43 +24,48 @@ export function pendingUserMessages(messages: MessageV2.WithParts[]): MessageV2.
   return messages.slice(lastAssistantIdx + 1).filter((m) => m.info.role === "user" && hasRealUserText(m))
 }
 
-function sameSessionAssistantsAfter(
-  messages: MessageV2.WithParts[],
-  fromIdx: number,
+function isSameSessionAssistant(
+  m: MessageV2.WithParts,
   sessionID: string,
-): boolean {
-  return messages
-    .slice(fromIdx + 1)
-    .some((m) => m.info.role === "assistant" && m.info.sessionID === sessionID)
+): m is MessageV2.WithParts & { info: MessageV2.Assistant } {
+  return m.info.role === "assistant" && m.info.sessionID === sessionID
 }
 
 /**
- * Steer = a real user message written while the previous same-session assistant
- * was still open, and still unanswered (no later same-session assistant).
+ * Steer pickup = the agent loop's "new user" branch: lastUser.id >
+ * lastAssistant.id. At that moment lastUser cannot already be answered —
+ * if it were, the loop would be in the continue-assistant branch.
  *
- * - Ordinary sequential turns after a finished reply do NOT fire.
- * - Once an assistant exists after this user, it is the current turn (like the
- *   first user of that turn) — not a pending steer.
- * - Several stacked real users after the last assistant all count as pending.
- * - Synthetic-only users (inbox.drain, goal re-entry, …) never count.
- * - Parent assistants from contextFrom (different sessionID) do not count.
+ * Fire only when that new user is real prose and was written while the
+ * previous same-session assistant was still open (true mid-turn steer),
+ * or when several real users are stacked after the last assistant.
+ *
+ * Ordinary sequential turns after a finished reply do NOT fire.
+ * Synthetic-only users never count. Parent assistants from contextFrom
+ * (different sessionID) do not count.
  */
-export function shouldInjectSteerHint(messages: MessageV2.WithParts[], lastUser: MessageV2.WithParts): boolean {
+export function shouldInjectSteerHint(input: {
+  messages: MessageV2.WithParts[]
+  lastUser: MessageV2.WithParts
+  lastAssistant: MessageV2.Assistant | undefined
+}): boolean {
+  const { messages, lastUser, lastAssistant } = input
   if (lastUser.info.role !== "user") return false
   if (!hasRealUserText(lastUser)) return false
+
+  // State machine: only the new-user branch is a steer pickup.
+  if (lastAssistant && lastAssistant.sessionID === lastUser.info.sessionID && lastUser.info.id < lastAssistant.id) {
+    return false
+  }
+
   const lastUserIdx = messages.findLastIndex((m) => m.info.id === lastUser.info.id)
   if (lastUserIdx < 0) return false
-  if (sameSessionAssistantsAfter(messages, lastUserIdx, lastUser.info.sessionID)) return false
 
-  const pending = pendingUserMessages(messages)
-  if (pending.length > 1) return true
+  if (pendingUserMessages(messages).length > 1) return true
 
   const lastAsst = messages
     .slice(0, lastUserIdx)
-    .filter(
-      (m): m is MessageV2.WithParts & { info: MessageV2.Assistant } =>
-        m.info.role === "assistant" && m.info.sessionID === lastUser.info.sessionID,
-    )
+    .filter((m) => isSameSessionAssistant(m, lastUser.info.sessionID))
     .at(-1)
   if (!lastAsst) return false
 

--- a/packages/opencode/test/session/steer-hint.test.ts
+++ b/packages/opencode/test/session/steer-hint.test.ts
@@ -4,6 +4,7 @@ import {
   STEER_HINT_MARKER,
   buildSteerHint,
   hasRealUserText,
+  lastRealUserMessage,
   pendingUserMessages,
   shouldInjectSteerHint,
 } from "../../src/session/steer-hint"
@@ -24,13 +25,14 @@ function msg(
   id: string,
   parts: MessageV2.Part[],
   time?: { created: number; completed?: number },
+  sessionID = "ses",
 ): MessageV2.WithParts {
   return {
     info: {
       id,
       role,
-      sessionID: "ses",
-      time: time ?? { created: 0, ...(role === "assistant" ? {} : {}) },
+      sessionID,
+      time: time ?? { created: 0 },
     } as unknown as MessageV2.WithParts["info"],
     parts,
   }
@@ -62,7 +64,19 @@ describe("steer hint", () => {
     expect(shouldInjectSteerHint(messages, next)).toBe(false)
   })
 
-  test("fires when user message arrived while assistant was still open", () => {
+  test("skips when an assistant already answers this user (current turn)", () => {
+    const u2 = msg("user", "u2", [textPart("STEER")], { created: 4 })
+    const a2 = msg("assistant", "a2", [textPart("working on steer")], { created: 5 })
+    const messages = [
+      msg("user", "u1", [textPart("first")], { created: 1 }),
+      msg("assistant", "a1", [textPart("done")], { created: 2, completed: 3 }),
+      u2,
+      a2,
+    ]
+    expect(shouldInjectSteerHint(messages, u2)).toBe(false)
+  })
+
+  test("fires when user arrived while prior assistant was still open and unanswered", () => {
     const steer = msg("user", "u2", [textPart("also install the package")], { created: 4 })
     const messages = [
       msg("user", "u1", [textPart("research names")], { created: 1 }),
@@ -72,7 +86,7 @@ describe("steer hint", () => {
     expect(shouldInjectSteerHint(messages, steer)).toBe(true)
   })
 
-  test("fires when multiple user messages are stacked after last assistant", () => {
+  test("fires when multiple real users are stacked after last assistant", () => {
     const a = msg("user", "u2", [textPart("STEER_A")], { created: 20 })
     const b = msg("user", "u3", [textPart("STEER_B")], { created: 21 })
     const messages = [
@@ -84,20 +98,29 @@ describe("steer hint", () => {
     expect(shouldInjectSteerHint(messages, b)).toBe(true)
   })
 
+  test("lastRealUserMessage skips newer synthetic inbox users", () => {
+    const real = msg("user", "u2", [textPart("STEER")], { created: 4 })
+    const drain = msg("user", "u3", [textPart("notification", { synthetic: true })], { created: 5 })
+    const messages = [
+      msg("user", "u1", [textPart("first")], { created: 1 }),
+      msg("assistant", "a1", [textPart("done")], { created: 2, completed: 3 }),
+      real,
+      drain,
+    ]
+    expect(String(lastRealUserMessage(messages)?.info.id)).toBe("u2")
+  })
+
   test("single pending message is one keep-work sentence", () => {
     const notice = buildSteerHint(1)
     expect(notice).toContain(STEER_HINT_MARKER)
     expect(notice).toContain("keep that work unless the message clearly replaces it")
     expect(notice).not.toContain("unanswered user messages")
-    expect(notice).toContain("<system-reminder>")
   })
 
   test("multiple pending messages name the set without re-embedding bodies", () => {
     const notice = buildSteerHint(3)
     expect(notice).toContain("3 unanswered user messages after your last reply")
-    expect(notice).toContain("already in order above")
     expect(notice).not.toContain("install the package")
-    expect(notice).not.toContain("Pending user messages (handle all of them):")
   })
 
   test("pendingUserMessages returns real users after last assistant", () => {
@@ -117,10 +140,7 @@ describe("steer hint", () => {
   })
 
   test("does not treat full-context fork first task as a steer", () => {
-    const parentAssistant = {
-      info: { id: "pa1", role: "assistant", sessionID: "parent", time: { created: 1, completed: 2 } },
-      parts: [textPart("parent work")],
-    } as unknown as MessageV2.WithParts
+    const parentAssistant = msg("assistant", "pa1", [textPart("parent work")], { created: 1, completed: 2 }, "parent")
     const firstTask = msg("user", "u1", [textPart("child task")], { created: 3 })
     expect(shouldInjectSteerHint([parentAssistant, firstTask], firstTask)).toBe(false)
   })

--- a/packages/opencode/test/session/steer-hint.test.ts
+++ b/packages/opencode/test/session/steer-hint.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+import type { MessageV2 } from "../../src/session/message-v2"
+import {
+  STEER_HINT_MARKER,
+  buildSteerHint,
+  hasRealUserText,
+  pendingUserMessages,
+  shouldInjectSteerHint,
+} from "../../src/session/steer-hint"
+
+function textPart(text: string, opts: { synthetic?: boolean } = {}): MessageV2.Part {
+  return {
+    id: `part_${Math.random().toString(36).slice(2, 10)}`,
+    messageID: "msg",
+    sessionID: "ses",
+    type: "text",
+    text,
+    synthetic: opts.synthetic,
+  } as unknown as MessageV2.Part
+}
+
+function msg(role: "user" | "assistant", id: string, parts: MessageV2.Part[]): MessageV2.WithParts {
+  return {
+    info: { id, role, sessionID: "ses" } as unknown as MessageV2.WithParts["info"],
+    parts,
+  }
+}
+
+describe("steer hint", () => {
+  test("skips first user message (no prior assistant)", () => {
+    const first = msg("user", "u1", [textPart("do the thing")])
+    expect(shouldInjectSteerHint([first], first)).toBe(false)
+  })
+
+  test("skips synthetic-only user messages", () => {
+    const synthetic = msg("user", "u2", [textPart("auto continue", { synthetic: true })])
+    const messages = [msg("user", "u1", [textPart("start")]), msg("assistant", "a1", [textPart("ok")]), synthetic]
+    expect(shouldInjectSteerHint(messages, synthetic)).toBe(false)
+  })
+
+  test("fires on real user prose after assistant work", () => {
+    const steer = msg("user", "u2", [textPart("also install the package")])
+    const messages = [msg("user", "u1", [textPart("research names")]), msg("assistant", "a1", [textPart("working")]), steer]
+    expect(shouldInjectSteerHint(messages, steer)).toBe(true)
+  })
+
+  test("single pending message is one keep-work sentence", () => {
+    const notice = buildSteerHint(1)
+    expect(notice).toContain(STEER_HINT_MARKER)
+    expect(notice).toContain("keep that work unless the message clearly replaces it")
+    expect(notice).not.toContain("unanswered user messages")
+    expect(notice).toContain("<system-reminder>")
+  })
+
+  test("multiple pending messages name the set without re-embedding bodies", () => {
+    const notice = buildSteerHint(3)
+    expect(notice).toContain("3 unanswered user messages after your last reply")
+    expect(notice).toContain("already in order above")
+    expect(notice).not.toContain("install the package")
+    expect(notice).not.toContain("Pending user messages (handle all of them):")
+  })
+
+  test("pendingUserMessages returns real users after last assistant", () => {
+    const messages = [
+      msg("user", "u1", [textPart("a")]),
+      msg("assistant", "a1", [textPart("b")]),
+      msg("user", "u2", [textPart("c")]),
+      msg("user", "u3", [textPart("d")]),
+    ]
+    expect(pendingUserMessages(messages)).toHaveLength(2)
+  })
+
+  test("hasRealUserText ignores empty and synthetic parts", () => {
+    expect(hasRealUserText(msg("user", "u1", [textPart("  ")]))).toBe(false)
+    expect(hasRealUserText(msg("user", "u1", [textPart("x", { synthetic: true })]))).toBe(false)
+    expect(hasRealUserText(msg("user", "u1", [textPart("x")]))).toBe(true)
+  })
+
+  test("does not treat full-context fork first task as a steer", () => {
+    const parentAssistant = {
+      info: { id: "pa1", role: "assistant", sessionID: "parent" },
+      parts: [textPart("parent work")],
+    } as unknown as MessageV2.WithParts
+    const firstTask = msg("user", "u1", [textPart("child task")])
+    expect(shouldInjectSteerHint([parentAssistant, firstTask], firstTask)).toBe(false)
+  })
+})

--- a/packages/opencode/test/session/steer-hint.test.ts
+++ b/packages/opencode/test/session/steer-hint.test.ts
@@ -28,30 +28,39 @@ function msg(
   sessionID = "ses",
 ): MessageV2.WithParts {
   return {
-    info: {
-      id,
-      role,
-      sessionID,
-      time: time ?? { created: 0 },
-    } as unknown as MessageV2.WithParts["info"],
+    info: { id, role, sessionID, time: time ?? { created: 0 } } as unknown as MessageV2.WithParts["info"],
     parts,
   }
+}
+
+function asstInfo(id: string, time: { created: number; completed?: number }): MessageV2.Assistant {
+  return { id, role: "assistant", sessionID: "ses", time } as unknown as MessageV2.Assistant
 }
 
 describe("steer hint", () => {
   test("skips first user message (no prior assistant)", () => {
     const first = msg("user", "u1", [textPart("do the thing")], { created: 1 })
-    expect(shouldInjectSteerHint([first], first)).toBe(false)
+    expect(
+      shouldInjectSteerHint({ messages: [first], lastUser: first, lastAssistant: undefined }),
+    ).toBe(false)
   })
 
-  test("skips synthetic-only user messages", () => {
-    const synthetic = msg("user", "u2", [textPart("auto continue", { synthetic: true })], { created: 3 })
+  test("skips when loop is continuing an assistant (lastUser.id < lastAssistant.id)", () => {
+    const u2 = msg("user", "u2", [textPart("STEER")], { created: 4 })
+    const a2 = msg("assistant", "a2", [textPart("answering")], { created: 5 })
     const messages = [
-      msg("user", "u1", [textPart("start")], { created: 1 }),
-      msg("assistant", "a1", [textPart("ok")], { created: 2, completed: 2 }),
-      synthetic,
+      msg("user", "u1", [textPart("first")], { created: 1 }),
+      msg("assistant", "a1", [textPart("done")], { created: 2, completed: 3 }),
+      u2,
+      a2,
     ]
-    expect(shouldInjectSteerHint(messages, synthetic)).toBe(false)
+    expect(
+      shouldInjectSteerHint({
+        messages,
+        lastUser: u2,
+        lastAssistant: asstInfo("a2", { created: 5 }),
+      }),
+    ).toBe(false)
   })
 
   test("skips ordinary sequential turn after a finished reply", () => {
@@ -61,29 +70,29 @@ describe("steer hint", () => {
       msg("assistant", "a1", [textPart("done")], { created: 2, completed: 5 }),
       next,
     ]
-    expect(shouldInjectSteerHint(messages, next)).toBe(false)
+    expect(
+      shouldInjectSteerHint({
+        messages,
+        lastUser: next,
+        lastAssistant: asstInfo("a1", { created: 2, completed: 5 }),
+      }),
+    ).toBe(false)
   })
 
-  test("skips when an assistant already answers this user (current turn)", () => {
-    const u2 = msg("user", "u2", [textPart("STEER")], { created: 4 })
-    const a2 = msg("assistant", "a2", [textPart("working on steer")], { created: 5 })
-    const messages = [
-      msg("user", "u1", [textPart("first")], { created: 1 }),
-      msg("assistant", "a1", [textPart("done")], { created: 2, completed: 3 }),
-      u2,
-      a2,
-    ]
-    expect(shouldInjectSteerHint(messages, u2)).toBe(false)
-  })
-
-  test("fires when user arrived while prior assistant was still open and unanswered", () => {
+  test("fires on new-user branch when user arrived while prior assistant was open", () => {
     const steer = msg("user", "u2", [textPart("also install the package")], { created: 4 })
     const messages = [
       msg("user", "u1", [textPart("research names")], { created: 1 }),
       msg("assistant", "a1", [textPart("working")], { created: 2, completed: 10 }),
       steer,
     ]
-    expect(shouldInjectSteerHint(messages, steer)).toBe(true)
+    expect(
+      shouldInjectSteerHint({
+        messages,
+        lastUser: steer,
+        lastAssistant: asstInfo("a1", { created: 2, completed: 10 }),
+      }),
+    ).toBe(true)
   })
 
   test("fires when multiple real users are stacked after last assistant", () => {
@@ -95,7 +104,29 @@ describe("steer hint", () => {
       a,
       b,
     ]
-    expect(shouldInjectSteerHint(messages, b)).toBe(true)
+    expect(
+      shouldInjectSteerHint({
+        messages,
+        lastUser: b,
+        lastAssistant: asstInfo("a1", { created: 2, completed: 5 }),
+      }),
+    ).toBe(true)
+  })
+
+  test("skips synthetic-only user messages", () => {
+    const synthetic = msg("user", "u2", [textPart("auto continue", { synthetic: true })], { created: 3 })
+    const messages = [
+      msg("user", "u1", [textPart("start")], { created: 1 }),
+      msg("assistant", "a1", [textPart("ok")], { created: 2, completed: 2 }),
+      synthetic,
+    ]
+    expect(
+      shouldInjectSteerHint({
+        messages,
+        lastUser: synthetic,
+        lastAssistant: asstInfo("a1", { created: 2, completed: 2 }),
+      }),
+    ).toBe(false)
   })
 
   test("lastRealUserMessage skips newer synthetic inbox users", () => {
@@ -142,6 +173,12 @@ describe("steer hint", () => {
   test("does not treat full-context fork first task as a steer", () => {
     const parentAssistant = msg("assistant", "pa1", [textPart("parent work")], { created: 1, completed: 2 }, "parent")
     const firstTask = msg("user", "u1", [textPart("child task")], { created: 3 })
-    expect(shouldInjectSteerHint([parentAssistant, firstTask], firstTask)).toBe(false)
+    expect(
+      shouldInjectSteerHint({
+        messages: [parentAssistant, firstTask],
+        lastUser: firstTask,
+        lastAssistant: undefined,
+      }),
+    ).toBe(false)
   })
 })

--- a/packages/opencode/test/session/steer-hint.test.ts
+++ b/packages/opencode/test/session/steer-hint.test.ts
@@ -19,29 +19,69 @@ function textPart(text: string, opts: { synthetic?: boolean } = {}): MessageV2.P
   } as unknown as MessageV2.Part
 }
 
-function msg(role: "user" | "assistant", id: string, parts: MessageV2.Part[]): MessageV2.WithParts {
+function msg(
+  role: "user" | "assistant",
+  id: string,
+  parts: MessageV2.Part[],
+  time?: { created: number; completed?: number },
+): MessageV2.WithParts {
   return {
-    info: { id, role, sessionID: "ses" } as unknown as MessageV2.WithParts["info"],
+    info: {
+      id,
+      role,
+      sessionID: "ses",
+      time: time ?? { created: 0, ...(role === "assistant" ? {} : {}) },
+    } as unknown as MessageV2.WithParts["info"],
     parts,
   }
 }
 
 describe("steer hint", () => {
   test("skips first user message (no prior assistant)", () => {
-    const first = msg("user", "u1", [textPart("do the thing")])
+    const first = msg("user", "u1", [textPart("do the thing")], { created: 1 })
     expect(shouldInjectSteerHint([first], first)).toBe(false)
   })
 
   test("skips synthetic-only user messages", () => {
-    const synthetic = msg("user", "u2", [textPart("auto continue", { synthetic: true })])
-    const messages = [msg("user", "u1", [textPart("start")]), msg("assistant", "a1", [textPart("ok")]), synthetic]
+    const synthetic = msg("user", "u2", [textPart("auto continue", { synthetic: true })], { created: 3 })
+    const messages = [
+      msg("user", "u1", [textPart("start")], { created: 1 }),
+      msg("assistant", "a1", [textPart("ok")], { created: 2, completed: 2 }),
+      synthetic,
+    ]
     expect(shouldInjectSteerHint(messages, synthetic)).toBe(false)
   })
 
-  test("fires on real user prose after assistant work", () => {
-    const steer = msg("user", "u2", [textPart("also install the package")])
-    const messages = [msg("user", "u1", [textPart("research names")]), msg("assistant", "a1", [textPart("working")]), steer]
+  test("skips ordinary sequential turn after a finished reply", () => {
+    const next = msg("user", "u2", [textPart("next task")], { created: 10 })
+    const messages = [
+      msg("user", "u1", [textPart("first")], { created: 1 }),
+      msg("assistant", "a1", [textPart("done")], { created: 2, completed: 5 }),
+      next,
+    ]
+    expect(shouldInjectSteerHint(messages, next)).toBe(false)
+  })
+
+  test("fires when user message arrived while assistant was still open", () => {
+    const steer = msg("user", "u2", [textPart("also install the package")], { created: 4 })
+    const messages = [
+      msg("user", "u1", [textPart("research names")], { created: 1 }),
+      msg("assistant", "a1", [textPart("working")], { created: 2, completed: 10 }),
+      steer,
+    ]
     expect(shouldInjectSteerHint(messages, steer)).toBe(true)
+  })
+
+  test("fires when multiple user messages are stacked after last assistant", () => {
+    const a = msg("user", "u2", [textPart("STEER_A")], { created: 20 })
+    const b = msg("user", "u3", [textPart("STEER_B")], { created: 21 })
+    const messages = [
+      msg("user", "u1", [textPart("first")], { created: 1 }),
+      msg("assistant", "a1", [textPart("done")], { created: 2, completed: 5 }),
+      a,
+      b,
+    ]
+    expect(shouldInjectSteerHint(messages, b)).toBe(true)
   })
 
   test("single pending message is one keep-work sentence", () => {
@@ -62,10 +102,10 @@ describe("steer hint", () => {
 
   test("pendingUserMessages returns real users after last assistant", () => {
     const messages = [
-      msg("user", "u1", [textPart("a")]),
-      msg("assistant", "a1", [textPart("b")]),
-      msg("user", "u2", [textPart("c")]),
-      msg("user", "u3", [textPart("d")]),
+      msg("user", "u1", [textPart("a")], { created: 1 }),
+      msg("assistant", "a1", [textPart("b")], { created: 2, completed: 3 }),
+      msg("user", "u2", [textPart("c")], { created: 4 }),
+      msg("user", "u3", [textPart("d")], { created: 5 }),
     ]
     expect(pendingUserMessages(messages)).toHaveLength(2)
   })
@@ -78,10 +118,10 @@ describe("steer hint", () => {
 
   test("does not treat full-context fork first task as a steer", () => {
     const parentAssistant = {
-      info: { id: "pa1", role: "assistant", sessionID: "parent" },
+      info: { id: "pa1", role: "assistant", sessionID: "parent", time: { created: 1, completed: 2 } },
       parts: [textPart("parent work")],
     } as unknown as MessageV2.WithParts
-    const firstTask = msg("user", "u1", [textPart("child task")])
+    const firstTask = msg("user", "u1", [textPart("child task")], { created: 3 })
     expect(shouldInjectSteerHint([parentAssistant, firstTask], firstTask)).toBe(false)
   })
 })

--- a/packages/opencode/test/session/steer-hint.test.ts
+++ b/packages/opencode/test/session/steer-hint.test.ts
@@ -38,19 +38,18 @@ function asstInfo(id: string, time: { created: number; completed?: number }): Me
 }
 
 describe("steer hint", () => {
-  test("skips first user message (no prior assistant)", () => {
-    const first = msg("user", "u1", [textPart("do the thing")], { created: 1 })
-    expect(
-      shouldInjectSteerHint({ messages: [first], lastUser: first, lastAssistant: undefined }),
-    ).toBe(false)
+  test("skips step 0 (runLoop just started)", () => {
+    const u1 = msg("user", "u1", [textPart("do the thing")], { created: 1 })
+    expect(shouldInjectSteerHint({ messages: [u1], lastUser: u1, lastAssistant: undefined, step: 0 })).toBe(false)
   })
 
-  test("skips when loop is continuing an assistant (lastUser.id < lastAssistant.id)", () => {
-    const u2 = msg("user", "u2", [textPart("STEER")], { created: 4 })
-    const a2 = msg("assistant", "a2", [textPart("answering")], { created: 5 })
+  test("skips when continuing current assistant (lastUser.id < lastAssistant.id)", () => {
+    // MessageIDs are ascending — later messages must compare greater.
+    const u2 = msg("user", "m2", [textPart("STEER")], { created: 4 })
+    const a2 = msg("assistant", "m3", [textPart("answering")], { created: 5 })
     const messages = [
-      msg("user", "u1", [textPart("first")], { created: 1 }),
-      msg("assistant", "a1", [textPart("done")], { created: 2, completed: 3 }),
+      msg("user", "m0", [textPart("first")], { created: 1 }),
+      msg("assistant", "m1", [textPart("done")], { created: 2, completed: 3 }),
       u2,
       a2,
     ]
@@ -58,75 +57,51 @@ describe("steer hint", () => {
       shouldInjectSteerHint({
         messages,
         lastUser: u2,
-        lastAssistant: asstInfo("a2", { created: 5 }),
+        lastAssistant: asstInfo("m3", { created: 5 }),
+        step: 2,
       }),
     ).toBe(false)
   })
 
-  test("skips ordinary sequential turn after a finished reply", () => {
-    const next = msg("user", "u2", [textPart("next task")], { created: 10 })
-    const messages = [
-      msg("user", "u1", [textPart("first")], { created: 1 }),
-      msg("assistant", "a1", [textPart("done")], { created: 2, completed: 5 }),
-      next,
-    ]
+  test("skips synthetic-only user", () => {
+    const synthetic = msg("user", "u2", [textPart("auto continue", { synthetic: true })], { created: 3 })
     expect(
       shouldInjectSteerHint({
-        messages,
-        lastUser: next,
-        lastAssistant: asstInfo("a1", { created: 2, completed: 5 }),
+        messages: [synthetic],
+        lastUser: synthetic,
+        lastAssistant: asstInfo("a1", { created: 1, completed: 2 }),
+        step: 1,
       }),
     ).toBe(false)
   })
 
-  test("fires on new-user branch when user arrived while prior assistant was open", () => {
+  test("fires when loop step ≥ 1 sees a new lastUser (mid-turn steer)", () => {
     const steer = msg("user", "u2", [textPart("also install the package")], { created: 4 })
     const messages = [
       msg("user", "u1", [textPart("research names")], { created: 1 }),
-      msg("assistant", "a1", [textPart("working")], { created: 2, completed: 10 }),
+      msg("assistant", "a1", [textPart("working")], { created: 2 }),
       steer,
     ]
     expect(
       shouldInjectSteerHint({
         messages,
         lastUser: steer,
-        lastAssistant: asstInfo("a1", { created: 2, completed: 10 }),
+        lastAssistant: asstInfo("a1", { created: 2 }),
+        step: 1,
       }),
     ).toBe(true)
   })
 
-  test("fires when multiple real users are stacked after last assistant", () => {
-    const a = msg("user", "u2", [textPart("STEER_A")], { created: 20 })
+  test("fires for stacked steers at step ≥ 1", () => {
     const b = msg("user", "u3", [textPart("STEER_B")], { created: 21 })
-    const messages = [
-      msg("user", "u1", [textPart("first")], { created: 1 }),
-      msg("assistant", "a1", [textPart("done")], { created: 2, completed: 5 }),
-      a,
-      b,
-    ]
     expect(
       shouldInjectSteerHint({
-        messages,
+        messages: [b],
         lastUser: b,
         lastAssistant: asstInfo("a1", { created: 2, completed: 5 }),
+        step: 3,
       }),
     ).toBe(true)
-  })
-
-  test("skips synthetic-only user messages", () => {
-    const synthetic = msg("user", "u2", [textPart("auto continue", { synthetic: true })], { created: 3 })
-    const messages = [
-      msg("user", "u1", [textPart("start")], { created: 1 }),
-      msg("assistant", "a1", [textPart("ok")], { created: 2, completed: 2 }),
-      synthetic,
-    ]
-    expect(
-      shouldInjectSteerHint({
-        messages,
-        lastUser: synthetic,
-        lastAssistant: asstInfo("a1", { created: 2, completed: 2 }),
-      }),
-    ).toBe(false)
   })
 
   test("lastRealUserMessage skips newer synthetic inbox users", () => {
@@ -141,20 +116,13 @@ describe("steer hint", () => {
     expect(String(lastRealUserMessage(messages)?.info.id)).toBe("u2")
   })
 
-  test("single pending message is one keep-work sentence", () => {
-    const notice = buildSteerHint(1)
-    expect(notice).toContain(STEER_HINT_MARKER)
-    expect(notice).toContain("keep that work unless the message clearly replaces it")
-    expect(notice).not.toContain("unanswered user messages")
+  test("hint text", () => {
+    expect(buildSteerHint(1)).toContain(STEER_HINT_MARKER)
+    expect(buildSteerHint(1)).toContain("keep that work unless")
+    expect(buildSteerHint(3)).toContain("3 unanswered user messages")
   })
 
-  test("multiple pending messages name the set without re-embedding bodies", () => {
-    const notice = buildSteerHint(3)
-    expect(notice).toContain("3 unanswered user messages after your last reply")
-    expect(notice).not.toContain("install the package")
-  })
-
-  test("pendingUserMessages returns real users after last assistant", () => {
+  test("pendingUserMessages", () => {
     const messages = [
       msg("user", "u1", [textPart("a")], { created: 1 }),
       msg("assistant", "a1", [textPart("b")], { created: 2, completed: 3 }),
@@ -164,21 +132,9 @@ describe("steer hint", () => {
     expect(pendingUserMessages(messages)).toHaveLength(2)
   })
 
-  test("hasRealUserText ignores empty and synthetic parts", () => {
+  test("hasRealUserText", () => {
     expect(hasRealUserText(msg("user", "u1", [textPart("  ")]))).toBe(false)
     expect(hasRealUserText(msg("user", "u1", [textPart("x", { synthetic: true })]))).toBe(false)
     expect(hasRealUserText(msg("user", "u1", [textPart("x")]))).toBe(true)
-  })
-
-  test("does not treat full-context fork first task as a steer", () => {
-    const parentAssistant = msg("assistant", "pa1", [textPart("parent work")], { created: 1, completed: 2 }, "parent")
-    const firstTask = msg("user", "u1", [textPart("child task")], { created: 3 })
-    expect(
-      shouldInjectSteerHint({
-        messages: [parentAssistant, firstTask],
-        lastUser: firstTask,
-        lastAssistant: undefined,
-      }),
-    ).toBe(false)
   })
 })

--- a/packages/opencode/test/session/steer-multi.integration.test.ts
+++ b/packages/opencode/test/session/steer-multi.integration.test.ts
@@ -146,7 +146,6 @@ describe("session.prompt mid-turn multi-steer drain", () => {
                   parts: [{ type: "text", text: "STEER_A alpha" }],
                 })
                 .pipe(Effect.forkChild)
-              yield* Effect.sleep("80 millis")
               yield* prompt
                 .prompt({
                   sessionID: session.id,
@@ -154,8 +153,15 @@ describe("session.prompt mid-turn multi-steer drain", () => {
                 })
                 .pipe(Effect.forkChild)
 
-              // Give createUserMessage a beat, then release call 1.
-              yield* Effect.sleep("200 millis")
+              // Wait until both steers are durable before releasing call 1.
+              for (let i = 0; i < 100; i++) {
+                const msgs = yield* sessions.messages({ sessionID: session.id })
+                const texts = msgs.flatMap((m) =>
+                  m.parts.flatMap((p) => (p.type === "text" && !p.synthetic ? [p.text] : [])),
+                )
+                if (texts.some((t) => t.includes("STEER_A")) && texts.some((t) => t.includes("STEER_B"))) break
+                yield* Effect.sleep("50 millis")
+              }
               steersReady()
 
               yield* Fiber.join(slow).pipe(Effect.timeout("20 seconds"), Effect.catch(() => Effect.void))

--- a/packages/opencode/test/session/steer-multi.integration.test.ts
+++ b/packages/opencode/test/session/steer-multi.integration.test.ts
@@ -1,0 +1,179 @@
+import path from "path"
+import { describe, expect, test } from "bun:test"
+import { Effect, Fiber, Layer } from "effect"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Log } from "../../src/util"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+function sse(chunks: object[]) {
+  const payload = [...chunks.map((c) => `data: ${JSON.stringify(c)}`), "data: [DONE]"].join("\n\n") + "\n\n"
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(ctrl) {
+      ctrl.enqueue(encoder.encode(payload))
+      ctrl.close()
+    },
+  })
+}
+
+function chat(text: string) {
+  return sse([
+    { id: "c", object: "chat.completion.chunk", choices: [{ delta: { role: "assistant" } }] },
+    { id: "c", object: "chat.completion.chunk", choices: [{ delta: { content: text } }] },
+    { id: "c", object: "chat.completion.chunk", choices: [{ delta: {}, finish_reason: "stop" }] },
+  ])
+}
+
+function chatToolCall(name: string, args: object) {
+  return sse([
+    { id: "c", object: "chat.completion.chunk", choices: [{ delta: { role: "assistant" } }] },
+    {
+      id: "c",
+      object: "chat.completion.chunk",
+      choices: [
+        {
+          delta: {
+            tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name, arguments: JSON.stringify(args) } }],
+          },
+        },
+      ],
+    },
+    { id: "c", object: "chat.completion.chunk", choices: [{ delta: {}, finish_reason: "tool_calls" }] },
+  ])
+}
+
+function userTexts(messages: Array<{ role: string; content: unknown }>): string[] {
+  return messages
+    .filter((m) => m.role === "user")
+    .flatMap((m) =>
+      typeof m.content === "string"
+        ? [m.content]
+        : Array.isArray(m.content)
+          ? m.content.filter((p: any) => p?.type === "text").map((p: any) => String(p.text))
+          : [],
+    )
+}
+
+describe("session.prompt mid-turn multi-steer drain", () => {
+  test("stacked user messages after last assistant produce unanswered-count hint", async () => {
+    const captures: Array<{ hasUnanswered: boolean; count: number | null; texts: string[] }> = []
+    let calls = 0
+    let steersReady: () => void = () => {}
+    const steersDone = new Promise<void>((r) => {
+      steersReady = r
+    })
+
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
+        calls++
+        const body = (await req.json()) as { messages: Array<{ role: string; content: unknown }> }
+        const texts = userTexts(body.messages)
+        const joined = texts.join("\n")
+        const m = joined.match(/There are (\d+) unanswered/)
+        captures.push({
+          hasUnanswered: /unanswered user messages/.test(joined),
+          count: m ? Number(m[1]) : null,
+          texts,
+        })
+        if (calls === 1) {
+          // Hold the first LLM response until steers are in the DB, then keep
+          // the loop alive with a tool call so the next iteration reloads them.
+          await steersDone
+          await new Promise((r) => setTimeout(r, 50))
+          return new Response(chatToolCall("glob", { pattern: "*.md" }), {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          })
+        }
+        return new Response(chat("DONE"), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(path.join(dir, "readme.md"), "hi\n")
+          await Bun.write(
+            path.join(dir, "mimocode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: { options: { apiKey: "test-key", baseURL: `${server.url.origin}/v1` } },
+              },
+              agent: { build: { model: "alibaba/qwen-plus" } },
+            }),
+          )
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          Effect.runPromise(
+            Effect.gen(function* () {
+              const prompt = yield* SessionPrompt.Service
+              const sessions = yield* Session.Service
+              const session = yield* sessions.create({ title: "multi-steer" })
+
+              const slow = yield* prompt
+                .prompt({
+                  sessionID: session.id,
+                  parts: [{ type: "text", text: "SLOW_TURN first" }],
+                })
+                .pipe(Effect.forkChild)
+
+              // Wait until the first LLM request is in flight (assistant exists).
+              yield* Effect.promise(async () => {
+                while (calls < 1) await new Promise((r) => setTimeout(r, 50))
+              })
+              yield* Effect.sleep("100 millis")
+
+              yield* prompt
+                .prompt({
+                  sessionID: session.id,
+                  parts: [{ type: "text", text: "STEER_A alpha" }],
+                })
+                .pipe(Effect.forkChild)
+              yield* Effect.sleep("80 millis")
+              yield* prompt
+                .prompt({
+                  sessionID: session.id,
+                  parts: [{ type: "text", text: "STEER_B beta" }],
+                })
+                .pipe(Effect.forkChild)
+
+              // Give createUserMessage a beat, then release call 1.
+              yield* Effect.sleep("200 millis")
+              steersReady()
+
+              yield* Fiber.join(slow).pipe(Effect.timeout("20 seconds"), Effect.catch(() => Effect.void))
+              yield* Effect.sleep("1500 millis")
+            }).pipe(Effect.scoped, Effect.provide(Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer))),
+          ),
+      })
+
+      const multi = captures.find((c) => c.hasUnanswered && (c.count ?? 0) >= 2)
+      expect(
+        multi,
+        `captures=${JSON.stringify(captures.map((c) => ({ u: c.hasUnanswered, n: c.count, texts: c.texts })))}`,
+      ).toBeDefined()
+      const blob = multi!.texts.join("\n")
+      expect(blob).toContain("STEER_A")
+      expect(blob).toContain("STEER_B")
+    } finally {
+      server.stop(true)
+    }
+  }, 60_000)
+})


### PR DESCRIPTION
## Summary
- When a real user message arrives after same-session assistant work (`promptAsync` while the runner is busy), models often abandon the in-progress task and treat the latest message as a full task switch.
- At the `runLoop` message-load checkpoint, attach a short **in-memory** `<system-reminder>` on `lastUser`: keep earlier work unless the message clearly replaces it.
- If several user messages are unanswered after the last assistant reply, the hint names the set (count only). Message bodies stay in the transcript — not re-embedded — so the agent can tell history from the reminder.
- Skips the first user turn, synthetic-only users, and full-context-fork parent assistants (different `sessionID`).

## Verification
- `bun typecheck` — PASS
- `bun test test/session/steer-hint.test.ts` — 8 pass
- `bun test test/session/plan-reminder-dedup.test.ts test/session/prompt-skill-command-multi.test.ts` — 10 pass