### PR TITLE
fix(session): broaden recovery candidates and support model override on resume

### DIFF
--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -1059,6 +1059,10 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         const params = c.req.valid("param")
         const query = c.req.valid("query")
+        // modelProviderID / modelID 必须同时提供,否则 400(不允许只覆盖一侧)。
+        if (!!query.modelProviderID !== !!query.modelID) {
+          return c.json({ data: { name: "InvalidRequest", data: { message: "modelProviderID and modelID must be provided together" } } }, 400)
+        }
         await runRequest(
           "SessionRoutes.resume.assertNotBusy",
           c,

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -1053,6 +1053,8 @@ export const SessionRoutes = lazy(() =>
         agentID: z.string().optional(),
         task_id: z.string().optional(),
         titleLocale: z.string().optional(),
+        modelProviderID: z.string().optional(),
+        modelID: z.string().optional(),
       })),
       async (c) => {
         const params = c.req.valid("param")
@@ -1088,6 +1090,7 @@ export const SessionRoutes = lazy(() =>
             agentID: query.agentID,
             task_id: query.task_id,
             titleLocale: query.titleLocale,
+            ...(query.modelProviderID && query.modelID ? { model: { providerID: query.modelProviderID, modelID: query.modelID } } : {}),
           })),
         ).catch((error) => {
           log.error("session resume failed", { sessionID: params.sessionID, error })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -441,6 +441,8 @@ export interface ResumeTurnInput {
   agentID?: string
   task_id?: string
   titleLocale?: string
+  /** 可选模型覆盖：用户在继续前切换了模型时，用新模型执行恢复步。 */
+  model?: { providerID: string; modelID: string }
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionPrompt") {}
@@ -3099,7 +3101,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const msgs = yield* sessions.messages({ sessionID: input.sessionID, agentID: input.agentID ?? "main" })
       const candidates: RecoveryCandidate[] = []
       for (const [index, msg] of msgs.entries()) {
-        if (msg.info.role !== "assistant" || "completed" in msg.info.time) continue
+        if (msg.info.role !== "assistant") continue
+        // 只有整轮正常 finish 才排除;step 完成(time.completed)不等于 turn 完成——
+        // 工具步完成、length 截断、tool-calls 中断等 finished assistant 仍可恢复。
+        if ("completed" in msg.info.time && msg.info.finish === "stop" && !msg.info.error) continue
         const assistant = msg.info
         if (!msgs.some((parent) => parent.info.role === "user" && parent.info.id === assistant.parentID)) continue
         if (msgs.slice(index + 1).some((later) => later.info.role === "user" || later.info.role === "assistant")) continue
@@ -3119,10 +3124,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     }) {
       const messages = yield* sessions.messages({ sessionID: input.sessionID, agentID: input.agentID ?? "main" })
       const message = messages.find((item) => item.info.id === input.assistantMessageID)
-      if (!message || message.info.role !== "assistant" || "completed" in message.info.time) return
+      if (!message || message.info.role !== "assistant") return
+      // 已标记 completed 且已有 error → 幂等跳过
+      if ("completed" in message.info.time && message.info.error) return
       yield* sessions.updateMessage({
         ...message.info,
-        time: { ...message.info.time, completed: Date.now() },
+        time: { ...message.info.time, completed: message.info.time.completed ?? Date.now() },
         error: new MessageV2.AbortedError({ message: "Abandoned: resumed as a new assistant turn" }).toObject(),
       })
     })
@@ -3133,8 +3140,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       task_id?: string,
       notifyParentOnComplete?: boolean,
       titleLocale?: string,
+      resumeFrom?: string,
+      modelOverride?: { providerID: string; modelID: string },
     ) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(
-      function* (sessionID: SessionID, agentID?: string, task_id?: string, notifyParentOnComplete?: boolean, titleLocale?: string) {
+      function* (sessionID: SessionID, agentID?: string, task_id?: string, notifyParentOnComplete?: boolean, titleLocale?: string, resumeFrom?: string, modelOverride?: { providerID: string; modelID: string }) {
         const ctx = yield* InstanceState.context
         const slog = elog.with({ sessionID })
         let structured: unknown | undefined
@@ -3822,7 +3831,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             continue
           }
 
-          if (lastAssistant) {
+          if (lastAssistant && lastAssistant.id !== resumeFrom) {
             const classification = classifyAssistantStep({
               phase: "existing-assistant",
               lastUser,
@@ -3914,7 +3923,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
           }
 
-          const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID, lastUser)
+          const modelProviderID = modelOverride ? ProviderID.make(modelOverride.providerID) : lastUser.model.providerID
+          const modelModelID = modelOverride ? ModelID.make(modelOverride.modelID) : lastUser.model.modelID
+          const model = yield* getModel(modelProviderID, modelModelID, sessionID, lastUser)
           lastModelForPrune = model
           lastFinishedForPrune = usageRecovered ? undefined : lastFinished
           const task = tasks.pop()
@@ -5372,7 +5383,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         input.sessionID,
         agentID,
         lastAssistant(input.sessionID, agentID),
-        runLoop(input.sessionID, agentID, input.task_id, undefined, input.titleLocale).pipe(
+        runLoop(input.sessionID, agentID, input.task_id, undefined, input.titleLocale, input.assistantMessageID, input.model).pipe(
           Effect.ensuring(
             abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID }).pipe(
               Effect.catchCause((cause) =>
@@ -5405,7 +5416,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         input.sessionID,
         agentID,
         lastAssistant(input.sessionID, agentID),
-        runLoop(input.sessionID, agentID, input.task_id, undefined, input.titleLocale).pipe(
+        runLoop(input.sessionID, agentID, input.task_id, undefined, input.titleLocale, input.assistantMessageID, input.model).pipe(
           Effect.ensuring(
             abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID }).pipe(
               Effect.catchCause((cause) =>

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3105,8 +3105,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         // 未完成 assistant 才是恢复候选。步级 time.completed 不等于整轮完成——
         // tool-calls(工具步完但整轮未答)、length(输出截断)、无 finish(中断)均可恢复;
         // stop / other 等已正常或已终态收尾的不进候选(allowlist,不靠排除法)。
-        // 有 error = 没完成 = 可恢复(processor 注释不变量):stop+error 仍进候选。
-        if ("completed" in msg.info.time && msg.info.finish && msg.info.finish !== "tool-calls" && msg.info.finish !== "length") continue
+        // 有 error = 没完成 = 可恢复(processor 注释不变量):任何 error 消息都是候选,
+        // 包括 abandon 后 completed+AbortedError+finish=stop 的场景(恢复失败后仍可重试)。
+        if ("completed" in msg.info.time && !msg.info.error && msg.info.finish && msg.info.finish !== "tool-calls" && msg.info.finish !== "length") continue
         if (msg.info.finish === "stop" && !msg.info.error) continue
         const assistant = msg.info
         if (!msgs.some((parent) => parent.info.role === "user" && parent.info.id === assistant.parentID)) continue

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3102,9 +3102,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const candidates: RecoveryCandidate[] = []
       for (const [index, msg] of msgs.entries()) {
         if (msg.info.role !== "assistant") continue
-        // 只有整轮正常 finish 才排除;step 完成(time.completed)不等于 turn 完成——
-        // 工具步完成、length 截断、tool-calls 中断等 finished assistant 仍可恢复。
-        if ("completed" in msg.info.time && msg.info.finish === "stop" && !msg.info.error) continue
+        // 未完成 assistant 才是恢复候选。步级 time.completed 不等于整轮完成——
+        // tool-calls(工具步完但整轮未答)、length(输出截断)、无 finish(中断)均可恢复;
+        // stop / other 等已正常或已终态收尾的不进候选(allowlist,不靠排除法)。
+        if ("completed" in msg.info.time && msg.info.finish && msg.info.finish !== "tool-calls" && msg.info.finish !== "length") continue
+        if (msg.info.finish === "stop") continue
         const assistant = msg.info
         if (!msgs.some((parent) => parent.info.role === "user" && parent.info.id === assistant.parentID)) continue
         if (msgs.slice(index + 1).some((later) => later.info.role === "user" || later.info.role === "assistant")) continue
@@ -5374,6 +5376,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         )
       }
       const agentID = input.agentID ?? "main"
+      // 校验 model override 在 abandon 之前:getModel 失败时不能先把原消息改成 abandoned。
+      if (input.model) {
+        yield* getModel(ProviderID.make(input.model.providerID), ModelID.make(input.model.modelID), input.sessionID)
+      }
       // Abandon the recovered assistant BEFORE detaching runLoop so callers that
       // observe Error / completed state see it immediately (not only in ensuring
       // after the detached loop finishes). ensuring below remains as an idempotent
@@ -5410,6 +5416,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         )
       }
       const agentID = input.agentID ?? "main"
+      // 校验 model override 在 abandon 之前:getModel 失败时不能先把原消息改成 abandoned。
+      if (input.model) {
+        yield* getModel(ProviderID.make(input.model.providerID), ModelID.make(input.model.modelID), input.sessionID)
+      }
       // Abandon before detaching runLoop — same timing requirement as resume.
       yield* abandonRecoveredAssistant({ sessionID: input.sessionID, assistantMessageID: input.assistantMessageID, agentID })
       yield* state.start(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3105,8 +3105,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         // 未完成 assistant 才是恢复候选。步级 time.completed 不等于整轮完成——
         // tool-calls(工具步完但整轮未答)、length(输出截断)、无 finish(中断)均可恢复;
         // stop / other 等已正常或已终态收尾的不进候选(allowlist,不靠排除法)。
+        // 有 error = 没完成 = 可恢复(processor 注释不变量):stop+error 仍进候选。
         if ("completed" in msg.info.time && msg.info.finish && msg.info.finish !== "tool-calls" && msg.info.finish !== "length") continue
-        if (msg.info.finish === "stop") continue
+        if (msg.info.finish === "stop" && !msg.info.error) continue
         const assistant = msg.info
         if (!msgs.some((parent) => parent.info.role === "user" && parent.info.id === assistant.parentID)) continue
         if (msgs.slice(index + 1).some((later) => later.info.role === "user" || later.info.role === "assistant")) continue

--- a/packages/opencode/test/server/session-recovery.test.ts
+++ b/packages/opencode/test/server/session-recovery.test.ts
@@ -150,6 +150,7 @@ describe("recovery candidate predicate", () => {
             ? { created: Date.now(), completed: Date.now() }
             : { created: Date.now() },
           ...(overrides.finish ? { finish: overrides.finish as "stop" | "length" | "tool-calls" | "other" } : {}),
+          ...(overrides.error ? { error: { name: "ProviderModelError", data: { message: "model unavailable", statusCode: 503, isRetryable: true } } } : {}),
         } as Parameters<typeof sessions.updateMessage>[0])
         const candidates = yield* SessionPrompt.Service.use((svc) =>
           svc.recovery({ sessionID: session.id, agentID: "main" }),
@@ -183,6 +184,18 @@ describe("recovery candidate predicate", () => {
   test("completed + other → NOT candidate", async () => {
     const result = await setupAssistant({ completed: true, finish: "other" })
     expect(result.candidates.length).toBe(0)
+  })
+
+  // [Finding #1 回归] finish=stop 但有 error:processor 因 error 不写 completed → 可恢复。
+  test("finish=stop + error → candidate (error means not completed)", async () => {
+    const result = await setupAssistant({ completed: false, finish: "stop", error: true })
+    expect(result.candidates.length).toBe(1)
+  })
+
+  // error + 无 completed:任何 finish 都是候选(有 error = 没完成)。
+  test("error + no completed → candidate", async () => {
+    const result = await setupAssistant({ completed: false, error: true })
+    expect(result.candidates.length).toBe(1)
   })
 })
 

--- a/packages/opencode/test/server/session-recovery.test.ts
+++ b/packages/opencode/test/server/session-recovery.test.ts
@@ -5,6 +5,7 @@ import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
 import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
 import { MessageID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Log } from "../../src/util"
@@ -113,4 +114,92 @@ test("SDK serializes resume titleLocale in the query string", async () => {
   expect(url.pathname).toBe("/session/ses_test/turn/msg_test/resume")
   expect(url.searchParams.get("titleLocale")).toBe("fr-FR")
   expect(captured!.body).toBeNull()
+})
+
+// [TP-SR-R21-07] 恢复判据:completed+tool-calls / completed+length / 无 completed 均为候选;
+// completed+stop / completed+other 不进候选。
+describe("recovery candidate predicate", () => {
+  async function setupAssistant(overrides: Partial<{ finish: string; completed: boolean; error: boolean }>) {
+    await using tmp = await tmpdir({ git: true })
+    return Instance.provide({
+      directory: tmp.path,
+      fn: async () => AppRuntime.runPromise(Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({ title: "predicate" })
+        const user = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() },
+        })
+        const assistant = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: user.id,
+          sessionID: session.id,
+          mode: "build",
+          agent: "build",
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: ModelID.make("test-model"),
+          providerID: ProviderID.make("test"),
+          time: overrides.completed
+            ? { created: Date.now(), completed: Date.now() }
+            : { created: Date.now() },
+          ...(overrides.finish ? { finish: overrides.finish as "stop" | "length" | "tool-calls" | "other" } : {}),
+        } as Parameters<typeof sessions.updateMessage>[0])
+        const candidates = yield* SessionPrompt.Service.use((svc) =>
+          svc.recovery({ sessionID: session.id, agentID: "main" }),
+        )
+        return { candidates, assistantId: assistant.id }
+      })),
+    })
+  }
+
+  test("completed + tool-calls → candidate", async () => {
+    const result = await setupAssistant({ completed: true, finish: "tool-calls" })
+    expect(result.candidates.length).toBe(1)
+    expect(result.candidates[0]!.assistantMessageID).toBe(result.assistantId)
+  })
+
+  test("completed + length → candidate", async () => {
+    const result = await setupAssistant({ completed: true, finish: "length" })
+    expect(result.candidates.length).toBe(1)
+  })
+
+  test("no completed → candidate", async () => {
+    const result = await setupAssistant({ completed: false })
+    expect(result.candidates.length).toBe(1)
+  })
+
+  test("completed + stop → NOT candidate", async () => {
+    const result = await setupAssistant({ completed: true, finish: "stop" })
+    expect(result.candidates.length).toBe(0)
+  })
+
+  test("completed + other → NOT candidate", async () => {
+    const result = await setupAssistant({ completed: true, finish: "other" })
+    expect(result.candidates.length).toBe(0)
+  })
+})
+
+// [TP-SR-R21-08] model 参数校验:modelProviderID / modelID 必须同时提供。
+test("resume with only modelProviderID returns 400", async () => {
+  await using tmp = await tmpdir({ git: true })
+  const result = await Instance.provide({
+    directory: tmp.path,
+    fn: async () => AppRuntime.runPromise(Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({ title: "model-param" })
+      const app = Server.Default().app
+      const res = yield* Effect.promise(() =>
+        Promise.resolve(app.request(`/session/${session.id}/turn/msg_test/resume?directory=${encodeURIComponent(tmp.path)}&modelProviderID=test`, { method: "POST" })),
+      )
+      return res.status
+    })),
+  })
+  expect(result).toBe(400)
 })

