### PR TITLE
fix(provider): stabilize defaultModel fallback (no menu-priority sort)

### DIFF
--- a/docs/compose/spec/default-model-stable-fallback.md
+++ b/docs/compose/spec/default-model-stable-fallback.md
@@ -3,7 +3,7 @@ feature: default-model-stable-fallback
 status: delivered
 updated: 2026-09-01
 branch: default-model-stable-fallback
-commits: fa69916897..50e4e6f83b
+commits: fa69916897..7ffae65525
 ---
 
 # Default Model Stable Fallback
@@ -77,5 +77,5 @@ Not changing in this feature:
 
 ## Tasks
 
-- [x] T1: Rewrite `defaultModel()` chain (validate cfg.model, keep recent, drop sort and retired mimo-auto) — acceptance: unit tests cover invalid cfg fallthrough, recent hit, no retired mimo-auto special case, first-provider stable pick, and no priority substring preference (covers: S2)
+- [x] T1: Rewrite `defaultModel()` chain (validate cfg.model, keep recent, drop sort and retired mimo-auto; last-resort requires usable chat model) — acceptance: unit tests cover invalid cfg fallthrough, recent hit, cfg-beats-recent, non-chat skip, no retired mimo-auto special case, first-provider stable pick, and no priority substring preference (covers: S2)
 - [x] T2: Adjust/extend provider tests — acceptance: `bun test packages/opencode/test/provider` passes; new cases assert the chain order and that `gpt-5`-like ids are not auto-preferred when earlier steps miss (covers: S2; depends: T1)

--- a/docs/compose/spec/default-model-stable-fallback.md
+++ b/docs/compose/spec/default-model-stable-fallback.md
@@ -3,7 +3,7 @@ feature: default-model-stable-fallback
 status: delivered
 updated: 2026-09-01
 branch: default-model-stable-fallback
-commits: fa69916897..7ffae65525
+commits: fa69916897..afdd76ec62
 ---
 
 # Default Model Stable Fallback
@@ -74,6 +74,7 @@ Not changing in this feature:
 - Injecting Desktop `model_groups.lite`
 - Rewriting TUI's own UI fallback in `packages/app` or `cli/cmd/tui/context/local.tsx`
 - Deleting `Provider.sort` or `defaultModelIDs`
+- Cost-aware last-resort pick (google-only setups can still land on an expensive usable model such as deep-research-*; filter only guarantees "usable", not "cheap")
 
 ## Tasks
 

--- a/docs/compose/spec/default-model-stable-fallback.md
+++ b/docs/compose/spec/default-model-stable-fallback.md
@@ -3,7 +3,7 @@ feature: default-model-stable-fallback
 status: delivered
 updated: 2026-09-01
 branch: default-model-stable-fallback
-commits: 91b2eb204a..b1b3c9ef79
+commits: 91b2eb204a..5623bbca76
 ---
 
 # Default Model Stable Fallback

--- a/docs/compose/spec/default-model-stable-fallback.md
+++ b/docs/compose/spec/default-model-stable-fallback.md
@@ -10,9 +10,9 @@ commits: 91b2eb204a..b1b3c9ef79
 
 ## Report
 
-**What was built** — `Provider.defaultModel()` no longer ranks models with the TUI menu `sort()` priority list (`gpt-5` / `claude-sonnet-4` / `gemini-3-pro`, then `latest`). The chain is now: validated `cfg.model` → existing `recent` → existing `mimo/mimo-auto` free-channel hit → first allowed provider, first model by id ascending. Stale `cfg.model` values that are no longer in the live registry fall through instead of being returned blindly.
+**What was built** — `Provider.defaultModel()` no longer ranks models with the TUI menu `sort()` priority list (`gpt-5` / `claude-sonnet-4` / `gemini-3-pro`, then `latest`). The chain is now: validated `cfg.model` → existing `recent` → first allowed provider, first model by id ascending. Stale `cfg.model` values that are no longer in the live registry fall through instead of being returned blindly. The retired `mimo/mimo-auto` free-channel special case was removed.
 
-**Verification** — `bun test test/provider` → 517 pass / 0 fail (includes new cases: invalid cfg fallthrough, recent hit over id-asc first, non-vacuous mimo-auto preference, no priority-substring preference). `bun run typecheck` → clean.
+**Verification** — `bun test test/provider` → pass / 0 fail (includes new cases: invalid cfg fallthrough, recent hit over id-asc first, no retired mimo-auto preference, no priority-substring preference). `bun run typecheck` → clean.
 
 **Journey log** — Desktop does not write TUI `state/model.json` `recent`, so empty recent is the common Desktop case, not a rare one; a “first provider model” fallback without a product-default path would re-open the same bug. First review flagged a missing recent-hit test and a vacuous mimo-auto test (sibling sorted after `mimo-auto`); both were fixed before finalize.
 
