### PR TITLE
fix(task): publish Bus events on the calling fiber's Instance

### DIFF
--- a/packages/opencode/src/task/registry.ts
+++ b/packages/opencode/src/task/registry.ts
@@ -7,7 +7,6 @@ import { TaskTable, TaskEventTable } from "./task.sql"
 import type { Task, TaskEvent } from "./schema"
 import { Created as TaskCreated, Updated as TaskUpdated, type UpdatedKind } from "./events"
 import { RecoverableError } from "@/tool/recoverable"
-import { EffectBridge } from "@/effect"
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -93,7 +92,6 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
   Effect.gen(function* () {
     const bus = yield* Bus.Service
     const config = yield* Config.Service
-    const bridge = yield* EffectBridge.make()
 
     const cleanupAfter = Effect.fn("TaskRegistry.cleanupAfter")(function* (now: number) {
       const cfg = yield* config.get()
@@ -116,11 +114,17 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       )
     }
 
+    // Publish on the calling fiber so Instance.directory matches the session
+    // workspace (the same key instance /event SSE and GlobalBus consumers use).
+    // A layer-scoped EffectBridge.fork captured Instance too early (often cwd /
+    // undefined), so task.* landed on a different Bus bucket than live subscribers.
+    // ignore: Bus delivery is best-effort telemetry — the DB row remains authoritative
+    // and HTTP GET /session/:id/task still hydrates TUI/desktop stores.
     const publishCreated = (task: Task) =>
-      bridge.fork(bus.publish(TaskCreated, { sessionID: task.session_id, task }))
+      bus.publish(TaskCreated, { sessionID: task.session_id, task }).pipe(Effect.ignore)
 
     const publishUpdated = (task: Task, kind: UpdatedKind) =>
-      bridge.fork(bus.publish(TaskUpdated, { sessionID: task.session_id, task, kind }))
+      bus.publish(TaskUpdated, { sessionID: task.session_id, task, kind }).pipe(Effect.ignore)
 
     const create = Effect.fn("TaskRegistry.create")(function* (input: {
       session_id: SessionID
@@ -161,7 +165,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       Database.use((db) => db.insert(TaskTable).values(row).run())
       insertEvent(input.session_id, id, "created", undefined, now)
       const task = fromTaskRow(row)
-      publishCreated(task)
+      yield* publishCreated(task)
       return task
     })
 
@@ -237,7 +241,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       insertEvent(input.session_id, input.id, "blocked", input.event_summary, now)
       const updated = yield* get({ session_id: input.session_id, id: input.id })
       if (!updated) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
-      publishUpdated(updated, "blocked")
+      yield* publishUpdated(updated, "blocked")
       return updated
     })
 
@@ -257,7 +261,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       insertEvent(input.session_id, input.id, "unblocked", input.event_summary, now)
       const updated = yield* get({ session_id: input.session_id, id: input.id })
       if (!updated) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
-      publishUpdated(updated, "unblocked")
+      yield* publishUpdated(updated, "unblocked")
       return updated
     })
 
@@ -300,7 +304,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       insertEvent(input.session_id, input.id, "started", input.event_summary, now)
       const updated = yield* get({ session_id: input.session_id, id: input.id })
       if (!updated) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
-      publishUpdated(updated, "started")
+      yield* publishUpdated(updated, "started")
       return updated
     })
 
@@ -326,7 +330,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       insertEvent(input.session_id, input.id, "done", input.event_summary, now)
       const updated = yield* get({ session_id: input.session_id, id: input.id })
       if (!updated) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
-      publishUpdated(updated, "done")
+      yield* publishUpdated(updated, "done")
       return updated
     })
 
@@ -352,7 +356,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       insertEvent(input.session_id, input.id, "abandoned", input.event_summary, now)
       const updated = yield* get({ session_id: input.session_id, id: input.id })
       if (!updated) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
-      publishUpdated(updated, "abandoned")
+      yield* publishUpdated(updated, "abandoned")
       return updated
     })
 
@@ -372,7 +376,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Config.Service> = 
       insertEvent(input.session_id, input.id, "renamed", input.summary, now)
       const updated = yield* get({ session_id: input.session_id, id: input.id })
       if (!updated) return yield* Effect.die(new RecoverableError(notFoundMessage(input.id)))
-      publishUpdated(updated, "renamed")
+      yield* publishUpdated(updated, "renamed")
       return updated
     })
 


### PR DESCRIPTION
## Summary

Live task list updates (TUI sidebar / desktop info panel) did not refresh while a turn was running. The DB was correct; consumers only caught up after `GET /session/:id/task` (session open / turn end).

**Root cause:** `TaskRegistry` published `task.created` / `task.updated` through a **layer-scoped** `EffectBridge.fork`. That bridge captured `Instance` at layer init (often `undefined` / process cwd). Instance Bus PubSubs and `GlobalBus` envelopes are keyed by `directory`. Live subscribers filter on that directory:

- Desktop: instance `/event?directory=<session workspace>`
- TUI: `/global/event`, then `event.directory === project.instance.directory()` (or workspace id)

Session events (`message.part`, `session.idle`, …) already used `yield* bus.publish(...)` on the calling fiber and arrived on the correct bucket. Task events went to a **different** bucket, so live UIs never saw them mid-turn.

## Fix

Publish task Bus events on the **calling fiber** (same pattern as other session Bus publishes):

```ts
const publishCreated = (task: Task) =>
  bus.publish(TaskCreated, { sessionID: task.session_id, task }).pipe(Effect.ignore)

// create / start / done / ...
yield* publishCreated(task)
```

`publishCreated` / `publishUpdated` return `bus.publish(...)` instead of `bridge.fork(...)`. All registry mutations `yield*` them so `InstanceState.directory` matches the session Instance that live subscribers use.

`Effect.ignore` keeps delivery **best-effort**: a Bus/SSE failure must not fail `task create` / `task done`. The SQLite row stays authoritative; TUI/desktop HTTP hydrate is unchanged.

## TUI impact

- **Sidebar rendering / store shape:** unchanged (`sync.tsx` still handles `task.created` / `task.updated`; `session.task` HTTP sync unchanged).
- **Live updates:** same or better — frames now carry the session `directory` TUI’s filter expects when `instance.directory` matches that session (normal TUI usage in a project). Previously many live task frames never matched.
- **No UI regression path:** no TUI component code changes in this PR.

## Testing

- `bun test` in `packages/opencode`:
  - `test/task/registry.test.ts`, `state-machine.test.ts`, `gate.test.ts`
  - `test/tool/task.test.ts`, `task.shell.test.ts`, `task-recover.test.ts`, `actor-wait.test.ts`
- Manual (desktop + embedded engine): mid-turn `task done` updates the live task list immediately (previously only after turn end / GET reconcile).
