### PR TITLE
feat(plugin): optional tool jsonSchema for bundled file tools

### DIFF
--- a/packages/opencode/src/server/routes/instance/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/experimental.ts
@@ -245,7 +245,7 @@ export const ExperimentalRoutes = lazy(() =>
           tools.map((t) => ({
             id: t.id,
             description: t.description,
-            parameters: z.toJSONSchema(t.parameters),
+            parameters: t.jsonSchema ?? z.toJSONSchema(t.parameters),
           })),
         )
       },

--- a/packages/opencode/src/session/llm-request-prefix.ts
+++ b/packages/opencode/src/session/llm-request-prefix.ts
@@ -96,7 +96,10 @@ export const buildLLMRequestPrefix = Effect.fn("Session.buildLLMRequestPrefix")(
   })
   const tools: Record<string, AITool> = {}
   for (const item of toolDefs) {
-    const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
+    const schema = ProviderTransform.schema(
+      input.model,
+      item.jsonSchema ?? z.toJSONSchema(item.parameters),
+    )
     tools[item.id] = tool({
       description: item.description,
       inputSchema: jsonSchema(schema),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1617,7 +1617,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         agent: input.agent,
         harness: input.harness,
       })) {
-        const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
+        const schema = ProviderTransform.schema(
+          input.model,
+          item.jsonSchema ?? z.toJSONSchema(item.parameters),
+        )
         tools[item.id] = tool({
           description: item.description,
           inputSchema: jsonSchema(schema),

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -190,6 +190,9 @@ export const layer = Layer.effect(
           return {
             id,
             parameters: z.object(def.args),
+            // Bundled file tools carry their own zod copy; prefer their
+            // pre-derived wire schema so .meta() is not lost across instances.
+            ...(def.jsonSchema ? { jsonSchema: def.jsonSchema } : {}),
             description: def.description,
             execute: (args, toolCtx) =>
               Effect.gen(function* () {
@@ -493,6 +496,9 @@ export const layer = Layer.effect(
               .filter(Boolean)
               .join("\n"),
             parameters: useShell ? effective.parameters : output.parameters,
+            // Shell mode rewrites parameters; only advertise a pre-derived
+            // schema for the JSON invocation style it was authored against.
+            ...(useShell ? {} : tool.jsonSchema ? { jsonSchema: tool.jsonSchema } : {}),
             execute: effective.execute,
             formatValidationError: effective.formatValidationError,
           }

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -48,6 +48,13 @@ export interface Def<Parameters extends z.ZodType = z.ZodType, M extends Metadat
   id: string
   description: string
   parameters: Parameters
+  /**
+   * Optional pre-derived provider-facing JSON Schema. When present, prompt
+   * assembly uses this instead of `z.toJSONSchema(parameters)`. Plugin/file
+   * tools that bundle their own zod set this so registry-local `.meta()`
+   * (e.g. `type: "object"` beside `anyOf`) is not dropped across instances.
+   */
+  jsonSchema?: Record<string, unknown>
   execute(args: z.infer<Parameters>, ctx: Context): Effect.Effect<ExecuteResult<M>>
   formatValidationError?(error: z.ZodError): string
   shell?: {

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -150,6 +150,41 @@ describe("tool.registry", () => {
     ),
   )
 
+  it.live("file tool jsonSchema is preferred over z.toJSONSchema(args)", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const tools = path.join(dir, ".mimocode", "tools")
+        yield* Effect.promise(() => fs.mkdir(tools, { recursive: true }))
+        yield* Effect.promise(() =>
+          Bun.write(
+            path.join(tools, "wire_schema.ts"),
+            [
+              "export default {",
+              "  description: 'pre-derived wire schema',",
+              "  args: {},",
+              "  jsonSchema: {",
+              "    type: 'object',",
+              "    properties: { voice: { type: 'object', anyOf: [{ type: 'object' }] } },",
+              "    required: ['voice'],",
+              "  },",
+              "  execute: async () => 'ok',",
+              "}",
+              "",
+            ].join("\n"),
+          ),
+        )
+        const registry = yield* ToolRegistry.Service
+        const matches = (yield* registry.all()).filter((tool) => tool.id === "wire_schema")
+        expect(matches).toHaveLength(1)
+        expect(matches[0].jsonSchema).toEqual({
+          type: "object",
+          properties: { voice: { type: "object", anyOf: [{ type: "object" }] } },
+          required: ["voice"],
+        })
+      }),
+    ),
+  )
+
   it.live("todowrite tool is not registered; task is", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -32,6 +32,18 @@ export type ToolResult = string | { output: string; metadata?: { [key: string]: 
 export function tool<Args extends z.ZodRawShape>(input: {
   description: string
   args: Args
+  /**
+   * Optional pre-derived JSON Schema for the provider-facing tool parameters.
+   * When set, the engine advertises this object as-is instead of
+   * `z.toJSONSchema(z.object(args))`.
+   *
+   * Needed for self-contained/bundled tools whose zod copy is not the engine's
+   * instance: `.meta()` / `.describe()` live in that copy's registry and are
+   * invisible to the engine's `toJSONSchema` (e.g. a nested union would lose
+   * the `type: "object"` sibling of `anyOf`). Omit for in-process tools that
+   * share the engine zod — those keep deriving the wire schema from `args`.
+   */
+  jsonSchema?: Record<string, unknown>
   execute(args: z.infer<z.ZodObject<Args>>, context: ToolContext): Promise<ToolResult>
 }) {
   return input


### PR DESCRIPTION
## Summary

Add an optional `jsonSchema` field on plugin/file tools so bundled tools can ship a pre-derived provider-facing JSON Schema.

Self-contained file tools (esbuild-inlined zod) cannot rely on `.meta()` / `.describe()`: those annotations live in the tool copy's registry and are invisible when the engine derives the wire schema via `z.toJSONSchema(z.object(def.args))`. A nested `discriminatedUnion` then emits only `anyOf` without the sibling `type: "object"`, and some models stringify the whole tool-call envelope.

This change is **backward compatible**:

- `tool({ jsonSchema? })` in `@mimo-ai/plugin` — optional
- `Tool.Def.jsonSchema?` — optional
- `fromPlugin` forwards `jsonSchema` when present
- `prompt` / `llm-request-prefix` / experimental tool list prefer `item.jsonSchema` over re-deriving from `parameters`
- Tools that omit `jsonSchema` keep the previous behavior

## Test plan

- [x] `bun typecheck` (repo turbo typecheck on push)
- [x] `bun test test/tool/registry.test.ts` — new case: file tool `jsonSchema` is surfaced on `Tool.Def`
- [ ] Follow-up consumer (MiMo Desktop `tts_speech`) will export a wire schema with `voice: { type: "object", anyOf: [...] }`

## Notes for reviewers

- Shell-mode invocation still uses the shell-wrapped parameters and does **not** advertise a JSON-style `jsonSchema` (the pre-derived schema is authored against the JSON shape).
- No change to execute validation: `parameters` remains a zod object built from `args`.