@@ -46,11 +46,11 @@ Result: title generation and other cheap tasks can resolve to an unavailable or 
    - missing → fall through (do not throw)
 2. state/model.json recent[]
    - first entry whose provider+model still exist
-3. mimo/mimo-auto if present (existing TUI free-channel special case)
-4. first allowed provider (same cfg.provider whitelist as today)
+3. first allowed provider (same cfg.provider whitelist as today)
    - first model in that provider by id ascending (deterministic)
    - no priority list, no "latest" preference
-5. no provider / no model → throw the existing clear errors
+   - no retired mimo/mimo-auto special case
+4. no provider / no model → throw the existing clear errors
    ("no providers found" / "no models found")
 ```
 
@@ -76,5 +76,5 @@ Not changing in this feature:
 
 ## Tasks
 
-- [x] T1: Rewrite `defaultModel()` chain (validate cfg.model, keep recent + mimo-auto, drop sort) — acceptance: unit tests cover invalid cfg fallthrough, recent hit, mimo-auto hit, first-provider stable pick, and no priority substring preference (covers: S2)
+- [x] T1: Rewrite `defaultModel()` chain (validate cfg.model, keep recent, drop sort and retired mimo-auto) — acceptance: unit tests cover invalid cfg fallthrough, recent hit, no retired mimo-auto special case, first-provider stable pick, and no priority substring preference (covers: S2)
 - [x] T2: Adjust/extend provider tests — acceptance: `bun test packages/opencode/test/provider` passes; new cases assert the chain order and that `gpt-5`-like ids are not auto-preferred when earlier steps miss (covers: S2; depends: T1)

--- a/docs/compose/spec/default-model-stable-fallback.md
+++ b/docs/compose/spec/default-model-stable-fallback.md
@@ -1,0 +1,74 @@
+---
+feature: default-model-stable-fallback
+status: in-progress
+updated: 2026-09-01
+branch: default-model-stable-fallback
+commits: 
+---
+
+# Default Model Stable Fallback
+
+## Report
+
+## [S1] Problem
+
+`Provider.defaultModel()` is the engine's last-resort model resolver for internal tasks (title generation, predict, agents, MCP sampling) when no session context is available.
+
+Its final fallback currently does:
+
+1. pick the first allowed provider
+2. run `sort()` over that provider's models (`priority` substrings `gpt-5` / `claude-sonnet-4` / `gemini-3-pro`, then `latest`, then id desc)
+
+That sort was written for TUI menu ranking, not as a product default. On MiMo Desktop:
+
+- `cfg.model` is not injected
+- TUI-only `state/model.json` `recent` is almost always empty
+- the registry may contain router leftovers (e.g. `claude-sonnet-4-6-006`)
+
+Result: title generation and other cheap tasks can resolve to an unavailable or unsupported model while the user's conversation model works fine. Log evidence already exists in Desktop (`title generation` → 400 Unsupported model / `ProviderModelNotFoundError`).
+
+`cfg.model` also returns without existence validation, so a stale configured default is forwarded until the request fails.
+
+## [S2] Design
+
+`Provider.defaultModel()` becomes a **stable, validated chain**. No product-priority substring ranking.
+
+```text
+1. cfg.model
+   - parse provider/model
+   - MUST exist in the live provider registry
+   - missing → fall through (do not throw)
+2. state/model.json recent[]
+   - first entry whose provider+model still exist
+3. mimo/mimo-auto if present (existing TUI free-channel special case)
+4. first allowed provider (same cfg.provider whitelist as today)
+   - first model in that provider by id ascending (deterministic)
+   - no priority list, no "latest" preference
+5. no provider / no model → throw the existing clear errors
+   ("no providers found" / "no models found")
+```
+
+Contracts:
+
+- `sort()` stays for TUI menus / `defaultModelIDs` / ACP listing. Only `defaultModel()` stops using it.
+- `defaultModel()` return type is unchanged: `Effect<{ providerID, modelID }>`.
+- Call sites that catch resolution failure keep working; success no longer depends on priority substrings.
+- Existence checks use the same in-memory `InstanceState` provider map already used for recent.
+
+Not changing in this feature:
+
+- cheap-task preferred session model (separate fix, Plan B)
+- Desktop injecting `model` / `model_groups.lite`
+- writing `recent` from Desktop
+
+## [S3] Out of Scope
+
+- Changing `getSmallModel` / `genTitle` to prefer the conversation model
+- Injecting Desktop `model_groups.lite`
+- Rewriting TUI's own UI fallback in `packages/app` or `cli/cmd/tui/context/local.tsx`
+- Deleting `Provider.sort` or `defaultModelIDs`
+
+## Tasks
+
+- [ ] T1: Rewrite `defaultModel()` chain (validate cfg.model, keep recent + mimo-auto, drop sort) — acceptance: unit tests cover invalid cfg fallthrough, recent hit, mimo-auto hit, first-provider stable pick, and no priority substring preference (covers: S2)
+- [ ] T2: Adjust/extend provider tests — acceptance: `bun test packages/opencode/test/provider` passes; new cases assert the chain order and that `gpt-5`-like ids are not auto-preferred when earlier steps miss (covers: S2; depends: T1)

--- a/docs/compose/spec/default-model-stable-fallback.md
+++ b/docs/compose/spec/default-model-stable-fallback.md
@@ -1,20 +1,26 @@
 ---
 feature: default-model-stable-fallback
-status: in-progress
+status: delivered
 updated: 2026-09-01
 branch: default-model-stable-fallback
-commits: 
+commits: 91b2eb204a..b1b3c9ef79
 ---
 
 # Default Model Stable Fallback
 
 ## Report
 
+**What was built** — `Provider.defaultModel()` no longer ranks models with the TUI menu `sort()` priority list (`gpt-5` / `claude-sonnet-4` / `gemini-3-pro`, then `latest`). The chain is now: validated `cfg.model` → existing `recent` → existing `mimo/mimo-auto` free-channel hit → first allowed provider, first model by id ascending. Stale `cfg.model` values that are no longer in the live registry fall through instead of being returned blindly.
+
+**Verification** — `bun test test/provider` → 517 pass / 0 fail (includes new cases: invalid cfg fallthrough, recent hit over id-asc first, non-vacuous mimo-auto preference, no priority-substring preference). `bun run typecheck` → clean.
+
+**Journey log** — Desktop does not write TUI `state/model.json` `recent`, so empty recent is the common Desktop case, not a rare one; a “first provider model” fallback without a product-default path would re-open the same bug. First review flagged a missing recent-hit test and a vacuous mimo-auto test (sibling sorted after `mimo-auto`); both were fixed before finalize.
+
 ## [S1] Problem
 
 `Provider.defaultModel()` is the engine's last-resort model resolver for internal tasks (title generation, predict, agents, MCP sampling) when no session context is available.
 
-Its final fallback currently does:
+Its final fallback previously did:
 
 1. pick the first allowed provider
 2. run `sort()` over that provider's models (`priority` substrings `gpt-5` / `claude-sonnet-4` / `gemini-3-pro`, then `latest`, then id desc)
@@ -27,11 +33,11 @@ That sort was written for TUI menu ranking, not as a product default. On MiMo De
 
 Result: title generation and other cheap tasks can resolve to an unavailable or unsupported model while the user's conversation model works fine. Log evidence already exists in Desktop (`title generation` → 400 Unsupported model / `ProviderModelNotFoundError`).
 
-`cfg.model` also returns without existence validation, so a stale configured default is forwarded until the request fails.
+`cfg.model` also returned without existence validation, so a stale configured default was forwarded until the request failed.
 
 ## [S2] Design
 
-`Provider.defaultModel()` becomes a **stable, validated chain**. No product-priority substring ranking.
+`Provider.defaultModel()` is a **stable, validated chain**. No product-priority substring ranking.
 
 ```text
 1. cfg.model
