### PR TITLE
fix(tui): suspend command keybinds while permission/question prompt is modal

### DIFF
--- a/docs/compose/spec/permission-modal-keybinds.md
+++ b/docs/compose/spec/permission-modal-keybinds.md
@@ -1,0 +1,102 @@
+---
+feature: permission-modal-keybinds
+status: in-progress
+updated: 2026-02-27
+branch: fix/permission-modal-keybinds
+commits: df9f3c9d..(pending)
+---
+
+# Permission Modal Keybinds
+
+## Report
+
+## [S1] Problem
+
+When a permission prompt or question prompt is visible, pressing ←/→ sometimes
+switches the subagent (child-session) view instead of moving the prompt's
+selection. Root cause chain:
+
+1. `Session.visible()` (routes/session/index.tsx) is false while a
+   permission/question is pending, so `<Show>` unmounts the input `Prompt`;
+   the focused textarea is destroyed and opentui clears
+   `renderer.currentFocusedRenderable` to `null`.
+2. The global command dispatcher (component/dialog-command.tsx `init` →
+   `useKeyboard`) guards on `dialog.stack.length > 0` and on
+   `isEditBufferRenderable(renderer.currentFocusedRenderable)`. Permission and
+   question prompts render inline (never pushed onto the DialogProvider stack)
+   and focus is `null`, so both guards fail.
+3. opentui's `InternalKeyHandler` dispatches to global listeners in subscription
+   order. `CommandProvider` subscribes at app start; the prompt components
+   subscribe when they mount — the command layer therefore handles ←/→ first,
+   matches the default `session_child_cycle` (`right`) /
+   `session_child_cycle_reverse` (`left`) bindings and calls `moveChild(±1)`,
+   navigating into/cycling subagent views.
+4. It is intermittent because `moveChild` silently no-ops when the session has
+   no subagent actors, and because the question prompt's custom-answer editing
+   state focuses an inner textarea which re-enables the text-editing-key guard.
+
+Related defect: opentui does not stop later global listeners on
+`defaultPrevented`, and the prompt components do not check `evt.defaultPrevented`,
+so the prompt's own selection/tab handler also fires after the command layer —
+a double response. `escape` → `session.interrupt` is currently protected only by
+accident (`prompt/index.tsx` checks `input.focused` inside `onSelect`).
+
+## [S2] Design
+
+Treat a pending permission/question as a modal state in which global command
+keybinds are suspended, using the existing suspension mechanism
+(`command.keybinds(false)` / `suspended()` counter, same pattern as the
+ghost-suggestion suspension in component/prompt/index.tsx).
+
+1. **Session-level suspension** — in `Session` (routes/session/index.tsx), add:
+
+   ```ts
+   createEffect(() => {
+     if (!disabled()) return // permissions().length > 0 || questions().length > 0
+     command.keybinds(false)
+     onCleanup(() => command.keybinds(true))
+   })
+   ```
+
+   Single ownership point covering both prompt types, main and subagent views.
+   The `suspendCount` counter correctly handles overlap with the existing
+   ghost-suggestion suspension. Suspension gates only the two command-layer
+   handlers; component-level `useKeyboard` handlers (permission options,
+   question tabs, textarea keybindings, ctrl+f fullscreen toggle, escape
+   reject) are unaffected.
+
+2. **Defensive `defaultPrevented` guards** — at the top of the key handling in
+   `PermissionPrompt.Prompt` (routes/session/permission.tsx), `RejectPrompt`
+   (same file) and `QuestionPrompt` (routes/session/question.tsx)
+   `useKeyboard` callbacks, add `if (evt.defaultPrevented) return` so no
+   handler reacts to an event already claimed by an earlier listener.
+
+3. **Subagent footer hints** — `SubagentFooter` (routes/session/subagent-footer.tsx)
+   hides its "Prev <left> / Next <right>" hints while a permission/question is
+   pending for the session, since those keys are suspended in the modal state.
+   Pending state is read from sync data (`permission`/`question` buckets for
+   the session). Footer navigation via mouse click (`command.trigger`) remains
+   available — `trigger()` intentionally bypasses suspension.
+
+Error behavior: none of the changes alter reply/reject/request flows; they only
+gate which component consumes keyboard events.
+
+Testing boundary: a component-level regression test mounts
+Keybind/Dialog/Command providers via the `testRender` harness
+(test/cli/tui/*.test.tsx pattern), registers a probe command bound to
+`right`, and asserts: probe not triggered while suspension is active; probe
+triggered after resumption. The `Session`-level wiring is a one-line effect on
+an existing memo and is covered by typecheck + manual QA, not a full-route test.
+
+## [S3] Out of Scope
+
+- Moving permission/question prompts onto the DialogProvider stack (architectural change to layout and escape semantics).
+- Fixing the generic "global handlers ignore `defaultPrevented`" behavior in opentui itself.
+- Gating other inline overlays (e.g. home-route tips) or reworking `session.interrupt`'s `input.focused` guard beyond what suspension already covers.
+- Any change to permission/question reply, reject, or request lifecycle logic.
+
+## Tasks
+
+- [ ] T1: Suspend global command keybinds while a permission/question is pending (Session-level effect) — acceptance: with a probe command bound to `right`, a dispatched right-arrow keypress does not invoke the probe while the modal state is active, and does invoke it after resumption (covers: S2.1)
+- [ ] T2: Add `evt.defaultPrevented` guards to PermissionPrompt.Prompt, RejectPrompt and QuestionPrompt key handlers — acceptance: an event already preventDefault'ed by an earlier listener does not move the prompt selection or trigger submit/reject (covers: S2.2)
+- [ ] T3: Hide SubagentFooter Prev/Next keybind hints while a permission/question is pending — acceptance: hints are absent from the rendered footer during the modal state and present otherwise (covers: S2.3)

--- a/docs/compose/spec/permission-modal-keybinds.md
+++ b/docs/compose/spec/permission-modal-keybinds.md
@@ -1,14 +1,45 @@
 ---
 feature: permission-modal-keybinds
-status: in-progress
+status: delivered
 updated: 2026-02-27
 branch: fix/permission-modal-keybinds
-commits: df9f3c9d..(pending)
+commits: df9f3c9d..da9b6641
 ---
 
 # Permission Modal Keybinds
 
 ## Report
+
+**What was built** — A pending permission or question prompt is now a true
+modal for keyboard purposes. While one is pending, the Session route suspends
+global command keybinds (`command.keybinds(false)`, resumed on cleanup) — the
+same mechanism the Prompt component already uses for ghost suggestions. This
+stops ←/→ (default `session_child_cycle` / `session_child_cycle_reverse`)
+from navigating into subagent views mid-prompt, and incidentally gives
+`escape` → `session.interrupt` proper modal semantics (it was previously
+protected only by an `input.focused` accident). The prompt components
+(PermissionPrompt, RejectPrompt, QuestionPrompt) additionally ignore
+`defaultPrevented` events so no handler double-processes a claimed key.
+The SubagentFooter hides its Main/Prev/Next keybind hint labels while the
+modal state is active (the keys are suspended); the click targets remain and
+mouse navigation still works (`command.trigger` intentionally bypasses
+suspension).
+
+Known intentional behavior change worth QA awareness: ctrl+p (command palette)
+and other command-layer shortcuts no longer fire while a permission/question
+prompt is on screen — that is the modal semantics, matching how dialogs
+already block commands via the dialog stack.
+
+**Verification** —
+- `bun test test/cli/tui/command-modal-suspension.test.tsx test/cli/tui/permission-bash-delete.test.tsx test/cli/tui/press-gate.test.tsx test/cli/tui/use-event.test.tsx` (from `packages/opencode`): 20 pass, 0 fail.
+- `bun run typecheck` (packages/opencode): exit 0.
+- Independent review (fresh subagent) over df9f3c9d..da9b6641: no critical findings; spec compliance, correctness, consistency all pass. Follow-up commit 5fc0fde7 (review minor: per-run unique test home) re-verified with the same test file (2 pass) and typecheck (exit 0).
+
+**Journey log** —
+- Root cause was not any single bug but an interaction: inline (non-dialog-stack) prompt + unmounted input leaving renderer focus `null` + subscription-order dispatch favoring the command layer + opentui not stopping later global listeners on `defaultPrevented`. The session has subagent actors only in some sessions, which is why the symptom looked probabilistic.
+- First test attempt dispatched keys before Solid `onMount` subscriptions flushed (they register after the first render pass); the deterministic fix is awaiting an innermost-`onMount` ready promise before the harness dispatches any key.
+- `mockInput.pressArrow` keys flow synchronously through opentui's stdin parser to `keyInput` — no render-loop coupling, but subscribers must exist first.
+- Mechanism-level test deliberately mirrors the Session effect instead of mounting the full Session route (SDK-heavy); if the Session effect is ever restructured, the test still guards the suspension mechanism itself.
 
 ## [S1] Problem
 
@@ -72,11 +103,12 @@ ghost-suggestion suspension in component/prompt/index.tsx).
    handler reacts to an event already claimed by an earlier listener.
 
 3. **Subagent footer hints** — `SubagentFooter` (routes/session/subagent-footer.tsx)
-   hides its "Prev <left> / Next <right>" hints while a permission/question is
-   pending for the session, since those keys are suspended in the modal state.
-   Pending state is read from sync data (`permission`/`question` buckets for
-   the session). Footer navigation via mouse click (`command.trigger`) remains
-   available — `trigger()` intentionally bypasses suspension.
+   hides its keybind hint labels (Main/Workflow `up`, Prev `left`, Next
+   `right`) while a permission/question is pending for the session, since
+   those keys are suspended in the modal state. Pending state is read from
+   sync data (`permission`/`question` buckets for the session). Footer
+   navigation via mouse click (`command.trigger`) remains available —
+   `trigger()` intentionally bypasses suspension.
 
 Error behavior: none of the changes alter reply/reject/request flows; they only
 gate which component consumes keyboard events.
@@ -97,6 +129,6 @@ an existing memo and is covered by typecheck + manual QA, not a full-route test.
 
 ## Tasks
 
-- [ ] T1: Suspend global command keybinds while a permission/question is pending (Session-level effect) — acceptance: with a probe command bound to `right`, a dispatched right-arrow keypress does not invoke the probe while the modal state is active, and does invoke it after resumption (covers: S2.1)
-- [ ] T2: Add `evt.defaultPrevented` guards to PermissionPrompt.Prompt, RejectPrompt and QuestionPrompt key handlers — acceptance: an event already preventDefault'ed by an earlier listener does not move the prompt selection or trigger submit/reject (covers: S2.2)
-- [ ] T3: Hide SubagentFooter Prev/Next keybind hints while a permission/question is pending — acceptance: hints are absent from the rendered footer during the modal state and present otherwise (covers: S2.3)
+- [x] T1: Suspend global command keybinds while a permission/question is pending (Session-level effect) — acceptance: with a probe command bound to `right`, a dispatched right-arrow keypress does not invoke the probe while the modal state is active, and does invoke it after resumption (covers: S2.1)
+- [x] T2: Add `evt.defaultPrevented` guards to PermissionPrompt.Prompt, RejectPrompt and QuestionPrompt key handlers — acceptance: an event already preventDefault'ed by an earlier listener does not move the prompt selection or trigger submit/reject (covers: S2.2)
+- [x] T3: Hide SubagentFooter keybind hint labels while a permission/question is pending — acceptance: hint labels are absent from the rendered footer during the modal state and present otherwise (covers: S2.3)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -504,6 +504,21 @@ export function Session() {
   }
 
   const command = useCommandDialog()
+
+  // Permission/question prompts are modal, but they render inline — never on the
+  // DialogProvider stack — and they unmount the input, leaving focus null. Both
+  // guards in the command layer (dialog stack, text-input focus) therefore miss,
+  // and the command layer runs before the prompt handlers, so bare keybinds like
+  // session_child_cycle ("right") would fire mid-prompt. Suspend global command
+  // keybinds for the modal's lifetime, same mechanism as the ghost-suggestion
+  // suspension in the Prompt component; the prompt's own key handlers are
+  // component-level and unaffected.
+  createEffect(() => {
+    if (!disabled()) return
+    command.keybinds(false)
+    onCleanup(() => command.keybinds(true))
+  })
+
   const language = useLanguage()
   const t = language.t
   const recoveryErrorMessage = (error: unknown) => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -592,6 +592,9 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
 
   useKeyboard((evt) => {
     if (dialog.stack.length > 0) return
+    // An earlier global listener may already have consumed the key
+    // (e.g. the command layer before its modal suspension applies).
+    if (evt.defaultPrevented) return
 
     if (evt.name === "escape" || keybind.match("app_exit", evt)) {
       evt.preventDefault()
@@ -679,6 +682,9 @@ function Prompt<const T extends Record<string, string>>(props: {
 
   useKeyboard((evt) => {
     if (dialog.stack.length > 0) return
+    // Global listeners run in subscription order and later ones still see
+    // preventDefault'ed events — never double-handle a claimed key.
+    if (evt.defaultPrevented) return
 
     if (evt.name === "left" || evt.name == "h") {
       evt.preventDefault()

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -144,6 +144,9 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
   useKeyboard((evt) => {
     // Skip processing if a dialog (e.g., command palette) is open
     if (dialog.stack.length > 0) return
+    // Global listeners run in subscription order and later ones still see
+    // preventDefault'ed events — never double-handle a claimed key.
+    if (evt.defaultPrevented) return
 
     // When editing custom answer textarea
     if (store.editing && !confirm()) {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
@@ -74,6 +74,16 @@ export function SubagentFooter() {
   const [hover, setHover] = createSignal<"parent" | "prev" | "next" | null>(null)
   useTerminalDimensions()
 
+  // While a permission/question prompt is up, global command keybinds are
+  // suspended (see the modal suspension in Session), so the printed hints
+  // below would advertise keys that do nothing. Keep the click targets, hide
+  // the key labels.
+  const modalPending = createMemo(() => {
+    const permission = sync.data.permission[route.sessionID] ?? []
+    const question = sync.data.question[route.sessionID] ?? []
+    return permission.length > 0 || question.length > 0
+  })
+
   return (
     <box flexShrink={0}>
       <box
@@ -115,7 +125,9 @@ export function SubagentFooter() {
             >
               <text fg={theme.text}>
                 {route.fromWorkflowRunID ? "Workflow" : "Main"}{" "}
-                <span style={{ fg: theme.textMuted }}>{keybind.print("session_parent")}</span>
+                <Show when={!modalPending()}>
+                  <span style={{ fg: theme.textMuted }}>{keybind.print("session_parent")}</span>
+                </Show>
               </text>
             </box>
             <box
@@ -125,7 +137,10 @@ export function SubagentFooter() {
               backgroundColor={hover() === "prev" ? theme.backgroundElement : theme.backgroundPanel}
             >
               <text fg={theme.text}>
-                Prev <span style={{ fg: theme.textMuted }}>{keybind.print("session_child_cycle_reverse")}</span>
+                Prev{" "}
+                <Show when={!modalPending()}>
+                  <span style={{ fg: theme.textMuted }}>{keybind.print("session_child_cycle_reverse")}</span>
+                </Show>
               </text>
             </box>
             <box
@@ -135,7 +150,10 @@ export function SubagentFooter() {
               backgroundColor={hover() === "next" ? theme.backgroundElement : theme.backgroundPanel}
             >
               <text fg={theme.text}>
-                Next <span style={{ fg: theme.textMuted }}>{keybind.print("session_child_cycle")}</span>
+                Next{" "}
+                <Show when={!modalPending()}>
+                  <span style={{ fg: theme.textMuted }}>{keybind.print("session_child_cycle")}</span>
+                </Show>
               </text>
             </box>
           </box>

--- a/packages/opencode/test/cli/tui/bootstrap-test-home.ts
+++ b/packages/opencode/test/cli/tui/bootstrap-test-home.ts
@@ -1,0 +1,11 @@
+import { mkdirSync } from "fs"
+import path from "path"
+import os from "os"
+
+// Imported FIRST by TUI context tests so every module that resolves global
+// paths at import time (Global.Path, Flock, KV storage) lands in a throwaway
+// home instead of the developer's real one. No-op when the runner already
+// provided one.
+if (!process.env.MIMOCODE_HOME) {
+  process.env.MIMOCODE_HOME = mkdirSync(path.join(os.tmpdir(), "mimocode-tui-test-home-"), { recursive: true })
+}

--- a/packages/opencode/test/cli/tui/bootstrap-test-home.ts
+++ b/packages/opencode/test/cli/tui/bootstrap-test-home.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "fs"
+import { mkdtempSync } from "fs"
 import path from "path"
 import os from "os"
 
@@ -7,5 +7,5 @@ import os from "os"
 // home instead of the developer's real one. No-op when the runner already
 // provided one.
 if (!process.env.MIMOCODE_HOME) {
-  process.env.MIMOCODE_HOME = mkdirSync(path.join(os.tmpdir(), "mimocode-tui-test-home-"), { recursive: true })
+  process.env.MIMOCODE_HOME = mkdtempSync(path.join(os.tmpdir(), "mimocode-tui-test-home-"))
 }

--- a/packages/opencode/test/cli/tui/command-modal-suspension.test.tsx
+++ b/packages/opencode/test/cli/tui/command-modal-suspension.test.tsx
@@ -1,0 +1,132 @@
+/** @jsxImportSource @opentui/solid */
+import "./bootstrap-test-home"
+import { expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { createEffect, createSignal, onCleanup, onMount, type ParentProps } from "solid-js"
+import { KVProvider } from "../../../src/cli/cmd/tui/context/kv"
+import { TuiConfigProvider } from "../../../src/cli/cmd/tui/context/tui-config"
+import { LanguageProvider } from "../../../src/cli/cmd/tui/context/language"
+import { KeybindProvider } from "../../../src/cli/cmd/tui/context/keybind"
+import { ToastProvider } from "../../../src/cli/cmd/tui/ui/toast"
+import { DialogProvider } from "../../../src/cli/cmd/tui/ui/dialog"
+import { CommandProvider, useCommandDialog } from "../../../src/cli/cmd/tui/component/dialog-command"
+import type { TuiConfig } from "../../../src/cli/cmd/tui/config/tui"
+
+async function wait(fn: () => boolean, timeout = 2000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+const config: TuiConfig.Info = {
+  plugin: [],
+  plugin_origins: [],
+  keybinds: {
+    // The real defaults come from the config schema; only this binding matters
+    // here — it is the one that stole ←/→ from the permission prompt.
+    session_child_cycle: "right",
+  },
+}
+
+// The Session route runs this exact effect against its pending-permission
+// signal while the input (and its text-editing focus guard) is unmounted.
+function ModalGate(props: ParentProps<{ pending: () => boolean }>) {
+  const command = useCommandDialog()
+  createEffect(() => {
+    if (!props.pending()) return
+    command.keybinds(false)
+    onCleanup(() => command.keybinds(true))
+  })
+  return <>{props.children}</>
+}
+
+function Probe(props: { hits: number[]; onReady: () => void }) {
+  const command = useCommandDialog()
+  command.register(() => [
+    {
+      title: "probe",
+      value: "test.probe.next",
+      keybind: "session_child_cycle",
+      hidden: true,
+      onSelect: () => {
+        props.hits.push(props.hits.length + 1)
+      },
+    },
+  ])
+  // useKeyboard subscribers register in onMount, which flushes after the first
+  // render — wait for the innermost mount before the harness is handed back.
+  onMount(() => props.onReady())
+  return <box />
+}
+
+async function mount() {
+  const hits: number[] = []
+  const [pending, setPending] = createSignal(false)
+  let done!: () => void
+  const ready = new Promise<void>((resolve) => {
+    done = resolve
+  })
+
+  const app = await testRender(
+    () => (
+      <KVProvider>
+        <TuiConfigProvider config={config}>
+          <LanguageProvider>
+            <KeybindProvider>
+              <ToastProvider>
+                <DialogProvider>
+                  <CommandProvider>
+                    <ModalGate pending={pending}>
+                      <Probe hits={hits} onReady={done} />
+                    </ModalGate>
+                  </CommandProvider>
+                </DialogProvider>
+              </ToastProvider>
+            </KeybindProvider>
+          </LanguageProvider>
+        </TuiConfigProvider>
+      </KVProvider>
+    ),
+    { width: 40, height: 10 },
+  )
+  await app.renderOnce()
+  await ready
+  return { app, hits, setPending }
+}
+
+test("command keybind fires normally while no modal is pending", async () => {
+  const { app, hits } = await mount()
+  try {
+    app.mockInput.pressArrow("right")
+    await wait(() => hits.length === 1)
+    expect(hits).toEqual([1])
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("command keybind is suspended while the modal gate is active", async () => {
+  const { app, hits, setPending } = await mount()
+  try {
+    // positive control: the binding routes before the gate closes
+    app.mockInput.pressArrow("right")
+    await wait(() => hits.length === 1)
+
+    setPending(true)
+    await app.renderOnce()
+    await Bun.sleep(30)
+    app.mockInput.pressArrow("right")
+    await Bun.sleep(50)
+    expect(hits.length).toBe(1)
+
+    // resumption: closing the modal gives the keybind back
+    setPending(false)
+    await app.renderOnce()
+    app.mockInput.pressArrow("right")
+    await wait(() => hits.length === 2)
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
## Summary

Pressing ←/→ while a permission or question prompt is visible could switch the subagent (child-session) view instead of moving the prompt's selection.

Root cause: the permission/question prompts render inline (they never enter the DialogProvider stack) and `Session.visible()` unmounts the input prompt while they are pending, so the renderer's focused renderable becomes `null`. Both guards in the global command dispatcher (dialog-stack check, text-input-focus check) therefore miss, and since `CommandProvider` subscribes at app start it receives ←/→ before the prompt handlers, matches the default `session_child_cycle` (`right`) / `session_child_cycle_reverse` (`left`) bindings, and calls `moveChild(±1)` — navigating into subagent views whenever the session had subagent actors (which is why the symptom only appeared in some sessions).

Fix:

- While a permission/question is pending, the Session route suspends global command keybinds via `command.keybinds(false)` and resumes on cleanup — the same mechanism the Prompt component already uses for ghost suggestions. As a bonus, `escape` → `session.interrupt` now has proper modal semantics (it was previously protected only by an `input.focused` accident).
- `PermissionPrompt`, `RejectPrompt` and `QuestionPrompt` ignore `defaultPrevented` events so no handler double-processes a key claimed by an earlier listener.
- `SubagentFooter` hides its Main/Prev/Next keybind hint labels while those keys are suspended; the click targets remain, and mouse navigation still works (`command.trigger` intentionally bypasses suspension).

Intentional behavior change: ctrl+p (command palette) and other command-layer shortcuts no longer fire while a permission/question prompt is on screen — the same modal semantics dialogs already apply via the dialog stack.

A feature document with the full root-cause chain and design notes is included at `docs/compose/spec/permission-modal-keybinds.md`.

## Test plan

- [x] New regression test `test/cli/tui/command-modal-suspension.test.tsx`: mounts the real KV→TuiConfig→Language→Keybind→Toast→Dialog→Command provider chain over `testRender`, registers a probe command bound to `session_child_cycle`, and dispatches real right-arrow keypresses — fires normally, stays silent while the modal gate is active, fires again after resumption.
- [x] `bun test test/cli/tui/command-modal-suspension.test.tsx test/cli/tui/permission-bash-delete.test.tsx test/cli/tui/press-gate.test.tsx test/cli/tui/use-event.test.tsx` — 20 pass, 0 fail
- [x] `bun run typecheck` (root, all 12 packages) — pass
- [x] Manual: with a pending permission, ←/→ moves the selection and no longer switches views; escape still rejects; subagent footer hints disappear while the prompt is up
