### PR TITLE
feat(media): bound inline attachment size and gate PDF reads on capability

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -209,6 +209,29 @@ export const Flag = {
   // placeholder when they can't be compressed. Values must be positive integers.
   MIMOCODE_MAX_PROMPT_IMAGES: number("MIMOCODE_MAX_PROMPT_IMAGES"),
   MIMOCODE_MAX_PROMPT_IMAGE_SIZE: number("MIMOCODE_MAX_PROMPT_IMAGE_SIZE"),
+  // Upper bound, in bytes, on a single inline attachment (image, PDF, audio,
+  // MCP blob). Enforced where the attachment is produced — the read tool, user
+  // prompt attachments, and MCP result normalization — with the size taken
+  // from stat or the base64 length so an under-limit payload costs nothing
+  // extra. Over the limit, an image is read and recompressed to fit; anything
+  // that still cannot fit (PDFs, audio, video, undecodable images) is replaced
+  // by a notice, so nothing oversized ever becomes a stored part. Defaults to
+  // 50 MB. Provider limits are lower (the Claude API takes 10 MB per image,
+  // Bedrock and Vertex 5 MB) and are still enforced at send time by the
+  // MIMOCODE_MAX_PROMPT_IMAGE_SIZE / provider cap in provider/transform.ts.
+  // Read lazily so tests can flip it at runtime.
+  get MIMOCODE_MAX_ATTACHMENT_SIZE() {
+    return number("MIMOCODE_MAX_ATTACHMENT_SIZE") ?? 50 * 1024 * 1024
+  },
+  // Ceiling, in bytes, above which an oversized image is refused outright
+  // instead of being read and recompressed. Defaults to 150 MB: compressImage
+  // already refuses anything over MAX_DECODE_IMAGE_PIXELS (64 MP), and a PNG
+  // that decodes within that budget is at most ~150-200 MB on disk, so a
+  // larger file would only be read into memory to fail the pixel guard.
+  // Read lazily so tests can flip it at runtime.
+  get MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE() {
+    return number("MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE") ?? 150 * 1024 * 1024
+  },
   MIMOCODE_MIMO_ONLY,
   MIMOCODE_DISABLE_PROVIDER_ENV: MIMOCODE_MIMO_ONLY || truthy("MIMOCODE_DISABLE_PROVIDER_ENV"),
   MIMOCODE_DISABLE_CLAUDE_CODE,

--- a/packages/opencode/src/mcp/tool-result.ts
+++ b/packages/opencode/src/mcp/tool-result.ts
@@ -1,5 +1,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import { isRecord } from "@/util/record"
+import { base64ByteSize, classifyAttachment, oversizedAttachmentNotice } from "@/util/media"
+import { shrinkAttachment } from "@/provider/image"
 
 export type ToolResultAttachment = {
   mime: string
@@ -45,6 +47,19 @@ function containsSerializedBlock(output: string, serialized: string) {
 export function normalizeToolResult(result: CallToolResult): NormalizedToolResult {
   const text: string[] = []
   const attachments: ToolResultAttachment[] = []
+  // Inline payloads are bounded here, at the tool result boundary, so nothing
+  // over the attachment limit reaches the session DB or the model. The size is
+  // classified O(1) on the base64 length (see classifyAttachment); only an
+  // oversized image within the source ceiling is decoded and recompressed.
+  const fit = (label: string, mime: string, base64: string) => {
+    const size = base64ByteSize(base64)
+    const verdict = classifyAttachment(mime, size)
+    if (verdict === "fits") return { mime, base64 }
+    const fitted = verdict === "shrink" ? shrinkAttachment(mime, Buffer.from(base64, "base64")) : undefined
+    if (fitted) return { mime: fitted.mime, base64: fitted.base64 }
+    text.push(oversizedAttachmentNotice({ label, size, compressed: verdict === "shrink", hint: "It was dropped." }))
+    return undefined
+  }
 
   for (const item of result.content) {
     if (item.type === "text") {
@@ -53,9 +68,11 @@ export function normalizeToolResult(result: CallToolResult): NormalizedToolResul
     }
 
     if (item.type === "image" || item.type === "audio") {
+      const fitted = fit(item.mimeType, item.mimeType, item.data)
+      if (!fitted) continue
       attachments.push({
-        mime: item.mimeType,
-        url: `data:${item.mimeType};base64,${item.data}`,
+        mime: fitted.mime,
+        url: `data:${fitted.mime};base64,${fitted.base64}`,
       })
       continue
     }
@@ -66,9 +83,11 @@ export function normalizeToolResult(result: CallToolResult): NormalizedToolResul
       if (/^data:/i.test(uri)) {
         const inline = uri.match(/^data:([a-z0-9.+-]+\/[a-z0-9.+-]+);base64,([a-z0-9+/]+={0,2})$/i)
         if (inline) {
+          const fitted = fit(`"${name}" (${inline[1]})`, inline[1], inline[2])
+          if (!fitted) continue
           attachments.push({
-            mime: inline[1],
-            url: uri,
+            mime: fitted.mime,
+            url: fitted.mime === inline[1] ? uri : `data:${fitted.mime};base64,${fitted.base64}`,
             filename: name,
           })
           text.push(`${name}: [inline ${inline[1]} resource]`)
@@ -85,9 +104,11 @@ export function normalizeToolResult(result: CallToolResult): NormalizedToolResul
       if ("text" in item.resource) text.push(item.resource.text)
       if ("blob" in item.resource) {
         const mime = item.resource.mimeType ?? "application/octet-stream"
+        const fitted = fit(`"${item.resource.uri}" (${mime})`, mime, item.resource.blob)
+        if (!fitted) continue
         attachments.push({
-          mime,
-          url: `data:${mime};base64,${item.resource.blob}`,
+          mime: fitted.mime,
+          url: `data:${fitted.mime};base64,${fitted.base64}`,
           filename: item.resource.uri,
         })
       }

--- a/packages/opencode/src/provider/image.ts
+++ b/packages/opencode/src/provider/image.ts
@@ -3,6 +3,7 @@ import jpeg from "jpeg-js"
 import z from "zod"
 import { NamedError } from "@mimo-ai/shared/util/error"
 import { sniffAttachmentMime } from "@/util/media"
+import { Flag } from "@/flag/flag"
 import type * as Provider from "./provider"
 import { modelDeclaration } from "./capability-registry"
 
@@ -411,4 +412,16 @@ export function compressImage(
     }
   }
   return undefined
+}
+
+// Shrink an attachment the caller already knows is over
+// Flag.MIMOCODE_MAX_ATTACHMENT_SIZE (from stat or the base64 length, so the
+// common under-limit case never pays for this). An image is recompressed to a
+// JPEG under the limit; anything that cannot be shrunk — undecodable image
+// formats, PDFs, audio, video — yields undefined and the caller drops it with
+// a notice.
+export function shrinkAttachment(mime: string, bytes: Buffer): { mime: string; base64: string } | undefined {
+  if (!mime.startsWith("image/")) return undefined
+  const shrunk = compressImage(mime, bytes, Flag.MIMOCODE_MAX_ATTACHMENT_SIZE)
+  return shrunk ? { mime: shrunk.mediaType, base64: shrunk.data } : undefined
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3,6 +3,8 @@ import os from "os"
 import z from "zod"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
+import { base64ByteSize, classifyAttachment, oversizedAttachmentNotice } from "@/util/media"
+import { shrinkAttachment } from "@/provider/image"
 import { classifyAssistantStep } from "./classify"
 import { Log, Token } from "../util"
 import { SessionRevert } from "./revert"
@@ -2566,7 +2568,39 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   { ...part, messageID: info.id, sessionID: input.sessionID },
                 ]
               }
-              break
+              // Inline payloads (clipboard pastes) are classified on the base64
+              // length: an oversized image within the source ceiling is
+              // recompressed, anything else oversized is dropped.
+              const inline = part.url.slice(part.url.indexOf(",") + 1)
+              const inlineSize = base64ByteSize(inline)
+              const verdict = classifyAttachment(part.mime, inlineSize)
+              if (verdict === "fits") break
+              const fitted = verdict === "shrink" ? shrinkAttachment(part.mime, Buffer.from(inline, "base64")) : undefined
+              if (!fitted) {
+                return [
+                  {
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: oversizedAttachmentNotice({
+                      label: `"${part.filename ?? part.mime}"`,
+                      size: inlineSize,
+                      compressed: verdict === "shrink",
+                      hint: "It was not attached.",
+                    }),
+                  },
+                ]
+              }
+              return [
+                {
+                  ...part,
+                  messageID: info.id,
+                  sessionID: input.sessionID,
+                  mime: fitted.mime,
+                  url: `data:${fitted.mime};base64,${fitted.base64}`,
+                },
+              ]
             case "file:": {
               log.info("file", { mime: part.mime })
               const filepath = fileURLToPath(part.url)
@@ -2712,23 +2746,58 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 ]
               }
 
+              const call: Draft<MessageV2.Part> = {
+                messageID: info.id,
+                sessionID: input.sessionID,
+                type: "text",
+                synthetic: true,
+                text: `Called the Read tool with the following input: {"file_path":"${filepath}"}`,
+              }
+              // Size gate on stat, before the file is read (see classifyAttachment):
+              // an under-limit file is inlined as-is, an oversized image within
+              // the source ceiling is read and recompressed, and anything else
+              // oversized becomes a notice without being read, so it never
+              // reaches the session DB.
+              const size = yield* fsys.stat(filepath).pipe(
+                Effect.map((info) => Number(info.size)),
+                Effect.catch(() => Effect.succeed(0)),
+              )
+              const verdict = classifyAttachment(part.mime, size)
+              const fitted =
+                verdict === "reject"
+                  ? undefined
+                  : verdict === "shrink"
+                    ? shrinkAttachment(part.mime, Buffer.from(yield* fsys.readFile(filepath).pipe(Effect.catch(Effect.die))))
+                    : {
+                        mime: part.mime,
+                        base64: Buffer.from(yield* fsys.readFile(filepath).pipe(Effect.catch(Effect.die))).toString("base64"),
+                      }
+              if (!fitted) {
+                return [
+                  call,
+                  {
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: oversizedAttachmentNotice({
+                      label: `"${filepath}" (${part.mime})`,
+                      size,
+                      compressed: verdict === "shrink",
+                      hint: "It was not attached.",
+                    }),
+                  },
+                ]
+              }
               return [
-                {
-                  messageID: info.id,
-                  sessionID: input.sessionID,
-                  type: "text",
-                  synthetic: true,
-                  text: `Called the Read tool with the following input: {"file_path":"${filepath}"}`,
-                },
+                call,
                 {
                   id: part.id,
                   messageID: info.id,
                   sessionID: input.sessionID,
                   type: "file",
-                  url:
-                    `data:${part.mime};base64,` +
-                    Buffer.from(yield* fsys.readFile(filepath).pipe(Effect.catch(Effect.die))).toString("base64"),
-                  mime: part.mime,
+                  url: `data:${fitted.mime};base64,${fitted.base64}`,
+                  mime: fitted.mime,
                   filename: part.filename!,
                   source: part.source,
                 },

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -12,7 +12,15 @@ import { assertExternalDirectoryEffect } from "./external-directory"
 import { SessionCwd } from "./session-cwd"
 import { Instruction } from "../session/instruction"
 import { Provider } from "@/provider"
-import { isImageAttachment, isPdfAttachment, sniffAttachmentMime } from "@/util/media"
+import { shrinkAttachment } from "@/provider/image"
+import { builtinSkillRoot } from "@/skill/builtin/extract"
+import {
+  classifyAttachment,
+  isImageAttachment,
+  isPdfAttachment,
+  oversizedAttachmentNotice,
+  sniffAttachmentMime,
+} from "@/util/media"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
@@ -210,32 +218,65 @@ export const ReadTool = Tool.define(
       const sample = yield* readSample(filepath, Number(stat.size), SAMPLE_BYTES)
 
       const mime = sniffAttachmentMime(sample, AppFileSystem.mimeType(filepath))
+      // Size gate on stat, before any bytes are read (see classifyAttachment):
+      // a rejected PDF or image is never read, an oversized image within the
+      // source ceiling is read and recompressed below. Either way nothing over
+      // the limit becomes base64 or reaches the session DB.
+      const verdict =
+        isImageAttachment(mime) || isPdfAttachment(mime) ? classifyAttachment(mime, Number(stat.size)) : "fits"
+      if (verdict === "reject") {
+        const warning = oversizedAttachmentNotice({
+          label: `"${path.basename(filepath)}" (${mime})`,
+          size: Number(stat.size),
+          hint: "It was not read.",
+        })
+        return {
+          title,
+          output: warning,
+          metadata: { preview: warning, truncated: false, loaded: loaded.map((item) => item.filepath) },
+        }
+      }
+      // The active model is carried on ctx.extra.model (set on both the
+      // agent-call path and the @file resolution path, which passes messages: []).
+      // Fall back to resolving the last user message's model for any caller that
+      // doesn't populate extra. Mirrors tool/websearch/index.ts.
+      const extraModel = (ctx.extra as { model?: Provider.Model } | undefined)?.model
+      const messageModelRef = extraModel
+        ? undefined
+        : [...ctx.messages]
+            .reverse()
+            .map((m) => m.info)
+            .find((i): i is Extract<typeof i, { role: "user" }> => i.role === "user")?.model
+      const model =
+        extraModel ??
+        (messageModelRef
+          ? yield* provider
+              .getModel(messageModelRef.providerID, messageModelRef.modelID)
+              .pipe(Effect.catchDefect(() => Effect.succeed(undefined)))
+          : undefined)
+
+      if (isPdfAttachment(mime) && !(model?.capabilities.input.pdf ?? false)) {
+        // Same shape as the image gate below: the bytes are never read, so a
+        // PDF the model cannot take never becomes base64 and never reaches the
+        // session DB. The model is pointed at the bundled pdf skill instead.
+        const warning = [
+          `Cannot attach PDF "${path.basename(filepath)}" — the current model has no PDF input support, so the file was not read.`,
+          `To work with its contents, extract text (or render pages to images) with the bundled pdf skill: read ${path.join(builtinSkillRoot(), "pdf-official", "SKILL.md")} and follow it.`,
+        ].join("\n")
+        return {
+          title,
+          output: warning,
+          metadata: { preview: warning, truncated: false, loaded: loaded.map((item) => item.filepath) },
+        }
+      }
       if (isImageAttachment(mime)) {
-        // The active model is carried on ctx.extra.model (set on both the
-        // agent-call path and the @file resolution path, which passes messages: []).
-        // Fall back to resolving the last user message's model for any caller that
-        // doesn't populate extra. Mirrors tool/websearch/index.ts.
-        const extraModel = (ctx.extra as { model?: Provider.Model } | undefined)?.model
-        const messageModelRef = extraModel
-          ? undefined
-          : [...ctx.messages]
-              .reverse()
-              .map((m) => m.info)
-              .find((i): i is Extract<typeof i, { role: "user" }> => i.role === "user")?.model
-        const model =
-          extraModel ??
-          (messageModelRef
-            ? yield* provider
-                .getModel(messageModelRef.providerID, messageModelRef.modelID)
-                .pipe(Effect.catchDefect(() => Effect.succeed(undefined)))
-            : undefined)
         const supportsImage = model?.capabilities.input.image ?? false
         if (!supportsImage) {
-        const preferred = yield* provider.getVisionModel().pipe(Effect.orElseSucceed(() => undefined))
-        const preferredRef = preferred ? `${preferred.providerID}/${preferred.id}` : undefined
-        const dispatch = preferredRef
-          ? `dispatch a vision-capable subagent: actor run <type> "<desc>" "analyze the image at ${filepath}" --model ${preferredRef} (run \`actor models --vision\` for the full list)`
-          : `no vision-capable model is configured — ask the user to configure one or use an OCR tool`
+          const preferred = yield* provider.getVisionModel().pipe(Effect.orElseSucceed(() => undefined))
+          const preferredRef = preferred ? `${preferred.providerID}/${preferred.id}` : undefined
+          const dispatch = preferredRef
+            ? `dispatch a vision-capable subagent: actor run <type> "<desc>" "analyze the image at ${filepath}" --model ${preferredRef} (run \`actor models --vision\` for the full list)`
+            : `no vision-capable model is configured — ask the user to configure one or use an OCR tool`
           const warning = [
             `Cannot read image "${path.basename(filepath)}" — the current model has no vision support, so its visual content is unavailable.`,
             `If you need to understand the image visually, ${dispatch}.`,
@@ -247,20 +288,38 @@ export const ReadTool = Tool.define(
             metadata: { preview: warning, truncated: false, loaded: [] as string[] },
           }
         }
-        const bytes = yield* fs.readFile(filepath)
+        const bytes = Buffer.from(yield* fs.readFile(filepath))
+        const fitted = verdict === "shrink" ? shrinkAttachment(mime, bytes) : { mime, base64: bytes.toString("base64") }
+        if (!fitted) {
+          const warning = oversizedAttachmentNotice({
+            label: `"${path.basename(filepath)}" (${mime})`,
+            size: bytes.byteLength,
+            compressed: true,
+            hint: "It was not attached.",
+          })
+          return {
+            title,
+            output: warning,
+            metadata: { preview: warning, truncated: false, loaded: loaded.map((item) => item.filepath) },
+          }
+        }
+        const output =
+          verdict === "shrink"
+            ? `Image read successfully (recompressed from ${bytes.byteLength} bytes to ${fitted.mime} to fit the attachment limit)`
+            : "Image read successfully"
         return {
           title,
-          output: "Image read successfully",
+          output,
           metadata: {
-            preview: "Image read successfully",
+            preview: output,
             truncated: false,
             loaded: loaded.map((item) => item.filepath),
           },
           attachments: [
             {
               type: "file" as const,
-              mime,
-              url: `data:${mime};base64,${Buffer.from(bytes).toString("base64")}`,
+              mime: fitted.mime,
+              url: `data:${fitted.mime};base64,${fitted.base64}`,
             },
           ],
         }

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -1,3 +1,5 @@
+import { Flag } from "@/flag/flag"
+
 const startsWith = (bytes: Uint8Array, prefix: number[]) => prefix.every((value, index) => bytes[index] === value)
 
 export function isPdfAttachment(mime: string) {
@@ -23,4 +25,45 @@ export function sniffAttachmentMime(bytes: Uint8Array, fallback: string) {
   }
 
   return fallback
+}
+
+// Attachment size gate, driven by Flag.MIMOCODE_MAX_ATTACHMENT_SIZE and
+// Flag.MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE. Enforced where the attachment is
+// produced (read tool, user prompt attachments, MCP result normalization) on a
+// size known up front (stat or base64 length), so nothing over the limit
+// reaches the session DB:
+//   fits    — under the limit, attach as-is
+//   shrink  — an image over the limit but under the source ceiling: read it
+//             and recompress under the limit, reject only if that fails
+//   reject  — anything else over the limit (non-image, or an image so large
+//             that recompressing it is not worth attempting)
+
+// Decoded byte count of raw base64, O(1) — no decoding needed to classify.
+export function base64ByteSize(base64: string) {
+  if (!base64) return 0
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0
+  return Math.floor((base64.length * 3) / 4) - padding
+}
+
+export function classifyAttachment(mime: string, size: number): "fits" | "shrink" | "reject" {
+  if (size <= Flag.MIMOCODE_MAX_ATTACHMENT_SIZE) return "fits"
+  if (!mime.startsWith("image/")) return "reject"
+  return size > Flag.MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE ? "reject" : "shrink"
+}
+
+function mb(bytes: number) {
+  return `${Math.round((bytes / 1024 / 1024) * 10) / 10} MB`
+}
+
+// Notice for a rejected attachment. `compressed: true` means a shrink was
+// attempted and failed; otherwise the payload was refused on size alone and
+// the notice says why (over the source ceiling, or not an image).
+export function oversizedAttachmentNotice(input: { label: string; size: number; compressed?: boolean; hint: string }) {
+  const limit = mb(Flag.MIMOCODE_MAX_ATTACHMENT_SIZE)
+  const reason = input.compressed
+    ? "it could not be compressed under the limit"
+    : input.size > Flag.MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE
+      ? `it is also over the ${mb(Flag.MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE)} ceiling above which compression is not attempted`
+      : "it cannot be compressed"
+  return `Attachment ${input.label} is ${input.size} bytes, over the ${limit} attachment limit, and ${reason}. ${input.hint}`
 }

--- a/packages/opencode/test/mcp/tool-result.test.ts
+++ b/packages/opencode/test/mcp/tool-result.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test"
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { PNG } from "pngjs"
 import { CallToolResultSchema, type CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import { normalizeToolResult } from "../../src/mcp/tool-result"
 
@@ -7,6 +8,18 @@ function parseResult(result: CallToolResult) {
 }
 
 describe("MCP tool result normalization", () => {
+  // Flag.MIMOCODE_MAX_ATTACHMENT_SIZE, lowered so the oversized fixture stays small.
+  const LIMIT = 4096
+  const CEILING = 32 * 1024
+  beforeAll(() => {
+    process.env["MIMOCODE_MAX_ATTACHMENT_SIZE"] = String(LIMIT)
+    process.env["MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE"] = String(CEILING)
+  })
+  afterAll(() => {
+    delete process.env["MIMOCODE_MAX_ATTACHMENT_SIZE"]
+    delete process.env["MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE"]
+  })
+
   test("preserves standard fields and classifies tool execution errors", () => {
     const result: CallToolResult = {
       content: [
@@ -169,5 +182,47 @@ describe("MCP tool result normalization", () => {
     const normalized = normalizeToolResult(parseResult(result))
 
     expect(normalized.output).toBe("Processed an empty {} template\n\nStructured content:\n{}")
+  })
+  test("recompresses an oversized decodable image and drops an uncompressible payload", () => {
+    const noisy = (size: number) => {
+      const png = new PNG({ width: size, height: size })
+      let seed = 4242
+      for (let i = 0; i < png.data.length; i++) {
+        seed = (seed * 1103515245 + 12345) & 0x7fffffff
+        png.data[i] = i % 4 === 3 ? 255 : seed % 256
+      }
+      return PNG.sync.write(png)
+    }
+    const image = noisy(120)
+    expect(image.byteLength).toBeGreaterThan(LIMIT)
+    expect(image.byteLength).toBeLessThanOrEqual(CEILING)
+    const giant = noisy(200)
+    expect(giant.byteLength).toBeGreaterThan(CEILING)
+    // Decoded size is 3 bytes per 4 base64 chars; one group past the cap.
+    const audio = "A".repeat(Math.ceil((LIMIT + 1) / 3) * 4)
+    const result: CallToolResult = {
+      content: [
+        { type: "text", text: "rendered" },
+        { type: "image", data: image.toString("base64"), mimeType: "image/png" },
+        { type: "audio", data: audio, mimeType: "audio/wav" },
+        { type: "image", data: giant.toString("base64"), mimeType: "image/png" },
+        { type: "image", data: "Zm9v", mimeType: "image/jpeg" },
+      ],
+    }
+
+    const normalized = normalizeToolResult(parseResult(result))
+
+    expect(normalized.attachments).toHaveLength(2)
+    expect(normalized.attachments[0].mime).toBe("image/jpeg")
+    const url = normalized.attachments[0].url
+    expect(Buffer.from(url.slice(url.indexOf(",") + 1), "base64").byteLength).toBeLessThanOrEqual(LIMIT)
+    expect(normalized.attachments[1]).toEqual({ mime: "image/jpeg", url: "data:image/jpeg;base64,Zm9v" })
+    expect(normalized.output).toContain("rendered")
+    expect(normalized.output).toContain("Attachment audio/wav is")
+    expect(normalized.output).toContain("it cannot be compressed")
+    expect(normalized.output).toContain(`Attachment image/png is ${giant.byteLength} bytes`)
+    expect(normalized.output).toContain("ceiling above which compression is not attempted")
+    expect(normalized.output).not.toContain(`Attachment image/png is ${image.byteLength} bytes`)
+    expect(normalized.output).not.toContain(audio.slice(0, 64))
   })
 })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2,7 +2,7 @@ import path from "path"
 import { rm } from "node:fs/promises"
 import { Global } from "../../src/global"
 import { PNG } from "pngjs"
-import { describe, expect, test } from "bun:test"
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
 import { NamedError } from "@mimo-ai/shared/util/error"
 import { fileURLToPath } from "url"
 import { Cause, Effect, Exit, Fiber, Layer } from "effect"
@@ -1259,5 +1259,137 @@ describe("session.prompt F37 subagent context isolation", () => {
     } finally {
       void server.stop(true)
     }
+  })
+})
+
+describe("session.prompt oversized attachment", () => {
+  // Flag.MIMOCODE_MAX_ATTACHMENT_SIZE, lowered so the fixtures stay small.
+  const LIMIT = 4096
+  const CEILING = 32 * 1024
+  beforeAll(() => {
+    process.env["MIMOCODE_MAX_ATTACHMENT_SIZE"] = String(LIMIT)
+    process.env["MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE"] = String(CEILING)
+  })
+  afterAll(() => {
+    delete process.env["MIMOCODE_MAX_ATTACHMENT_SIZE"]
+    delete process.env["MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE"]
+  })
+  const config = { agent: { build: { model: "openai/gpt-5.2" } } }
+  const noFileParts = (parts: MessageV2.Part[]) => parts.every((part) => part.type !== "file")
+  const notice = (parts: MessageV2.Part[], needle: string) =>
+    parts.some((part) => part.type === "text" && part.synthetic === true && part.text.includes(needle))
+
+  test("stats a file attachment first and replaces an oversized undecodable one with a notice", async () => {
+    await using tmp = await tmpdir({ git: true, config })
+    const huge = path.join(tmp.path, "huge.png")
+    // Valid PNG signature, garbage body: over the limit and not compressible.
+    const bytes = Buffer.alloc(LIMIT + 1)
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes)
+    await Bun.write(huge, bytes)
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Effect.gen(function* () {
+            const prompt = yield* SessionPrompt.Service
+            const sessions = yield* Session.Service
+            const session = yield* sessions.create({})
+            const msg = yield* prompt.prompt({
+              sessionID: session.id,
+              agent: "build",
+              noReply: true,
+              parts: [
+                { type: "text", text: "look at @huge.png" },
+                { type: "file", mime: "image/png", url: `file://${huge}`, filename: "huge.png" },
+              ],
+            })
+            if (msg.info.role !== "user") throw new Error("expected user message")
+            expect(noFileParts(msg.parts)).toBe(true)
+            expect(notice(msg.parts, `"${huge}" (image/png) is ${bytes.byteLength} bytes`)).toBe(true)
+
+            const stored = yield* sessions.messages({ sessionID: session.id })
+            expect(noFileParts(stored.flatMap((item) => item.parts))).toBe(true)
+            yield* sessions.remove(session.id)
+          }),
+        ),
+    })
+  })
+
+  test("recompresses an oversized decodable file attachment and stores the smaller copy", async () => {
+    await using tmp = await tmpdir({ git: true, config })
+    const huge = path.join(tmp.path, "photo.png")
+    const png = new PNG({ width: 120, height: 120 })
+    let seed = 4242
+    for (let i = 0; i < png.data.length; i++) {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      png.data[i] = i % 4 === 3 ? 255 : seed % 256
+    }
+    const bytes = PNG.sync.write(png)
+    expect(bytes.byteLength).toBeGreaterThan(LIMIT)
+    expect(bytes.byteLength).toBeLessThanOrEqual(CEILING)
+    await Bun.write(huge, bytes)
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Effect.gen(function* () {
+            const prompt = yield* SessionPrompt.Service
+            const sessions = yield* Session.Service
+            const session = yield* sessions.create({})
+            const msg = yield* prompt.prompt({
+              sessionID: session.id,
+              agent: "build",
+              noReply: true,
+              parts: [
+                { type: "text", text: "look at @photo.png" },
+                { type: "file", mime: "image/png", url: `file://${huge}`, filename: "photo.png" },
+              ],
+            })
+            if (msg.info.role !== "user") throw new Error("expected user message")
+            const stored = yield* sessions.messages({ sessionID: session.id })
+            const file = stored.flatMap((item) => item.parts).find((part) => part.type === "file")
+            if (file?.type !== "file") throw new Error("expected a stored file part")
+            expect(file.mime).toBe("image/jpeg")
+            expect(Buffer.from(file.url.slice(file.url.indexOf(",") + 1), "base64").byteLength).toBeLessThanOrEqual(LIMIT)
+            yield* sessions.remove(session.id)
+          }),
+        ),
+    })
+  })
+
+  test("drops an oversized inline data attachment with a notice", async () => {
+    await using tmp = await tmpdir({ git: true, config })
+    // Uncompressible: not an image at all, so it can only be dropped.
+    const base64 = "A".repeat(Math.ceil((LIMIT + 1) / 3) * 4)
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Effect.gen(function* () {
+            const prompt = yield* SessionPrompt.Service
+            const sessions = yield* Session.Service
+            const session = yield* sessions.create({})
+            const msg = yield* prompt.prompt({
+              sessionID: session.id,
+              agent: "build",
+              noReply: true,
+              parts: [
+                { type: "text", text: "what is this" },
+                { type: "file", mime: "audio/wav", url: `data:audio/wav;base64,${base64}`, filename: "clip.wav" },
+              ],
+            })
+            if (msg.info.role !== "user") throw new Error("expected user message")
+            expect(noFileParts(msg.parts)).toBe(true)
+            expect(notice(msg.parts, `"clip.wav" is`)).toBe(true)
+
+            const stored = yield* sessions.messages({ sessionID: session.id })
+            expect(noFileParts(stored.flatMap((item) => item.parts))).toBe(true)
+            yield* sessions.remove(session.id)
+          }),
+        ),
+    })
   })
 })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect } from "bun:test"
