### PR TITLE
feat(node): export LLMServerTokens from the Node entry

### DIFF
--- a/packages/opencode/src/node.ts
+++ b/packages/opencode/src/node.ts
@@ -6,3 +6,5 @@ export { Log } from "./util"
 export { Database } from "./storage"
 export { JsonMigration } from "./storage"
 export { ChildProcessEnv } from "./util/child-process-env"
+/** Capability API tokens — single mint/verify source for embedders. */
+export { LLMServerTokens } from "./llm-server/tokens"


### PR DESCRIPTION
## Summary
- Re-export `LLMServerTokens` from the Node entry (`packages/opencode/src/node.ts`).
- Embedders can issue capability tokens through the single mint/verify implementation instead of reimplementing tokens.json hashing and path layout.

## Test plan
- [x] turbo typecheck packages pass
- [ ] Consumer-side pin gate after downstream pin bump