### PR TITLE
fix(tui): restore voice_input schema shape and tolerate missing tool name

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/voice.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/voice.ts
@@ -326,6 +326,9 @@ const VoiceInputArgsSchema = z.object({
         })
         .strict(),
     ])
+    // Same as actor/task/cron `operation`: without this the emitted schema has
+    // only anyOf and some models stringify the whole envelope.
+    .meta({ type: "object" })
     .optional()
     .describe("Text edit, if any. Choose exactly one arm: insert, set, or set_with_cursor."),
   send: z.boolean().optional().describe("true to submit. Only when send_enabled is true."),
@@ -334,7 +337,6 @@ const VoiceInputArgsSchema = z.object({
 export type VoiceInputArgs = z.infer<typeof VoiceInputArgsSchema>
 
 // Single source of truth: zod is the runtime validator; JSON Schema is derived for the API.
-// Field descriptions live on the zod schema via .describe() and are emitted by toJSONSchema.
 // Drop $schema — some OpenAI-compatible gateways reject unknown top-level keys in tool parameters.
 function stripSchemaKeyword(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stripSchemaKeyword)
@@ -348,17 +350,7 @@ function stripSchemaKeyword(value: unknown): unknown {
   return value
 }
 
-export const VOICE_INPUT_TOOL_SCHEMA = (() => {
-  const schema = stripSchemaKeyword(z.toJSONSchema(VoiceInputArgsSchema)) as Record<string, unknown>
-  // zod emits anyOf without a parent type on the optional union property.
-  // Desktop / Xiaomi tool schema keeps type:"object" beside anyOf — match that shape.
-  const props = schema.properties as Record<string, unknown> | undefined
-  const operation = props?.operation as Record<string, unknown> | undefined
-  if (operation && Array.isArray(operation.anyOf) && operation.type === undefined) {
-    operation.type = "object"
-  }
-  return schema
-})()
+export const VOICE_INPUT_TOOL_SCHEMA = stripSchemaKeyword(z.toJSONSchema(VoiceInputArgsSchema)) as Record<string, unknown>
 
 export type VoiceControlAction =
   | { action: "insert"; text: string }

--- a/packages/opencode/src/cli/cmd/tui/util/voice.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/voice.ts
@@ -348,7 +348,17 @@ function stripSchemaKeyword(value: unknown): unknown {
   return value
 }
 
-export const VOICE_INPUT_TOOL_SCHEMA = stripSchemaKeyword(z.toJSONSchema(VoiceInputArgsSchema)) as Record<string, unknown>
+export const VOICE_INPUT_TOOL_SCHEMA = (() => {
+  const schema = stripSchemaKeyword(z.toJSONSchema(VoiceInputArgsSchema)) as Record<string, unknown>
+  // zod emits anyOf without a parent type on the optional union property.
+  // Desktop / Xiaomi tool schema keeps type:"object" beside anyOf — match that shape.
+  const props = schema.properties as Record<string, unknown> | undefined
+  const operation = props?.operation as Record<string, unknown> | undefined
+  if (operation && Array.isArray(operation.anyOf) && operation.type === undefined) {
+    operation.type = "object"
+  }
+  return schema
+})()
 
 export type VoiceControlAction =
   | { action: "insert"; text: string }
@@ -455,8 +465,9 @@ export function parseVoiceControlResponse(message: unknown, opts: { sendEnabled?
     if (toolCalls.length > 1) {
       return { ok: false, actions: [], protocolError: `Call the ${VOICE_INPUT_TOOL_NAME} tool exactly once.`, previous }
     }
-    const fn = ((toolCalls[0] as { function?: { name?: string; arguments?: string } })?.function) ?? {}
-    if (fn.name !== VOICE_INPUT_TOOL_NAME) {
+    const fn = ((toolCalls[0] as { function?: { name?: string; arguments?: string | Record<string, unknown> } })?.function) ?? {}
+    // Some gateways omit function.name when only one tool is registered.
+    if (fn.name && fn.name !== VOICE_INPUT_TOOL_NAME) {
       return { ok: false, actions: [], protocolError: `Call the ${VOICE_INPUT_TOOL_NAME} tool.`, previous }
     }
     const rawArg = fn.arguments
@@ -543,7 +554,14 @@ export async function processVoiceControl(opts: {
       log.debug("voice control result", { model, actions: parsed.actions.length, attempt })
       return { ok: true, actions: parsed.actions }
     }
-    log.warn("voice control protocol error", { model, attempt, protocolError: parsed.protocolError })
+    log.warn("voice control protocol error", {
+      model,
+      attempt,
+      protocolError: parsed.protocolError,
+      hasToolCalls: !!parsed.previous.tool_calls?.length,
+      toolCallNames: parsed.previous.tool_calls?.map((c) => (c as { function?: { name?: string } })?.function?.name),
+      contentPreview: parsed.previous.content?.slice(0, 200),
+    })
     if (attempt >= VOICE_CONTROL_MAX_PROTOCOL_RETRIES) return { ok: false, reason: "protocol" }
     body = buildVoiceControlRetryBody(body, parsed.previous, parsed.protocolError ?? "protocol error")
   }

--- a/packages/opencode/test/cli/tui/voice.test.ts
+++ b/packages/opencode/test/cli/tui/voice.test.ts
@@ -428,6 +428,12 @@ describe("voice", () => {
     test("tool schema is derived from zod with field descriptions", async () => {
       const { VOICE_INPUT_TOOL_SCHEMA } = await import("../../../src/cli/cmd/tui/util/voice")
       expect(VOICE_INPUT_TOOL_SCHEMA).toMatchObject({ type: "object" })
+      // .meta({ type: "object" }) on the union — without this, models may
+      // stringify the whole envelope (see tool/actor.ts).
+      const operation = (VOICE_INPUT_TOOL_SCHEMA as { properties?: { operation?: { type?: string; anyOf?: unknown[] } } })
+        .properties?.operation
+      expect(operation?.type).toBe("object")
+      expect(Array.isArray(operation?.anyOf)).toBe(true)
       const json = JSON.stringify(VOICE_INPUT_TOOL_SCHEMA)
       expect(json).toContain("set_with_cursor")
       expect(json).not.toContain("$schema")

--- a/packages/opencode/test/cli/tui/voice.test.ts
+++ b/packages/opencode/test/cli/tui/voice.test.ts
@@ -306,22 +306,22 @@ describe("voice", () => {
       expect(result.protocolError).toContain("Call the voice_input tool.")
     })
 
-    test("rejects empty tool name", async () => {
+    test("accepts missing tool name when a single call is present", async () => {
       const { parseVoiceControlResponse } = await import("../../../src/cli/cmd/tui/util/voice")
       const result = parseVoiceControlResponse(
         {
           tool_calls: [
             {
               function: {
-                arguments: "{}",
+                arguments: JSON.stringify({ operation: { action: "insert", text: "hi" } }),
               },
             },
           ],
         },
         {},
       )
-      expect(result.ok).toBe(false)
-      expect(result.protocolError).toContain("Call the voice_input tool.")
+      expect(result.ok).toBe(true)
+      expect(result.actions).toEqual([{ action: "insert", text: "hi" }])
     })
 
     test("rejects multiple tool calls", async () => {


### PR DESCRIPTION
## Summary
After #2308, every TUI voice-control segment failed with「不是有效的 voice_input 调用」.

Root cause: `z.toJSONSchema` emitted `operation` with only `anyOf` and no `type: "object"`. That mismatches actor/task/cron tool params (see `.meta({ type: "object" })` in `tool/actor.ts`); some models then stringify the whole envelope and zod rejects it.

- Declare `operation` as `z.discriminatedUnion(...).meta({ type: "object" })` — schema stays zod-only
- Accept a single `tool_call` whose `function.name` is missing (only reject a present wrong name)
- Log protocol failures with tool-call names and a content preview

## Schema shape
```
operation: { type: "object", description, anyOf: [insert|set|set_with_cursor] }
```
Matches desktop hand-written schema and actor `operation`. No `$schema`.

## Verification
- `bun typecheck` PASS
- `bun test test/cli/tui/voice.test.ts` 42 pass
- Nested `properties.operation.type === "object"` asserted