--- a/packages/opencode/test/server/session-recovery.test.ts
+++ b/packages/opencode/test/server/session-recovery.test.ts
@@ -150,7 +150,7 @@ describe("recovery candidate predicate", () => {
             ? { created: Date.now(), completed: Date.now() }
             : { created: Date.now() },
           ...(overrides.finish ? { finish: overrides.finish as "stop" | "length" | "tool-calls" | "other" } : {}),
-          ...(overrides.error ? { error: { name: "ProviderModelError", data: { message: "model unavailable", statusCode: 503, isRetryable: true } } } : {}),
+          ...(overrides.error ? { error: { name: "APIError", data: { message: "model unavailable", statusCode: 503, isRetryable: true } } } : {}),
         } as Parameters<typeof sessions.updateMessage>[0])
         const candidates = yield* SessionPrompt.Service.use((svc) =>
           svc.recovery({ sessionID: session.id, agentID: "main" }),

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2691,6 +2691,8 @@ export class Session2 extends HeyApiClient {
       agentID?: string
       task_id?: string
       titleLocale?: string
+      modelProviderID?: string
+      modelID?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2706,6 +2708,8 @@ export class Session2 extends HeyApiClient {
             { in: "query", key: "agentID" },
             { in: "query", key: "task_id" },
             { in: "query", key: "titleLocale" },
+            { in: "query", key: "modelProviderID" },
+            { in: "query", key: "modelID" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5576,6 +5576,8 @@ export type SessionResumeData = {
     agentID?: string
     task_id?: string
     titleLocale?: string
+    modelProviderID?: string
+    modelID?: string
   }
   url: "/session/{sessionID}/turn/{assistantMessageID}/resume"
 }


### PR DESCRIPTION
## Summary

- **Recovery candidates**: only exclude assistants that are *normally completed* (`completed` + `finish=stop` + no `error`). Step-level `time.completed` no longer blocks recovery for length/tool-calls/interrupted turns.
- **Resume actually continues**: add `resumeFrom` parameter to `runLoop` so the abandoned assistant's classify is skipped, allowing a new step to be created instead of immediately failing.
- **Idempotent abandon**: `abandonRecoveredAssistant` now handles completed-but-not-error messages; already completed+error messages are skipped.
- **Model override**: `resume`/`resumeBackground` accept optional `model` field; HTTP route accepts `modelProviderID`/`modelID` query params so callers can switch models before continuing.

## Changes

### `packages/opencode/src/session/prompt.ts`
- `recovery`: change exclusion predicate from `"completed" in time` to `"completed" in time && finish === "stop" && !error`
- `runLoop`: add `resumeFrom?: string` and `modelOverride?: { providerID, modelID }` parameters
- In the while loop: skip classify when `lastAssistant.id === resumeFrom`; use `modelOverride` when set
- `abandonRecoveredAssistant`: idempotent for completed+error; preserve existing `time.completed`
- `resume`/`resumeBackground`: pass `input.assistantMessageID` as `resumeFrom` and `input.model` as `modelOverride`

### `packages/opencode/src/server/routes/instance/session.ts`
- Resume route query: add `modelProviderID` and `modelID` optional params
- Pass them as `model` to `resumeBackground`

## Testing

- `bun typecheck` — pass
- `bun test test/server/session-recovery.test.ts` — 2 pass