### PR TITLE
fix(websearch): use session model for Xiaomi sidecar requests

### DIFF
--- a/packages/opencode/src/tool/websearch/index.ts
+++ b/packages/opencode/src/tool/websearch/index.ts
@@ -73,7 +73,7 @@ export const WebSearchTool = Tool.define(
                       model.api.url,
                       info.key,
                       params.query,
-                      "mimo-v2.5",
+                      model.api.id,
                       timeout ?? "30 seconds",
                     )
                   }),

--- a/packages/opencode/test/tool/websearch.test.ts
+++ b/packages/opencode/test/tool/websearch.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Effect, Layer } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
+import { Agent } from "../../src/agent/agent"
+import { Auth } from "../../src/auth"
+import { Truncate } from "../../src/tool"
+import { Instance } from "../../src/project/instance"
+import { WebSearchTool } from "../../src/tool/websearch"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { ProviderTest } from "../fake/provider"
+
+const projectRoot = path.join(import.meta.dir, "../..")
+
+const sse = (model: string) => {
+  const frame = {
+    model,
+    choices: [
+      {
+        delta: {
+          annotations: [
+            {
+              type: "url_citation",
+              url: "https://example.com/result",
+              title: "Example",
+              summary: "A search hit",
+              site_name: "Example",
+              publish_time: "2026-01-01",
+            },
+          ],
+        },
+      },
+    ],
+  }
+  return `data: ${JSON.stringify(frame)}\n\ndata: [DONE]\n\n`
+}
+
+describe("tool.websearch", () => {
+  test("xiaomi sidecar uses the session model's API id, not a hardcoded model", async () => {
+    let requested: string | undefined
+    using server = Bun.serve({
+      port: 0,
+      fetch: async (req) => {
+        requested = ((await req.json()) as { model?: string }).model
+        return new Response(sse(requested ?? ""), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        })
+      },
+    })
+
+    const model = ProviderTest.model({
+      id: ModelID.make("catalog-mimo-pro"),
+      providerID: ProviderID.make("xiaomi"),
+      api: {
+        id: "mimo-v2.5-pro",
+        url: server.url.origin,
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+
+    const fakeAuth = Layer.mock(Auth.Service)({
+      get: (providerID: string) =>
+        Effect.succeed(providerID === "xiaomi" ? new Auth.Api({ type: "api", key: "test-key" }) : undefined),
+    })
+
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const result = await WebSearchTool.pipe(
+          Effect.flatMap((info) => info.init()),
+          Effect.flatMap((tool) =>
+            tool.execute(
+              { query: "latest mimo release" },
+              {
+                sessionID: SessionID.make("ses_test"),
+                messageID: MessageID.make("message"),
+                callID: "",
+                agent: "build",
+                abort: AbortSignal.any([]),
+                messages: [],
+                extra: { model },
+                metadata: () => Effect.void,
+                ask: () => Effect.void,
+              },
+            ),
+          ),
+          Effect.provide(
+            Layer.mergeAll(FetchHttpClient.layer, Truncate.defaultLayer, Agent.defaultLayer, fakeAuth),
+          ),
+          Effect.runPromise,
+        )
+
+        expect(requested).toBe("mimo-v2.5-pro")
+        expect(result.output).toContain("https://example.com/result")
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue / context (if applicable)

Xiaomi `websearch` sidecar hard-coded the request model as `mimo-v2.5`. Sessions on `mimo-v2.5-pro`(and other Xiaomi models) still billed and called `mimo-v2.5`, which can fail or fall back to webfetch when that model is unavailable.

### Type of change

Bug fix

### What does this PR do?

Pass the current session model's API id (`model.api.id`) into the Xiaomi `web_search` sidecar instead of the hardcoded `mimo-v2.5`. The sidecar already used `model.api.url`; the model field now matches.

### How did you verify your code works?

- `bun test test/tool/websearch.test.ts` in `packages/opencode` (asserts the request body uses the session API id, not `mimo-v2.5`)
- `bun typecheck` in `packages/opencode`

### Screenshots / recordings

_N/A — engine-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR