### PR TITLE
fix(session): freeze prefix snapshot across MCP catalog drift

### DIFF
--- a/packages/opencode/src/session/prefix-snapshot.ts
+++ b/packages/opencode/src/session/prefix-snapshot.ts
@@ -4,6 +4,7 @@ import { asSchema } from "@ai-sdk/provider-utils"
 import { Effect } from "effect"
 import { and, Database, eq } from "@/storage"
 import type { Permission } from "@/permission"
+import { MCP_TOOL_SEARCH_ID } from "@/tool/mcp-tool-search"
 import type { MessageID, SessionID } from "./schema"
 import { SessionPrefixSnapshotTable, type SessionPrefixToolSnapshot } from "./session.sql"
 
@@ -80,6 +81,41 @@ export function restoreTools(items: SessionPrefixToolSnapshot[]) {
       }),
     ]),
   )
+}
+
+export function advertisePinned(
+  live: Record<string, AITool>,
+  liveActive: string[],
+  frozen: SessionPrefixToolSnapshot[] | null | undefined,
+) {
+  if (frozen == null) return { tools: live, activeTools: liveActive }
+  const restored = restoreTools(frozen)
+  const tools: Record<string, AITool> = {}
+  for (const item of frozen) {
+    const pinned = restored[item.name]
+    const current = live[item.name]
+    if (current && pinned) {
+      tools[item.name] = { ...current, description: pinned.description, inputSchema: pinned.inputSchema }
+      continue
+    }
+    if (current) {
+      tools[item.name] = current
+      continue
+    }
+    if (pinned) tools[item.name] = pinned
+  }
+  for (const [name, item] of Object.entries(live)) {
+    if (tools[name]) continue
+    tools[name] = item
+  }
+  const frozenNames = frozen.map((item) => item.name).filter((name) => tools[name])
+  const frozenSet = new Set(frozenNames)
+  const allowSearchExtras = frozenSet.has(MCP_TOOL_SEARCH_ID)
+  const extras = liveActive.filter((name) => {
+    if (frozenSet.has(name) || !tools[name]) return false
+    return name === "StructuredOutput" || allowSearchExtras
+  })
+  return { tools, activeTools: [...frozenNames, ...extras] }
 }
 
 export const get = Effect.fn("SessionPrefixSnapshot.get")(function* (sessionID: SessionID, key: string) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4481,12 +4481,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 ...(Flag.MIMOCODE_DISABLE_INSTRUCTIONS ? [] : instructions.content),
               ]
             })
-            // Note: `buildLLMRequestPrefix` also returns a `tools` field, but we
-            // intentionally don't use it here — the `tools` variable from `resolveTools`
-            // (set earlier via `handle.process({tools: ...})`) carries `execute` closures
-            // the AI SDK needs for runtime tool dispatch, while `buildLLMRequestPrefix`
-            // produces schema-only tools. Schema bytes match between both paths (both call
-            // registry.tools with identical args), so prefix cache parity holds.
+            // `buildLLMRequestPrefix` tools are schema-only; dispatch uses resolveTools
+            // execute closures. After the first pin, advertised schemas stay frozen so
+            // MCP catalog drift cannot miss the prefix cache.
             // Main runLoop: no watermark — LLM must see the full msgs list,
             // including this turn's intermediate assistant turns (tool reads,
             // task creates, etc.) so each step doesn't replay from the bare
@@ -4507,42 +4504,23 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               Effect.provideService(LLM.Service, llm),
               Effect.provideService(ToolRegistry.Service, registry),
             )
