### PR TITLE
test(history): use audio/aac as the unsupported attachment fixture

### DIFF
--- a/packages/opencode/test/history/details.test.ts
+++ b/packages/opencode/test/history/details.test.ts
@@ -106,7 +106,8 @@ it.live("get reads original parts without index; Unicode pages, errors, stable m
             error: `oops ${url}`,
             attachments: [
               { id: "old-id", mime: "image/png", url },
-              { mime: "audio/ogg", url: "data:audio/ogg;base64,YWJj" },
+              // tool:1 unsupported audio (aac off allowlist); tool:3 wav is routable.
+              { mime: "audio/aac", url: "data:audio/aac;base64,YWJj" },
               { mime: "application/pdf", url: "data:application/pdf;base64,YWJj" },
               { mime: "audio/wav", url: "data:audio/wav;base64,YWJj" },
               { mime: "image/png", url: "https://example.com/never-downloaded.png" },


### PR DESCRIPTION
## Summary
- main CI test shard 2/4 failed in `test/history/details.test.ts`: `tool:1` expected `"Cannot display"` but audio/ogg now correctly routes through the media channel when `input.audio=true` and the OpenAI-compatible allowlist accepts it.
- Keep the negative routing assertion; replace the unreadable fixture with `audio/aac` (same pattern as `b80fc3ad`). Positive audio coverage stays on `tool:3` (`audio/wav`).
- Test-only change; no production code.

## Verification
- `bun test test/history/details.test.ts test/session/tool-attachment.test.ts test/util/media.test.ts test/tool/read.test.ts` — 69 pass / 0 fail
- `bun test test/history/` — 49 pass / 0 fail / 6 skip
- `bun typecheck` (packages/opencode) — pass