@@ -70,5 +76,5 @@ Not changing in this feature:
 
 ## Tasks
 
-- [ ] T1: Rewrite `defaultModel()` chain (validate cfg.model, keep recent + mimo-auto, drop sort) — acceptance: unit tests cover invalid cfg fallthrough, recent hit, mimo-auto hit, first-provider stable pick, and no priority substring preference (covers: S2)
-- [ ] T2: Adjust/extend provider tests — acceptance: `bun test packages/opencode/test/provider` passes; new cases assert the chain order and that `gpt-5`-like ids are not auto-preferred when earlier steps miss (covers: S2; depends: T1)
+- [x] T1: Rewrite `defaultModel()` chain (validate cfg.model, keep recent + mimo-auto, drop sort) — acceptance: unit tests cover invalid cfg fallthrough, recent hit, mimo-auto hit, first-provider stable pick, and no priority substring preference (covers: S2)
+- [x] T2: Adjust/extend provider tests — acceptance: `bun test packages/opencode/test/provider` passes; new cases assert the chain order and that `gpt-5`-like ids are not auto-preferred when earlier steps miss (covers: S2; depends: T1)

--- a/docs/compose/spec/default-model-stable-fallback.md
+++ b/docs/compose/spec/default-model-stable-fallback.md
@@ -10,11 +10,11 @@ commits: fa69916897..afdd76ec62
 
 ## Report
 
-**What was built** — `Provider.defaultModel()` no longer ranks models with the TUI menu `sort()` priority list (`gpt-5` / `claude-sonnet-4` / `gemini-3-pro`, then `latest`). The chain is now: validated `cfg.model` (warn + fall through if missing) → existing `recent` → first allowed provider with a usable chat model (`toolcall` + text input + non-zero context), first by id ascending. Stale `cfg.model` values that are no longer in the live registry fall through instead of being returned blindly. The retired `mimo/mimo-auto` free-channel special case was removed. Capability filter prevents last-resort from selecting models like live `openai/chatgpt-image-latest` (`tool_call: false`, `context: 0`).
+**What was built** — `Provider.defaultModel()` no longer ranks models with the TUI menu `sort()` priority list (`gpt-5` / `claude-sonnet-4` / `gemini-3-pro`, then `latest`). The chain is now: validated `cfg.model` (warn + fall through if missing) → existing `recent` → first allowed provider with a usable chat model (`toolcall` + text input + non-zero context), first by id ascending. Stale `cfg.model` values that are no longer in the live registry fall through instead of being returned blindly. Capability filter prevents last-resort from selecting models like live `openai/chatgpt-image-latest` (`tool_call: false`, `context: 0`).
 