-            const currentToolsHash = SessionPrefixSnapshot.toolsHash(tools, activeTools)
-            const currentTools = yield* Effect.promise(() => SessionPrefixSnapshot.snapshotTools(tools, activeTools))
             const resolvedPrefix = yield* Effect.gen(function* () {
-              if (!frozen) {
-                const snapshot = yield* SessionPrefixSnapshot.pin({
-                  sessionID,
-                  profileKey: prefixProfileKey,
-                  system: initialPrefix.system,
-                  toolsHash: currentToolsHash,
-                  tools: currentTools,
-                  watermarkMessageID: lastUser.id,
-                })
-                return { prefix: initialPrefix, snapshot }
+              if (frozen) {
+                return {
+                  prefix: initialPrefix,
+                  snapshot: frozen,
+                  ...SessionPrefixSnapshot.advertisePinned(tools, activeTools, frozen.tools),
+                }
               }
-              if (frozen.tools && frozen.tools_hash === currentToolsHash) return { prefix: initialPrefix, snapshot: frozen }
-              const prefix = yield* buildLLMRequestPrefix({
-                sessionID,
-                agent,
-                model,
-                msgs,
-                additions: yield* currentAdditions(),
-                prompt: sessionPrompt,
-                collapseCheckpointTail: true,
-              }).pipe(
-                Effect.provideService(LLM.Service, llm),
-                Effect.provideService(ToolRegistry.Service, registry),
-              )
-              const snapshot = yield* SessionPrefixSnapshot.rotate({
+              const snapshot = yield* SessionPrefixSnapshot.pin({
                 sessionID,
                 profileKey: prefixProfileKey,
-                system: prefix.system,
-                toolsHash: currentToolsHash,
-                tools: currentTools,
+                system: initialPrefix.system,
+                toolsHash: SessionPrefixSnapshot.toolsHash(tools, activeTools),
+                tools: yield* Effect.promise(() => SessionPrefixSnapshot.snapshotTools(tools, activeTools)),
                 watermarkMessageID: lastUser.id,
               })
-              return { prefix, snapshot }
+              return { prefix: initialPrefix, snapshot, tools, activeTools }
             })
             const prebuiltSystem = resolvedPrefix.prefix.system
             const modelMsgs = resolvedPrefix.prefix.inheritedMessages
@@ -4562,8 +4540,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               prebuiltSystem,
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
               mergeTurnContextIntoLastUser: true,
-              tools,
-              activeTools,
+              tools: resolvedPrefix.tools,
+              activeTools: resolvedPrefix.activeTools,
               model,
               toolChoice: isLastStep ? ("none" as const) : format.type === "json_schema" ? ("required" as const) : undefined,
               agentID: lastUser.agentID,

--- a/packages/opencode/test/session/prefix-snapshot.test.ts
+++ b/packages/opencode/test/session/prefix-snapshot.test.ts
@@ -139,4 +139,65 @@ describe("session prefix snapshot", () => {
       SessionPrefixSnapshot.toolsHash(second, ["alpha", "beta"]),
     )
   })
+
+  test("advertisePinned keeps frozen schemas and execute while ignoring later catalog tools", () => {
+    const execute = async () => ({ output: "live", title: "", metadata: {} })
+    const live = {
+      read: tool({
+        description: "live read",
+        inputSchema: jsonSchema({ type: "object", properties: { path: { type: "string" } } }),
+        execute,
+      }),
+      mcp_late: tool({
+        description: "appeared after pin",
+        inputSchema: jsonSchema({ type: "object", properties: {} }),
+        execute,
+      }),
+    }
+    const advertised = SessionPrefixSnapshot.advertisePinned(live, ["read", "mcp_late"], [
+      {
+        name: "read",
+        description: "pinned read",
+        input_schema: { type: "object", properties: { path: { type: "string" } } },
+      },
+    ])
+    expect(advertised.activeTools).toEqual(["read"])
+    expect(advertised.tools.read?.description).toBe("pinned read")
+    expect(advertised.tools.read?.execute).toBe(execute)
+    expect(advertised.tools.mcp_late?.execute).toBe(execute)
+  })
+
+  test("advertisePinned appends mcp_tool_search activations and StructuredOutput", () => {
+    const execute = async () => ({ output: "live", title: "", metadata: {} })
+    const live = {
+      mcp_tool_search: tool({
+        description: "live catalog",
+        inputSchema: jsonSchema({ type: "object", properties: { query: { type: "string" } } }),
+        execute,
+      }),
+      mcp_success: tool({
+        description: "loaded later",
+        inputSchema: jsonSchema({ type: "object", properties: {} }),
+        execute,
+      }),
+      StructuredOutput: tool({
+        description: "schema",
+        inputSchema: jsonSchema({ type: "object", properties: {} }),
+        execute,
+      }),
+    }
+    const advertised = SessionPrefixSnapshot.advertisePinned(
+      live,
+      ["mcp_tool_search", "mcp_success", "StructuredOutput"],
+      [
+        {
+          name: "mcp_tool_search",
+          description: "pinned catalog",
+          input_schema: { type: "object", properties: { query: { type: "string" } } },
+        },
+      ],
+    )
+    expect(advertised.activeTools).toEqual(["mcp_tool_search", "mcp_success", "StructuredOutput"])
+    expect(advertised.tools.mcp_tool_search?.description).toBe("pinned catalog")
+  })
 })

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -334,34 +334,38 @@ const mcpSuccessResult: CallToolResult = {
   structuredContent: { changed: true, windowID: 42 },
   _meta: { privateToken: "success-meta-is-client-only" },
 }
