### PR TITLE
test(session): cover case-insensitive search for mixed CJK titles

### DIFF
--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -93,6 +93,25 @@ describe("session.list", () => {
     })
   })
 
+  test("search is case-insensitive for mixed CJK and Latin titles", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await svc.create({ title: "使用 OpenCode 重构测试" })
+        await svc.create({ title: "中文标题ABC" })
+
+        const lower = [...svc.list({ search: "opencode" })].map((s) => s.title)
+        const upper = [...svc.list({ search: "OPENCODE" })].map((s) => s.title)
+        const mixed = [...svc.list({ search: "abc" })].map((s) => s.title)
+
+        expect(lower).toContain("使用 OpenCode 重构测试")
+        expect(upper).toContain("使用 OpenCode 重构测试")
+        expect(mixed).toContain("中文标题ABC")
+      },
+    })
+  })
+
   test("respects limit parameter", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({


### PR DESCRIPTION
## Summary
- Add a regression test for `session.list` search over mixed CJK/Latin titles
- Locks in case-insensitive matching (`opencode` / `OPENCODE` against `使用 OpenCode 重构测试`, `abc` against `中文标题ABC`)

## Why
Session search is server-side via SQLite `LIKE`. The list API documents case-insensitive title search; this test guards that behavior for Chinese titles that embed English words, which is the path the TUI session dialog uses.

## Test plan
- `bun test test/server/session-list.test.ts` — 6 pass
- `bun typecheck` — clean