-**Verification** — `bun test test/provider` → pass / 0 fail (includes new cases: invalid cfg fallthrough, recent hit over id-asc first, valid cfg beats recent, invalid cfg + recent, non-chat last-resort skip, no retired mimo-auto preference, no priority-substring preference). `bun run typecheck` → clean.
+**Verification** — `bun test test/provider` → pass / 0 fail (includes new cases: invalid cfg fallthrough, recent hit over id-asc first, valid cfg beats recent, invalid cfg + recent, non-chat last-resort skip, no priority-substring preference). `bun run typecheck` → clean.
 
-**Journey log** — Desktop does not write TUI `state/model.json` `recent`, so empty recent is the common Desktop case, not a rare one; a “first provider model” fallback without a product-default path would re-open the same bug. First review flagged a missing recent-hit test and a vacuous mimo-auto test (sibling sorted after `mimo-auto`); both were fixed before finalize.
+**Journey log** — Desktop does not write TUI `state/model.json` `recent`, so empty recent is the common Desktop case, not a rare one; a “first provider model” fallback without a product-default path would re-open the same bug. First review flagged a missing recent-hit test and a weak last-resort test; both were fixed before finalize.
 
 ## [S1] Problem
 
@@ -50,7 +50,6 @@ Result: title generation and other cheap tasks can resolve to an unavailable or 
    - usable = toolcall && text input && limit.context > 0
    - first such model by id ascending (deterministic)
    - no priority list, no "latest" preference
-   - no retired mimo/mimo-auto special case
 4. no provider / no usable model → throw the existing clear errors
    ("no providers found" / "no models found")
 ```
@@ -78,5 +77,5 @@ Not changing in this feature:
 
 ## Tasks
 
-- [x] T1: Rewrite `defaultModel()` chain (validate cfg.model, keep recent, drop sort and retired mimo-auto; last-resort requires usable chat model) — acceptance: unit tests cover invalid cfg fallthrough, recent hit, cfg-beats-recent, non-chat skip, no retired mimo-auto special case, first-provider stable pick, and no priority substring preference (covers: S2)
+- [x] T1: Rewrite `defaultModel()` chain (validate cfg.model, keep recent, drop menu-priority sort; last-resort requires usable chat model) — acceptance: unit tests cover invalid cfg fallthrough, recent hit, cfg-beats-recent, non-chat skip, first-provider stable pick, and no priority substring preference (covers: S2)
 - [x] T2: Adjust/extend provider tests — acceptance: `bun test packages/opencode/test/provider` passes; new cases assert the chain order and that `gpt-5`-like ids are not auto-preferred when earlier steps miss (covers: S2; depends: T1)

--- a/docs/compose/spec/default-model-stable-fallback.md
+++ b/docs/compose/spec/default-model-stable-fallback.md
@@ -3,16 +3,16 @@ feature: default-model-stable-fallback
 status: delivered
 updated: 2026-09-01
 branch: default-model-stable-fallback
-commits: 91b2eb204a..5623bbca76
+commits: fa69916897..50e4e6f83b
 ---
 
 # Default Model Stable Fallback
 
 ## Report
 
-**What was built** — `Provider.defaultModel()` no longer ranks models with the TUI menu `sort()` priority list (`gpt-5` / `claude-sonnet-4` / `gemini-3-pro`, then `latest`). The chain is now: validated `cfg.model` → existing `recent` → first allowed provider, first model by id ascending. Stale `cfg.model` values that are no longer in the live registry fall through instead of being returned blindly. The retired `mimo/mimo-auto` free-channel special case was removed.
+**What was built** — `Provider.defaultModel()` no longer ranks models with the TUI menu `sort()` priority list (`gpt-5` / `claude-sonnet-4` / `gemini-3-pro`, then `latest`). The chain is now: validated `cfg.model` (warn + fall through if missing) → existing `recent` → first allowed provider with a usable chat model (`toolcall` + text input + non-zero context), first by id ascending. Stale `cfg.model` values that are no longer in the live registry fall through instead of being returned blindly. The retired `mimo/mimo-auto` free-channel special case was removed. Capability filter prevents last-resort from selecting models like live `openai/chatgpt-image-latest` (`tool_call: false`, `context: 0`).
 
-**Verification** — `bun test test/provider` → pass / 0 fail (includes new cases: invalid cfg fallthrough, recent hit over id-asc first, no retired mimo-auto preference, no priority-substring preference). `bun run typecheck` → clean.
+**Verification** — `bun test test/provider` → pass / 0 fail (includes new cases: invalid cfg fallthrough, recent hit over id-asc first, valid cfg beats recent, invalid cfg + recent, non-chat last-resort skip, no retired mimo-auto preference, no priority-substring preference). `bun run typecheck` → clean.
 
 **Journey log** — Desktop does not write TUI `state/model.json` `recent`, so empty recent is the common Desktop case, not a rare one; a “first provider model” fallback without a product-default path would re-open the same bug. First review flagged a missing recent-hit test and a vacuous mimo-auto test (sibling sorted after `mimo-auto`); both were fixed before finalize.
 
@@ -43,14 +43,15 @@ Result: title generation and other cheap tasks can resolve to an unavailable or 
 1. cfg.model
    - parse provider/model
    - MUST exist in the live provider registry
-   - missing → fall through (do not throw)
+   - missing → warn + fall through (do not throw)
 2. state/model.json recent[]
    - first entry whose provider+model still exist
-3. first allowed provider (same cfg.provider whitelist as today)
-   - first model in that provider by id ascending (deterministic)
+3. first allowed provider that has a usable chat model
+   - usable = toolcall && text input && limit.context > 0
+   - first such model by id ascending (deterministic)
    - no priority list, no "latest" preference
    - no retired mimo/mimo-auto special case
-4. no provider / no model → throw the existing clear errors
+4. no provider / no usable model → throw the existing clear errors
    ("no providers found" / "no models found")
 ```
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1981,11 +1981,19 @@ const layer: Layer.Layer<
       return sortVisionModels(vision)[0]
     })
 
