### PR TITLE
fix(provider): skip plugin auth loader when provider is missing from catalog

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -367,7 +367,8 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
       provider: "openai",
       async loader(getAuth, provider) {
         const auth = await getAuth()
-        if (auth.type !== "oauth") return {}
+        if (!auth || auth.type !== "oauth") return {}
+        if (!provider) return {}
 
         // Zero out costs for Codex (included with ChatGPT subscription)
         for (const [modelID, model] of Object.entries(provider.models)) {
@@ -395,7 +396,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
             }
 
             const currentAuth = await getAuth()
-            if (currentAuth.type !== "oauth") return fetch(requestInput, init)
+            if (!currentAuth || currentAuth.type !== "oauth") return fetch(requestInput, init)
 
             // Cast to include accountId field
             const authWithAccount = currentAuth as typeof currentAuth & { accountId?: string }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1452,10 +1452,16 @@ const layer: Layer.Layer<
           if (!stored) continue
           if (!plugin.auth.loader) continue
 
+          const catalog = database[plugin.auth.provider]
+          if (!catalog) {
+            log.warn("skipping plugin auth loader; provider missing from model catalog", { providerID })
+            continue
+          }
+
           const options = yield* Effect.promise(() =>
             plugin.auth!.loader!(
               () => bridge.promise(auth.get(providerID).pipe(Effect.orDie)) as any,
-              database[plugin.auth!.provider],
+              catalog,
             ),
           )
           const opts = options ?? {}

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -64,6 +64,32 @@ describe("plugin.codex", () => {
       }
     })
 
+    test("returns empty options when provider is missing from the catalog", async () => {
+      const hooks = await CodexAuthPlugin(fakeInput)
+      const result = await hooks.auth!.loader!(
+        async () => ({ type: "oauth", access: "access", refresh: "refresh", expires: Date.now() + 60_000 }),
+        undefined as never,
+      )
+      expect(result).toEqual({})
+    })
+
+    test("passes through fetch when oauth auth is cleared after load", async () => {
+      globalThis.fetch = mock(() => Promise.resolve(new Response("ok"))) as unknown as typeof fetch
+      const hooks = await CodexAuthPlugin(fakeInput)
+      const auths: Array<{ type: "oauth"; access: string; refresh: string; expires: number } | undefined> = [
+        { type: "oauth", access: "access", refresh: "refresh", expires: Date.now() + 60_000 },
+        undefined,
+      ]
+      const options = await hooks.auth!.loader!(
+        async () => auths.shift() as never,
+        { models: {} } as never,
+      )
+
+      const response = await options.fetch!("https://api.openai.com/v1/responses")
+      expect(response.ok).toBe(true)
+      expect(await response.text()).toBe("ok")
+    })
+
     test("forwards request cancellation while refreshing an expired token", async () => {
       const signal = AbortSignal.timeout(25)
       const signals: Array<AbortSignal | null | undefined> = []

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -8,6 +8,7 @@ import { Plugin } from "../../src/plugin/index"
 import { ModelsDev } from "../../src/provider"
 import { Provider } from "../../src/provider"
 import { ProviderID, ModelID } from "../../src/provider/schema"
+import { Auth } from "../../src/auth"
 import { Env } from "../../src/env"
 import { Global } from "../../src/global"
 import { Effect } from "effect"
@@ -3315,6 +3316,57 @@ test("plugin config providers persist after instance dispose", async () => {
   })
   expect(second[ProviderID.make("demo")]).toBeDefined()
   expect(second[ProviderID.make("demo")].models[ModelID.make("chat")]).toBeDefined()
+})
+
+test("plugin auth loader is skipped when provider is missing from catalog", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const root = path.join(dir, ".mimocode", "plugin")
+      await mkdir(root, { recursive: true })
+      await Bun.write(
+        path.join(root, "missing-catalog.ts"),
+        [
+          "export default {",
+          '  id: "demo.missing-catalog",',
+          "  server: async () => ({",
+          "    auth: {",
+          '      provider: "test-missing-provider",',
+          "      async loader() {",
+          '        throw new Error("plugin auth loader should not run when provider is missing from catalog")',
+          "      },",
+          "      methods: [],",
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  Auth.inject(
+    JSON.stringify({
+      "test-missing-provider": {
+        type: "api",
+        key: "test-key",
+      },
+    }),
+  )
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        set("ANTHROPIC_API_KEY", "test-api-key")
+      },
+      fn: async () => {
+        const providers = await list()
+        expect(providers[ProviderID.anthropic]).toBeDefined()
+        expect(providers[ProviderID.make("test-missing-provider")]).toBeUndefined()
+      },
+    })
+  } finally {
+    Auth.inject(undefined)
+  }
 })
 
 test("plugin config enabled and disabled providers are honored", async () => {


### PR DESCRIPTION
## Summary

Provider state is built once per instance and runs every plugin auth loader with `database[plugin.auth.provider]`. When the model catalog lacks that provider (custom `MIMOCODE_MODELS_URL`/`MIMOCODE_MODELS_PATH`, or a truncated cache) but `auth.json` still holds a record for it, the Codex loader dereferenced `provider.models` on `undefined` and the whole state build failed as an Effect defect. After an instance reload (for example the add-model wizard, which calls `instance.dispose` then re-bootstraps) `provider.list` errored and the TUI lost its model list.

## Changes

- `provider.ts`: skip the plugin auth loader with a warn log when the catalog entry is absent. `mergeProvider` would have returned early for that provider anyway, so no data is lost.
- `codex.ts`: guard `provider` and both `getAuth()` results against `undefined`, so a logout after load falls back to plain `fetch` instead of throwing.
- Tests:
  - `test/provider/provider.test.ts`: end-to-end case with a plugin whose loader throws if called and a provider absent from the catalog; fails on `main`, passes with this change.
  - `test/plugin/codex.test.ts`: loader returns `{}` when the catalog entry is missing; `fetch` passes through when oauth auth is cleared after load.

## Verification

```
cd packages/opencode
bun run test test/plugin/codex.test.ts test/provider/provider.test.ts
bun typecheck
```

Note: the new provider test loads a `.mimocode/plugin` file and takes several seconds, like the neighbouring plugin tests, so it needs the `--timeout 30000` that `bun run test` already applies.