+import { afterAll, afterEach, beforeAll, describe, expect } from "bun:test"
+import { PNG } from "pngjs"
 import { Cause, Effect, Exit, Layer } from "effect"
 import path from "path"
 import { Agent } from "../../src/agent/agent"
@@ -8,6 +9,7 @@ import { LSP } from "../../src/lsp"
 import { Permission } from "../../src/permission"
 import { Instance } from "../../src/project/instance"
 import { SessionID, MessageID } from "../../src/session/schema"
+import { ModelID } from "../../src/provider/schema"
 import { Instruction } from "../../src/session/instruction"
 import { ReadTool } from "../../src/tool/read"
 import { Truncate } from "../../src/tool"
@@ -18,6 +20,24 @@ import { testEffect } from "../lib/effect"
 import { ProviderTest } from "../fake/provider"
 
 const FIXTURES_DIR = path.join(import.meta.dir, "fixtures")
+
+// Random noise defeats PNG's own compression, so a small canvas yields a file
+// far larger than the tiny attachment limit the size-gate tests run under.
+function noisyPng(size: number) {
+  let seed = 4242
+  const rand = () => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff
+    return seed % 256
+  }
+  const png = new PNG({ width: size, height: size })
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = rand()
+    png.data[i + 1] = rand()
+    png.data[i + 2] = rand()
+    png.data[i + 3] = 255
+  }
+  return PNG.sync.write(png)
+}
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -526,6 +546,129 @@ describe("tool.read binary detection", () => {
 
       const err = yield* fail(dir, { file_path: path.join(dir, "module.wasm") })
       expect(err.message).toContain("Cannot read binary file")
+    }),
+  )
+})
+
+describe("tool.read pdf capability gate", () => {
+  const pdf = Buffer.from("%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF\n")
+
+  it.live("attaches a PDF when the active model accepts pdf input", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "doc.pdf"), pdf)
+
+      const result = yield* exec(dir, { file_path: path.join(dir, "doc.pdf") })
+      expect(result.output).toBe("PDF read successfully")
+      expect(result.attachments?.length).toBe(1)
+      expect(result.attachments?.[0].mime).toBe("application/pdf")
+    }),
+  )
+
+  it.live("refuses a PDF without reading it when the model lacks pdf input", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "doc.pdf"), pdf)
+      const textOnly = ProviderTest.model({ id: ModelID.make("text-only"), providerID: visionModel.providerID })
+
+      const result = yield* exec(dir, { file_path: path.join(dir, "doc.pdf") }, { ...ctx, extra: { model: textOnly } })
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain('Cannot attach PDF "doc.pdf"')
+      expect(result.output).toContain(path.join("pdf-official", "SKILL.md"))
+      expect(result.metadata.truncated).toBe(false)
+    }),
+  )
+})
+
+describe("tool.read attachment size limit", () => {
+  // The size comes from stat, before any bytes are read. An oversized image is
+  // then read and recompressed; a PDF or an undecodable image is refused, so
+  // the base64 that would have bloated the session DB never exists.
+  // The limits come from Flag.MIMOCODE_MAX_ATTACHMENT_SIZE and
+  // Flag.MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE, lowered here so the fixtures
+  // stay small.
+  const LIMIT = 4096
+  const CEILING = 32 * 1024
+  beforeAll(() => {
+    process.env["MIMOCODE_MAX_ATTACHMENT_SIZE"] = String(LIMIT)
+    process.env["MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE"] = String(CEILING)
+  })
+  afterAll(() => {
+    delete process.env["MIMOCODE_MAX_ATTACHMENT_SIZE"]
+    delete process.env["MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE"]
+  })
+  it.live("recompresses an oversized image under the limit instead of refusing it", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const bytes = noisyPng(120) // noise defeats PNG compression: ~18 KB raw, over LIMIT and under CEILING
+      expect(bytes.byteLength).toBeGreaterThan(LIMIT)
+      expect(bytes.byteLength).toBeLessThanOrEqual(CEILING)
+      yield* put(path.join(dir, "huge.png"), bytes)
+
+      const result = yield* exec(dir, { file_path: path.join(dir, "huge.png") })
+      expect(result.attachments?.length).toBe(1)
+      expect(result.attachments?.[0].mime).toBe("image/jpeg")
+      const url = result.attachments![0].url
+      expect(Buffer.from(url.slice(url.indexOf(",") + 1), "base64").byteLength).toBeLessThanOrEqual(LIMIT)
+      expect(result.output).toContain(`recompressed from ${bytes.byteLength} bytes`)
+      expect(result.metadata.truncated).toBe(false)
+    }),
+  )
+
+  it.live("drops an oversized image that cannot be decoded", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      // Valid PNG signature, garbage body: over the limit and undecodable.
+      const bytes = Buffer.alloc(LIMIT + 1)
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes)
+      yield* put(path.join(dir, "broken.png"), bytes)
+
+      const result = yield* exec(dir, { file_path: path.join(dir, "broken.png") })
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain(`"broken.png" (image/png) is ${LIMIT + 1} bytes`)
+      expect(result.output).toContain("could not be compressed")
+    }),
+  )
+
+  it.live("refuses an image over the source ceiling without reading or compressing it", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      // A decodable PNG that compression could handle, but too large to bother.
+      const bytes = noisyPng(200)
+      expect(bytes.byteLength).toBeGreaterThan(CEILING)
+      yield* put(path.join(dir, "giant.png"), bytes)
+
+      const result = yield* exec(dir, { file_path: path.join(dir, "giant.png") })
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain(`"giant.png" (image/png) is ${bytes.byteLength} bytes`)
+      expect(result.output).toContain("ceiling above which compression is not attempted")
+      expect(result.output).toContain("It was not read")
+    }),
+  )
+
+  it.live("refuses an oversized PDF", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const bytes = Buffer.alloc(LIMIT + 1)
+      Buffer.from("%PDF-1.4").copy(bytes)
+      yield* put(path.join(dir, "huge.pdf"), bytes)
+
+      const result = yield* exec(dir, { file_path: path.join(dir, "huge.pdf") })
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain(`"huge.pdf" (application/pdf)`)
+      expect(result.output).toContain("It was not read")
+    }),
+  )
+
+  it.live("still attaches an image just under the limit", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const bytes = Buffer.alloc(LIMIT)
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes)
+      yield* put(path.join(dir, "edge.png"), bytes)
+
+      const result = yield* exec(dir, { file_path: path.join(dir, "edge.png") })
+      expect(result.attachments?.length).toBe(1)
     }),
   )
 })