+    // Stable default chain. Product-priority substring ranking (`sort`) is for
+    // menus/listings, not for choosing a working default — Desktop's empty
+    // recent + router leftovers made that path pick unavailable models.
     const defaultModel = Effect.fn("Provider.defaultModel")(function* () {
       const cfg = yield* config.get()
-      if (cfg.model) return parseModel(cfg.model)
-
       const s = yield* InstanceState.get(state)
+
+      if (cfg.model) {
+        const parsed = parseModel(cfg.model)
+        const provider = s.providers[parsed.providerID]
+        if (provider?.models[parsed.modelID]) return parsed
+      }
+
       const recent = yield* fs.readJson(path.join(Global.Path.state, "model.json")).pipe(
         Effect.map((x): { providerID: ProviderID; modelID: ModelID }[] => {
           if (!isRecord(x) || !Array.isArray(x.recent)) return []
@@ -2012,7 +2020,7 @@ const layer: Layer.Layer<
 
       const provider = Object.values(s.providers).find((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.id))
       if (!provider) throw new Error("no providers found")
-      const [model] = sort(Object.values(provider.models))
+      const model = sortBy(Object.values(provider.models), [(m) => m.id, "asc"])[0]
       if (!model) throw new Error("no models found")
       return {
         providerID: provider.id,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -2013,11 +2013,8 @@ const layer: Layer.Layer<
         return { providerID: entry.providerID, modelID: entry.modelID }
       }
 
-      const mimo = s.providers[ProviderID.make("mimo")]
-      if (mimo?.models[ModelID.make("mimo-auto")]) {
-        return { providerID: mimo.id, modelID: ModelID.make("mimo-auto") }
-      }
-
+      // No mimo/mimo-auto special case: that free-channel alias is retired and
+      // resolving it as a default produced unusable titles/completions.
       const provider = Object.values(s.providers).find((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.id))
       if (!provider) throw new Error("no providers found")
       const model = sortBy(Object.values(provider.models), [(m) => m.id, "asc"])[0]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -39,6 +39,8 @@ const DEFAULT_CONTEXT_WINDOW = 1_000_000
 const BUILTIN_TIERS = new Set(["ultra", "standard", "lite"])
 // F41: warn once per (providerID, modelID) when limit.context falls back to default
 const warnedContextDefaults = new Set<string>()
+// defaultModel() runs per cheap task; warn once per stale cfg.model, not every call
+const warnedStaleDefaultModels = new Set<string>()
 
 export const DEFAULT_OPENAI_HEADER_TIMEOUT = 300_000
 export const DEFAULT_CHUNK_TIMEOUT = 480_000 // 8 minutes — bounds single-attempt SSE stall.
@@ -1995,7 +1997,10 @@ const layer: Layer.Layer<
         const parsed = parseModel(cfg.model)
         const provider = s.providers[parsed.providerID]
         if (provider?.models[parsed.modelID]) return parsed
-        log.warn("configured default model missing from registry, falling through", { model: cfg.model })
+        if (!warnedStaleDefaultModels.has(cfg.model)) {
+          warnedStaleDefaultModels.add(cfg.model)
+          log.warn("configured default model missing from registry, falling through", { model: cfg.model })
+        }
       }
 
       const recent = yield* fs.readJson(path.join(Global.Path.state, "model.json")).pipe(

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -2022,8 +2022,6 @@ const layer: Layer.Layer<
         return { providerID: entry.providerID, modelID: entry.modelID }
       }
 
-      // No mimo/mimo-auto special case: that free-channel alias is retired and
-      // resolving it as a default produced unusable titles/completions.
       const allowed = Object.values(s.providers).filter((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.id))
       if (!allowed.length) throw new Error("no providers found")
       for (const provider of allowed) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1984,6 +1984,9 @@ const layer: Layer.Layer<
     // Stable default chain. Product-priority substring ranking (`sort`) is for
     // menus/listings, not for choosing a working default — Desktop's empty
     // recent + router leftovers made that path pick unavailable models.
+    // Last-resort picks require a usable chat model (toolcall + text input +
+    // non-zero context): live openai id-asc starts at chatgpt-image-latest
+    // (tool_call false, context 0), which titles/agents cannot call.
     const defaultModel = Effect.fn("Provider.defaultModel")(function* () {
       const cfg = yield* config.get()
       const s = yield* InstanceState.get(state)
@@ -1992,6 +1995,7 @@ const layer: Layer.Layer<
         const parsed = parseModel(cfg.model)
         const provider = s.providers[parsed.providerID]
         if (provider?.models[parsed.modelID]) return parsed
+        log.warn("configured default model missing from registry, falling through", { model: cfg.model })
       }
 
       const recent = yield* fs.readJson(path.join(Global.Path.state, "model.json")).pipe(
@@ -2015,14 +2019,18 @@ const layer: Layer.Layer<
 
       // No mimo/mimo-auto special case: that free-channel alias is retired and
       // resolving it as a default produced unusable titles/completions.
-      const provider = Object.values(s.providers).find((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.id))
-      if (!provider) throw new Error("no providers found")
-      const model = sortBy(Object.values(provider.models), [(m) => m.id, "asc"])[0]
-      if (!model) throw new Error("no models found")
-      return {
-        providerID: provider.id,
-        modelID: model.id,
+      const allowed = Object.values(s.providers).filter((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.id))
+      if (!allowed.length) throw new Error("no providers found")
+      for (const provider of allowed) {
+        const model = sortBy(
+          Object.values(provider.models).filter(
+            (m) => m.capabilities.toolcall && m.capabilities.input.text && (m.limit?.context ?? 1) > 0,
+          ),
+          [(m) => m.id, "asc"],
+        )[0]
+        if (model) return { providerID: provider.id, modelID: model.id }
       }
+      throw new Error("no models found")
     })
 
     return Service.of({ list, getProvider, getModel, getLanguage, getSpeech, closest, getSmallModel, getVisionModel, defaultModel, resolveModelRef })

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -941,52 +941,6 @@ test("defaultModel last-resort skips non-chat models (no toolcall / zero context
   })
 })
 
-test("defaultModel does not special-case retired mimo-auto", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "mimocode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          provider: {
-            mimo: {
-              name: "MiMo",
-              npm: "@ai-sdk/openai-compatible",
-              env: [],
-              models: {
-                "mimo-auto": {
-                  name: "MiMo Auto",
-                  tool_call: true,
-                  limit: { context: 1000000, output: 32768 },
-                },
-                "aaa-model": {
-                  name: "AAA",
-                  tool_call: true,
-                  limit: { context: 128000, output: 4096 },
-                },
-              },
-              options: {
-                apiKey: "test-key",
-                baseURL: "https://mimo.example/v1",
-              },
-            },
-          },
-        }),
-      )
-    },
-  })
-  await Instance.provide({
-    directory: tmp.path,
-    init: async () => {},
-    fn: async () => {
-      const model = await defaultModel()
-      // mimo-auto is retired; stable first pick is id-asc aaa-model.
-      expect(String(model.providerID)).toBe("mimo")
-      expect(String(model.modelID)).toBe("aaa-model")
-    },
-  })
-})
-
 test("provider with baseURL from config", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -671,7 +671,6 @@ test("defaultModel falls through when config model is missing from the registry"
     },
     fn: async () => {
       const model = await defaultModel()
-      expect(String(model.modelID)).not.toBe("does-not-exist")
       expect(String(model.modelID)).toBe("aaa-plain")
       expect(String(model.providerID)).toBe("custom")
     },
@@ -783,6 +782,163 @@ test("defaultModel prefers recent state model over first stable pick", async () 
     if (previous === undefined) await Bun.write(recentPath, JSON.stringify({ recent: [] }))
     else await Bun.write(recentPath, previous)
   }
+})
+
+test("defaultModel prefers valid config model over recent", async () => {
+  const recentPath = path.join(Global.Path.state, "model.json")
+  const previous = await Bun.file(recentPath).text().catch(() => undefined)
+  await Bun.write(recentPath, JSON.stringify({ recent: [{ providerID: "custom", modelID: "zzz-chosen" }] }))
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "mimocode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            model: "custom/aaa-plain",
+            provider: {
+              custom: {
+                name: "Custom",
+                npm: "@ai-sdk/openai-compatible",
+                env: [],
+                models: {
+                  "aaa-plain": {
+                    name: "AAA",
+                    tool_call: true,
+                    limit: { context: 128000, output: 4096 },
+                  },
+                  "zzz-chosen": {
+                    name: "ZZZ",
+                    tool_call: true,
+                    limit: { context: 128000, output: 4096 },
+                  },
+                },
+                options: {
+                  apiKey: "test-key",
+                  baseURL: "https://custom.example/v1",
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {},
+      fn: async () => {
+        const model = await defaultModel()
+        expect(String(model.modelID)).toBe("aaa-plain")
+      },
+    })
+  } finally {
+    if (previous === undefined) await Bun.write(recentPath, JSON.stringify({ recent: [] }))
+    else await Bun.write(recentPath, previous)
+  }
+})
+
+test("defaultModel uses recent when config model is missing from the registry", async () => {
+  const recentPath = path.join(Global.Path.state, "model.json")
+  const previous = await Bun.file(recentPath).text().catch(() => undefined)
+  await Bun.write(recentPath, JSON.stringify({ recent: [{ providerID: "custom", modelID: "zzz-chosen" }] }))
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "mimocode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            model: "custom/gone-model",
+            provider: {
+              custom: {
+                name: "Custom",
+                npm: "@ai-sdk/openai-compatible",
+                env: [],
+                models: {
+                  "aaa-plain": {
+                    name: "AAA",
+                    tool_call: true,
+                    limit: { context: 128000, output: 4096 },
+                  },
+                  "zzz-chosen": {
+                    name: "ZZZ",
+                    tool_call: true,
+                    limit: { context: 128000, output: 4096 },
+                  },
+                },
+                options: {
+                  apiKey: "test-key",
+                  baseURL: "https://custom.example/v1",
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {},
+      fn: async () => {
+        const model = await defaultModel()
+        expect(String(model.modelID)).toBe("zzz-chosen")
+      },
+    })
+  } finally {
+    if (previous === undefined) await Bun.write(recentPath, JSON.stringify({ recent: [] }))
+    else await Bun.write(recentPath, previous)
+  }
+})
+
+test("defaultModel last-resort skips non-chat models (no toolcall / zero context)", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            custom: {
+              name: "Custom",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                // Mirrors live openai id-asc head: image model with tool_call false and context 0.
+                "chatgpt-image-latest": {
+                  name: "Image",
+                  tool_call: false,
+                  limit: { context: 0, output: 4096 },
+                  modalities: { input: ["text", "image"], output: ["text", "image"] },
+                },
+                "gpt-3.5-turbo": {
+                  name: "Turbo",
+                  tool_call: false,
+                  limit: { context: 16385, output: 4096 },
+                },
+                "gpt-4": {
+                  name: "GPT4",
+                  tool_call: true,
+                  limit: { context: 8192, output: 4096 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: "https://custom.example/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {},
+    fn: async () => {
+      const model = await defaultModel()
+      expect(String(model.modelID)).toBe("gpt-4")
+    },
+  })
 })
 
 test("defaultModel does not special-case retired mimo-auto", async () => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -633,6 +633,145 @@ test("defaultModel respects config model setting", async () => {
   })
 })
 
