### PR TITLE
fix(session): cap compaction trigger at safe input budget for OpenAI-compatible providers

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -16,7 +16,8 @@ import { SystemPrompt } from "./system"
 import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
 import { Bus } from "@/bus"
-import { Wildcard, ToolCompat } from "@/util"
+import { Wildcard, ToolCompat, Token } from "@/util"
+import { completionBudget } from "./overflow"
 import { asSchema } from "@ai-sdk/provider-utils"
 import { SessionID } from "@/session/schema"
 import * as Session from "@/session/session"
@@ -592,6 +593,14 @@ const live: Layer.Layer<
         },
       )
 
+      // Applied after the plugin hook so a plugin's own max_tokens is clamped
+      // too, and a plugin that drops it keeps it dropped.
+      const maxOutputTokens = completionBudget({
+        model: input.model,
+        requested: params.maxOutputTokens,
+        inputTokens: () => Token.estimate(JSON.stringify(messages)),
+      })
+
       const { headers } = input.ephemeral ? { headers: {} } : yield* plugin.trigger(
         "chat.headers",
         {
@@ -819,7 +828,7 @@ const live: Layer.Layer<
         activeTools,
         tools: ProviderTransform.tools(tools, input.model),
         toolChoice: input.toolChoice,
-        maxOutputTokens: params.maxOutputTokens,
+        maxOutputTokens,
         abortSignal: input.abort,
         headers: {
           ...(!input.ephemeral ? { "x-session-affinity": input.sessionID } : {}),

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -84,10 +84,17 @@ export function contextWindow(input: { cfg: Config.Info; model: Provider.Model }
   const reserved = reserves(input)
   const configured = budget(input, hard, reserved)
   const effective = configured ?? hard
+  // When the provider has no dedicated input cap the API enforces
+  // input + max_tokens ≤ context. Cap the trigger at the safe input budget so
+  // the request after compaction still fits (#2356). Keep at least half the
+  // window so tiny contexts don't collapse the trigger to zero.
+  const completionReserve = input.model.limit.input ? 0 : ProviderTransform.maxOutputTokens(input.model)
+  const maxSafeInput = Math.max(effective - completionReserve, Math.floor(effective * 0.5))
+  const trigger = Math.floor(effective * Flag.MIMOCODE_COMPACTION_TRIGGER_RATIO)
   return {
     hard,
     effective,
-    usable: Math.floor(effective * Flag.MIMOCODE_COMPACTION_TRIGGER_RATIO),
+    usable: Math.min(trigger, maxSafeInput),
     source: configured === undefined ? "model" : "config",
   }
 }

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -31,13 +31,23 @@ export type Window = {
   source: "model" | "config"
 }
 
+// Output headroom to keep clear of the input budget. Providers that publish no
+// dedicated input cap enforce `input + max_tokens <= context`, so the completion
+// has to fit inside the same window the prompt does. Where the provider does
+// publish one, output tokens are already outside it and reserving again would
+// double-count. Capped at OUTPUT_CAP rather than the model's full max_tokens:
+// `maxOutputTokens()` is an optimistic request ceiling (128K for anything the
+// large-model heuristic matches), and reserving that much would halve the
+// working window on a 200K model. The hard guarantee lives in
+// `completionBudget()` instead.
+function outputReserve(model: Provider.Model) {
+  return model.limit.input ? 0 : Math.min(ProviderTransform.maxOutputTokens(model), OUTPUT_CAP)
+}
+
 function reserves(input: { cfg: Config.Info; model: Provider.Model }) {
   const reserved =
     input.cfg.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model))
-  // When the provider publishes a dedicated input cap, output tokens are already
-  // outside it, so reserving output headroom again would double-count.
-  const output = input.model.limit.input ? 0 : Math.min(ProviderTransform.maxOutputTokens(input.model), OUTPUT_CAP)
-  return reserved + output
+  return reserved + outputReserve(input.model)
 }
 
 function budget(input: { cfg: Config.Info; model: Provider.Model }, hard: number, reserved: number) {
@@ -84,23 +94,54 @@ export function contextWindow(input: { cfg: Config.Info; model: Provider.Model }
   const reserved = reserves(input)
   const configured = budget(input, hard, reserved)
   const effective = configured ?? hard
-  // When the provider has no dedicated input cap the API enforces
-  // input + max_tokens ≤ context. Cap the trigger at the safe input budget so
-  // the request after compaction still fits (#2356). Keep at least half the
-  // window so tiny contexts don't collapse the trigger to zero.
-  const completionReserve = input.model.limit.input ? 0 : ProviderTransform.maxOutputTokens(input.model)
-  const maxSafeInput = Math.max(effective - completionReserve, Math.floor(effective * 0.5))
-  const trigger = Math.floor(effective * Flag.MIMOCODE_COMPACTION_TRIGGER_RATIO)
+  // `input + max_tokens <= context` means the trigger has to stop short of the
+  // whole window, or the reply has nowhere to go (#2356). Never reserve more
+  // than half the window, so a tiny context still gets a workable trigger.
+  const completion = Math.min(outputReserve(input.model), Math.floor(effective * 0.5))
   return {
     hard,
     effective,
-    usable: Math.min(trigger, maxSafeInput),
+    usable: Math.min(Math.floor(effective * Flag.MIMOCODE_COMPACTION_TRIGGER_RATIO), effective - completion),
     source: configured === undefined ? "model" : "config",
   }
 }
 
 export function usable(input: { cfg: Config.Info; model: Provider.Model }) {
   return contextWindow(input).usable
+}
+
+// `Token.estimate` counts chars/4, so the prompt that reaches the wire can land
+// a little above what we measured. Hold this much back so that error does not
+// turn into a rejected request at the boundary.
+const COMPLETION_MARGIN = 1_024
+
+// Below this there is no reply worth asking for: the prompt itself is over
+// budget and overflow handling, not `max_tokens`, owns the recovery.
+const COMPLETION_FLOOR = 1_024
+
+/**
+ * Trim a request's `max_tokens` to what the prompt leaves inside the provider's
+ * context window.
+ *
+ * Providers without a dedicated `limit.input` reject the whole request when
+ * `input + max_tokens` exceeds the window, and the compaction trigger is only
+ * sampled between turns — so the trigger alone cannot guarantee the next
+ * request fits. This can, because it reads the prompt actually being sent.
+ *
+ * `undefined` passes through so plugins that drop `max_tokens` keep that.
+ */
+export function completionBudget(input: {
+  model: Provider.Model
+  requested: number | undefined
+  /** Deferred so the estimate is only paid for on the models that need it. */
+  inputTokens: () => number
+}) {
+  if (input.requested === undefined) return input.requested
+  if (input.model.limit.input) return input.requested
+  if (input.model.limit.context === 0) return input.requested
+  const remaining = input.model.limit.context - input.inputTokens() - COMPLETION_MARGIN
+  if (remaining >= input.requested) return input.requested
+  return Math.max(remaining, COMPLETION_FLOOR)
 }
 
 export function isOverflow(input: { cfg: Config.Info; tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {

--- a/packages/opencode/test/session/auto-overflow-writer-first.test.ts
+++ b/packages/opencode/test/session/auto-overflow-writer-first.test.ts
@@ -451,7 +451,7 @@ describe("Auto context overflow: write a checkpoint before degrading to compacti
           init: (dir) =>
             Bun.write(
               path.join(dir, "mimocode.json"),
-              mimocodeConfig(llm.origin, 80_000, { thresholds: ["24K"], reserved: 100 }),
+              mimocodeConfig(llm.origin, 50_000, { thresholds: ["24K"], reserved: 100 }),
             ),
         })
 
@@ -472,9 +472,9 @@ describe("Auto context overflow: write a checkpoint before degrading to compacti
                   agent: "build",
                 })
 
-                // usable = min(floor(80K × 0.9), 80K − 32K) = min(72K, 48K) = 48K.
-                // The single 24K checkpoint threshold is below it, so 25K must
-                // write a checkpoint without rebuilding before the 48K trigger.
+                // usable = min(floor(50K * 0.9), 50K - 20K reserve) = 30K. The
+                // single 24K checkpoint threshold is below it, so 25K must
+                // write a checkpoint without rebuilding before the 30K trigger.
                 const first = yield* Effect.promise(() => seedUserMessage(info.id, "earlier question"))
                 yield* Effect.promise(() => seedFinishedAssistant(info.id, first.id, 25_000))
 

--- a/packages/opencode/test/session/auto-overflow-writer-first.test.ts
+++ b/packages/opencode/test/session/auto-overflow-writer-first.test.ts
@@ -451,7 +451,7 @@ describe("Auto context overflow: write a checkpoint before degrading to compacti
           init: (dir) =>
             Bun.write(
               path.join(dir, "mimocode.json"),
-              mimocodeConfig(llm.origin, 50_000, { thresholds: ["24K"], reserved: 100 }),
+              mimocodeConfig(llm.origin, 80_000, { thresholds: ["24K"], reserved: 100 }),
             ),
         })
 
@@ -472,9 +472,9 @@ describe("Auto context overflow: write a checkpoint before degrading to compacti
                   agent: "build",
                 })
 
-                // usable = floor(50K * 0.9) = 45K. The single 24K checkpoint
-                // threshold is below it, so 25K must write a checkpoint
-                // without rebuilding before the 45K trigger.
+                // usable = min(floor(80K × 0.9), 80K − 32K) = min(72K, 48K) = 48K.
+                // The single 24K checkpoint threshold is below it, so 25K must
+                // write a checkpoint without rebuilding before the 48K trigger.
                 const first = yield* Effect.promise(() => seedUserMessage(info.id, "earlier question"))
                 yield* Effect.promise(() => seedFinishedAssistant(info.id, first.id, 25_000))
 

--- a/packages/opencode/test/session/overflow.test.ts
+++ b/packages/opencode/test/session/overflow.test.ts
@@ -535,20 +535,45 @@ describe("SessionNs.getUsage", () => {
 })
 
 describe("usable", () => {
-  test("is a flat 90% of the model window regardless of output size", () => {
-    // The trigger is a fixed fraction of the window now, so output size no
-    // longer shrinks it — a 32K-output model and an 8K-output model with the
-    // same context share the same 90% trigger.
-    const big = createModel({ context: 200_000, output: 32_000 })
-    const small = createModel({ context: 200_000, output: 8_000 })
-    expect(usable({ cfg: mockCfg(), model: big })).toBe(180_000) // floor(200K * 0.9)
-    expect(usable({ cfg: mockCfg(), model: small })).toBe(180_000)
+  test("caps at the safe input budget when limit.input is absent", () => {
+    // OpenAI-compatible providers enforce input + max_tokens ≤ context.
+    // usable must not exceed context − max_tokens, otherwise the request
+    // after compaction is rejected (#2356).
+    const model = createModel({ context: 200_000, output: 32_000 })
+    // maxOutputTokens = min(32_000, 32_000) = 32_000
+    // maxSafeInput = 200_000 − 32_000 = 168_000
+    // trigger = floor(200_000 × 0.9) = 180_000
+    // usable = min(180_000, 168_000) = 168_000
+    expect(usable({ cfg: mockCfg(), model })).toBe(168_000)
+  })
+
+  test("small output models keep the flat 90% trigger", () => {
+    const model = createModel({ context: 200_000, output: 8_000 })
+    // maxOutputTokens = min(8_000, 32_000) = 8_000
+    // maxSafeInput = 200_000 − 8_000 = 192_000 > 180_000, so 90% wins
+    expect(usable({ cfg: mockCfg(), model })).toBe(180_000)
+  })
+
+  test("models with a dedicated input cap are not further reduced", () => {
+    // When limit.input is set the provider already excludes output tokens
+    // from the input budget, so no extra reserve is needed.
+    const model = createModel({ context: 400_000, input: 272_000, output: 128_000 })
+    // hard = 272_000; trigger = floor(272_000 × 0.9) = 244_800
+    expect(usable({ cfg: mockCfg(), model })).toBe(244_800)
   })
 
   test("cfg.compaction.reserved no longer shrinks the trigger", () => {
     // reserved only gates config-budget validation now; the trigger stays 90%.
-    const model = createModel({ context: 200_000, output: 32_000 })
+    const model = createModel({ context: 200_000, output: 8_000 })
     expect(usable({ cfg: mockCfg({ reserved: 5_000 }), model })).toBe(180_000)
+  })
+
+  test("reproduces the #2356 arithmetic: 131K context with 32K max_tokens", () => {
+    const model = createModel({ context: 131_072, output: 32_000 })
+    // maxOutputTokens = 32_000; maxSafeInput = 99_072
+    // trigger = floor(131_072 × 0.9) = 117_964
+    // usable = min(117_964, 99_072) = 99_072
+    expect(usable({ cfg: mockCfg(), model })).toBe(99_072)
   })
 })
 
@@ -567,9 +592,10 @@ describe("MIMOCODE_COMPACTION_TRIGGER_RATIO", () => {
     expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(150_000)
   })
 
-  test("1 lets usage fill the whole working window", () => {
+  test("1 lets usage fill the safe input budget", () => {
     process.env["MIMOCODE_COMPACTION_TRIGGER_RATIO"] = "1"
-    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(200_000)
+    // Even at ratio 1 the trigger is capped at context − max_tokens.
+    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(168_000)
   })
 
   test("applies on top of the max_context budget rather than replacing it", () => {
@@ -585,7 +611,8 @@ describe("MIMOCODE_COMPACTION_TRIGGER_RATIO", () => {
 
   test.each(["0", "-0.5", "1.5", "150%", "abc", ""])("ignores %p and keeps the 0.9 default", (value) => {
     process.env["MIMOCODE_COMPACTION_TRIGGER_RATIO"] = value
-    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(180_000)
+    // Default 0.9 → 180K, capped at 200K − 32K = 168K.
+    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(168_000)
   })
 })
 
@@ -628,10 +655,12 @@ describe("compaction.max_context", () => {
   test("never raises the window above the provider cap", () => {
     const model = createModel({ context: 128_000, output: 16_384 })
     const cfg = mockCfg({ max_context: "1M" })
+    // maxOutputTokens = 16_384; maxSafeInput = 128_000 − 16_384 = 111_616
+    // trigger = floor(128_000 × 0.9) = 115_200; usable = min(115_200, 111_616)
     expect(contextWindow({ cfg, model })).toEqual({
       hard: 128_000,
       effective: 128_000,
-      usable: 115_200,
+      usable: 111_616,
       source: "model",
     })
   })
@@ -704,13 +733,15 @@ describe("compaction.max_context reset sentinel", () => {
 describe("small windows", () => {
   test("the trigger stays proportional instead of collapsing to 0", () => {
     // The old fixed-reserve formula could drive usable to 0 on a tiny window
-    // (reserved 8K + output 8K > 8K window). The flat 90% fraction keeps a
-    // usable trigger no matter how small the window is.
+    // (reserved 8K + output 8K > 8K window). The flat 90% fraction combined
+    // with the 50% floor keeps a usable trigger no matter how small the window.
     const model = createModel({ context: 8_192, output: 8_192 })
+    // maxOutputTokens = 8_192; maxSafeInput = max(0, 4_096) = 4_096
+    // trigger = floor(8_192 × 0.9) = 7_372; usable = min(7_372, 4_096) = 4_096
     expect(contextWindow({ cfg: mockCfg(), model })).toEqual({
       hard: 8_192,
       effective: 8_192,
-      usable: 7_372, // floor(8_192 * 0.9)
+      usable: 4_096,
       source: "model",
     })
   })
@@ -718,7 +749,7 @@ describe("small windows", () => {
   test("an oversized cfg.compaction.reserved no longer zeroes the trigger", () => {
     // reserved only gates config-budget validation now, so a huge value leaves
     // the model window's 90% trigger intact.
-    const model = createModel({ context: 200_000, output: 32_000 })
+    const model = createModel({ context: 200_000, output: 8_000 })
     expect(usable({ cfg: mockCfg({ reserved: 500_000 }), model })).toBe(180_000)
   })
 })

--- a/packages/opencode/test/session/overflow.test.ts
+++ b/packages/opencode/test/session/overflow.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { contextPressureLevel, contextWindow, isOverflow, pressureLevel, usable } from "../../src/session/overflow"
+import {
+  completionBudget,
+  contextPressureLevel,
+  contextWindow,
+  isOverflow,
+  pressureLevel,
+  usable,
+} from "../../src/session/overflow"
 import { Token } from "../../src/util"
 import { Session as SessionNs } from "../../src/session"
 import type { Provider } from "../../src/provider"
@@ -535,22 +542,28 @@ describe("SessionNs.getUsage", () => {
 })
 
 describe("usable", () => {
-  test("caps at the safe input budget when limit.input is absent", () => {
-    // OpenAI-compatible providers enforce input + max_tokens ≤ context.
-    // usable must not exceed context − max_tokens, otherwise the request
-    // after compaction is rejected (#2356).
+  test("leaves output headroom when limit.input is absent", () => {
+    // Providers with no dedicated input cap enforce input + max_tokens <=
+    // context, so the trigger has to stop short of the whole window (#2356).
+    // The reserve is capped at OUTPUT_CAP, which on a 200K window is still
+    // below the 90% trigger — so this model is unaffected.
     const model = createModel({ context: 200_000, output: 32_000 })
-    // maxOutputTokens = min(32_000, 32_000) = 32_000
-    // maxSafeInput = 200_000 − 32_000 = 168_000
-    // trigger = floor(200_000 × 0.9) = 180_000
-    // usable = min(180_000, 168_000) = 168_000
-    expect(usable({ cfg: mockCfg(), model })).toBe(168_000)
+    // reserve = min(32_000, 20_000) = 20_000; 200_000 - 20_000 = 180_000
+    // trigger = floor(200_000 * 0.9) = 180_000
+    expect(usable({ cfg: mockCfg(), model })).toBe(180_000)
   })
 
-  test("small output models keep the flat 90% trigger", () => {
+  test("the reserve bites once 10% of the window is under OUTPUT_CAP", () => {
+    // #2356's model: 131K context, 32K max_tokens. 90% leaves only 13K for the
+    // completion, so the reserve is what decides the trigger here.
+    const model = createModel({ context: 131_072, output: 32_000 })
+    // reserve = 20_000 -> 111_072; trigger = floor(131_072 * 0.9) = 117_964
+    expect(usable({ cfg: mockCfg(), model })).toBe(111_072)
+  })
+
+  test("small output models reserve only what they can emit", () => {
     const model = createModel({ context: 200_000, output: 8_000 })
-    // maxOutputTokens = min(8_000, 32_000) = 8_000
-    // maxSafeInput = 200_000 − 8_000 = 192_000 > 180_000, so 90% wins
+    // reserve = min(8_000, 20_000) = 8_000 -> 192_000, so the 90% trigger wins
     expect(usable({ cfg: mockCfg(), model })).toBe(180_000)
   })
 
@@ -558,8 +571,19 @@ describe("usable", () => {
     // When limit.input is set the provider already excludes output tokens
     // from the input budget, so no extra reserve is needed.
     const model = createModel({ context: 400_000, input: 272_000, output: 128_000 })
-    // hard = 272_000; trigger = floor(272_000 × 0.9) = 244_800
+    // hard = 272_000; trigger = floor(272_000 * 0.9) = 244_800
     expect(usable({ cfg: mockCfg(), model })).toBe(244_800)
+  })
+
+  test("the large-model output ceiling does not shrink the trigger", () => {
+    // ProviderTransform.maxOutputTokens returns LARGE_MODEL_OUTPUT_TOKEN_MAX
+    // (128K) for any id matching claude/gpt/mimo, whatever limit.output says.
+    // Reserving that in full would drop a 200K window from 180K to 72K, so the
+    // reserve is capped at OUTPUT_CAP and these models keep the flat 90%.
+    for (const id of ["claude-opus-4-5", "gpt-4.1", "mimo-pro"]) {
+      const model = createModel({ context: 200_000, output: 64_000, id })
+      expect(usable({ cfg: mockCfg(), model })).toBe(180_000)
+    }
   })
 
   test("cfg.compaction.reserved no longer shrinks the trigger", () => {
@@ -567,13 +591,51 @@ describe("usable", () => {
     const model = createModel({ context: 200_000, output: 8_000 })
     expect(usable({ cfg: mockCfg({ reserved: 5_000 }), model })).toBe(180_000)
   })
+})
 
-  test("reproduces the #2356 arithmetic: 131K context with 32K max_tokens", () => {
+describe("completionBudget", () => {
+  const inputTokens = (n: number) => () => n
+
+  test("passes max_tokens through when the prompt leaves room", () => {
     const model = createModel({ context: 131_072, output: 32_000 })
-    // maxOutputTokens = 32_000; maxSafeInput = 99_072
-    // trigger = floor(131_072 × 0.9) = 117_964
-    // usable = min(117_964, 99_072) = 99_072
-    expect(usable({ cfg: mockCfg(), model })).toBe(99_072)
+    expect(completionBudget({ model, requested: 32_000, inputTokens: inputTokens(50_000) })).toBe(32_000)
+  })
+
+  test("trims max_tokens to what is left of the window", () => {
+    // The exact #2356 failure: 99_509 input + 32_000 max_tokens = 131_509 on a
+    // 131_072 window. Trimming keeps the request inside the limit.
+    const model = createModel({ context: 131_072, output: 32_000 })
+    // 131_072 - 99_509 - 1_024 margin = 30_539
+    expect(completionBudget({ model, requested: 32_000, inputTokens: inputTokens(99_509) })).toBe(30_539)
+  })
+
+  test("never returns less than the floor", () => {
+    // The prompt is already over budget — max_tokens cannot save this request,
+    // and overflow handling owns the recovery.
+    const model = createModel({ context: 131_072, output: 32_000 })
+    expect(completionBudget({ model, requested: 32_000, inputTokens: inputTokens(131_072) })).toBe(1_024)
+  })
+
+  test("leaves models with a dedicated input cap alone", () => {
+    // input and output are budgeted separately, so a full prompt does not
+    // squeeze the completion.
+    const model = createModel({ context: 400_000, input: 272_000, output: 128_000 })
+    expect(completionBudget({ model, requested: 128_000, inputTokens: inputTokens(271_000) })).toBe(128_000)
+  })
+
+  test("keeps an unset max_tokens unset", () => {
+    // Some plugins drop max_tokens entirely; that must survive.
+    const model = createModel({ context: 131_072, output: 32_000 })
+    expect(completionBudget({ model, requested: undefined, inputTokens: inputTokens(130_000) })).toBeUndefined()
+  })
+
+  test("does not estimate the prompt when the model cannot need it", () => {
+    // The estimate stringifies the whole request, so it must stay unpaid for
+    // the models that are exempt.
+    const model = createModel({ context: 400_000, input: 272_000, output: 128_000 })
+    let calls = 0
+    completionBudget({ model, requested: 128_000, inputTokens: () => (calls++, 0) })
+    expect(calls).toBe(0)
   })
 })
 
@@ -592,10 +654,10 @@ describe("MIMOCODE_COMPACTION_TRIGGER_RATIO", () => {
     expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(150_000)
   })
 
-  test("1 lets usage fill the safe input budget", () => {
+  test("1 lets usage fill the window bar the output reserve", () => {
     process.env["MIMOCODE_COMPACTION_TRIGGER_RATIO"] = "1"
-    // Even at ratio 1 the trigger is capped at context − max_tokens.
-    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(168_000)
+    // Even at ratio 1 the completion still needs somewhere to go.
+    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(180_000)
   })
 
   test("applies on top of the max_context budget rather than replacing it", () => {
@@ -611,8 +673,7 @@ describe("MIMOCODE_COMPACTION_TRIGGER_RATIO", () => {
 
   test.each(["0", "-0.5", "1.5", "150%", "abc", ""])("ignores %p and keeps the 0.9 default", (value) => {
     process.env["MIMOCODE_COMPACTION_TRIGGER_RATIO"] = value
-    // Default 0.9 → 180K, capped at 200K − 32K = 168K.
-    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(168_000)
+    expect(usable({ cfg: mockCfg(), model: createModel({ context: 200_000 }) })).toBe(180_000)
   })
 })
 
@@ -655,8 +716,8 @@ describe("compaction.max_context", () => {
   test("never raises the window above the provider cap", () => {
     const model = createModel({ context: 128_000, output: 16_384 })
     const cfg = mockCfg({ max_context: "1M" })
-    // maxOutputTokens = 16_384; maxSafeInput = 128_000 − 16_384 = 111_616
-    // trigger = floor(128_000 × 0.9) = 115_200; usable = min(115_200, 111_616)
+    // reserve = min(16_384, 20_000) = 16_384 -> 111_616
+    // trigger = floor(128_000 * 0.9) = 115_200; usable = min(115_200, 111_616)
     expect(contextWindow({ cfg, model })).toEqual({
       hard: 128_000,
       effective: 128_000,
@@ -733,11 +794,11 @@ describe("compaction.max_context reset sentinel", () => {
 describe("small windows", () => {
   test("the trigger stays proportional instead of collapsing to 0", () => {
     // The old fixed-reserve formula could drive usable to 0 on a tiny window
-    // (reserved 8K + output 8K > 8K window). The flat 90% fraction combined
-    // with the 50% floor keeps a usable trigger no matter how small the window.
+    // (reserved 8K + output 8K > 8K window). Capping the reserve at half the
+    // window keeps a usable trigger no matter how small the window is.
     const model = createModel({ context: 8_192, output: 8_192 })
-    // maxOutputTokens = 8_192; maxSafeInput = max(0, 4_096) = 4_096
-    // trigger = floor(8_192 × 0.9) = 7_372; usable = min(7_372, 4_096) = 4_096
+    // reserve = min(8_192, floor(8_192 * 0.5)) = 4_096 -> 4_096
+    // trigger = floor(8_192 * 0.9) = 7_372; usable = min(7_372, 4_096) = 4_096
     expect(contextWindow({ cfg: mockCfg(), model })).toEqual({
       hard: 8_192,
       effective: 8_192,

--- a/packages/opencode/test/session/prune.test.ts
+++ b/packages/opencode/test/session/prune.test.ts
@@ -545,14 +545,15 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
 
           yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(21_000), promptOps })
           yield* Effect.sleep(100)
-          // Final threshold 45K fired at maxAllowed itself, so the gate would be
-          // min(47_000 + 25_000, 47_000) = 47_000 — not ahead of where it fired.
+          // usable = min(90K, 100K − 32K) = 68K; maxAllowed = 68K − 13K = 55K.
+          // Final threshold 45K fired at 55K (== maxAllowed), so the gate would
+          // be min(55K + 25K, 55K) = 55K — not ahead of where it fired.
           // The retry budget IS the unused window, so here it is zero.
-          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(47_000), promptOps })
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(55_000), promptOps })
           yield* Effect.sleep(100)
           expect(harness.state.enqueueCount).toBe(2)
 
-          for (const tokens of [47_000, 50_000, 59_000]) {
+          for (const tokens of [55_000, 58_000, 67_000]) {
             yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(tokens), promptOps })
             yield* Effect.sleep(100)
           }

--- a/packages/opencode/test/session/prune.test.ts
+++ b/packages/opencode/test/session/prune.test.ts
@@ -545,15 +545,15 @@ describe("SessionPrune.fireCheckpoints writer failure is not retried in place", 
 
           yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(21_000), promptOps })
           yield* Effect.sleep(100)
-          // usable = min(90K, 100K − 32K) = 68K; maxAllowed = 68K − 13K = 55K.
-          // Final threshold 45K fired at 55K (== maxAllowed), so the gate would
-          // be min(55K + 25K, 55K) = 55K — not ahead of where it fired.
-          // The retry budget IS the unused window, so here it is zero.
-          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(55_000), promptOps })
+          // usable = min(90K, 100K - 20K reserve) = 80K; maxAllowed = 80K - 13K
+          // = 67K. Final threshold 45K fired at 67K (== maxAllowed), so the
+          // gate would be min(67K + 25K, 67K) = 67K - not ahead of where it
+          // fired. The retry budget IS the unused window, so here it is zero.
+          yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(67_000), promptOps })
           yield* Effect.sleep(100)
           expect(harness.state.enqueueCount).toBe(2)
 
-          for (const tokens of [55_000, 58_000, 67_000]) {
+          for (const tokens of [67_000, 70_000, 79_000]) {
             yield* svc.fireCheckpoints({ sessionID: info.id, model, tokens: makeTokensAt(tokens), promptOps })
             yield* Effect.sleep(100)
           }


### PR DESCRIPTION
### Issue / context

Fixes #2356

### Type of change

Bug fix

### What does this PR do?

When a provider has no dedicated `limit.input`, the API enforces `input + max_tokens ≤ context_limit`. Nothing in the request path accounted for that, so a session could be rejected with a 400 before compaction ever fired.

**Root cause** (from the issue's arithmetic):
- Model context: 131,072 · max_tokens: 32,000
- Safe input budget: 131,072 − 32,000 = **99,072**
- The request died at 99,509 input — well below the old 90% trigger of **117,964**, so compaction never ran.

The fix splits the concern across the two layers that can each do their part:

**1. The request trims `max_tokens` to what actually remains** — this is the hard guarantee. The compaction trigger is only sampled between turns, so it can never guarantee the *next* request fits; reading the prompt being sent can.

```ts
export function completionBudget(input: {
  model: Provider.Model
  requested: number | undefined
  inputTokens: () => number
}) {
  if (input.requested === undefined) return input.requested
  if (input.model.limit.input) return input.requested
  if (input.model.limit.context === 0) return input.requested
  const remaining = input.model.limit.context - input.inputTokens() - COMPLETION_MARGIN
  if (remaining >= input.requested) return input.requested
  return Math.max(remaining, COMPLETION_FLOOR)
}
```

Applied in `SessionLLM` *after* the `chat.params` hook, so a plugin's own `max_tokens` is clamped too and a plugin that drops it keeps it dropped. The 1,024-token margin absorbs `Token.estimate`'s chars/4 error. The estimate is deferred behind a thunk so exempt models never pay for the stringify.

**2. The trigger keeps capped output headroom**, so the reply has somewhere to go rather than being squeezed to nothing as usage approaches the cap:

```ts
const completion = Math.min(outputReserve(input.model), Math.floor(effective * 0.5))
usable: Math.min(Math.floor(effective * Flag.MIMOCODE_COMPACTION_TRIGGER_RATIO), effective - completion)
```

`outputReserve()` is now shared with `reserves()`, which already used `min(maxOutputTokens, OUTPUT_CAP)` behind the same `limit.input` guard — the file had grown two divergent answers to "how much output do we reserve".

Models with a dedicated `limit.input` are exempt at both layers: output is already outside their input budget.

#### Why not reserve the model's full `max_tokens`

An earlier revision of this PR capped `usable` at `effective − ProviderTransform.maxOutputTokens(model)`. That function is an optimistic *request ceiling*, not a realistic reserve — `usesLargeModelDefaults()` returns 128K for any model whose id matches `claude`/`gpt`/`mimo` (or provider `mimo`/`xiaomi`), regardless of `limit.output`:

| Model | before | full-reserve revision | this PR |
|---|---|---|---|
| `anthropic/claude-opus-4-5` (200K/64K) | 180,000 | **100,000** | 180,000 |
| `google-vertex/claude-sonnet-4` (200K) | 180,000 | **100,000** | 180,000 |
| `xiaomi/mimo-x-pro-preview` (1M/32K) | 900,000 | 872,000 | 900,000 |
| `openai/gpt-5.1` (has `limit.input`) | 244,800 | 244,800 | 244,800 |
| #2356's model (131K/32K) | 117,964 | 99,072 | **111,072** |

Across the models.dev catalogue that revision moved 3,966 models, and 795 of them landed on its 50% floor — where the invariant it was enforcing does not hold anyway (100,000 input + 128,000 `max_tokens` still exceeds a 200K window). This PR moves only the shapes that need to move.

### How did you verify your code works?

- `bun test test/session/overflow.test.ts` — 69 pass, incl. new coverage for the large-model output ceiling (which the previous tests could not reach: `createModel`'s default id never matches the heuristic) and for `completionBudget`
- `bun test test/session/` — 1097 pass, 2 fail (both pre-existing on `main`, confirmed by stashing)
- `bun typecheck` — clean
- `oxlint` on changed files — 0 errors

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR