### PR TITLE
fix(session): send x-opencode-session on outbound requests

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -812,7 +812,9 @@ const live: Layer.Layer<
         maxOutputTokens: params.maxOutputTokens,
         abortSignal: input.abort,
         headers: {
-          ...(!input.ephemeral ? { "x-session-affinity": input.sessionID } : {}),
+          // Stable per-conversation ID for upstream routing/optimization —
+          // OpenCode Go requires this from 09/05 (github.com/XiaomiMiMo/MiMo-Code/issues/2317).
+          ...(!input.ephemeral ? { "x-session-affinity": input.sessionID, "x-opencode-session": input.sessionID } : {}),
           ...(!input.ephemeral && input.parentSessionID ? { "x-parent-session-id": input.parentSessionID } : {}),
           ...input.model.headers,
           ...headers,

--- a/packages/opencode/test/session/llm-system-prompt.test.ts
+++ b/packages/opencode/test/session/llm-system-prompt.test.ts
@@ -558,3 +558,121 @@ describe("session.llm system prompt — memory-instructions guard", () => {
     }
   })
 })
+
+
+// https://github.com/XiaomiMiMo/MiMo-Code/issues/2317 — OpenCode Go rejects
+// requests with no per-conversation ID from 09/05. This reuses the module's
+// scripted-upstream harness (see the memory-instructions guard above) purely
+// to inspect the outbound request headers, not the system prompt.
+describe("session.llm outbound headers", () => {
+  test("a non-ephemeral stream call carries x-opencode-session and x-session-affinity", async () => {
+    const server = queueState.server!
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hi"), { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "mimocode.json"), tmpConfig(providerID, `${server.url.origin}/v1`))
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(fixture.model.id))
+        const sessionRt = ManagedRuntime.make(SessionNs.defaultLayer)
+        let sessionID: SessionID
+        try {
+          const info = await sessionRt.runPromise(SessionNs.Service.use((svc) => svc.create({})))
+          sessionID = info.id
+        } finally {
+          await sessionRt.dispose()
+        }
+        const rt = ManagedRuntime.make(Layer.mergeAll(LLM.defaultLayer))
+        try {
+          await rt.runPromise(
+            LLM.Service.use((svc) =>
+              svc
+                .stream({
+                  user: makeBaseUser(sessionID, providerID, resolved.id),
+                  sessionID,
+                  model: resolved,
+                  agent: makeAgent(),
+                  system: ["You are a helpful assistant."],
+                  messages: [{ role: "user", content: "Hello" }],
+                  tools: {},
+                })
+                .pipe(Stream.runDrain),
+            ),
+          )
+        } finally {
+          await rt.dispose()
+        }
+        const capture = await request
+        expect(capture.headers.get("x-opencode-session")).toBe(sessionID)
+        expect(capture.headers.get("x-session-affinity")).toBe(sessionID)
+      },
+    })
+  })
+
+  test("an ephemeral call (title generation) carries neither header", async () => {
+    const server = queueState.server!
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hi"), { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "mimocode.json"), tmpConfig(providerID, `${server.url.origin}/v1`))
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(fixture.model.id))
+        const sessionRt = ManagedRuntime.make(SessionNs.defaultLayer)
+        let sessionID: SessionID
+        try {
+          const info = await sessionRt.runPromise(SessionNs.Service.use((svc) => svc.create({})))
+          sessionID = info.id
+        } finally {
+          await sessionRt.dispose()
+        }
+        const rt = ManagedRuntime.make(Layer.mergeAll(LLM.defaultLayer))
+        try {
+          await rt.runPromise(
+            LLM.Service.use((svc) =>
+              svc
+                .stream({
+                  user: makeBaseUser(sessionID, providerID, resolved.id),
+                  sessionID,
+                  model: resolved,
+                  agent: makeAgent(),
+                  system: ["You are a helpful assistant."],
+                  messages: [{ role: "user", content: "Hello" }],
+                  tools: {},
+                  ephemeral: true,
+                })
+                .pipe(Stream.runDrain),
+            ),
+          )
+        } finally {
+          await rt.dispose()
+        }
+        const capture = await request
+        expect(capture.headers.get("x-opencode-session")).toBeNull()
+        expect(capture.headers.get("x-session-affinity")).toBeNull()
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue / context (if applicable)

Fixes #2317. OpenCode Go (the API behind the `opencode` provider) starts rejecting requests with no per-conversation ID from 09/05.

### Type of change

Bug fix

### What does this PR do?

Adds `x-opencode-session` alongside the existing `x-session-affinity` header in `session/llm.ts`, carrying the same stable `sessionID`, under the same non-ephemeral condition. Same idea as the existing header, just a second name for OpenCode Go's routing.

### How did you verify your code works?

Added two tests to `llm-system-prompt.test.ts` (reusing its existing scripted-upstream mock): one asserts both headers carry the sessionID on a normal call, the other asserts neither header is sent on an ephemeral call. Ran `bun typecheck`, `bun lint`, and `bun test --cwd packages/opencode test/session/llm-system-prompt.test.ts` (8 pass, 0 fail). Reverting the header line locally makes the new test fail with the expected assertion, confirming it actually catches the regression.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