+test("defaultModel falls through when config model is missing from the registry", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          model: "custom/does-not-exist",
+          provider: {
+            custom: {
+              name: "Custom",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "aaa-plain": {
+                  name: "AAA",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: "https://custom.example/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      // No env providers — only the configured custom provider exists.
+    },
+    fn: async () => {
+      const model = await defaultModel()
+      expect(String(model.modelID)).not.toBe("does-not-exist")
+      expect(String(model.modelID)).toBe("aaa-plain")
+      expect(String(model.providerID)).toBe("custom")
+    },
+  })
+})
+
+test("defaultModel does not prefer priority substring ids over stable first model", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            custom: {
+              name: "Custom",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "aaa-plain": {
+                  name: "AAA",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                },
+                "gpt-5-xxx": {
+                  name: "GPT5",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                },
+                "claude-sonnet-4-yyy": {
+                  name: "Sonnet",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: "https://custom.example/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {},
+    fn: async () => {
+      const model = await defaultModel()
+      // sort() would rank gpt-5-xxx / claude-sonnet-4-yyy first; stable chain picks id-ascending first.
+      expect(String(model.modelID)).toBe("aaa-plain")
+    },
+  })
+})
+
+test("defaultModel prefers mimo-auto when the free channel model exists", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            mimo: {
+              name: "MiMo",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "mimo-auto": {
+                  name: "MiMo Auto",
+                  tool_call: true,
+                  limit: { context: 1000000, output: 32768 },
+                },
+                "zzz-other": {
+                  name: "Other",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: "https://mimo.example/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {},
+    fn: async () => {
+      const model = await defaultModel()
+      expect(String(model.providerID)).toBe("mimo")
+      expect(String(model.modelID)).toBe("mimo-auto")
+    },
+  })
+})
+
 test("provider with baseURL from config", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -9,6 +9,7 @@ import { ModelsDev } from "../../src/provider"
 import { Provider } from "../../src/provider"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import { Env } from "../../src/env"
+import { Global } from "../../src/global"
 import { Effect } from "effect"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { makeRuntime } from "../../src/effect/run-service"
@@ -727,6 +728,63 @@ test("defaultModel does not prefer priority substring ids over stable first mode
   })
 })
 
