### PR TITLE
fix(provider): keep Xiaomi non-PTC chat on the stock openai-compatible SDK

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1713,12 +1713,23 @@ const layer: Layer.Layer<
           return wrapSSE(bounded, chunkTimeout, chunkAbortCtl)
         }
 
+        // Xiaomi: only PTC needs the bundled Responses harness (free-form `exec` custom tool);
+        // every non-PTC model must stay on the stock openai-compatible chat model. The bundled
+        // Copilot fork only understands Copilot's `reasoning_text`, so routing chat through it
+        // silently drops the `reasoning_content` that Xiaomi models stream back.
         const bundledLoader =
           model.providerID === "xiaomi" && model.api.npm === "@ai-sdk/openai-compatible"
             ? () =>
-                import("./sdk/copilot").then(
-                  (module) => (options: any) =>
-                    module.createOpenaiCompatible({ ...options, customToolNames: ["exec"] }),
+                Promise.all([BUNDLED_PROVIDERS["@ai-sdk/openai-compatible"](), import("./sdk/copilot")]).then(
+                  ([createChat, copilot]) =>
+                    (options: any) => {
+                      const chat = createChat(options)
+                      const responses = copilot.createOpenaiCompatible({ ...options, customToolNames: ["exec"] })
+                      return {
+                        languageModel: (modelId: string) => chat.languageModel(modelId),
+                        responses: (modelId: string) => responses.responses(modelId),
+                      }
+                    },
                 )
             : BUNDLED_PROVIDERS[model.api.npm]
         if (bundledLoader) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -14,6 +14,7 @@ import { Global } from "../../src/global"
 import { Effect } from "effect"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { makeRuntime } from "../../src/effect/run-service"
+import { OpenAICompatibleChatLanguageModel } from "@ai-sdk/openai-compatible"
 
 const env = makeRuntime(Env.Service, Env.defaultLayer)
 const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
@@ -1912,8 +1913,74 @@ test("xiaomi models outside PTC mode stay on Chat Completions regardless of vers
       )
       const languages = await Promise.all(models.map((model) => getLanguage(model)))
       expect(languages.map((language) => language.provider)).toEqual(["xiaomi.chat", "xiaomi.chat"])
+      // Non-PTC must be the stock SDK, not the bundled Copilot fork (which only parses `reasoning_text`).
+      for (const language of languages) expect(language).toBeInstanceOf(OpenAICompatibleChatLanguageModel)
     },
   })
+})
+
+test("xiaomi non-PTC chat streams reasoning_content as reasoning parts", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          enabled_providers: ["xiaomi"],
+          provider: {
+            xiaomi: {
+              models: {
+                "mimo-v2.6": {
+                  name: "MiMo V2.6",
+                  reasoning: true,
+                  tool_call: true,
+                  limit: { context: 8192, output: 2048 },
+                },
+              },
+              options: { apiKey: "test-key", baseURL: "https://example.test/v1" },
+            },
+          },
+        }),
+      )
+    },
+  })
+  const chunks = [
+    { id: "c1", choices: [{ delta: { role: "assistant", reasoning_content: "think " } }] },
+    { id: "c1", choices: [{ delta: { reasoning_content: "hard" } }] },
+    { id: "c1", choices: [{ delta: { content: "answer" }, finish_reason: "stop" }] },
+  ]
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async () =>
+    new Response(chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("") + "data: [DONE]\n\n", {
+      headers: { "content-type": "text/event-stream" },
+    })) as unknown as typeof fetch
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        set("XIAOMI_API_KEY", "test-key")
+      },
+      fn: async () => {
+        const model = await getModel(ProviderID.make("xiaomi"), ModelID.make("mimo-v2.6"))
+        const language = await getLanguage(model)
+        const result = await language.doStream({ prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }] })
+        const parts: any[] = []
+        const reader = result.stream.getReader()
+        while (true) {
+          const next = await reader.read()
+          if (next.done) break
+          parts.push(next.value)
+        }
+        expect(parts.filter((part) => part.type === "reasoning-delta").map((part) => part.delta)).toEqual([
+          "think ",
+          "hard",
+        ])
+        expect(parts.filter((part) => part.type === "text-delta").map((part) => part.delta)).toEqual(["answer"])
+      },
+    })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
 })
 
 // Edge cases for model configuration


### PR DESCRIPTION
## Why

Xiaomi models were wholesale routed through the bundled Copilot fork (`src/provider/sdk/copilot`) so PTC could use a free-form `exec` custom tool on the Responses API. But `customToolNames` is only consumed by the Responses path; the fork's **chat** model brings Copilot's field conventions along for nothing. Its chunk schema only declares `reasoning_text` / `reasoning_opaque`, so the `reasoning_content` that Xiaomi models stream on Chat Completions is stripped by zod and never becomes a reasoning part. BYOK providers on the stock `@ai-sdk/openai-compatible` show thinking; the logged-in Xiaomi provider does not.

## What

- `provider.ts`: the Xiaomi bundled loader is now a hybrid. `languageModel()` comes from the stock `@ai-sdk/openai-compatible`; `responses()` stays on the Copilot fork with `customToolNames: ["exec"]`. PTC behaviour is unchanged.
- Tests (`test/provider/provider.test.ts`):
  - "outside PTC mode stay on Chat Completions" now also asserts the model is the stock `OpenAICompatibleChatLanguageModel` (fails against the old loader: it received the fork's class).
  - New: stub `fetch` streams `reasoning_content` chunks to a non-PTC Xiaomi model and asserts `reasoning-delta` parts `["think ", "hard"]` followed by `text-delta` `["answer"]`.

## Verification

- `bun typecheck` clean.
- `bun test test/provider/`: 531 pass. One pre-existing flake ("plugin config providers persist after instance dispose") timed out at 5s in the full run and passes when run alone, both with and without this change.

## Not in this PR

Sending reasoning back on later turns still needs `interleaved: { field: "reasoning_content" }` on the Xiaomi model entries; that is a desktop-side registry change and is tracked separately.
