### PR TITLE
fix(provider): keep Xiaomi models on the stock openai-compatible SDK

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1128,6 +1128,19 @@ function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
   return result
 }
 
+const OPENAI_COMPATIBLE_NPM = "@ai-sdk/openai-compatible"
+
+// MiMo models (and the `mimo-auto` smart alias) only speak the OpenAI-compatible Chat
+// Completions API. Whatever npm a catalog entry or mimocode.json declares for such an
+// id, the model is pinned to @ai-sdk/openai-compatible.
+export function isMimoOrSmartModel(id: string) {
+  return /(^|[/_-])mimo(?:-|$)/i.test(id) || id === "mimo-auto"
+}
+
+function resolveModelNpm(npm: string, ...ids: string[]) {
+  return ids.some(isMimoOrSmartModel) ? OPENAI_COMPATIBLE_NPM : npm
+}
+
 function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
   const base: Model = {
     id: ModelID.make(model.id),
@@ -1137,7 +1150,7 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
     api: {
       id: model.id,
       url: model.provider?.api ?? provider.api ?? "",
-      npm: model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible",
+      npm: resolveModelNpm(model.provider?.npm ?? provider.npm ?? OPENAI_COMPATIBLE_NPM, model.id),
     },
     status: model.status ?? "active",
     headers: {},
@@ -1297,12 +1310,15 @@ const layer: Layer.Layer<
           for (const [modelID, model] of Object.entries(provider.models ?? {})) {
             const existingModel = parsed.models[model.id ?? modelID]
             const apiID = model.id ?? existingModel?.api.id ?? modelID
-            const apiNpm =
+            const apiNpm = resolveModelNpm(
               model.provider?.npm ??
-              provider.npm ??
-              existingModel?.api.npm ??
-              modelsDev[providerID]?.npm ??
-              "@ai-sdk/openai-compatible"
+                provider.npm ??
+                existingModel?.api.npm ??
+                modelsDev[providerID]?.npm ??
+                OPENAI_COMPATIBLE_NPM,
+              modelID,
+              apiID,
+            )
             const name = iife(() => {
               if (model.name) return model.name
               if (model.id && model.id !== modelID) return modelID
@@ -1343,7 +1359,7 @@ const layer: Layer.Layer<
                 interleaved:
                   model.interleaved ??
                   existingModel?.capabilities.interleaved ??
-                  (!existingModel && apiNpm === "@ai-sdk/openai-compatible" && apiID.includes("deepseek")
+                  (!existingModel && apiNpm === OPENAI_COMPATIBLE_NPM && apiID.includes("deepseek")
                     ? { field: "reasoning_content" }
                     : false),
               },

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -27,7 +27,6 @@ import { AppFileSystem } from "@mimo-ai/shared/filesystem"
 import { isRecord } from "@/util/record"
 import { withStatics } from "@/util/schema"
 import { isFreeApiModel, isFreeApiSunset } from "@/util/free-api-sunset"
-import { usesMimoResponsesApi } from "../tool/gpt"
 
 import * as ProviderTransform from "./transform"
 import { ModelID, ProviderID } from "./schema"
@@ -326,14 +325,6 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           return sdk.responses(modelID)
         },
         options: { headerTimeout: DEFAULT_OPENAI_HEADER_TIMEOUT },
-      }),
-    xiaomi: () =>
-      Effect.succeed({
-        autoload: false,
-        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
-          return usesMimoResponsesApi(modelID) ? sdk.responses(modelID) : sdk.languageModel(modelID)
-        },
-        options: {},
       }),
     xai: () =>
       Effect.succeed({
@@ -1713,25 +1704,7 @@ const layer: Layer.Layer<
           return wrapSSE(bounded, chunkTimeout, chunkAbortCtl)
         }
 
-        // Xiaomi: only PTC needs the bundled Responses harness (free-form `exec` custom tool);
-        // every non-PTC model must stay on the stock openai-compatible chat model. The bundled
-        // Copilot fork only understands Copilot's `reasoning_text`, so routing chat through it
-        // silently drops the `reasoning_content` that Xiaomi models stream back.
-        const bundledLoader =
-          model.providerID === "xiaomi" && model.api.npm === "@ai-sdk/openai-compatible"
-            ? () =>
-                Promise.all([BUNDLED_PROVIDERS["@ai-sdk/openai-compatible"](), import("./sdk/copilot")]).then(
-                  ([createChat, copilot]) =>
-                    (options: any) => {
-                      const chat = createChat(options)
-                      const responses = copilot.createOpenaiCompatible({ ...options, customToolNames: ["exec"] })
-                      return {
-                        languageModel: (modelId: string) => chat.languageModel(modelId),
-                        responses: (modelId: string) => responses.responses(modelId),
-                      }
-                    },
-                )
-            : BUNDLED_PROVIDERS[model.api.npm]
+        const bundledLoader = BUNDLED_PROVIDERS[model.api.npm]
         if (bundledLoader) {
           log.info("using bundled provider", {
             providerID: model.providerID,

--- a/packages/opencode/src/tool/gpt.ts
+++ b/packages/opencode/src/tool/gpt.ts
@@ -29,15 +29,6 @@ export function isMcpToolSearchEnabled(
   return enabled || usesCodexMode(harness, ...modelIDs)
 }
 
-export function isMimoModel(...values: Array<string | undefined>) {
-  return values.some((value) => value && /(?:^|[/_-])mimo(?:$|[/_.-])/i.test(value))
-}
-
-export function usesMimoResponsesApi(...values: Array<string | undefined>) {
-  const ids = values.flatMap((value) => (value ? [value.toLowerCase()] : []))
-  return isMimoModel(...ids) && ids.some((id) => /(?:^|[/_.-])ptc(?:$|[/_.-])/.test(id))
-}
-
 export function usesGPTToolset(
   modelID: string,
   harness?: HarnessMode,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1978,7 +1978,7 @@ test("mimo model ids are pinned to @ai-sdk/openai-compatible in config", async (
       expect(models["gpt-5.4"].api.npm).toBe("@ai-sdk/openai")
       expect(models["mimosa-1"].api.npm).toBe("@ai-sdk/openai")
       // Only the SDK is pinned; the provider stays as configured.
-      expect(models["MiMo-V2.6"].providerID).toBe("my-gateway")
+      expect(models["MiMo-V2.6"].providerID).toBe(ProviderID.make("my-gateway"))
     },
   })
 })
@@ -2009,7 +2009,7 @@ test("mimo model ids are pinned to @ai-sdk/openai-compatible from models.dev", (
   expect(models["xiaomi/mimo-v2.5"].api.npm).toBe("@ai-sdk/openai-compatible")
   expect(models["XiaomiMiMo/MiMo-V2.5-Pro"].api.npm).toBe("@ai-sdk/openai-compatible")
   expect(models["gpt-5.4"].api.npm).toBe("@ai-sdk/openai")
-  expect(models["xiaomi/mimo-v2.5"].providerID).toBe("test-provider")
+  expect(models["xiaomi/mimo-v2.5"].providerID).toBe(ProviderID.make("test-provider"))
 })
 
 test("isMimoOrSmartModel matches mimo ids and the mimo-auto alias only", () => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1942,6 +1942,85 @@ test("xiaomi chat streams reasoning_content as reasoning parts", async () => {
   }
 })
 
+test("mimo model ids are pinned to @ai-sdk/openai-compatible in config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "mimocode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "my-gateway": {
+              name: "My Gateway",
+              npm: "@ai-sdk/openai",
+              env: [],
+              models: {
+                "MiMo-V2.6": { tool_call: true, limit: { context: 8192, output: 2048 } },
+                "alias-model": { id: "vendor/mimo-v2.5", tool_call: true, limit: { context: 8192, output: 2048 } },
+                "mimo-auto": { tool_call: true, limit: { context: 8192, output: 2048 } },
+                "gpt-5.4": { tool_call: true, limit: { context: 8192, output: 2048 } },
+                "mimosa-1": { tool_call: true, limit: { context: 8192, output: 2048 } },
+              },
+              options: { apiKey: "test-key", baseURL: "https://example.test/v1" },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const models = (await list())[ProviderID.make("my-gateway")].models
+      expect(models["MiMo-V2.6"].api.npm).toBe("@ai-sdk/openai-compatible")
+      expect(models["alias-model"].api.npm).toBe("@ai-sdk/openai-compatible")
+      expect(models["mimo-auto"].api.npm).toBe("@ai-sdk/openai-compatible")
+      expect(models["gpt-5.4"].api.npm).toBe("@ai-sdk/openai")
+      expect(models["mimosa-1"].api.npm).toBe("@ai-sdk/openai")
+      // Only the SDK is pinned; the provider stays as configured.
+      expect(models["MiMo-V2.6"].providerID).toBe("my-gateway")
+    },
+  })
+})
+
+test("mimo model ids are pinned to @ai-sdk/openai-compatible from models.dev", () => {
+  const model = (id: string, npm?: string) => ({
+    id,
+    name: id,
+    provider: npm ? { npm } : undefined,
+    limit: { context: 8192, output: 2048 },
+    cost: { input: 0, output: 0 },
+    modalities: { input: ["text"], output: ["text"] },
+  })
+  const provider = {
+    id: "test-provider",
+    name: "Test Provider",
+    env: [],
+    npm: "@ai-sdk/openai",
+    api: "https://example.test/v1",
+    models: {
+      "xiaomi/mimo-v2.5": model("xiaomi/mimo-v2.5"),
+      "XiaomiMiMo/MiMo-V2.5-Pro": model("XiaomiMiMo/MiMo-V2.5-Pro", "@ai-sdk/deepinfra"),
+      "gpt-5.4": model("gpt-5.4", "@ai-sdk/openai"),
+    },
+  } as unknown as ModelsDev.Provider
+
+  const models = Provider.fromModelsDevProvider(provider).models
+  expect(models["xiaomi/mimo-v2.5"].api.npm).toBe("@ai-sdk/openai-compatible")
+  expect(models["XiaomiMiMo/MiMo-V2.5-Pro"].api.npm).toBe("@ai-sdk/openai-compatible")
+  expect(models["gpt-5.4"].api.npm).toBe("@ai-sdk/openai")
+  expect(models["xiaomi/mimo-v2.5"].providerID).toBe("test-provider")
+})
+
+test("isMimoOrSmartModel matches mimo ids and the mimo-auto alias only", () => {
+  for (const id of ["mimo-v2.5", "MiMo-V2.6", "xiaomi/mimo-v2.5", "vendor_mimo-1", "mimo", "mimo-auto"]) {
+    expect(Provider.isMimoOrSmartModel(id)).toBe(true)
+  }
+  for (const id of ["mimosa-1", "gpt-5.4", "claude-opus-4-6", "xmimo-1"]) {
+    expect(Provider.isMimoOrSmartModel(id)).toBe(false)
+  }
+})
+
 // Edge cases for model configuration
 
 test("model alias name defaults to alias key when id differs", async () => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1832,48 +1832,7 @@ test("provider with custom npm package", async () => {
   })
 })
 
