### PR TITLE
feat(tool): gate tool-name case folding behind a flag

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -177,6 +177,15 @@ export const Flag = {
   MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT: number("MIMOCODE_OUTPUT_LENGTH_CONTINUATION_LIMIT") ?? 3,
   MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT: number("MIMOCODE_INVALID_OUTPUT_CONTINUATION_LIMIT") ?? 2,
   MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT: number("MIMOCODE_TEXT_TOOL_CALL_RETRY_LIMIT") ?? 2,
+  // Defaults to true (lenient): a tool call whose name only differs from the
+  // registered one by letter case (`Read` for `read`, `applyPatch` for
+  // `apply_patch`) still resolves instead of failing. Set
+  // MIMOCODE_IGNORE_TOOL_NAME_CASE=false to require exact casing, which leaves
+  // separator-only aliasing (`apply-patch` for `apply_patch`) as the sole
+  // remaining repair.
+  get MIMOCODE_IGNORE_TOOL_NAME_CASE() {
+    return !falsy("MIMOCODE_IGNORE_TOOL_NAME_CASE")
+  },
   // Defaults to false. When enabled, unsigned historical reasoning sent through
   // the Anthropic Messages format receives an empty placeholder signature so it
   // follows the same native thinking-block serialization path as signed content.

--- a/packages/opencode/src/util/tool-compat.ts
+++ b/packages/opencode/src/util/tool-compat.ts
@@ -1,22 +1,50 @@
 import type { JSONSchema7 } from "@ai-sdk/provider"
+import { Flag } from "@/flag/flag"
 import { isRecord } from "./record"
 
-/** Collapse PascalCase, camelCase, snake_case, and kebab-case to one comparable token. */
-export function canonical(name: string): string {
-  const mcp = /^mcp__(.+?)__(.+)$/.exec(name)
-  return (mcp ? mcp[1] + "_" + mcp[2] : name).replace(/[-_\s]+/g, "").toLowerCase()
+/** `mcp__<server>__<tool>`, the AI SDK's prefixed form of an MCP tool name. */
+const MCP_NAME = /^mcp__(.+?)__(.+)$/
+
+/**
+ * Collapse PascalCase, camelCase, snake_case, and kebab-case to one comparable
+ * token, flattening the `mcp__server__tool` prefix to `server_tool`. With
+ * `ignoreCase` off, separators are still stripped but letter case is preserved,
+ * so `apply-patch` and `apply_patch` share a token while `applyPatch` does not.
+ */
+export function canonical(name: string, ignoreCase = true): string {
+  const mcp = MCP_NAME.exec(name)
+  const collapsed = (mcp ? mcp[1] + "_" + mcp[2] : name).replace(/[-_\s]+/g, "")
+  return ignoreCase ? collapsed.toLowerCase() : collapsed
 }
 
-/** Resolve a model-provided identifier to a registered name when casing or separators differ. */
+/**
+ * Resolve a model-provided identifier to a registered name when casing or
+ * separators differ. Case folding is gated on
+ * `Flag.MIMOCODE_IGNORE_TOOL_NAME_CASE` (lenient by default); with the flag off
+ * only separator differences are repaired and a mis-cased name stays unresolved.
+ *
+ * MCP names are exempt and always fold case: `mcp__server__tool` is an SDK-level
+ * convention whose two segments are authored by the remote server, so there is
+ * no local casing for the strict mode to enforce there.
+ */
 export function resolveName(name: string, candidates: readonly string[]): string | undefined {
-  if (candidates.includes(name)) return name
-
+  const always = Flag.MIMOCODE_IGNORE_TOOL_NAME_CASE || MCP_NAME.test(name)
   const lower = name.toLowerCase()
-  const caseMatch = candidates.find((candidate) => candidate.toLowerCase() === lower)
-  if (caseMatch) return caseMatch
+  const foldedKey = canonical(name, true)
+  const exactKey = canonical(name, false)
 
-  const key = canonical(name)
-  return candidates.find((candidate) => canonical(candidate) === key)
+  // Single pass over the catalog; the strongest match still wins regardless of
+  // where it sits: exact name > case-insensitive name > canonical token.
+  let caseMatch: string | undefined
+  let canonicalMatch: string | undefined
+  for (const candidate of candidates) {
+    if (candidate === name) return candidate
+    const fold = always || MCP_NAME.test(candidate)
+    if (fold && !caseMatch && candidate.toLowerCase() === lower) caseMatch = candidate
+    if (!canonicalMatch && canonical(candidate, fold) === (fold ? foldedKey : exactKey)) canonicalMatch = candidate
+  }
+
+  return caseMatch ?? canonicalMatch
 }
 
 export function schemaPropertyKeys(schema: JSONSchema7): string[] {

--- a/packages/opencode/test/util/tool-compat.test.ts
+++ b/packages/opencode/test/util/tool-compat.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import type { JSONSchema7 } from "@ai-sdk/provider"
 import {
   canonical,
@@ -44,6 +44,58 @@ describe("util.tool-compat", () => {
 
       expect(resolveName("mcp__feishu-mcp-pro__doc_read", mcpTools)).toBe("feishu-mcp-pro_doc_read")
       expect(resolveName("mcp__feishu_mcp_pro__doc_read", mcpTools)).toBe("feishu-mcp-pro_doc_read")
+    })
+
+    test("prefers an exact match over an earlier case-insensitive one", () => {
+      expect(resolveName("Read", ["Read", "read"])).toBe("Read")
+      expect(resolveName("read", ["Read", "read"])).toBe("read")
+    })
+
+    test("prefers a case-insensitive match over an earlier canonical one", () => {
+      expect(resolveName("apply_patch", ["applyPatch", "Apply_Patch"])).toBe("Apply_Patch")
+    })
+
+    describe("with MIMOCODE_IGNORE_TOOL_NAME_CASE=false", () => {
+      const previous = process.env["MIMOCODE_IGNORE_TOOL_NAME_CASE"]
+
+      beforeEach(() => {
+        process.env["MIMOCODE_IGNORE_TOOL_NAME_CASE"] = "false"
+      })
+
+      afterEach(() => {
+        if (previous === undefined) delete process.env["MIMOCODE_IGNORE_TOOL_NAME_CASE"]
+        else process.env["MIMOCODE_IGNORE_TOOL_NAME_CASE"] = previous
+      })
+
+      test("still returns exact matches", () => {
+        expect(resolveName("read", tools)).toBe("read")
+        expect(resolveName("apply_patch", tools)).toBe("apply_patch")
+      })
+
+      test("rejects names that only differ by case", () => {
+        expect(resolveName("Read", tools)).toBeUndefined()
+        expect(resolveName("ApplyPatch", tools)).toBeUndefined()
+        expect(resolveName("MultiEdit", tools)).toBeUndefined()
+      })
+
+      test("still repairs separator-only differences", () => {
+        expect(resolveName("apply-patch", tools)).toBe("apply_patch")
+        expect(resolveName("multi edit", tools)).toBe("multi_edit")
+      })
+
+      test("keeps MCP names case-insensitive", () => {
+        const mcpTools = ["feishu-mcp-pro_doc_read"] as const
+
+        expect(resolveName("mcp__feishu-mcp-pro__doc_read", mcpTools)).toBe("feishu-mcp-pro_doc_read")
+        expect(resolveName("mcp__feishu-mcp-pro__Doc_Read", mcpTools)).toBe("feishu-mcp-pro_doc_read")
+        expect(resolveName("mcp__Feishu_MCP_Pro__doc_read", mcpTools)).toBe("feishu-mcp-pro_doc_read")
+      })
+
+      test("keeps MCP-prefixed candidates case-insensitive", () => {
+        const mcpTools = ["mcp__feishu-mcp-pro__doc_read"] as const
+
+        expect(resolveName("feishu_mcp_pro_Doc_Read", mcpTools)).toBe("mcp__feishu-mcp-pro__doc_read")
+      })
     })
   })
 


### PR DESCRIPTION
## What

Tool-call name resolution folded letter case unconditionally. This makes that lenient behavior a switch, `MIMOCODE_IGNORE_TOOL_NAME_CASE`, declared in `src/flag/flag.ts` and **defaulting to on** so existing calls keep resolving.

| | default (flag on) | `MIMOCODE_IGNORE_TOOL_NAME_CASE=false` |
| --- | --- | --- |
| exact name (`read`) | resolves | resolves |
| case-only difference (`Read`, `ApplyPatch`) | resolves | **unresolved** |
| separator-only difference (`apply-patch`, `multi edit`) | resolves | resolves |
| MCP name (`mcp__server__tool`, either side) | resolves | resolves |
| argument keys (`filePath` → `file_path`) | case-insensitive | case-insensitive |

## MCP compatibility

MCP names are exempt from strict mode and always fold case, in both directions — an `mcp__`-prefixed incoming name, or an `mcp__`-prefixed registered candidate. The two segments of `mcp__server__tool` are authored by the remote server, so there is no local casing for strict mode to enforce there. Turning the flag off cannot break an MCP tool call.

## Also

`resolveName` collapsed from three catalog traversals to one pass, preserving precedence: exact name > case-insensitive name > canonical token. Argument-key aliasing in `normalizeInput` is untouched and stays unconditionally case-insensitive; the flag only affects tool-name resolution.

## Verification

- `bun test test/util/tool-compat.test.ts` → 29 pass, 0 fail, 50 expect() calls
- `bun typecheck` → clean