### PR TITLE
test(session): assert the Anthropic prompt template by structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - CI triggers on `main`.
 - Prefer automation: execute requested actions without confirmation unless blocked by missing info or safety/irreversibility.
 - Install deps with `bun ci` (= `bun install --frozen-lockfile`) — install per `bun.lock`, don't mutate the lockfile. ⛔ Do NOT use `bun install`/`npm install`.
+- Comments, docs, shipped skill content and test assertions use synthetic values, never machine-specific ones — `/tmp/example` for paths, `test/model` for model refs, `feat/example` for branches.
 
 ## Core Focus
 

--- a/packages/opencode/src/skill/builtin/.bundle/deep-research/SKILL.md
+++ b/packages/opencode/src/skill/builtin/.bundle/deep-research/SKILL.md
@@ -78,29 +78,3 @@ You alone write `REPORT.md` in one pass, following [reference/report.md](referen
 For deep mode, before finalizing do one critique pass: reread the report as a skeptical reviewer (unsupported claims? stale data? missing counter-view?) and fix in place.
 
 Finally, give the user a 5-10 line summary of key conclusions and the report path.
-
-## Alternative: scripted workflow (unattended runs)
-
-The same pipeline exists as a deterministic workflow script at `/Users/mi/claude-workspace/.mimocode/workflows/deep-research-pro.js` — use it instead of the manual phases above when the run should be fully autonomous, resumable, or batch-invoked. It is convergent: re-running with the same `dir` skips completed phases (brief.md / plan.json / findings/F*.md / reflect.json / REPORT.md act as checkpoints).
-
-Invocation (workflow tool; custom scripts must be passed inline via `script`, not `name`):
-
-```
-workflow({
-  operation: "run",
-  script: <full text of deep-research-pro.js, Read it first>,
-  workspace: "<ABS_DIR>",            # same value as args.dir
-  args: {
-    dir: "<ABS_DIR>",                # e.g. /path/to/research/<slug> — mkdir -p <ABS_DIR>/findings first
-    question: "<refined research question>",
-    today: "<YYYY-MM-DD>",           # REQUIRED — run `date +%Y-%m-%d` first; sandbox has no Date
-    depth: "standard",               # quick | standard | deep
-    context: "<audience/language notes, optional>"
-  }
-})
-```
-
-Notes:
-- Do HITL clarification BEFORE invoking (the script never asks the user); fold answers into `question`/`context`.
-- Interrupted or failed run? Re-invoke with identical args — it resumes from the last checkpoint. `workflow({operation:"resume", run_id})` also works.
-- Returns `{ angles, deltaAngles, findingsFiles, reviewCritical, report }`.

--- a/packages/opencode/test/cli/tui/session-list-visibility.test.ts
+++ b/packages/opencode/test/cli/tui/session-list-visibility.test.ts
@@ -93,7 +93,7 @@ const scaffold = Effect.gen(function* () {
   // the actor row — which is how it reaches the TUI store via `session.updated`.
   const writerHost = yield* sessions.create({
     parentID: root.id as SessionID,
-    title: "checkpoint-writer: Previous checkpoint: /Users/mi/.local/share/mimocode/memory/sessions/ses_x/checkpoint.md",
+    title: "checkpoint-writer: Previous checkpoint: /tmp/memory/sessions/ses_x/checkpoint.md",
   })
   yield* actorReg.register({
     sessionID: writerHost.id as SessionID,

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -57,10 +57,12 @@ describe("session.system", () => {
       }),
     )[0]
 
-    expect(prompt).not.toContain("/Users/mi/Desktop/MCracker")
-    expect(prompt).not.toContain("feat/wiki-seal-cot-recovery")
+    // Structural markers rather than sample values: the template must carry no rendered
+    // environment block at all, and a literal path or branch name from whoever wrote the
+    // test is itself machine-specific information.
     expect(prompt).not.toContain("# Environment")
     expect(prompt).not.toContain("gitStatus:")
+    expect(prompt).not.toMatch(/\/Users\/[^/\s]+\//)
   })
 
   test("the explicit harness selects the prompt for MiMo regardless of API transport", () => {


### PR DESCRIPTION
## Summary

- `test/session/system.test.ts`:守卫测试改为断言结构标记(`# Environment`、`gitStatus:`)加一条绝对家目录路径的正则。原来的示例值不承担断言意义——要证明的是模板里没有渲染过的环境块,结构标记直接说明这件事。
- `src/skill/builtin/.bundle/deep-research/SKILL.md`:删掉「Alternative: scripted workflow」一节。它引用的脚本不随仓库发行,对任何安装都执行不了。
- `test/cli/tui/session-list-visibility.test.ts`:fixture 标题改用 `/tmp/...`,与同文件已有的 `/tmp/decoy.md` 一致。
- `AGENTS.md`:补一条约定,示例值统一用合成形式。

## Verification

- `bun typecheck`（packages/opencode）通过
- `bun test test/session/system.test.ts test/cli/tui/session-list-visibility.test.ts test/skill`：105 pass
