### PR TITLE
docs: announce MiMo Desktop open beta in readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,25 @@
   <a href="https://mimo.xiaomi.com/coder">Website</a> | <a href="https://mimo.xiaomi.com/en/blog/mimo-code-long-horizon">Blog</a>
 </p>
 
+<p align="center"><strong>MiMo Desktop Beta Invitation</strong>: <a href="https://mimo-ai.xiaomimimo.com/desktop/invite/">Apply for the international beta</a></p>
+
 ---
 
 MiMoCode is a terminal-native AI coding assistant. It can read and write code, run commands, manage Git, and use a persistent memory system to keep a deep understanding of your project across sessions while continuously improving itself.
+
+## Xiaomi MiMo Desktop Beta
+
+<p align="center"><img src="packages/desktop/icons/beta/icon.png" alt="Xiaomi MiMo Desktop" width="128"></p>
+
+Xiaomi MiMo Desktop is built for real-world work: one conversation can handle office work, design, coding, and multimodal creation, while multiple conversations can divide work and collaborate. The desktop app is powered by **MiMo Code as its core engine**, bringing its terminal-native intelligence to desktop workflows.
+
+- **Smart orchestration**: evaluates task type and cost, then dynamically selects models, frameworks, and tools; complex tasks can run across multiple agents in parallel.
+- **Continuous iteration**: drag in files in multiple formats, create PPTs, webpages, 3D assets, and apps, preview and operate on results in-session, edit selected regions precisely, and roll back versions.
+- **Controlled long-task cost**: routes between standard and flagship models, edits only the required regions, and supports up to 99% same-session and 95% cross-session cache hit rates.
+- **Browser control**: opens webpages, retrieves information, fills forms, and checks key interactions after generating webpages.
+- **Computer control (international version only)**: reads the screen and operates mouse and keyboard across apps; Record & Replay lets you reuse recorded workflows with natural language.
+
+After beta approval, users can access limited-time, limited-quantity trials of the new **MiMo-X-Pro-Preview** and **MiMo-X-Flash-Preview** models.
 
 MiMoCode supports connecting to any mainstream LLM provider API.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,9 +14,25 @@
   <a href="https://mimo.xiaomi.com/zh/mimocode">官网</a> | <a href="https://mimo.xiaomi.com/zh/blog/mimo-code-long-horizon">博客</a>
 </p>
 
+<p align="center"><strong>MiMo 桌面端内测邀请</strong>：<a href="https://mimo.xiaomimimo.com/desktop/invite/">立即申请国内邀测</a></p>
+
 ---
 
 MiMoCode 是一个终端原生的 AI 编程助手。它能读写代码、执行命令、管理 Git，通过持久化记忆系统，在多次会话间保持对你项目的深度理解，并自我进化。
+
+## Xiaomi MiMo Desktop 开放邀测
+
+<p align="center"><img src="packages/desktop/icons/beta/icon.png" alt="Xiaomi MiMo Desktop" width="128"></p>
+
+Xiaomi MiMo Desktop 面向真实工作场景打造，一个会话即可完成办公、设计、编程和全模态创作；多个会话可自动分工、协作与通信。桌面端以 **MiMo Code 作为核心引擎**，将终端原生的智能能力延伸到桌面工作流。
+
+- **「Smart」调度**：自动评估任务类型与成本，动态选择模型、框架与工具，复杂任务由多个 Agent 并行推进。
+- **从生成结果到持续迭代**：支持拖入多格式文件，成果覆盖 PPT、网页、3D、App 等；会话内实时预览和操作，选中局部即可精准修改，并支持版本回退。
+- **让长任务成本可控**：标准与旗舰模型自动路由，局部编辑只修改需要的部分；同会话缓存命中率最高 99%，跨会话最高 95%。
+- **浏览器操控**：自主打开网页、检索和提取信息、填写表单，生成网页后自动检查关键交互。
+- **电脑操控（仅限海外版）**：读屏并操作键鼠，跨应用执行；Record & Replay 录制一次后，可用自然语言复用。
+
+通过邀测审核后，可限时限量体验新一代小米模型 **MiMo-X-Pro-Preview** 和 **MiMo-X-Flash-Preview**。
 
 支持接入各家主流 LLM 厂商 API。
 


### PR DESCRIPTION
## Summary
- Announce the Xiaomi MiMo Desktop open beta in both `README.md` (EN) and `README.zh.md` (ZH).
- Adds a beta invitation banner under the header and a "MiMo Desktop Beta / 开放邀测" section describing orchestration, multimodal iteration, long-task cost control, browser control, and computer control (international only), plus the MiMo-X-Pro-Preview / MiMo-X-Flash-Preview trial note.
- Docs-only change; no code or tests affected.
