### PR TITLE
test(child-env): 锁定 baseline set 后不读 process.env

### DIFF
--- a/packages/opencode/test/util/child-process-env.test.ts
+++ b/packages/opencode/test/util/child-process-env.test.ts
@@ -36,6 +36,16 @@ test("no-set callers keep reading the current process environment", () => {
   expect(env.resolve()).toEqual({ VALUE: "second" })
 })
 
+test("when a baseline is set, process.env is not used as a source", () => {
+  const env = makeChildProcessEnv(() => ({ FALLBACK: "ignored" }))
+  env.set({ PATH: "/terminal/bin" })
+  const resolved = env.resolve()
+
+  expect(resolved.PATH).toBe("/terminal/bin")
+  expect(resolved.FALLBACK).toBeUndefined()
+  expect(Object.keys(resolved)).toEqual(["PATH"])
+})
+
 test("credential scrub applies only to inherited baseline", () => {
   const env = makeChildProcessEnv(() => ({
     MIMOCODE_AUTH_CONTENT: "inherited-secret",


### PR DESCRIPTION
## 背景

Desktop !4269 要求「tool env 完全不继承宿主」。引擎侧已有 `makeChildProcessEnv` 的 baseline 机制（`set()` 后 `resolve()` 只读 baseline，不 fallback 到 `process.env`），但缺一条断言钉住这个不变量。

## 改动

`packages/opencode/test/util/child-process-env.test.ts` 新增一条测试：

```
when a baseline is set, process.env is not used as a source
```

验证：`env.set({ PATH: "/terminal/bin" })` 后 `resolve()` 只返回 baseline 里的键，不包含 `source()`（即 `process.env`）里的任何键。

## 验证

`bun test test/util/child-process-env.test.ts` — 9 pass / 0 fail

## 关联

- Desktop MR: https://git.n.xiaomi.com/mimo-innovation/mimo-desktop/-/merge_requests/4269