### PR TITLE
fix(ui): preserve patch line endings in session diff view

### DIFF
--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -194,6 +194,7 @@ beforeAll(async () => {
   mock.module("@/context/language", () => ({
     useLanguage: () => ({
       t: (key: string) => key,
+      intl: () => "en-US",
     }),
   }))
 

--- a/packages/enterprise/bunfig.toml
+++ b/packages/enterprise/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test/preload.ts"]

--- a/packages/enterprise/test/preload.ts
+++ b/packages/enterprise/test/preload.ts
@@ -1,0 +1,48 @@
+import { afterAll, spyOn } from "bun:test"
+
+// Exercise the real storage adapter against an isolated S3 HTTP fixture.
+// Never use developer credentials or write to a deployed bucket during tests.
+const env = {
+  OPENCODE_STORAGE_ADAPTER: "s3",
+  OPENCODE_STORAGE_BUCKET: "test-bucket",
+  OPENCODE_STORAGE_REGION: "us-east-1",
+  OPENCODE_STORAGE_ACCESS_KEY_ID: "test-key",
+  OPENCODE_STORAGE_SECRET_ACCESS_KEY: "test-secret",
+}
+const previous = Object.fromEntries(Object.keys(env).map((key) => [key, process.env[key]]))
+Object.assign(process.env, env)
+
+const objects = new Map<string, string>()
+const original = globalThis.fetch
+const fetch = spyOn(globalThis, "fetch").mockImplementation((async (input, init) => {
+  const request = new Request(input, init)
+  const url = new URL(request.url)
+  if (url.origin !== "https://s3.us-east-1.amazonaws.com") return original(input, init)
+  if (url.searchParams.get("list-type") === "2") {
+    const keys = [...objects.keys()]
+      .sort()
+      .filter((key) => key.startsWith(url.searchParams.get("prefix") ?? ""))
+      .filter((key) => key > (url.searchParams.get("start-after") ?? ""))
+      .slice(0, Number(url.searchParams.get("max-keys") ?? 1000))
+    return new Response(`<ListBucketResult>${keys.map((key) => `<Contents><Key>${key}</Key></Contents>`).join("")}</ListBucketResult>`)
+  }
+  const key = decodeURIComponent(url.pathname.slice("/test-bucket/".length))
+  if (request.method === "PUT") {
+    objects.set(key, await request.text())
+    return new Response(null)
+  }
+  if (request.method === "DELETE") {
+    objects.delete(key)
+    return new Response(null, { status: 204 })
+  }
+  const value = objects.get(key)
+  return new Response(value ?? null, { status: value == null ? 404 : 200 })
+}) as typeof globalThis.fetch)
+
+afterAll(() => {
+  fetch.mockRestore()
+  Object.entries(previous).forEach(([key, value]) => {
+    if (value == null) delete process.env[key]
+    if (value != null) process.env[key] = value
+  })
+})

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -5257,6 +5257,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         )
       }
       const agentID = input.agentID ?? "main"
+      // Abandon the recovered assistant BEFORE detaching runLoop so callers that
+      // observe Error / completed state see it immediately (not only in ensuring
+      // after the detached loop finishes). ensuring below remains as an idempotent
+      // safety net (abandonRecoveredAssistant no-ops once completed is set).
+      yield* abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID })
       return yield* state.ensureRunning(
         input.sessionID,
         agentID,
@@ -5288,6 +5293,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         )
       }
       const agentID = input.agentID ?? "main"
+      // Abandon before detaching runLoop — same timing requirement as resume.
+      yield* abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID })
       yield* state.start(
         input.sessionID,
         agentID,

--- a/packages/ui/src/components/session-diff.test.ts
+++ b/packages/ui/src/components/session-diff.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, test } from "bun:test"
+import { createPatch } from "diff"
 import { normalize, text } from "./session-diff"
 
 describe("session diff", () => {
+  test.each([
+    ["one\ntwo", "one\nthree"],
+    ["one\ntwo\n", "one\nthree"],
+    ["one\ntwo", "one\nthree\n"],
+    ["one\ntwo", "three\ntwo"],
+    ["", "one\n"],
+    ["one\n", ""],
+  ])("preserves patch line endings for %j -> %j", (before, after) => {
+    const view = normalize({
+      file: "endings.ts",
+      patch: createPatch("endings.ts", before, after),
+      additions: 1,
+      deletions: 1,
+    })
+    expect(text(view, "deletions")).toBe(before)
+    expect(text(view, "additions")).toBe(after)
+  })
+
   test("keeps unified patch content", () => {
     const diff = {
       file: "a.ts",

--- a/packages/ui/src/components/session-diff.ts
+++ b/packages/ui/src/components/session-diff.ts
@@ -29,24 +29,34 @@ function patch(diff: ReviewDiff) {
   if (typeof diff.patch === "string") {
     const [patch] = parsePatch(diff.patch)
 
-    const beforeLines = []
-    const afterLines = []
+    const beforeLines: string[] = []
+    const afterLines: string[] = []
 
     for (const hunk of patch.hunks) {
-      for (const line of hunk.lines) {
+      for (const [index, line] of hunk.lines.entries()) {
+        if (line.startsWith("\\")) {
+          const previous = hunk.lines[index - 1]?.[0]
+          if (previous === "-" || previous === " ") {
+            beforeLines[beforeLines.length - 1] = beforeLines.at(-1)!.replace(/\n$/, "")
+          }
+          if (previous === "+" || previous === " ") {
+            afterLines[afterLines.length - 1] = afterLines.at(-1)!.replace(/\n$/, "")
+          }
+          continue
+        }
         if (line.startsWith("-")) {
-          beforeLines.push(line.slice(1))
+          beforeLines.push(line.slice(1) + "\n")
         } else if (line.startsWith("+")) {
-          afterLines.push(line.slice(1))
+          afterLines.push(line.slice(1) + "\n")
         } else {
           // context line (starts with ' ')
-          beforeLines.push(line.slice(1))
-          afterLines.push(line.slice(1))
+          beforeLines.push(line.slice(1) + "\n")
+          afterLines.push(line.slice(1) + "\n")
         }
       }
     }
 
-    return { before: beforeLines.join("\n"), after: afterLines.join("\n"), patch: diff.patch }
+    return { before: beforeLines.join(""), after: afterLines.join(""), patch: diff.patch }
   }
   return {
     before: "before" in diff && typeof diff.before === "string" ? diff.before : "",


### PR DESCRIPTION
## Summary
- **session-diff**: rebuild `before`/`after` text from unified patches while keeping each line's newline and honoring `\ No newline at end of file` markers, so files without a trailing newline round-trip exactly. Adds a table-driven test over trailing-newline combinations.
- **session/prompt**: abandon the recovered assistant *before* detaching `runLoop` on resume/start so callers that observe Error/completed state see it immediately; the `ensuring` call remains as an idempotent safety net.
- **app**: add `intl()` to the mocked `useLanguage` in `submit.test.ts`.
- **enterprise**: add a bun test preload that exercises the real S3 storage adapter against an in-memory S3 HTTP fixture instead of developer credentials.

## Test plan
- [x] `bun test src/components/session-diff.test.ts` in `packages/ui` (8 pass)
- [x] `bun typecheck` in `packages/opencode`
