### PR TITLE
chore(sdk): regenerate openapi and js sdk types

### DIFF
--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5310,7 +5310,7 @@ export type SessionPromptData = {
      */
     systemMode?: "append" | "replace-agent"
     /**
-     * Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.
+     * Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference and explicit default forces the native tool schema for non-GPT models. MIMOCODE_CODEX_MODE=false forces the default harness for every model, including GPT.
      */
     harness?: "auto" | "codex" | "default"
     variant?: string
@@ -5619,7 +5619,7 @@ export type SessionPromptAsyncData = {
      */
     systemMode?: "append" | "replace-agent"
     /**
-     * Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.
+     * Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference and explicit default forces the native tool schema for non-GPT models. MIMOCODE_CODEX_MODE=false forces the default harness for every model, including GPT.
      */
     harness?: "auto" | "codex" | "default"
     variant?: string
@@ -5678,7 +5678,7 @@ export type SessionCommandData = {
      */
     systemMode?: "append" | "replace-agent"
     /**
-     * Harness mode selected by the session's first user command. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.
+     * Harness mode selected by the session's first user command. Later values are ignored. Auto preserves model/process inference and explicit default forces the native tool schema for non-GPT models. MIMOCODE_CODEX_MODE=false forces the default harness for every model, including GPT.
      */
     harness?: "auto" | "codex" | "default"
     parts?: Array<{

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -4208,7 +4208,7 @@
                     "enum": ["append", "replace-agent"]
                   },
                   "harness": {
-                    "description": "Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
+                    "description": "Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference and explicit default forces the native tool schema for non-GPT models. MIMOCODE_CODEX_MODE=false forces the default harness for every model, including GPT.",
                     "type": "string",
                     "enum": ["auto", "codex", "default"]
                   },
@@ -4923,7 +4923,7 @@
                     "enum": ["append", "replace-agent"]
                   },
                   "harness": {
-                    "description": "Harness mode selected by the session's first user query. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
+                    "description": "Harness mode selected by the session's first user query. Later values are ignored. Auto preserves model/process inference and explicit default forces the native tool schema for non-GPT models. MIMOCODE_CODEX_MODE=false forces the default harness for every model, including GPT.",
                     "type": "string",
                     "enum": ["auto", "codex", "default"]
                   },
@@ -5077,7 +5077,7 @@
                     "enum": ["append", "replace-agent"]
                   },
                   "harness": {
-                    "description": "Harness mode selected by the session's first user command. Later values are ignored. GPT models always use the Codex harness. For other models, auto preserves model/process inference and explicit default forces the native tool schema.",
+                    "description": "Harness mode selected by the session's first user command. Later values are ignored. Auto preserves model/process inference and explicit default forces the native tool schema for non-GPT models. MIMOCODE_CODEX_MODE=false forces the default harness for every model, including GPT.",
                     "type": "string",
                     "enum": ["auto", "codex", "default"]
                   },
@@ -13280,6 +13280,55 @@
           "tail_start_id": {
             "type": "string",
             "pattern": "^msg.*"
+          },
+          "projection": {
+            "type": "object",
+            "properties": {
+              "version": {
+                "type": "number",
+                "const": 1
+              },
+              "summary_message_id": {
+                "type": "string",
+                "pattern": "^msg.*"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "manifest": {
+                "type": "string"
+              },
+              "trigger": {
+                "type": "string",
+                "enum": ["manual", "automatic", "provider-overflow"]
+              },
+              "tail_start_id": {
+                "type": "string",
+                "pattern": "^msg.*"
+              },
+              "tail_end_id": {
+                "type": "string",
+                "pattern": "^msg.*"
+              },
+              "compacted_tool_calls": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "call_id": {
+                      "type": "string"
+                    },
+                    "tokens": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": ["call_id", "tokens"]
+                }
+              }
+            },
+            "required": ["version", "summary_message_id", "summary", "trigger"]
           }
         },
         "required": ["id", "sessionID", "messageID", "type", "auto"]
@@ -16189,13 +16238,13 @@
                 "type": "boolean"
               },
               "tail_turns": {
-                "description": "Number of recent user turns, including their following assistant/tool responses, to keep verbatim during compaction (default: 2)",
+                "description": "Deprecated compatibility setting. Projected compaction now keeps only whole API rounds that arrive while compaction is running.",
                 "type": "integer",
                 "minimum": 0,
                 "maximum": 9007199254740991
               },
               "preserve_recent_tokens": {
-                "description": "Maximum number of tokens from recent turns to preserve verbatim after compaction",
+                "description": "Deprecated compatibility setting. Compression-time API rounds now use a fixed 40000-token hard budget.",
                 "type": "integer",
                 "minimum": 0,
                 "maximum": 9007199254740991


### PR DESCRIPTION
Regenerate `packages/sdk/openapi.json` and JS SDK types via `./script/generate.ts` before the 0.1.14 release.

Includes:
- session projection schema
- harness description updates
- compaction field docs