+const mcpSuccessTool = dynamicTool({
+  description: "Return a standard structured MCP success result",
+  inputSchema: jsonSchema({
+    type: "object",
+    properties: {
+      private_window_id: { type: "number", description: "Secret nested MCP window selector" },
+    },
+    additionalProperties: false,
+  }),
+  execute: async () => mcpSuccessResult,
+})
+const mcpResultTool = dynamicTool({
+  description: "Return a standard MCP tool execution error",
+  inputSchema: jsonSchema({
+    type: "object",
+    properties: {
+      private_error_code: { type: "string", description: "Secret nested MCP error selector" },
+    },
+    additionalProperties: false,
+  }),
+  execute: async () => mcpErrorResult,
+})
 const mcpIt = testEffect(
   makeHttp(
     mcpLayer(() => ({
-      mcp_success: dynamicTool({
-        description: "Return a standard structured MCP success result",
-        inputSchema: jsonSchema({
-          type: "object",
-          properties: {
-            private_window_id: { type: "number", description: "Secret nested MCP window selector" },
-          },
-          additionalProperties: false,
-        }),
-        execute: async () => mcpSuccessResult,
-      }),
-      mcp_result: dynamicTool({
-        description: "Return a standard MCP tool execution error",
-        inputSchema: jsonSchema({
-          type: "object",
-          properties: {
-            private_error_code: { type: "string", description: "Secret nested MCP error selector" },
-          },
-          additionalProperties: false,
-        }),
-        execute: async () => mcpErrorResult,
-      }),
+      mcp_success: mcpSuccessTool,
+      mcp_result: mcpResultTool,
     })),
   ),
 )
+const growingMcp: Record<string, AITool> = {}
+const growingMcpIt = testEffect(makeHttp(mcpLayer(() => ({ ...growingMcp }))))
 const lifecycleContexts: MCP.TurnContext[] = []
 const lifecycleNotifications: Array<Record<string, any>> = []
 let lifecycleNotificationHangs = false
@@ -1470,6 +1474,75 @@ it.live(
             revision: 1,
             watermark_message_id: lastAssistant?.info.id,
           })
+        }),
+        { git: true, config: providerCfg },
+      ),
+    ),
+  30_000,
+)
+
+growingMcpIt.live(
+  "keeps the frozen prefix when MCP tools appear after the first pin",
+  () =>
+    withoutDynamicSystemPrompt(() =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          for (const key of Object.keys(growingMcp)) delete growingMcp[key]
+          growingMcp.mcp_success = mcpSuccessTool
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const file = path.join(Instance.directory, "AGENTS.md")
+          yield* Effect.promise(() => Bun.write(file, "PREFIX_INSTRUCTION_V1"))
+          const chat = yield* sessions.create({
+            title: "Frozen MCP prefix",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+
+          yield* llm.text("first")
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "first query" }],
+          })
+          growingMcp.mcp_result = mcpResultTool
+          yield* Effect.promise(() => Bun.write(file, "PREFIX_INSTRUCTION_V2"))
+          yield* llm.text("second")
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "second query" }],
+          })
+
+          const inputs = yield* llm.inputs
+          const names = inputs.slice(0, 2).map((input) =>
+            ((input.tools ?? []) as Array<Record<string, unknown>>).map(wireToolName),
+          )
+          expect(names[0]).toContain("mcp_success")
+          expect(names[0]).not.toContain("mcp_result")
+          expect(names[1]).toEqual(names[0])
+          const systems = inputs.slice(0, 2).map((input) =>
+            ((input.messages ?? []) as { role: string; content: unknown }[])
+              .flatMap((message) =>
+                message.role === "system" && typeof message.content === "string" ? [message.content] : [],
+              )
+              .join("\n"),
+          )
+          expect(systems[1]).toBe(systems[0])
+          expect(systems[1]).not.toContain("PREFIX_INSTRUCTION_V2")
+
+          const snapshots = yield* Effect.sync(() =>
+            Database.use((db) =>
+              db
+                .select()
+                .from(SessionPrefixSnapshotTable)
+                .where(eq(SessionPrefixSnapshotTable.session_id, chat.id))
+                .all(),
+            ),
+          )
+          expect(snapshots).toHaveLength(1)
+          expect(snapshots[0]?.revision).toBe(1)
         }),
         { git: true, config: providerCfg },
       ),


### PR DESCRIPTION
### Issue / context (if applicable)

Related: #2318 (larger MCP freeze design with flag / overlay / last-advertised cache marker). This PR is the smaller pin-not-rotate path on the existing session prefix snapshot.

### Type of change

Bug fix

### What does this PR do?

MCP connect / `list_changed` / late catalog tools currently rotate the session prefix snapshot because the advertised tool hash changes. That busts provider prefix cache on later turns of the same session+profile.

After the first pin for `(session_id, profile_key)`:

- freeze system text and advertised tool *schemas*
- overlay those schemas onto live `execute` closures via `advertisePinned`
- do not `rotate()` on tools-hash mismatch
- later catalog tools stay in the dispatch map but off `activeTools`
- `mcp_tool_search` extras and `StructuredOutput` remain eligible to advertise

### How did you verify your code works?

- `bun test test/session/prefix-snapshot.test.ts` (4 pass)
- `bun test test/session/prompt-effect.test.ts -t "keeps the frozen prefix when MCP tools appear"` (1 pass)
- pre-push `bun turbo typecheck` passed

### Screenshots / recordings

_N/A (no UI change)._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR