### PR TITLE
fix(compose-next): require spec to land in the worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The `/goal` command sets a stopping condition for a session. When the agent trie
 
 Compose is MiMoCode's structured workflow for specs-driven development, orchestrating the full lifecycle from spec to shipped code.
 
-The recommended way to use it is the **`/compose-next`** skill on the **build** agent: a single self-contained contract covering grill → spec → workspace → implement → verify → review → finalize → finish, with feature documents at `docs/compose/spec/<feature>.md`. It is designed for frontier models (Fable/Sol-class), which internalize most of the workflow and work best from one compact contract.
+The recommended way to use it is the **`/compose-next`** skill on the **build** agent: a single self-contained contract covering grill → workspace → spec → implement → verify → review → finalize → finish, with feature documents at `docs/compose/spec/<feature>.md` under the workspace root. It is designed for frontier models (Fable/Sol-class), which internalize most of the workflow and work best from one compact contract.
 
 The legacy path is the dedicated **compose agent** (switch with `Tab`), which orchestrates fourteen built-in skills for planning, execution, code review, TDD, debugging, verification, and merging — a step-by-step curriculum that remains useful for weaker models.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -187,7 +187,7 @@ mimo attach http://127.0.0.1:4096
 
 Compose 是 MiMoCode 的 specs-driven 结构化开发流程，编排从 spec 到交付的完整开发生命周期。
 
-推荐用法是在 **build** agent 中使用 **`/compose-next`** 技能：一份独立完整的契约，覆盖 grill → spec → workspace → implement → verify → review → finalize → finish，功能文档落在 `docs/compose/spec/<feature>.md`。它面向前沿模型（Fable/Sol 级）设计——这类模型已内化大部分流程，用一份紧凑契约效果最好。
+推荐用法是在 **build** agent 中使用 **`/compose-next`** 技能：一份独立完整的契约，覆盖 grill → workspace → spec → implement → verify → review → finalize → finish，功能文档落在 workspace root 下的 `docs/compose/spec/<feature>.md`。它面向前沿模型（Fable/Sol 级）设计——这类模型已内化大部分流程，用一份紧凑契约效果最好。
 
 Legacy 路径是专用的 **compose agent**（按 `Tab` 切换），它编排规划、执行、代码审查、TDD、调试、验证、合并等十四个内置技能——这套分步技能课程对较弱模型依然适用。
 

--- a/docs/compose/spec/compose-next.md
+++ b/docs/compose/spec/compose-next.md
@@ -1,7 +1,7 @@
 ---
 feature: compose-next
 status: delivered
