### PR TITLE
fix(tui): disable mouse tracking when the TUI exits

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -37,11 +37,21 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
           // Reset window title before destroying renderer
           renderer.setTerminalTitle("")
           renderer.destroy()
-          // SGR reset + show cursor + OSC 110/111/112 reset terminal fg/bg/cursor color.
+          // SGR reset + show cursor + disable mouse tracking + OSC 110/111/112
+          // reset terminal fg/bg/cursor color.
+          // Mouse tracking (X10/button/any-motion + SGR encoding, enabled for
+          // the TUI's mouse support) is switched off explicitly: if the terminal
+          // is left in any-motion mode, every mouse move after exit prints
+          // escape sequences such as `[555;17;51M` into the shell (seen on
+          // Windows Terminal / PowerShell).
           // Without the OSC resets, whatever fg/bg the active mimocode theme pushed
           // via OSC 10/11/12 would persist in the terminal session, leaving the
           // shell prompt unreadable (e.g. white-on-white).
-          process.stdout.write("\x1b[0m\x1b[?25h\x1b]110\x07\x1b]111\x07\x1b]112\x07")
+          process.stdout.write(
+            "\x1b[0m\x1b[?25h" +
+              "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" +
+              "\x1b]110\x07\x1b]111\x07\x1b]112\x07",
+          )
           win32FlushInputBuffer()
           if (reason) {
             const formatted = FormatError(reason) ?? FormatUnknownError(reason)


### PR DESCRIPTION
### Issue / context (if applicable)

Fixes #2316

### Type of change

Bug fix

### What does this PR do?

After quitting the TUI, mouse movements printed escape sequences such as `[555;17;51M` into the shell on Windows Terminal / PowerShell until the terminal was reopened. The exit cleanup in `context/exit.tsx` reset SGR, the cursor and the OSC colors, but not the terminal's mouse tracking modes. This adds the disable sequences for the X10 / button / any-motion modes and the SGR encoding (`?1000l ?1002l ?1003l ?1006l`) to the same write, so the terminal is back to normal regardless of how the renderer shut down.

### How did you verify your code works?

Verified the sequences are the standard DECRESET counterparts of the modes the TUI's mouse support enables; `prettier --check` passes. I could not exercise the Windows Terminal repro from the issue on macOS, so a confirmation there would be welcome.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
