### PR TITLE
fix(prompt): republish InstructionsLoaded after a restart on the frozen fast path

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4439,6 +4439,21 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               permission: runtimePermission,
             })
             const frozen = yield* SessionPrefixSnapshot.get(sessionID, prefixProfileKey)
+            // Surface loaded instruction files to the TUI. This must live on the common
+            // path, NOT inside currentAdditions: the frozen-snapshot fast path skips
+            // currentAdditions entirely, so after a TUI restart (fresh in-memory store,
+            // persisted prefix snapshot) the sidebar list was never repopulated (#2320).
+            if (!session.parentID && !instructionsNotified.has(sessionID)) {
+              instructionsNotified.add(sessionID)
+              const paths = yield* instruction.systemPaths().pipe(
+                Effect.catch(() => Effect.succeed(new Set<string>())),
+              )
+              const worktree = (yield* InstanceState.context).worktree
+              const files = Array.from(paths, (path) => Instruction.display(path, worktree))
+              if (files.length > 0) {
+                yield* bus.publish(TuiEvent.InstructionsLoaded, { files }).pipe(Effect.ignore)
+              }
+            }
             const currentAdditions = Effect.fnUntraced(function* () {
               const [env, skills, instructions] = yield* Effect.all([
                 Flag.MIMOCODE_ENABLE_DYNAMIC_SYSTEM_PROMPT
@@ -4447,14 +4462,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 sys.skills({ ...agent, permission: runtimePermission }),
                 instruction.system().pipe(Effect.orDie),
               ])
-              if (!session.parentID && !instructionsNotified.has(sessionID)) {
-                instructionsNotified.add(sessionID)
-                const worktree = (yield* InstanceState.context).worktree
-                const files = Array.from(instructions.paths, (path) => Instruction.display(path, worktree))
-                if (files.length > 0) {
-                  yield* bus.publish(TuiEvent.InstructionsLoaded, { files }).pipe(Effect.ignore)
-                }
-              }
               return [
                 ...env,
                 ...(format.type === "json_schema" ? [STRUCTURED_OUTPUT_SYSTEM_PROMPT] : []),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -27,6 +27,7 @@ import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { SessionPrune } from "../../src/session/prune"
 import { SessionSummary } from "../../src/session/summary"
 import { Instruction } from "../../src/session/instruction"
+import { TuiEvent } from "../../src/cli/cmd/tui/event"
 import { SessionProcessor } from "../../src/session/processor"
 import { SessionCompaction } from "../../src/session/compaction"
 import { SessionPrompt } from "../../src/session/prompt"
@@ -1470,6 +1471,69 @@ it.live(
             revision: 1,
             watermark_message_id: lastAssistant?.info.id,
           })
+        }),
+        { git: true, config: providerCfg },
+      ),
+    ),
+  30_000,
+)
+
+it.live(
+  "publishes InstructionsLoaded once per session and not again on frozen-snapshot requeries",
+  () =>
+    withoutDynamicSystemPrompt(() =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const bus = yield* Bus.Service
+
+          yield* Effect.promise(() =>
+            Bun.write(path.join(Instance.directory, "AGENTS.md"), "INSTRUCTION_MARKER"),
+          )
+
+          // In-process we can only pin down the de-dup semantics: the event fires
+          // exactly once per session, and a later query riding the frozen-snapshot
+          // fast path must not repeat it. (The cross-process half of #2320 — the
+          // event must fire again after a process restart even though the snapshot
+          // is already persisted — needs a second process; it was verified end-to-end
+          // with two `serve` runs against a shared data home.)
+          const seen: string[][] = []
+          const firstEvent = defer<void>()
+          const off = yield* bus.subscribeCallback(TuiEvent.InstructionsLoaded, (event) => {
+            seen.push(event.properties.files)
+            if (seen.length === 1) firstEvent.resolve()
+          })
+
+          const chat = yield* sessions.create({
+            title: "Instructions dedup",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+
+          yield* llm.text("first")
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "first query" }],
+          })
+          yield* Effect.promise(() => firstEvent.promise)
+          expect(seen).toHaveLength(1)
+          expect(seen[0].some((file) => file.includes("AGENTS.md"))).toBe(true)
+
+          // Second query rides the frozen snapshot; the notification must not repeat.
+          yield* llm.text("second")
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "second query" }],
+          })
+          // Give any stray publish a moment to land before asserting absence.
+          yield* Effect.sleep("500 millis")
+          expect(seen).toHaveLength(1)
+
+          off()
         }),
         { git: true, config: providerCfg },
       ),


### PR DESCRIPTION
Fixes #2320

## Root cause

The `InstructionsLoaded` TUI notification lived inside the `currentAdditions` closure (`session/prompt.ts`), which the v0.1.14 prefix-snapshot fast path skips entirely:

```ts
additions: frozen ? [] : yield* currentAdditions(),
```

After a TUI restart the in-memory sidebar store starts empty (`sync.tsx` is purely event-driven, no REST pull), while the persisted prefix snapshot (SQLite, `session_prefix_snapshot`) makes every subsequent query take the fast path — so the event never fires again and the sidebar's instruction-file list stays empty forever. New sessions were unaffected (first query takes the `pin` path), which is why the bug only showed up for resumed sessions.

## The fix

Move the publish onto the common path, right after the `frozen` lookup and independent of `currentAdditions`. It uses the already-exposed `instruction.systemPaths()` (fs lookups only — no file reads), so the frozen fast path does not rebuild the full additions. The per-process `instructionsNotified` de-dup (once per session) is preserved, so the toast does not repeat per message.

## Testing

**Unit/integration** (`test/session/prompt-effect.test.ts`): the existing once-per-session semantics are now locked by a test — the event fires exactly once on the first query and is *not* repeated when a later query rides the frozen snapshot.

Note that the cross-process half of the regression cannot be expressed in a single-process test (the de-dup set and the persisted snapshot never diverge in-process), so it was verified end-to-end:

**End-to-end** (two real `serve` processes sharing one data home, `mimo run --attach` clients, SSE `/event` capture):

| code under test | event on new session (pin path) | event on resumed session in a *new* process (frozen fast path) |
|---|---|---|
| before (main) | 1 | **0** ← #2320 reproduced |
| after (this PR) | 1 | **1** ✓ |

Both `bun turbo typecheck` and the `prompt-effect` / `instruction` test suites pass locally.