-updated: 2026-07-22
+updated: 2026-09-01
 branch: compose-next
 commits: 8e2817cfddb35ba19fcea221b6567966890dfc87..42613223d00eec340651b632aacfcac01677f795
 predecessor: compose-slim (draft PR #1850)
@@ -33,7 +33,7 @@ autocomplete, the deprecation touchpoints, and the i18n keys — is unchanged.
 
 ## Report
 
-**What was built** - One self-contained builtin skill `compose-next` (grill → spec → workspace → implement → verify → review → finalize → finish), invoked from Build as `/compose-next`. Hidden from model auto-discovery via an exact `"compose-next": "deny"` default-agent skill permission plus `skill_search` sourcing from `Skill.available(agent)`; still present in `Skill.all()` so slash autocomplete works. Legacy Compose is untouched functionally and marked deprecated through three additive touchpoints: agent description line, `Compose (legacy)` input-bar label, and a compose-only home-tip display override. Side fix: tips now render for first-time users (first-session gate removed).
+**What was built** - One self-contained builtin skill `compose-next` (grill → workspace → spec → implement → verify → review → finalize → finish), invoked from Build as `/compose-next`. Hidden from model auto-discovery via an exact `"compose-next": "deny"` default-agent skill permission plus `skill_search` sourcing from `Skill.available(agent)`; still present in `Skill.all()` so slash autocomplete works. Legacy Compose is untouched functionally and marked deprecated through three additive touchpoints: agent description line, `Compose (legacy)` input-bar label, and a compose-only home-tip display override. Side fix: tips now render for first-time users (first-session gate removed).
 
 **Verification** - From `packages/opencode`: `bun test test/skill test/permission test/tool/skill-search.test.ts` — 230 pass / 0 fail / 555 assertions. `bun typecheck` — PASS. `git diff --check` — PASS. CI (lint, typecheck, unit shards 1-4) — all green on PR #1861.
 
@@ -68,13 +68,13 @@ Canonical name: `compose-next`. Bundle root: builtin. Not prefixed with `compose
 The skill body is a single executable contract, in this order:
 
 1. **Grill** - resolve genuine user decisions (question tool with concrete options); apply Never-Ask to a single decision only; do not batch later decisions under one grant.
-2. **Spec** - create or amend a feature document at `docs/compose/spec/<feature>.md` when the work warrants one; keep design, tasks, and delivery report in that one document. The path is fixed in the skill text; no `<compose_docs_dir>` prompt injection is involved (that block only exists for the Compose agent and `compose.js`, neither of which is in the `/compose-next` path).
-3. **Workspace** - own a worktree before implementation on every path (linked worktree under `.worktrees/` by default); never start on `main`/`master` without explicit consent.
-4. **Implement** - proceed in dependency order; use test-first where applicable; do not spawn parallel edits into the same worktree.
+2. **Workspace** - own the active workspace before Spec or Implement on every path (linked worktree under `.worktrees/` by default; skip creation when the workspace is already chosen); never start on `main`/`master` without explicit consent.
+3. **Spec** - create or amend a feature document at `docs/compose/spec/<feature>.md` from the workspace root when the work warrants one; keep design, tasks, and delivery report in that one document. Do not write the feature document before Workspace owns the active workspace. The path is fixed in the skill text; no `<compose_docs_dir>` prompt injection is involved (that block only exists for the Compose agent and `compose.js`, neither of which is in the `/compose-next` path).
+4. **Implement** - proceed in dependency order; use test-first where applicable; do not spawn parallel edits into the same workspace.
 5. **Verify** - run verification and produce a compact PASS/FAIL/PRE-EXISTING summary; verification must complete before review is dispatched.
-6. **Review** - dispatch one fresh reviewer with spec path, worktree path, base/head SHAs, diff coordinates, and the compact verification summary; the reviewer reuses that summary rather than duplicating heavy E2E commands without cause.
-7. **Finalize** - update the feature document (report, journey log, verification evidence) before branch completion.
-8. **Finish** - explicit merge / PR / keep-branch / discard, with worktree ownership stated; destructive actions never auto-approve.
+6. **Review** - dispatch one fresh reviewer with spec path, workspace path, base/head SHAs, diff coordinates, and the compact verification summary; the reviewer reuses that summary rather than duplicating heavy E2E commands without cause. If there is no feature document, take acceptance criteria from the conversation or ask the user before dispatching.
+7. **Finalize** - if a feature document exists, update it (report, journey log, verification evidence) before branch completion.
+8. **Finish** - explicit merge / PR / keep-branch / discard, with workspace ownership stated; destructive actions never auto-approve.
 
 The three slim experimental skills are source material for this document; they are not carried into the production bundle.
 

--- a/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
@@ -5,7 +5,7 @@ description: Use for multi-step feature work, bug fixes, or refactors where requ
 
 # Compose Next
 
-Compact end-to-end contract for grill → spec → workspace → implement → verify → review → finalize → finish. One skill load, no internal skill hand-offs.
+Compact end-to-end contract for grill → workspace → spec → implement → verify → review → finalize → finish. One skill load, no internal skill hand-offs.
 
 When writing a checkpoint or compacting context, preserve this recovery instruction in the checkpoint or compacted summary: on resumption, if the Compose Next instructions are absent, reload the `compose-next` skill before continuing.
 
@@ -19,7 +19,7 @@ Decide the shape of the work:
 
 - **Fully constrained mechanical change with no durable design surface** → skip Grill and Spec, go to Workspace then Implement.
 - **Requirements or design ambiguous** → Grill first.
-- **Requirements clear, feature deserves a durable document** → Spec first.
+- **Requirements clear, feature deserves a durable document** → Workspace then Spec.
 
 User gates and project overrides:
 
@@ -27,7 +27,7 @@ User gates and project overrides:
 - If the user explicitly says `without spec`, "no spec needed", "this is a small fix", or gives an equivalent instruction, skip the durable feature document and its spec gate. Keep verification and review when the task still warrants them.
 - An explicit project instruction, `AGENTS.md`, or user-provided agent/worktree configuration may define a project-specific worktree path, branch convention, spec path, or spec format. Use that configuration instead of the defaults in this skill. Record the override in the feature document or final report when it changes the normal artifact location.
 
-Every path passes through Workspace before Implement; no branch skips it.
+Every path passes through Workspace before Spec or Implement; no branch skips it.
 
 ## Grill — resolve decisions
 
@@ -55,7 +55,7 @@ Never-Ask applies to the current decision only. At every later decision point, c
 
 ## Spec — one document per feature
 
-Maintain one document per feature at `docs/compose/spec/<feature-name>.md` from the repository root. Do not add a date to the filename. A user-specified location overrides this path. Edit an existing document in place; never create a separate plan or report.
+Maintain one document per feature at `docs/compose/spec/<feature-name>.md` from the worktree root, not the session/main repository. Do not add a date to the filename. A user-specified location overrides this path. Edit an existing document in place; never create a separate plan or report. Do not write the feature document before Workspace owns a worktree.
 
 ### Template
 
@@ -104,7 +104,7 @@ Update only affected sections, bump `updated:`, preserve anchors, and keep only 
 
 ## Workspace — worktree ownership
 
-Never begin implementation on `main` or `master` without explicit user consent.
+Never begin implementation on `main` or `master` without explicit user consent. Spec and docs-only turns share this gate: do not write a feature document under the session/main repository path; create or reuse a worktree first.
 
 - Compare `git rev-parse --git-dir` with `git rev-parse --git-common-dir`. If they differ, use the current linked worktree; do not nest another. A non-empty `git rev-parse --show-superproject-working-tree` indicates a submodule, not a linked worktree.
 - Create a linked worktree at `.worktrees/<slug>` by default. Run `git check-ignore -q "$path"`; if it is not ignored, write `*` to `.worktrees/.gitignore`. Then run `git worktree add "$path" -b "$branch"`.

--- a/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
@@ -55,7 +55,7 @@ Never-Ask applies to the current decision only. At every later decision point, c
 
 ## Workspace — worktree ownership
 
-Never begin implementation on `main` or `master` without explicit user consent.
+Never begin implementation on `main` or `master` without explicit user consent. If the active workspace is already chosen, skip creation below and continue with toolchain setup.
 
 - Compare `git rev-parse --git-dir` with `git rev-parse --git-common-dir`. If they differ, use the current linked worktree; do not nest another. A non-empty `git rev-parse --show-superproject-working-tree` indicates a submodule, not a linked worktree.
 - Create a linked worktree at `.worktrees/<slug>` by default. Run `git check-ignore -q "$path"`; if it is not ignored, write `*` to `.worktrees/.gitignore`. Then run `git worktree add "$path" -b "$branch"`.
@@ -143,6 +143,8 @@ Provide the reviewer:
 - the worktree path, base branch, base SHA, head SHA, and exact diff command or precomputed diff;
 - a compact verification summary: one line per command with `PASS`, `FAIL`, or `PRE-EXISTING`, plus test counts when available. Do not paste full command output unless a specific failure requires it.
 
+If there is no feature document, take acceptance criteria from the conversation. If none are explicit, ask the user for them before dispatching the reviewer.
+
 Do not provide an implementer-authored narrative. The reviewer may inspect the diff and run additional commands needed to validate its conclusions. It must not repeat a command already reported as passing, especially a heavy E2E suite, unless the result is stale, the code changed afterward, or concrete evidence makes the result suspect. Before any justified rerun, confirm no equivalent command is still running. Missing evidence should be reported or gathered with the cheapest non-duplicative command.
 
 Use a reviewer model at least as capable as the strongest implementer it reviews.
@@ -161,7 +163,7 @@ For parallel task work, review integrated task diffs at useful boundaries only w
 
 ## Finalize — commit the feature document
 
-After review passes, before finishing the branch, finalize the feature document:
+If a feature document exists, after review passes and before finishing the branch:
 
 1. Set `status: delivered`, bump `updated:`, and record the reviewed range as `<base-sha>..<head-sha>`.
 2. Check off completed tasks; leave incomplete tasks unchecked and do not claim delivery if they block acceptance.

--- a/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
@@ -23,7 +23,7 @@ Decide the shape of the work:
 
 User gates and project overrides:
 
-- If the user explicitly requests `without worktree` or specifies a worktree or workspace path, use that workspace choice and skip the default worktree gate. Spec and Implement then run in that workspace. Do not ask again for worktree consent.
+- If the user explicitly requests `without worktree` or specifies a worktree or workspace path, use that workspace choice and skip the default worktree gate. Do not ask again for worktree consent.
 - If the user explicitly says `without spec`, "no spec needed", "this is a small fix", or gives an equivalent instruction, skip the durable feature document and its spec gate. Keep verification and review when the task still warrants them.
 - An explicit project instruction, `AGENTS.md`, or user-provided agent/worktree configuration may define a project-specific worktree path, branch convention, spec path, or spec format. Use that configuration instead of the defaults in this skill. Record the override in the feature document or final report when it changes the normal artifact location.
 

--- a/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
@@ -23,7 +23,7 @@ Decide the shape of the work:
 
 User gates and project overrides:
 
-- If the user explicitly requests `without worktree` or specifies a worktree or workspace path, use that workspace choice and skip the default worktree gate. Do not ask again for worktree consent.
+- If the user explicitly requests `without worktree` or specifies a worktree or workspace path, use that workspace choice and skip the default worktree gate. Spec and Implement then run in that workspace. Do not ask again for worktree consent.
 - If the user explicitly says `without spec`, "no spec needed", "this is a small fix", or gives an equivalent instruction, skip the durable feature document and its spec gate. Keep verification and review when the task still warrants them.
 - An explicit project instruction, `AGENTS.md`, or user-provided agent/worktree configuration may define a project-specific worktree path, branch convention, spec path, or spec format. Use that configuration instead of the defaults in this skill. Record the override in the feature document or final report when it changes the normal artifact location.
 
@@ -53,9 +53,18 @@ If the `question` tool is unavailable or returns `[Never-Ask]`, resolve **this o
 
 Never-Ask applies to the current decision only. At every later decision point, call the `question` tool again — Never-Ask does not disable future questions or pause the workflow.
 
+## Workspace — worktree ownership
+
+Never begin implementation on `main` or `master` without explicit user consent.
+
+- Compare `git rev-parse --git-dir` with `git rev-parse --git-common-dir`. If they differ, use the current linked worktree; do not nest another. A non-empty `git rev-parse --show-superproject-working-tree` indicates a submodule, not a linked worktree.
+- Create a linked worktree at `.worktrees/<slug>` by default. Run `git check-ignore -q "$path"`; if it is not ignored, write `*` to `.worktrees/.gitignore`. Then run `git worktree add "$path" -b "$branch"`.
+- When targeting the worktree with a command, pass its absolute path as `workdir`; omitted `workdir` uses the current session directory.
+- Install dependencies per repository instructions. Prefer lockfile-frozen, hardlink-friendly modes (`bun ci`, `uv sync --frozen`) over commands that mutate the lockfile. Confirm the toolchain is usable before continuing.
+
 ## Spec — one document per feature
 
-Maintain one document per feature at `docs/compose/spec/<feature-name>.md` from the worktree root. Do not add a date to the filename. A user-specified location overrides this path. Edit an existing document in place; never create a separate plan or report. Do not write the feature document before Workspace owns a worktree.
+Maintain one document per feature at `docs/compose/spec/<feature-name>.md` from the workspace root. Do not add a date to the filename. A user-specified location overrides this path. Edit an existing document in place; never create a separate plan or report. Do not write the feature document before Workspace owns the active workspace.
 
 ### Template
 
@@ -101,15 +110,6 @@ Before implementation, fix ambiguous requirements, contradictions, unresolved re
 ### Amendments
 
 Update only affected sections, bump `updated:`, preserve anchors, and keep only the tasks required by the amendment and their dependents. Do not regenerate the document or create duplicate tasks.
-
-## Workspace — worktree ownership
-
-Never begin implementation on `main` or `master` without explicit user consent.
-
-- Compare `git rev-parse --git-dir` with `git rev-parse --git-common-dir`. If they differ, use the current linked worktree; do not nest another. A non-empty `git rev-parse --show-superproject-working-tree` indicates a submodule, not a linked worktree.
-- Create a linked worktree at `.worktrees/<slug>` by default. Run `git check-ignore -q "$path"`; if it is not ignored, write `*` to `.worktrees/.gitignore`. Then run `git worktree add "$path" -b "$branch"`.
-- When targeting the worktree with a command, pass its absolute path as `workdir`; omitted `workdir` uses the current session directory.
-- Install dependencies per repository instructions. Prefer lockfile-frozen, hardlink-friendly modes (`bun ci`, `uv sync --frozen`) over commands that mutate the lockfile. Confirm the toolchain is usable before continuing.
 
 ## Implement
 

--- a/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
@@ -55,7 +55,7 @@ Never-Ask applies to the current decision only. At every later decision point, c
 
 ## Spec — one document per feature
 
-Maintain one document per feature at `docs/compose/spec/<feature-name>.md` from the worktree root, not the session/main repository. Do not add a date to the filename. A user-specified location overrides this path. Edit an existing document in place; never create a separate plan or report. Do not write the feature document before Workspace owns a worktree.
+Maintain one document per feature at `docs/compose/spec/<feature-name>.md` from the worktree root. Do not add a date to the filename. A user-specified location overrides this path. Edit an existing document in place; never create a separate plan or report. Do not write the feature document before Workspace owns a worktree.
 
 ### Template
 
@@ -104,7 +104,7 @@ Update only affected sections, bump `updated:`, preserve anchors, and keep only 
 
 ## Workspace — worktree ownership
 
-Never begin implementation on `main` or `master` without explicit user consent. Spec and docs-only turns share this gate: do not write a feature document under the session/main repository path; create or reuse a worktree first.
+Never begin implementation on `main` or `master` without explicit user consent.
 
 - Compare `git rev-parse --git-dir` with `git rev-parse --git-common-dir`. If they differ, use the current linked worktree; do not nest another. A non-empty `git rev-parse --show-superproject-working-tree` indicates a submodule, not a linked worktree.
 - Create a linked worktree at `.worktrees/<slug>` by default. Run `git check-ignore -q "$path"`; if it is not ignored, write `*` to `.worktrees/.gitignore`. Then run `git worktree add "$path" -b "$branch"`.

--- a/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md
@@ -123,7 +123,7 @@ For failures, reproduce before editing and identify the root cause from errors, 
 
 ### Parallel work
 
-Dispatch independent tasks in parallel when isolation prevents collisions; keep tightly coupled work together. Prefer giving parallel subagents disjoint file sets and keeping commits with the orchestrator. Give each subagent the worktree path, task, acceptance criteria, relevant spec sections, and required verification. Do not pass session history. Treat its report as a claim and inspect the resulting diff.
+Dispatch independent tasks in parallel when isolation prevents collisions; keep tightly coupled work together. Prefer giving parallel subagents disjoint file sets and keeping commits with the orchestrator. Give each subagent the workspace path, task, acceptance criteria, relevant spec sections, and required verification. Do not pass session history. Treat its report as a claim and inspect the resulting diff.
 
 Continue through tasks without routine approval pauses. Stop only for an unresolved product decision, a blocker that cannot be worked around, a destructive action requiring consent, or completion.
 
@@ -140,7 +140,7 @@ After implementation is verified and before finalizing the feature document, dis
 Provide the reviewer:
 
 - the applicable spec sections and acceptance criteria;
-- the worktree path, base branch, base SHA, head SHA, and exact diff command or precomputed diff;
+- the workspace path, base branch, base SHA, head SHA, and exact diff command or precomputed diff;
 - a compact verification summary: one line per command with `PASS`, `FAIL`, or `PRE-EXISTING`, plus test counts when available. Do not paste full command output unless a specific failure requires it.
 
 If there is no feature document, take acceptance criteria from the conversation. If none are explicit, ask the user for them before dispatching the reviewer.
@@ -183,7 +183,7 @@ Update a design section only when it contradicts the delivered behavior. Commit 
 
 ## Finish
 
-Do not auto-finish. After Finalize, report branch, base, head SHA, worktree, feature-doc path, and suggest a closing action.
+Do not auto-finish. After Finalize, report branch, base, head SHA, workspace, feature-doc path when available, and suggest a closing action.
 
 If the user asks to finish but the path is unclear, use the `question` tool to settle:
 

--- a/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/guide.md
+++ b/packages/opencode/src/skill/builtin/.bundle/mimocode-docs/reference/guide.md
@@ -133,7 +133,7 @@ Inspect/manage with `mimo mcp`. Request timeout defaults to 5000ms (`timeout` pe
 
 Compose is MiMoCode's specs-driven spec→ship lifecycle. Two interactive paths:
 
-- **Recommended: `compose-next` on Build** — one self-contained skill covering grill → spec → workspace → implement → verify → review → finalize → finish, with feature documents at `docs/compose/spec/<feature>.md`. Built for frontier models (Fable/Sol-class). The model may invoke it after the user explicitly requests this workflow by slash command, name, or any other clear natural language; it must not infer that request from task complexity.
+- **Recommended: `compose-next` on Build** — one self-contained skill covering grill → workspace → spec → implement → verify → review → finalize → finish, with feature documents at `docs/compose/spec/<feature>.md` under the workspace root. Built for frontier models (Fable/Sol-class). The model may invoke it after the user explicitly requests this workflow by slash command, name, or any other clear natural language; it must not infer that request from task complexity.
 - **Legacy: the `compose` agent** (switch with `Tab`) — coordinates built-in skills (plan, tdd, debug, review, verify, merge) across the lifecycle; its step-by-step curriculum remains useful for weaker models.
 
 Artifacts land under `docs/compose/` by default (`specs/`, `plans/`, `reports/`). Change the location with `compose.docs`; set `compose.docs_absolute: true` to anchor a relative path to the worktree root.


### PR DESCRIPTION
## Summary

Agents following `compose-next` often wrote the feature document to the session/main repository instead of the worktree. Three contract gaps caused this:

1. The pipeline order was `grill → spec → workspace`, so Spec ran before a worktree existed.
2. The Spec path was anchored to the "repository root" (session cwd).
3. The Workspace gate only blocked "Implement", so docs-only / Spec-only turns could skip worktree ownership entirely.

This is a skill-text-only change in `packages/opencode/src/skill/builtin/.bundle/compose-next/SKILL.md`:

- Reorder the pipeline to `grill → workspace → spec → implement`.
- Anchor the feature document path to the **worktree root**, not the session/main repository.
- Extend the Workspace gate to cover Spec and docs-only turns.
- Update the Orient shape branch from "Spec first" to "Workspace then Spec".

Existing escapes remain: explicit `without worktree`, a user-specified worktree path, or an already-linked worktree.

## Verification

- `git diff --check` — clean
- Confirmed no remaining "repository root" / "Spec first" / Implement-only gate phrasing in the skill
- No code changes; no typecheck/test band required