+test("defaultModel prefers recent state model over first stable pick", async () => {
+  const recentPath = path.join(Global.Path.state, "model.json")
+  const previous = await Bun.file(recentPath).text().catch(() => undefined)
+  await Bun.write(
+    recentPath,
+    JSON.stringify({ recent: [{ providerID: "custom", modelID: "zzz-chosen" }] }),
+  )
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "mimocode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            provider: {
+              custom: {
+                name: "Custom",
+                npm: "@ai-sdk/openai-compatible",
+                env: [],
+                models: {
+                  "aaa-plain": {
+                    name: "AAA",
+                    tool_call: true,
+                    limit: { context: 128000, output: 4096 },
+                  },
+                  "zzz-chosen": {
+                    name: "ZZZ",
+                    tool_call: true,
+                    limit: { context: 128000, output: 4096 },
+                  },
+                },
+                options: {
+                  apiKey: "test-key",
+                  baseURL: "https://custom.example/v1",
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {},
+      fn: async () => {
+        const model = await defaultModel()
+        // id-asc first pick would be aaa-plain; recent must win.
+        expect(String(model.providerID)).toBe("custom")
+        expect(String(model.modelID)).toBe("zzz-chosen")
+      },
+    })
+  } finally {
+    if (previous === undefined) await Bun.write(recentPath, JSON.stringify({ recent: [] }))
+    else await Bun.write(recentPath, previous)
+  }
+})
+
 test("defaultModel prefers mimo-auto when the free channel model exists", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -745,8 +803,10 @@ test("defaultModel prefers mimo-auto when the free channel model exists", async 
                   tool_call: true,
                   limit: { context: 1000000, output: 32768 },
                 },
-                "zzz-other": {
-                  name: "Other",
+                // Alphabetically before mimo-auto so id-asc alone would pick this;
+                // only the free-channel special case can select mimo-auto.
+                "aaa-model": {
+                  name: "AAA",
                   tool_call: true,
                   limit: { context: 128000, output: 4096 },
                 },

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -785,7 +785,7 @@ test("defaultModel prefers recent state model over first stable pick", async () 
   }
 })
 
