### PR TITLE
test(child-env): 锁定 baseline set 后不读 process.env

### DIFF
--- a/packages/opencode/test/util/child-process-env.test.ts
+++ b/packages/opencode/test/util/child-process-env.test.ts
@@ -36,6 +36,16 @@ test("no-set callers keep reading the current process environment", () => {
   expect(env.resolve()).toEqual({ VALUE: "second" })
 })
 
+test("when a baseline is set, process.env is not used as a source", () => {
+  const env = makeChildProcessEnv(() => ({ FALLBACK: "ignored" }))
+  env.set({ PATH: "/terminal/bin" })
+  const resolved = env.resolve()
+
+  expect(resolved.PATH).toBe("/terminal/bin")
+  expect(resolved.FALLBACK).toBeUndefined()
+  expect(Object.keys(resolved)).toEqual(["PATH"])
+})
+
 test("credential scrub applies only to inherited baseline", () => {
   const env = makeChildProcessEnv(() => ({
     MIMOCODE_AUTH_CONTENT: "inherited-secret",


### PR DESCRIPTION
## 这个 PR 做了什么

给 `child-process-env.test.ts` 加了一条测试，确保工具子进程的环境变量不会偷看宿主进程的 `process.env`。

## 为什么

引擎给 Bash/PTY/MCP 等外部进程设了 baseline（`set()`），之后每次 spawn 应该只用这份 baseline（`resolve()`）。但之前没有测试锁死这一点——万一以后有人改坏了，`resolve()` 偷偷 fallback 到 `process.env`，宿主环境里的敏感变量就漏给工具了。

## 测试内容

```
set({ PATH: "/terminal/bin" }) 之后，resolve() 只返回 PATH
不包含 source()（即 process.env）里的任何键
```

## 验证

`bun test test/util/child-process-env.test.ts` — 9 pass / 0 fail