### PR TITLE
fix(util): stop decodeDataUrl throwing on a malformed percent escape

### DIFF
--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -4,6 +4,17 @@ export function decodeDataUrl(url: string) {
 
   const head = url.slice(0, idx)
   const body = url.slice(idx + 1)
-  if (head.includes(";base64")) return Buffer.from(body, "base64").toString("utf8")
-  return decodeURIComponent(body)
+  // The `;base64` token is case-insensitive per RFC 2397, and the media type
+  // and parameters that precede it may be written in any case too.
+  if (head.toLowerCase().includes(";base64")) return Buffer.from(body, "base64").toString("utf8")
+  try {
+    return decodeURIComponent(body)
+  } catch {
+    // A percent that does not introduce a valid escape (`100%`, `a%zz`) makes
+    // decodeURIComponent throw URIError. Attachments reach here straight from
+    // the message part, whose `url` is an unvalidated string, so throwing would
+    // fail the whole turn over one malformed attachment. Fall back to the raw
+    // body: it is what the sender wrote, minus the percent-decoding.
+    return body
+  }
 }

--- a/packages/opencode/test/util/data-url.test.ts
+++ b/packages/opencode/test/util/data-url.test.ts
@@ -11,4 +11,29 @@ describe("decodeDataUrl", () => {
   test("decodes plain data URLs", () => {
     expect(decodeDataUrl("data:text/plain,hello%20world")).toBe("hello world")
   })
+
+  test("decodes base64 data URLs whatever the case of the token", () => {
+    // RFC 2397 makes `;base64` case-insensitive, and clients do send `;Base64`.
+    const encoded = Buffer.from("hello").toString("base64")
+    expect(decodeDataUrl(`data:text/plain;BASE64,${encoded}`)).toBe("hello")
+    expect(decodeDataUrl(`data:text/plain;Base64,${encoded}`)).toBe("hello")
+    expect(decodeDataUrl(`data:TEXT/PLAIN;base64,${encoded}`)).toBe("hello")
+  })
+
+  test("keeps the raw body when percent-decoding fails", () => {
+    // `FilePart.url` is an unvalidated string, so a malformed escape must not
+    // throw URIError out of decodeDataUrl and fail the whole turn.
+    expect(decodeDataUrl("data:text/plain,coverage is 100%")).toBe("coverage is 100%")
+    expect(decodeDataUrl("data:text/plain,a%zzb")).toBe("a%zzb")
+    expect(decodeDataUrl("data:text/plain,50%25 done, 50% left")).toBe("50%25 done, 50% left")
+  })
+
+  test("still decodes valid escapes, including multi-byte ones", () => {
+    expect(decodeDataUrl("data:text/plain,%E4%BD%A0%E5%A5%BD")).toBe("你好")
+    expect(decodeDataUrl("data:text/plain,100%25")).toBe("100%")
+  })
+
+  test("returns empty string when there is no comma", () => {
+    expect(decodeDataUrl("notadataurl")).toBe("")
+  })
 })


### PR DESCRIPTION
## 问题

`decodeDataUrl` 把非 base64 data URL 的 body 直接交给 `decodeURIComponent`。当 `%` 后面不是合法转义时（`coverage is 100%`、`a%zz`），`decodeURIComponent` 抛 `URIError`：

```
data:text/plain,coverage is 100%   -> URIError: URI error
data:text/plain,a%zzb              -> URIError: URI error
```

`prompt.ts` 在拼装 message part 时调用它，**没有 try/catch**；而 `FilePart.url` 的 schema 只是 `z.string()`，不校验 data URL 形态。我用真实 schema + 真实分支验证过这条路径确实走得通：

```
FilePart.safeParse({... mime:"text/plain", url:"data:text/plain,coverage is 100%"})  -> true
new URL(part.url).protocol === "data:" && part.mime === "text/plain"                 -> 进入 decodeDataUrl
decodeDataUrl(...)                                                                  -> URIError 抛给调用方
```

结果是**一个畸形附件会让整轮对话失败**，而不是只让那个附件降级。

顺带修了同一函数里第二个问题：`;base64` 判断用的是 `head.includes(";base64")`，大小写敏感。RFC 2397 规定该 token 与 media type 都不区分大小写，所以 `data:text/plain;BASE64,aGVsbG8=` 会走进百分号解码分支，把**未解码的 base64 原文**当成内容返回（实测返回 `"aGVsbG8="` 而不是 `"hello"`）。

## 改动

- 用 `try/catch` 包住 `decodeURIComponent`，失败时返回原始 body。这是发送方写下的原文（只是没做百分号解码），比丢掉整轮更合理；也不会掩盖问题，因为内容照常传给模型。
- `head.toLowerCase().includes(";base64")`，让 token 与 media type 的大小写都不影响判定。

只动了这一个纯函数，没有改调用方。既有两条用例（base64 解码、`%20` 解码）行为不变。

## 验证

- `bun test test/util/data-url.test.ts` — **6 pass / 0 fail**（新增 4 条用例）。
- **确认新用例有效**：还原成原实现后 **2 fail / 4 pass**（大写 `;BASE64`、畸形转义两条）。
- `bun test test/util/` — **287 pass / 0 fail**（22 文件），确认没有影响同目录其他行为。
- `bun x oxlint` — 0 warnings / 0 errors；`bun x prettier --check` — 通过。

新增用例覆盖：`;BASE64` / `;Base64` / 大写 media type、裸 `%`、非法 `%zz`、`%25` 与裸 `%` 混排、合法多字节转义（`你好`）仍正确解码、无逗号返回空串。

🤖 Written with [Claude Code](https://claude.ai/code).