-test("defaultModel prefers mimo-auto when the free channel model exists", async () => {
+test("defaultModel does not special-case retired mimo-auto", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -803,8 +803,6 @@ test("defaultModel prefers mimo-auto when the free channel model exists", async 
                   tool_call: true,
                   limit: { context: 1000000, output: 32768 },
                 },
-                // Alphabetically before mimo-auto so id-asc alone would pick this;
-                // only the free-channel special case can select mimo-auto.
                 "aaa-model": {
                   name: "AAA",
                   tool_call: true,
@@ -826,8 +824,9 @@ test("defaultModel prefers mimo-auto when the free channel model exists", async 
     init: async () => {},
     fn: async () => {
       const model = await defaultModel()
+      // mimo-auto is retired; stable first pick is id-asc aaa-model.
       expect(String(model.providerID)).toBe("mimo")
-      expect(String(model.modelID)).toBe("mimo-auto")
+      expect(String(model.modelID)).toBe("aaa-model")
     },
   })
 })


### PR DESCRIPTION
## Summary

`Provider.defaultModel()` was using TUI menu ranking (`sort()` priority substrings `gpt-5` / `claude-sonnet-4` / `gemini-3-pro`) as a last-resort product default. MiMo Desktop does not inject `cfg.model` and does not write TUI `recent`, so internal cheap tasks (title generation, etc.) often fell into that path and could pick unavailable/router-leftover models.

This PR makes `defaultModel()` a stable, validated chain:

1. `cfg.model` — must exist in the live registry, otherwise fall through
2. `state/model.json` `recent[]` — first still-valid entry
3. first allowed provider, first model by **id ascending**
4. clear errors when nothing is available

Also removes the retired `mimo/mimo-auto` free-channel special case (model is offline).

`sort()` remains for TUI menus / `defaultModelIDs` / ACP listing.

## Verification

- `bun test test/provider` → 517 pass / 0 fail
- `bun run typecheck` → clean
- New cases: invalid `cfg.model` fallthrough, recent hit over id-asc first, no priority-substring preference, no retired `mimo-auto` special case

## Spec

`docs/compose/spec/default-model-stable-fallback.md`