### PR TITLE
feat(media): read audio and video as inline attachments

### DIFF
--- a/docs/harness/xiaomi-media-api-doc.md
+++ b/docs/harness/xiaomi-media-api-doc.md
@@ -1,0 +1,587 @@
+## 音频理解
+
+音频理解模型可以根据您传入的音频进行回答，支持音频 URL 和 Base64 编码两种传入方式，适用于音频分析等场景。
+
+## 快速开始
+
+获取 API Key 等准备工作，请参考 [首次调用API](https://mimo.mi.com/#/docs/quick-start/first-api-call)。
+
+通过音频 URL 方式传入模型快速体验音频理解效果，示例代码如下。
+
+```
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("MIMO_API_KEY"),
+    base_url="https://api.xiaomimimo.com/v1"
+)
+
+completion = client.chat.completions.create(
+    model="mimo-v2.5",
+    messages=[
+        {
+            "role": "system",
+            "content": "You are MiMo, an AI assistant developed by Xiaomi. Today is date: Tuesday, December 16, 2025. Your knowledge cutoff date is December 2024."
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_audio",
+                    "input_audio": {
+                        "data": "https://example-files.cnbj1.mi-fds.com/example-files/audio/audio_example.wav"
+                    }
+                },
+                {
+                    "type": "text",
+                    "text": "please describe the content of the audio"
+                }
+            ]
+        }
+    ],
+    max_completion_tokens=1024
+)
+
+print(completion.model_dump_json())
+```
+
+**响应结果**
+
+```
+{
+    "id": "550a678a6c2046a29128883eaaf849e7",
+    "choices": [
+        {
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+                "content": "",
+                "role": "assistant",
+                "tool_calls": null,
+                "reasoning_content": "Good morning. Could you tell me what the weather will be like today?"
+            }
+        }
+    ],
+    "created": 1776850627,
+    "model": "mimo-v2.5",
+    "object": "chat.completion",
+    "usage": {
+        "completion_tokens": 17,
+        "prompt_tokens": 86,
+        "total_tokens": 103,
+        "completion_tokens_details": {
+            "reasoning_tokens": 15
+        },
+        "prompt_tokens_details": {
+            "audio_tokens": 25,
+            "cached_tokens": 82
+        }
+    }
+}
+```
+
+## 支持的模型列表
+
+当前仅支持 `mimo-v2.5` 模型。
+
+## 音频传入方式
+
+支持的音频传入方式如下：
+
+* 音频 URL 传入：需提供公网可访问的音频 URL 地址。
+    
+* Base64 编码传入：将音频转换为 Base64 编码字符串后再传入。
+    
+
+### 音频 URL 传入
+
+通过公网可访问的音频 URL 地址直接传入音频文件，适用于音频文件已存储在公网可访问环境的场景。单个音频文件大小不能超过 100 MB。
+
+```
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("MIMO_API_KEY"),
+    base_url="https://api.xiaomimimo.com/v1"
+)
+
+completion = client.chat.completions.create(
+    model="mimo-v2.5",
+    messages=[
+        {
+            "role": "system",
+            "content": "You are MiMo, an AI assistant developed by Xiaomi. Today is date: Tuesday, December 16, 2025. Your knowledge cutoff date is December 2024."
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_audio",
+                    "input_audio": {
+                        "data": "https://example-files.cnbj1.mi-fds.com/example-files/audio/audio_example.wav"
+                    }
+                },
+                {
+                    "type": "text",
+                    "text": "please describe the content of the audio"
+                }
+            ]
+        }
+    ],
+    max_completion_tokens=1024
+)
+
+print(completion.model_dump_json())
+```
+
+### Base64 编码传入
+
+将音频文件转换为 Base64 编码字符串后传入，适用于音频文件无法通过公网 URL 访问的场景。转换后的 Base64 编码的字符串大小不能超过 50 MB。
+
+请在 Base64 编码前携带前缀：`data:{MIME_TYPE};base64,$BASE64_AUDIO`
+
+* `{MIME_TYPE}`：音频的 MIME 类型（媒体类型），用于标识音频格式，需替换为实际音频对应的 MIME 值。
+    
+* `$BASE64_AUDIO`：音频文件的纯 Base64 编码字符串（不含任何前缀）。
+    
+
+> 下述示例中的 `{MIME_TYPE}` 与 `$BASE64_AUDIO` 均为占位符，运行前请替换为实际有效数据。
+
+```
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("MIMO_API_KEY"),
+    base_url="https://api.xiaomimimo.com/v1"
+)
+
+completion = client.chat.completions.create(
+    model="mimo-v2.5",
+    messages=[
+        {
+            "role": "system",
+            "content": "You are MiMo, an AI assistant developed by Xiaomi. Today is date: Tuesday, December 16, 2025. Your knowledge cutoff date is December 2024."
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_audio",
+                    "input_audio": {
+                        "data": "data:{MIME_TYPE};base64,$BASE64_AUDIO"
+                    }
+                },
+                {
+                    "type": "text",
+                    "text": "please describe the content of the audio"
+                }
+            ]
+        }
+    ],
+    max_completion_tokens=1024
+)
+
+print(completion.model_dump_json())
+```
+
+## 音频限制
+
+* 音频格式：MP3，WAV，FLAC，M4A，OGG。
+
+> 音频文件格式变种较多，不能保证所有文件都能被识别，请通过测试验证文件能够被正常识别。
+
+* 音频大小：
+    
+    * 以 URL 方式传入时：单个音频文件大小不超过 100 MB。
+        
+    * 以 Base64 编码传入时：单个音频的 Base64 编码字符串大小不超过 50 MB。
+        
+* 音频数量：传入多个音频时，音频数量受模型上下文长度限制，所有音频和文本的总 Token 数必须小于模型的上下文长度。
+    
+
+> 注：计算音频的 Token 请参考 [音频 Token 用量说明](https://mimo.mi.com/#/docs/usage-guide/multimodal-understanding/audio-understanding?target=%E9%9F%B3%E9%A2%91-token-%E7%94%A8%E9%87%8F%E8%AF%B4%E6%98%8E)。模型上下文长度请参考 [定价与限速](https://mimo.mi.com/#/docs/pricing)。
+
+音频的 Token 转化请参考以下代码。估算结果仅供参考，实际用量以 API 响应为准。
+
+```
+总 Tokens 数 ≈ 音频时长（单位：秒，例如：10.6 秒）* 6.25
+```
+
+## 计费说明
+
+* 计费：总费用根据输入、输入（命中缓存）和输出 Token 数计算；价格请参考 [定价与限速](https://mimo.mi.com/#/docs/pricing)。
+    
+    * 可通过 [音频 Token 用量说明](https://mimo.mi.com/#/docs/usage-guide/multimodal-understanding/audio-understanding?target=%E9%9F%B3%E9%A2%91-token-%E7%94%A8%E9%87%8F%E8%AF%B4%E6%98%8E) 计算音频的 Token 消耗。估算结果仅供参考，实际用量以 API 响应为准。
+* 查看账单：您可以在控制台的 [账单明细](https://platform.xiaomimimo.com/#/console/usage) 页面查看账单及用量。
+    
+
+## 常见问题
+
+### 是否支持本地文件上传？
+
+`mimo-v2.5` 模型暂不支持音频本地文件上传。支持的上传方式请参考 [音频传入方式](https://mimo.mi.com/#/docs/usage-guide/multimodal-understanding/audio-understanding?target=%E9%9F%B3%E9%A2%91%E4%BC%A0%E5%85%A5%E6%96%B9%E5%BC%8F)。
+
+## 视频理解
+
+视频理解模型可以根据您传入的视频进行回答，支持视频 URL 和 Base64 编码两种传入方式，适用于视频分析等场景。
+
+## 快速开始
+
+获取 API Key 等准备工作，请参考 [首次调用API](https://mimo.mi.com/#/docs/quick-start/first-api-call)。
+
+通过视频 URL 方式传入模型快速体验视频理解效果，示例代码如下。
+
+```
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("MIMO_API_KEY"),
+    base_url="https://api.xiaomimimo.com/v1"
+)
+
+completion = client.chat.completions.create(
+    model="mimo-v2.5",
+    messages=[
+        {
+            "role": "system",
+            "content": "You are MiMo, an AI assistant developed by Xiaomi. Today is date: Tuesday, December 16, 2025. Your knowledge cutoff date is December 2024."
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "video_url",
+                    "video_url": {
+                        "url": "https://example-files.cnbj1.mi-fds.com/example-files/video/video_example.mp4"
+                    },
+                    "fps": 2,
+                    "media_resolution": "default"
+                },
+                {
+                    "type": "text",
+                    "text": "please describe the content of the video"
+                }
+            ]
+        }
+    ],
+    max_completion_tokens=1024
+)
+
+print(completion.model_dump_json())
+```
+
+**响应结果**
+
+```
+{
+    "id": "a7a6fe52ffeb40ab9e699fe018592b16",
+    "choices": [
+        {
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+                "content": "The video features a small, fluffy white kitten with bright blue eyes sitting on a polished wooden floor. The kitten is positioned near a window draped with sheer, light-colored curtains, through which sunlight is streaming, casting warm shadows on the floorboards. In the background to the right, a potted green plant, resembling a Monstera, adds a touch of color to the room.\\n\\nThroughout the clip, the kitten is meowing repeatedly. It opens its mouth wide to let out high-pitched meows, looking slightly to its left before turning its gaze directly toward the camera. The audio consists entirely of the kitten's vocalizations.",
+                "role": "assistant",
+                "tool_calls": null,
+                "reasoning_content": "The user wants me to describe the video provided.\\n\\n1.  **Analyze the video:**\\n*   **Subject:** A small white kitten with striking blue eyes.\\n*   **Action:** The kitten is sitting on a wooden floor near a window. It is meowing. Its mouth opens and closes repeatedly. It looks slightly to its left and then more directly forward.\\n*   **Setting:** Indoors. There's a window on the left with light-colored curtains. Sunlight is streaming in, casting shadows on the floor. In the background, there's a green plant (looks like a Monstera) in a pot. The walls are light-colored.\\n*   **Audio:** The audio consists of the kitten meowing. It's a series of high-pitched meows.\\n*   **Visual details:** The kitten is fluffy. The floor is polished wood. The lighting is warm and natural.\\n\\n2.  **Break down the description chronologically:**\\n*   **Start (00:00 - 00:01):** The video opens with a white kitten sitting on a wooden floor. It's positioned near a window with sheer curtains. Sunlight is hitting the floor. The kitten is looking slightly to the side.\\n*   **Middle (00:01 - 00:02):** The kitten opens its mouth wide to meow. It does this multiple times. Its gaze shifts a bit. The sunlight highlights its white fur.\\n*   **End (00:02 - 00:03):** The kitten continues to meow. It looks directly at the camera/viewer. The background remains consistent with the plant and the wall.\\n\\n3.  **Synthesize the description:**\\n*   Start with the main subject: A white kitten with blue eyes.\\n*   Describe the environment: Sitting on a wooden floor near a window with curtains. Sunlight is present. A plant is in the background.\\n*   Describe the action: The kitten is meowing repeatedly. It looks around and then at the camera.\\n*   Mention the audio: The sound of the kitten meowing.\\n\\n4.  **Refine the language:**\\n*   \\\"A white kitten with blue eyes is sitting on a wooden floor.\\\"\\n*   \\\"It is positioned next to a window with light curtains.\\\"\\n*   \\\"Sunlight is streaming in, creating shadows.\\\"\\n*   \\\"The kitten is meowing, opening its mouth wide.\\\"\\n*   \\\"In the background, there is a potted green plant.\\\"\\n*   \\\"The kitten looks to the side and then towards the camera while meowing.\\\"\\n\\n5.  **Final Polish:** Combine these points into a coherent paragraph or a list of key observations. The prompt asks to \\\"describe the content of the video,\\\" so a narrative description is appropriate.\\n\\n*   *Draft:* The video shows a cute white kitten with blue eyes sitting on a polished wooden floor. It's near a window with white curtains that are letting in bright sunlight. To the right, in the background, there is a large green plant. The kitten is meowing repeatedly, opening its mouth wide. It looks around a bit and then stares directly at the camera. The audio is just the sound of the kitten's meows.\\n\\n*   *Structure:*\\n*   **Scene:** White kitten, wooden floor, window, sunlight, plant.\\n*   **Action:** Meowing, looking around.\\n*   **Audio:** Meowing sounds.\\n\\nThis covers all the essential aspects of the video."
+            }
+        }
+    ],
+    "created": 1776850708,
+    "model": "mimo-v2.5",
+    "object": "chat.completion",
+    "usage": {
+        "completion_tokens": 849,
+        "prompt_tokens": 1260,
+        "total_tokens": 2109,
+        "completion_tokens_details": {
+            "reasoning_tokens": 719
+        },
+        "prompt_tokens_details": {
+            "audio_tokens": 19,
+            "cached_tokens": 1256,
+            "video_tokens": 1144
+        }
+    }
+}
+```
+
+## 支持的模型列表
+
+当前仅支持 `mimo-v2.5` 模型。
+
+## 视频传入方式
+
+支持的视频传入方式如下：
+
+* 视频 URL 传入：需提供公网可访问的视频 URL 地址。
+    
+* Base64 编码传入：将视频转换为 Base64 编码字符串后再传入。
+    
+
+### 视频 URL 传入
+
+通过公网可访问的视频 URL 地址直接传入视频，适用于视频已存储在公网可访问环境的场景。单个视频文件大小不能超过 300 MB。
+
+```
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("MIMO_API_KEY"),
+    base_url="https://api.xiaomimimo.com/v1"
+)
+
+completion = client.chat.completions.create(
+    model="mimo-v2.5",
+    messages=[
+        {
+            "role": "system",
+            "content": "You are MiMo, an AI assistant developed by Xiaomi. Today is date: Tuesday, December 16, 2025. Your knowledge cutoff date is December 2024."
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "video_url",
+                    "video_url": {
+                        "url": "https://example-files.cnbj1.mi-fds.com/example-files/video/video_example.mp4"
+                    },
+                    "fps": 2,
+                    "media_resolution": "default"
+                },
+                {
+                    "type": "text",
+                    "text": "please describe the content of the video"
+                }
+            ]
+        }
+    ],
+    max_completion_tokens=1024
+)
+
+print(completion.model_dump_json())
+```
+
+### Base64 编码传入
+
+将视频文件转换为 Base64 编码字符串后传入，适用于视频无法通过公网 URL 访问的场景。转换后的 Base64 编码的字符串大小不能超过 50 MB。
+
+请在 Base64 编码前携带前缀：`data:{MIME_TYPE};base64,$BASE64_VIDEO`
+
+* `{MIME_TYPE}`：视频的 MIME 类型（媒体类型），用于标识视频格式，需替换为实际视频对应的 MIME 值。
+    
+* `$BASE64_VIDEO`：视频文件的纯 Base64 编码字符串（不含任何前缀）。
+    
+
+> 下述示例中的 `{MIME_TYPE}` 与 `$BASE64_VIDEO` 均为占位符，运行前请替换为实际有效数据。
+
+```
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("MIMO_API_KEY"),
+    base_url="https://api.xiaomimimo.com/v1"
+)
+
+completion = client.chat.completions.create(
+    model="mimo-v2.5",
+    messages=[
+        {
+            "role": "system",
+            "content": "You are MiMo, an AI assistant developed by Xiaomi. Today is date: Tuesday, December 16, 2025. Your knowledge cutoff date is December 2024."
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "video_url",
+                    "video_url": {
+                        "url": "data:{MIME_TYPE};base64,$BASE64_VIDEO"
+                    },
+                    "fps": 2,
+                    "media_resolution": "default"
+                },
+                {
+                    "type": "text",
+                    "text": "please describe the content of the video"
+                }
+            ]
+        }
+    ],
+    max_completion_tokens=1024
+)
+
+print(completion.model_dump_json())
+```
+
+## 使用说明
+
+### 视频限制
+
+* 视频格式：MP4，MOV，AVI，WMV。
+
+> 视频文件格式变种较多，不能保证所有文件都能被识别，请通过测试验证文件能够被正常识别。
+
+* 视频大小：
+    
+    * 以 URL 方式传入时：单个视频文件大小不超过 300 MB。
+        
+    * 以 Base64 编码传入时：单个视频的 Base64 编码字符串大小不超过 50 MB。
+        
+* 视频数量：传入多个视频时，视频数量受模型上下文长度限制，所有视频和文本的总 Token 数必须小于模型的上下文长度。
+    
+
+> 注：计算视频的 Token 请参考 [视频 Token 用量说明](https://mimo.mi.com/#/docs/usage-guide/multimodal-understanding/video-understanding?target=%E8%A7%86%E9%A2%91-token-%E7%94%A8%E9%87%8F%E8%AF%B4%E6%98%8E)。模型上下文长度请参考 [定价与限速](https://mimo.mi.com/#/docs/pricing)。
+
+### 控制视频理解的精细度
+
+您可以分别通过 `fps` 和 `media_resolution` 两个字段来控制视频理解的精细度。
+
+1. `fps` 即每秒从视频中抽取图像的帧数，用于控制视频时间维度的理解精细度。默认值为 2，范围为 `[0.1, 10]`。
+    
+    * 数值越高，抽帧越密集，模型对画面变化、动作、时序细节的感知越精细；
+        
+    * 数值越低，抽帧越稀疏，处理速度越快，Token 消耗越少。
+        
+2. `media_resolution` 即视频帧的解析分辨率档次，用于控制单帧画面的视觉理解精细度。默认值为 `default`。
+    
+    * `default`：默认档次，平衡识别效果与处理效率；
+        
+    * `max`：最高分辨率档次，提升对小物体、细节纹理的识别能力。
+        
+
+视频的 Token 分为 `video_tokens`（视觉）与 `audio_tokens`（音频）。
+
+* `video_tokens` 计算请参考以下代码。估算结果仅供参考，实际用量以 API 响应为准。
+    
+    ```
+    """
+    根据视频的时长、分辨率，估算 API 调用所消耗的 Token 数。
+    用户可通过 fps 和 media_resolution 两个参数控制精细度：
+      - fps: 每秒抽帧数，默认 2，范围 [0.1, 10]。越高时序越精细，Token 越多。
+      - media_resolution: 单帧分辨率档次。"default" 平衡效果与效率；"max" 提升细节识别。
+    """
+    
+    import math
+    
+    def estimate_video_tokens(
+        duration: float,
+        width: int,
+        height: int,
+        fps: float = 2.0,
+        media_resolution: str = "default",
+        mute: bool = False,
+    ) -> int:
+        """
+        估算视频输入的 Token 数。
+    
+        Args:
+            duration:         视频时长（秒）
+            width:            视频宽度（像素）
+            height:           视频高度（像素）
+            fps:              抽帧帧率，默认 2，范围 [0.1, 10]
+            media_resolution: "default" 或 "max"
+            mute:             True 则不计算音频 Token
+    
+        Returns:
+            预估总 Token 数
+        """
+        # ---- 常量 ----
+        PATCH, MERGE, T_PATCH = 16, 2, 2
+        SPATIAL = PATCH * MERGE                         # 32
+        PIX_PER_TOKEN = SPATIAL ** 2                    # 1024
+        MAX_TOTAL_TOKENS = 131072
+        TOTAL_MAX_PIX = MAX_TOTAL_TOKENS * PIX_PER_TOKEN
+        MIN_PIX, MAX_PIX = 8192, 8388608
+        MAX_FRAMES = 2048
+        DEFAULT_MAX_FRAME_TOKEN = 300
+    
+        # ---- 1. 抽帧数 ----
+        nframes = math.ceil(duration * fps)
+        nframes = min(nframes, MAX_FRAMES)
+        nframes = max(math.ceil(nframes / T_PATCH) * T_PATCH, T_PATCH)
+    
+        # ---- 2. 单帧像素预算 ----
+        max_pix = TOTAL_MAX_PIX * T_PATCH // nframes
+        if media_resolution != "max":
+            max_pix = min(max_pix, DEFAULT_MAX_FRAME_TOKEN * PIX_PER_TOKEN)
+        max_pix = max(MIN_PIX, min(max_pix, MAX_PIX))
+    
+        # ---- 3. 缩放分辨率 ----
+        h, w = height, width
+        if min(h, w) < SPATIAL:
+            if h < w:
+                w = int(w * SPATIAL / h); h = SPATIAL
+            else:
+                h = int(h * SPATIAL / w); w = SPATIAL
+        h_bar = round(h / SPATIAL) * SPATIAL
+        w_bar = round(w / SPATIAL) * SPATIAL
+        if h_bar * w_bar > max_pix:
+            beta = math.sqrt(h * w / max_pix)
+            h_bar = math.floor(h / beta / SPATIAL) * SPATIAL
+            w_bar = math.floor(w / beta / SPATIAL) * SPATIAL
+        elif h_bar * w_bar < MIN_PIX:
+            beta = math.sqrt(MIN_PIX / (h * w))
+            h_bar = math.ceil(h * beta / SPATIAL) * SPATIAL
+            w_bar = math.ceil(w * beta / SPATIAL) * SPATIAL
+    
+        # ---- 4. Token 计算 ----
+        grids = nframes // T_PATCH                       # 时序网格数
+        tokens_per_grid = (h_bar // PATCH) * (w_bar // PATCH) // (MERGE ** 2)
+        vision = grids * tokens_per_grid
+        timestamps = grids * (5 if fps > 2 else 3)       # 时间戳文本 token
+        special = grids * 2 + 2                           # 特殊标记
+    
+        # ---- 5. 音频 Token ----
+        audio = 0
+        if not mute:
+            spec_len = int(duration * 24000) // 240 + 1
+            t = (spec_len - 1) // 2 + 1
+            t = t // 2 + int(t % 2 != 0)
+            audio = math.ceil(t / 4) + 2                 # +2 for audio special tokens
+    
+        return vision + timestamps + special + audio
+    
+    # ============ 示例 ============
+    if __name__ == "__main__":
+        # 一个 1080p、60 秒的视频
+        tokens = estimate_video_tokens(duration=60, width=1920, height=1080)
+        print(f"默认参数 (fps=2, default): {tokens:,} tokens")
+    
+        tokens = estimate_video_tokens(duration=60, width=1920, height=1080, fps=5)
+        print(f"高帧率  (fps=5, default): {tokens:,} tokens")
+    
+        tokens = estimate_video_tokens(duration=60, width=1920, height=1080, media_resolution="max")
+        print(f"高分辨率 (fps=2, max):     {tokens:,} tokens")
+    
+        tokens = estimate_video_tokens(duration=60, width=1920, height=1080, mute=True)
+        print(f"静音    (fps=2, mute):    {tokens:,} tokens")
+    
+    ```
+    
+* `audio_tokens` 计算请参考以下代码。估算结果仅供参考，实际用量以 API 响应为准。
+    
+    ```
+    总 Tokens 数 ≈ 音频时长（单位：秒）* 6.25
+    ```
+    
+
+## 计费说明
+
+* 计费：总费用根据输入、输入（命中缓存）和输出 Token 数计算；价格请参考 [定价与限速](https://mimo.mi.com/#/docs/pricing)。
+    
+    * 可通过 [视频 Token 用量说明](https://mimo.mi.com/#/docs/usage-guide/multimodal-understanding/video-understanding?target=%E8%A7%86%E9%A2%91-token-%E7%94%A8%E9%87%8F%E8%AF%B4%E6%98%8E) 计算视频的 Token 消耗。估算结果仅供参考，实际用量以 API 响应为准。
+* 查看账单：您可以在控制台的 [账单明细](https://platform.xiaomimimo.com/#/console/usage) 页面查看账单及用量。
+    
+
+## 常见问题
+
+### 是否支持本地文件上传？
+
+`mimo-v2.5` 模型暂不支持视频本地文件上传。支持的上传方式请参考 [视频传入方式](https://mimo.mi.com/#/docs/usage-guide/multimodal-understanding/video-understanding?target=%E8%A7%86%E9%A2%91%E4%BC%A0%E5%85%A5%E6%96%B9%E5%BC%8F)。

--- a/packages/opencode/src/mcp/tool-result.ts
+++ b/packages/opencode/src/mcp/tool-result.ts
@@ -62,8 +62,10 @@ export function normalizeToolResult(result: CallToolResult): NormalizedToolResul
   const fit = (label: string, mime: string, base64: string) => {
     const size = base64ByteSize(base64)
     // Audio/video travel as an inline data URL, and the provider bounds the
-    // encoded string rather than the decoded bytes (see MAX_MEDIA_BASE64_BYTES).
-    if ((isAudioAttachment(mime) || isVideoAttachment(mime)) && base64.length > MAX_MEDIA_BASE64_BYTES) {
+    // encoded string rather than the decoded bytes (see MAX_MEDIA_BASE64_BYTES),
+    // so they never enter classifyAttachment.
+    if (isAudioAttachment(mime) || isVideoAttachment(mime)) {
+      if (base64.length <= MAX_MEDIA_BASE64_BYTES) return { mime, base64 }
       text.push(oversizedMediaNotice({ label, size, hint: "It was dropped." }))
       return undefined
     }

--- a/packages/opencode/src/mcp/tool-result.ts
+++ b/packages/opencode/src/mcp/tool-result.ts
@@ -1,6 +1,14 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import { isRecord } from "@/util/record"
-import { base64ByteSize, classifyAttachment, oversizedAttachmentNotice } from "@/util/media"
+import {
+  base64ByteSize,
+  classifyAttachment,
+  isAudioAttachment,
+  isVideoAttachment,
+  MAX_MEDIA_BASE64_BYTES,
+  oversizedAttachmentNotice,
+  oversizedMediaNotice,
+} from "@/util/media"
 import { shrinkAttachment } from "@/provider/image"
 
 export type ToolResultAttachment = {
@@ -53,6 +61,12 @@ export function normalizeToolResult(result: CallToolResult): NormalizedToolResul
   // oversized image within the source ceiling is decoded and recompressed.
   const fit = (label: string, mime: string, base64: string) => {
     const size = base64ByteSize(base64)
+    // Audio/video travel as an inline data URL, and the provider bounds the
+    // encoded string rather than the decoded bytes (see MAX_MEDIA_BASE64_BYTES).
+    if ((isAudioAttachment(mime) || isVideoAttachment(mime)) && base64.length > MAX_MEDIA_BASE64_BYTES) {
+      text.push(oversizedMediaNotice({ label, size, hint: "It was dropped." }))
+      return undefined
+    }
     const verdict = classifyAttachment(mime, size)
     if (verdict === "fits") return { mime, base64 }
     const fitted = verdict === "shrink" ? shrinkAttachment(mime, Buffer.from(base64, "base64")) : undefined

--- a/packages/opencode/src/provider/capability-registry.ts
+++ b/packages/opencode/src/provider/capability-registry.ts
@@ -10,7 +10,7 @@ import type { Provider } from "@/provider"
  *
  * Two independent gates are ANDed:
  *
- *  1. The MODEL gate — `model.capabilities.input.{text,image,audio}`, sourced
+ *  1. The MODEL gate — `model.capabilities.input.{text,image,audio,video}`, sourced
  *     from models.dev metadata or the user's own `/modalities` config.
  *  2. The ADAPTER gate — whether the ai-sdk package behind the model can
  *     actually serialize that media. A model may accept audio while the adapter
@@ -23,7 +23,7 @@ import type { Provider } from "@/provider"
  * distinctly so an operator can tell "this cannot work" from "we do not know".
  */
 
-export type Modality = "text" | "image" | "audio"
+export type Modality = "text" | "image" | "audio" | "video"
 
 export type Support = "supported" | "unsupported" | "unknown"
 
@@ -40,6 +40,7 @@ export interface AdapterDeclaration {
   readonly text: ModalityDeclaration
   readonly image: ModalityDeclaration
   readonly audio: ModalityDeclaration
+  readonly video: ModalityDeclaration
   /** Why this declaration reads the way it does. Surfaced in errors and docs. */
   readonly evidence: string
 }
@@ -72,6 +73,12 @@ const OPENAI_AUDIO_MIMES = [
   "audio/x-m4a",
   "audio/ogg",
 ]
+// Mirrors OPENAI_VIDEO_MIMES in src/session/tool-attachment.ts — the formats
+// the MiMo video API documents (MP4, MOV, AVI, WMV), as the MIMEs a mime lookup
+// yields for them. The repo patch serializes ANY video/* as video_url, so this
+// list is what the API accepts, not what the adapter refuses: anything else
+// (e.g. video/webm, video/x-matroska) would be sent and fail server-side.
+const OPENAI_VIDEO_MIMES = ["video/mp4", "video/quicktime", "video/x-msvideo", "video/x-ms-wmv"]
 
 const TEXT_SUPPORTED: ModalityDeclaration = {
   support: "supported",
@@ -108,30 +115,35 @@ const ADAPTERS: Record<string, AdapterDeclaration> = {
     text: TEXT_SUPPORTED,
     image: IMAGE_SUPPORTED,
     audio: { support: "supported", mimeTypes: OPENAI_AUDIO_MIMES, maxBytes: DEFAULT_MAX_MEDIA_BYTES },
+    video: { support: "supported", mimeTypes: OPENAI_VIDEO_MIMES, maxBytes: DEFAULT_MAX_MEDIA_BYTES },
     // Observed: the stock adapter serializes wav/mp3/mpeg to `input_audio` and
     // throws "'audio media type ...' functionality not supported" for the rest;
     // the repo patch extends the format map to flac/m4a/ogg. Anything outside
     // that list (e.g. audio/aac) still throws.
     evidence:
-      "@ai-sdk/openai-compatible@2 (repo-patched) serializes wav/mp3/flac/m4a/ogg as input_audio and rejects other audio",
+      "@ai-sdk/openai-compatible@2 (repo-patched) serializes wav/mp3/flac/m4a/ogg as input_audio and rejects other audio; video is serialized as video_url and narrowed to the MiMo video API's mp4/mov/avi/wmv",
   },
   "@ai-sdk/google": {
     text: TEXT_SUPPORTED,
     image: IMAGE_SUPPORTED,
     audio: { support: "supported", mimeTypes: "any", maxBytes: DEFAULT_MAX_MEDIA_BYTES },
-    // Observed: any audio/* passes through as `inlineData` with its MIME intact.
-    evidence: "@ai-sdk/google passes any audio/* through as inlineData",
+    video: { support: "supported", mimeTypes: "any", maxBytes: DEFAULT_MAX_MEDIA_BYTES },
+    // Observed: any audio/* passes through as `inlineData` with its MIME intact;
+    // video/* takes the same path.
+    evidence: "@ai-sdk/google passes any audio/* and video/* through as inlineData",
   },
   "@ai-sdk/google-vertex": {
     text: TEXT_SUPPORTED,
     image: IMAGE_SUPPORTED,
     audio: { support: "supported", mimeTypes: "any", maxBytes: DEFAULT_MAX_MEDIA_BYTES },
+    video: { support: "supported", mimeTypes: "any", maxBytes: DEFAULT_MAX_MEDIA_BYTES },
     evidence: "@ai-sdk/google-vertex shares the @ai-sdk/google content conversion",
   },
   "@ai-sdk/anthropic": {
     text: TEXT_SUPPORTED,
     image: IMAGE_SUPPORTED,
     audio: absent(),
+    video: absent(),
     // Observed: an audio/wav part throws "'media type: audio/wav' functionality
     // not supported" while image/png serializes fine. Known-absent, not unproven.
     evidence: "@ai-sdk/anthropic throws 'media type: audio/wav' functionality not supported",
@@ -140,13 +152,15 @@ const ADAPTERS: Record<string, AdapterDeclaration> = {
     text: TEXT_SUPPORTED,
     image: IMAGE_SUPPORTED,
     audio: absent(),
+    video: absent(),
     evidence: "@ai-sdk/google-vertex/anthropic shares the @ai-sdk/anthropic content conversion",
   },
   "@ai-sdk/amazon-bedrock": {
     text: TEXT_SUPPORTED,
     image: IMAGE_SUPPORTED,
     audio: absent(),
-    evidence: "tool-attachment.ts:49-53,69-71 exclude @ai-sdk/amazon-bedrock from every audio route",  // no direct wire probe; routing logic is the evidence
+    video: absent(),
+    evidence: "tool-attachment.ts:49-53,69-71 exclude @ai-sdk/amazon-bedrock from every audio and video route", // no direct wire probe; routing logic is the evidence
   },
 }
 
@@ -154,13 +168,15 @@ const ADAPTERS: Record<string, AdapterDeclaration> = {
  * Adapters with no entry above. Text and image are still declared supported
  * because every ai-sdk language model carries text, and image parts are a
  * baseline `LanguageModelV3` file part that adapters reject loudly rather than
- * silently mangle. Audio is `unknown`: we have no evidence, so we say so.
+ * silently mangle. Audio and video are `unknown`: we have no evidence, so we
+ * say so.
  */
 const UNDECLARED: AdapterDeclaration = {
   text: TEXT_SUPPORTED,
   image: IMAGE_SUPPORTED,
   audio: unknown(),
-  evidence: "no capability declaration for this adapter; audio support is unproven, not disproven",
+  video: unknown(),
+  evidence: "no capability declaration for this adapter; audio and video support is unproven, not disproven",
 }
 
 export function adapterDeclaration(npm: string | undefined): AdapterDeclaration {
@@ -176,6 +192,7 @@ export function declaredAdapters(): ReadonlyArray<string> {
 function modelGate(model: Provider.Model, modality: Modality): boolean {
   if (modality === "text") return model.capabilities.input.text
   if (modality === "image") return model.capabilities.input.image
+  if (modality === "video") return model.capabilities.input.video
   return model.capabilities.input.audio
 }
 

--- a/packages/opencode/src/provider/capability-registry.ts
+++ b/packages/opencode/src/provider/capability-registry.ts
@@ -58,8 +58,20 @@ export const DEFAULT_MAX_TEXT_BYTES = 1 * 1024 * 1024
 
 const SAFE_IMAGE_MIMES = ["image/jpeg", "image/png", "image/gif", "image/webp"]
 // Mirrors OPENAI_AUDIO_MIMES in src/session/tool-attachment.ts — the set the
-// OpenAI-compatible chat adapter can serialize as input_audio.
-const OPENAI_AUDIO_MIMES = ["audio/wav", "audio/mp3", "audio/mpeg"]
+// (repo-patched) OpenAI-compatible chat adapter can serialize as input_audio:
+// the MiMo audio API's MP3, WAV, FLAC, M4A and OGG.
+const OPENAI_AUDIO_MIMES = [
+  "audio/wav",
+  "audio/x-wav",
+  "audio/mp3",
+  "audio/mpeg",
+  "audio/flac",
+  "audio/x-flac",
+  "audio/mp4",
+  "audio/m4a",
+  "audio/x-m4a",
+  "audio/ogg",
+]
 
 const TEXT_SUPPORTED: ModalityDeclaration = {
   support: "supported",
@@ -96,9 +108,12 @@ const ADAPTERS: Record<string, AdapterDeclaration> = {
     text: TEXT_SUPPORTED,
     image: IMAGE_SUPPORTED,
     audio: { support: "supported", mimeTypes: OPENAI_AUDIO_MIMES, maxBytes: DEFAULT_MAX_MEDIA_BYTES },
-    // Observed: wav/mp3/mpeg serialize to `input_audio`; flac and ogg throw
-    // "'audio media type ...' functionality not supported".
-    evidence: "@ai-sdk/openai-compatible@3 serializes wav/mp3/mpeg as input_audio and rejects other audio",
+    // Observed: the stock adapter serializes wav/mp3/mpeg to `input_audio` and
+    // throws "'audio media type ...' functionality not supported" for the rest;
+    // the repo patch extends the format map to flac/m4a/ogg. Anything outside
+    // that list (e.g. audio/aac) still throws.
+    evidence:
+      "@ai-sdk/openai-compatible@2 (repo-patched) serializes wav/mp3/flac/m4a/ogg as input_audio and rejects other audio",
   },
   "@ai-sdk/google": {
     text: TEXT_SUPPORTED,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2581,13 +2581,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }
               // Inline payloads (clipboard pastes) are classified on the base64
               // length: an oversized image within the source ceiling is
-              // recompressed, anything else oversized is dropped.
+              // recompressed, anything else oversized is dropped. Audio and
+              // video are bounded only by the provider's ENCODED-size cap (see
+              // MAX_MEDIA_BASE64_BYTES) and never enter classifyAttachment.
               const inline = part.url.slice(part.url.indexOf(",") + 1)
               const inlineSize = base64ByteSize(inline)
-              if (
-                (isAudioAttachment(part.mime) || isVideoAttachment(part.mime)) &&
-                inline.length > MAX_MEDIA_BASE64_BYTES
-              ) {
+              if (isAudioAttachment(part.mime) || isVideoAttachment(part.mime)) {
+                if (inline.length <= MAX_MEDIA_BASE64_BYTES) break
                 return [
                   {
                     messageID: info.id,
@@ -2786,7 +2786,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               // an under-limit file is inlined as-is, an oversized image within
               // the source ceiling is read and recompressed, and anything else
               // oversized becomes a notice without being read, so it never
-              // reaches the session DB.
+              // reaches the session DB. Audio and video are bounded only by the
+              // provider's ENCODED-size cap (fitsMediaBase64) and never enter
+              // classifyAttachment.
               const size = yield* fsys.stat(filepath).pipe(
                 Effect.map((info) => Number(info.size)),
                 Effect.catch(() => Effect.succeed(0)),
@@ -2808,7 +2810,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   },
                 ]
               }
-              const verdict = classifyAttachment(part.mime, size)
+              const verdict = media ? "fits" : classifyAttachment(part.mime, size)
               const fitted =
                 verdict === "reject"
                   ? undefined

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3,7 +3,16 @@ import os from "os"
 import z from "zod"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
-import { base64ByteSize, classifyAttachment, oversizedAttachmentNotice } from "@/util/media"
+import {
+  base64ByteSize,
+  classifyAttachment,
+  fitsMediaBase64,
+  isAudioAttachment,
+  isVideoAttachment,
+  MAX_MEDIA_BASE64_BYTES,
+  oversizedAttachmentNotice,
+  oversizedMediaNotice,
+} from "@/util/media"
 import { shrinkAttachment } from "@/provider/image"
 import { classifyAssistantStep } from "./classify"
 import { Log, Token } from "../util"
@@ -2575,6 +2584,24 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               // recompressed, anything else oversized is dropped.
               const inline = part.url.slice(part.url.indexOf(",") + 1)
               const inlineSize = base64ByteSize(inline)
+              if (
+                (isAudioAttachment(part.mime) || isVideoAttachment(part.mime)) &&
+                inline.length > MAX_MEDIA_BASE64_BYTES
+              ) {
+                return [
+                  {
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: oversizedMediaNotice({
+                      label: `"${part.filename ?? part.mime}"`,
+                      size: inlineSize,
+                      hint: "It was not attached.",
+                    }),
+                  },
+                ]
+              }
               const verdict = classifyAttachment(part.mime, inlineSize)
               if (verdict === "fits") break
               const fitted = verdict === "shrink" ? shrinkAttachment(part.mime, Buffer.from(inline, "base64")) : undefined
@@ -2764,6 +2791,23 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 Effect.map((info) => Number(info.size)),
                 Effect.catch(() => Effect.succeed(0)),
               )
+              const media = isAudioAttachment(part.mime) || isVideoAttachment(part.mime)
+              if (media && !fitsMediaBase64(size)) {
+                return [
+                  call,
+                  {
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: oversizedMediaNotice({
+                      label: `"${filepath}" (${part.mime})`,
+                      size,
+                      hint: "It was not attached.",
+                    }),
+                  },
+                ]
+              }
               const verdict = classifyAttachment(part.mime, size)
               const fitted =
                 verdict === "reject"

--- a/packages/opencode/src/session/tool-attachment.ts
+++ b/packages/opencode/src/session/tool-attachment.ts
@@ -26,6 +26,12 @@ const OPENAI_AUDIO_MIMES = new Set([
   "audio/x-m4a",
   "audio/ogg",
 ])
+// The formats the MiMo video API documents (MP4, MOV, AVI, WMV). The patched
+// openai-compatible adapter serializes ANY video/* as `video_url`
+// (patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch), so this allowlist is
+// what keeps e.g. video/webm from being sent only to fail server-side.
+// Mirrors OPENAI_VIDEO_MIMES in src/provider/capability-registry.ts.
+const OPENAI_VIDEO_MIMES = new Set(["video/mp4", "video/quicktime", "video/x-msvideo", "video/x-ms-wmv"])
 const BEDROCK_TEXT_MIMES = new Set(["text/csv", "text/html", "text/plain", "text/markdown"])
 const OPENAI_CHAT_PACKAGES = new Set(["@ai-sdk/openai-compatible"])
 const ANTHROPIC_PACKAGES = new Set(["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"])
@@ -67,9 +73,12 @@ function providerAcceptsSynthetic(model: Provider.Model, attachment: ToolAttachm
     return GOOGLE_PACKAGES.has(npm)
   }
   // The patched openai-compatible chat adapter serializes inline video as a
-  // `video_url` data URL (patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch).
+  // `video_url` data URL (patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch),
+  // narrowed here to the formats the MiMo video API accepts.
   if (mime.startsWith("video/")) {
-    return isInlineAttachment(attachment) && (GOOGLE_PACKAGES.has(npm) || OPENAI_CHAT_PACKAGES.has(npm))
+    if (!isInlineAttachment(attachment)) return false
+    if (OPENAI_CHAT_PACKAGES.has(npm)) return OPENAI_VIDEO_MIMES.has(mime)
+    return GOOGLE_PACKAGES.has(npm)
   }
   if (mime.startsWith("text/")) {
     if (!isInlineAttachment(attachment)) return false

--- a/packages/opencode/src/session/tool-attachment.ts
+++ b/packages/opencode/src/session/tool-attachment.ts
@@ -10,7 +10,22 @@ export type ToolAttachmentRoute = "native" | "synthetic" | "placeholder"
 
 const MAX_ATTACHMENT_NAME_LENGTH = 120
 const SAFE_IMAGE_MIMES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"])
-const OPENAI_AUDIO_MIMES = new Set(["audio/wav", "audio/mp3", "audio/mpeg"])
+// The formats the MiMo audio API documents (MP3, WAV, FLAC, M4A, OGG), as the
+// MIMEs a mime lookup or sniff yields for them. The stock openai-compatible
+// adapter only knows wav/mp3; patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
+// extends its input_audio format map to the rest.
+const OPENAI_AUDIO_MIMES = new Set([
+  "audio/wav",
+  "audio/x-wav",
+  "audio/mp3",
+  "audio/mpeg",
+  "audio/flac",
+  "audio/x-flac",
+  "audio/mp4",
+  "audio/m4a",
+  "audio/x-m4a",
+  "audio/ogg",
+])
 const BEDROCK_TEXT_MIMES = new Set(["text/csv", "text/html", "text/plain", "text/markdown"])
 const OPENAI_CHAT_PACKAGES = new Set(["@ai-sdk/openai-compatible"])
 const ANTHROPIC_PACKAGES = new Set(["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"])
@@ -51,7 +66,11 @@ function providerAcceptsSynthetic(model: Provider.Model, attachment: ToolAttachm
     if (OPENAI_CHAT_PACKAGES.has(npm)) return OPENAI_AUDIO_MIMES.has(mime)
     return GOOGLE_PACKAGES.has(npm)
   }
-  if (mime.startsWith("video/")) return isInlineAttachment(attachment) && GOOGLE_PACKAGES.has(npm)
+  // The patched openai-compatible chat adapter serializes inline video as a
+  // `video_url` data URL (patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch).
+  if (mime.startsWith("video/")) {
+    return isInlineAttachment(attachment) && (GOOGLE_PACKAGES.has(npm) || OPENAI_CHAT_PACKAGES.has(npm))
+  }
   if (mime.startsWith("text/")) {
     if (!isInlineAttachment(attachment)) return false
     if (OPENAI_CHAT_PACKAGES.has(npm) || GOOGLE_PACKAGES.has(npm)) return true

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -11,18 +11,66 @@ import { Instance } from "../project/instance"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { SessionCwd } from "./session-cwd"
 import { Instruction } from "../session/instruction"
-import { Provider } from "@/provider"
+import { ModelCapability, Provider } from "@/provider"
 import { shrinkAttachment } from "@/provider/image"
 import { builtinSkillRoot } from "@/skill/builtin/extract"
 import {
   classifyAttachment,
+  fitsMediaBase64,
+  isAudioAttachment,
   isImageAttachment,
   isPdfAttachment,
+  isVideoAttachment,
   oversizedAttachmentNotice,
+  oversizedMediaNotice,
   sniffAttachmentMime,
 } from "@/util/media"
 
 const DEFAULT_READ_LIMIT = 2000
+
+// Formats the MiMo audio/video APIs document, keyed by the MIME the adapter
+// declaration lists (see capability-registry.ts) so the description names only
+// what the current model+adapter can actually take.
+const AUDIO_FORMAT_NAMES: Record<string, string> = {
+  "audio/wav": "wav",
+  "audio/x-wav": "wav",
+  "audio/mp3": "mp3",
+  "audio/mpeg": "mp3",
+  "audio/flac": "flac",
+  "audio/x-flac": "flac",
+  "audio/mp4": "m4a",
+  "audio/m4a": "m4a",
+  "audio/x-m4a": "m4a",
+  "audio/ogg": "ogg",
+}
+const AUDIO_FORMATS = ["wav", "mp3", "flac", "m4a", "ogg"]
+const VIDEO_FORMATS = ["mp4", "mov", "avi", "wmv"]
+
+/**
+ * The audio/video paragraph of the tool description, or undefined when the
+ * model accepts neither. Appended per model by the tool registry so a
+ * text-only model is never told it can attach media.
+ */
+export function describeMedia(model: Provider.Model | undefined) {
+  if (!model) return undefined
+  const audio = model.capabilities.input.audio
+    ? (() => {
+        const declared = ModelCapability.modelDeclaration(model, "audio")
+        const names =
+          declared.support === "supported" && declared.mimeTypes !== "any"
+            ? [...new Set(declared.mimeTypes.map((mime) => AUDIO_FORMAT_NAMES[mime] ?? mime))]
+            : AUDIO_FORMATS
+        return `audio (${names.join(", ")})`
+      })()
+    : undefined
+  const video = model.capabilities.input.video ? `video (${VIDEO_FORMATS.join(", ")})` : undefined
+  const kinds = [audio, video].filter((kind): kind is string => kind !== undefined)
+  if (kinds.length === 0) return undefined
+  return [
+    `- You can read and understand ${kinds.join(" and ")} files directly: this tool returns them as file attachments, and you can then describe, transcribe, summarize, or answer questions about their content yourself, without an external transcription or vision service.`,
+    `- Media is inlined when small enough (about 37 MB on disk, 50 MB once base64-encoded); otherwise the tool explains why the file was not read. Read the file first, then analyze its content in the same turn.`,
+  ].join("\n")
+}
 const MAX_LINE_LENGTH = 2000
 const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
 const MAX_BYTES = 50 * 1024
@@ -223,7 +271,9 @@ export const ReadTool = Tool.define(
       // source ceiling is read and recompressed below. Either way nothing over
       // the limit becomes base64 or reaches the session DB.
       const verdict =
-        isImageAttachment(mime) || isPdfAttachment(mime) ? classifyAttachment(mime, Number(stat.size)) : "fits"
+        isImageAttachment(mime) || isPdfAttachment(mime) || isAudioAttachment(mime) || isVideoAttachment(mime)
+          ? classifyAttachment(mime, Number(stat.size))
+          : "fits"
       if (verdict === "reject") {
         const warning = oversizedAttachmentNotice({
           label: `"${path.basename(filepath)}" (${mime})`,
@@ -339,6 +389,69 @@ export const ReadTool = Tool.define(
             {
               type: "file" as const,
               mime,
+              url: `data:${mime};base64,${Buffer.from(bytes).toString("base64")}`,
+            },
+          ],
+        }
+      }
+
+      if (isAudioAttachment(mime) || isVideoAttachment(mime)) {
+        // Audio and video are opaque to the read tool: the bytes go to the model
+        // as an inline `data:` attachment, or nowhere. Gate on the model first,
+        // then on the encoded size, so a file the model cannot take is never
+        // read and an oversized one never becomes base64.
+        const kind = isAudioAttachment(mime) ? "audio" : "video"
+        const supported = model?.capabilities.input[kind] ?? false
+        if (!supported) {
+          const warning = [
+            `Cannot attach ${kind} "${path.basename(filepath)}" — the current model has no ${kind} input support, so the file was not read.`,
+            `Ask the user to switch to a model with ${kind} input, or use a shell tool (e.g. ffprobe) to inspect its metadata instead.`,
+          ].join("\n")
+          return {
+            title,
+            output: warning,
+            metadata: { preview: warning, truncated: false, loaded: loaded.map((item) => item.filepath) },
+          }
+        }
+        // The model may take audio while its adapter can only serialize some
+        // formats (the OpenAI-compatible chat adapter emits input_audio for
+        // wav/mp3 only). Refuse those up front instead of attaching bytes that
+        // tool-attachment.ts would later replace with a placeholder.
+        const declared = model && kind === "audio" ? ModelCapability.modelDeclaration(model, "audio") : undefined
+        if (declared?.support === "supported" && declared.mimeTypes !== "any" && !declared.mimeTypes.includes(mime)) {
+          const warning = [
+            `Cannot attach audio "${path.basename(filepath)}" (${mime}) — the current provider only accepts ${declared.mimeTypes.join(", ")}, so the file was not read.`,
+            `Convert it first (e.g. ffmpeg -i "${filepath}" /tmp/example.wav) and read the converted file.`,
+          ].join("\n")
+          return {
+            title,
+            output: warning,
+            metadata: { preview: warning, truncated: false, loaded: loaded.map((item) => item.filepath) },
+          }
+        }
+        if (!fitsMediaBase64(Number(stat.size))) {
+          const warning = oversizedMediaNotice({
+            label: `"${path.basename(filepath)}" (${mime})`,
+            size: Number(stat.size),
+            hint: "It was not read.",
+          })
+          return {
+            title,
+            output: warning,
+            metadata: { preview: warning, truncated: false, loaded: loaded.map((item) => item.filepath) },
+          }
+        }
+        const bytes = yield* fs.readFile(filepath)
+        const output = `${kind === "audio" ? "Audio" : "Video"} read successfully and attached for the model to analyze`
+        return {
+          title,
+          output,
+          metadata: { preview: output, truncated: false, loaded: loaded.map((item) => item.filepath) },
+          attachments: [
+            {
+              type: "file" as const,
+              mime,
+              filename: path.basename(filepath),
               url: `data:${mime};base64,${Buffer.from(bytes).toString("base64")}`,
             },
           ],

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -44,7 +44,25 @@ const AUDIO_FORMAT_NAMES: Record<string, string> = {
   "audio/ogg": "ogg",
 }
 const AUDIO_FORMATS = ["wav", "mp3", "flac", "m4a", "ogg"]
+const VIDEO_FORMAT_NAMES: Record<string, string> = {
+  "video/mp4": "mp4",
+  "video/quicktime": "mov",
+  "video/x-msvideo": "avi",
+  "video/x-ms-wmv": "wmv",
+}
 const VIDEO_FORMATS = ["mp4", "mov", "avi", "wmv"]
+
+// The format names the current model+adapter can take for one media kind:
+// the adapter declaration's MIME list when it has one, else the documented
+// MiMo API formats.
+function mediaFormatNames(model: Provider.Model, kind: "audio" | "video") {
+  const declared = ModelCapability.modelDeclaration(model, kind)
+  const names = kind === "audio" ? AUDIO_FORMAT_NAMES : VIDEO_FORMAT_NAMES
+  const fallback = kind === "audio" ? AUDIO_FORMATS : VIDEO_FORMATS
+  return declared.support === "supported" && declared.mimeTypes !== "any"
+    ? [...new Set(declared.mimeTypes.map((mime) => names[mime] ?? mime))]
+    : fallback
+}
 
 /**
  * The audio/video paragraph of the tool description, or undefined when the
@@ -53,17 +71,8 @@ const VIDEO_FORMATS = ["mp4", "mov", "avi", "wmv"]
  */
 export function describeMedia(model: Provider.Model | undefined) {
   if (!model) return undefined
-  const audio = model.capabilities.input.audio
-    ? (() => {
-        const declared = ModelCapability.modelDeclaration(model, "audio")
-        const names =
-          declared.support === "supported" && declared.mimeTypes !== "any"
-            ? [...new Set(declared.mimeTypes.map((mime) => AUDIO_FORMAT_NAMES[mime] ?? mime))]
-            : AUDIO_FORMATS
-        return `audio (${names.join(", ")})`
-      })()
-    : undefined
-  const video = model.capabilities.input.video ? `video (${VIDEO_FORMATS.join(", ")})` : undefined
+  const audio = model.capabilities.input.audio ? `audio (${mediaFormatNames(model, "audio").join(", ")})` : undefined
+  const video = model.capabilities.input.video ? `video (${mediaFormatNames(model, "video").join(", ")})` : undefined
   const kinds = [audio, video].filter((kind): kind is string => kind !== undefined)
   if (kinds.length === 0) return undefined
   return [
@@ -269,11 +278,11 @@ export const ReadTool = Tool.define(
       // Size gate on stat, before any bytes are read (see classifyAttachment):
       // a rejected PDF or image is never read, an oversized image within the
       // source ceiling is read and recompressed below. Either way nothing over
-      // the limit becomes base64 or reaches the session DB.
+      // the limit becomes base64 or reaches the session DB. Audio and video are
+      // not gated here: the provider bounds their ENCODED size, which the media
+      // branch below checks with fitsMediaBase64.
       const verdict =
-        isImageAttachment(mime) || isPdfAttachment(mime) || isAudioAttachment(mime) || isVideoAttachment(mime)
-          ? classifyAttachment(mime, Number(stat.size))
-          : "fits"
+        isImageAttachment(mime) || isPdfAttachment(mime) ? classifyAttachment(mime, Number(stat.size)) : "fits"
       if (verdict === "reject") {
         const warning = oversizedAttachmentNotice({
           label: `"${path.basename(filepath)}" (${mime})`,
@@ -413,15 +422,16 @@ export const ReadTool = Tool.define(
             metadata: { preview: warning, truncated: false, loaded: loaded.map((item) => item.filepath) },
           }
         }
-        // The model may take audio while its adapter can only serialize some
-        // formats (the OpenAI-compatible chat adapter emits input_audio for
-        // wav/mp3 only). Refuse those up front instead of attaching bytes that
+        // The model may take the media kind while its adapter/API only takes
+        // some formats (the OpenAI-compatible chat adapter emits input_audio for
+        // wav/mp3/flac/m4a/ogg; the MiMo video API takes mp4/mov/avi/wmv).
+        // Refuse the rest up front instead of attaching bytes that
         // tool-attachment.ts would later replace with a placeholder.
-        const declared = model && kind === "audio" ? ModelCapability.modelDeclaration(model, "audio") : undefined
+        const declared = model ? ModelCapability.modelDeclaration(model, kind) : undefined
         if (declared?.support === "supported" && declared.mimeTypes !== "any" && !declared.mimeTypes.includes(mime)) {
           const warning = [
-            `Cannot attach audio "${path.basename(filepath)}" (${mime}) — the current provider only accepts ${declared.mimeTypes.join(", ")}, so the file was not read.`,
-            `Convert it first (e.g. ffmpeg -i "${filepath}" /tmp/example.wav) and read the converted file.`,
+            `Cannot attach ${kind} "${path.basename(filepath)}" (${mime}) — the current provider only accepts ${declared.mimeTypes.join(", ")}, so the file was not read.`,
+            `Convert it first (e.g. ffmpeg -i "${filepath}" /tmp/example.${kind === "audio" ? "wav" : "mp4"}) and read the converted file.`,
           ].join("\n")
           return {
             title,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -8,7 +8,7 @@ import { GlobTool } from "./glob"
 import { GrepTool } from "./grep"
 import { HistoryTool } from "./history"
 import { MemoryTool } from "./memory"
-import { ReadTool } from "./read"
+import { ReadTool, describeMedia } from "./read"
 import { ViewImageTool } from "./view-image"
 import { ActorTool } from "./actor"
 import { TaskTool } from "./task"
@@ -152,6 +152,7 @@ export const layer = Layer.effect(
     const agents = yield* Agent.Service
     const skill = yield* Skill.Service
     const truncate = yield* Truncate.Service
+    const provider = yield* Provider.Service
 
     const invalid = yield* InvalidTool
     const actor = yield* ActorTool
@@ -449,6 +450,17 @@ export const layer = Layer.effect(
     toolScriptRegistry.current = (input) =>
       input ? available(input).pipe(Effect.map((result) => result.filtered)) : all()
 
+    // The read tool's media paragraph depends on the model the turn runs on.
+    const describeReadMedia = Effect.fn("ToolRegistry.describeReadMedia")(function* (input: {
+      providerID: ProviderID
+      modelID: ModelID
+    }) {
+      const model = yield* provider
+        .getModel(input.providerID, input.modelID)
+        .pipe(Effect.catchDefect(() => Effect.succeed(undefined)))
+      return describeMedia(model)
+    })
+
     const definitions = Effect.fn("ToolRegistry.definitions")(function* (
       input: {
         providerID: ProviderID
@@ -488,6 +500,7 @@ export const layer = Layer.effect(
             id: tool.id,
             description: [
               description,
+              tool.id === ReadTool.id ? yield* describeReadMedia(input) : undefined,
               tool.id === ActorTool.id ? yield* describeTask(input.agent) : undefined,
               tool.id === WorkflowTool.id ? yield* describeWorkflow() : undefined,
               tool.id === ToolScriptTool.id ? yield* describeToolScript(availableTools.filtered) : undefined,

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -6,12 +6,39 @@ export function isPdfAttachment(mime: string) {
   return mime === "application/pdf"
 }
 
+export function isAudioAttachment(mime: string) {
+  return mime.startsWith("audio/")
+}
+
+export function isVideoAttachment(mime: string) {
+  return mime.startsWith("video/")
+}
+
 export function isMedia(mime: string) {
-  return mime.startsWith("image/") || isPdfAttachment(mime)
+  return mime.startsWith("image/") || isAudioAttachment(mime) || isVideoAttachment(mime) || isPdfAttachment(mime)
 }
 
 export function isImageAttachment(mime: string) {
   return mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
+}
+
+// Inline audio/video is sent as a `data:{mime};base64,...` string, and the
+// provider bounds the ENCODED string (50 MB for both the MiMo audio and video
+// APIs), not the decoded bytes. Base64 grows the payload by 4/3, so a file must
+// stay under ~37.5 MB on disk to fit. Checked on the stat size, before any
+// bytes are read.
+export const MAX_MEDIA_BASE64_BYTES = 50 * 1024 * 1024
+
+export function base64Length(size: number) {
+  return Math.ceil(size / 3) * 4
+}
+
+export function fitsMediaBase64(size: number) {
+  return base64Length(size) <= MAX_MEDIA_BASE64_BYTES
+}
+
+export function oversizedMediaNotice(input: { label: string; size: number; hint: string }) {
+  return `Attachment ${input.label} is ${input.size} bytes, which encodes to ${base64Length(input.size)} bytes of base64, over the ${mb(MAX_MEDIA_BASE64_BYTES)} inline media limit. ${input.hint}`
 }
 
 export function sniffAttachmentMime(bytes: Uint8Array, fallback: string) {
@@ -22,6 +49,9 @@ export function sniffAttachmentMime(bytes: Uint8Array, fallback: string) {
   if (startsWith(bytes, [0x25, 0x50, 0x44, 0x46, 0x2d])) return "application/pdf"
   if (startsWith(bytes, [0x52, 0x49, 0x46, 0x46]) && startsWith(bytes.subarray(8), [0x57, 0x45, 0x42, 0x50])) {
     return "image/webp"
+  }
+  if (startsWith(bytes, [0x52, 0x49, 0x46, 0x46]) && startsWith(bytes.subarray(8), [0x57, 0x41, 0x56, 0x45])) {
+    return "audio/wav"
   }
 
   return fallback

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -67,6 +67,8 @@ export function sniffAttachmentMime(bytes: Uint8Array, fallback: string) {
 //             and recompress under the limit, reject only if that fails
 //   reject  — anything else over the limit (non-image, or an image so large
 //             that recompressing it is not worth attempting)
+// Audio and video never enter this gate: the provider bounds their ENCODED
+// size, so they are checked with fitsMediaBase64 / MAX_MEDIA_BASE64_BYTES only.
 
 // Decoded byte count of raw base64, O(1) — no decoding needed to classify.
 export function base64ByteSize(base64: string) {

--- a/packages/opencode/test/mcp/tool-result.test.ts
+++ b/packages/opencode/test/mcp/tool-result.test.ts
@@ -199,12 +199,19 @@ describe("MCP tool result normalization", () => {
     const giant = noisy(200)
     expect(giant.byteLength).toBeGreaterThan(CEILING)
     // Decoded size is 3 bytes per 4 base64 chars; one group past the cap.
-    const audio = "A".repeat(Math.ceil((LIMIT + 1) / 3) * 4)
+    const oversized = "A".repeat(Math.ceil((LIMIT + 1) / 3) * 4)
     const result: CallToolResult = {
       content: [
         { type: "text", text: "rendered" },
         { type: "image", data: image.toString("base64"), mimeType: "image/png" },
-        { type: "audio", data: audio, mimeType: "audio/wav" },
+        // Audio is bounded by the provider's encoded-size cap, not the decoded
+        // attachment limit, so it passes even though it is over LIMIT.
+        { type: "audio", data: oversized, mimeType: "audio/wav" },
+        // A non-image, non-media blob over LIMIT can only be dropped.
+        {
+          type: "resource",
+          resource: { uri: "file:///tmp/example.bin", mimeType: "application/pdf", blob: oversized },
+        },
         { type: "image", data: giant.toString("base64"), mimeType: "image/png" },
         { type: "image", data: "Zm9v", mimeType: "image/jpeg" },
       ],
@@ -212,17 +219,18 @@ describe("MCP tool result normalization", () => {
 
     const normalized = normalizeToolResult(parseResult(result))
 
-    expect(normalized.attachments).toHaveLength(2)
+    expect(normalized.attachments).toHaveLength(3)
     expect(normalized.attachments[0].mime).toBe("image/jpeg")
     const url = normalized.attachments[0].url
     expect(Buffer.from(url.slice(url.indexOf(",") + 1), "base64").byteLength).toBeLessThanOrEqual(LIMIT)
-    expect(normalized.attachments[1]).toEqual({ mime: "image/jpeg", url: "data:image/jpeg;base64,Zm9v" })
+    expect(normalized.attachments[1]).toEqual({ mime: "audio/wav", url: `data:audio/wav;base64,${oversized}` })
+    expect(normalized.attachments[2]).toEqual({ mime: "image/jpeg", url: "data:image/jpeg;base64,Zm9v" })
     expect(normalized.output).toContain("rendered")
-    expect(normalized.output).toContain("Attachment audio/wav is")
+    expect(normalized.output).not.toContain("Attachment audio/wav is")
+    expect(normalized.output).toContain('Attachment "file:///tmp/example.bin" (application/pdf) is')
     expect(normalized.output).toContain("it cannot be compressed")
     expect(normalized.output).toContain(`Attachment image/png is ${giant.byteLength} bytes`)
     expect(normalized.output).toContain("ceiling above which compression is not attempted")
     expect(normalized.output).not.toContain(`Attachment image/png is ${image.byteLength} bytes`)
-    expect(normalized.output).not.toContain(audio.slice(0, 64))
   })
 })

--- a/packages/opencode/test/provider/capability-registry-wire.test.ts
+++ b/packages/opencode/test/provider/capability-registry-wire.test.ts
@@ -82,22 +82,40 @@ async function sendAudio(
 }
 
 describe("@ai-sdk/openai-compatible audio behaviour matches the registry", () => {
-  test.each(["audio/wav", "audio/mp3", "audio/mpeg"])("%s is serialized as input_audio", async (mediaType) => {
-    // The registry declares exactly this MIME set as supported.
-    expect(ModelCapability.adapterDeclaration("@ai-sdk/openai-compatible").audio.mimeTypes).toContain(mediaType)
-    const outcome = await sendAudio("openai-compatible", mediaType)
-    expect(outcome).not.toHaveProperty("error")
-    if ("error" in outcome) throw new Error("unreachable")
-    expect(outcome.parts).toEqual([{ type: "input_audio", input_audio: { data: AUDIO, format: expect.any(String) } }])
-  })
+  test.each(["audio/wav", "audio/mp3", "audio/mpeg", "audio/flac", "audio/x-flac", "audio/mp4", "audio/ogg"])(
+    "%s is serialized as input_audio",
+    async (mediaType) => {
+      // The registry declares exactly this MIME set as supported. wav/mp3 are
+      // stock adapter behaviour; flac/m4a/ogg come from the repo patch that
+      // extends the input_audio format map to the MiMo audio API's formats.
+      expect(ModelCapability.adapterDeclaration("@ai-sdk/openai-compatible").audio.mimeTypes).toContain(mediaType)
+      const outcome = await sendAudio("openai-compatible", mediaType)
+      expect(outcome).not.toHaveProperty("error")
+      if ("error" in outcome) throw new Error("unreachable")
+      expect(outcome.parts).toEqual([{ type: "input_audio", input_audio: { data: AUDIO, format: expect.any(String) } }])
+    },
+  )
 
-  test.each(["audio/flac", "audio/ogg"])("%s is refused by the adapter, so the registry excludes it", async (mediaType) => {
+  test.each(["audio/aac", "audio/webm"])("%s is refused by the adapter, so the registry excludes it", async (mediaType) => {
     const declaration = ModelCapability.adapterDeclaration("@ai-sdk/openai-compatible").audio
     expect(declaration.mimeTypes).not.toContain(mediaType)
     const outcome = await sendAudio("openai-compatible", mediaType)
     expect(outcome).toHaveProperty("error")
     if (!("error" in outcome)) throw new Error("unreachable")
     expect(outcome.error).toMatch(/not supported/)
+  })
+})
+
+describe("@ai-sdk/openai-compatible video is serialized by the repo patch", () => {
+  // Not stock adapter behaviour: patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
+  // adds the `video_url` branch the MiMo video API expects, with the payload
+  // inlined as a `data:` URL and no per-part tuning fields (the API defaults
+  // fps and media_resolution). A dependency upgrade that drops the patch fails here.
+  test.each(["video/mp4", "video/quicktime"])("%s is serialized as video_url", async (mediaType) => {
+    const outcome = await sendAudio("openai-compatible", mediaType)
+    expect(outcome).not.toHaveProperty("error")
+    if ("error" in outcome) throw new Error("unreachable")
+    expect(outcome.parts).toEqual([{ type: "video_url", video_url: { url: `data:${mediaType};base64,${AUDIO}` } }])
   })
 })
 

--- a/packages/opencode/test/provider/capability-registry-wire.test.ts
+++ b/packages/opencode/test/provider/capability-registry-wire.test.ts
@@ -112,6 +112,7 @@ describe("@ai-sdk/openai-compatible video is serialized by the repo patch", () =
   // inlined as a `data:` URL and no per-part tuning fields (the API defaults
   // fps and media_resolution). A dependency upgrade that drops the patch fails here.
   test.each(["video/mp4", "video/quicktime"])("%s is serialized as video_url", async (mediaType) => {
+    expect(ModelCapability.adapterDeclaration("@ai-sdk/openai-compatible").video.mimeTypes).toContain(mediaType)
     const outcome = await sendAudio("openai-compatible", mediaType)
     expect(outcome).not.toHaveProperty("error")
     if ("error" in outcome) throw new Error("unreachable")

--- a/packages/opencode/test/provider/capability-registry.test.ts
+++ b/packages/opencode/test/provider/capability-registry.test.ts
@@ -70,15 +70,33 @@ describe("adapter declarations", () => {
     ])
   })
 
-  test("anthropic and bedrock adapters declare audio KNOWN-ABSENT, not unknown", () => {
-    for (const npm of ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic", "@ai-sdk/amazon-bedrock"]) {
-      expect(ModelCapability.adapterDeclaration(npm).audio.support).toBe("unsupported")
+  test("openai-compatible narrows video to the MiMo formats (mp4/mov/avi/wmv)", () => {
+    const declaration = ModelCapability.adapterDeclaration("@ai-sdk/openai-compatible")
+    expect(declaration.video.support).toBe("supported")
+    expect(declaration.video.mimeTypes).toEqual(["video/mp4", "video/quicktime", "video/x-msvideo", "video/x-ms-wmv"])
+  })
+
+  test("google adapters declare video supported for any video MIME", () => {
+    for (const npm of ["@ai-sdk/google", "@ai-sdk/google-vertex"]) {
+      expect(ModelCapability.adapterDeclaration(npm).video).toEqual({
+        support: "supported",
+        mimeTypes: "any",
+        maxBytes: ModelCapability.DEFAULT_MAX_MEDIA_BYTES,
+      })
     }
   })
 
-  test("an undeclared adapter reports audio as unknown rather than guessing", () => {
+  test("anthropic and bedrock adapters declare audio KNOWN-ABSENT, not unknown", () => {
+    for (const npm of ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic", "@ai-sdk/amazon-bedrock"]) {
+      expect(ModelCapability.adapterDeclaration(npm).audio.support).toBe("unsupported")
+      expect(ModelCapability.adapterDeclaration(npm).video.support).toBe("unsupported")
+    }
+  })
+
+  test("an undeclared adapter reports audio and video as unknown rather than guessing", () => {
     const declaration = ModelCapability.adapterDeclaration("@ai-sdk/some-future-provider")
     expect(declaration.audio.support).toBe("unknown")
+    expect(declaration.video.support).toBe("unknown")
     // Text and image stay usable so an unknown adapter is not locked out of
     // ordinary sampling.
     expect(declaration.text.support).toBe("supported")

--- a/packages/opencode/test/provider/capability-registry.test.ts
+++ b/packages/opencode/test/provider/capability-registry.test.ts
@@ -53,10 +53,21 @@ describe("adapter declarations", () => {
     }
   })
 
-  test("openai-compatible declares audio supported only for wav/mp3/mpeg", () => {
+  test("openai-compatible declares audio supported for the MiMo formats (wav/mp3/flac/m4a/ogg)", () => {
     const declaration = ModelCapability.adapterDeclaration("@ai-sdk/openai-compatible")
     expect(declaration.audio.support).toBe("supported")
-    expect(declaration.audio.mimeTypes).toEqual(["audio/wav", "audio/mp3", "audio/mpeg"])
+    expect(declaration.audio.mimeTypes).toEqual([
+      "audio/wav",
+      "audio/x-wav",
+      "audio/mp3",
+      "audio/mpeg",
+      "audio/flac",
+      "audio/x-flac",
+      "audio/mp4",
+      "audio/m4a",
+      "audio/x-m4a",
+      "audio/ogg",
+    ])
   })
 
   test("anthropic and bedrock adapters declare audio KNOWN-ABSENT, not unknown", () => {
@@ -110,9 +121,9 @@ describe("rejectionFor", () => {
   test("rejects an audio MIME the adapter does not accept", () => {
     const subject = model({ id: "mimo-v2.5", audio: true })
     const reason = ModelCapability.rejectionFor(subject, [
-      { modality: "audio", mimeType: "audio/flac", bytes: 1000 },
+      { modality: "audio", mimeType: "audio/aac", bytes: 1000 },
     ])
-    expect(reason).toEqual({ kind: "mime-unsupported", modality: "audio", mimeType: "audio/flac" })
+    expect(reason).toEqual({ kind: "mime-unsupported", modality: "audio", mimeType: "audio/aac" })
   })
 
   test("rejects content over the declared byte cap", () => {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -789,9 +789,9 @@ describe("session.message-v2.toModelMessage", () => {
                 {
                   ...basePart(assistantID, "file-3"),
                   type: "file",
-                  mime: "audio/ogg",
-                  filename: "unsupported.ogg",
-                  url: "data:audio/ogg;base64,T2dnUw==",
+                  mime: "audio/aac",
+                  filename: "unsupported.aac",
+                  url: "data:audio/aac;base64,//FQgA==",
                 },
                 {
                   ...basePart(assistantID, "file-4"),
@@ -858,7 +858,7 @@ describe("session.message-v2.toModelMessage", () => {
           },
           {
             type: "text",
-            text: '[Tool attachment "unsupported.ogg" (audio/ogg) was retained but cannot be safely sent to this model/provider.]',
+            text: '[Tool attachment "unsupported.aac" (audio/aac) was retained but cannot be safely sent to this model/provider.]',
           },
           {
             type: "text",

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1359,9 +1359,10 @@ describe("session.prompt oversized attachment", () => {
     })
   })
 
-  test("drops an oversized inline data attachment with a notice", async () => {
+  test("attaches oversized inline audio that fits the encoded media cap", async () => {
     await using tmp = await tmpdir({ git: true, config })
-    // Uncompressible: not an image at all, so it can only be dropped.
+    // Over Flag.MIMOCODE_MAX_ATTACHMENT_SIZE, but audio is bounded only by the
+    // provider's encoded-size cap (MAX_MEDIA_BASE64_BYTES), so it passes.
     const base64 = "A".repeat(Math.ceil((LIMIT + 1) / 3) * 4)
 
     await Instance.provide({
@@ -1382,8 +1383,41 @@ describe("session.prompt oversized attachment", () => {
               ],
             })
             if (msg.info.role !== "user") throw new Error("expected user message")
+            const file = msg.parts.find((part) => part.type === "file")
+            expect(file?.type === "file" && file.url).toBe(`data:audio/wav;base64,${base64}`)
+            expect(notice(msg.parts, `"clip.wav" is`)).toBe(false)
+            yield* sessions.remove(session.id)
+          }),
+        ),
+    })
+  })
+
+  test("drops an oversized inline data attachment with a notice", async () => {
+    await using tmp = await tmpdir({ git: true, config })
+    // Uncompressible: not an image (and not audio/video, which have their own
+    // encoded-size cap), so it can only be dropped.
+    const base64 = "A".repeat(Math.ceil((LIMIT + 1) / 3) * 4)
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Effect.gen(function* () {
+            const prompt = yield* SessionPrompt.Service
+            const sessions = yield* Session.Service
+            const session = yield* sessions.create({})
+            const msg = yield* prompt.prompt({
+              sessionID: session.id,
+              agent: "build",
+              noReply: true,
+              parts: [
+                { type: "text", text: "what is this" },
+                { type: "file", mime: "application/pdf", url: `data:application/pdf;base64,${base64}`, filename: "doc.pdf" },
+              ],
+            })
+            if (msg.info.role !== "user") throw new Error("expected user message")
             expect(noFileParts(msg.parts)).toBe(true)
-            expect(notice(msg.parts, `"clip.wav" is`)).toBe(true)
+            expect(notice(msg.parts, `"doc.pdf" is`)).toBe(true)
 
             const stored = yield* sessions.messages({ sessionID: session.id })
             expect(noFileParts(stored.flatMap((item) => item.parts))).toBe(true)

--- a/packages/opencode/test/session/tool-attachment.test.ts
+++ b/packages/opencode/test/session/tool-attachment.test.ts
@@ -61,12 +61,23 @@ describe("session tool attachment routing", () => {
       npm: "@ai-sdk/openai-compatible",
       image: true,
       audio: true,
+      video: true,
       pdf: true,
     })
 
     expect(routeToolAttachment({ model, attachment: attachment("image/png"), allowNative: true })).toBe("synthetic")
     expect(routeToolAttachment({ model, attachment: attachment("audio/wav"), allowNative: true })).toBe("synthetic")
-    expect(routeToolAttachment({ model, attachment: attachment("audio/ogg"), allowNative: true })).toBe("placeholder")
+    expect(routeToolAttachment({ model, attachment: attachment("audio/ogg"), allowNative: true })).toBe("synthetic")
+    expect(routeToolAttachment({ model, attachment: attachment("audio/x-flac"), allowNative: true })).toBe("synthetic")
+    expect(routeToolAttachment({ model, attachment: attachment("audio/aac"), allowNative: true })).toBe("placeholder")
+    expect(routeToolAttachment({ model, attachment: attachment("video/mp4"), allowNative: true })).toBe("synthetic")
+    expect(
+      routeToolAttachment({
+        model,
+        attachment: { mime: "video/mp4", url: "https://example.com/clip.mp4", filename: "clip.mp4" },
+        allowNative: true,
+      }),
+    ).toBe("placeholder")
     expect(routeToolAttachment({ model, attachment: attachment("application/octet-stream"), allowNative: true })).toBe(
       "placeholder",
     )

--- a/packages/opencode/test/session/tool-attachment.test.ts
+++ b/packages/opencode/test/session/tool-attachment.test.ts
@@ -71,6 +71,15 @@ describe("session tool attachment routing", () => {
     expect(routeToolAttachment({ model, attachment: attachment("audio/x-flac"), allowNative: true })).toBe("synthetic")
     expect(routeToolAttachment({ model, attachment: attachment("audio/aac"), allowNative: true })).toBe("placeholder")
     expect(routeToolAttachment({ model, attachment: attachment("video/mp4"), allowNative: true })).toBe("synthetic")
+    expect(routeToolAttachment({ model, attachment: attachment("video/quicktime"), allowNative: true })).toBe(
+      "synthetic",
+    )
+    // The patch would serialize any video/* as video_url, but the MiMo video
+    // API only takes mp4/mov/avi/wmv, so the rest never leave as attachments.
+    expect(routeToolAttachment({ model, attachment: attachment("video/webm"), allowNative: true })).toBe("placeholder")
+    expect(routeToolAttachment({ model, attachment: attachment("video/x-matroska"), allowNative: true })).toBe(
+      "placeholder",
+    )
     expect(
       routeToolAttachment({
         model,

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -11,7 +11,7 @@ import { Instance } from "../../src/project/instance"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { ModelID } from "../../src/provider/schema"
 import { Instruction } from "../../src/session/instruction"
-import { ReadTool } from "../../src/tool/read"
+import { ReadTool, describeMedia } from "../../src/tool/read"
 import { Truncate } from "../../src/tool"
 import { Tool } from "../../src/tool"
 import { Filesystem } from "../../src/util"
@@ -576,6 +576,136 @@ describe("tool.read pdf capability gate", () => {
       expect(result.output).toContain('Cannot attach PDF "doc.pdf"')
       expect(result.output).toContain(path.join("pdf-official", "SKILL.md"))
       expect(result.metadata.truncated).toBe(false)
+    }),
+  )
+})
+
+describe("tool.read audio and video capability gate", () => {
+  // Minimal RIFF/WAVE header: sniffed as audio/wav regardless of the mime
+  // lookup, and full of zero bytes so the binary detector would otherwise
+  // refuse it.
+  const wav = Buffer.concat([
+    Buffer.from("RIFF"),
+    Buffer.from([0x24, 0x00, 0x00, 0x00]),
+    Buffer.from("WAVEfmt "),
+    Buffer.alloc(24),
+  ])
+  const mediaModel = (input: { audio?: boolean; video?: boolean; npm?: string }) =>
+    ProviderTest.model({
+      id: ModelID.make("media"),
+      providerID: visionModel.providerID,
+      api: { id: "media", url: "https://example.com", npm: input.npm ?? "@ai-sdk/openai" },
+      capabilities: {
+        ...visionModel.capabilities,
+        input: { ...visionModel.capabilities.input, audio: input.audio ?? false, video: input.video ?? false },
+      },
+    })
+
+  it.live("attaches audio when the active model accepts audio input", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "clip.wav"), wav)
+
+      const result = yield* exec(
+        dir,
+        { file_path: path.join(dir, "clip.wav") },
+        { ...ctx, extra: { model: mediaModel({ audio: true }) } },
+      )
+      expect(result.output).toContain("Audio read successfully")
+      expect(result.attachments?.length).toBe(1)
+      expect(result.attachments?.[0].mime).toBe("audio/wav")
+      expect(result.attachments?.[0].filename).toBe("clip.wav")
+      expect(result.attachments?.[0].url).toBe(`data:audio/wav;base64,${wav.toString("base64")}`)
+    }),
+  )
+
+  it.live("refuses audio without reading it when the model lacks audio input", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "clip.wav"), wav)
+
+      const result = yield* exec(dir, { file_path: path.join(dir, "clip.wav") })
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain('Cannot attach audio "clip.wav"')
+      expect(result.output).toContain("no audio input support")
+    }),
+  )
+
+  it.live("refuses an audio format the provider adapter cannot serialize", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "clip.aac"), Buffer.from("\xff\xf1\0\0\0\0", "binary"))
+
+      const result = yield* exec(
+        dir,
+        { file_path: path.join(dir, "clip.aac") },
+        { ...ctx, extra: { model: mediaModel({ audio: true, npm: "@ai-sdk/openai-compatible" }) } },
+      )
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain('Cannot attach audio "clip.aac" (audio/aac)')
+      expect(result.output).toContain("audio/wav")
+    }),
+  )
+
+  it.live("attaches video when the active model accepts video input", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const mp4 = Buffer.concat([Buffer.from([0, 0, 0, 0x18]), Buffer.from("ftypmp42"), Buffer.alloc(12)])
+      yield* put(path.join(dir, "clip.mp4"), mp4)
+
+      const result = yield* exec(
+        dir,
+        { file_path: path.join(dir, "clip.mp4") },
+        { ...ctx, extra: { model: mediaModel({ video: true }) } },
+      )
+      expect(result.output).toContain("Video read successfully")
+      expect(result.attachments?.[0].mime).toBe("video/mp4")
+
+      const denied = yield* exec(dir, { file_path: path.join(dir, "clip.mp4") })
+      expect(denied.attachments).toBeUndefined()
+      expect(denied.output).toContain('Cannot attach video "clip.mp4"')
+    }),
+  )
+})
+
+describe("tool.read media description", () => {
+  const withMedia = (input: { audio?: boolean; video?: boolean; npm?: string }) =>
+    ProviderTest.model({
+      api: { id: "media", url: "https://example.com", npm: input.npm ?? "@ai-sdk/openai" },
+      capabilities: {
+        ...visionModel.capabilities,
+        input: { ...visionModel.capabilities.input, audio: input.audio ?? false, video: input.video ?? false },
+      },
+    })
+
+  it.live("omits the media paragraph for a model without audio or video input", () =>
+    Effect.sync(() => {
+      expect(describeMedia(undefined)).toBeUndefined()
+      expect(describeMedia(withMedia({}))).toBeUndefined()
+    }),
+  )
+
+  it.live("names only the modalities the model accepts", () =>
+    Effect.sync(() => {
+      const audio = describeMedia(withMedia({ audio: true }))
+      expect(audio).toContain("audio (wav, mp3, flac, m4a, ogg)")
+      expect(audio).not.toContain("video")
+
+      const video = describeMedia(withMedia({ video: true }))
+      expect(video).toContain("video (mp4, mov, avi, wmv)")
+      expect(video).not.toContain("audio")
+
+      expect(describeMedia(withMedia({ audio: true, video: true }))).toContain(
+        "audio (wav, mp3, flac, m4a, ogg) and video (mp4, mov, avi, wmv)",
+      )
+    }),
+  )
+
+  it.live("narrows the audio formats to what the provider adapter can serialize", () =>
+    Effect.sync(() => {
+      expect(describeMedia(withMedia({ audio: true, npm: "@ai-sdk/openai-compatible" }))).toContain(
+        "audio (wav, mp3, flac, m4a, ogg)",
+      )
     }),
   )
 })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -666,6 +666,25 @@ describe("tool.read audio and video capability gate", () => {
       expect(denied.output).toContain('Cannot attach video "clip.mp4"')
     }),
   )
+
+  it.live("refuses a video format the MiMo video API does not take", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      // EBML header: what a .webm/.mkv starts with. The mime lookup yields
+      // video/webm from the extension, which is outside mp4/mov/avi/wmv.
+      yield* put(path.join(dir, "clip.webm"), Buffer.concat([Buffer.from([0x1a, 0x45, 0xdf, 0xa3]), Buffer.alloc(12)]))
+
+      const result = yield* exec(
+        dir,
+        { file_path: path.join(dir, "clip.webm") },
+        { ...ctx, extra: { model: mediaModel({ video: true, npm: "@ai-sdk/openai-compatible" }) } },
+      )
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain('Cannot attach video "clip.webm" (video/webm)')
+      expect(result.output).toContain("video/mp4, video/quicktime, video/x-msvideo, video/x-ms-wmv")
+      expect(result.output).toContain("/tmp/example.mp4")
+    }),
+  )
 })
 
 describe("tool.read media description", () => {
@@ -698,6 +717,16 @@ describe("tool.read media description", () => {
       expect(describeMedia(withMedia({ audio: true, video: true }))).toContain(
         "audio (wav, mp3, flac, m4a, ogg) and video (mp4, mov, avi, wmv)",
       )
+    }),
+  )
+
+  it.live("narrows the video formats to what the MiMo video API takes", () =>
+    Effect.gen(function* () {
+      expect(describeMedia(withMedia({ video: true, npm: "@ai-sdk/openai-compatible" }))).toContain(
+        "video (mp4, mov, avi, wmv)",
+      )
+      // An adapter that carries any video/* falls back to the documented list.
+      expect(describeMedia(withMedia({ video: true, npm: "@ai-sdk/google" }))).toContain("video (mp4, mov, avi, wmv)")
     }),
   )
 
@@ -773,6 +802,33 @@ describe("tool.read attachment size limit", () => {
       expect(result.output).toContain(`"giant.png" (image/png) is ${bytes.byteLength} bytes`)
       expect(result.output).toContain("ceiling above which compression is not attempted")
       expect(result.output).toContain("It was not read")
+    }),
+  )
+
+  it.live("attaches audio over the attachment limit when it fits the encoded media cap", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      // Audio is bounded by the provider's encoded-size cap (fitsMediaBase64),
+      // not Flag.MIMOCODE_MAX_ATTACHMENT_SIZE, so a file over LIMIT is still read.
+      const bytes = Buffer.concat([
+        Buffer.from("RIFF"),
+        Buffer.from([0x24, 0x00, 0x00, 0x00]),
+        Buffer.from("WAVEfmt "),
+        Buffer.alloc(LIMIT),
+      ])
+      expect(bytes.byteLength).toBeGreaterThan(LIMIT)
+      yield* put(path.join(dir, "long.wav"), bytes)
+      const model = ProviderTest.model({
+        id: ModelID.make("media"),
+        providerID: visionModel.providerID,
+        api: { id: "media", url: "https://example.com", npm: "@ai-sdk/openai" },
+        capabilities: { ...visionModel.capabilities, input: { ...visionModel.capabilities.input, audio: true } },
+      })
+
+      const result = yield* exec(dir, { file_path: path.join(dir, "long.wav") }, { ...ctx, extra: { model } })
+      expect(result.output).toContain("Audio read successfully")
+      expect(result.attachments?.length).toBe(1)
+      expect(result.attachments?.[0].url).toBe(`data:audio/wav;base64,${bytes.toString("base64")}`)
     }),
   )
 

--- a/packages/opencode/test/util/media.test.ts
+++ b/packages/opencode/test/util/media.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import {
+  base64Length,
+  fitsMediaBase64,
+  isMedia,
+  MAX_MEDIA_BASE64_BYTES,
+  sniffAttachmentMime,
+} from "../../src/util/media"
+
+describe("util.media", () => {
+  test("bounds inline audio/video on the encoded size", () => {
+    // 3 raw bytes encode to 4; the last byte under the limit is 3/4 of it.
+    const raw = (MAX_MEDIA_BASE64_BYTES / 4) * 3
+    expect(base64Length(raw)).toBe(MAX_MEDIA_BASE64_BYTES)
+    expect(fitsMediaBase64(raw)).toBe(true)
+    expect(fitsMediaBase64(raw + 1)).toBe(false)
+    expect(base64Length(Buffer.from("hello").byteLength)).toBe(Buffer.from("hello").toString("base64").length)
+  })
+
+  test("treats audio and video as media", () => {
+    expect(isMedia("audio/wav")).toBe(true)
+    expect(isMedia("video/mp4")).toBe(true)
+    expect(isMedia("image/png")).toBe(true)
+    expect(isMedia("text/plain")).toBe(false)
+  })
+
+  test("sniffs a RIFF/WAVE header as audio/wav", () => {
+    const wav = Buffer.concat([Buffer.from("RIFF"), Buffer.alloc(4), Buffer.from("WAVE")])
+    expect(sniffAttachmentMime(wav, "application/octet-stream")).toBe("audio/wav")
+    const webp = Buffer.concat([Buffer.from("RIFF"), Buffer.alloc(4), Buffer.from("WEBP")])
+    expect(sniffAttachmentMime(webp, "application/octet-stream")).toBe("image/webp")
+  })
+})

--- a/patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
+++ b/patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
@@ -1,8 +1,50 @@
 diff --git a/dist/index.js b/dist/index.js
-index dca128d3a790378c51a24a16d92585178343b278..84f21b064e487c62377241fb0737321cd0968e76 100644
+index dca128d..abe027f 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -791,6 +791,7 @@
+@@ -114,9 +114,20 @@ function getAudioFormat(mediaType) {
+   switch (mediaType) {
+     case "audio/wav":
+       return "wav";
++    case "audio/x-wav":
++      return "wav";
+     case "audio/mp3":
+     case "audio/mpeg":
+       return "mp3";
++    case "audio/flac":
++    case "audio/x-flac":
++      return "flac";
++    case "audio/mp4":
++    case "audio/m4a":
++    case "audio/x-m4a":
++      return "m4a";
++    case "audio/ogg":
++      return "ogg";
+     default:
+       return null;
+   }
+@@ -196,6 +207,20 @@ function convertToOpenAICompatibleChatMessages(prompt) {
+                     ...partMetadata
+                   };
+                 }
++                if (part.mediaType.startsWith("video/")) {
++                  if (part.data instanceof URL) {
++                    throw new import_provider.UnsupportedFunctionalityError({
++                      functionality: "video file parts with URLs"
++                    });
++                  }
++                  return {
++                    type: "video_url",
++                    video_url: {
++                      url: `data:${part.mediaType};base64,${(0, import_provider_utils.convertToBase64)(part.data)}`
++                    },
++                    ...partMetadata
++                  };
++                }
+                 if (part.mediaType.startsWith("text/")) {
+                   const textContent = part.data instanceof URL ? part.data.toString() : typeof part.data === "string" ? new TextDecoder().decode(
+                     (0, import_provider_utils.convertBase64ToUint8Array)(part.data)
+@@ -791,6 +816,7 @@ var OpenAICompatibleChatLanguageModel = class {
                        arguments: (_e = toolCallDelta.function.arguments) != null ? _e : ""
                      },
                      hasFinished: false,
@@ -10,7 +52,7 @@ index dca128d3a790378c51a24a16d92585178343b278..84f21b064e487c62377241fb0737321c
                      thoughtSignature: (_h = (_g = (_f = toolCallDelta.extra_content) == null ? void 0 : _f.google) == null ? void 0 : _g.thought_signature) != null ? _h : void 0
                    };
                    const toolCall2 = toolCalls[index];
-@@ -803,24 +804,7 @@
+@@ -803,24 +829,7 @@ var OpenAICompatibleChatLanguageModel = class {
                        });
                      }
                      if ((0, import_provider_utils2.isParsableJson)(toolCall2.function.arguments)) {
@@ -36,7 +78,7 @@ index dca128d3a790378c51a24a16d92585178343b278..84f21b064e487c62377241fb0737321c
                      }
                    }
                    continue;
-@@ -837,25 +821,8 @@
+@@ -837,25 +846,8 @@ var OpenAICompatibleChatLanguageModel = class {
                    id: toolCall.id,
                    delta: (_o = toolCallDelta.function.arguments) != null ? _o : ""
                  });
@@ -64,7 +106,7 @@ index dca128d3a790378c51a24a16d92585178343b278..84f21b064e487c62377241fb0737321c
                  }
                }
              }
-@@ -879,7 +846,7 @@
+@@ -879,7 +871,7 @@ var OpenAICompatibleChatLanguageModel = class {
                  type: "tool-call",
                  toolCallId: (_a2 = toolCall.id) != null ? _a2 : (0, import_provider_utils2.generateId)(),
                  toolName: toolCall.function.name,
@@ -74,10 +116,52 @@ index dca128d3a790378c51a24a16d92585178343b278..84f21b064e487c62377241fb0737321c
                    providerMetadata: {
                      [providerOptionsName]: {
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..6a926f818251fd1f046e3aa816842d9517332ca9 100644
+index 3b1e1b6..4abca1c 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -778,6 +778,7 @@
+@@ -99,9 +99,20 @@ function getAudioFormat(mediaType) {
+   switch (mediaType) {
+     case "audio/wav":
+       return "wav";
++    case "audio/x-wav":
++      return "wav";
+     case "audio/mp3":
+     case "audio/mpeg":
+       return "mp3";
++    case "audio/flac":
++    case "audio/x-flac":
++      return "flac";
++    case "audio/mp4":
++    case "audio/m4a":
++    case "audio/x-m4a":
++      return "m4a";
++    case "audio/ogg":
++      return "ogg";
+     default:
+       return null;
+   }
+@@ -181,6 +192,20 @@ function convertToOpenAICompatibleChatMessages(prompt) {
+                     ...partMetadata
+                   };
+                 }
++                if (part.mediaType.startsWith("video/")) {
++                  if (part.data instanceof URL) {
++                    throw new UnsupportedFunctionalityError({
++                      functionality: "video file parts with URLs"
++                    });
++                  }
++                  return {
++                    type: "video_url",
++                    video_url: {
++                      url: `data:${part.mediaType};base64,${convertToBase64(part.data)}`
++                    },
++                    ...partMetadata
++                  };
++                }
+                 if (part.mediaType.startsWith("text/")) {
+                   const textContent = part.data instanceof URL ? part.data.toString() : typeof part.data === "string" ? new TextDecoder().decode(
+                     convertBase64ToUint8Array(part.data)
+@@ -778,6 +803,7 @@ var OpenAICompatibleChatLanguageModel = class {
                        arguments: (_e = toolCallDelta.function.arguments) != null ? _e : ""
                      },
                      hasFinished: false,
@@ -85,7 +169,7 @@ index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..6a926f818251fd1f046e3aa816842d95
                      thoughtSignature: (_h = (_g = (_f = toolCallDelta.extra_content) == null ? void 0 : _f.google) == null ? void 0 : _g.thought_signature) != null ? _h : void 0
                    };
                    const toolCall2 = toolCalls[index];
-@@ -790,24 +791,7 @@
+@@ -790,24 +816,7 @@ var OpenAICompatibleChatLanguageModel = class {
                        });
                      }
                      if (isParsableJson(toolCall2.function.arguments)) {
@@ -111,7 +195,7 @@ index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..6a926f818251fd1f046e3aa816842d95
                      }
                    }
                    continue;
-@@ -824,25 +808,8 @@
+@@ -824,25 +833,8 @@ var OpenAICompatibleChatLanguageModel = class {
                    id: toolCall.id,
                    delta: (_o = toolCallDelta.function.arguments) != null ? _o : ""
                  });
@@ -139,7 +223,7 @@ index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..6a926f818251fd1f046e3aa816842d95
                  }
                }
              }
-@@ -866,7 +833,7 @@
+@@ -866,7 +858,7 @@ var OpenAICompatibleChatLanguageModel = class {
                  type: "tool-call",
                  toolCallId: (_a2 = toolCall.id) != null ? _a2 : generateId(),
                  toolName: toolCall.function.name,


### PR DESCRIPTION
## Summary
- Extend the `read` tool so models with audio/video input can attach those files as inline `data:` attachments (wav/mp3/flac/m4a/ogg audio; mp4/mov/avi/wmv video).
- Gate on the current model's declared capability and adapter MIME list, and reject files whose base64 encoding would exceed the 50 MB provider ceiling (~37.5 MB on disk) before any bytes are read.
- Patch `@ai-sdk/openai-compatible@2.0.41` to serialize the extra audio formats as `input_audio` and inline video as `video_url`.
- Surface the supported media formats in the read tool description per model, and add coverage in capability-registry / tool-attachment / read / media tests.
- Include the Xiaomi media API reference under `docs/harness/xiaomi-media-api-doc.md`.

## Verification
- `bun turbo typecheck` passes (pre-push hook).
- New/updated unit tests cover media helpers, capability declarations, attachment routing, and the read tool's audio/video paths.