### PR DESCRIPTION
## Summary

Inline payloads had no upper bound. A large `@file` mention, a clipboard paste, or an MCP tool result was base64-encoded in full and stored as a session part, so an oversized attachment bloated the session DB and only reached the provider to be rejected at send time.

Attachments are now classified where they are produced, on a size known up front — `stat` for files, base64 length for inline payloads — so the under-limit path pays nothing extra:

| verdict | condition | action |
| --- | --- | --- |
| `fits` | ≤ `MIMOCODE_MAX_ATTACHMENT_SIZE` (default 50 MB) | attached as-is |
| `shrink` | image over the limit, ≤ `MIMOCODE_MAX_ATTACHMENT_SOURCE_SIZE` (default 150 MB) | read and recompressed to a JPEG under the limit |
| `reject` | anything else, including an image above the source ceiling | replaced by a notice naming the size and the limit |

Enforced at the three places an attachment can enter a session:

- `tool/read.ts` — gate on `stat.size` before porting bytes
- `session/prompt.ts` — both the `data:` inline path (clipboard) and the `file:` path
- `mcp/tool-result.ts` — image/audio items and `data:`/blob resources

A rejected payload is never read, so its base64 never exists and never reaches the session DB.

The read tool additionally refuses a **PDF** when the active model declares no `input.pdf` support, pointing at the bundled `pdf-official` skill for text extraction instead of attaching bytes the model cannot consume. This required hoisting the active-model resolution above the image branch so the PDF gate can reuse it.

Provider-side limits in `provider/transform.ts` are unchanged and still apply at send time; the new 50 MB bound is a storage/transport guard, not a replacement for the per-provider image caps.

## Verification

- `bun typecheck` in `packages/opencode` — clean
- Full monorepo typecheck via the pre-push hook — 12/12 tasks successful
- New tests, all passing:
  - `bun test test/tool/read.test.ts -t "attachment size limit"` → 5 pass
  - `bun test test/tool/read.test.ts -t "pdf capability gate"` → 2 pass
  - `bun test test/session/prompt.test.ts -t "oversized attachment"` → 3 pass
  - `bun test test/mcp/tool-result.test.ts -t "recompresses an oversized"` → 1 pass

The new tests lower both flags via `process.env` and restore them in `afterAll`, so the fixtures stay small (4 KB limit / 32 KB ceiling) rather than allocating 50 MB buffers.

## Known unrelated failures

Running the three touched files together reports 11 failures, all outside these changes — the `tool.read env file permissions > .env*` cases in `test/tool/read.test.ts`. They fail independently of this diff and are not addressed here.