-test("xiaomi models use the Responses harness for free-form exec PTC", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "mimocode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          enabled_providers: ["xiaomi"],
-          provider: {
-            xiaomi: {
-              npm: "@ai-sdk/openai-compatible",
-              models: {
-                "mimo-ptc-test": {
-                  name: "MiMo PTC Test",
-                  tool_call: true,
-                  limit: { context: 8192, output: 2048 },
-                },
-              },
-              options: {
-                apiKey: "test-key",
-                baseURL: "https://example.test/v1",
-              },
-            },
-          },
-        }),
-      )
-    },
-  })
-  await Instance.provide({
-    directory: tmp.path,
-    init: async () => {
-      set("XIAOMI_API_KEY", "test-key")
-    },
-    fn: async () => {
-      const model = await getModel(ProviderID.make("xiaomi"), ModelID.make("mimo-ptc-test"))
-      const language = await getLanguage(model)
-      expect(language.provider).toBe("xiaomi.responses")
-    },
-  })
-})
-
-test("xiaomi models outside PTC mode stay on Chat Completions regardless of version", async () => {
+test("xiaomi models stay on Chat Completions regardless of version", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -1913,13 +1872,13 @@ test("xiaomi models outside PTC mode stay on Chat Completions regardless of vers
       )
       const languages = await Promise.all(models.map((model) => getLanguage(model)))
       expect(languages.map((language) => language.provider)).toEqual(["xiaomi.chat", "xiaomi.chat"])
-      // Non-PTC must be the stock SDK, not the bundled Copilot fork (which only parses `reasoning_text`).
+      // Must be the stock SDK, not the bundled Copilot fork (which only parses `reasoning_text`).
       for (const language of languages) expect(language).toBeInstanceOf(OpenAICompatibleChatLanguageModel)
     },
   })
 })
 
-test("xiaomi non-PTC chat streams reasoning_content as reasoning parts", async () => {
+test("xiaomi chat streams reasoning_content as reasoning parts", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(


### PR DESCRIPTION
## Summary
- Remove the Xiaomi PTC Responses harness special-case so every Xiaomi model stays on the stock openai-compatible chat SDK
- Drop unused Mimo PTC helpers from gpt.ts
- Update provider tests for the chat-only path

## Why
The bundled Copilot fork only understands Copilot's `reasoning_text`, so routing Xiaomi chat through it silently drops the `reasoning_content` that Xiaomi models stream back.

## Verification
- `bun typecheck` in `packages/opencode` passes